### PR TITLE
Build googletest with ASAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ find_package(Readline REQUIRED)
 
 # Include sub-CMakeLists.txt
 add_subdirectory(third_party/)
-add_subdirectory(src)
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
+add_subdirectory(src)
 
 if(${NUMA_FOUND})
     set(PGASUS_WITH_TASKING OFF CACHE BOOL "" FORCE)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -96,6 +96,18 @@ set(
     gtest
 )
 
+# Build special ASAN version of googletest
+include_directories(../../third_party/googletest/googletest/)
+
+set(
+    GTEST_SOURCES
+    ../../third_party/googletest/googletest/src/gtest-all.cc
+)
+add_library(gtestAsan EXCLUDE_FROM_ALL STATIC ${GTEST_SOURCES})
+set_target_properties(gtestAsan PROPERTIES SUFFIX "_asan")
+set_target_properties(gtestAsan PROPERTIES COMPILE_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
+
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Configure opossumTest
@@ -109,7 +121,7 @@ set_target_properties(opossumCoverage PROPERTIES COMPILE_FLAGS "-fprofile-arcs -
 
 # Configure opossumAsanApp
 add_executable(opossumAsan EXCLUDE_FROM_ALL ${OPOSSUM_TEST_SOURCES})
-target_link_libraries(opossumAsan opossumAsanLib ${LIBRARIES} -fsanitize=address)
+target_link_libraries(opossumAsan opossumAsanLib gtestAsan -fsanitize=address)
 set_target_properties(opossumAsan PROPERTIES COMPILE_FLAGS "-fsanitize=address -fno-omit-frame-pointer")
 
 # Configure opossumTestTPCC


### PR DESCRIPTION
To fix #66, this adds a separate `googletest` build target that is built with ASAN options. This is necessary on some systems for `opossumAsan` to work, e.g., on macOS with clang. This issue is also mentioned in the `googletest` repo [here](https://github.com/google/googletest/issues/487).