### PR TITLE
Rename TableGenerator::get_table

### DIFF
--- a/src/benchmark/base_fixture.cpp
+++ b/src/benchmark/base_fixture.cpp
@@ -19,9 +19,9 @@ void BenchmarkBasicFixture::SetUp(::benchmark::State& state) {
 
   auto table_generator2 = std::make_shared<TableGenerator>();
 
-  _table_wrapper_a = std::make_shared<TableWrapper>(table_generator->get_table(_chunk_size));
-  _table_wrapper_b = std::make_shared<TableWrapper>(table_generator2->get_table(_chunk_size));
-  _table_dict_wrapper = std::make_shared<TableWrapper>(table_generator->get_table(_chunk_size, true));
+  _table_wrapper_a = std::make_shared<TableWrapper>(table_generator->generate_table(_chunk_size));
+  _table_wrapper_b = std::make_shared<TableWrapper>(table_generator2->generate_table(_chunk_size));
+  _table_dict_wrapper = std::make_shared<TableWrapper>(table_generator->generate_table(_chunk_size, true));
   _table_wrapper_a->execute();
   _table_wrapper_b->execute();
   _table_dict_wrapper->execute();

--- a/src/benchmark/table_generator.cpp
+++ b/src/benchmark/table_generator.cpp
@@ -17,7 +17,7 @@
 
 namespace opossum {
 
-std::shared_ptr<Table> TableGenerator::get_table(const ChunkID chunk_size, const bool compress) {
+std::shared_ptr<Table> TableGenerator::generate_table(const ChunkID chunk_size, const bool compress) {
   std::shared_ptr<Table> table = std::make_shared<Table>(chunk_size);
   std::vector<tbb::concurrent_vector<int>> value_vectors;
   auto vector_size = chunk_size > 0 ? chunk_size : _num_rows;

--- a/src/benchmark/table_generator.hpp
+++ b/src/benchmark/table_generator.hpp
@@ -10,7 +10,7 @@ class Table;
 
 class TableGenerator {
  public:
-  std::shared_ptr<Table> get_table(const ChunkID chunk_size, const bool compress = false);
+  std::shared_ptr<Table> generate_table(const ChunkID chunk_size, const bool compress = false);
 
  protected:
   const size_t _num_columns = 10;


### PR DESCRIPTION
Something that generates a table should be named "generate", not "get"