### PR TITLE
Remove use of [] operator in column statistics

### DIFF
--- a/src/lib/optimizer/column_statistics.cpp
+++ b/src/lib/optimizer/column_statistics.cpp
@@ -91,12 +91,10 @@ void ColumnStatistics<ColumnType>::_initialize_min_max() const {
 
   auto min_column =
       std::static_pointer_cast<ValueColumn<ColumnType>>(aggregate_table->get_chunk(ChunkID{0}).get_column(ColumnID{0}));
-  DebugAssert(min_column != nullptr, "MIN column in aggregate is not a ValueColumn");
   _min = min_column->values()[0];
 
   auto max_column =
       std::static_pointer_cast<ValueColumn<ColumnType>>(aggregate_table->get_chunk(ChunkID{0}).get_column(ColumnID{1}));
-  DebugAssert(max_column != nullptr, "MAX column in aggregate is not a ValueColumn");
   _max = max_column->values()[0];
 }
 


### PR DESCRIPTION
This PR will exorcise the evil that is `operator[]` in `ColumnStatistics::_initialize_min_max`. Instead, the aggregate output is cast into `ValueColumn` so that the value vector can be read directly.

Fixes #327 