### PR TITLE
Fix issue #421: Test BufferedLoggerTests.simple_checkpoint_test fails

### DIFF
--- a/src/bin/perf_regression/SimpleTableScan.cpp
+++ b/src/bin/perf_regression/SimpleTableScan.cpp
@@ -35,7 +35,7 @@ class SimpleTableScanBase : public ::testing::Benchmark {
 
   void BenchmarkTearDown() override { delete ts; }
 
-  void TearDown() override { sm->clear(); }
+  void TearDown() override {}
 
   SimpleTableScanBase() {
     SetNumIterations(10);
@@ -129,7 +129,7 @@ class AdhocScanBench : public ::testing::Benchmark {
   }
   void BenchmarkSetup() {}
 
-  void TearDown() { sm->clear(); }
+  void TearDown() {}
 
   AdhocScanBench() {
     SetNumIterations(10);

--- a/src/bin/units_access/TpccStoredProceduresTest.cpp
+++ b/src/bin/units_access/TpccStoredProceduresTest.cpp
@@ -28,7 +28,7 @@ void TpccStoredProceduresTest::SetUp() {
   i_history_size = getTable(History)->size();
 }
 
-void TpccStoredProceduresTest::TearDown() { io::ResourceManager::getInstance().clear(); }
+void TpccStoredProceduresTest::TearDown() {}
 
 void TpccStoredProceduresTest::loadTables() { executeJsonAndWait(loadFromFile("test/tpcc/load_tpcc_tables.json")); }
 

--- a/src/bin/units_io/storagemgr_tests.cpp
+++ b/src/bin/units_io/storagemgr_tests.cpp
@@ -16,8 +16,6 @@ class StorageManagerTests : public ::hyrise::Test {
  public:
   StorageManagerTests() { sm = StorageManager::getInstance(); }
 
-  virtual void SetUp() { sm->removeAll(); }
-
   StorageManager* sm;
 };
 

--- a/src/lib/testing/base_test.h
+++ b/src/lib/testing/base_test.h
@@ -3,12 +3,16 @@
 
 #include <gtest/gtest.h>
 
+#include <io/ResourceManager.h>
+
 namespace hyrise {
 
 class Test : public ::testing::Test {
  public:
   virtual ~Test() {};
-  virtual void SetUp() {}
+  virtual void SetUp() {
+    io::ResourceManager::getInstance().clear();
+  }
   virtual void TearDown() {}
 };
 

--- a/src/lib/testing/test.h
+++ b/src/lib/testing/test.h
@@ -38,21 +38,11 @@ template <typename It1, typename It2>
 
 
 class StorageManagerTest : public Test {
- public:
-  virtual ~StorageManagerTest() {};
-
-  virtual void SetUp() { io::ResourceManager::getInstance().clear(); }
-
-  virtual void TearDown() {}
 };
 
 namespace access {
 
 class AccessTest : public Test {
- public:
-  virtual void SetUp() { io::ResourceManager::getInstance().clear(); }
-
-  virtual void TearDown() {}
 };
 
 }  // namespace access


### PR DESCRIPTION
Fixes #421 by clearing the storage manager during the SetUp of every test. It also removes calls to clear the StorageManager which are now unnecessary. 

The test calls the recoverTables method of the storage manager. This method will recover all tables, including their indexes, whose names were found in the tableDumpDir. Therefore, it will also recover indexes which are still existing. This leads to failing.

Before executing recoverTables the test creates folders with names of tables which were used in previous tests by executing the Checkpoint plan operation. It creates folders for all table names, also table names used in previous tests, which are returned by the getTableNames method of the StorageManager.