### PR TITLE
Remove non-standard LIKE behavior

### DIFF
--- a/src/lib/operators/table_scan/like_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.hpp
@@ -54,8 +54,6 @@ class LikeTableScanImpl : public BaseSingleColumnTableScanImpl {
    * @{
    */
 
-  static std::map<std::string, std::string> _extract_character_ranges(std::string& str);
-
   static std::string _sqllike_to_regex(std::string sqllike);
 
   /**@}*/

--- a/src/test/operators/table_scan_like_test.cpp
+++ b/src/test/operators/table_scan_like_test.cpp
@@ -66,6 +66,13 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyString) {
   scan->execute();
   EXPECT_TABLE_EQ(scan->get_output(), expected_result);
 }
+TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringOnDict) {
+  std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
+  // wildcard has to be placed at front and/or back of search string
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "%");
+  scan->execute();
+  EXPECT_TABLE_EQ(scan->get_output(), expected_result);
+}
 TEST_F(OperatorsTableScanLikeTest, ScanLikeCaseInsensitivity) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
@@ -78,13 +85,6 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeUnderscoreWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
   auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "d_m_f%");
-  scan->execute();
-  EXPECT_TABLE_EQ(scan->get_output(), expected_result);
-}
-TEST_F(OperatorsTableScanLikeTest, ScanLikeCharacterWildcard) {
-  std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "dam[abcp]f%");
   scan->execute();
   EXPECT_TABLE_EQ(scan->get_output(), expected_result);
 }


### PR DESCRIPTION
Currently, the TableScan supports this:
`SELECT * FROM t WHERE a LIKE 'hau[fs]en'`.

This is not part of the SQL standard and only supported by SQL Server. Since this would not work with the sqlite test, this PR removes that behavior. Also, it removes code that will not be used anyway.

The correct way to do this in an SQL query would be `REGEXP`, not `LIKE`.