### PR TITLE
Fixed inserting into compressed chunk (#68)

### DIFF
--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -7,6 +7,7 @@
 
 #include "concurrency/transaction_context.hpp"
 #include "storage/storage_manager.hpp"
+#include "storage/untyped_dictionary_column.hpp"
 #include "storage/value_column.hpp"
 #include "utils/assert.hpp"
 
@@ -89,6 +90,12 @@ std::shared_ptr<const Table> Insert::on_execute(std::shared_ptr<TransactionConte
     start_chunk_id = _target_table->chunk_count() - 1;
     auto& last_chunk = _target_table->get_chunk(start_chunk_id);
     start_index = last_chunk.size();
+
+    // If last chunk is compressed, add a new uncompressed chunk
+    if (std::dynamic_pointer_cast<UntypedDictionaryColumn>(last_chunk.get_column(0)) != nullptr) {
+      _target_table->create_new_chunk();
+      total_chunks_inserted++;
+    }
 
     auto remaining_rows = total_rows_to_insert;
     while (remaining_rows > 0) {

--- a/src/test/operators/insert_test.cpp
+++ b/src/test/operators/insert_test.cpp
@@ -8,6 +8,7 @@
 #include "../../lib/concurrency/transaction_context.hpp"
 #include "../../lib/operators/get_table.hpp"
 #include "../../lib/operators/insert.hpp"
+#include "../../lib/storage/dictionary_compression.hpp"
 #include "../../lib/storage/storage_manager.hpp"
 #include "../../lib/storage/table.hpp"
 
@@ -88,6 +89,32 @@ TEST_F(OperatorsInsertTest, MultipleChunks) {
 
   EXPECT_EQ(t->chunk_count(), 7u);
   EXPECT_EQ(t->get_chunk(6).size(), 1u);
+  EXPECT_EQ(t->row_count(), 13u);
+}
+
+TEST_F(OperatorsInsertTest, CompressedChunks) {
+  auto t_name = "test1";
+  auto t_name2 = "test2";
+
+  // 3 Rows
+  auto t = load_table("src/test/tables/int.tbl", 2u);
+  StorageManager::get().add_table(t_name, t);
+  opossum::DictionaryCompression::compress_table(*t);
+
+  // 10 Rows
+  auto t2 = load_table("src/test/tables/10_ints.tbl", 0u);
+  StorageManager::get().add_table(t_name2, t2);
+
+  auto gt2 = std::make_shared<GetTable>(t_name2);
+  gt2->execute();
+
+  auto ins = std::make_shared<Insert>(t_name, gt2);
+  auto context = std::make_shared<TransactionContext>(1, 1);
+  ins->set_transaction_context(context);
+  ins->execute();
+
+  EXPECT_EQ(t->chunk_count(), 7u);
+  EXPECT_EQ(t->get_chunk(6).size(), 2u);
   EXPECT_EQ(t->row_count(), 13u);
 }
 


### PR DESCRIPTION
- Fixed by adding a new chunk to output table, if the last chunk is compressed
- Check for compression is done by a dynamic pointer cast of a column of the last chunk to `UntypedDictionaryColumn`
Closes #68 