### PR TITLE
Fix install script running out of memory (Ubuntu)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             if sudo apt-get update >/dev/null; then
                 if sudo apt-get install -y libboost-all-dev clang-format gcovr python2.7 gcc-6 clang llvm libnuma-dev libnuma1 libtbb-dev build-essential autoconf libtool cmake libreadline-dev; then
                     if git submodule update --init --recursive; then
-                        if CPPFLAGS="-Wno-deprecated-declarations" CFLAGS="-Wno-deprecated-declarations -Wno-implicit-function-declaration -Wno-shift-negative-value" make static -j $(sysctl -n hw.ncpu) --directory=third_party/grpc REQUIRE_CUSTOM_LIBRARIES_opt=true; then
+                        if CPPFLAGS="-Wno-deprecated-declarations" CFLAGS="-Wno-deprecated-declarations -Wno-implicit-function-declaration -Wno-shift-negative-value" make static -j $(nproc) --directory=third_party/grpc REQUIRE_CUSTOM_LIBRARIES_opt=true; then
                             echo "Installation successful"
                         else
                             echo "Error during gRPC installation."


### PR DESCRIPTION
On my machine (Ubuntu 17.04), the command `sysctl -n hw.ncpu` errors with `sysctl: cannot stat /proc/sys/hw/ncpu: No such file or directory`, which then results in running out of memory during the third party installs.
Can we use the command `nproc` instead, which returns the number of cores, or is anything else wrong with that?