### PR TITLE
Fix missing include in types.hpp

### DIFF
--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <limits>
 #include <string>
+#include <tuple>
 #include <vector>
 
 #include "strong_typedef.hpp"


### PR DESCRIPTION
std::tie needs the include of the tuple header