### PR TITLE
Remove CSV parser's error message, only throw exception.

### DIFF
--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -175,7 +175,8 @@ void CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vector<
       try {
         converters[column_id]->insert(field, row_id);
       } catch (const std::exception& exception) {
-        throw std::logic_error("Exception while parsing CSV, row " + std::to_string(row_id) + ", column " + std::to_string(column_id) + ".");
+        throw std::logic_error("Exception while parsing CSV, row " + std::to_string(row_id) + ", column " +
+                               std::to_string(column_id) + ".");
       }
     }
   }

--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -176,7 +176,7 @@ void CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vector<
         converters[column_id]->insert(field, row_id);
       } catch (const std::exception& exception) {
         throw std::logic_error("Exception while parsing CSV, row " + std::to_string(row_id) + ", column " +
-                               std::to_string(column_id) + ".");
+                               std::to_string(column_id) + ":\n" + exception.what());
       }
     }
   }

--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -175,8 +175,7 @@ void CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vector<
       try {
         converters[column_id]->insert(field, row_id);
       } catch (const std::exception& exception) {
-        std::cerr << "Exception while parsing CSV, row " << row_id << ", column " << column_id << "." << std::endl;
-        throw;
+        throw std::logic_error("Exception while parsing CSV, row " + std::to_string(row_id) + ", column " + std::to_string(column_id) + ".");
       }
     }
   }


### PR DESCRIPTION
There are two reasons for this: Error messages are shown during test execution which pollutes the terminal. More important, the general Hyrise error paradigm is to fail loud and early and not handling error cases while informing the user. However, the current implementation throws an exception anyways. 

One could argue that a crash during the import of the last rows of a large CSV file might be annoying for the user, but the current approach does also throw. Handling such problems could be the task of the console at some point.