### PR TITLE
Make ccache fast again

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\"") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
 
     try {
       stage("Setup") {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ if (CMAKE_CXX_COMPILER_LAUNCHER)
         string(LENGTH "" SOURCE_PATH_SIZE)
     endif()
 endif()
+MESSAGE(STATUS "SOURCE_PATH_SIZE ${SOURCE_PATH_SIZE}")
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 # Global flags and include directories

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,6 @@ if (CMAKE_CXX_COMPILER_LAUNCHER)
         string(LENGTH "" SOURCE_PATH_SIZE)
     endif()
 endif()
-MESSAGE(STATUS "SOURCE_PATH_SIZE ${SOURCE_PATH_SIZE}")
 add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 
 # Global flags and include directories


### PR DESCRIPTION
We are using __FILE__ in our DebugAsserts. Since Jenkins always creates a new path for everything, we should ignore those changes.