### PR TITLE
Fix issue #414.

### DIFF
--- a/src/bin/units_access/CompoundIndexScanTests.cpp
+++ b/src/bin/units_access/CompoundIndexScanTests.cpp
@@ -184,5 +184,16 @@ TEST_F(CompoundIndexScanTests, not_all_columns) {
   ASSERT_THROW(is.execute(), std::runtime_error);
 }
 
+TEST_F(CompoundIndexScanTests, two_ints_both_not_in_dictionary) {
+  CompoundIndexScan is;
+  is.addInput(t);
+  is.setMainIndex("test_main_idx_0_and_3");
+  is.addPredicate(0, (hyrise_int_t)123456);
+  is.addPredicate(3, (hyrise_int_t)123456);
+  is.execute();
+  auto result = is.getResultTable();
+  ASSERT_EQ(result->size(), 0);
+}
+
 }  // namespace access
 }  // namespace hyrise

--- a/src/lib/access/CompoundIndexScan.cpp
+++ b/src/lib/access/CompoundIndexScan.cpp
@@ -46,9 +46,12 @@ void CompoundIndexScan::executePlanOperation() {
         throw std::runtime_error(
             "Incomplete predicate set specified - Partial Search only Implemeted for Validating-IndexScan");
       }
-      storage::PositionRange main_result = _main_index->getPositionsForKey(_valueid_key_builder.get());
-      result->resize(main_result.size());
-      std::copy(main_result.cbegin(), main_result.cend(), result->begin());
+
+      if (!_no_hits_in_main) {
+        storage::PositionRange main_result = _main_index->getPositionsForKey(_valueid_key_builder.get());
+        result->resize(main_result.size());
+        std::copy(main_result.cbegin(), main_result.cend(), result->begin());
+      }
     }
 
     if (_delta_index) {
@@ -152,9 +155,11 @@ void CompoundIndexScan::executePlanOperation() {
         // note: can this break if the largest value id is a power of two?
 
       } else {
-        storage::PositionRange main_result = _main_index->getPositionsForKey(_valueid_key_builder.get());
-        result->resize(main_result.size());
-        std::copy(main_result.cbegin(), main_result.cend(), result->begin());
+        if (!_no_hits_in_main) {
+          storage::PositionRange main_result = _main_index->getPositionsForKey(_valueid_key_builder.get());
+          result->resize(main_result.size());
+          std::copy(main_result.cbegin(), main_result.cend(), result->begin());
+        }
       }
       c_store->validatePositions(*result, _txContext.lastCid, _txContext.tid);
     }


### PR DESCRIPTION
The idea behind the now deleted code was probably an optimization. If `_main_index` was provided, but no value was found in the dictionary, `_main_index` would be set to `nullptr`. If no `_delta_index` was provided this would ultimately lead to a misleading error message and no scan operation at all. Which is unacceptable.