### PR TITLE
Fix JoinDetectionRule naming

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -15,7 +15,7 @@ const Optimizer& Optimizer::get() {
 
 Optimizer::Optimizer() {
   _rules.emplace_back(std::make_shared<PredicateReorderingRule>());
-  _rules.emplace_back(std::make_shared<JoinConditionDetectionRule>());
+  _rules.emplace_back(std::make_shared<JoinDetectionRule>());
 }
 
 std::shared_ptr<AbstractASTNode> Optimizer::optimize(const std::shared_ptr<AbstractASTNode>& input) const {

--- a/src/lib/optimizer/strategy/join_detection_rule.cpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.cpp
@@ -16,7 +16,7 @@
 
 namespace opossum {
 
-bool JoinConditionDetectionRule::apply_to(const std::shared_ptr<AbstractASTNode>& node) {
+bool JoinDetectionRule::apply_to(const std::shared_ptr<AbstractASTNode>& node) {
   if (node->type() == ASTNodeType::Join) {
     // ... "potential"_cross_join_node until this if below
     auto cross_join_node = std::dynamic_pointer_cast<JoinNode>(node);
@@ -46,7 +46,7 @@ bool JoinConditionDetectionRule::apply_to(const std::shared_ptr<AbstractASTNode>
   return _apply_to_children(node);
 }
 
-std::optional<JoinConditionDetectionRule::JoinCondition> JoinConditionDetectionRule::_find_predicate_for_cross_join(
+std::optional<JoinDetectionRule::JoinCondition> JoinDetectionRule::_find_predicate_for_cross_join(
     const std::shared_ptr<JoinNode>& cross_join) {
   Assert(cross_join->left_child() && cross_join->right_child(), "Cross Join must have two children");
 
@@ -109,7 +109,7 @@ std::optional<JoinConditionDetectionRule::JoinCondition> JoinConditionDetectionR
   return std::nullopt;
 }
 
-bool JoinConditionDetectionRule::_is_join_condition(ColumnID left, ColumnID right, size_t left_num_cols,
+bool JoinDetectionRule::_is_join_condition(ColumnID left, ColumnID right, size_t left_num_cols,
                                                     size_t right_num_cols) const {
   auto left_value = static_cast<ColumnID::base_type>(left);
   auto right_value = static_cast<ColumnID::base_type>(right);

--- a/src/lib/optimizer/strategy/join_detection_rule.hpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.hpp
@@ -38,7 +38,7 @@ struct ColumnID;
  * have to deal with ColumnID re-mappings for now. Projections, Aggregates, etc. amidst Joins and Predicates
  * should be rare anyway.
  */
-class JoinConditionDetectionRule : public AbstractRule {
+class JoinDetectionRule : public AbstractRule {
  protected:
   bool apply_to(const std::shared_ptr<AbstractASTNode>& node) override;
 

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -36,7 +36,7 @@ class JoinDetectionRuleTest : public StrategyBaseTest, public ::testing::WithPar
     _table_node_b = std::make_shared<StoredTableNode>("b");
     _table_node_c = std::make_shared<StoredTableNode>("c");
 
-    _rule = std::make_shared<JoinConditionDetectionRule>();
+    _rule = std::make_shared<JoinDetectionRule>();
   }
 
   uint8_t _count_cross_joins(const std::shared_ptr<AbstractASTNode>& node) {
@@ -59,7 +59,7 @@ class JoinDetectionRuleTest : public StrategyBaseTest, public ::testing::WithPar
   }
 
   std::shared_ptr<StoredTableNode> _table_node_a, _table_node_b, _table_node_c;
-  std::shared_ptr<JoinConditionDetectionRule> _rule;
+  std::shared_ptr<JoinDetectionRule> _rule;
 };
 
 TEST_F(JoinDetectionRuleTest, SimpleDetectionTest) {


### PR DESCRIPTION
...was accidentally named `JoinConditionDetectionRule`