### PR TITLE
Fix color in welcome message.

### DIFF
--- a/src/bin/console.cpp
+++ b/src/bin/console.cpp
@@ -25,9 +25,9 @@
 #include "tpcc/tpcc_table_generator.hpp"
 #include "utils/load_table.hpp"
 
-#define ANSI_COLOR_RED   "\001\e[0;31m\002"
-#define ANSI_COLOR_GREEN "\001\e[0;32m\002"
-#define ANSI_COLOR_RESET "\001\e[0m\002"
+#define ANSI_COLOR_RED   "\x1b[31m"
+#define ANSI_COLOR_GREEN "\x1b[32m"
+#define ANSI_COLOR_RESET "\x1b[0m"
 
 namespace {
 


### PR DESCRIPTION
Somehow the colored `(debug)` and `(release)` had some weird symbols at the beginning and end for me in the welcome message (not in the prompt though). I changed the color definitions, now it works for me.