### PR TITLE
Add Validate operator to query plan

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -149,6 +149,8 @@ set(
     optimizer/abstract_syntax_tree/sort_node.hpp
     optimizer/abstract_syntax_tree/stored_table_node.cpp
     optimizer/abstract_syntax_tree/stored_table_node.hpp
+    optimizer/abstract_syntax_tree/validate_node.cpp
+    optimizer/abstract_syntax_tree/validate_node.hpp
     optimizer/base_column_statistics.hpp
     optimizer/column_statistics.cpp
     optimizer/column_statistics.hpp

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
@@ -9,7 +9,7 @@ namespace opossum {
 
 class TableStatistics;
 
-enum class ASTNodeType { Aggregate, Join, Predicate, Projection, Sort, StoredTable };
+enum class ASTNodeType { Aggregate, Join, Predicate, Projection, Sort, StoredTable, Validate };
 
 /**
  * Abstract element in an Abstract Syntax Tree.

--- a/src/lib/optimizer/abstract_syntax_tree/ast_to_operator_translator.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/ast_to_operator_translator.cpp
@@ -12,13 +12,14 @@
 #include "operators/projection.hpp"
 #include "operators/sort.hpp"
 #include "operators/table_scan.hpp"
+#include "operators/validate.hpp"
 #include "optimizer/abstract_syntax_tree/abstract_ast_node.hpp"
 #include "optimizer/abstract_syntax_tree/aggregate_node.hpp"
 #include "optimizer/abstract_syntax_tree/join_node.hpp"
 #include "optimizer/abstract_syntax_tree/predicate_node.hpp"
+#include "optimizer/abstract_syntax_tree/projection_node.hpp"
 #include "optimizer/abstract_syntax_tree/sort_node.hpp"
 #include "optimizer/abstract_syntax_tree/stored_table_node.hpp"
-#include "projection_node.hpp"
 
 namespace opossum {
 
@@ -47,6 +48,8 @@ ASTToOperatorTranslator::ASTToOperatorTranslator() {
       std::bind(&ASTToOperatorTranslator::_translate_join_node, this, std::placeholders::_1);
   _operator_factory[ASTNodeType::Aggregate] =
       std::bind(&ASTToOperatorTranslator::_translate_aggregate_node, this, std::placeholders::_1);
+  _operator_factory[ASTNodeType::Validate] =
+      std::bind(&ASTToOperatorTranslator::_translate_validate_node, this, std::placeholders::_1);
 }
 
 std::shared_ptr<AbstractOperator> ASTToOperatorTranslator::translate_node(
@@ -176,6 +179,12 @@ std::shared_ptr<AbstractOperator> ASTToOperatorTranslator::_translate_aggregate_
   out_operator = std::make_shared<Aggregate>(out_operator, aggregate_definitions, aggregate_node->groupby_columns());
 
   return out_operator;
+}
+
+std::shared_ptr<AbstractOperator> ASTToOperatorTranslator::_translate_validate_node(
+    const std::shared_ptr<AbstractASTNode> &node) const {
+  const auto input_operator = translate_node(node->left_child());
+  return std::make_shared<Validate>(input_operator);
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/abstract_syntax_tree/ast_to_operator_translator.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/ast_to_operator_translator.hpp
@@ -33,6 +33,7 @@ class ASTToOperatorTranslator final : public boost::noncopyable {
   std::shared_ptr<AbstractOperator> _translate_sort_node(const std::shared_ptr<AbstractASTNode> &node) const;
   std::shared_ptr<AbstractOperator> _translate_join_node(const std::shared_ptr<AbstractASTNode> &node) const;
   std::shared_ptr<AbstractOperator> _translate_aggregate_node(const std::shared_ptr<AbstractASTNode> &node) const;
+  std::shared_ptr<AbstractOperator> _translate_validate_node(const std::shared_ptr<AbstractASTNode> &node) const;
 
   std::unordered_map<ASTNodeType, std::function<std::shared_ptr<AbstractOperator>(std::shared_ptr<AbstractASTNode>)>>
       _operator_factory;

--- a/src/lib/optimizer/abstract_syntax_tree/validate_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/validate_node.cpp
@@ -1,0 +1,11 @@
+#include "validate_node.hpp"
+
+#include <string>
+
+namespace opossum {
+
+ValidateNode::ValidateNode() : AbstractASTNode(ASTNodeType::Validate) {}
+
+std::string ValidateNode::description() const { return "Validate"; }
+
+}  // namespace opossum

--- a/src/lib/optimizer/abstract_syntax_tree/validate_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/validate_node.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+
+#include "common.hpp"
+#include "optimizer/abstract_syntax_tree/abstract_ast_node.hpp"
+
+namespace opossum {
+
+/**
+ * This node type represents validating tables with the Validate operator.
+ */
+class ValidateNode : public AbstractASTNode {
+ public:
+  explicit ValidateNode();
+
+  std::string description() const override;
+};
+
+}  // namespace opossum

--- a/src/lib/sql/sql_to_ast_translator.cpp
+++ b/src/lib/sql/sql_to_ast_translator.cpp
@@ -14,6 +14,7 @@
 #include "optimizer/abstract_syntax_tree/projection_node.hpp"
 #include "optimizer/abstract_syntax_tree/sort_node.hpp"
 #include "optimizer/abstract_syntax_tree/stored_table_node.hpp"
+#include "optimizer/abstract_syntax_tree/validate_node.hpp"
 #include "optimizer/expression/expression_node.hpp"
 #include "sql/sql_expression_translator.hpp"
 #include "storage/storage_manager.hpp"
@@ -167,10 +168,17 @@ std::shared_ptr<AbstractASTNode> SQLToASTTranslator::_translate_cross_product(
   return product;
 }
 
+std::shared_ptr<AbstractASTNode> SQLToASTTranslator::_get_table_and_validate(const std::string& table_name) {
+  auto stored_table_node = std::make_shared<StoredTableNode>(table_name);
+  auto validate_node = std::make_shared<ValidateNode>();
+  validate_node->set_left_child(stored_table_node);
+  return validate_node;
+}
+
 std::shared_ptr<AbstractASTNode> SQLToASTTranslator::_translate_table_ref(const hsql::TableRef& table) {
   switch (table.type) {
     case hsql::kTableName:
-      return std::make_shared<StoredTableNode>(table.name);
+      return _get_table_and_validate(std::string(table.name));
     case hsql::kTableSelect:
       return _translate_select(*table.select);
     case hsql::kTableJoin:

--- a/src/lib/sql/sql_to_ast_translator.hpp
+++ b/src/lib/sql/sql_to_ast_translator.hpp
@@ -57,6 +57,7 @@ class SQLToASTTranslator final : public boost::noncopyable {
   std::shared_ptr<AbstractASTNode> _translate_select(const hsql::SelectStatement& select);
 
   std::shared_ptr<AbstractASTNode> _translate_table_ref(const hsql::TableRef& table);
+  std::shared_ptr<AbstractASTNode> _get_table_and_validate(const std::string& table_name);
 
   std::shared_ptr<AbstractASTNode> _translate_filter_expr(const hsql::Expr& expr,
                                                           const std::shared_ptr<AbstractASTNode>& input_node);


### PR DESCRIPTION
The `Validate` operator is required to filter rows that are not visible to the current transaction.
Currently, the `Translator` does not add it to the query plan.

In this PR, `Validate` will be added to the plan right after `GetTable`. This ensures that only valid rows are visible for each of the operators.
However, this might not be the ideal place to place this operator since it potentially is expensive. There should be a follow-up PR with an optimizer rule that can re-order this node in the AST.

This PR is blocked by #187. We have to find a solution there first and it has to be implemented in here so that other parts (e.g. `SQLQueryOperator`) take it into account.