### PR TITLE
Make Jenkins build a non-NUMA version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ node {
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 .. &\
         mkdir clang-release && cd clang-release && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 .. &\
+        mkdir clang-release-no-numa && cd clang-release-no-numa && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 -DDISABLE_NUMA_SUPPORT=On .. &\
         mkdir gcc-debug && cd gcc-debug && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         mkdir gcc-release-coverage && cd gcc-release-coverage && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
@@ -77,6 +78,11 @@ node {
         stage("clang-release:sanitizers") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make hyriseSanitizers -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=asan-ignore.txt ./clang-release/hyriseSanitizers"
+        }
+      }, clangReleaseSanitizers: {
+        stage("clang-release:sanitizers w/o NUMA") {
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-no-numa && make hyriseSanitizers -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "LSAN_OPTIONS=suppressions=asan-ignore.txt ./clang-release-no-numa/hyriseSanitizers"
         }
       }, coverage: {
         stage("Coverage") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ node {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make hyriseSanitizers -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=asan-ignore.txt ./clang-release/hyriseSanitizers"
         }
-      }, clangReleaseSanitizers: {
+      }, clangReleaseSanitizersWoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-no-numa && make hyriseSanitizers -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=asan-ignore.txt ./clang-release-no-numa/hyriseSanitizers"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,7 +79,7 @@ node {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make hyriseSanitizers -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=asan-ignore.txt ./clang-release/hyriseSanitizers"
         }
-      }, clangReleaseSanitizersWoNuma: {
+      }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-no-numa && make hyriseSanitizers -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=asan-ignore.txt ./clang-release-no-numa/hyriseSanitizers"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,10 +4,12 @@ else()
     add_definitions(-DIS_DEBUG=0)
 endif()
 
-if (${NUMA_FOUND})
+option(DISABLE_NUMA_SUPPORT "Build without NUMA support" OFF)
+if (NOT DISABLE_NUMA_SUPPORT AND ${NUMA_FOUND})
     add_definitions(-DHYRISE_NUMA_SUPPORT=1)
 else()
     add_definitions(-DHYRISE_NUMA_SUPPORT=0)
+    MESSAGE(STATUS "Building without NUMA support")
 endif()
 
 # This will be used by the DebugAssert macro to output

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -264,7 +264,7 @@ set(
     ${TBB_LIBRARY}
 )
 
-if(${NUMA_FOUND})
+if (NOT DISABLE_NUMA_SUPPORT AND ${NUMA_FOUND})
     set(LIBRARIES ${LIBRARIES} ${NUMA_LIBRARY} hpinuma_msource_s)
 endif()
 


### PR DESCRIPTION
For safety, Jenkins should also check if the non-NUMA version works. Instead of doubling its efforts, it should be enough to just compile and run the sanitized clang-release build. That should catch most problems.