### PR TITLE
147: Re-factor TableScan tests

### DIFF
--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -27,7 +27,7 @@ class OperatorsTableScanTest : public BaseTest {
     std::shared_ptr<Table> test_even_dict = std::make_shared<Table>(5);
     test_even_dict->add_column("a", "int");
     test_even_dict->add_column("b", "int");
-    for (auto i = 0u; i <= 24u; i += 2) test_even_dict->append({AllTypeVariant(i), AllTypeVariant(100 + i)});
+    for (int i = 0; i <= 24; i += 2) test_even_dict->append({i, 100 + i});
     DictionaryCompression::compress_chunks(*test_even_dict, {ChunkID{0}, ChunkID{1}});
 
     _table_wrapper_even_dict = std::make_shared<TableWrapper>(std::move(test_even_dict));
@@ -39,8 +39,8 @@ class OperatorsTableScanTest : public BaseTest {
     table->add_column("a", "int");
     table->add_column("b", "float");
 
-    for (auto i = 1u; i < 20; ++i) {
-      table->append({AllTypeVariant(i), AllTypeVariant(100.1 + i)});
+    for (int i = 1; i < 20; ++i) {
+      table->append({i, 100.1 + i});
     }
 
     DictionaryCompression::compress_chunks(*table, {ChunkID{0}, ChunkID{2}});
@@ -83,16 +83,19 @@ class OperatorsTableScanTest : public BaseTest {
     return table_wrapper;
   }
 
-  std::shared_ptr<TableWrapper> get_table_op_with_n_dict_entries(const uint32_t num_entries) {
+  std::shared_ptr<TableWrapper> get_table_op_with_n_dict_entries(const int num_entries) {
     // Set up dictionary encoded table with a dictionary consisting of num_entries entries.
-    std::shared_ptr<TableWrapper> table_wrapper;
     auto table = std::make_shared<opossum::Table>(0);
     table->add_column("a", "int");
     table->add_column("b", "float");
-    for (auto i = 0u; i <= num_entries; i += 1) table->append({AllTypeVariant(i), AllTypeVariant(100.0f + i)});
+
+    for (int i = 0; i <= num_entries; i++) {
+      table->append({i, 100.0f + i});
+    }
+
     DictionaryCompression::compress_chunks(*table, {ChunkID{0}});
 
-    table_wrapper = std::make_shared<opossum::TableWrapper>(std::move(table));
+    auto table_wrapper = std::make_shared<opossum::TableWrapper>(std::move(table));
     table_wrapper->execute();
     return table_wrapper;
   }


### PR DESCRIPTION
The `SetUp()` method in `OperatorsTableScanTest` is setting up quite a few tables that are only used in a single test (or none at all, for that matter). In particular, one test is using a quite large table that is currently set up for every single test case.
This PR refactors the set-up and only sets up tables in `SetUp()` that are used in more than one test case. On my laptop, the execution time for the `OperatorsTableScanTest` was reduced from ~16.4s to ~1.6s, virtually all of which is spent for that one test case.

Fixes #147.