### PR TITLE
Fix issue #418: Failing tests Scheduler/SchedulerTest.wait_task_test

### DIFF
--- a/src/lib/taskscheduler/ThreadLevelQueue.h
+++ b/src/lib/taskscheduler/ThreadLevelQueue.h
@@ -37,7 +37,13 @@ class ThreadLevelQueue : public AbstractTaskScheduler,
   std::condition_variable_any _queuecheck;
 
  public:
-  ThreadLevelQueue(size_t threads) : _threadCount(threads), _status(START_UP), _blocked(false) {}
+  ThreadLevelQueue(size_t threads) : _status(START_UP), _blocked(false) {
+    if (threads > 0) {
+      _threadCount = threads;
+    } else {
+      _threadCount = 1;
+    }
+  }
   virtual ~ThreadLevelQueue() {
     if (_status != STOPPED)
       shutdown();

--- a/src/lib/taskscheduler/ThreadLevelQueuesScheduler.h
+++ b/src/lib/taskscheduler/ThreadLevelQueuesScheduler.h
@@ -56,7 +56,13 @@ class ThreadLevelQueuesScheduler : public AbstractTaskScheduler,
   }
 
  public:
-  ThreadLevelQueuesScheduler(int queues) : _queueCount(queues), _nextQueue(0), _status(START_UP) {};
+  ThreadLevelQueuesScheduler(int queues) : _nextQueue(0), _status(START_UP) {
+    if (queues > 0) {
+      _queueCount = queues;
+    } else {
+      _queueCount = 1;
+    }
+  };
   ~ThreadLevelQueuesScheduler() { shutdown(); }
 
   /*


### PR DESCRIPTION
Fixes #418 by preventing to be able to create ThreadLevelQueue with 0 threads and ThreadLevelQueuesScheduler with 0 queues. E.g., division by zero takes place without this fix.

The number of threads are determined in ``init`` and ``resetScheduler`` in [SharedScheduler.h](https://github.com/hyrise/hyrise/blob/337f1cedd97e45629b0d847b1ad2b756e3f2b9de/src/lib/taskscheduler/SharedScheduler.h#L64-L97). By default ``NUM_RESERVED_CORES`` is set to 1. On systems with a single core this leads to the creation of schedulers with 0 threads because ``threads = getNumberOfCoresOnSystem() - NUM_RESERVED_CORES``.