### PR TITLE
Adds custom vector types

### DIFF
--- a/src/benchmark/base_fixture.cpp
+++ b/src/benchmark/base_fixture.cpp
@@ -40,7 +40,7 @@ class BenchmarkBasicFixture : public benchmark::Fixture {
   std::shared_ptr<TableWrapper> _table_wrapper_b;
 
   void clear_cache() {
-    std::vector<int> clear = std::vector<int>();
+    alloc_vector<int> clear = alloc_vector<int>();
     clear.resize(500 * 1000 * 1000, 42);
     for (uint i = 0; i < clear.size(); i++) {
       clear[i] += 1;

--- a/src/benchmark/operators/projection_benchmark.cpp
+++ b/src/benchmark/operators/projection_benchmark.cpp
@@ -27,7 +27,7 @@ class OperatorsProjectionBenchmark : public BenchmarkBasicFixture {
 
  protected:
   std::shared_ptr<TableScan> _table_ref;
-  std::vector<std::shared_ptr<AbstractOperator>> _tables;
+  alloc_vector<std::shared_ptr<AbstractOperator>> _tables;
 };
 
 BENCHMARK_DEFINE_F(OperatorsProjectionBenchmark, BM_ProjectionSimple)(benchmark::State& state) {

--- a/src/bin/server_main.cpp
+++ b/src/bin/server_main.cpp
@@ -55,7 +55,7 @@ void import_dummy_data(const std::string& directory, const std::string& filename
   for (size_t i = 0; i < t->chunk_count(); ++i) {
     auto& chunk = t->get_chunk(i);
     for (size_t row_id = 0; row_id < chunk.size(); ++row_id) {
-      auto row = std::vector<opossum::AllTypeVariant>();
+      auto row = opossum::alloc_vector<opossum::AllTypeVariant>();
       for (size_t col_id = 0; col_id < t->col_count(); ++col_id) {
         row.push_back((*chunk.get_column(col_id))[row_id]);
       }

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -53,7 +53,7 @@ class TransactionContext {
 
   void register_rw_operator(AbstractReadWriteOperator* op) { _rw_operators.emplace_back(op); }
 
-  std::vector<AbstractReadWriteOperator*> get_rw_operators() const { return _rw_operators; }
+  alloc_vector<AbstractReadWriteOperator*> get_rw_operators() const { return _rw_operators; }
 
   /**
    * Update the counter of active operators
@@ -66,7 +66,7 @@ class TransactionContext {
  private:
   const TransactionID _transaction_id;
   const CommitID _last_commit_id;
-  std::vector<AbstractReadWriteOperator*> _rw_operators;
+  alloc_vector<AbstractReadWriteOperator*> _rw_operators;
 
   std::atomic<TransactionPhase> _phase;
   std::shared_ptr<CommitContext> _commit_context;

--- a/src/lib/import_export/csv_converter.hpp
+++ b/src/lib/import_export/csv_converter.hpp
@@ -81,7 +81,7 @@ class CsvConverter : public AbstractCsvConverter {
    * csv characters.
    */
   static std::function<T(const char *)> _get_conversion_function();
-  tbb::concurrent_vector<T> _parsed_values;
+  alloc_concurrent_vector<T> _parsed_values;
 };
 
 template <>

--- a/src/lib/import_export/csv_non_rfc_parser.hpp
+++ b/src/lib/import_export/csv_non_rfc_parser.hpp
@@ -27,7 +27,7 @@ struct TableInfo {
   }
 
   size_t _col_count;
-  std::vector<std::string> _col_types;
+  alloc_vector<std::string> _col_types;
 };
 /**
  * In contrast to the CsvRfcParse, the CsvNonRfcParser works with a more constraint set of csv files:
@@ -75,14 +75,14 @@ class CsvNonRfcParser {
   std::streamsize _file_size;
 
   // we need a vector to store the jobs objects so they don't end up leaking memory
-  std::vector<std::shared_ptr<JobTask>> _jobs;
+  alloc_vector<std::shared_ptr<JobTask>> _jobs;
 
   // holds information to the table that is going to be created
   TableInfo _file_info;
 
   // Before a new task is shceduled, a place in this array is reserved, so the order of chunks can be preserved, even
   // though some parsing tasks might finish after tasks that were scheduled after them
-  std::vector<std::shared_ptr<ParsingResult>> _parsing_results;
+  alloc_vector<std::shared_ptr<ParsingResult>> _parsing_results;
 
   // holds the current number of running tasks, needs to be atomic to be thread-safe
   std::atomic_uint _task_counter;
@@ -114,7 +114,7 @@ class CsvNonRfcParser {
   bool _read_csv(std::istream& stream, std::string& out, char delimiter);
 
   // parses one row of the csv, internally employs _get_fields
-  std::vector<AllTypeVariant> _parse_row(const std::string line, const TableInfo& info);
+  alloc_vector<AllTypeVariant> _parse_row(const std::string line, const TableInfo& info);
 
   /**
    * This method sanitizes the resultlist that has the following form:
@@ -133,7 +133,7 @@ class CsvNonRfcParser {
    * @param results the result list
    * @param info the structure of the chunks inside the result list
    */
-  void _resolve_orphans_widows(std::vector<std::shared_ptr<ParsingResult>>& results, const TableInfo& info);
+  void _resolve_orphans_widows(alloc_vector<std::shared_ptr<ParsingResult>>& results, const TableInfo& info);
 
   /**
    * This method is the entrypoint for all tasks
@@ -142,7 +142,7 @@ class CsvNonRfcParser {
    * @param buffer a vector containing a section of the file to be parsed
    * @param info information about the structure of the chunks to be created
    */
-  void _parse_csv(std::shared_ptr<std::promise<ParsingResult>> new_chunk, std::shared_ptr<std::vector<char>> buffer,
+  void _parse_csv(std::shared_ptr<std::promise<ParsingResult>> new_chunk, std::shared_ptr<alloc_vector<char>> buffer,
                   const TableInfo& info);
 
   /**
@@ -186,8 +186,8 @@ class CsvNonRfcParser {
   bool _get_field(std::istream& stream, std::string& out);
 
   // Splits and returns all fields from a given CSV row.
-  std::vector<std::string> _get_fields(const std::string& row);
+  alloc_vector<std::string> _get_fields(const std::string& row);
 
-  bool _start_new_job(std::shared_ptr<std::vector<char>> buffer);
+  bool _start_new_job(std::shared_ptr<alloc_vector<char>> buffer);
 };
 }  // namespace opossum

--- a/src/lib/import_export/csv_rfc_parser.cpp
+++ b/src/lib/import_export/csv_rfc_parser.cpp
@@ -35,12 +35,12 @@ std::shared_ptr<Table> CsvRfcParser::parse(const std::string& filename) {
 
   // Add additional null byte at the end in order to allow stroi and friends to work on a c string that ends on a null
   // byte
-  std::vector<char> file_content(file_size + 1);
+  alloc_vector<char> file_content(file_size + 1);
   file.read(file_content.data(), file_size);
 
   // Safe chunks in list to avoid memory relocations
   std::list<Chunk> chunks;
-  std::vector<std::shared_ptr<JobTask>> tasks;
+  alloc_vector<std::shared_ptr<JobTask>> tasks;
 
   auto position = file_content.begin();
   // Use the end without the additional null byte
@@ -78,13 +78,13 @@ std::shared_ptr<Table> CsvRfcParser::parse(const std::string& filename) {
   return table;
 }
 
-void CsvRfcParser::_parse_file_chunk(std::vector<char>::iterator start, std::vector<char>::iterator end, Chunk& chunk,
+void CsvRfcParser::_parse_file_chunk(alloc_vector<char>::iterator start, alloc_vector<char>::iterator end, Chunk& chunk,
                                      const Table& table, ChunkOffset row_count) {
   if (start == end) return;
   auto position = start;
 
   // For each csv column create a CsvConverter which builds up a ValueColumn
-  std::vector<std::unique_ptr<AbstractCsvConverter>> converters;
+  alloc_vector<std::unique_ptr<AbstractCsvConverter>> converters;
   for (ColumnID column_id = 0; column_id < table.col_count(); ++column_id) {
     converters.emplace_back(
         make_unique_by_column_type<AbstractCsvConverter, CsvConverter>(table.column_type(column_id), row_count));
@@ -125,7 +125,7 @@ const std::shared_ptr<Table> CsvRfcParser::_process_meta_file(const std::string&
   file.seekg(0);
 
   // reserve one extra slot that can be overwritten to a null byte
-  std::vector<char> file_content(file_size + 1);
+  alloc_vector<char> file_content(file_size + 1);
   file.read(file_content.data(), file_size);
 
   // ignore additional null byte
@@ -165,8 +165,8 @@ const std::shared_ptr<Table> CsvRfcParser::_process_meta_file(const std::string&
   return table;
 }
 
-std::vector<char>::iterator CsvRfcParser::_next_field(const std::vector<char>::iterator& start,
-                                                      const std::vector<char>::iterator& end, char& last_char) {
+alloc_vector<char>::iterator CsvRfcParser::_next_field(const alloc_vector<char>::iterator& start,
+                                                       const alloc_vector<char>::iterator& end, char& last_char) {
   if (start == end) return start;
   auto position = start;
 
@@ -193,8 +193,8 @@ std::vector<char>::iterator CsvRfcParser::_next_field(const std::vector<char>::i
   return position;
 }
 
-std::vector<char>::iterator CsvRfcParser::_next_row(const std::vector<char>::iterator& start,
-                                                    const std::vector<char>::iterator& end) {
+alloc_vector<char>::iterator CsvRfcParser::_next_row(const alloc_vector<char>::iterator& start,
+                                                     const alloc_vector<char>::iterator& end) {
   bool is_escaped = false;
   auto position = start;
   // find the next delimiter that is not surrounded by quotes

--- a/src/lib/import_export/csv_rfc_parser.hpp
+++ b/src/lib/import_export/csv_rfc_parser.hpp
@@ -62,7 +62,7 @@ class CsvRfcParser {
    * @param table      Table for that the data should be parsed.
    * @param row_count  Number of rows in the chunk from start to end
    */
-  static void _parse_file_chunk(std::vector<char>::iterator start, std::vector<char>::iterator end, Chunk& chunk,
+  static void _parse_file_chunk(alloc_vector<char>::iterator start, alloc_vector<char>::iterator end, Chunk& chunk,
                                 const Table& table, ChunkOffset row_count);
 
   /*
@@ -75,8 +75,8 @@ class CsvRfcParser {
    * @param end        Search until 'end' for the next field
    * @param last_char  In this parameter the character after the field is saved (separator or delimiter)
    */
-  static std::vector<char>::iterator _next_field(const std::vector<char>::iterator& start,
-                                                 const std::vector<char>::iterator& end, char& last_char);
+  static alloc_vector<char>::iterator _next_field(const alloc_vector<char>::iterator& start,
+                                                  const alloc_vector<char>::iterator& end, char& last_char);
 
   /*
    * Returns the start position of the next csv row after 'start'.
@@ -85,7 +85,7 @@ class CsvRfcParser {
    * @param start      Iterator pointing to the begin of a csv row
    * @param end        Search until 'end' for the next row
    */
-  static std::vector<char>::iterator _next_row(const std::vector<char>::iterator& start,
-                                               const std::vector<char>::iterator& end);
+  static alloc_vector<char>::iterator _next_row(const alloc_vector<char>::iterator& start,
+                                                const alloc_vector<char>::iterator& end);
 };
 }  // namespace opossum

--- a/src/lib/import_export/csv_writer.cpp
+++ b/src/lib/import_export/csv_writer.cpp
@@ -28,7 +28,7 @@ std::string CsvWriter::escape(const std::string& string) {
   return result;
 }
 
-void CsvWriter::write_line(const std::vector<AllTypeVariant>& values) {
+void CsvWriter::write_line(const alloc_vector<AllTypeVariant>& values) {
   for (const auto& value : values) {
     write(value);
   }

--- a/src/lib/import_export/csv_writer.hpp
+++ b/src/lib/import_export/csv_writer.hpp
@@ -37,7 +37,7 @@ class CsvWriter {
    * Writes a full line of AllTypeVariants as a row.
    * Also calls end_line() to finish the row.
    */
-  void write_line(const std::vector<AllTypeVariant>& values);
+  void write_line(const alloc_vector<AllTypeVariant>& values);
 
  protected:
   std::string escape(const std::string& string);

--- a/src/lib/network/operator_translator.cpp
+++ b/src/lib/network/operator_translator.cpp
@@ -53,7 +53,7 @@ inline optional<AllTypeVariant> translate_optional_variant(const proto::Variant&
 inline std::shared_ptr<OperatorTask> OperatorTranslator::translate(
     const proto::ProjectionOperator& projection_operator) {
   const auto column_names_field = projection_operator.column_name();
-  auto column_names = std::vector<std::string>(std::begin(column_names_field), std::end(column_names_field));
+  auto column_names = alloc_vector<std::string>(std::begin(column_names_field), std::end(column_names_field));
   Assert((projection_operator.has_input_operator()), "Missing Input Operator in Projection.");
 
   auto input_task = translate_proto(projection_operator.input_operator());
@@ -299,7 +299,7 @@ inline std::shared_ptr<OperatorTask> OperatorTranslator::translate(const proto::
   return print_task;
 }
 
-const std::vector<std::shared_ptr<OperatorTask>>& OperatorTranslator::build_tasks_from_proto(
+const alloc_vector<std::shared_ptr<OperatorTask>>& OperatorTranslator::build_tasks_from_proto(
     const proto::OperatorVariant& op) {
   translate_proto(op);
   _root_task = _tasks.back();

--- a/src/lib/network/operator_translator.hpp
+++ b/src/lib/network/operator_translator.hpp
@@ -17,7 +17,7 @@ namespace opossum {
 class OperatorTranslator {
  public:
   // Recursively creates Tasks for all input-operators of `op` and a task for `op` itself
-  const std::vector<std::shared_ptr<OperatorTask>>& build_tasks_from_proto(const proto::OperatorVariant& op);
+  const alloc_vector<std::shared_ptr<OperatorTask>>& build_tasks_from_proto(const proto::OperatorVariant& op);
   // Returns the root task, i.e. the root element of the dependency tree structure. It is the last one to be executed by
   // the scheduler.
   std::shared_ptr<OperatorTask> root_task() { return _root_task; }
@@ -37,7 +37,7 @@ class OperatorTranslator {
   inline std::shared_ptr<OperatorTask> translate(const proto::ExportBinaryOperator&);
   inline std::shared_ptr<OperatorTask> translate(const proto::IndexColumnScanOperator&);
   inline std::shared_ptr<OperatorTask> translate(const proto::NestedLoopJoinOperator&);
-  std::vector<std::shared_ptr<OperatorTask>> _tasks;
+  alloc_vector<std::shared_ptr<OperatorTask>> _tasks;
   std::shared_ptr<OperatorTask> _root_task;
 };
 

--- a/src/lib/network/server.hpp
+++ b/src/lib/network/server.hpp
@@ -39,10 +39,10 @@ class Server {
   void thread_func_handle_rpcs(const size_t thread_index);
   void create_and_register_request_handler(const size_t thread_index);
 
-  std::vector<std::unique_ptr<grpc::ServerCompletionQueue>> _cqs;
+  alloc_vector<std::unique_ptr<grpc::ServerCompletionQueue>> _cqs;
   proto::OpossumService::AsyncService _service;
   std::unique_ptr<grpc::Server> _server;
-  std::vector<std::thread> _listener_threads;
+  alloc_vector<std::thread> _listener_threads;
   bool _skip_scheduler;
 };
 

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -38,6 +38,6 @@ class Delete : public AbstractReadWriteOperator {
   const std::string _table_name;
   std::shared_ptr<Table> _table;
   TransactionID _transaction_id;
-  std::vector<std::shared_ptr<const PosList>> _pos_lists;
+  alloc_vector<std::shared_ptr<const PosList>> _pos_lists;
 };
 }  // namespace opossum

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<const Table> Difference::on_execute() {
   for (ChunkID chunk_id = 0; chunk_id < input_table_right()->chunk_count(); chunk_id++) {
     const Chunk &chunk = input_table_right()->get_chunk(chunk_id);
     // creating a temporary row representation with strings to be filled column wise
-    auto string_row_vector = std::vector<std::string>(chunk.size());
+    auto string_row_vector = alloc_vector<std::string>(chunk.size());
     for (size_t column_id = 0; column_id < input_table_right()->col_count(); column_id++) {
       const auto base_column = chunk.get_column(column_id);
 

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -57,7 +57,7 @@ void ExportCsv::_generate_content_file(const std::shared_ptr<const Table> &table
   CsvWriter writer(csv_file);
 
   // Create visitors for every column, so that we do not have to do that more than once.
-  std::vector<std::shared_ptr<ColumnVisitable>> visitors(table->col_count());
+  alloc_vector<std::shared_ptr<ColumnVisitable>> visitors(table->col_count());
   for (ColumnID col_id = 0; col_id < table->col_count(); ++col_id) {
     auto visitor = make_shared_by_column_type<ColumnVisitable, ExportCsvVisitor>(table->column_type(col_id));
     visitors[col_id] = std::move(visitor);

--- a/src/lib/operators/import_binary.cpp
+++ b/src/lib/operators/import_binary.cpp
@@ -28,25 +28,25 @@ uint8_t ImportBinary::num_in_tables() const { return 0; }
 uint8_t ImportBinary::num_out_tables() const { return 1; }
 
 template <typename T>
-std::vector<T> ImportBinary::_read_values(std::ifstream& file, const size_t count) {
-  std::vector<T> values(count);
+alloc_vector<T> ImportBinary::_read_values(std::ifstream& file, const size_t count) {
+  alloc_vector<T> values(count);
   file.read(reinterpret_cast<char*>(values.data()), values.size() * sizeof(T));
   return values;
 }
 
 // specialized implementation for string values
 template <>
-std::vector<std::string> ImportBinary::_read_values(std::ifstream& file, const size_t count) {
+alloc_vector<std::string> ImportBinary::_read_values(std::ifstream& file, const size_t count) {
   return _read_string_values(file, count);
 }
 
 template <typename T>
-std::vector<std::string> ImportBinary::_read_string_values(std::ifstream& file, const size_t count) {
+alloc_vector<std::string> ImportBinary::_read_string_values(std::ifstream& file, const size_t count) {
   const auto string_lengths = _read_values<T>(file, count);
   const auto total_length = std::accumulate(string_lengths.cbegin(), string_lengths.cend(), static_cast<size_t>(0));
   const auto buffer = _read_values<char>(file, total_length);
 
-  std::vector<std::string> values(count);
+  alloc_vector<std::string> values(count);
   size_t start = 0;
 
   for (size_t i = 0; i < count; ++i) {
@@ -158,10 +158,10 @@ std::shared_ptr<BaseAttributeVector> ImportBinary::_import_attribute_vector(
 
 template <typename T>
 std::shared_ptr<ValueColumn<T>> ImportBinary::_import_value_column(std::ifstream& file, ChunkOffset row_count) {
-  // TODO(unknown): Ideally _read_values would directly write into a tbb::concurrent_vector so that no conversion is
+  // TODO(unknown): Ideally _read_values would directly write into a alloc_concurrent_vector so that no conversion is
   // needed
   const auto values = _read_values<T>(file, row_count);
-  return std::make_shared<ValueColumn<T>>(tbb::concurrent_vector<T>{values.begin(), values.end()});
+  return std::make_shared<ValueColumn<T>>(alloc_concurrent_vector<T>{values.begin(), values.end()});
 }
 
 template <typename T>

--- a/src/lib/operators/import_binary.hpp
+++ b/src/lib/operators/import_binary.hpp
@@ -133,11 +133,11 @@ class ImportBinary : public AbstractReadOnlyOperator {
 
   // Reads row_count many values from type T and returns them in a vector
   template <typename T>
-  static std::vector<T> _read_values(std::ifstream& file, const size_t count);
+  static alloc_vector<T> _read_values(std::ifstream& file, const size_t count);
 
   // Reads row_count many strings from input file. String lengths are encoded in type T.
   template <typename T = StringLength>
-  static std::vector<std::string> _read_string_values(std::ifstream& file, const size_t count);
+  static alloc_vector<std::string> _read_string_values(std::ifstream& file, const size_t count);
 
   // Reads a single value of type T from the input file.
   template <typename T>

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<const Table> Insert::on_execute(std::shared_ptr<TransactionConte
   _target_table = StorageManager::get().get_table(_target_table_name);
 
   // These TypedColumnProcessors kind of retrieve the template parameter of the columns.
-  auto typed_column_processors = std::vector<std::unique_ptr<AbstractTypedColumnProcessor>>();
+  auto typed_column_processors = alloc_vector<std::unique_ptr<AbstractTypedColumnProcessor>>();
   for (auto column_id = 0u; column_id < _target_table->get_chunk(0).col_count(); ++column_id) {
     typed_column_processors.emplace_back(make_unique_by_column_type<AbstractTypedColumnProcessor, TypedColumnProcessor>(
         _target_table->column_type(column_id)));
@@ -155,7 +155,7 @@ std::shared_ptr<const Table> Insert::on_execute(std::shared_ptr<TransactionConte
       // we do not need to check whether other operators have locked the rows, we have just created them
       // and they are not visible for other operators.
       // the transaction IDs are set here and not during the resize, because
-      // tbb::concurrent_vector::grow_to_at_least(n, t)" does not work with atomics, since their copy constructor is
+      // alloc_concurrent_vector::grow_to_at_least(n, t)" does not work with atomics, since their copy constructor is
       // deleted.
       target_chunk.mvcc_columns()->tids[i] = context->transaction_id();
       _inserted_rows.emplace_back(_target_table->calculate_row_id(target_chunk_id, i));

--- a/src/lib/operators/join_nested_loop_a.hpp
+++ b/src/lib/operators/join_nested_loop_a.hpp
@@ -99,8 +99,8 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
                            ChunkID right_id, std::shared_ptr<PosList> left, std::shared_ptr<PosList> right,
                            JoinMode mode, std::function<bool(LeftType, RightType)> compare,
                            std::shared_ptr<std::map<RowID, bool>> null_value_rows,
-                           std::shared_ptr<std::vector<ChunkOffset>> filter_left = nullptr,
-                           std::shared_ptr<std::vector<ChunkOffset>> filter_right = nullptr)
+                           std::shared_ptr<alloc_vector<ChunkOffset>> filter_left = nullptr,
+                           std::shared_ptr<alloc_vector<ChunkOffset>> filter_right = nullptr)
         : column_left(coleft),
           column_right(coright),
           chunk_id_left(left_id),
@@ -123,8 +123,8 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
     std::function<bool(LeftType, RightType)> compare_func;
     size_t size_left;
     std::function<LeftType(ChunkOffset)> get_left_column_value;
-    std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets_in_left;
-    std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets_in_right;
+    std::shared_ptr<alloc_vector<ChunkOffset>> chunk_offsets_in_left;
+    std::shared_ptr<alloc_vector<ChunkOffset>> chunk_offsets_in_right;
     std::shared_ptr<std::map<RowID, bool>> rows_potentially_joined_with_null_values;
   };
 
@@ -132,7 +132,7 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
   struct JoinNestedLoopBLeftContext : public JoinNestedLoopBContext {
     JoinNestedLoopBLeftContext(std::shared_ptr<BaseColumn> referenced_column, const std::shared_ptr<const Table>,
                                std::shared_ptr<ColumnVisitableContext> base_context, ChunkID chunk_id,
-                               std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets) {
+                               std::shared_ptr<alloc_vector<ChunkOffset>> chunk_offsets) {
       auto ctx = std::static_pointer_cast<JoinNestedLoopBContext>(base_context);
 
       this->column_left = referenced_column;
@@ -154,7 +154,7 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
   struct JoinNestedLoopBRightContext : public JoinNestedLoopBContext {
     JoinNestedLoopBRightContext(std::shared_ptr<BaseColumn> referenced_column, const std::shared_ptr<const Table>,
                                 std::shared_ptr<ColumnVisitableContext> base_context, ChunkID chunk_id,
-                                std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets) {
+                                std::shared_ptr<alloc_vector<ChunkOffset>> chunk_offsets) {
       auto ctx = std::static_pointer_cast<JoinNestedLoopBContext>(base_context);
 
       this->column_left = ctx->column_left;
@@ -203,7 +203,7 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
       auto ctx = std::static_pointer_cast<JoinNestedLoopBContext>(context);
 
       auto dc_right = std::static_pointer_cast<DictionaryColumn<RightType>>(ctx->column_right);
-      const auto &right_dictionary = static_cast<const std::vector<RightType> &>(*dc_right->dictionary());
+      const auto &right_dictionary = static_cast<const alloc_vector<RightType> &>(*dc_right->dictionary());
       const auto &right_attribute_vector = static_cast<const BaseAttributeVector &>(*dc_right->attribute_vector());
 
       // Function to get the value of right column
@@ -240,7 +240,7 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
       auto ctx = std::static_pointer_cast<JoinNestedLoopBContext>(context);
       auto dc_left = std::static_pointer_cast<DictionaryColumn<LeftType>>(ctx->column_left);
 
-      const auto &left_dictionary = static_cast<const std::vector<LeftType> &>(*dc_left->dictionary());
+      const auto &left_dictionary = static_cast<const alloc_vector<LeftType> &>(*dc_left->dictionary());
       const auto &left_attribute_vector = static_cast<const BaseAttributeVector &>(*dc_left->attribute_vector());
 
       // Size of the current left column
@@ -273,10 +273,10 @@ class JoinNestedLoopA::JoinNestedLoopAImpl : public AbstractJoinOperatorImpl {
       auto chunk_offsets_in_right = context->chunk_offsets_in_right;
 
       if (!chunk_offsets_in_left) {
-        chunk_offsets_in_left = std::make_shared<std::vector<ChunkOffset>>(size_left);
+        chunk_offsets_in_left = std::make_shared<alloc_vector<ChunkOffset>>(size_left);
         std::iota(chunk_offsets_in_left->begin(), chunk_offsets_in_left->end(), 0);
       } else if (!chunk_offsets_in_right) {
-        chunk_offsets_in_right = std::make_shared<std::vector<ChunkOffset>>(size_right);
+        chunk_offsets_in_right = std::make_shared<alloc_vector<ChunkOffset>>(size_right);
         std::iota(chunk_offsets_in_right->begin(), chunk_offsets_in_right->end(), 0);
       }
 

--- a/src/lib/operators/join_nested_loop_b.cpp
+++ b/src/lib/operators/join_nested_loop_b.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<PosList> JoinNestedLoopB::_dereference_pos_list(std::shared_ptr<
                                                                 size_t column_id,
                                                                 std::shared_ptr<const PosList> pos_list) {
   // Get all the input pos lists so that we only have to pointer cast the columns once
-  auto input_pos_lists = std::vector<std::shared_ptr<const PosList>>();
+  auto input_pos_lists = alloc_vector<std::shared_ptr<const PosList>>();
   for (ChunkID chunk_id = 0; chunk_id < input_table->chunk_count(); chunk_id++) {
     auto base_column = input_table->get_chunk(chunk_id).get_column(column_id);
     auto reference_column = std::dynamic_pointer_cast<ReferenceColumn>(base_column);

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -63,8 +63,8 @@ std::shared_ptr<const Table> Print::on_execute() {
 // In order to print the table as an actual table, with columns being aligned, we need to calculate the
 // number of characters in the printed representation of each column
 // `min` and `max` can be used to limit the width of the columns - however, every column fits at least the column's name
-std::vector<uint16_t> Print::column_string_widths(uint16_t min, uint16_t max, std::shared_ptr<const Table> t) const {
-  std::vector<uint16_t> widths(t->col_count());
+alloc_vector<uint16_t> Print::column_string_widths(uint16_t min, uint16_t max, std::shared_ptr<const Table> t) const {
+  alloc_vector<uint16_t> widths(t->col_count());
   // calculate the length of the column name
   for (size_t col = 0; col < t->col_count(); ++col) {
     widths[col] = std::max(min, static_cast<uint16_t>(to_string(t->column_name(col)).size()));

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -18,7 +18,7 @@ class Print : public AbstractReadOnlyOperator {
   uint8_t num_out_tables() const override;
 
  protected:
-  std::vector<uint16_t> column_string_widths(uint16_t min, uint16_t max, std::shared_ptr<const Table> t) const;
+  alloc_vector<uint16_t> column_string_widths(uint16_t min, uint16_t max, std::shared_ptr<const Table> t) const;
   std::shared_ptr<const Table> on_execute() override;
 
   // stream to print the result

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -16,7 +16,7 @@ namespace opossum {
 Projection::Projection(const std::shared_ptr<const AbstractOperator> in, const ProjectionDefinitions& columns)
     : AbstractReadOnlyOperator(in), _projection_definitions(columns) {}
 
-Projection::Projection(const std::shared_ptr<const AbstractOperator> in, const std::vector<std::string>& columns)
+Projection::Projection(const std::shared_ptr<const AbstractOperator> in, const alloc_vector<std::string>& columns)
     : AbstractReadOnlyOperator(in), _simple_projection(columns) {}
 
 const std::string Projection::name() const { return "Projection"; }

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -20,10 +20,10 @@ class Projection : public AbstractReadOnlyOperator {
   // Type as String
   // Name of the new column
   using ProjectionDefinition = std::tuple<std::string /*Expression*/, std::string /*Type*/, std::string /*Name*/>;
-  using ProjectionDefinitions = std::vector<ProjectionDefinition>;
+  using ProjectionDefinitions = alloc_vector<ProjectionDefinition>;
 
   Projection(const std::shared_ptr<const AbstractOperator> in, const ProjectionDefinitions& definitions);
-  Projection(const std::shared_ptr<const AbstractOperator> in, const std::vector<std::string>& columns);
+  Projection(const std::shared_ptr<const AbstractOperator> in, const alloc_vector<std::string>& columns);
 
   const std::string name() const override;
   uint8_t num_in_tables() const override;
@@ -31,7 +31,7 @@ class Projection : public AbstractReadOnlyOperator {
 
  protected:
   ProjectionDefinitions _projection_definitions;
-  std::vector<std::string> _simple_projection;
+  alloc_vector<std::string> _simple_projection;
 
   class ColumnCreator {
    public:

--- a/src/lib/operators/term.hpp
+++ b/src/lib/operators/term.hpp
@@ -50,8 +50,8 @@ template <typename T>
 class AbstractTerm {
  public:
   virtual ~AbstractTerm() = default;
-  virtual const tbb::concurrent_vector<T> get_values(const std::shared_ptr<const Table> table,
-                                                     const ChunkID chunk_id) = 0;
+  virtual const alloc_concurrent_vector<T> get_values(const std::shared_ptr<const Table> table,
+                                                      const ChunkID chunk_id) = 0;
 };
 
 /**
@@ -63,8 +63,8 @@ class ConstantTerm : public AbstractTerm<T> {
  public:
   explicit ConstantTerm(const AllTypeVariant& value) : _value(type_cast<T>(value)) {}
 
-  const tbb::concurrent_vector<T> get_values(const std::shared_ptr<const Table> table, const ChunkID chunk_id) final {
-    return tbb::concurrent_vector<T>(table->get_chunk(chunk_id).size(), _value);
+  const alloc_concurrent_vector<T> get_values(const std::shared_ptr<const Table> table, const ChunkID chunk_id) final {
+    return alloc_concurrent_vector<T>(table->get_chunk(chunk_id).size(), _value);
   }
 
   const T get_value() { return _value; }
@@ -88,7 +88,7 @@ class VariableTerm : public AbstractTerm<T> {
     return table->get_chunk(chunk_id).get_column(table->column_id_by_name(_column_name));
   }
 
-  const tbb::concurrent_vector<T> get_values(const std::shared_ptr<const Table> table, const ChunkID chunk_id) {
+  const alloc_concurrent_vector<T> get_values(const std::shared_ptr<const Table> table, const ChunkID chunk_id) {
     auto column = table->get_chunk(chunk_id).get_column(table->column_id_by_name(_column_name));
 
     if (auto value_column = std::dynamic_pointer_cast<ValueColumn<T>>(column)) {
@@ -121,8 +121,8 @@ class ArithmeticTerm : public AbstractTerm<T> {
       : _left(left_term), _right(right_term), _operator(get_operator(string_op)) {}
 
   // recursive solving of terms
-  const tbb::concurrent_vector<T> get_values(const std::shared_ptr<const Table> table, const ChunkID chunk_id) final {
-    tbb::concurrent_vector<T> values;
+  const alloc_concurrent_vector<T> get_values(const std::shared_ptr<const Table> table, const ChunkID chunk_id) final {
+    alloc_concurrent_vector<T> values;
     values.resize(table->get_chunk(chunk_id).size());
 
     // optimization for Constant Terms: the value for a constant term can be directly binded to the operator function

--- a/src/lib/scheduler/abstract_scheduler.hpp
+++ b/src/lib/scheduler/abstract_scheduler.hpp
@@ -31,7 +31,7 @@ class AbstractScheduler {
 
   virtual void finish() = 0;
 
-  virtual const std::vector<std::shared_ptr<TaskQueue>>& queues() const = 0;
+  virtual const alloc_vector<std::shared_ptr<TaskQueue>>& queues() const = 0;
 
   virtual void schedule(std::shared_ptr<AbstractTask> task, uint32_t preferred_node_id = CURRENT_NODE_ID,
                         SchedulePriority priority = SchedulePriority::Normal) = 0;

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -125,7 +125,7 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
 
   // For dependencies
   std::atomic_uint _predecessor_counter{0};
-  std::vector<std::shared_ptr<AbstractTask>> _successors;
+  alloc_vector<std::shared_ptr<AbstractTask>> _successors;
 
   // For making sure a task gets only scheduled and enqueued once, respectively
   // A Task is scheduled once schedule() is called and enqueued, which is an internal process, once it has been added

--- a/src/lib/scheduler/current_scheduler.cpp
+++ b/src/lib/scheduler/current_scheduler.cpp
@@ -20,7 +20,7 @@ void CurrentScheduler::set(const std::shared_ptr<AbstractScheduler>& instance) {
 
 bool CurrentScheduler::is_set() { return !!_instance; }
 
-void CurrentScheduler::wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
+void CurrentScheduler::wait_for_tasks(const alloc_vector<std::shared_ptr<AbstractTask>>& tasks) {
   if (IS_DEBUG) {
     for (auto& task : tasks) {
       if (!task->is_scheduled()) {

--- a/src/lib/scheduler/current_scheduler.hpp
+++ b/src/lib/scheduler/current_scheduler.hpp
@@ -27,7 +27,7 @@ class CurrentScheduler {
    * If there is an active Scheduler, block execution until all @tasks have finished
    * If there is no active Scheduler, returns immediately since all @tasks have executed when they were scheduled
    */
-  static void wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
+  static void wait_for_tasks(const alloc_vector<std::shared_ptr<AbstractTask>>& tasks);
 
  private:
   static std::shared_ptr<AbstractScheduler> _instance;

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -78,7 +78,7 @@ void NodeQueueScheduler::finish() {
   _shut_down = true;
 }
 
-const std::vector<std::shared_ptr<TaskQueue>>& NodeQueueScheduler::queues() const { return _queues; }
+const alloc_vector<std::shared_ptr<TaskQueue>>& NodeQueueScheduler::queues() const { return _queues; }
 
 void NodeQueueScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID preferred_node_id,
                                   SchedulePriority priority) {

--- a/src/lib/scheduler/node_queue_scheduler.hpp
+++ b/src/lib/scheduler/node_queue_scheduler.hpp
@@ -93,7 +93,7 @@ class NodeQueueScheduler : public AbstractScheduler {
 
   void finish() override;
 
-  const std::vector<std::shared_ptr<TaskQueue>>& queues() const override;
+  const alloc_vector<std::shared_ptr<TaskQueue>>& queues() const override;
 
   /**
    * @param task
@@ -106,8 +106,8 @@ class NodeQueueScheduler : public AbstractScheduler {
  private:
   std::atomic<TaskID> _task_counter{0};
   std::shared_ptr<UidAllocator> _worker_id_allocator;
-  std::vector<std::shared_ptr<TaskQueue>> _queues;
-  std::vector<std::shared_ptr<ProcessingUnit>> _processing_units;
+  alloc_vector<std::shared_ptr<TaskQueue>> _queues;
+  alloc_vector<std::shared_ptr<ProcessingUnit>> _processing_units;
   std::atomic_bool _shut_down{false};
 };
 

--- a/src/lib/scheduler/processing_unit.hpp
+++ b/src/lib/scheduler/processing_unit.hpp
@@ -67,8 +67,8 @@ class ProcessingUnit final : public std::enable_shared_from_this<ProcessingUnit>
   std::shared_ptr<UidAllocator> _worker_id_allocator;
   CpuID _cpuID;
   std::mutex _mutex;  // Synchronizes access to _threads, _workers
-  std::vector<std::thread> _threads;
-  std::vector<std::shared_ptr<Worker>> _workers;
+  alloc_vector<std::thread> _threads;
+  alloc_vector<std::shared_ptr<Worker>> _workers;
   std::atomic_bool _shutdown_flag{false};
   std::atomic<WorkerID> _active_worker_token{INVALID_WORKER_ID};
   std::mutex _hibernation_mutex;

--- a/src/lib/scheduler/topology.cpp
+++ b/src/lib/scheduler/topology.cpp
@@ -26,13 +26,13 @@ std::shared_ptr<Topology> Topology::create_fake_numa_topology(uint32_t max_num_w
   auto num_nodes = num_workers / workers_per_node;
   if (num_workers % workers_per_node != 0) num_nodes++;
 
-  std::vector<TopologyNode> nodes;
+  alloc_vector<TopologyNode> nodes;
   nodes.reserve(num_nodes);
 
   auto cpuID = 0u;
 
   for (auto n = 0u; n < num_nodes; n++) {
-    std::vector<TopologyCpu> cpus;
+    alloc_vector<TopologyCpu> cpus;
 
     for (auto w = 0u; w < workers_per_node && cpuID < num_workers; w++) {
       cpus.emplace_back(TopologyCpu(cpuID));
@@ -61,11 +61,11 @@ std::shared_ptr<Topology> Topology::create_numa_topology(uint32_t max_num_cores)
   auto cpu_bitmask = numa_allocate_cpumask();
   uint32_t core_count = 0;
 
-  std::vector<TopologyNode> nodes;
+  alloc_vector<TopologyNode> nodes;
 
   for (int n = 0; n <= max_node; n++) {
     if (max_num_cores == 0 || core_count < max_num_cores) {
-      std::vector<TopologyCpu> cpus;
+      alloc_vector<TopologyCpu> cpus;
 
       numa_node_to_cpus(n, cpu_bitmask);
 

--- a/src/lib/scheduler/topology.hpp
+++ b/src/lib/scheduler/topology.hpp
@@ -19,9 +19,9 @@ struct TopologyCpu final {
 };
 
 struct TopologyNode final {
-  explicit TopologyNode(std::vector<TopologyCpu>&& cpus) : cpus(std::move(cpus)) {}
+  explicit TopologyNode(alloc_vector<TopologyCpu>&& cpus) : cpus(std::move(cpus)) {}
 
-  std::vector<TopologyCpu> cpus;
+  alloc_vector<TopologyCpu> cpus;
 };
 
 /**
@@ -38,14 +38,14 @@ class Topology final {
                                                              uint32_t workers_per_node = 1);
   static std::shared_ptr<Topology> create_numa_topology(uint32_t max_num_cores = 0);
 
-  Topology(std::vector<TopologyNode>&& nodes, size_t numCpus) : _nodes(std::move(nodes)), _numCpus(numCpus) {}
+  Topology(alloc_vector<TopologyNode>&& nodes, size_t numCpus) : _nodes(std::move(nodes)), _numCpus(numCpus) {}
 
-  const std::vector<TopologyNode>& nodes() { return _nodes; }
+  const alloc_vector<TopologyNode>& nodes() { return _nodes; }
 
   size_t numCpus() const { return _numCpus; }
 
  private:
-  std::vector<TopologyNode> _nodes;
+  alloc_vector<TopologyNode> _nodes;
   size_t _numCpus;
 };
 }  // namespace opossum

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -40,7 +40,7 @@ CpuID Worker::cpu_id() const { return _cpu_id; }
 
 std::weak_ptr<ProcessingUnit> Worker::processing_unit() const { return _processing_unit; }
 
-void Worker::_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
+void Worker::_wait_for_tasks(const alloc_vector<std::shared_ptr<AbstractTask>>& tasks) {
   /**
    * This method blocks the calling thread (worker) until all tasks have been completed.
    * It hands off the active worker token so that another worker can execute tasks while the calling worker is blocked.

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -40,7 +40,7 @@ class Worker : public std::enable_shared_from_this<Worker> {
   void operator=(Worker&& rhs) = delete;
 
  protected:
-  void _wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& task);
+  void _wait_for_tasks(const alloc_vector<std::shared_ptr<AbstractTask>>& task);
 
  private:
   /**

--- a/src/lib/sql/sql_query_translator.cpp
+++ b/src/lib/sql/sql_query_translator.cpp
@@ -36,7 +36,7 @@ SQLQueryTranslator::SQLQueryTranslator() {}
 
 SQLQueryTranslator::~SQLQueryTranslator() {}
 
-const std::vector<std::shared_ptr<OperatorTask>>& SQLQueryTranslator::get_tasks() { return _tasks; }
+const alloc_vector<std::shared_ptr<OperatorTask>>& SQLQueryTranslator::get_tasks() { return _tasks; }
 
 const std::string& SQLQueryTranslator::get_error_msg() { return _error_msg; }
 
@@ -76,7 +76,7 @@ bool SQLQueryTranslator::parse_query(const std::string& query, hsql::SQLParserRe
 }
 
 bool SQLQueryTranslator::translate_parse_result(const hsql::SQLParserResult& result) {
-  const std::vector<SQLStatement*>& statements = result.getStatements();
+  const alloc_vector<SQLStatement*>& statements = result.getStatements();
 
   for (const SQLStatement* stmt : statements) {
     if (!translate_statement(*stmt)) {
@@ -208,9 +208,9 @@ bool SQLQueryTranslator::_translate_filter_expr(const hsql::Expr& expr,
   return true;
 }
 
-bool SQLQueryTranslator::_translate_projection(const std::vector<hsql::Expr*>& expr_list,
+bool SQLQueryTranslator::_translate_projection(const alloc_vector<hsql::Expr*>& expr_list,
                                                const std::shared_ptr<OperatorTask>& input_task) {
-  std::vector<std::string> columns;
+  alloc_vector<std::string> columns;
   for (const Expr* expr : expr_list) {
     // At this moment we only support selecting columns in the projection.
     if (!expr->isType(hsql::kExprColumnRef) && !expr->isType(hsql::kExprStar)) {
@@ -238,7 +238,7 @@ bool SQLQueryTranslator::_translate_projection(const std::vector<hsql::Expr*>& e
   return true;
 }
 
-bool SQLQueryTranslator::_translate_order_by(const std::vector<hsql::OrderDescription*> order_list,
+bool SQLQueryTranslator::_translate_order_by(const alloc_vector<hsql::OrderDescription*> order_list,
                                              const std::shared_ptr<OperatorTask>& input_task) {
   // Make mutable copy.
   std::shared_ptr<OperatorTask> prev_task = input_task;

--- a/src/lib/sql/sql_query_translator.hpp
+++ b/src/lib/sql/sql_query_translator.hpp
@@ -18,7 +18,7 @@ class SQLQueryTranslator {
   virtual ~SQLQueryTranslator();
 
   // Returns the list of tasks that were created during translation.
-  const std::vector<std::shared_ptr<OperatorTask>>& get_tasks();
+  const alloc_vector<std::shared_ptr<OperatorTask>>& get_tasks();
 
   // Get the error message, if any exists.
   const std::string& get_error_msg();
@@ -47,10 +47,10 @@ class SQLQueryTranslator {
   // OR expressions are not supported yet.
   bool _translate_filter_expr(const hsql::Expr& expr, const std::shared_ptr<OperatorTask>& input_task);
 
-  bool _translate_projection(const std::vector<hsql::Expr*>& expr_list,
+  bool _translate_projection(const alloc_vector<hsql::Expr*>& expr_list,
                              const std::shared_ptr<OperatorTask>& input_task);
 
-  bool _translate_order_by(const std::vector<hsql::OrderDescription*> order_list,
+  bool _translate_order_by(const alloc_vector<hsql::OrderDescription*> order_list,
                            const std::shared_ptr<OperatorTask>& input_task);
 
   bool _translate_table_ref(const hsql::TableRef& table);
@@ -62,7 +62,7 @@ class SQLQueryTranslator {
   static std::string _get_column_name(const hsql::Expr& expr);
 
   // Generated execution plan.
-  std::vector<std::shared_ptr<OperatorTask>> _tasks;
+  alloc_vector<std::shared_ptr<OperatorTask>> _tasks;
 
   // Details about the error, if one occurred.
   std::string _error_msg;

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -38,7 +38,7 @@ void Chunk::replace_column(size_t column_id, std::shared_ptr<BaseColumn> column)
   std::atomic_store(&_columns.at(column_id), column);
 }
 
-void Chunk::append(std::vector<AllTypeVariant> values) {
+void Chunk::append(alloc_vector<AllTypeVariant> values) {
   // Do this first to ensure that the first thing to exist in a row are the MVCC columns.
   if (has_mvcc_columns()) grow_mvcc_column_size_by(1u, Chunk::MAX_COMMIT_ID);
 
@@ -104,9 +104,9 @@ void Chunk::shrink_mvcc_columns() {
   _mvcc_columns->end_cids.shrink_to_fit();
 }
 
-std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices_for(
-    const std::vector<std::shared_ptr<BaseColumn>>& columns) const {
-  auto result = std::vector<std::shared_ptr<BaseIndex>>();
+alloc_vector<std::shared_ptr<BaseIndex>> Chunk::get_indices_for(
+    const alloc_vector<std::shared_ptr<BaseColumn>>& columns) const {
+  auto result = alloc_vector<std::shared_ptr<BaseIndex>>();
   std::copy_if(_indices.cbegin(), _indices.cend(), std::back_inserter(result),
                [&columns](const std::shared_ptr<BaseIndex>& index) { return index->is_index_for(columns); });
   return result;

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -8,8 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "tbb/concurrent_vector.h"
-
 #include "all_type_variant.hpp"
 #include "copyable_atomic.hpp"
 #include "index/base_index.hpp"
@@ -35,9 +33,9 @@ class Chunk {
     friend class Chunk;
 
    public:
-    tbb::concurrent_vector<copyable_atomic<TransactionID>> tids;  ///< 0 unless locked by a transaction
-    tbb::concurrent_vector<CommitID> begin_cids;                  ///< commit id when record was added
-    tbb::concurrent_vector<CommitID> end_cids;                    ///< commit id when record was deleted
+    alloc_concurrent_vector<copyable_atomic<TransactionID>> tids;  ///< 0 unless locked by a transaction
+    alloc_concurrent_vector<CommitID> begin_cids;                  ///< commit id when record was added
+    alloc_concurrent_vector<CommitID> end_cids;                    ///< commit id when record was deleted
 
    private:
     /**
@@ -78,7 +76,7 @@ class Chunk {
 
   // adds a new row, given as a list of values, to the chunk
   // note this is slow and not thread-safe and should be used for testing purposes only
-  void append(std::vector<AllTypeVariant> values);
+  void append(alloc_vector<AllTypeVariant> values);
 
   /**
    * Atomically accesses and returns the column at a given position
@@ -125,11 +123,11 @@ class Chunk {
    */
   void use_mvcc_columns_from(const Chunk &chunk);
 
-  std::vector<std::shared_ptr<BaseIndex>> get_indices_for(
-      const std::vector<std::shared_ptr<BaseColumn>> &columns) const;
+  alloc_vector<std::shared_ptr<BaseIndex>> get_indices_for(
+      const alloc_vector<std::shared_ptr<BaseColumn>> &columns) const;
 
   template <typename Index>
-  std::shared_ptr<BaseIndex> create_index(const std::vector<std::shared_ptr<BaseColumn>> &index_columns) {
+  std::shared_ptr<BaseIndex> create_index(const alloc_vector<std::shared_ptr<BaseColumn>> &index_columns) {
     auto index = std::make_shared<Index>(index_columns);
     _indices.emplace_back(index);
     return index;
@@ -138,9 +136,9 @@ class Chunk {
   bool references_only_one_table() const;
 
  protected:
-  tbb::concurrent_vector<std::shared_ptr<BaseColumn>> _columns;
+  alloc_concurrent_vector<std::shared_ptr<BaseColumn>> _columns;
   std::unique_ptr<MvccColumns> _mvcc_columns;
-  std::vector<std::shared_ptr<BaseIndex>> _indices;
+  alloc_vector<std::shared_ptr<BaseIndex>> _indices;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/dictionary_column.cpp
+++ b/src/lib/storage/dictionary_column.cpp
@@ -14,9 +14,9 @@
 namespace opossum {
 
 template <typename T>
-DictionaryColumn<T>::DictionaryColumn(const std::vector<T>&& dictionary,
+DictionaryColumn<T>::DictionaryColumn(const alloc_vector<T>&& dictionary,
                                       const std::shared_ptr<BaseAttributeVector>& attribute_vector)
-    : _dictionary(std::make_shared<std::vector<T>>(std::move(dictionary))), _attribute_vector(attribute_vector) {}
+    : _dictionary(std::make_shared<alloc_vector<T>>(std::move(dictionary))), _attribute_vector(attribute_vector) {}
 
 template <typename T>
 const AllTypeVariant DictionaryColumn<T>::operator[](const size_t i) const {
@@ -50,7 +50,7 @@ void DictionaryColumn<T>::append(const AllTypeVariant&) {
 }
 
 template <typename T>
-std::shared_ptr<const std::vector<T>> DictionaryColumn<T>::dictionary() const {
+std::shared_ptr<const alloc_vector<T>> DictionaryColumn<T>::dictionary() const {
   return _dictionary;
 }
 
@@ -60,8 +60,8 @@ std::shared_ptr<const BaseAttributeVector> DictionaryColumn<T>::attribute_vector
 }
 
 template <typename T>
-const tbb::concurrent_vector<T> DictionaryColumn<T>::materialize_values() const {
-  tbb::concurrent_vector<T> values(_attribute_vector->size());
+const alloc_concurrent_vector<T> DictionaryColumn<T>::materialize_values() const {
+  alloc_concurrent_vector<T> values(_attribute_vector->size());
 
   for (ChunkOffset chunk_offset = 0; chunk_offset < _attribute_vector->size(); ++chunk_offset) {
     values[chunk_offset] = (*_dictionary)[_attribute_vector->get(chunk_offset)];
@@ -140,9 +140,9 @@ void DictionaryColumn<T>::copy_value_to_value_column(BaseColumn& value_column, C
 }
 
 template <typename T>
-const std::shared_ptr<std::vector<std::pair<RowID, T>>> DictionaryColumn<T>::materialize(
-    ChunkID chunk_id, std::shared_ptr<std::vector<ChunkOffset>> offsets) {
-  auto materialized_vector = std::make_shared<std::vector<std::pair<RowID, T>>>();
+const std::shared_ptr<alloc_vector<std::pair<RowID, T>>> DictionaryColumn<T>::materialize(
+    ChunkID chunk_id, std::shared_ptr<alloc_vector<ChunkOffset>> offsets) {
+  auto materialized_vector = std::make_shared<alloc_vector<std::pair<RowID, T>>>();
 
   /*
   We only offset if this ValueColumn was referenced by a ReferenceColumn. Thus it might actually be filtered.

--- a/src/lib/storage/dictionary_column.hpp
+++ b/src/lib/storage/dictionary_column.hpp
@@ -6,8 +6,6 @@
 #include <utility>
 #include <vector>
 
-#include "tbb/concurrent_vector.h"
-
 #include "untyped_dictionary_column.hpp"
 #include "utils/assert.hpp"
 
@@ -24,7 +22,7 @@ template <typename T>
 class DictionaryColumn : public UntypedDictionaryColumn {
  public:
   // Creates a Dictionary column from a given dictionary and attribute vector.
-  explicit DictionaryColumn(const std::vector<T>&& dictionary,
+  explicit DictionaryColumn(const alloc_vector<T>&& dictionary,
                             const std::shared_ptr<BaseAttributeVector>& attribute_vector);
 
   // return the value at a certain position. If you want to write efficient operators, back off!
@@ -37,13 +35,13 @@ class DictionaryColumn : public UntypedDictionaryColumn {
   void append(const AllTypeVariant&) override;
 
   // returns an underlying dictionary
-  std::shared_ptr<const std::vector<T>> dictionary() const;
+  std::shared_ptr<const alloc_vector<T>> dictionary() const;
 
   // returns an underlying data structure
   std::shared_ptr<const BaseAttributeVector> attribute_vector() const final;
 
   // return a generated vector of all values
-  const tbb::concurrent_vector<T> materialize_values() const;
+  const alloc_concurrent_vector<T> materialize_values() const;
 
   // return the value represented by a given ValueID
   const T& value_by_value_id(ValueID value_id) const;
@@ -79,11 +77,11 @@ class DictionaryColumn : public UntypedDictionaryColumn {
   void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const override;
 
   // TODO(anyone): Move this to base column once final optimization is supported by gcc
-  const std::shared_ptr<std::vector<std::pair<RowID, T>>> materialize(
-      ChunkID chunk_id, std::shared_ptr<std::vector<ChunkOffset>> offsets = nullptr);
+  const std::shared_ptr<alloc_vector<std::pair<RowID, T>>> materialize(
+      ChunkID chunk_id, std::shared_ptr<alloc_vector<ChunkOffset>> offsets = nullptr);
 
  protected:
-  std::shared_ptr<std::vector<T>> _dictionary;
+  std::shared_ptr<alloc_vector<T>> _dictionary;
   std::shared_ptr<BaseAttributeVector> _attribute_vector;
 };
 

--- a/src/lib/storage/dictionary_compression.cpp
+++ b/src/lib/storage/dictionary_compression.cpp
@@ -48,7 +48,7 @@ class ColumnCompressor : public ColumnCompressorBase {
     // See: https://goo.gl/MCM5rr
     // Create dictionary (enforce unqiueness and sorting)
     const auto& values = value_column->values();
-    auto dictionary = std::vector<T>{values.cbegin(), values.cend()};
+    auto dictionary = alloc_vector<T>{values.cbegin(), values.cend()};
 
     std::sort(dictionary.begin(), dictionary.end());
     dictionary.erase(std::unique(dictionary.begin(), dictionary.end()), dictionary.end());
@@ -72,7 +72,7 @@ std::shared_ptr<BaseColumn> DictionaryCompression::compress_column(const std::st
   return compressor->compress_column(column);
 }
 
-void DictionaryCompression::compress_chunk(const std::vector<std::string>& column_types, Chunk& chunk) {
+void DictionaryCompression::compress_chunk(const alloc_vector<std::string>& column_types, Chunk& chunk) {
   DebugAssert((column_types.size() == chunk.col_count()),
               "Number of column types does not match the chunk’s column count.");
 
@@ -85,7 +85,7 @@ void DictionaryCompression::compress_chunk(const std::vector<std::string>& colum
   chunk.shrink_mvcc_columns();
 }
 
-void DictionaryCompression::compress_chunks(Table& table, const std::vector<ChunkID>& chunk_ids) {
+void DictionaryCompression::compress_chunks(Table& table, const alloc_vector<ChunkID>& chunk_ids) {
   for (auto chunk_id : chunk_ids) {
     if (chunk_id >= table.chunk_count()) {
       throw std::logic_error("Chunk with given ID does not exist.");

--- a/src/lib/storage/dictionary_compression.hpp
+++ b/src/lib/storage/dictionary_compression.hpp
@@ -34,12 +34,12 @@ class DictionaryCompression {
    * @param column_types from the chunk’s table
    * @param chunk to be compressed
    */
-  static void compress_chunk(const std::vector<std::string>& column_types, Chunk& chunk);
+  static void compress_chunk(const alloc_vector<std::string>& column_types, Chunk& chunk);
 
   /**
    * @brief Compresses specified chunks of a table
    */
-  static void compress_chunks(Table& table, const std::vector<ChunkID>& chunk_ids);
+  static void compress_chunks(Table& table, const alloc_vector<ChunkID>& chunk_ids);
 
   /**
    * @brief Compresses a table by calling compress_chunk for each chunk

--- a/src/lib/storage/fitted_attribute_vector.hpp
+++ b/src/lib/storage/fitted_attribute_vector.hpp
@@ -17,7 +17,7 @@ class FittedAttributeVector : public BaseAttributeVector {
   explicit FittedAttributeVector(size_t size) : _attributes(size) {}
 
   // Creates a FittedAttributeVector from given attributes
-  explicit FittedAttributeVector(const std::vector<uintX_t>& attributes) : _attributes(attributes) {}
+  explicit FittedAttributeVector(const alloc_vector<uintX_t>& attributes) : _attributes(attributes) {}
 
   ValueID get(const size_t i) const final { return _attributes[i]; }
 
@@ -25,7 +25,7 @@ class FittedAttributeVector : public BaseAttributeVector {
   void set(const size_t i, const ValueID value_id) final { _attributes[i] = static_cast<uintX_t>(value_id); }
 
   // returns all attributes
-  const std::vector<uintX_t>& attributes() const { return _attributes; }
+  const alloc_vector<uintX_t>& attributes() const { return _attributes; }
 
   // returns the number of values
   size_t size() const final { return _attributes.size(); }
@@ -33,6 +33,6 @@ class FittedAttributeVector : public BaseAttributeVector {
   AttributeVectorWidth width() const final { return sizeof(uintX_t); }
 
  private:
-  std::vector<uintX_t> _attributes;
+  alloc_vector<uintX_t> _attributes;
 };
 }  // namespace opossum

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -36,7 +36,7 @@ class AdaptiveRadixTreeIndex : public BaseIndex {
   friend class AdaptiveRadixTreeIndexTest_BinaryComparableFromChunkOffset_Test;
 
  public:
-  explicit AdaptiveRadixTreeIndex(const std::vector<std::shared_ptr<BaseColumn>> &index_columns);
+  explicit AdaptiveRadixTreeIndex(const alloc_vector<std::shared_ptr<BaseColumn>> &index_columns);
 
   AdaptiveRadixTreeIndex(const AdaptiveRadixTreeIndex &) = delete;
 
@@ -65,27 +65,27 @@ class AdaptiveRadixTreeIndex : public BaseIndex {
     uint8_t operator[](size_t position) const;
 
    private:
-    std::vector<uint8_t> _parts;
+    alloc_vector<uint8_t> _parts;
   };
 
  private:
-  Iterator _lower_bound(const std::vector<AllTypeVariant> &values) const final;
+  Iterator _lower_bound(const alloc_vector<AllTypeVariant> &values) const final;
 
-  Iterator _upper_bound(const std::vector<AllTypeVariant> &values) const final;
+  Iterator _upper_bound(const alloc_vector<AllTypeVariant> &values) const final;
 
   Iterator _cbegin() const final;
 
   Iterator _cend() const final;
 
-  std::shared_ptr<Node> _bulk_insert(const std::vector<std::pair<BinaryComparable, ChunkOffset>> &values);
+  std::shared_ptr<Node> _bulk_insert(const alloc_vector<std::pair<BinaryComparable, ChunkOffset>> &values);
 
-  std::shared_ptr<Node> _bulk_insert(const std::vector<std::pair<BinaryComparable, ChunkOffset>> &values, size_t depth,
+  std::shared_ptr<Node> _bulk_insert(const alloc_vector<std::pair<BinaryComparable, ChunkOffset>> &values, size_t depth,
                                      Iterator &it);
 
-  std::vector<std::shared_ptr<BaseColumn>> _get_index_columns() const;
+  alloc_vector<std::shared_ptr<BaseColumn>> _get_index_columns() const;
 
   const std::shared_ptr<UntypedDictionaryColumn> _index_column;
-  std::vector<ChunkOffset> _chunk_offsets;
+  alloc_vector<ChunkOffset> _chunk_offsets;
   std::shared_ptr<Node> _root;
 };
 

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.cpp
@@ -25,7 +25,7 @@ static const uint8_t INVALID_INDEX = 255u;
  * default value of the _partial_keys array is 255u
  */
 
-Node4::Node4(std::vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
+Node4::Node4(alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
   std::sort(children.begin(), children.end(),
             [](const std::pair<uint8_t, std::shared_ptr<Node>> &lhs,
                const std::pair<uint8_t, std::shared_ptr<Node>> &rhs) { return lhs.first < rhs.first; });
@@ -108,7 +108,7 @@ BaseIndex::Iterator Node4::end() const {
  *
  */
 
-Node16::Node16(std::vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
+Node16::Node16(alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
   std::sort(children.begin(), children.end(),
             [](const std::pair<uint8_t, std::shared_ptr<Node>> &lhs,
                const std::pair<uint8_t, std::shared_ptr<Node>> &rhs) { return lhs.first < rhs.first; });
@@ -208,7 +208,7 @@ BaseIndex::Iterator Node16::end() const {
  * 47 as this is the maximum index for _children.
  */
 
-Node48::Node48(const std::vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
+Node48::Node48(const alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
   _index_to_child.fill(INVALID_INDEX);
   for (uint8_t i = 0u; i < children.size(); ++i) {
     _index_to_child[children[i].first] = i;
@@ -303,7 +303,7 @@ BaseIndex::Iterator Node48::end() const {
  *
  */
 
-Node256::Node256(const std::vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
+Node256::Node256(const alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children) {
   for (uint16_t i = 0; i < children.size(); ++i) {
     _children[children[i].first] = children[i].second;
   }

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.hpp
@@ -8,7 +8,7 @@
 
 namespace opossum {
 
-using Iterator = std::vector<ChunkOffset>::const_iterator;
+using Iterator = alloc_vector<ChunkOffset>::const_iterator;
 
 /**
  * This file declares the Node-types needed for the Adaptive-Radix-Tree (ART)
@@ -52,7 +52,7 @@ class Node4 final : public Node {
   friend class AdaptiveRadixTreeIndexTest_BulkInsert_Test;
 
  public:
-  explicit Node4(std::vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children);
+  explicit Node4(alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>> &children);
 
   Iterator lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable &key, size_t depth) const override;
 
@@ -91,9 +91,9 @@ class Node4 final : public Node {
 
 class Node16 final : public Node {
  public:
-  explicit Node16(std::vector<std::pair<uint8_t, std::shared_ptr<Node>>
+  explicit Node16(alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>
 
-                              > &children);
+                               > &children);
 
   Iterator lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable &key, size_t depth) const override;
 
@@ -130,9 +130,9 @@ class Node16 final : public Node {
  */
 class Node48 final : public Node {
  public:
-  explicit Node48(const std::vector<std::pair<uint8_t, std::shared_ptr<Node>>
+  explicit Node48(const alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>
 
-                                    > &children);
+                                     > &children);
 
   Iterator lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable &key, size_t depth) const override;
 
@@ -160,9 +160,9 @@ class Node48 final : public Node {
  */
 class Node256 final : public Node {
  public:
-  explicit Node256(const std::vector<std::pair<uint8_t, std::shared_ptr<Node>>
+  explicit Node256(const alloc_vector<std::pair<uint8_t, std::shared_ptr<Node>>
 
-                                     > &children);
+                                      > &children);
 
   Iterator lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable &key, size_t depth) const override;
 
@@ -182,7 +182,7 @@ class Node256 final : public Node {
 
 /**
  *
- * Leafs contain two std::vector<ChunkOffset>::const_iterator: _lower_bound and _upper_bound.
+ * Leafs contain two alloc_vector<ChunkOffset>::const_iterator: _lower_bound and _upper_bound.
  *
  * Consider the following example tree showing only its leafs:
  *

--- a/src/lib/storage/index/base_index.hpp
+++ b/src/lib/storage/index/base_index.hpp
@@ -32,7 +32,7 @@ namespace opossum {
 class BaseIndex {
  public:
   // For now we use an iterator over a vector of chunkoffsets as the GroupKeyIndex works like this
-  using Iterator = std::vector<ChunkOffset>::const_iterator;
+  using Iterator = alloc_vector<ChunkOffset>::const_iterator;
 
   /**
    * Creates an index on all given columns. Since all indices are composite indices the order of
@@ -57,7 +57,7 @@ class BaseIndex {
    * The index is NOT considerd to be applicable for columns A, DABC, BAD etc.
    * @return true if the given columns are covered by the index.
    */
-  bool is_index_for(const std::vector<std::shared_ptr<BaseColumn>> &columns) const {
+  bool is_index_for(const alloc_vector<std::shared_ptr<BaseColumn>> &columns) const {
     auto index_columns = _get_index_columns();
     if (columns.size() > index_columns.size()) return false;
     if (columns.empty()) return false;
@@ -79,7 +79,7 @@ class BaseIndex {
    * @param values are used to query the index.
    * @return An Iterator on the position of the first element equal or greater then provided values.
    */
-  Iterator lower_bound(const std::vector<AllTypeVariant> &values) const {
+  Iterator lower_bound(const alloc_vector<AllTypeVariant> &values) const {
     DebugAssert((_get_index_columns().size() >= values.size()),
                 "BaseIndex: The amount of queried columns has to be less or equal to the number of indexed columns.");
 
@@ -97,7 +97,7 @@ class BaseIndex {
    * @param values are used to query the index.
    * @return An Iterator on the position of the first element greater then provided values.
    */
-  Iterator upper_bound(const std::vector<AllTypeVariant> &values) const {
+  Iterator upper_bound(const alloc_vector<AllTypeVariant> &values) const {
     DebugAssert((_get_index_columns().size() >= values.size()),
                 "BaseIndex: The amount of queried columns has to be less or equal to the number of indexed columns.");
 
@@ -127,10 +127,10 @@ class BaseIndex {
    * Seperate the public interface of the index from the interface for programmers implementing own
    * indices. Each method has to fullfill the contract of the corresponding public methods.
    */
-  virtual Iterator _lower_bound(const std::vector<AllTypeVariant> &) const = 0;
-  virtual Iterator _upper_bound(const std::vector<AllTypeVariant> &) const = 0;
+  virtual Iterator _lower_bound(const alloc_vector<AllTypeVariant> &) const = 0;
+  virtual Iterator _upper_bound(const alloc_vector<AllTypeVariant> &) const = 0;
   virtual Iterator _cbegin() const = 0;
   virtual Iterator _cend() const = 0;
-  virtual std::vector<std::shared_ptr<BaseColumn>> _get_index_columns() const = 0;
+  virtual alloc_vector<std::shared_ptr<BaseColumn>> _get_index_columns() const = 0;
 };
 }  // namespace opossum

--- a/src/lib/storage/index/group_key/composite_group_key_index.cpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.cpp
@@ -19,7 +19,7 @@
 
 namespace opossum {
 
-CompositeGroupKeyIndex::CompositeGroupKeyIndex(const std::vector<std::shared_ptr<BaseColumn>> &indexed_columns) {
+CompositeGroupKeyIndex::CompositeGroupKeyIndex(const alloc_vector<std::shared_ptr<BaseColumn>> &indexed_columns) {
   DebugAssert(!indexed_columns.empty(), "CompositeGroupKeyIndex requires at least one column to be indexed.");
 
   if (IS_DEBUG) {
@@ -47,7 +47,7 @@ CompositeGroupKeyIndex::CompositeGroupKeyIndex(const std::vector<std::shared_ptr
   // create concatenated keys and save their positions
   // at this point duplicated keys may be created, they will be handled later
   auto column_size = _indexed_columns.front()->size();
-  auto keys = std::vector<VariableLengthKey>(column_size);
+  auto keys = alloc_vector<VariableLengthKey>(column_size);
   _position_list.resize(column_size);
 
   for (ChunkOffset chunkOffset = 0; chunkOffset < column_size; ++chunkOffset) {
@@ -87,17 +87,17 @@ BaseIndex::Iterator CompositeGroupKeyIndex::_cbegin() const { return _position_l
 
 BaseIndex::Iterator CompositeGroupKeyIndex::_cend() const { return _position_list.cend(); }
 
-BaseIndex::Iterator CompositeGroupKeyIndex::_lower_bound(const std::vector<AllTypeVariant> &values) const {
+BaseIndex::Iterator CompositeGroupKeyIndex::_lower_bound(const alloc_vector<AllTypeVariant> &values) const {
   auto composite_key = _create_composite_key(values, false);
   return _get_position_iterator_for_key(composite_key);
 }
 
-BaseIndex::Iterator CompositeGroupKeyIndex::_upper_bound(const std::vector<AllTypeVariant> &values) const {
+BaseIndex::Iterator CompositeGroupKeyIndex::_upper_bound(const alloc_vector<AllTypeVariant> &values) const {
   auto composite_key = _create_composite_key(values, true);
   return _get_position_iterator_for_key(composite_key);
 }
 
-VariableLengthKey CompositeGroupKeyIndex::_create_composite_key(const std::vector<AllTypeVariant> &values,
+VariableLengthKey CompositeGroupKeyIndex::_create_composite_key(const alloc_vector<AllTypeVariant> &values,
                                                                 bool is_upper_bound) const {
   auto result = VariableLengthKey(_keys.key_size());
 
@@ -143,8 +143,8 @@ BaseIndex::Iterator CompositeGroupKeyIndex::_get_position_iterator_for_key(const
   return position_iter;
 }
 
-std::vector<std::shared_ptr<BaseColumn>> CompositeGroupKeyIndex::_get_index_columns() const {
-  auto result = std::vector<std::shared_ptr<BaseColumn>>();
+alloc_vector<std::shared_ptr<BaseColumn>> CompositeGroupKeyIndex::_get_index_columns() const {
+  auto result = alloc_vector<std::shared_ptr<BaseColumn>>();
   result.reserve(_indexed_columns.size());
   for (auto &&indexed_column : _indexed_columns) {
     result.emplace_back(indexed_column);

--- a/src/lib/storage/index/group_key/composite_group_key_index.hpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.hpp
@@ -49,14 +49,14 @@ class CompositeGroupKeyIndex : public BaseIndex {
   CompositeGroupKeyIndex &operator=(CompositeGroupKeyIndex &&) = default;
   ~CompositeGroupKeyIndex() = default;
 
-  explicit CompositeGroupKeyIndex(const std::vector<std::shared_ptr<BaseColumn>> &indexed_columns);
+  explicit CompositeGroupKeyIndex(const alloc_vector<std::shared_ptr<BaseColumn>> &indexed_columns);
 
  private:
-  Iterator _lower_bound(const std::vector<AllTypeVariant> &values) const final;
-  Iterator _upper_bound(const std::vector<AllTypeVariant> &values) const final;
+  Iterator _lower_bound(const alloc_vector<AllTypeVariant> &values) const final;
+  Iterator _upper_bound(const alloc_vector<AllTypeVariant> &values) const final;
   Iterator _cbegin() const final;
   Iterator _cend() const final;
-  std::vector<std::shared_ptr<BaseColumn>> _get_index_columns() const final;
+  alloc_vector<std::shared_ptr<BaseColumn>> _get_index_columns() const final;
 
   /**
    * Creates a VariableLengthKey using the values given as parameters.
@@ -88,7 +88,7 @@ class CompositeGroupKeyIndex : public BaseIndex {
    *
    * @returns a VariableLengthKey created based on the given values
    */
-  VariableLengthKey _create_composite_key(const std::vector<AllTypeVariant> &values, bool is_upper_bound) const;
+  VariableLengthKey _create_composite_key(const alloc_vector<AllTypeVariant> &values, bool is_upper_bound) const;
 
   /**
    *
@@ -99,15 +99,15 @@ class CompositeGroupKeyIndex : public BaseIndex {
 
  private:
   // the columns the index is based on
-  std::vector<std::shared_ptr<UntypedDictionaryColumn>> _indexed_columns;
+  alloc_vector<std::shared_ptr<UntypedDictionaryColumn>> _indexed_columns;
 
   // contains concatenated value-ids
   VariableLengthKeyStore _keys;
 
   // the start positions within _position_list for every key
-  std::vector<ChunkOffset> _key_offsets;
+  alloc_vector<ChunkOffset> _key_offsets;
 
   // contains positions, ie ChunkOffsets, for the concatenated value-ids
-  std::vector<ChunkOffset> _position_list;
+  alloc_vector<ChunkOffset> _position_list;
 };
 }  // namespace opossum

--- a/src/lib/storage/index/group_key/variable_length_key_store.cpp
+++ b/src/lib/storage/index/group_key/variable_length_key_store.cpp
@@ -9,7 +9,7 @@ VariableLengthKeyStore::VariableLengthKeyStore(ChunkOffset size, CompositeKeyLen
   static const CompositeKeyLength alignment = 8u;
   _bytes_per_key = bytes_per_key;
   _key_alignment = (bytes_per_key / alignment + (bytes_per_key % alignment == 0u ? 0u : 1u)) * alignment;
-  _data = std::vector<VariableLengthKeyWord>(size * _key_alignment);
+  _data = alloc_vector<VariableLengthKeyWord>(size * _key_alignment);
 }
 
 VariableLengthKeyProxy VariableLengthKeyStore::operator[](ChunkOffset position) {

--- a/src/lib/storage/index/group_key/variable_length_key_store.hpp
+++ b/src/lib/storage/index/group_key/variable_length_key_store.hpp
@@ -17,15 +17,15 @@ class VariableLengthKeyConstProxy;
 
 /**
  * This class stores multiple VariableLengthKeys with a specified byte length of each entry.
- * The intention is to use this class as replacement for std::vector<VariableLengthKey> if every stored
+ * The intention is to use this class as replacement for alloc_vector<VariableLengthKey> if every stored
  * entry has the specified byte size. The provided advantage is the continuous placement of the key data in
- * memory. Since every key has to manage memory by itself in order to achieve variable lengths, a std::vector
+ * memory. Since every key has to manage memory by itself in order to achieve variable lengths, a alloc_vector
  * can only store the VariableKeyLength objects continuously in memory, every object pointing to its memory location.
  * The VariableLengthKeyStore also provides continuous placement of the data pointed to by VariableLengthKey objects.
  * Additionally, every entry is saved word-aligned.
  *
  * In order to achieve the desired result, a proxied container is implemented. The implementation is similiar to
- * common std::vector<bool> implementations, sharing the same drawbacks: a proxied container can never fulfill
+ * common alloc_vector<bool> implementations, sharing the same drawbacks: a proxied container can never fulfill
  * the requirements of a Container and provided iterators can never be standard conform RandomAccessIterators.
  * This implies all common algorithms provided by the standard library are not guaranteed to work with these, but
  * clang and gcc seem to work properly.
@@ -58,7 +58,7 @@ class VariableLengthKeyStore {
   explicit VariableLengthKeyStore(ChunkOffset size, CompositeKeyLength bytes_per_key);
 
   /**
-   * Mimics the operator[] as used in std::vector with the difference that proxy objects are returned instead of
+   * Mimics the operator[] as used in alloc_vector with the difference that proxy objects are returned instead of
    * references. Although proxy objects are returned, they can be nearly used as if they would be references to
    * VariableLengthKeys. The only limitation is that for writing the length of the new key has to match the size of the
    * already stored key.
@@ -104,7 +104,7 @@ class VariableLengthKeyStore {
  private:
   CompositeKeyLength _bytes_per_key;
   CompositeKeyLength _key_alignment;
-  std::vector<VariableLengthKeyWord> _data;
+  alloc_vector<VariableLengthKeyWord> _data;
 
  private:
   /**

--- a/src/lib/storage/reference_column.hpp
+++ b/src/lib/storage/reference_column.hpp
@@ -41,8 +41,8 @@ class ReferenceColumn : public BaseColumn {
 
   // return generated vector of all values
   template <typename T>
-  const tbb::concurrent_vector<T> materialize_values() const {
-    tbb::concurrent_vector<T> values;
+  const alloc_concurrent_vector<T> materialize_values() const {
+    alloc_concurrent_vector<T> values;
     values.reserve(_pos_list->size());
 
     std::map<ChunkID, std::shared_ptr<ValueColumn<T>>> value_columns;
@@ -102,14 +102,14 @@ class ReferenceColumn : public BaseColumn {
     unsorted.
     */
 
-    std::unordered_map<ChunkID, std::shared_ptr<std::vector<ChunkOffset>>> all_chunk_offsets;
+    std::unordered_map<ChunkID, std::shared_ptr<alloc_vector<ChunkOffset>>> all_chunk_offsets;
 
     for (auto pos : *(_pos_list)) {
       auto chunk_info = _referenced_table->locate_row(pos);
 
       auto iter = all_chunk_offsets.find(chunk_info.first);
       if (iter == all_chunk_offsets.end())
-        iter = all_chunk_offsets.emplace(chunk_info.first, std::make_shared<std::vector<ChunkOffset>>()).first;
+        iter = all_chunk_offsets.emplace(chunk_info.first, std::make_shared<alloc_vector<ChunkOffset>>()).first;
 
       iter->second->emplace_back(chunk_info.second);
     }

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -34,7 +34,7 @@ void Table::add_column(const std::string &name, const std::string &type, bool cr
   }
 }
 
-void Table::append(std::vector<AllTypeVariant> values) {
+void Table::append(alloc_vector<AllTypeVariant> values) {
   // TODO(Anyone): Chunks should be preallocated for chunk size
   if (_chunk_size > 0 && _chunks.back().size() == _chunk_size) create_new_chunk();
 
@@ -77,7 +77,7 @@ const std::string &Table::column_name(ColumnID column_id) const { return _column
 
 const std::string &Table::column_type(ColumnID column_id) const { return _column_types[column_id]; }
 
-const std::vector<std::string> &Table::column_types() const { return _column_types; }
+const alloc_vector<std::string> &Table::column_types() const { return _column_types; }
 
 Chunk &Table::get_chunk(ChunkID chunk_id) { return _chunks[chunk_id]; }
 const Chunk &Table::get_chunk(ChunkID chunk_id) const { return _chunks[chunk_id]; }

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -52,7 +52,7 @@ class Table {
   const std::string &column_type(ColumnID column_id) const;
 
   // returns the vector of column types
-  const std::vector<std::string> &column_types() const;
+  const alloc_vector<std::string> &column_types() const;
 
   // returns the column with the given name
   ColumnID column_id_by_name(const std::string &column_name) const;
@@ -65,7 +65,7 @@ class Table {
 
   // inserts a row at the end of the table
   // note this is slow and not thread-safe and should be used for testing purposes only
-  void append(std::vector<AllTypeVariant> values);
+  void append(alloc_vector<AllTypeVariant> values);
 
   // creates a new chunk and appends it
   void create_new_chunk();
@@ -82,12 +82,12 @@ class Table {
  protected:
   // 0 means that the chunk has an unlimited size.
   const uint32_t _chunk_size;
-  std::vector<Chunk> _chunks;
+  alloc_vector<Chunk> _chunks;
 
   // these should be const strings, but having a vector of const values is a C++17 feature
   // that is not yet completely implemented in all compilers
-  std::vector<std::string> _column_names;
-  std::vector<std::string> _column_types;
+  alloc_vector<std::string> _column_names;
+  alloc_vector<std::string> _column_types;
 
   std::unique_ptr<std::mutex> _append_mutex;
 };

--- a/src/lib/storage/value_column.cpp
+++ b/src/lib/storage/value_column.cpp
@@ -14,7 +14,7 @@
 namespace opossum {
 
 template <typename T>
-ValueColumn<T>::ValueColumn(tbb::concurrent_vector<T>&& values) : _values(std::move(values)) {}
+ValueColumn<T>::ValueColumn(alloc_concurrent_vector<T>&& values) : _values(std::move(values)) {}
 
 template <typename T>
 const AllTypeVariant ValueColumn<T>::operator[](const size_t i) const {
@@ -56,12 +56,12 @@ void ValueColumn<std::string>::append(const AllTypeVariant& val) {
 }
 
 template <typename T>
-const tbb::concurrent_vector<T>& ValueColumn<T>::values() const {
+const alloc_concurrent_vector<T>& ValueColumn<T>::values() const {
   return _values;
 }
 
 template <typename T>
-tbb::concurrent_vector<T>& ValueColumn<T>::values() {
+alloc_concurrent_vector<T>& ValueColumn<T>::values() {
   return _values;
 }
 
@@ -97,9 +97,9 @@ void ValueColumn<T>::copy_value_to_value_column(BaseColumn& value_column, ChunkO
 }
 
 template <typename T>
-const std::shared_ptr<std::vector<std::pair<RowID, T>>> ValueColumn<T>::materialize(
-    ChunkID chunk_id, std::shared_ptr<std::vector<ChunkOffset>> offsets) {
-  auto materialized_vector = std::make_shared<std::vector<std::pair<RowID, T>>>();
+const std::shared_ptr<alloc_vector<std::pair<RowID, T>>> ValueColumn<T>::materialize(
+    ChunkID chunk_id, std::shared_ptr<alloc_vector<ChunkOffset>> offsets) {
+  auto materialized_vector = std::make_shared<alloc_vector<std::pair<RowID, T>>>();
 
   // we may want to sort offsets first?
   if (offsets) {

--- a/src/lib/storage/value_column.hpp
+++ b/src/lib/storage/value_column.hpp
@@ -5,8 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "tbb/concurrent_vector.h"
-
 #include "base_column.hpp"
 #include "utils/assert.hpp"
 
@@ -19,7 +17,7 @@ class ValueColumn : public BaseColumn {
   ValueColumn() = default;
 
   // Create a ValueColumn with the given values
-  explicit ValueColumn(tbb::concurrent_vector<T>&& values);
+  explicit ValueColumn(alloc_concurrent_vector<T>&& values);
 
   // return the value at a certain position. If you want to write efficient operators, back off!
   const AllTypeVariant operator[](const size_t i) const override;
@@ -30,8 +28,8 @@ class ValueColumn : public BaseColumn {
   void append(const AllTypeVariant& val) override;
 
   // returns all values
-  const tbb::concurrent_vector<T>& values() const;
-  tbb::concurrent_vector<T>& values();
+  const alloc_concurrent_vector<T>& values() const;
+  alloc_concurrent_vector<T>& values();
 
   // return the number of entries
   size_t size() const override;
@@ -46,10 +44,10 @@ class ValueColumn : public BaseColumn {
   // we cannot always use the materialize method below because sort results might come from different BaseColumns
   void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const override;
 
-  const std::shared_ptr<std::vector<std::pair<RowID, T>>> materialize(
-      ChunkID chunk_id, std::shared_ptr<std::vector<ChunkOffset>> offsets = nullptr);
+  const std::shared_ptr<alloc_vector<std::pair<RowID, T>>> materialize(
+      ChunkID chunk_id, std::shared_ptr<alloc_vector<ChunkOffset>> offsets = nullptr);
 
  protected:
-  tbb::concurrent_vector<T> _values;
+  alloc_concurrent_vector<T> _values;
 };
 }  // namespace opossum

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -10,9 +10,9 @@
 namespace opossum {
 
 ChunkCompressionTask::ChunkCompressionTask(const std::string& table_name, const ChunkID chunk_id, bool check_completion)
-    : ChunkCompressionTask{table_name, std::vector<ChunkID>{chunk_id}, check_completion} {}
+    : ChunkCompressionTask{table_name, alloc_vector<ChunkID>{chunk_id}, check_completion} {}
 
-ChunkCompressionTask::ChunkCompressionTask(const std::string& table_name, const std::vector<ChunkID>& chunk_ids,
+ChunkCompressionTask::ChunkCompressionTask(const std::string& table_name, const alloc_vector<ChunkID>& chunk_ids,
                                            bool check_completion)
     : _check_completion{check_completion}, _table_name{table_name}, _chunk_ids{chunk_ids} {}
 

--- a/src/lib/tasks/chunk_compression_task.hpp
+++ b/src/lib/tasks/chunk_compression_task.hpp
@@ -37,7 +37,7 @@ class Chunk;
 class ChunkCompressionTask : public AbstractTask {
  public:
   explicit ChunkCompressionTask(const std::string& table_name, const ChunkID chunk_id, bool check_completion = true);
-  explicit ChunkCompressionTask(const std::string& table_name, const std::vector<ChunkID>& chunk_ids,
+  explicit ChunkCompressionTask(const std::string& table_name, const alloc_vector<ChunkID>& chunk_ids,
                                 bool check_completion = true);
 
  protected:
@@ -54,6 +54,6 @@ class ChunkCompressionTask : public AbstractTask {
  private:
   const bool _check_completion;  ///< decides whether chunk_is_completed is called before compression
   const std::string _table_name;
-  const std::vector<ChunkID> _chunk_ids;
+  const alloc_vector<ChunkID> _chunk_ids;
 };
 }  // namespace opossum

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -5,7 +5,15 @@
 #include <string>
 #include <vector>
 
+#include "tbb/concurrent_vector.h"
+
 namespace opossum {
+
+template <typename T>
+using alloc_vector = std::vector<T>;
+
+template <typename T>
+using alloc_concurrent_vector = tbb::concurrent_vector<T>;
 
 using ChunkID = uint32_t;
 using ChunkOffset = uint32_t;
@@ -38,7 +46,7 @@ using StringLength = uint16_t;     // The length of column value strings must fi
 using ColumnNameLength = uint8_t;  // The length of column names must fit in this type.
 using AttributeVectorWidth = uint8_t;
 
-using PosList = std::vector<RowID>;
+using PosList = alloc_vector<RowID>;
 
 class ColumnName {
  public:

--- a/src/lib/utils/cuckoo_hashtable.hpp
+++ b/src/lib/utils/cuckoo_hashtable.hpp
@@ -23,7 +23,7 @@ class HashTable {
  public:
   explicit HashTable(size_t input_table_size) : _input_table_size(input_table_size) {
     // prepare internal hash tables and fill with empty elements
-    _hashtables.resize(NUMBER_OF_HASH_FUNCTIONS, std::vector<std::shared_ptr<HashElement>>(input_table_size));
+    _hashtables.resize(NUMBER_OF_HASH_FUNCTIONS, alloc_vector<std::shared_ptr<HashElement>>(input_table_size));
   }
 
   // copying a HashTable is not allowed
@@ -49,7 +49,7 @@ class HashTable {
       }
     }
     auto element =
-        std::make_shared<HashElement>(HashElement{value, std::make_shared<PosList>(std::vector<RowID>{row_id})});
+        std::make_shared<HashElement>(HashElement{value, std::make_shared<PosList>(alloc_vector<RowID>{row_id})});
     place(element, 0, 0);
   }
 
@@ -123,6 +123,6 @@ class HashTable {
   }
 
   size_t _input_table_size;
-  std::vector<std::vector<std::shared_ptr<HashElement>>> _hashtables;
+  alloc_vector<alloc_vector<std::shared_ptr<HashElement>>> _hashtables;
 };
 }  // namespace opossum

--- a/src/test/base_test.cpp
+++ b/src/test/base_test.cpp
@@ -35,7 +35,7 @@ void BaseTest::ASSERT_TABLE_EQ(std::shared_ptr<const Table> tleft, std::shared_p
 
 BaseTest::Matrix BaseTest::_table_to_matrix(const Table &t) {
   // initialize matrix with table sizes
-  Matrix matrix(t.row_count(), std::vector<AllTypeVariant>(t.col_count()));
+  Matrix matrix(t.row_count(), alloc_vector<AllTypeVariant>(t.col_count()));
 
   // set values
   unsigned row_offset = 0;
@@ -123,8 +123,8 @@ void BaseTest::_print_matrix(const BaseTest::Matrix &m) {
 }
 
 template <typename T>
-std::vector<T> BaseTest::_split(const std::string &str, char delimiter) {
-  std::vector<T> internal;
+alloc_vector<T> BaseTest::_split(const std::string &str, char delimiter) {
+  alloc_vector<T> internal;
   std::stringstream ss(str);
   std::string tok;
 
@@ -142,16 +142,16 @@ std::shared_ptr<Table> BaseTest::load_table(const std::string &file_name, size_t
   std::string line;
 
   std::getline(infile, line);
-  std::vector<std::string> col_names = _split<std::string>(line, '|');
+  alloc_vector<std::string> col_names = _split<std::string>(line, '|');
   std::getline(infile, line);
-  std::vector<std::string> col_types = _split<std::string>(line, '|');
+  alloc_vector<std::string> col_types = _split<std::string>(line, '|');
 
   for (size_t i = 0; i < col_names.size(); i++) {
     test_table->add_column(col_names[i], col_types[i]);
   }
 
   while (std::getline(infile, line)) {
-    std::vector<AllTypeVariant> values = _split<AllTypeVariant>(line, '|');
+    alloc_vector<AllTypeVariant> values = _split<AllTypeVariant>(line, '|');
 
     test_table->append(values);
 

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -16,10 +16,10 @@ namespace opossum {
 
 class Table;
 
-using Matrix = std::vector<std::vector<AllTypeVariant>>;
+using Matrix = alloc_vector<alloc_vector<AllTypeVariant>>;
 
 class BaseTest : public ::testing::Test {
-  using Matrix = std::vector<std::vector<AllTypeVariant>>;
+  using Matrix = alloc_vector<alloc_vector<AllTypeVariant>>;
 
   // helper functions for _table_equal
   static BaseTest::Matrix _table_to_matrix(const Table &t);
@@ -27,7 +27,7 @@ class BaseTest : public ::testing::Test {
 
   // helper function for load_table
   template <typename T>
-  static std::vector<T> _split(const std::string &str, char delimiter);
+  static alloc_vector<T> _split(const std::string &str, char delimiter);
 
   // compares two tables with regard to the schema and content
   // but ignores the internal representation (chunk size, column type)
@@ -46,8 +46,9 @@ class BaseTest : public ::testing::Test {
 
   // creates a dictionary column with the given type and values
   template <class T>
-  static std::shared_ptr<BaseColumn> create_dict_column_by_type(const std::string &type, const std::vector<T> &values) {
-    auto vector_values = tbb::concurrent_vector<T>(values.begin(), values.end());
+  static std::shared_ptr<BaseColumn> create_dict_column_by_type(const std::string &type,
+                                                                const alloc_vector<T> &values) {
+    auto vector_values = alloc_concurrent_vector<T>(values.begin(), values.end());
     auto value_column = std::make_shared<ValueColumn<T>>(std::move(vector_values));
     return DictionaryCompression::compress_column(type, value_column);
   }

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -51,8 +51,8 @@ class OperatorsAggregateTest : public BaseTest {
   }
 
   void test_output(const std::shared_ptr<AbstractOperator> in,
-                   const std::vector<std::pair<std::string, AggregateFunction>> aggregates,
-                   const std::vector<std::string> groupby_columns, const std::string &file_name, size_t chunk_size) {
+                   const alloc_vector<std::pair<std::string, AggregateFunction>> aggregates,
+                   const alloc_vector<std::string> groupby_columns, const std::string &file_name, size_t chunk_size) {
     // load expected results from file
     std::shared_ptr<Table> expected_result = load_table(file_name, chunk_size);
     EXPECT_NE(expected_result, nullptr) << "Could not load expected result table";
@@ -93,8 +93,9 @@ class OperatorsAggregateTest : public BaseTest {
 
 TEST_F(OperatorsAggregateTest, NumInputTables) {
   auto aggregate = std::make_shared<Aggregate>(
-      _table_wrapper_1_1, std::vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("b"), Max)},
-      std::vector<std::string>{std::string("a")});
+      _table_wrapper_1_1,
+      alloc_vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("b"), Max)},
+      alloc_vector<std::string>{std::string("a")});
   aggregate->execute();
 
   EXPECT_EQ(aggregate->num_in_tables(), 1);
@@ -102,16 +103,18 @@ TEST_F(OperatorsAggregateTest, NumInputTables) {
 
 TEST_F(OperatorsAggregateTest, NumOutputTables) {
   auto aggregate = std::make_shared<Aggregate>(
-      _table_wrapper_1_1, std::vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("b"), Max)},
-      std::vector<std::string>{std::string("a")});
+      _table_wrapper_1_1,
+      alloc_vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("b"), Max)},
+      alloc_vector<std::string>{std::string("a")});
 
   EXPECT_EQ(aggregate->num_out_tables(), 1);
 }
 
 TEST_F(OperatorsAggregateTest, OperatorName) {
   auto aggregate = std::make_shared<Aggregate>(
-      _table_wrapper_1_1, std::vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("b"), Max)},
-      std::vector<std::string>{std::string("a")});
+      _table_wrapper_1_1,
+      alloc_vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("b"), Max)},
+      alloc_vector<std::string>{std::string("a")});
 
   EXPECT_EQ(aggregate->name(), "Aggregate");
 }
@@ -119,8 +122,8 @@ TEST_F(OperatorsAggregateTest, OperatorName) {
 TEST_F(OperatorsAggregateTest, CannotAggregateStringColumns) {
   auto aggregate = std::make_shared<Aggregate>(
       _table_wrapper_1_1_string,
-      std::vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("a"), Min)},
-      std::vector<std::string>{std::string("a")});
+      alloc_vector<std::pair<std::string, AggregateFunction>>{std::make_pair(std::string("a"), Min)},
+      alloc_vector<std::string>{std::string("a")});
 
   EXPECT_THROW(aggregate->execute(), std::logic_error);
 }
@@ -340,8 +343,8 @@ TEST_F(OperatorsAggregateTest, TwoGroupbyAndNoAggregate) {
 
 TEST_F(OperatorsAggregateTest, NoGroupbyAndNoAggregate) {
   EXPECT_THROW(
-      std::make_shared<Aggregate>(_table_wrapper_1_1_string, std::vector<std::pair<std::string, AggregateFunction>>{},
-                                  std::vector<std::string>{}),
+      std::make_shared<Aggregate>(_table_wrapper_1_1_string, alloc_vector<std::pair<std::string, AggregateFunction>>{},
+                                  alloc_vector<std::string>{}),
       std::logic_error);
 }
 

--- a/src/test/operators/difference_test.cpp
+++ b/src/test/operators/difference_test.cpp
@@ -41,7 +41,7 @@ TEST_F(OperatorsDifferenceTest, DifferenceOnValueTables) {
 TEST_F(OperatorsDifferenceTest, DifferneceOnReferenceTables) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 2);
 
-  std::vector<std::string> column_filter = {"a", "b"};
+  alloc_vector<std::string> column_filter = {"a", "b"};
   auto projection1 = std::make_shared<Projection>(_table_wrapper_a, column_filter);
   projection1->execute();
 

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -41,7 +41,7 @@ class PrintWrapper : public Print {
 
  public:
   explicit PrintWrapper(const std::shared_ptr<AbstractOperator> in) : Print(in), tab(in->get_output()) {}
-  std::vector<uint16_t> test_column_string_widths(uint16_t min, uint16_t max) {
+  alloc_vector<uint16_t> test_column_string_widths(uint16_t min, uint16_t max) {
     return column_string_widths(min, max, tab);
   }
 };

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -50,7 +50,7 @@ TEST_F(OperatorsProjectionTest, SingleColumn) {
 TEST_F(OperatorsProjectionTest, SingleColumnOldInterface) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int.tbl", 1);
 
-  std::vector<std::string> columns = {"a"};
+  alloc_vector<std::string> columns = {"a"};
   auto projection = std::make_shared<Projection>(_table_wrapper, columns);
   projection->execute();
   auto out = projection->get_output();

--- a/src/test/operators/union_all_test.cpp
+++ b/src/test/operators/union_all_test.cpp
@@ -40,7 +40,7 @@ TEST_F(OperatorsUnionAllTest, UnionOfValueTables) {
 TEST_F(OperatorsUnionAllTest, UnionOfValueReferenceTables) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_union.tbl", 2);
 
-  std::vector<std::string> column_filter = {"a", "b"};
+  alloc_vector<std::string> column_filter = {"a", "b"};
   auto projection = std::make_shared<Projection>(_table_wrapper_a, column_filter);
   projection->execute();
 

--- a/src/test/operators/update_test.cpp
+++ b/src/test/operators/update_test.cpp
@@ -33,8 +33,8 @@ void OperatorsUpdateTest::helper(std::shared_ptr<GetTable> table_to_update, std:
   ref_table->set_transaction_context(t_context);
   ref_table->execute();
 
-  std::vector<std::string> column_filter_left = {"a"};
-  std::vector<std::string> column_filter_right = {"b"};
+  alloc_vector<std::string> column_filter_left = {"a"};
+  alloc_vector<std::string> column_filter_right = {"b"};
 
   auto projection1 = std::make_shared<Projection>(ref_table, column_filter_left);
   auto projection2 = std::make_shared<Projection>(update_values, column_filter_right);

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -70,7 +70,7 @@ TEST_F(OperatorsValidateTest, ProjectedValidate) {
 
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/validate_output_validated_projected.tbl", 2u);
 
-  std::vector<std::string> column_filter = {"c", "a"};
+  alloc_vector<std::string> column_filter = {"c", "a"};
   auto projection = std::make_shared<Projection>(_table_wrapper, column_filter);
   projection->set_transaction_context(context);
   projection->execute();

--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -85,10 +85,10 @@ class SchedulerTest : public BaseTest {
   }
 
   void increment_counter_in_subtasks(std::atomic_uint& counter) {
-    std::vector<std::shared_ptr<AbstractTask>> tasks;
+    alloc_vector<std::shared_ptr<AbstractTask>> tasks;
     for (size_t i = 0; i < 10; i++) {
       auto task = std::make_shared<JobTask>([&]() {
-        std::vector<std::shared_ptr<AbstractTask>> jobs;
+        alloc_vector<std::shared_ptr<AbstractTask>> jobs;
         for (size_t j = 0; j < 3; j++) {
           auto job = std::make_shared<JobTask>([&]() { counter++; });
 

--- a/src/test/storage/adaptive_radix_tree_index_test.cpp
+++ b/src/test/storage/adaptive_radix_tree_index_test.cpp
@@ -21,7 +21,7 @@ class AdaptiveRadixTreeIndexTest : public BaseTest {
     // we want to custom-build the index, but we have to create an index with a non-empty column.
     // Therefore we build an index and reset the root.
     dict_col1 = create_dict_column_by_type<std::string>("string", {"test"});
-    index1 = std::make_shared<AdaptiveRadixTreeIndex>(std::vector<std::shared_ptr<BaseColumn>>({dict_col1}));
+    index1 = std::make_shared<AdaptiveRadixTreeIndex>(alloc_vector<std::shared_ptr<BaseColumn>>({dict_col1}));
     index1->_root = nullptr;
     index1->_chunk_offsets.clear();
     /* root   childx    childxx  childxxx  leaf->chunk offsets
@@ -46,9 +46,9 @@ class AdaptiveRadixTreeIndexTest : public BaseTest {
   std::shared_ptr<AdaptiveRadixTreeIndex> index1 = nullptr;
   std::shared_ptr<BaseColumn> dict_col1 = nullptr;
   std::shared_ptr<Node> root = nullptr;
-  std::vector<std::pair<AdaptiveRadixTreeIndex::BinaryComparable, ChunkOffset>> pairs;
-  std::vector<ValueID> keys1;
-  std::vector<ChunkOffset> values1;
+  alloc_vector<std::pair<AdaptiveRadixTreeIndex::BinaryComparable, ChunkOffset>> pairs;
+  alloc_vector<ValueID> keys1;
+  alloc_vector<ChunkOffset> values1;
 };
 
 TEST_F(AdaptiveRadixTreeIndexTest, BinaryComparableFromChunkOffset) {
@@ -62,8 +62,8 @@ TEST_F(AdaptiveRadixTreeIndexTest, BinaryComparableFromChunkOffset) {
 }
 
 TEST_F(AdaptiveRadixTreeIndexTest, BulkInsert) {
-  std::vector<ChunkOffset> expectedChunkOffets = {0x00000001u, 0x00000007u, 0x00000002u, 0x00000003u,
-                                                  0x00000004u, 0x00000005u, 0x00000006u};
+  alloc_vector<ChunkOffset> expectedChunkOffets = {0x00000001u, 0x00000007u, 0x00000002u, 0x00000003u,
+                                                   0x00000004u, 0x00000005u, 0x00000006u};
   EXPECT_FALSE(std::dynamic_pointer_cast<Leaf>(root));
   EXPECT_EQ(index1->_chunk_offsets, expectedChunkOffets);
 

--- a/src/test/storage/composite_group_key_index_test.cpp
+++ b/src/test/storage/composite_group_key_index_test.cpp
@@ -22,8 +22,8 @@ opossum::VariableLengthKey create_key(uint16_t value) {
   return result;
 }
 
-std::vector<opossum::VariableLengthKey> to_vector(const opossum::VariableLengthKeyStore &keys) {
-  auto result = std::vector<opossum::VariableLengthKey>(keys.size());
+opossum::alloc_vector<opossum::VariableLengthKey> to_vector(const opossum::VariableLengthKeyStore &keys) {
+  auto result = opossum::alloc_vector<opossum::VariableLengthKey>(keys.size());
   std::copy(keys.cbegin(), keys.cend(), result.begin());
   return result;
 }
@@ -36,8 +36,8 @@ testing::AssertionResult is_contained_in(opossum::ChunkOffset value, const std::
   }
 }
 
-void EXPECT_POSITION_LIST_EQ(const std::vector<std::set<opossum::ChunkOffset>> &expected,
-                             const std::vector<opossum::ChunkOffset> &actual) {
+void EXPECT_POSITION_LIST_EQ(const opossum::alloc_vector<std::set<opossum::ChunkOffset>> &expected,
+                             const opossum::alloc_vector<opossum::ChunkOffset> &actual) {
   std::set<opossum::ChunkOffset> distinct_expected_positions = {};
   for (const auto &expection_for_position : expected) {
     distinct_expected_positions.insert(expection_for_position.begin(), expection_for_position.end());
@@ -62,9 +62,9 @@ class CompositeGroupKeyIndexTest : public BaseTest {
         "string", {"hotel", "delta", "frank", "delta", "apple", "charlie", "charlie", "inbox"});
 
     _index_int_str =
-        std::make_shared<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<BaseColumn>>{_column_int, _column_str});
+        std::make_shared<CompositeGroupKeyIndex>(alloc_vector<std::shared_ptr<BaseColumn>>{_column_int, _column_str});
     _index_str_int =
-        std::make_shared<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<BaseColumn>>{_column_str, _column_int});
+        std::make_shared<CompositeGroupKeyIndex>(alloc_vector<std::shared_ptr<BaseColumn>>{_column_str, _column_int});
 
     _keys_int_str = &(_index_int_str->_keys);
     _keys_str_int = &(_index_str_int->_keys);
@@ -90,36 +90,36 @@ class CompositeGroupKeyIndexTest : public BaseTest {
   VariableLengthKeyStore *_keys_int_str;
   VariableLengthKeyStore *_keys_str_int;
 
-  std::vector<ChunkOffset> *_offsets_int_str;
-  std::vector<ChunkOffset> *_offsets_str_int;
+  alloc_vector<ChunkOffset> *_offsets_int_str;
+  alloc_vector<ChunkOffset> *_offsets_str_int;
 
-  std::vector<ChunkOffset> *_position_list_int_str;
-  std::vector<ChunkOffset> *_position_list_str_int;
+  alloc_vector<ChunkOffset> *_position_list_int_str;
+  alloc_vector<ChunkOffset> *_position_list_str_int;
 };
 
 TEST_F(CompositeGroupKeyIndexTest, ConcatenatedKeys) {
   auto expected_int_str =
-      std::vector<VariableLengthKey>{create_key(0x0000), create_key(0x0003), create_key(0x0102), create_key(0x0201),
-                                     create_key(0x0204), create_key(0x0301), create_key(0x0305)};
+      alloc_vector<VariableLengthKey>{create_key(0x0000), create_key(0x0003), create_key(0x0102), create_key(0x0201),
+                                      create_key(0x0204), create_key(0x0301), create_key(0x0305)};
   auto expected_str_int =
-      std::vector<VariableLengthKey>{create_key(0x0000), create_key(0x0102), create_key(0x0103), create_key(0x0201),
-                                     create_key(0x0300), create_key(0x0402), create_key(0x0503)};
+      alloc_vector<VariableLengthKey>{create_key(0x0000), create_key(0x0102), create_key(0x0103), create_key(0x0201),
+                                      create_key(0x0300), create_key(0x0402), create_key(0x0503)};
 
   EXPECT_EQ(expected_int_str, to_vector(*_keys_int_str));
   EXPECT_EQ(expected_str_int, to_vector(*_keys_str_int));
 }
 
 TEST_F(CompositeGroupKeyIndexTest, Offsets) {
-  auto expected_int_str = std::vector<ChunkOffset>{0, 1, 2, 4, 5, 6, 7};
-  auto expected_str_int = std::vector<ChunkOffset>{0, 1, 2, 3, 5, 6, 7};
+  auto expected_int_str = alloc_vector<ChunkOffset>{0, 1, 2, 4, 5, 6, 7};
+  auto expected_str_int = alloc_vector<ChunkOffset>{0, 1, 2, 3, 5, 6, 7};
 
   EXPECT_EQ(expected_int_str, *_offsets_int_str);
   EXPECT_EQ(expected_str_int, *_offsets_str_int);
 }
 
 TEST_F(CompositeGroupKeyIndexTest, PositionList) {
-  auto expected_int_str = std::vector<std::set<ChunkOffset>>{{4}, {2}, {1, 3}, {1, 3}, {6}, {0}, {5}, {7}};
-  auto expected_str_int = std::vector<std::set<ChunkOffset>>{{4}, {6}, {5}, {1, 3}, {1, 3}, {2}, {0}, {7}};
+  auto expected_int_str = alloc_vector<std::set<ChunkOffset>>{{4}, {2}, {1, 3}, {1, 3}, {6}, {0}, {5}, {7}};
+  auto expected_str_int = alloc_vector<std::set<ChunkOffset>>{{4}, {6}, {5}, {1, 3}, {1, 3}, {2}, {0}, {7}};
 
   EXPECT_POSITION_LIST_EQ(expected_int_str, *_position_list_int_str);
   EXPECT_POSITION_LIST_EQ(expected_str_int, *_position_list_str_int);

--- a/src/test/storage/group_key_index_test.cpp
+++ b/src/test/storage/group_key_index_test.cpp
@@ -22,7 +22,7 @@ class GroupKeyIndexTest : public BaseTest {
   void SetUp() override {
     dict_col = BaseTest::create_dict_column_by_type<std::string>(
         "string", {"hotel", "delta", "frank", "delta", "apple", "charlie", "charlie", "inbox"});
-    index = std::make_shared<GroupKeyIndex>(std::vector<std::shared_ptr<BaseColumn>>({dict_col}));
+    index = std::make_shared<GroupKeyIndex>(alloc_vector<std::shared_ptr<BaseColumn>>({dict_col}));
 
     index_offsets = &(index->_index_offsets);
     index_postings = &(index->_index_postings);
@@ -36,12 +36,12 @@ class GroupKeyIndexTest : public BaseTest {
    * private scope. In order to minimize the friend classes of CompositeGroupKeyIndex the fixture
    * is used as proxy. Since the variables are set in setup() references are not possible.
    */
-  std::vector<std::size_t> *index_offsets;
-  std::vector<ChunkOffset> *index_postings;
+  alloc_vector<std::size_t> *index_offsets;
+  alloc_vector<ChunkOffset> *index_postings;
 };
 
 TEST_F(GroupKeyIndexTest, IndexOffsets) {
-  auto expected_offsets = std::vector<size_t>{0, 1, 3, 5, 6, 7, 8};
+  auto expected_offsets = alloc_vector<size_t>{0, 1, 3, 5, 6, 7, 8};
   EXPECT_EQ(expected_offsets, *index_offsets);
 }
 
@@ -52,7 +52,7 @@ TEST_F(GroupKeyIndexTest, IndexPostings) {
 
   // check if the correct postings are present for each value-id
   auto expected_postings =
-      std::vector<std::unordered_set<ChunkOffset>>{{4}, {5, 6}, {5, 6}, {1, 3}, {1, 3}, {2}, {0}, {7}};
+      alloc_vector<std::unordered_set<ChunkOffset>>{{4}, {5, 6}, {5, 6}, {1, 3}, {1, 3}, {2}, {0}, {7}};
 
   for (size_t i = 0; i < index_postings->size(); ++i) {
     EXPECT_EQ(1u, expected_postings[i].count(index_postings->at(i)));

--- a/src/test/storage/multi_column_index_test.cpp
+++ b/src/test/storage/multi_column_index_test.cpp
@@ -26,17 +26,17 @@ class MultiColumnIndexTest : public BaseTest {
         "string", {"foo", "bar", "baz", "foo", "bar", "baz", "foo", "bar", "baz", "foo"});
 
     index_int_str =
-        std::make_shared<DerivedIndex>(std::vector<std::shared_ptr<BaseColumn>>{dict_col_int, dict_col_str});
+        std::make_shared<DerivedIndex>(alloc_vector<std::shared_ptr<BaseColumn>>{dict_col_int, dict_col_str});
     index_str_int =
-        std::make_shared<DerivedIndex>(std::vector<std::shared_ptr<BaseColumn>>{dict_col_str, dict_col_int});
+        std::make_shared<DerivedIndex>(alloc_vector<std::shared_ptr<BaseColumn>>{dict_col_str, dict_col_int});
   }
 
   template <class Iterator>
-  static std::vector<std::vector<AllTypeVariant>> result_as_vector(const std::vector<std::shared_ptr<BaseColumn>> cols,
-                                                                   Iterator begin, Iterator end) {
-    std::vector<std::vector<AllTypeVariant>> result{};
+  static alloc_vector<alloc_vector<AllTypeVariant>> result_as_vector(
+      const alloc_vector<std::shared_ptr<BaseColumn>> cols, Iterator begin, Iterator end) {
+    alloc_vector<alloc_vector<AllTypeVariant>> result{};
     for (auto iter(std::move(begin)); iter != end; ++iter) {
-      auto row = std::vector<AllTypeVariant>{};
+      auto row = alloc_vector<AllTypeVariant>{};
       for (auto column : cols) {
         row.emplace_back((*column)[*iter]);
       }
@@ -61,8 +61,8 @@ TYPED_TEST(MultiColumnIndexTest, FullRange) {
   auto result_values_int_str =
       this->result_as_vector({this->dict_col_int, this->dict_col_str}, begin_int_str, end_int_str);
   auto expected_values_int_str =
-      std::vector<std::vector<AllTypeVariant>>{{0, "baz"}, {1, "baz"}, {2, "bar"}, {3, "foo"}, {4, "bar"},
-                                               {4, "bar"}, {4, "foo"}, {7, "baz"}, {8, "foo"}, {9, "foo"}};
+      alloc_vector<alloc_vector<AllTypeVariant>>{{0, "baz"}, {1, "baz"}, {2, "bar"}, {3, "foo"}, {4, "bar"},
+                                                 {4, "bar"}, {4, "foo"}, {7, "baz"}, {8, "foo"}, {9, "foo"}};
   EXPECT_EQ(expected_values_int_str, result_values_int_str);
 
   auto begin_str_int = this->index_str_int->cbegin();
@@ -70,8 +70,8 @@ TYPED_TEST(MultiColumnIndexTest, FullRange) {
   auto result_values_str_int =
       this->result_as_vector({this->dict_col_str, this->dict_col_int}, begin_str_int, end_str_int);
   auto expected_values_str_int =
-      std::vector<std::vector<AllTypeVariant>>{{"bar", 2}, {"bar", 4}, {"bar", 4}, {"baz", 0}, {"baz", 1},
-                                               {"baz", 7}, {"foo", 3}, {"foo", 4}, {"foo", 8}, {"foo", 9}};
+      alloc_vector<alloc_vector<AllTypeVariant>>{{"bar", 2}, {"bar", 4}, {"bar", 4}, {"baz", 0}, {"baz", 1},
+                                                 {"baz", 7}, {"foo", 3}, {"foo", 4}, {"foo", 8}, {"foo", 9}};
   EXPECT_EQ(expected_values_str_int, result_values_str_int);
 }
 

--- a/src/test/storage/single_column_index_test.cpp
+++ b/src/test/storage/single_column_index_test.cpp
@@ -25,16 +25,16 @@ class SingleColumnIndexTest : public BaseTest {
  protected:
   void SetUp() override {
     dict_col_int = BaseTest::create_dict_column_by_type<int>("int", {3, 4, 0, 4, 2, 7, 8, 1, 4, 9});
-    index_int = std::make_shared<DerivedIndex>(std::vector<std::shared_ptr<BaseColumn>>({dict_col_int}));
+    index_int = std::make_shared<DerivedIndex>(alloc_vector<std::shared_ptr<BaseColumn>>({dict_col_int}));
 
     dict_col_str =
         BaseTest::create_dict_column_by_type<std::string>("string", {"hello", "world", "test", "foo", "bar", "foo"});
-    index_str = std::make_shared<DerivedIndex>(std::vector<std::shared_ptr<BaseColumn>>({dict_col_str}));
+    index_str = std::make_shared<DerivedIndex>(alloc_vector<std::shared_ptr<BaseColumn>>({dict_col_str}));
   }
 
   template <class Iterator>
-  static std::vector<AllTypeVariant> result_as_vector(std::shared_ptr<BaseColumn> col, Iterator begin, Iterator end) {
-    std::vector<AllTypeVariant> result{};
+  static alloc_vector<AllTypeVariant> result_as_vector(std::shared_ptr<BaseColumn> col, Iterator begin, Iterator end) {
+    alloc_vector<AllTypeVariant> result{};
     for (auto iter(std::move(begin)); iter != end; ++iter) {
       result.emplace_back((*col)[*iter]);
     }
@@ -56,13 +56,13 @@ TYPED_TEST(SingleColumnIndexTest, FullRange) {
   auto begin_int = this->index_int->cbegin();
   auto end_int = this->index_int->cend();
   auto result_values_int = this->result_as_vector(this->dict_col_int, begin_int, end_int);
-  auto expected_values_int = std::vector<AllTypeVariant>{0, 1, 2, 3, 4, 4, 4, 7, 8, 9};
+  auto expected_values_int = alloc_vector<AllTypeVariant>{0, 1, 2, 3, 4, 4, 4, 7, 8, 9};
   EXPECT_EQ(expected_values_int, result_values_int);
 
   auto begin_str = this->index_str->cbegin();
   auto end_str = this->index_str->cend();
   auto result_values_str = this->result_as_vector(this->dict_col_str, begin_str, end_str);
-  auto expected_values_str = std::vector<AllTypeVariant>{"bar", "foo", "foo", "hello", "test", "world"};
+  auto expected_values_str = alloc_vector<AllTypeVariant>{"bar", "foo", "foo", "hello", "test", "world"};
   EXPECT_EQ(expected_values_str, result_values_str);
 }
 
@@ -102,7 +102,7 @@ TYPED_TEST(SingleColumnIndexTest, RangeQuery) {
   auto result_values = this->result_as_vector(this->dict_col_int, begin, end);
 
   auto expected_positions = std::set<std::size_t>{0, 4, 7};
-  auto expected_values = std::vector<AllTypeVariant>{1, 2, 3};
+  auto expected_values = alloc_vector<AllTypeVariant>{1, 2, 3};
 
   EXPECT_EQ(expected_positions, result_positions);
   EXPECT_EQ(expected_values, result_values);
@@ -177,7 +177,7 @@ TYPED_TEST(SingleColumnIndexTest, IndexOnNonDictionaryThrows) {
   auto vc_int = make_shared_by_column_type<BaseColumn, ValueColumn>("int");
   vc_int->append(4);
 
-  EXPECT_THROW(std::make_shared<TypeParam>(std::vector<std::shared_ptr<BaseColumn>>({vc_int})), std::logic_error);
+  EXPECT_THROW(std::make_shared<TypeParam>(alloc_vector<std::shared_ptr<BaseColumn>>({vc_int})), std::logic_error);
 }
 
 }  // namespace opossum

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -80,7 +80,7 @@ TEST_F(StorageTableTest, ShrinkingMvccColumnsHasNoSideEffects) {
 
   auto& chunk = t.get_chunk(0u);
 
-  const auto values = std::vector<CommitID>{1u, 2u};
+  const auto values = alloc_vector<CommitID>{1u, 2u};
 
   {
     // acquiring mvcc_columns locks them

--- a/src/test/storage/variable_length_key_store_test.cpp
+++ b/src/test/storage/variable_length_key_store_test.cpp
@@ -130,8 +130,8 @@ TEST_F(VariableLengthKeyStoreTest, DereferenceIterator) {
 }
 
 TEST_F(VariableLengthKeyStoreTest, CopyWithStd) {
-  auto result = std::vector<VariableLengthKey>(_store.size());
-  auto expected = std::vector<VariableLengthKey>{_key_reference, _key_equal, _key_less, _key_greater};
+  auto result = alloc_vector<VariableLengthKey>(_store.size());
+  auto expected = alloc_vector<VariableLengthKey>{_key_reference, _key_equal, _key_less, _key_greater};
   std::copy(_store.cbegin(), _store.cend(), result.begin());
   EXPECT_EQ(expected, result);
 }

--- a/src/test/tasks/chunk_compression_task_test.cpp
+++ b/src/test/tasks/chunk_compression_task_test.cpp
@@ -26,7 +26,7 @@ TEST_F(ChunkCompressionTaskTest, CompressionPreservesTableContent) {
   auto table_dict = load_table("src/test/tables/compression_input.tbl", 6u);
   StorageManager::get().add_table("table_dict", table_dict);
 
-  auto compression = std::make_unique<ChunkCompressionTask>("table_dict", std::vector<ChunkID>{0u, 1u}, false);
+  auto compression = std::make_unique<ChunkCompressionTask>("table_dict", alloc_vector<ChunkID>{0u, 1u}, false);
   compression->execute();
 
   ASSERT_TABLE_EQ(table, table_dict);
@@ -36,14 +36,14 @@ TEST_F(ChunkCompressionTaskTest, DictionarySize) {
   auto table_dict = load_table("src/test/tables/compression_input.tbl", 6u);
   StorageManager::get().add_table("table_dict", table_dict);
 
-  auto compression = std::make_unique<ChunkCompressionTask>("table_dict", std::vector<ChunkID>{0u, 1u}, false);
+  auto compression = std::make_unique<ChunkCompressionTask>("table_dict", alloc_vector<ChunkID>{0u, 1u}, false);
   compression->execute();
 
   constexpr auto chunk_count = 2u;
 
   ASSERT_EQ(table_dict->chunk_count(), chunk_count);
 
-  auto dictionary_sizes = std::array<std::vector<size_t>, chunk_count>{{{3u, 3u}, {2u, 3u}}};
+  auto dictionary_sizes = std::array<alloc_vector<size_t>, chunk_count>{{{3u, 3u}, {2u, 3u}}};
 
   for (auto chunk_id = 0u; chunk_id < chunk_count; ++chunk_id) {
     auto& chunk = table_dict->get_chunk(chunk_id);


### PR DESCRIPTION
This PR adds the custom vector types `opossum::alloc_vector` and `opossum::alloc_concurrent_vector`. Defined in `src/lib/types.hpp`.

When using custom allocators with vectors, the allocator type needs to be specified in the type definition e.g., `std::vector<int, CustomAllocator<int>>`. This typedef needs to be carried throughout the code base. Renaming the vectors in one place makes this less painful and easily changeable.

Currently, they are just renames of their std/tbb counter parts. In the near future, this could be used with custom allocators with NUMA or alignment capabilities.