### PR TITLE
Fix bug #285 MacOS Clang Build Error - unused variable

### DIFF
--- a/src/lib/utils/numa_memory_resource.hpp
+++ b/src/lib/utils/numa_memory_resource.hpp
@@ -25,8 +25,8 @@ class NUMAMemoryResource : public boost::container::pmr::memory_resource {
  private:
 #if OPOSSUM_NUMA_SUPPORT
   const numa::MemSource _mem_source;
-#endif
   const size_t _alignment = 1;
+#endif
 };
 
 }  // namespace opossum


### PR DESCRIPTION
Variable _alignment is only used when flag OPOSSUM_NUMA_SUPPORT is set.
With this fix the variable is also only defined when flag is set.
Closes #285 .