### PR TITLE
Add missing include to table_generator.cpp. Fixes #29

### DIFF
--- a/src/benchmark/table_generator.cpp
+++ b/src/benchmark/table_generator.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include "types.hpp"
 
+#include "storage/value_column.hpp"
 #include "tbb/concurrent_vector.h"
 
 namespace opossum {


### PR DESCRIPTION
Fixes #29, by adding the missing include.