### PR TITLE
Only format changed files

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,10 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
 format_cmd="clang-format -i -style=file '{}'"
 
-if [ -z "${1}" ]; then
+if [ "${1}" = "all" ]; then
+    find src -iname "*.cpp" -o -iname "*.hpp" | xargs -I{} sh -c "${format_cmd}"
+elif [ "$1" = "modified" ]; then
+    # Run on all changed as well as untracked cpp/hpp files, as compared to the current HEAD. Skip deleted files.
+    { git diff --diff-filter=d --name-only & git ls-files --others --exclude-standard; } | grep -E "\.[ch]pp$" | xargs -I{} sh -c "${format_cmd}"
+else
     # Run on all changed as well as untracked cpp/hpp files, as compared to the current master. Skip deleted files.
     { git diff --diff-filter=d --name-only master & git ls-files --others --exclude-standard; } | grep -E "\.[ch]pp$" | xargs -I{} sh -c "${format_cmd}"
-else
-    find src -iname "*.cpp" -o -iname "*.hpp" | xargs -I{} sh -c "${format_cmd}"
 fi


### PR DESCRIPTION
We currently struggle with different versions of `clang-format` producing different results, as well as contradictions between the linter and formatter (#105).

In order to, at least temporarily, ease the pain I propose to only format files in the current branch that have been changed as compared to `master`.
I do not guarantee that this command will work under all circumstances, but I tested it with some different settings and I think I fixed the potentially most common issues.

Whenever you call the script without any arguments (`scripts/format.sh`) it will only format the modified and newly added files, as compared to `master`.
If you call `scripts/format.sh modified`, all those files will be formatted that have been modified or added, as compared to `HEAD` (and therefore have not been committed).
If you use `scripts/format.sh all` it will behave as before and lint all files in `src/`.

Please reach out to me if you find yourself experiencing unexpected behavior.