### PR TITLE
Prevent AbstractASTNode::clear_parent() from producing inconsistent state

### DIFF
--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
@@ -15,7 +15,20 @@ AbstractASTNode::AbstractASTNode(ASTNodeType node_type) : _type(node_type) {}
 
 std::shared_ptr<AbstractASTNode> AbstractASTNode::parent() const { return _parent.lock(); }
 
-void AbstractASTNode::clear_parent() { _parent = {}; }
+void AbstractASTNode::clear_parent() {
+  // _parent is a weak_ptr that we need to lock
+  auto parent_ptr = parent();
+  if (!parent_ptr) return;
+
+  if (parent_ptr->_left_child.get() == this) {
+    parent_ptr->set_left_child(nullptr);
+  } else if (parent_ptr->_right_child.get() == this) {
+    parent_ptr->set_right_child(nullptr);
+  } else {
+    Fail("Invalid AST: ASTNode is not child of his parent.");
+  }
+  _parent = {};
+}
 
 const std::shared_ptr<AbstractASTNode> &AbstractASTNode::left_child() const { return _left_child; }
 

--- a/src/test/optimizer/abstract_syntax_tree_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree_test.cpp
@@ -44,6 +44,25 @@ TEST_F(AbstractSyntaxTreeTest, ParentTest) {
   ASSERT_EQ(projection_node->parent(), nullptr);
 }
 
+TEST_F(AbstractSyntaxTreeTest, ClearParentTest) {
+  const auto table_node = std::make_shared<StoredTableNode>("a");
+
+  const auto predicate_node = std::make_shared<PredicateNode>("c1", nullptr, ScanType::OpEquals, "a");
+  predicate_node->set_left_child(table_node);
+
+  ASSERT_EQ(table_node->parent(), predicate_node);
+  ASSERT_EQ(predicate_node->left_child(), table_node);
+  ASSERT_EQ(predicate_node->right_child(), nullptr);
+  ASSERT_EQ(predicate_node->parent(), nullptr);
+
+  table_node->clear_parent();
+
+  ASSERT_EQ(table_node->parent(), nullptr);
+  ASSERT_EQ(predicate_node->left_child(), nullptr);
+  ASSERT_EQ(predicate_node->right_child(), nullptr);
+  ASSERT_EQ(predicate_node->parent(), nullptr);
+}
+
 TEST_F(AbstractSyntaxTreeTest, ChainSameNodesTest) {
   const auto table_node = std::make_shared<StoredTableNode>("a");
 


### PR DESCRIPTION
This fixes ```AbstractASTNode::clear_parent```, which led to inconsistent ASTs.

Whenever ```clear_parent``` was called, the parent relationship was deleted, but not the respective child relationship. Due to that the parent node kept its pointer to this child, whereas the child did not have a parent anymore.