### PR TITLE
Make AST printing support column names

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -19,7 +19,6 @@ add_executable(
 target_link_libraries(
     hyrisePlayground
     hyrise
-    hyriseBenchmarkLib
 )
 
 # Configure tpccTableGenerator

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
 target_link_libraries(
     hyrisePlayground
     hyrise
+    hyriseBenchmarkLib
 )
 
 # Configure tpccTableGenerator

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
@@ -244,6 +244,39 @@ void AbstractASTNode::print(std::ostream& out, std::vector<bool> levels) const {
   levels.pop_back();
 }
 
+std::string AbstractASTNode::get_verbose_column_name(ColumnID column_id) const {
+  Assert(!_right_child, "Nodes with both children need to override get_verbose_column_name()");
+
+  /**
+   *  A AbstractASTNode without a left child should generally be a StoredTableNode, which overrides this function. But
+   *  since get_verbose_column_name() is just a convenience function we don't want to force anyone to override this
+   *  function when experimenting with nodes. Thus we handle the case of no left child here as well.
+   */
+  if (!_left_child) {
+    if (_table_alias) {
+      return *_table_alias + "." + output_column_names()[column_id];
+    }
+
+    return output_column_names()[column_id];
+  }
+
+  const auto verbose_name = _left_child->get_verbose_column_name(column_id);
+
+  if (_table_alias) {
+    return *_table_alias + "." + verbose_name;
+  }
+
+  return verbose_name;
+}
+
+std::vector<std::string> AbstractASTNode::get_verbose_column_names() const {
+  std::vector<std::string> verbose_names(output_col_count());
+  for (auto column_id = ColumnID{0}; column_id < output_col_count(); ++column_id) {
+    verbose_names[column_id] = get_verbose_column_name(column_id);
+  }
+  return verbose_names;
+}
+
 std::optional<NamedColumnReference> AbstractASTNode::_resolve_local_alias(const NamedColumnReference& reference) const {
   if (reference.table_name && _table_alias) {
     if (*reference.table_name == *_table_alias) {

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
@@ -225,7 +225,6 @@ class AbstractASTNode : public std::enable_shared_from_this<AbstractASTNode> {
   std::vector<std::string> get_verbose_column_names() const;
   // @}
 
-
  protected:
   virtual void _on_child_changed() {}
 

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "types.hpp"
+
 namespace opossum {
 
 struct ColumnID;
@@ -199,8 +201,30 @@ class AbstractASTNode : public std::enable_shared_from_this<AbstractASTNode> {
    */
   void set_alias(const std::optional<std::string>& table_alias);
 
+  // @{
+  /**
+   * Functions for debugging purposes.
+   */
+
+  /**
+   * Prints this node and all its descendants formatted as a tree
+   */
   void print(std::ostream& out = std::cout, std::vector<bool> levels = {}) const;
+
+  /**
+   * Returns a string describing this node, but nothing about its children.
+   */
   virtual std::string description() const = 0;
+
+  /**
+   * Generate a name for a column that contains all aliases it went through as well as the name of the table that it
+   * originally came from, if any
+   */
+  virtual std::string get_verbose_column_name(ColumnID column_id) const;
+
+  std::vector<std::string> get_verbose_column_names() const;
+  // @}
+
 
  protected:
   virtual void _on_child_changed() {}

--- a/src/lib/optimizer/abstract_syntax_tree/aggregate_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/aggregate_node.cpp
@@ -32,8 +32,16 @@ const std::vector<ColumnID>& AggregateNode::groupby_column_ids() const { return 
 std::string AggregateNode::description() const {
   std::ostringstream s;
 
+  s << "[Aggregate] ";
+
+  std::vector<std::string> verbose_column_names;
+  if (left_child()) {
+    verbose_column_names = left_child()->get_verbose_column_names();
+  }
+
   auto stream_aggregate = [&](const std::shared_ptr<Expression>& aggregate_expr) {
-    s << aggregate_expr->to_string();
+    s << aggregate_expr->to_string(verbose_column_names);
+
     if (aggregate_expr->alias()) {
       s << " AS \"" << (*aggregate_expr->alias()) << "\"";
     }
@@ -53,20 +61,41 @@ std::string AggregateNode::description() const {
   if (!_groupby_column_ids.empty()) {
     s << " GROUP BY [";
 
-    auto group_by_it = _groupby_column_ids.begin();
-    if (group_by_it != _groupby_column_ids.end()) {
-      s << *group_by_it;
-      ++group_by_it;
+    for (size_t group_by_idx = 0; group_by_idx < _groupby_column_ids.size(); ++group_by_idx) {
+      if (left_child()) {
+        s << left_child()->get_verbose_column_name(_groupby_column_ids[group_by_idx]);
+        if (group_by_idx + 1 < _groupby_column_ids.size()) {
+          s << ", ";
+        }
+      }
     }
-
-    for (; group_by_it != _groupby_column_ids.end(); ++group_by_it) {
-      s << ", " << *group_by_it;
-    }
-
     s << "]";
   }
 
   return s.str();
+}
+
+std::string AggregateNode::get_verbose_column_name(ColumnID column_id) const {
+  DebugAssert(left_child(), "Need input to generate name");
+
+  if (column_id < _aggregate_expressions.size()) {
+    const auto& aggregate_expression = _aggregate_expressions[column_id];
+
+    if (aggregate_expression->alias()) {
+      return *aggregate_expression->alias();
+    }
+
+    if (left_child()) {
+      return aggregate_expression->to_string(left_child()->get_verbose_column_names());
+    } else {
+      return aggregate_expression->to_string();
+    }
+  }
+
+  const auto group_by_column_id = column_id - _aggregate_expressions.size();
+  DebugAssert (group_by_column_id < _groupby_column_ids.size(), "ColumnID out of range");
+
+  return left_child()->get_verbose_column_name(_groupby_column_ids[group_by_column_id]);
 }
 
 void AggregateNode::_on_child_changed() {

--- a/src/lib/optimizer/abstract_syntax_tree/aggregate_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/aggregate_node.cpp
@@ -93,7 +93,7 @@ std::string AggregateNode::get_verbose_column_name(ColumnID column_id) const {
   }
 
   const auto group_by_column_id = column_id - _aggregate_expressions.size();
-  DebugAssert (group_by_column_id < _groupby_column_ids.size(), "ColumnID out of range");
+  DebugAssert(group_by_column_id < _groupby_column_ids.size(), "ColumnID out of range");
 
   return left_child()->get_verbose_column_name(_groupby_column_ids[group_by_column_id]);
 }

--- a/src/lib/optimizer/abstract_syntax_tree/aggregate_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/aggregate_node.hpp
@@ -55,6 +55,8 @@ class AggregateNode : public AbstractASTNode {
 
   std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
 
+  std::string get_verbose_column_name(ColumnID column_id) const override;
+
  protected:
   void _on_child_changed() override;
 

--- a/src/lib/optimizer/abstract_syntax_tree/ast_root_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/ast_root_node.cpp
@@ -8,6 +8,6 @@ namespace opossum {
 
 ASTRootNode::ASTRootNode() : AbstractASTNode(ASTNodeType::Root) {}
 
-std::string ASTRootNode::description() const { return "ASTRootNode"; }
+std::string ASTRootNode::description() const { return "[ASTRootNode]"; }
 
 }  // namespace opossum

--- a/src/lib/optimizer/abstract_syntax_tree/delete_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/delete_node.cpp
@@ -14,7 +14,7 @@ DeleteNode::DeleteNode(const std::string& table_name) : AbstractASTNode(ASTNodeT
 std::string DeleteNode::description() const {
   std::ostringstream desc;
 
-  desc << "Delete from " << _table_name;
+  desc << "[Delete] Table: '" << _table_name << "'";
 
   return desc.str();
 }

--- a/src/lib/optimizer/abstract_syntax_tree/dummy_table_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/dummy_table_node.cpp
@@ -11,7 +11,7 @@ namespace opossum {
 
 DummyTableNode::DummyTableNode() : AbstractASTNode(ASTNodeType::DummyTable) {}
 
-std::string DummyTableNode::description() const { return "DummyTable"; }
+std::string DummyTableNode::description() const { return "[DummyTable]"; }
 
 void DummyTableNode::_on_child_changed() { Fail("DummyTableNode cannot have children."); }
 

--- a/src/lib/optimizer/abstract_syntax_tree/insert_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/insert_node.cpp
@@ -16,7 +16,7 @@ InsertNode::InsertNode(const std::string table_name) : AbstractASTNode(ASTNodeTy
 std::string InsertNode::description() const {
   std::ostringstream desc;
 
-  desc << "Insert into " << _table_name;
+  desc << "[Insert] Into table '" << _table_name << "'";
 
   return desc.str();
 }

--- a/src/lib/optimizer/abstract_syntax_tree/join_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/join_node.cpp
@@ -32,15 +32,17 @@ JoinNode::JoinNode(const JoinMode join_mode, const std::pair<ColumnID, ColumnID>
 }
 
 std::string JoinNode::description() const {
+  Assert(left_child() && right_child(), "Can't generate description if children aren't set");
+
   std::ostringstream desc;
 
-  desc << "Join";
-  desc << " [" << join_mode_to_string.at(_join_mode) << "]";
+  desc << "[" << join_mode_to_string.at(_join_mode) << " Join]";
 
   if (_join_column_ids && _scan_type) {
-    desc << " [" << (*_join_column_ids).first;
+    desc << " " << get_verbose_column_name(_join_column_ids->first);
     desc << " " << scan_type_to_string.left.at(*_scan_type);
-    desc << " " << (*_join_column_ids).second << "]";
+    desc << " " << get_verbose_column_name(ColumnID{
+    static_cast<ColumnID::base_type>(left_child()->output_col_count() + _join_column_ids->second)});
   }
 
   return desc.str();
@@ -187,6 +189,17 @@ const std::optional<std::pair<ColumnID, ColumnID>>& JoinNode::join_column_ids() 
 const std::optional<ScanType>& JoinNode::scan_type() const { return _scan_type; }
 
 JoinMode JoinNode::join_mode() const { return _join_mode; }
+
+std::string JoinNode::get_verbose_column_name(ColumnID column_id) const {
+  Assert(left_child() && right_child(), "Can't generate column names without children being set");
+
+  if (column_id < left_child()->output_col_count()) {
+    return left_child()->get_verbose_column_name(column_id);
+  }
+  return right_child()->get_verbose_column_name(
+  ColumnID{static_cast<ColumnID::base_type>(column_id - left_child()->output_col_count())});
+}
+
 
 void JoinNode::_on_child_changed() {
   // Only set output information if both children have already been set.

--- a/src/lib/optimizer/abstract_syntax_tree/join_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/join_node.cpp
@@ -42,7 +42,7 @@ std::string JoinNode::description() const {
     desc << " " << get_verbose_column_name(_join_column_ids->first);
     desc << " " << scan_type_to_string.left.at(*_scan_type);
     desc << " " << get_verbose_column_name(ColumnID{
-    static_cast<ColumnID::base_type>(left_child()->output_col_count() + _join_column_ids->second)});
+                       static_cast<ColumnID::base_type>(left_child()->output_col_count() + _join_column_ids->second)});
   }
 
   return desc.str();
@@ -197,9 +197,8 @@ std::string JoinNode::get_verbose_column_name(ColumnID column_id) const {
     return left_child()->get_verbose_column_name(column_id);
   }
   return right_child()->get_verbose_column_name(
-  ColumnID{static_cast<ColumnID::base_type>(column_id - left_child()->output_col_count())});
+      ColumnID{static_cast<ColumnID::base_type>(column_id - left_child()->output_col_count())});
 }
-
 
 void JoinNode::_on_child_changed() {
   // Only set output information if both children have already been set.

--- a/src/lib/optimizer/abstract_syntax_tree/join_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/join_node.hpp
@@ -40,6 +40,8 @@ class JoinNode : public AbstractASTNode {
   std::optional<ColumnID> find_column_id_by_named_column_reference(
       const NamedColumnReference& named_column_reference) const override;
 
+  std::string get_verbose_column_name(ColumnID column_id) const override;
+
  protected:
   void _on_child_changed() override;
 

--- a/src/lib/optimizer/abstract_syntax_tree/limit_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/limit_node.cpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 LimitNode::LimitNode(const size_t num_rows) : AbstractASTNode(ASTNodeType::Limit), _num_rows(num_rows) {}
 
-std::string LimitNode::description() const { return "Limit: " + std::to_string(_num_rows); }
+std::string LimitNode::description() const { return "[Limit] " + std::to_string(_num_rows) + " rows"; }
 
 size_t LimitNode::num_rows() const { return _num_rows; }
 

--- a/src/lib/optimizer/abstract_syntax_tree/mock_table_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/mock_table_node.cpp
@@ -26,7 +26,15 @@ const std::vector<ColumnID>& MockTableNode::output_column_id_to_input_column_id(
 
 const std::vector<std::string>& MockTableNode::output_column_names() const { return _output_column_names; }
 
+std::string MockTableNode::get_verbose_column_name(ColumnID column_id) const {
+  // Aliasing a MockTableNode doesn't really make sense, but let's stay covered
+  if (_table_alias) {
+    return *_table_alias + "." + output_column_names()[column_id];
+  }
+  return output_column_names()[column_id];
+}
+
 void MockTableNode::_on_child_changed() { Fail("MockTableNode cannot have children."); }
 
-std::string MockTableNode::description() const { return "MockTable"; }
+std::string MockTableNode::description() const { return "[MockTable]"; }
 }  // namespace opossum

--- a/src/lib/optimizer/abstract_syntax_tree/mock_table_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/mock_table_node.hpp
@@ -21,6 +21,7 @@ class MockTableNode : public AbstractASTNode {
   const std::vector<std::string>& output_column_names() const override;
 
   std::string description() const override;
+  std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
   void _on_child_changed() override;

--- a/src/lib/optimizer/abstract_syntax_tree/predicate_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/predicate_node.cpp
@@ -21,12 +21,26 @@ PredicateNode::PredicateNode(const ColumnID column_id, const ScanType scan_type,
       _value2(value2) {}
 
 std::string PredicateNode::description() const {
+  std::string left_operand_name = get_verbose_column_name(_column_id);
+  std::string right_a_operand_name;
+
+  if (_value.type() == typeid(ColumnID)) {
+    right_a_operand_name = get_verbose_column_name(boost::get<ColumnID>(_value));
+  } else {
+    right_a_operand_name = boost::lexical_cast<std::string>(_value);
+  }
+
   std::ostringstream desc;
 
-  desc << "Predicate: Col #" << _column_id << " " << scan_type_to_string.left.at(_scan_type);
-  desc << " '" << _value << "'";
+  desc << "[Predicate] " << left_operand_name << " " << scan_type_to_string.left.at(_scan_type);
+  desc << " " << right_a_operand_name << "";
   if (_value2) {
-    desc << " '" << (*_value2) << "";
+    desc << " AND ";
+    if (_value2->type() == typeid(std::string)) {
+      desc << "'" << *_value2 << "'";
+    } else {
+      desc << (*_value2);
+    }
   }
 
   return desc.str();

--- a/src/lib/optimizer/abstract_syntax_tree/projection_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/projection_node.hpp
@@ -31,6 +31,8 @@ class ProjectionNode : public AbstractASTNode {
 
   std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
 
+  std::string get_verbose_column_name(ColumnID column_id) const override;
+
  protected:
   void _on_child_changed() override;
 

--- a/src/lib/optimizer/abstract_syntax_tree/show_columns_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/show_columns_node.cpp
@@ -7,7 +7,7 @@ namespace opossum {
 ShowColumnsNode::ShowColumnsNode(const std::string& table_name)
     : AbstractNonOptimizableASTNode(ASTNodeType::ShowColumns), _table_name(table_name) {}
 
-std::string ShowColumnsNode::description() const { return "ShowColumns: " + _table_name; }
+std::string ShowColumnsNode::description() const { return "[ShowColumns] Table: '" + _table_name + "'"; }
 
 const std::string& ShowColumnsNode::table_name() const { return _table_name; }
 

--- a/src/lib/optimizer/abstract_syntax_tree/show_tables_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/show_tables_node.cpp
@@ -6,6 +6,6 @@ namespace opossum {
 
 ShowTablesNode::ShowTablesNode() : AbstractNonOptimizableASTNode(ASTNodeType::ShowTables) {}
 
-std::string ShowTablesNode::description() const { return "ShowTables"; }
+std::string ShowTablesNode::description() const { return "[ShowTables]"; }
 
 }  // namespace opossum

--- a/src/lib/optimizer/abstract_syntax_tree/sort_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/sort_node.cpp
@@ -18,12 +18,12 @@ SortNode::SortNode(const std::vector<OrderByDefinition>& order_by_definitions)
 std::string SortNode::description() const {
   std::ostringstream s;
 
+  s << "[Sort] ";
+
   auto stream_aggregate = [&](const OrderByDefinition& definition) {
-    s << std::to_string(definition.column_id);
+    s << get_verbose_column_name(definition.column_id);
     s << " (" << order_by_mode_to_string.at(definition.order_by_mode) + ")";
   };
-
-  s << "Sort: ";
 
   auto it = _order_by_definitions.begin();
   if (it != _order_by_definitions.end()) {

--- a/src/lib/optimizer/abstract_syntax_tree/stored_table_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/stored_table_node.cpp
@@ -23,7 +23,7 @@ StoredTableNode::StoredTableNode(const std::string& table_name)
   _output_column_id_to_input_column_id.resize(output_col_count(), INVALID_COLUMN_ID);
 }
 
-std::string StoredTableNode::description() const { return "Table: " + _table_name; }
+std::string StoredTableNode::description() const { return "[StoredTable] Name: '" + _table_name + "'"; }
 
 const std::vector<ColumnID>& StoredTableNode::output_column_id_to_input_column_id() const {
   return _output_column_id_to_input_column_id;
@@ -83,6 +83,13 @@ std::vector<ColumnID> StoredTableNode::get_output_column_ids_for_table(const std
   }
 
   return column_ids;
+}
+
+std::string StoredTableNode::get_verbose_column_name(ColumnID column_id) const {
+  if (_table_alias) {
+    return "(" + _table_name + " AS " + *_table_alias + ")." + output_column_names()[column_id];
+  }
+  return _table_name + "." + output_column_names()[column_id];
 }
 
 void StoredTableNode::_on_child_changed() { Fail("StoredTableNode cannot have children."); }

--- a/src/lib/optimizer/abstract_syntax_tree/stored_table_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/stored_table_node.hpp
@@ -37,6 +37,8 @@ class StoredTableNode : public AbstractASTNode {
   std::optional<ColumnID> find_column_id_by_named_column_reference(
       const NamedColumnReference& named_column_reference) const override;
 
+  std::string get_verbose_column_name(ColumnID column_id) const override;
+
  protected:
   void _on_child_changed() override;
 

--- a/src/lib/optimizer/abstract_syntax_tree/update_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/update_node.cpp
@@ -18,7 +18,7 @@ UpdateNode::UpdateNode(const std::string& table_name,
 std::string UpdateNode::description() const {
   std::ostringstream desc;
 
-  desc << "Update " << _table_name;
+  desc << "[Update] Table: '" << _table_name << "'";
 
   return desc.str();
 }

--- a/src/lib/optimizer/abstract_syntax_tree/validate_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/validate_node.cpp
@@ -6,6 +6,6 @@ namespace opossum {
 
 ValidateNode::ValidateNode() : AbstractASTNode(ASTNodeType::Validate) {}
 
-std::string ValidateNode::description() const { return "Validate"; }
+std::string ValidateNode::description() const { return "[Validate]"; }
 
 }  // namespace opossum


### PR DESCRIPTION
Because YOU are not good at dealing with ColumnIDs

```
[Sort] revenue (Descending)
 \_[Projection] revenue, nation.n_name
    \_[Aggregate] SUM(lineitem.l_extendedprice * (1 - lineitem.l_discount)) AS "revenue" GROUP BY [nation.n_name]
       \_[Predicate] orders.o_orderdate < 1995-01-01
          \_[Predicate] orders.o_orderdate >= 1994-01-01
             \_[Predicate] region.r_name = ASIA
                \_[Predicate] nation.n_regionkey = region.r_regionkey
                   \_[Predicate] supplier.s_nationkey = nation.n_nationkey
                      \_[Predicate] customer.c_nationkey = supplier.s_nationkey
                         \_[Predicate] lineitem.l_suppkey = supplier.s_suppkey
                            \_[Predicate] lineitem.l_orderkey = orders.o_orderkey
                               \_[Predicate] customer.c_custkey = orders.o_custkey
                                  \_[Cross Join]
                                     \_[Cross Join]
                                     |  \_[Cross Join]
                                     |  |  \_[Cross Join]
                                     |  |  |  \_[Cross Join]
                                     |  |  |  |  \_[StoredTable] Name: 'orders'
                                     |  |  |  |  \_[StoredTable] Name: 'lineitem'
                                     |  |  |  \_[StoredTable] Name: 'supplier'
                                     |  |  \_[StoredTable] Name: 'nation'
                                     |  \_[StoredTable] Name: 'region'
                                     \_[StoredTable] Name: 'customer'
```
