### PR TITLE
Add DebugAssert for TransactionContext in Validate operator

### DIFF
--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -41,7 +41,9 @@ std::shared_ptr<const Table> Validate::on_execute() {
   return {};
 }
 
-std::shared_ptr<const Table> Validate::on_execute(std::shared_ptr<TransactionContext> transactionContext) {
+std::shared_ptr<const Table> Validate::on_execute(std::shared_ptr<TransactionContext> transaction_context) {
+  DebugAssert(transaction_context != nullptr, "Validate requires a valid TransactionContext.");
+
   const auto _in_table = input_table_left();
   auto output = std::make_shared<Table>();
 
@@ -50,8 +52,8 @@ std::shared_ptr<const Table> Validate::on_execute(std::shared_ptr<TransactionCon
     output->add_column_definition(_in_table->column_name(column_id), _in_table->column_type(column_id));
   }
 
-  const auto our_tid = transactionContext->transaction_id();
-  const auto our_lcid = transactionContext->last_commit_id();
+  const auto our_tid = transaction_context->transaction_id();
+  const auto our_lcid = transaction_context->last_commit_id();
 
   for (ChunkID chunk_id{0}; chunk_id < _in_table->chunk_count(); ++chunk_id) {
     const auto &chunk_in = _in_table->get_chunk(chunk_id);

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -30,7 +30,7 @@ class Validate : public AbstractReadOnlyOperator {
   }
 
  protected:
-  std::shared_ptr<const Table> on_execute(std::shared_ptr<TransactionContext> transactionContext) override;
+  std::shared_ptr<const Table> on_execute(std::shared_ptr<TransactionContext> transaction_context) override;
   std::shared_ptr<const Table> on_execute() override;
 };
 


### PR DESCRIPTION
The `Validate` operator should make sure that there is a valid `TransactionContext` when it is executed. Otherwise, we potentially experience undefined behavior without noticing it.