### PR TITLE
Adding chunk size to benchmark

### DIFF
--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -10,14 +10,20 @@
 
 namespace opossum {
 
-BENCHMARK_F(BenchmarkBasicFixture, BM_Sort)(benchmark::State& state) {
+BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_Sort_ChunkSize)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<Sort>(_table_wrapper_a, "a");
+  auto warm_up = std::make_shared<Sort>(_table_wrapper_a, "a", state.range(0));
   warm_up->execute();
   while (state.KeepRunning()) {
-    auto sort = std::make_shared<Sort>(_table_wrapper_a, "a");
+    auto sort = std::make_shared<Sort>(_table_wrapper_a, "a", state.range(0));
     sort->execute();
   }
 }
+
+static void ChunkSize(benchmark::internal::Benchmark* b) {
+  for (int i : {0, 100}) b->Args({i});  // i = chunk size
+}
+
+BENCHMARK_REGISTER_F(BenchmarkBasicFixture, BM_Sort_ChunkSize)->Apply(ChunkSize);
 
 }  // namespace opossum


### PR DESCRIPTION
http://pella.eaalab.hpi.uni-potsdam.de:8080/changes/?rev=138462851a&exe=8&env=1

The tremendous change of the sort benchmark was due to the new sort implementation. Which expects a chunk size to be given or else has an unlimited chunk size for the output.
To keep the past results comparable, the benchmark now executes the sort with an unlimited chunk size and the standard benchmark chunk size of 100.