### PR TITLE
[MP internal, WIP] Adding correct statistics for predicate colA = colB

### DIFF
--- a/src/bin/playgroundStatistics.cpp
+++ b/src/bin/playgroundStatistics.cpp
@@ -17,7 +17,8 @@ int main() {
   opossum::StorageManager::get().add_table("CUSTOMER", generator.generate_customer_table());
 
   auto table_statistics = opossum::StorageManager::get().get_table("CUSTOMER")->get_table_statistics();
-  auto stat1 = table_statistics->predicate_statistics("C_ID", opossum::ScanType::OpEquals, opossum::AllParameterVariant(1));
+  auto stat1 =
+      table_statistics->predicate_statistics("C_ID", opossum::ScanType::OpEquals, opossum::AllParameterVariant(1));
   auto stat2 = stat1->predicate_statistics("C_D_ID", opossum::ScanType::OpNotEquals, opossum::AllParameterVariant(2));
   auto stat3 = stat1->predicate_statistics("C_D_ID", opossum::ScanType::OpLessThan, opossum::AllParameterVariant(5));
   std::cout << "original CUSTOMER table" << std::endl;
@@ -30,8 +31,8 @@ int main() {
   std::cout << *stat3 << std::endl;
 
   std::cout << "--- COLUMN Table Scans ---" << std::endl;
-  stat1 =
-      table_statistics->predicate_statistics("C_ID", opossum::ScanType::OpEquals, opossum::AllParameterVariant(opossum::ColumnName("C_D_ID")));
+  stat1 = table_statistics->predicate_statistics("C_ID", opossum::ScanType::OpEquals,
+                                                 opossum::AllParameterVariant(opossum::ColumnName("C_D_ID")));
   std::cout << "original CUSTOMER table" << std::endl;
   std::cout << *table_statistics << std::endl;
   std::cout << "C_ID = C_D_ID" << std::endl;

--- a/src/lib/optimizer/abstract_column_statistics.hpp
+++ b/src/lib/optimizer/abstract_column_statistics.hpp
@@ -18,9 +18,10 @@ class AbstractColumnStatistics {
   friend std::ostream &operator<<(std::ostream &os, AbstractColumnStatistics &obj) { return obj.to_stream(os); }
   virtual std::tuple<double, std::shared_ptr<AbstractColumnStatistics>> predicate_selectivity(
       const ScanType scan_type, const AllTypeVariant value, const optional<AllTypeVariant> value2) = 0;
-  virtual std::tuple<double, std::shared_ptr<AbstractColumnStatistics>, std::shared_ptr<AbstractColumnStatistics>> predicate_selectivity(
-      const ScanType scan_type, const std::shared_ptr<AbstractColumnStatistics> abstract_value_column_statistics,
-      const optional<AllTypeVariant> value2) = 0;
+  virtual std::tuple<double, std::shared_ptr<AbstractColumnStatistics>, std::shared_ptr<AbstractColumnStatistics>>
+  predicate_selectivity(const ScanType scan_type,
+                        const std::shared_ptr<AbstractColumnStatistics> abstract_value_column_statistics,
+                        const optional<AllTypeVariant> value2) = 0;
   virtual ~AbstractColumnStatistics() = default;
 
   AbstractColumnStatistics() = default;

--- a/src/lib/optimizer/column_statistics.hpp
+++ b/src/lib/optimizer/column_statistics.hpp
@@ -41,9 +41,10 @@ class ColumnStatistics : public AbstractColumnStatistics {
   ~ColumnStatistics() override = default;
   std::tuple<double, std::shared_ptr<AbstractColumnStatistics>> predicate_selectivity(
       const ScanType scan_type, const AllTypeVariant value, const optional<AllTypeVariant> value2) override;
-  std::tuple<double, std::shared_ptr<AbstractColumnStatistics>, std::shared_ptr<AbstractColumnStatistics>> predicate_selectivity(
-      const ScanType scan_type, const std::shared_ptr<AbstractColumnStatistics> abstract_value_column_statistics,
-      const optional<AllTypeVariant> value2) override;
+  std::tuple<double, std::shared_ptr<AbstractColumnStatistics>, std::shared_ptr<AbstractColumnStatistics>>
+  predicate_selectivity(const ScanType scan_type,
+                        const std::shared_ptr<AbstractColumnStatistics> abstract_value_column_statistics,
+                        const optional<AllTypeVariant> value2) override;
 
  protected:
   std::ostream& to_stream(std::ostream& os) override;

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const std
   auto table = _table.lock();
   const ColumnID column_id = table->column_id_by_name(column_name);
 
-  auto old_column_statistic = get_column_statistics(column_id);
+  auto old_column_statistics = get_column_statistics(column_id);
   auto clone = std::make_shared<TableStatistics>(*this);
   double selectivity;
   std::shared_ptr<AbstractColumnStatistics> new_column_statistics;
@@ -70,13 +70,14 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const std
     auto value_column_statistics = get_column_statistics(value_column_id);
     std::shared_ptr<AbstractColumnStatistics> new_value_column_statistics;
     std::tie(selectivity, new_column_statistics, new_value_column_statistics) =
-        old_column_statistic->predicate_selectivity(scan_type, value_column_statistics, value2);
+        old_column_statistics->predicate_selectivity(scan_type, value_column_statistics, value2);
     if (new_value_column_statistics != nullptr) {
       clone->_column_statistics[value_column_id] = new_value_column_statistics;
     }
   } else {
     auto casted_value1 = boost::get<AllTypeVariant>(value);
-    std::tie(selectivity, new_column_statistics) = old_column_statistic->predicate_selectivity(scan_type, casted_value1, value2);
+    std::tie(selectivity, new_column_statistics) =
+        old_column_statistics->predicate_selectivity(scan_type, casted_value1, value2);
   }
   if (new_column_statistics != nullptr) {
     clone->_column_statistics[column_id] = new_column_statistics;


### PR DESCRIPTION
PlaygroundStatistics failt mit `std::bad_alloc` nach dem mergen.
@FabianWiebe , falls du Zeit hast, kannst du mal draufschauen?