### PR TITLE
Fix issue #421: Test BufferedLoggerTests.simple_checkpoint_test fails

### DIFF
--- a/src/bin/units_io/BufferedLoggerTests.cpp
+++ b/src/bin/units_io/BufferedLoggerTests.cpp
@@ -25,7 +25,11 @@
 namespace hyrise {
 namespace io {
 
-class BufferedLoggerTests : public ::hyrise::Test {};
+class BufferedLoggerTests : public ::hyrise::Test {
+  virtual void SetUp() {
+    StorageManager::getInstance()->clear();
+  };
+};
 
 TEST_F(BufferedLoggerTests, log_test) {
   BufferedLogger::getInstance().truncate();


### PR DESCRIPTION
Fixes #421 by clearing the storage manager before executing the tests.

The test [calls](https://github.com/hyrise/hyrise/blob/337f1cedd97e45629b0d847b1ad2b756e3f2b9de/src/bin/units_io/BufferedLoggerTests.cpp#L220) the ``recoverTables`` method of the storage manager. This method will recover all tables, including their indexes, whose names were found in the ``tableDumpDir``. Therefore, it will also recover indexes which are still existing. This leads to failing.

Before executing ``recoverTables`` the test creates folders with names of tables which were used in previous tests by [executing](https://github.com/hyrise/hyrise/blob/337f1cedd97e45629b0d847b1ad2b756e3f2b9de/src/bin/units_io/BufferedLoggerTests.cpp#L186) the ``Checkpoint`` plan operation. It creates folders for all table names, also table names used in previous tests, which are returned by the ``getTableNames`` method of the StorageManager.