### PR TITLE
Fix linter for non-bash shells

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-python2.7 cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11 --linelength=120 src/**/*.{hpp,cpp}
+python2.7 cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11 --linelength=120 $(find src -iname "*.cpp" -o -iname "*.hpp")


### PR DESCRIPTION
Fix for #95 

The lint script should now work on all shells, and it's still fast :)

@torpedro I checked on my machine and pella, but can you please check if this works for you now too?