### PR TITLE
Validate Operator Constructor accesses input - issue #48

### DIFF
--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -28,8 +28,7 @@ bool is_row_visible(CommitID our_tid, CommitID our_lcid, ChunkOffset chunk_offse
 
 }  // namespace
 
-Validate::Validate(const std::shared_ptr<AbstractOperator> in)
-    : AbstractReadOnlyOperator(in), _in_table(in->get_output()), _output(std::make_shared<Table>()) {}
+Validate::Validate(const std::shared_ptr<AbstractOperator> in) : AbstractReadOnlyOperator(in) {}
 
 const std::string Validate::name() const { return "Validate"; }
 
@@ -42,6 +41,7 @@ std::shared_ptr<const Table> Validate::on_execute() {
 }
 
 std::shared_ptr<const Table> Validate::on_execute(std::shared_ptr<TransactionContext> transactionContext) {
+  const auto _in_table = input_table_left();
   auto output = std::make_shared<Table>();
 
   // Save column structure.

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -26,10 +26,6 @@ class Validate : public AbstractReadOnlyOperator {
  protected:
   std::shared_ptr<const Table> on_execute(std::shared_ptr<TransactionContext> transactionContext) override;
   std::shared_ptr<const Table> on_execute() override;
-
- protected:
-  const std::shared_ptr<const Table> _in_table;
-  std::shared_ptr<Table> _output;
 };
 
 }  // namespace opossum


### PR DESCRIPTION
- Remove unused variables from Validate Class
- Move get input table from constructor to on_execute function
Closes #48 .