### PR TITLE
[SMALL] Add file and line to DebugAssert output

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,11 @@ else()
     add_definitions(-DOPOSSUM_NUMA_SUPPORT=0)
 endif()
 
+# This will be used by the DebugAssert macro to output
+# a file path relative to CMAKE_SOURCE_DIR
+string(LENGTH "${CMAKE_SOURCE_DIR}/" SOURCE_PATH_SIZE)
+add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
+
 # Global flags and include directories
 add_compile_options(-std=c++1z -pthread -Wno-error=unused-parameter -Wall -Werror)
 

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <boost/preprocessor/stringize.hpp>
+
 #include <exception>
 #include <string>
 
@@ -45,7 +47,9 @@ inline void Fail(const std::string& msg) { throw std::logic_error(msg); }
 
 #if IS_DEBUG
 
-#define DebugAssert(expr, msg) opossum::Assert(expr, msg)
+#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+
+#define DebugAssert(expr, msg) opossum::Assert(expr, std::string{__FILENAME__} + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg)
 
 #else
 


### PR DESCRIPTION
This adds the location where DebugAssert failed to the output message.

```
src/bin/playground.cpp:10 Something happened.
```