### PR TITLE
Fix creation of string from basic_string_view

### DIFF
--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -170,7 +170,7 @@ void CsvParser::_parse_into_chunk(string_view csv_chunk, const std::vector<size_
   for (ChunkOffset row_id = 0; row_id < row_count; ++row_id) {
     for (ColumnID column_id{0}; column_id < col_count; ++column_id) {
       const auto end = field_ends.at(row_id * col_count + column_id);
-      auto field = csv_chunk.substr(start, end - start).to_string();
+      auto field = std::string{csv_chunk.substr(start, end - start)};
       start = end + 1;
 
       if (!_csv_config.rfc_mode) {


### PR DESCRIPTION
Hyrise cannot be built with certain compilers due to the following error:

```c++
/Users/tim/Documents/school/hpi/master/ss2017/mp/code/zweirise/src/lib/import_export/csv_parser.cpp:173:57: error: no member named 'to_string' in 'std::__1::basic_string_view<char, std::__1::char_traits<char> >'
     auto field = csv_chunk.substr(start, end - start).to_string();
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
```

Apparently, this method is only available in the experimental header and has been removed from the standard. Instead, we can use the constructor of `std::string`.