### PR TITLE
Don't start operator if Tx already failed

### DIFF
--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -21,6 +21,11 @@ void AbstractOperator::execute() {
   auto transaction_context = this->transaction_context();
 
   if (transaction_context) {
+    /**
+     * Do not execute Operators if transaction has been aborted.
+     * Not doing so is crucial in order to make sure no other
+     * tasks of the Transaction run while the Rollback happens.
+     */
     if (transaction_context->aborted()) {
       return;
     }

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -30,9 +30,12 @@ void AbstractOperator::execute() {
       return;
     }
     transaction_context->on_operator_started();
+    _output = _on_execute(transaction_context);
+    transaction_context->on_operator_finished();
   }
-  _output = _on_execute(transaction_context);
-  if (transaction_context) transaction_context->on_operator_finished();
+  else {
+    _output = _on_execute(transaction_context);
+  }
 
   // release any temporary data if possible
   _on_cleanup();

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -32,8 +32,7 @@ void AbstractOperator::execute() {
     transaction_context->on_operator_started();
     _output = _on_execute(transaction_context);
     transaction_context->on_operator_finished();
-  }
-  else {
+  } else {
     _output = _on_execute(transaction_context);
   }
 

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -20,7 +20,12 @@ void AbstractOperator::execute() {
 
   auto transaction_context = this->transaction_context();
 
-  if (transaction_context) transaction_context->on_operator_started();
+  if (transaction_context) {
+    if (transaction_context->aborted()) {
+      return;
+    }
+    transaction_context->on_operator_started();
+  }
   _output = _on_execute(transaction_context);
   if (transaction_context) transaction_context->on_operator_finished();
 

--- a/src/lib/scheduler/operator_task.cpp
+++ b/src/lib/scheduler/operator_task.cpp
@@ -45,13 +45,6 @@ const std::shared_ptr<AbstractOperator>& OperatorTask::get_operator() const { re
 void OperatorTask::_on_execute() {
   auto context = _op->transaction_context();
 
-  /**
-   * Do not execute Operators if transaction has been aborted.
-   * Not doing so is crucial in order to make sure no other
-   * tasks of the Transaction run while the Rollback happens.
-   */
-  if (context && context->aborted()) return;
-
   _op->execute();
 
   /**


### PR DESCRIPTION
If the TX is already gone, no operator should be executed. This also fixes #76 because the second update will not be executed.
