### PR TITLE
Remove num_(in/out)_tables

### DIFF
--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -47,12 +47,6 @@ class AbstractOperator : private Noncopyable {
   virtual const std::string name() const = 0;
   virtual const std::string description() const;
 
-  // returns the number of input tables, range of values is [0, 2]
-  virtual uint8_t num_in_tables() const = 0;
-
-  // returns the number of output tables, range of values is [0, 1]
-  virtual uint8_t num_out_tables() const = 0;
-
   std::shared_ptr<TransactionContext> transaction_context() const;
   void set_transaction_context(std::weak_ptr<TransactionContext> transaction_context);
 

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -53,8 +53,6 @@ bool AbstractReadWriteOperator::execute_failed() const {
 
 ReadWriteOperatorState AbstractReadWriteOperator::state() const { return _state; }
 
-uint8_t AbstractReadWriteOperator::num_out_tables() const { return 0; }
-
 void AbstractReadWriteOperator::_mark_as_failed() {
   Assert(_state == ReadWriteOperatorState::Pending, "Operator can only be marked as failed if pending.");
 

--- a/src/lib/operators/abstract_read_write_operator.hpp
+++ b/src/lib/operators/abstract_read_write_operator.hpp
@@ -55,8 +55,6 @@ class AbstractReadWriteOperator : public AbstractOperator,
 
   ReadWriteOperatorState state() const;
 
-  uint8_t num_out_tables() const override;
-
  protected:
   /**
    * Executes the operator. The context parameter is used to lock the rows that should be modified.

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -36,10 +36,6 @@ const std::vector<ColumnID>& Aggregate::groupby_column_ids() const { return _gro
 
 const std::string Aggregate::name() const { return "Aggregate"; }
 
-uint8_t Aggregate::num_in_tables() const { return 1; }
-
-uint8_t Aggregate::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> Aggregate::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<Aggregate>(_input_left->recreate(args), _aggregates, _groupby_column_ids);
 }

--- a/src/lib/operators/aggregate.hpp
+++ b/src/lib/operators/aggregate.hpp
@@ -85,8 +85,6 @@ class Aggregate : public AbstractReadOnlyOperator {
   const std::vector<ColumnID>& groupby_column_ids() const;
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
   // write the aggregated output for a given aggregate column

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -15,8 +15,6 @@ Delete::Delete(const std::string& table_name, const std::shared_ptr<const Abstra
 
 const std::string Delete::name() const { return "Delete"; }
 
-uint8_t Delete::num_in_tables() const { return 1u; }
-
 std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionContext> context) {
   DebugAssert(_execution_input_valid(context), "Input to Delete isn't valid");
 

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -21,7 +21,6 @@ class Delete : public AbstractReadWriteOperator {
   explicit Delete(const std::string& table_name, const std::shared_ptr<const AbstractOperator>& values_to_delete);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -17,10 +17,6 @@ Difference::Difference(const std::shared_ptr<const AbstractOperator> left_in,
 
 const std::string Difference::name() const { return "Difference"; }
 
-uint8_t Difference::num_in_tables() const { return 2; }
-
-uint8_t Difference::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> Difference::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<Difference>(_input_left->recreate(args), _input_right->recreate(args));
 }

--- a/src/lib/operators/difference.hpp
+++ b/src/lib/operators/difference.hpp
@@ -19,8 +19,6 @@ class Difference : public AbstractReadOnlyOperator {
              const std::shared_ptr<const AbstractOperator> right_in);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -98,10 +98,6 @@ ExportBinary::ExportBinary(const std::shared_ptr<const AbstractOperator> in, con
 
 const std::string ExportBinary::name() const { return "ExportBinary"; }
 
-uint8_t ExportBinary::num_in_tables() const { return 1; }
-
-uint8_t ExportBinary::num_out_tables() const { return 1; }
-
 std::shared_ptr<const Table> ExportBinary::_on_execute() {
   std::ofstream ofstream;
   ofstream.exceptions(std::ofstream::failbit | std::ofstream::badbit);

--- a/src/lib/operators/export_binary.hpp
+++ b/src/lib/operators/export_binary.hpp
@@ -32,16 +32,6 @@ class ExportBinary : public AbstractReadOnlyOperator {
    */
   const std::string name() const final;
 
-  /**
-   * This operator allows one table as input
-   */
-  uint8_t num_in_tables() const final;
-
-  /**
-   * This operator has one table as output.
-   */
-  uint8_t num_out_tables() const final;
-
  private:
   // Path of the binary file
   const std::string _filename;

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -19,8 +19,6 @@ ExportCsv::ExportCsv(const std::shared_ptr<const AbstractOperator> in, const std
     : AbstractReadOnlyOperator(in), _filename(filename) {}
 
 const std::string ExportCsv::name() const { return "ExportCSV"; }
-uint8_t ExportCsv::num_in_tables() const { return 1; }
-uint8_t ExportCsv::num_out_tables() const { return 1; }
 
 std::shared_ptr<const Table> ExportCsv::_on_execute() {
   CsvConfig config{};

--- a/src/lib/operators/export_csv.hpp
+++ b/src/lib/operators/export_csv.hpp
@@ -90,16 +90,6 @@ class ExportCsv : public AbstractReadOnlyOperator {
    */
   const std::string name() const override;
 
-  /*
-   * This operator allows one table as input
-   */
-  uint8_t num_in_tables() const override;
-
-  /*
-   * This operator has one table as output.
-   */
-  uint8_t num_out_tables() const override;
-
  private:
   // Name of the output file
   const std::string _filename;

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -14,10 +14,6 @@ const std::string GetTable::name() const { return "GetTable"; }
 
 const std::string GetTable::description() const { return name() + "\\n(" + table_name() + ")"; }
 
-uint8_t GetTable::num_in_tables() const { return 0; }
-
-uint8_t GetTable::num_out_tables() const { return 1; }
-
 const std::string& GetTable::table_name() const { return _name; }
 
 std::shared_ptr<AbstractOperator> GetTable::recreate(const std::vector<AllParameterVariant>& args) const {

--- a/src/lib/operators/get_table.hpp
+++ b/src/lib/operators/get_table.hpp
@@ -15,8 +15,6 @@ class GetTable : public AbstractReadOnlyOperator {
 
   const std::string name() const override;
   const std::string description() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
   const std::string& table_name() const;
 

--- a/src/lib/operators/import_binary.cpp
+++ b/src/lib/operators/import_binary.cpp
@@ -24,10 +24,6 @@ ImportBinary::ImportBinary(const std::string& filename, const std::optional<std:
 
 const std::string ImportBinary::name() const { return "ImportBinary"; }
 
-uint8_t ImportBinary::num_in_tables() const { return 0; }
-
-uint8_t ImportBinary::num_out_tables() const { return 1; }
-
 template <typename T>
 pmr_vector<T> ImportBinary::_read_values(std::ifstream& file, const size_t count) {
   pmr_vector<T> values(count);

--- a/src/lib/operators/import_binary.hpp
+++ b/src/lib/operators/import_binary.hpp
@@ -45,12 +45,6 @@ class ImportBinary : public AbstractReadOnlyOperator {
   // Returns the name of the operator
   const std::string name() const final;
 
-  // This operator has no inputs.
-  uint8_t num_in_tables() const final;
-
-  // This operator has one table as output.
-  uint8_t num_out_tables() const final;
-
  private:
   /*
    * Reads the header from the given file.

--- a/src/lib/operators/import_csv.cpp
+++ b/src/lib/operators/import_csv.cpp
@@ -19,10 +19,6 @@ ImportCsv::ImportCsv(const std::string& filename, const CsvConfig& config, const
 
 const std::string ImportCsv::name() const { return "ImportCSV"; }
 
-uint8_t ImportCsv::num_in_tables() const { return 0; }
-
-uint8_t ImportCsv::num_out_tables() const { return 1; }
-
 std::shared_ptr<const Table> ImportCsv::_on_execute() {
   if (_tablename && StorageManager::get().has_table(*_tablename)) {
     return StorageManager::get().get_table(*_tablename);

--- a/src/lib/operators/import_csv.hpp
+++ b/src/lib/operators/import_csv.hpp
@@ -42,12 +42,6 @@ class ImportCsv : public AbstractReadOnlyOperator {
   // Name of the operator is "ImportCSV"
   const std::string name() const override;
 
-  // This operator has no input
-  uint8_t num_in_tables() const override;
-
-  // This operator has one table as output.
-  uint8_t num_out_tables() const override;
-
  protected:
   // Returns the table that was created from the csv file.
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/lib/operators/index_column_scan.cpp
+++ b/src/lib/operators/index_column_scan.cpp
@@ -30,10 +30,6 @@ IndexColumnScan::IndexColumnScan(const std::shared_ptr<AbstractOperator> in, con
 
 const std::string IndexColumnScan::name() const { return "IndexColumnScan"; }
 
-uint8_t IndexColumnScan::num_in_tables() const { return 1; }
-
-uint8_t IndexColumnScan::num_out_tables() const { return 1; }
-
 std::shared_ptr<const Table> IndexColumnScan::_on_execute() {
   _impl = make_unique_by_column_type<AbstractReadOnlyOperatorImpl, IndexColumnScanImpl>(
       _input_table_left()->column_type(_column_id), _input_left, _column_id, _scan_type, _value, _value2);

--- a/src/lib/operators/index_column_scan.hpp
+++ b/src/lib/operators/index_column_scan.hpp
@@ -33,8 +33,6 @@ class IndexColumnScan : public AbstractReadOnlyOperator {
                   const AllTypeVariant value, const std::optional<AllTypeVariant> value2 = std::nullopt);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -60,8 +60,6 @@ Insert::Insert(const std::string& target_table_name, const std::shared_ptr<Abstr
 
 const std::string Insert::name() const { return "Insert"; }
 
-uint8_t Insert::num_in_tables() const { return 1; }
-
 std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionContext> context) {
   context->register_rw_operator(shared_from_this());
 

--- a/src/lib/operators/insert.hpp
+++ b/src/lib/operators/insert.hpp
@@ -24,7 +24,6 @@ class Insert : public AbstractReadWriteOperator {
   explicit Insert(const std::string& target_table_name, const std::shared_ptr<AbstractOperator>& values_to_insert);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -31,10 +31,6 @@ JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator> left,
 
 const std::string JoinHash::name() const { return "JoinHash"; }
 
-uint8_t JoinHash::num_in_tables() const { return 2; }
-
-uint8_t JoinHash::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> JoinHash::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<JoinHash>(_input_left->recreate(args), _input_right->recreate(args), _mode, _column_ids,
                                     _scan_type);

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -29,8 +29,6 @@ class JoinHash : public AbstractJoinOperator {
            const JoinMode mode, const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:

--- a/src/lib/operators/join_nested_loop_a.cpp
+++ b/src/lib/operators/join_nested_loop_a.cpp
@@ -25,10 +25,6 @@ JoinNestedLoopA::JoinNestedLoopA(const std::shared_ptr<const AbstractOperator> l
 
 const std::string JoinNestedLoopA::name() const { return "JoinNestedLoopA"; }
 
-uint8_t JoinNestedLoopA::num_in_tables() const { return 2; }
-
-uint8_t JoinNestedLoopA::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> JoinNestedLoopA::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<JoinNestedLoopA>(_input_left->recreate(args), _input_right->recreate(args), _mode,
                                            _column_ids, _scan_type);

--- a/src/lib/operators/join_nested_loop_a.hpp
+++ b/src/lib/operators/join_nested_loop_a.hpp
@@ -31,8 +31,6 @@ class JoinNestedLoopA : public AbstractJoinOperator {
                   const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:

--- a/src/lib/operators/join_nested_loop_b.cpp
+++ b/src/lib/operators/join_nested_loop_b.cpp
@@ -193,10 +193,6 @@ std::shared_ptr<const Table> JoinNestedLoopB::_on_execute() {
 
 const std::string JoinNestedLoopB::name() const { return "JoinNestedLoopB"; }
 
-uint8_t JoinNestedLoopB::num_in_tables() const { return 2u; }
-
-uint8_t JoinNestedLoopB::num_out_tables() const { return 1u; }
-
 std::shared_ptr<AbstractOperator> JoinNestedLoopB::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<JoinNestedLoopB>(_input_left->recreate(args), _input_right->recreate(args), _mode,
                                            _column_ids, _scan_type);

--- a/src/lib/operators/join_nested_loop_b.hpp
+++ b/src/lib/operators/join_nested_loop_b.hpp
@@ -27,8 +27,6 @@ class JoinNestedLoopB : public AbstractJoinOperator {
                   const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -71,10 +71,6 @@ void JoinSortMerge::_on_cleanup() { _impl.reset(); }
 
 const std::string JoinSortMerge::name() const { return "JoinSortMerge"; }
 
-uint8_t JoinSortMerge::num_in_tables() const { return 2u; }
-
-uint8_t JoinSortMerge::num_out_tables() const { return 1u; }
-
 /**
 ** Start of implementation.
 **/

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -30,8 +30,6 @@ class JoinSortMerge : public AbstractJoinOperator {
   void _on_cleanup() override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
  protected:
   template <typename T>

--- a/src/lib/operators/limit.cpp
+++ b/src/lib/operators/limit.cpp
@@ -16,10 +16,6 @@ Limit::Limit(const std::shared_ptr<const AbstractOperator> in, const size_t num_
 
 const std::string Limit::name() const { return "Limit"; }
 
-uint8_t Limit::num_in_tables() const { return 1; }
-
-uint8_t Limit::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> Limit::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<Limit>(_input_left->recreate(args), _num_rows);
 }

--- a/src/lib/operators/limit.hpp
+++ b/src/lib/operators/limit.hpp
@@ -13,8 +13,6 @@ class Limit : public AbstractReadOnlyOperator {
   explicit Limit(const std::shared_ptr<const AbstractOperator> in, const size_t num_rows);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
   size_t num_rows() const;

--- a/src/lib/operators/maintenance/show_columns.cpp
+++ b/src/lib/operators/maintenance/show_columns.cpp
@@ -16,10 +16,6 @@ namespace opossum {
 
 ShowColumns::ShowColumns(const std::string& table_name) : _table_name(table_name) {}
 
-uint8_t ShowColumns::num_in_tables() const { return 0; }
-
-uint8_t ShowColumns::num_out_tables() const { return 1; }
-
 const std::string ShowColumns::name() const { return "ShowColumns"; }
 
 std::shared_ptr<AbstractOperator> ShowColumns::recreate(const std::vector<AllParameterVariant>& args) const {

--- a/src/lib/operators/maintenance/show_columns.hpp
+++ b/src/lib/operators/maintenance/show_columns.hpp
@@ -14,8 +14,6 @@ class ShowColumns : public AbstractReadOnlyOperator {
   explicit ShowColumns(const std::string& table_name);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 

--- a/src/lib/operators/maintenance/show_tables.cpp
+++ b/src/lib/operators/maintenance/show_tables.cpp
@@ -14,10 +14,6 @@
 
 namespace opossum {
 
-uint8_t ShowTables::num_in_tables() const { return 0; }
-
-uint8_t ShowTables::num_out_tables() const { return 1; }
-
 const std::string ShowTables::name() const { return "ShowTables"; }
 
 std::shared_ptr<AbstractOperator> ShowTables::recreate(const std::vector<AllParameterVariant>& args) const {

--- a/src/lib/operators/maintenance/show_tables.hpp
+++ b/src/lib/operators/maintenance/show_tables.hpp
@@ -12,8 +12,6 @@ namespace opossum {
 class ShowTables : public AbstractReadOnlyOperator {
  public:
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -19,10 +19,6 @@ Print::Print(const std::shared_ptr<const AbstractOperator> in, std::ostream& out
 
 const std::string Print::name() const { return "Print"; }
 
-uint8_t Print::num_in_tables() const { return 1; }
-
-uint8_t Print::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> Print::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<Print>(_input_left->recreate(args), _out);
 }

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -20,8 +20,6 @@ class Print : public AbstractReadOnlyOperator {
   explicit Print(const std::shared_ptr<const AbstractOperator> in, std::ostream& out = std::cout, uint32_t flags = 0);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
   static void print(std::shared_ptr<const Table> table, uint32_t flags = 0, std::ostream& out = std::cout);

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -15,10 +15,6 @@ Product::Product(const std::shared_ptr<const AbstractOperator> left,
 
 const std::string Product::name() const { return "Product"; }
 
-uint8_t Product::num_in_tables() const { return 2; }
-
-uint8_t Product::num_out_tables() const { return 1; }
-
 std::shared_ptr<const Table> Product::_on_execute() {
   auto output = std::make_shared<Table>();
 

--- a/src/lib/operators/product.hpp
+++ b/src/lib/operators/product.hpp
@@ -21,8 +21,6 @@ class Product : public AbstractReadOnlyOperator {
   Product(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
  protected:
   void add_product_of_two_chunks(std::shared_ptr<Table> output, ChunkID chunk_id_left, ChunkID chunk_id_right);

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -18,10 +18,6 @@ Projection::Projection(const std::shared_ptr<const AbstractOperator> in, const C
 
 const std::string Projection::name() const { return "Projection"; }
 
-uint8_t Projection::num_in_tables() const { return 1; }
-
-uint8_t Projection::num_out_tables() const { return 1; }
-
 const Projection::ColumnExpressions& Projection::column_expressions() const { return _column_expressions; }
 
 std::shared_ptr<AbstractOperator> Projection::recreate(const std::vector<AllParameterVariant>& args) const {

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -31,8 +31,6 @@ class Projection : public AbstractReadOnlyOperator {
   Projection(const std::shared_ptr<const AbstractOperator> in, const ColumnExpressions& column_expressions);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
   const ColumnExpressions& column_expressions() const;
 

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -29,10 +29,6 @@ OrderByMode Sort::order_by_mode() const { return _order_by_mode; }
 
 const std::string Sort::name() const { return "Sort"; }
 
-uint8_t Sort::num_in_tables() const { return 1; }
-
-uint8_t Sort::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> Sort::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<Sort>(_input_left->recreate(args), _column_id, _order_by_mode, _output_chunk_size);
 }

--- a/src/lib/operators/sort.hpp
+++ b/src/lib/operators/sort.hpp
@@ -29,8 +29,6 @@ class Sort : public AbstractReadOnlyOperator {
   OrderByMode order_by_mode() const;
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -63,10 +63,6 @@ const std::string TableScan::description() const {
   return name() + "\\n(" + column_name + " " + scan_type_to_string.left.at(_scan_type) + " " + predicate_string + ")";
 }
 
-uint8_t TableScan::num_in_tables() const { return 1; }
-
-uint8_t TableScan::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> TableScan::recreate(const std::vector<AllParameterVariant>& args) const {
   // Replace value in the new operator, if it’s a parameter and an argument is available.
   if (is_placeholder(_right_parameter)) {

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -29,8 +29,6 @@ class TableScan : public AbstractReadOnlyOperator {
 
   const std::string name() const override;
   const std::string description() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 

--- a/src/lib/operators/table_wrapper.cpp
+++ b/src/lib/operators/table_wrapper.cpp
@@ -10,10 +10,6 @@ TableWrapper::TableWrapper(const std::shared_ptr<const Table> table) : _table(ta
 
 const std::string TableWrapper::name() const { return "TableWrapper"; }
 
-uint8_t TableWrapper::num_in_tables() const { return 0; }
-
-uint8_t TableWrapper::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> TableWrapper::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<TableWrapper>(_table);
 }

--- a/src/lib/operators/table_wrapper.hpp
+++ b/src/lib/operators/table_wrapper.hpp
@@ -17,8 +17,6 @@ class TableWrapper : public AbstractReadOnlyOperator {
   explicit TableWrapper(const std::shared_ptr<const Table> table);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -16,10 +16,6 @@ UnionAll::UnionAll(const std::shared_ptr<const AbstractOperator> left_in,
 
 const std::string UnionAll::name() const { return "UnionAll"; }
 
-uint8_t UnionAll::num_in_tables() const { return 2; }
-
-uint8_t UnionAll::num_out_tables() const { return 1; }
-
 std::shared_ptr<const Table> UnionAll::_on_execute() {
   auto output = std::make_shared<Table>();
 

--- a/src/lib/operators/union_all.hpp
+++ b/src/lib/operators/union_all.hpp
@@ -15,8 +15,6 @@ class UnionAll : public AbstractReadOnlyOperator {
   UnionAll(const std::shared_ptr<const AbstractOperator> left_in,
            const std::shared_ptr<const AbstractOperator> right_in);
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -23,8 +23,6 @@ Update::~Update() = default;
 
 const std::string Update::name() const { return "Update"; }
 
-uint8_t Update::num_in_tables() const { return 1; }
-
 std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionContext> context) {
   DebugAssert((_execution_input_valid(context)), "Input to Update isn't valid");
 

--- a/src/lib/operators/update.hpp
+++ b/src/lib/operators/update.hpp
@@ -32,7 +32,6 @@ class Update : public AbstractReadWriteOperator {
   ~Update();
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -33,10 +33,6 @@ Validate::Validate(const std::shared_ptr<AbstractOperator> in) : AbstractReadOnl
 
 const std::string Validate::name() const { return "Validate"; }
 
-uint8_t Validate::num_in_tables() const { return 1; }
-
-uint8_t Validate::num_out_tables() const { return 1; }
-
 std::shared_ptr<AbstractOperator> Validate::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<Validate>(_input_left->recreate(args));
 }

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -21,8 +21,6 @@ class Validate : public AbstractReadOnlyOperator {
   explicit Validate(const std::shared_ptr<AbstractOperator> in);
 
   const std::string name() const override;
-  uint8_t num_in_tables() const override;
-  uint8_t num_out_tables() const override;
 
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 

--- a/src/lib/planviz/sql_query_plan_visualizer.cpp
+++ b/src/lib/planviz/sql_query_plan_visualizer.cpp
@@ -55,12 +55,12 @@ void SQLQueryPlanVisualizer::_visualize_subtree(const std::shared_ptr<const Abst
   }
   file << "]" << std::endl;
 
-  if (op->num_in_tables() >= 1) {
+  if (op->input_left() != nullptr) {
     _visualize_dataflow(op->input_left(), op, file);
     _visualize_subtree(op->input_left(), file);
   }
 
-  if (op->num_in_tables() == 2) {
+  if (op->input_right() != nullptr) {
     _visualize_dataflow(op->input_right(), op, file);
     _visualize_subtree(op->input_right(), file);
   }

--- a/src/lib/sql/sql_query_operator.cpp
+++ b/src/lib/sql/sql_query_operator.cpp
@@ -43,10 +43,6 @@ SQLQueryOperator::SQLQueryOperator(const std::string& query, bool schedule_plan,
 
 const std::string SQLQueryOperator::name() const { return "SQLQueryOperator"; }
 
-uint8_t SQLQueryOperator::num_in_tables() const { return 0; }
-
-uint8_t SQLQueryOperator::num_out_tables() const { return 0; }
-
 const std::shared_ptr<OperatorTask>& SQLQueryOperator::get_result_task() const { return _result_task; }
 
 const SQLQueryPlan& SQLQueryOperator::get_query_plan() const { return _plan; }

--- a/src/lib/sql/sql_query_operator.hpp
+++ b/src/lib/sql/sql_query_operator.hpp
@@ -34,10 +34,6 @@ class SQLQueryOperator : public AbstractOperator {
 
   const std::string name() const override;
 
-  uint8_t num_in_tables() const override;
-
-  uint8_t num_out_tables() const override;
-
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
   const std::shared_ptr<OperatorTask>& get_result_task() const;

--- a/src/lib/sql/sql_result_operator.cpp
+++ b/src/lib/sql/sql_result_operator.cpp
@@ -12,10 +12,6 @@ SQLResultOperator::SQLResultOperator() {}
 
 const std::string SQLResultOperator::name() const { return "SQLResultOperator"; }
 
-uint8_t SQLResultOperator::num_in_tables() const { return 1; }
-
-uint8_t SQLResultOperator::num_out_tables() const { return 1; }
-
 void SQLResultOperator::set_input_operator(const std::shared_ptr<const AbstractOperator> input) { _input_left = input; }
 
 std::shared_ptr<const Table> SQLResultOperator::_on_execute() {

--- a/src/lib/sql/sql_result_operator.hpp
+++ b/src/lib/sql/sql_result_operator.hpp
@@ -20,10 +20,6 @@ class SQLResultOperator : public AbstractReadOnlyOperator {
 
   const std::string name() const override;
 
-  uint8_t num_in_tables() const override;
-
-  uint8_t num_out_tables() const override;
-
   std::shared_ptr<const Table> _on_execute() override;
 
   // Called by SQLQueryOperator to dynamically set the input operator.

--- a/src/test/concurrency/transaction_context_test.cpp
+++ b/src/test/concurrency/transaction_context_test.cpp
@@ -34,7 +34,6 @@ class CommitFuncOp : public AbstractReadWriteOperator {
   explicit CommitFuncOp(std::function<void()> func) : _func{func} {}
 
   const std::string name() const override { return "CommitOp"; }
-  uint8_t num_in_tables() const override { return 0u; }
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override {

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -135,23 +135,6 @@ class OperatorsAggregateTest : public BaseTest {
       _table_wrapper_3_1, _table_wrapper_3_2;
 };
 
-TEST_F(OperatorsAggregateTest, NumInputTables) {
-  auto aggregate = std::make_shared<Aggregate>(_table_wrapper_1_1,
-                                               std::vector<AggregateDefinition>{{ColumnID{1}, AggregateFunction::Max}},
-                                               std::vector<ColumnID>{ColumnID{0}});
-  aggregate->execute();
-
-  EXPECT_EQ(aggregate->num_in_tables(), 1);
-}
-
-TEST_F(OperatorsAggregateTest, NumOutputTables) {
-  auto aggregate = std::make_shared<Aggregate>(_table_wrapper_1_1,
-                                               std::vector<AggregateDefinition>{{ColumnID{1}, AggregateFunction::Max}},
-                                               std::vector<ColumnID>{ColumnID{0}});
-
-  EXPECT_EQ(aggregate->num_out_tables(), 1);
-}
-
 TEST_F(OperatorsAggregateTest, OperatorName) {
   auto aggregate = std::make_shared<Aggregate>(_table_wrapper_1_1,
                                                std::vector<AggregateDefinition>{{ColumnID{1}, AggregateFunction::Max}},

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -32,18 +32,6 @@ TEST_F(OperatorsGetTableTest, ThrowsUnknownTableName) {
   EXPECT_THROW(gt->execute(), std::exception) << "Should throw unknown table name exception";
 }
 
-TEST_F(OperatorsGetTableTest, NumInputTables) {
-  auto gt = std::make_shared<opossum::GetTable>("aNiceTestTable");
-
-  EXPECT_EQ(gt->num_in_tables(), 0);
-}
-
-TEST_F(OperatorsGetTableTest, NumOutputTables) {
-  auto gt = std::make_shared<opossum::GetTable>("aNiceTestTable");
-
-  EXPECT_EQ(gt->num_out_tables(), 1);
-}
-
 TEST_F(OperatorsGetTableTest, NumOutputTablesForUnknownTable) {
   auto gt = std::make_shared<opossum::GetTable>("anUglyTestTable");
 

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -32,12 +32,6 @@ TEST_F(OperatorsGetTableTest, ThrowsUnknownTableName) {
   EXPECT_THROW(gt->execute(), std::exception) << "Should throw unknown table name exception";
 }
 
-TEST_F(OperatorsGetTableTest, NumOutputTablesForUnknownTable) {
-  auto gt = std::make_shared<opossum::GetTable>("anUglyTestTable");
-
-  EXPECT_EQ(gt->num_out_tables(), 1);
-}
-
 TEST_F(OperatorsGetTableTest, OperatorName) {
   auto gt = std::make_shared<opossum::GetTable>("aNiceTestTable");
 

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -117,18 +117,6 @@ TEST_F(OperatorsPrintTest, GetColumnWidths) {
   EXPECT_EQ(print_lengths.at(1), static_cast<size_t>(max));
 }
 
-TEST_F(OperatorsPrintTest, NumInputTables) {
-  auto pr = std::make_shared<opossum::Print>(gt, output);
-
-  EXPECT_EQ(pr->num_in_tables(), 1);
-}
-
-TEST_F(OperatorsPrintTest, NumOutputTables) {
-  auto pr = std::make_shared<opossum::Print>(gt, output);
-
-  EXPECT_EQ(pr->num_out_tables(), 1);
-}
-
 TEST_F(OperatorsPrintTest, OperatorName) {
   auto pr = std::make_shared<opossum::Print>(gt, output);
 

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -248,18 +248,6 @@ TEST_F(OperatorsProjectionTest, Literals) {
   EXPECT_TABLE_EQ(projection->get_output(), expected_result);
 }
 
-TEST_F(OperatorsProjectionTest, NumInputTables) {
-  auto projection_1 = std::make_shared<opossum::Projection>(_table_wrapper, _a_b_expr);
-
-  EXPECT_EQ(projection_1->num_in_tables(), 1);
-}
-
-TEST_F(OperatorsProjectionTest, NumOutputTables) {
-  auto projection_1 = std::make_shared<opossum::Projection>(_table_wrapper, _a_b_expr);
-
-  EXPECT_EQ(projection_1->num_out_tables(), 1);
-}
-
 TEST_F(OperatorsProjectionTest, OperatorName) {
   auto projection_1 = std::make_shared<opossum::Projection>(_table_wrapper, _a_b_expr);
 

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -443,19 +443,6 @@ TEST_F(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
 }
 
-TEST_F(OperatorsTableScanTest, NumInputTables) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
-  scan_1->execute();
-
-  EXPECT_EQ(scan_1->num_in_tables(), 1);
-}
-
-TEST_F(OperatorsTableScanTest, NumOutputTables) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
-
-  EXPECT_EQ(scan_1->num_out_tables(), 1);
-}
-
 TEST_F(OperatorsTableScanTest, OperatorName) {
   auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
 


### PR DESCRIPTION
When we introduced the AbstractOperator interface, it felt natural that all operator should hold information on how many tables they take in and how many they produce. Turns out we don't need that information. Don't believe me? Update::num_out_tables has always been wrong.