### PR TITLE
Improve performance of dereferencing RefColumns

### DIFF
--- a/src/lib/storage/reference_column.hpp
+++ b/src/lib/storage/reference_column.hpp
@@ -102,7 +102,7 @@ class ReferenceColumn : public BaseColumn {
     unsorted.
     */
 
-    std::unordered_map<size_t, std::shared_ptr<std::vector<ChunkOffset>>> all_chunk_offsets;
+    std::unordered_map<ChunkID, std::shared_ptr<std::vector<ChunkOffset>>> all_chunk_offsets;
 
     for (auto pos : *(_pos_list)) {
       auto chunk_info = _referenced_table->locate_row(pos);


### PR DESCRIPTION
We currently allocate shared pointers on vectors quadratically to the number of chunks in a table when handling RefColumns, even though a lot of those vectors might never be used.

This PR refactors this part to use a hash map to only allocate vectors if they are needed.