### PR TITLE
Make lint script faster

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python2.7 cpplint.py --verbose=3 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11 --linelength=120 src/**/*.{hpp,cpp}
+python2.7 cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11 --linelength=120 src/**/*.{hpp,cpp}


### PR DESCRIPTION
The `lint.sh` script has always been pretty slow - for me at least -, so I decided to optimize it a little.

Instead of calling `cpplint.py` for every single file, it know uses one `cpplint.py` call that get a list of all files. On my MacBook, this made it 4X faster: 32secs vs. 7.8secs

