### PR TITLE
Link playground with hyriseBenchmarkLib

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
 target_link_libraries(
     hyrisePlayground
     hyrise
+    hyriseBenchmarkLib
 )
 
 # Configure tpccTableGenerator

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 
 int main() {


### PR DESCRIPTION
Doing a few playground experiments this always came in useful (if you need TPCH queries, for example) and shouldn't hurt.