### PR TITLE
Chunk: Use enum class instead of boolean parameter

### DIFF
--- a/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
+++ b/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
@@ -115,7 +115,7 @@ class AbstractBenchmarkTableGenerator {
           auto value_column = std::make_shared<opossum::ValueColumn<T>>(std::move(column));
 
           if (is_first_column) {
-            opossum::Chunk chunk(opossum::ChunkMvccMode::UseMvccColumns);
+            opossum::Chunk chunk(opossum::ChunkUseMvcc::Yes);
             chunk.add_column(value_column);
             table->emplace_chunk(std::move(chunk));
           } else {
@@ -138,7 +138,7 @@ class AbstractBenchmarkTableGenerator {
 
       // add Chunk if it is the first column, e.g. WAREHOUSE_ID in the example above
       if (is_first_column) {
-        opossum::Chunk chunk(opossum::ChunkMvccMode::UseMvccColumns);
+        opossum::Chunk chunk(opossum::ChunkUseMvcc::Yes);
         chunk.add_column(value_column);
         table->emplace_chunk(std::move(chunk));
       } else {

--- a/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
+++ b/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
@@ -115,7 +115,7 @@ class AbstractBenchmarkTableGenerator {
           auto value_column = std::make_shared<opossum::ValueColumn<T>>(std::move(column));
 
           if (is_first_column) {
-            opossum::Chunk chunk(true);
+            opossum::Chunk chunk(opossum::ChunkMvccMode::UseMvccColumns);
             chunk.add_column(value_column);
             table->emplace_chunk(std::move(chunk));
           } else {
@@ -138,7 +138,7 @@ class AbstractBenchmarkTableGenerator {
 
       // add Chunk if it is the first column, e.g. WAREHOUSE_ID in the example above
       if (is_first_column) {
-        opossum::Chunk chunk(true);
+        opossum::Chunk chunk(opossum::ChunkMvccMode::UseMvccColumns);
         chunk.add_column(value_column);
         table->emplace_chunk(std::move(chunk));
       } else {

--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename) {
   std::vector<size_t> field_ends;
   while (_find_fields_in_chunk(content_view, *table.get(), field_ends)) {
     // create empty chunk
-    chunks.emplace_back(Chunk{ChunkMvccMode::UseMvccColumns});
+    chunks.emplace_back(ChunkUseMvcc::Yes);
     auto& chunk = chunks.back();
 
     // Only pass the part of the string that is actually needed to the parsing task

--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -40,7 +40,7 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename) {
   std::vector<size_t> field_ends;
   while (_find_fields_in_chunk(content_view, *table.get(), field_ends)) {
     // create empty chunk
-    chunks.emplace_back(true);
+    chunks.emplace_back(Chunk{ChunkMvccMode::UseMvccColumns});
     auto& chunk = chunks.back();
 
     // Only pass the part of the string that is actually needed to the parsing task

--- a/src/lib/operators/import_binary.cpp
+++ b/src/lib/operators/import_binary.cpp
@@ -110,7 +110,7 @@ std::pair<std::shared_ptr<Table>, ChunkID> ImportBinary::_read_header(std::ifstr
 
 Chunk ImportBinary::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& table) {
   const auto row_count = _read_value<ChunkOffset>(file);
-  Chunk chunk{true};
+  Chunk chunk{ChunkMvccMode::UseMvccColumns};
 
   for (ColumnID column_id{0}; column_id < table->column_count(); ++column_id) {
     chunk.add_column(_import_column(file, row_count, table->column_type(column_id)));

--- a/src/lib/operators/import_binary.cpp
+++ b/src/lib/operators/import_binary.cpp
@@ -110,7 +110,7 @@ std::pair<std::shared_ptr<Table>, ChunkID> ImportBinary::_read_header(std::ifstr
 
 Chunk ImportBinary::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& table) {
   const auto row_count = _read_value<ChunkOffset>(file);
-  Chunk chunk{ChunkMvccMode::UseMvccColumns};
+  Chunk chunk{ChunkUseMvcc::Yes};
 
   for (ColumnID column_id{0}; column_id < table->column_count(); ++column_id) {
     chunk.add_column(_import_column(file, row_count, table->column_type(column_id)));

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
     }
 
     // Add ReferenceColumns with built poslist.
-    Chunk chunk{ChunkMvccMode::NoMvccColumns};
+    Chunk chunk{ChunkUseMvcc::No};
     for (ColumnID column_id{0}; column_id < table_to_update->column_count(); ++column_id) {
       chunk.add_column(std::make_shared<ReferenceColumn>(table_to_update, column_id, pos_list));
     }

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
     }
 
     // Add ReferenceColumns with built poslist.
-    Chunk chunk{false};
+    Chunk chunk{ChunkMvccMode::NoMvccColumns};
     for (ColumnID column_id{0}; column_id < table_to_update->column_count(); ++column_id) {
       chunk.add_column(std::make_shared<ReferenceColumn>(table_to_update, column_id, pos_list));
     }

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -16,10 +16,10 @@ namespace opossum {
 
 const CommitID Chunk::MAX_COMMIT_ID = std::numeric_limits<CommitID>::max();
 
-Chunk::Chunk(ChunkMvccMode mvcc_mode): Chunk({}, mvcc_mode) {}
+Chunk::Chunk(ChunkUseMvcc mvcc_mode): Chunk({}, mvcc_mode) {}
 
-Chunk::Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkMvccMode mvcc_mode): _columns(alloc), _indices(alloc) {
-  if (mvcc_mode == ChunkMvccMode::UseMvccColumns) {
+Chunk::Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkUseMvcc mvcc_mode): _columns(alloc), _indices(alloc) {
+  if (mvcc_mode == ChunkUseMvcc::Yes) {
     _mvcc_columns = std::make_shared<MvccColumns>();
   }
 }

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -16,15 +16,12 @@ namespace opossum {
 
 const CommitID Chunk::MAX_COMMIT_ID = std::numeric_limits<CommitID>::max();
 
-Chunk::Chunk() : Chunk(PolymorphicAllocator<Chunk>(), false) {}
+Chunk::Chunk(ChunkMvccMode mvcc_mode): Chunk({}, mvcc_mode) {}
 
-Chunk::Chunk(const bool has_mvcc_columns) : Chunk(PolymorphicAllocator<Chunk>(), has_mvcc_columns) {}
-
-Chunk::Chunk(const PolymorphicAllocator<Chunk>& alloc) : Chunk(alloc, false) {}
-
-Chunk::Chunk(const PolymorphicAllocator<Chunk>& alloc, const bool has_mvcc_columns)
-    : _alloc(alloc), _columns(alloc), _indices(alloc) {
-  if (has_mvcc_columns) _mvcc_columns = std::make_shared<MvccColumns>();
+Chunk::Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkMvccMode mvcc_mode): _columns(alloc), _indices(alloc) {
+  if (mvcc_mode == ChunkMvccMode::UseMvccColumns) {
+    _mvcc_columns = std::make_shared<MvccColumns>();
+  }
 }
 
 void Chunk::add_column(std::shared_ptr<BaseColumn> column) {

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -18,10 +18,17 @@ namespace opossum {
 class BaseIndex;
 class BaseColumn;
 
-// A chunk is a horizontal partition of a table.
-// It stores the data column by column.
-//
-// Find more information about this in our wiki: https://github.com/hyrise/zweirise/wiki/chunk-concept
+enum class ChunkMvccMode {
+  UseMvccColumns, NoMvccColumns
+};
+
+/**
+ * A Chunk is a horizontal partition of a table.
+ * It stores the table's data column by column.
+ * Optionally, mostly applying to StoredTables, it may also hold a set of MvccColumns.
+ *
+ * Find more information about this in our wiki: https://github.com/hyrise/zweirise/wiki/chunk-concept
+ */
 class Chunk : private Noncopyable {
  public:
   static const CommitID MAX_COMMIT_ID;
@@ -50,11 +57,11 @@ class Chunk : private Noncopyable {
   };
 
  public:
-  // creates an empty chunk without mvcc columns
-  Chunk();
-  explicit Chunk(const bool has_mvcc_columns);
-  explicit Chunk(const PolymorphicAllocator<Chunk>& alloc);
-  explicit Chunk(const PolymorphicAllocator<Chunk>& alloc, const bool has_mvcc_columns);
+  // Use the default allocator
+  explicit Chunk(ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
+
+  // Use the specified allocator
+  Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
 
   // we need to explicitly set the move constructor to default when
   // we overwrite the copy constructor
@@ -139,7 +146,6 @@ class Chunk : private Noncopyable {
   bool references_only_one_table() const;
 
  protected:
-  PolymorphicAllocator<Chunk> _alloc;
   pmr_concurrent_vector<std::shared_ptr<BaseColumn>> _columns;
   std::shared_ptr<MvccColumns> _mvcc_columns;
   pmr_vector<std::shared_ptr<BaseIndex>> _indices;

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -18,8 +18,8 @@ namespace opossum {
 class BaseIndex;
 class BaseColumn;
 
-enum class ChunkMvccMode {
-  UseMvccColumns, NoMvccColumns
+enum class ChunkUseMvcc {
+  Yes, No
 };
 
 /**
@@ -58,10 +58,10 @@ class Chunk : private Noncopyable {
 
  public:
   // Use the default allocator
-  explicit Chunk(ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
+  explicit Chunk(ChunkUseMvcc mvcc_mode = ChunkUseMvcc::No);
 
   // Use the specified allocator
-  explicit Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
+  explicit Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkUseMvcc mvcc_mode = ChunkUseMvcc::No);
 
   // we need to explicitly set the move constructor to default when
   // we overwrite the copy constructor

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -61,7 +61,7 @@ class Chunk : private Noncopyable {
   explicit Chunk(ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
 
   // Use the specified allocator
-  Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
+  explicit Chunk(const PolymorphicAllocator<Chunk>& alloc, ChunkMvccMode mvcc_mode = ChunkMvccMode::NoMvccColumns);
 
   // we need to explicitly set the move constructor to default when
   // we overwrite the copy constructor

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -16,7 +16,7 @@
 namespace opossum {
 
 Table::Table(const uint32_t chunk_size) : _chunk_size(chunk_size), _append_mutex(std::make_unique<std::mutex>()) {
-  _chunks.push_back(Chunk{ChunkMvccMode::UseMvccColumns});
+  _chunks.push_back(Chunk{ChunkUseMvcc::Yes});
 }
 
 void Table::add_column_definition(const std::string& name, const std::string& type, bool nullable) {
@@ -46,7 +46,7 @@ void Table::inc_invalid_row_count(uint64_t count) { _approx_invalid_row_count +=
 
 void Table::create_new_chunk() {
   // Create chunk with mvcc columns
-  Chunk newChunk{ChunkMvccMode::UseMvccColumns};
+  Chunk newChunk{ChunkUseMvcc::Yes};
 
   for (auto column_id = 0u; column_id < _column_types.size(); ++column_id) {
     const auto& type = _column_types[column_id];

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -16,7 +16,7 @@
 namespace opossum {
 
 Table::Table(const uint32_t chunk_size) : _chunk_size(chunk_size), _append_mutex(std::make_unique<std::mutex>()) {
-  _chunks.push_back(Chunk{true});
+  _chunks.push_back(Chunk{ChunkMvccMode::UseMvccColumns});
 }
 
 void Table::add_column_definition(const std::string& name, const std::string& type, bool nullable) {
@@ -46,7 +46,7 @@ void Table::inc_invalid_row_count(uint64_t count) { _approx_invalid_row_count +=
 
 void Table::create_new_chunk() {
   // Create chunk with mvcc columns
-  Chunk newChunk{true};
+  Chunk newChunk{ChunkMvccMode::UseMvccColumns};
 
   for (auto column_id = 0u; column_id < _column_types.size(); ++column_id) {
     const auto& type = _column_types[column_id];


### PR DESCRIPTION
Because noone likes to read code with boolean params. Also, Chunk had too many constructors.