### PR TITLE
More Test Coverage for AST Nodes (green badge inside)

### DIFF
--- a/src/lib/optimizer/abstract_syntax_tree/dummy_table_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/dummy_table_node.cpp
@@ -15,21 +15,6 @@ DummyTableNode::DummyTableNode() : AbstractASTNode(ASTNodeType::DummyTable) {
 
 std::string DummyTableNode::description() const { return "[DummyTable]"; }
 
-void DummyTableNode::_on_child_changed() { Fail("DummyTableNode cannot have children."); }
-
 const std::vector<std::string>& DummyTableNode::output_column_names() const { return _output_column_names; }
-
-const std::vector<ColumnID>& DummyTableNode::output_column_ids_to_input_column_ids() const {
-  return *_output_column_ids_to_input_column_ids;
-}
-
-std::vector<ColumnID> DummyTableNode::get_output_column_ids_for_table(const std::string& table_name) const {
-  return {};
-}
-
-std::optional<ColumnID> DummyTableNode::find_column_id_by_named_column_reference(
-    const NamedColumnReference& named_column_reference) const {
-  return {};
-}
 
 }  // namespace opossum

--- a/src/lib/optimizer/abstract_syntax_tree/dummy_table_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/dummy_table_node.hpp
@@ -18,17 +18,9 @@ class DummyTableNode : public AbstractASTNode {
 
   std::string description() const override;
 
-  const std::vector<ColumnID>& output_column_ids_to_input_column_ids() const override;
   const std::vector<std::string>& output_column_names() const override;
 
-  std::optional<ColumnID> find_column_id_by_named_column_reference(
-      const NamedColumnReference& named_column_reference) const override;
-
-  std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
-
  protected:
-  void _on_child_changed() override;
-
   std::vector<std::string> _output_column_names;
 };
 

--- a/src/lib/optimizer/abstract_syntax_tree/union_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/union_node.cpp
@@ -34,7 +34,7 @@ const std::vector<std::string>& UnionNode::output_column_names() const {
 
 const std::vector<ColumnID>& UnionNode::output_column_ids_to_input_column_ids() const {
   if (!_output_column_ids_to_input_column_ids) {
-    _output_column_ids_to_input_column_ids->resize(output_column_count());
+    _output_column_ids_to_input_column_ids.emplace(output_column_count());
     std::iota(_output_column_ids_to_input_column_ids->begin(), _output_column_ids_to_input_column_ids->end(),
               ColumnID{0});
   }
@@ -53,9 +53,6 @@ std::optional<ColumnID> UnionNode::find_column_id_by_named_column_reference(
    * This function has to be overwritten if columns or their order are in any way redefined by this Node.
    * Examples include Projections, Aggregates, and Joins.
    */
-  DebugAssert(left_child() && !right_child(),
-              "Node has no or two inputs and therefore needs to override this function");
-
   auto named_column_reference_without_local_alias = _resolve_local_alias(named_column_reference);
   if (!named_column_reference_without_local_alias) {
     return {};

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -45,9 +45,21 @@ set(
     operators/validate_visibility_test.cpp
     optimizer/abstract_syntax_tree/abstract_syntax_tree_test.cpp
     optimizer/abstract_syntax_tree/aggregate_node_test.cpp
+    optimizer/abstract_syntax_tree/delete_node_test.cpp
+    optimizer/abstract_syntax_tree/dummy_table_node_test.cpp
+    optimizer/abstract_syntax_tree/insert_node_test.cpp
     optimizer/abstract_syntax_tree/join_node_test.cpp
+    optimizer/abstract_syntax_tree/limit_node_test.cpp
+    optimizer/abstract_syntax_tree/mock_node_test.cpp
     optimizer/abstract_syntax_tree/stored_table_node_test.cpp
+    optimizer/abstract_syntax_tree/predicate_node_test.cpp
     optimizer/abstract_syntax_tree/projection_node_test.cpp
+    optimizer/abstract_syntax_tree/show_columns_node_test.cpp
+    optimizer/abstract_syntax_tree/show_tables_node_test.cpp
+    optimizer/abstract_syntax_tree/sort_node_test.cpp
+    optimizer/abstract_syntax_tree/union_node_test.cpp
+    optimizer/abstract_syntax_tree/update_node_test.cpp
+    optimizer/abstract_syntax_tree/validate_node_test.cpp
     optimizer/ast_to_operator_translator_test.cpp
     optimizer/column_statistics_test.cpp
     optimizer/strategy/join_detection_rule_test.cpp

--- a/src/test/optimizer/abstract_syntax_tree/abstract_syntax_tree_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/abstract_syntax_tree_test.cpp
@@ -73,6 +73,8 @@ TEST_F(AbstractSyntaxTreeTest, SimpleParentTest) {
   ASSERT_EQ(projection_node->left_child(), predicate_node);
   ASSERT_EQ(projection_node->right_child(), nullptr);
   ASSERT_TRUE(projection_node->parents().empty());
+
+  ASSERT_ANY_THROW(projection_node->get_child_side(table_node));
 }
 
 TEST_F(AbstractSyntaxTreeTest, SimpleClearParentsTest) {
@@ -176,6 +178,29 @@ TEST_F(AbstractSyntaxTreeTest, ComplexGraphStructure) {
   ASSERT_AST_TIE(_nodes[5], ASTChildSide::Left, _nodes[6]);
   ASSERT_AST_TIE(_nodes[5], ASTChildSide::Right, _nodes[7]);
   ASSERT_AST_TIE(_nodes[4], ASTChildSide::Right, _nodes[7]);
+}
+
+TEST_F(AbstractSyntaxTreeTest, ComplexGraphPrinted) {
+  std::stringstream stream;
+  _nodes[0]->print(stream, {});
+
+  ASSERT_EQ(stream.str(), R"([MockTable]
+ \_[MockTable]
+ |  \_[MockTable]
+ |  |  \_[MockTable]
+ |  |     \_[MockTable]
+ |  |     \_[MockTable]
+ |  \_[MockTable]
+ |     \_[MockTable]
+ |     |  \_[MockTable]
+ |     |  \_[MockTable]
+ |     \_[MockTable]
+ \_[MockTable]
+    \_[MockTable]
+    |  \_[MockTable]
+    |  \_[MockTable]
+    \_[MockTable]
+)");
 }
 
 TEST_F(AbstractSyntaxTreeTest, ComplexGraphRemoveFromTree) {

--- a/src/test/optimizer/abstract_syntax_tree/aggregate_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/aggregate_node_test.cpp
@@ -119,4 +119,17 @@ TEST_F(AggregateNodeTest, AliasedSubqueryTest) {
   EXPECT_EQ(aggregate_node_with_alias->find_column_id_by_named_column_reference({"some_sum", {"t_a"}}), std::nullopt);
 }
 
+TEST_F(AggregateNodeTest, Description) {
+  auto description = _aggregate_node->description();
+
+  EXPECT_EQ(description, "[Aggregate] SUM(t_a.a + t_a.b), SUM(t_a.a + t_a.c) AS \"some_sum\" GROUP BY [t_a.a, t_a.c]");
+}
+
+TEST_F(AggregateNodeTest, VerboseColumnNames) {
+  EXPECT_EQ(_aggregate_node->get_verbose_column_name(ColumnID{0}), "SUM(t_a.a + t_a.b)");
+  EXPECT_EQ(_aggregate_node->get_verbose_column_name(ColumnID{1}), "some_sum");
+  EXPECT_EQ(_aggregate_node->get_verbose_column_name(ColumnID{2}), "t_a.a");
+  EXPECT_EQ(_aggregate_node->get_verbose_column_name(ColumnID{3}), "t_a.c");
+}
+
 }  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/aggregate_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/aggregate_node_test.cpp
@@ -132,4 +132,14 @@ TEST_F(AggregateNodeTest, VerboseColumnNames) {
   EXPECT_EQ(_aggregate_node->get_verbose_column_name(ColumnID{3}), "t_a.c");
 }
 
+TEST_F(AggregateNodeTest, ColumnInputMapping) {
+  auto column_ids = _aggregate_node->get_output_column_ids_for_table("t_a");
+
+  // we are grouping by two columns
+  EXPECT_EQ(column_ids.size(), 2u);
+
+  EXPECT_EQ(column_ids[0], ColumnID{0});
+  EXPECT_EQ(column_ids[1], ColumnID{1});
+}
+
 }  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/delete_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/delete_node_test.cpp
@@ -1,0 +1,22 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/delete_node.hpp"
+
+namespace opossum {
+
+class DeleteNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _delete_node = std::make_shared<DeleteNode>("table_a"); }
+
+  void TearDown() override {}
+
+  std::shared_ptr<DeleteNode> _delete_node;
+};
+
+TEST_F(DeleteNodeTest, Description) { EXPECT_EQ(_delete_node->description(), "[Delete] Table: 'table_a'"); }
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/dummy_table_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/dummy_table_node_test.cpp
@@ -1,0 +1,24 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/dummy_table_node.hpp"
+
+namespace opossum {
+
+class DummyTableNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _dummy_table_node = std::make_shared<DummyTableNode>(); }
+
+  std::shared_ptr<DummyTableNode> _dummy_table_node;
+};
+
+TEST_F(DummyTableNodeTest, Description) { EXPECT_EQ(_dummy_table_node->description(), "[DummyTable]"); }
+
+TEST_F(DummyTableNodeTest, ImplementsOutputColumnInterface) {
+  EXPECT_GE(_dummy_table_node->output_column_names().size(), 0u);
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/insert_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/insert_node_test.cpp
@@ -1,0 +1,22 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/insert_node.hpp"
+
+namespace opossum {
+
+class InsertNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _insert_node = std::make_shared<InsertNode>("table_a"); }
+
+  std::shared_ptr<InsertNode> _insert_node;
+};
+
+TEST_F(InsertNodeTest, Description) { EXPECT_EQ(_insert_node->description(), "[Insert] Into table 'table_a'"); }
+
+TEST_F(InsertNodeTest, TableName) { EXPECT_EQ(_insert_node->table_name(), "table_a"); }
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/limit_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/limit_node_test.cpp
@@ -1,0 +1,22 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/limit_node.hpp"
+
+namespace opossum {
+
+class LimitNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _limit_node = std::make_shared<LimitNode>(10); }
+
+  std::shared_ptr<LimitNode> _limit_node;
+};
+
+TEST_F(LimitNodeTest, Description) { EXPECT_EQ(_limit_node->description(), "[Limit] 10 rows"); }
+
+TEST_F(LimitNodeTest, NumberOfRows) { EXPECT_EQ(_limit_node->num_rows(), 10u); }
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/mock_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/mock_node_test.cpp
@@ -1,0 +1,39 @@
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/mock_node.hpp"
+#include "optimizer/table_statistics.hpp"
+
+namespace opossum {
+
+class MockNodeTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    auto table = load_table("src/test/tables/int_float_double_string.tbl", 0);
+    _statistics = std::make_shared<TableStatistics>(table);
+
+    _mock_node = std::make_shared<MockNode>(_statistics);
+  }
+
+  std::shared_ptr<MockNode> _mock_node;
+  std::shared_ptr<TableStatistics> _statistics;
+};
+
+TEST_F(MockNodeTest, Description) { EXPECT_EQ(_mock_node->description(), "[MockTable]"); }
+
+TEST_F(MockNodeTest, OutputColumnNames) {
+  auto& column_names = _mock_node->output_column_names();
+
+  for (ColumnID column_index{0}; column_index < ColumnID{4}; ++column_index) {
+    auto expected_name = "MockCol" + std::to_string(column_index);
+
+    EXPECT_EQ(column_names[column_index], expected_name);
+    EXPECT_EQ(_mock_node->get_verbose_column_name(column_index), expected_name);
+  }
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/mock_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/mock_node_test.cpp
@@ -36,4 +36,24 @@ TEST_F(MockNodeTest, OutputColumnNames) {
   }
 }
 
+TEST_F(MockNodeTest, ColumnNamesWithAlias) {
+  auto aliased_node = std::make_shared<MockNode>(_statistics);
+  aliased_node->set_alias("foo");
+
+  for (ColumnID column_index{0}; column_index < ColumnID{4}; ++column_index) {
+    auto expected_name = "foo.MockCol" + std::to_string(column_index);
+    EXPECT_EQ(aliased_node->get_verbose_column_name(column_index), expected_name);
+  }
+}
+
+TEST_F(MockNodeTest, NoMappingForInputColumns) {
+  auto column_ids = _mock_node->output_column_ids_to_input_column_ids();
+
+  EXPECT_EQ(column_ids.size(), _mock_node->output_column_count());
+
+  for (auto column_id : column_ids) {
+    EXPECT_EQ(column_id, INVALID_COLUMN_ID);
+  }
+}
+
 }  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/predicate_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/predicate_node_test.cpp
@@ -1,0 +1,41 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/predicate_node.hpp"
+#include "optimizer/abstract_syntax_tree/stored_table_node.hpp"
+
+namespace opossum {
+
+class PredicateNodeTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    StorageManager::get().add_table("table_a", load_table("src/test/tables/int_float_double_string.tbl", 2));
+
+    _table_node = std::make_shared<StoredTableNode>("table_a");
+  }
+
+  std::shared_ptr<StoredTableNode> _table_node;
+};
+
+TEST_F(PredicateNodeTest, Descriptions) {
+  auto predicate_a = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, 5);
+  predicate_a->set_left_child(_table_node);
+  EXPECT_EQ(predicate_a->description(), "[Predicate] table_a.i = 5");
+
+  auto predicate_b = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpNotEquals, 2.5);
+  predicate_b->set_left_child(_table_node);
+  EXPECT_EQ(predicate_b->description(), "[Predicate] table_a.f != 2.5");
+
+  auto predicate_c = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::OpBetween, 2.5, 10.0);
+  predicate_c->set_left_child(_table_node);
+  EXPECT_EQ(predicate_c->description(), "[Predicate] table_a.d BETWEEN 2.5 AND 10");
+
+  auto predicate_d = std::make_shared<PredicateNode>(ColumnID{3}, ScanType::OpEquals, "test");
+  predicate_d->set_left_child(_table_node);
+  EXPECT_EQ(predicate_d->description(), "[Predicate] table_a.s = test");
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/projection_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/projection_node_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -67,6 +68,28 @@ TEST_F(ProjectionNodeTest, AliasedSubqueryTest) {
   EXPECT_EQ(projection_node_with_alias->get_column_id_by_named_column_reference({"alias_for_b", {"foo"}}), 2);
   EXPECT_EQ(projection_node_with_alias->find_column_id_by_named_column_reference({"alias_for_b", {"t_a"}}),
             std::nullopt);
+}
+
+TEST_F(ProjectionNodeTest, ColumnIdsForTable) {
+  auto column_ids = _projection_node->get_output_column_ids_for_table("t_a");
+
+  EXPECT_EQ(column_ids.size(), 3u);
+
+  // make sure all three used columns are in the vector
+  EXPECT_NE(std::find(column_ids.begin(), column_ids.end(), ColumnID{0}), column_ids.end());
+  EXPECT_NE(std::find(column_ids.begin(), column_ids.end(), ColumnID{1}), column_ids.end());
+  EXPECT_NE(std::find(column_ids.begin(), column_ids.end(), ColumnID{2}), column_ids.end());
+}
+
+TEST_F(ProjectionNodeTest, ColumnIdsForUnknownTable) {
+  EXPECT_EQ(_projection_node->get_output_column_ids_for_table("invalid").size(), 0u);
+}
+
+TEST_F(ProjectionNodeTest, VerboseColumnNames) {
+  EXPECT_EQ(_projection_node->get_verbose_column_name(ColumnID{0}), "c");
+  EXPECT_EQ(_projection_node->get_verbose_column_name(ColumnID{1}), "a");
+  EXPECT_EQ(_projection_node->get_verbose_column_name(ColumnID{2}), "alias_for_b");
+  EXPECT_EQ(_projection_node->get_verbose_column_name(ColumnID{3}), "some_addition");
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/projection_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/projection_node_test.cpp
@@ -37,6 +37,10 @@ class ProjectionNodeTest : public BaseTest {
   std::shared_ptr<ProjectionNode> _projection_node;
 };
 
+TEST_F(ProjectionNodeTest, Description) {
+  EXPECT_EQ(_projection_node->description(), "[Projection] t_a.c, t_a.a, t_a.b, t_a.b + t_a.c, t_a.a + t_a.c");
+}
+
 TEST_F(ProjectionNodeTest, ColumnIdForColumnIdentifier) {
   EXPECT_EQ(_projection_node->get_column_id_by_named_column_reference({"c", std::nullopt}), 0);
   EXPECT_EQ(_projection_node->get_column_id_by_named_column_reference({"c", {"t_a"}}), 0);

--- a/src/test/optimizer/abstract_syntax_tree/show_columns_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/show_columns_node_test.cpp
@@ -1,0 +1,24 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/show_columns_node.hpp"
+
+namespace opossum {
+
+class ShowColumnsNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _show_columns_node = std::make_shared<ShowColumnsNode>("table_a"); }
+
+  std::shared_ptr<ShowColumnsNode> _show_columns_node;
+};
+
+TEST_F(ShowColumnsNodeTest, Description) {
+  EXPECT_EQ(_show_columns_node->description(), "[ShowColumns] Table: 'table_a'");
+}
+
+TEST_F(ShowColumnsNodeTest, TableName) { EXPECT_EQ(_show_columns_node->table_name(), "table_a"); }
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/show_tables_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/show_tables_node_test.cpp
@@ -1,0 +1,20 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/show_tables_node.hpp"
+
+namespace opossum {
+
+class ShowTablesNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _show_tables_node = std::make_shared<ShowTablesNode>(); }
+
+  std::shared_ptr<ShowTablesNode> _show_tables_node;
+};
+
+TEST_F(ShowTablesNodeTest, Description) { EXPECT_EQ(_show_tables_node->description(), "[ShowTables]"); }
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/sort_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/sort_node_test.cpp
@@ -39,4 +39,37 @@ TEST_F(SortNodeTest, Descriptions) {
   EXPECT_EQ(sort_c->description(), "[Sort] table_a.d (Descending), table_a.f (Ascending), table_a.i (Descending)");
 }
 
+TEST_F(SortNodeTest, UnchangedColumnMapping) {
+  auto sort_node = std::make_shared<SortNode>(
+      std::vector<OrderByDefinition>{OrderByDefinition{ColumnID{0}, OrderByMode::Ascending}});
+  sort_node->set_left_child(_table_node);
+
+  auto column_ids = sort_node->output_column_ids_to_input_column_ids();
+
+  EXPECT_EQ(column_ids.size(), _table_node->output_column_names().size());
+
+  for (ColumnID column_id{0}; column_id < column_ids.size(); ++column_id) {
+    EXPECT_EQ(column_ids[column_id], column_id);
+  }
+}
+
+TEST_F(SortNodeTest, OutputColumnIDs) {
+  auto sort_node = std::make_shared<SortNode>(
+      std::vector<OrderByDefinition>{OrderByDefinition{ColumnID{0}, OrderByMode::Ascending}});
+  sort_node->set_left_child(_table_node);
+
+  // Valid table name
+  auto column_ids = sort_node->get_output_column_ids_for_table("table_a");
+
+  EXPECT_EQ(column_ids.size(), _table_node->output_column_names().size());
+
+  for (ColumnID column_id{0}; column_id < column_ids.size(); ++column_id) {
+    EXPECT_EQ(column_ids[column_id], column_id);
+  }
+
+  // Invalid table name
+  column_ids = sort_node->get_output_column_ids_for_table("invalid_table");
+  EXPECT_EQ(column_ids.size(), 0u);
+}
+
 }  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/sort_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/sort_node_test.cpp
@@ -1,0 +1,42 @@
+#include <memory>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/sort_node.hpp"
+#include "optimizer/abstract_syntax_tree/stored_table_node.hpp"
+
+namespace opossum {
+
+class SortNodeTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    StorageManager::get().add_table("table_a", load_table("src/test/tables/int_float_double_string.tbl", 2));
+
+    _table_node = std::make_shared<StoredTableNode>("table_a");
+  }
+
+  std::shared_ptr<StoredTableNode> _table_node;
+};
+
+TEST_F(SortNodeTest, Descriptions) {
+  auto sort_a = std::make_shared<SortNode>(
+      std::vector<OrderByDefinition>{OrderByDefinition{ColumnID{0}, OrderByMode::Ascending}});
+  sort_a->set_left_child(_table_node);
+  EXPECT_EQ(sort_a->description(), "[Sort] table_a.i (Ascending)");
+
+  auto sort_b = std::make_shared<SortNode>(
+      std::vector<OrderByDefinition>{OrderByDefinition{ColumnID{0}, OrderByMode::Descending}});
+  sort_b->set_left_child(_table_node);
+  EXPECT_EQ(sort_b->description(), "[Sort] table_a.i (Descending)");
+
+  auto sort_c = std::make_shared<SortNode>(std::vector<OrderByDefinition>{
+      OrderByDefinition{ColumnID{2}, OrderByMode::Descending}, OrderByDefinition{ColumnID{1}, OrderByMode::Ascending},
+      OrderByDefinition{ColumnID{0}, OrderByMode::Descending}});
+  sort_c->set_left_child(_table_node);
+  EXPECT_EQ(sort_c->description(), "[Sort] table_a.d (Descending), table_a.f (Ascending), table_a.i (Descending)");
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/stored_table_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/stored_table_node_test.cpp
@@ -48,6 +48,22 @@ TEST_F(StoredTableNodeTest, OwnOutputColumnIDs) {
   EXPECT_EQ(column_ids[1], ColumnID{1});
 }
 
+TEST_F(StoredTableNodeTest, UnknownTableColumns) {
+  auto column_ids = _stored_table_node->get_output_column_ids_for_table("invalid_table");
+  EXPECT_EQ(column_ids.size(), 0u);
+}
+
+TEST_F(StoredTableNodeTest, AliasTableColumns) {
+  const auto alias_table_node = std::make_shared<StoredTableNode>(*_stored_table_node);
+  alias_table_node->set_alias({"foo"});
+
+  auto column_ids = alias_table_node->get_output_column_ids_for_table("foo");
+
+  EXPECT_EQ(column_ids.size(), 2u);
+  EXPECT_EQ(column_ids[0], ColumnID{0});
+  EXPECT_EQ(column_ids[1], ColumnID{1});
+}
+
 TEST_F(StoredTableNodeTest, VerboseColumnNames) {
   EXPECT_EQ(_stored_table_node->get_verbose_column_name(ColumnID{0}), "t_a.a");
   EXPECT_EQ(_stored_table_node->get_verbose_column_name(ColumnID{1}), "t_a.b");

--- a/src/test/optimizer/abstract_syntax_tree/stored_table_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/stored_table_node_test.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -22,6 +23,14 @@ class StoredTableNodeTest : public BaseTest {
   std::shared_ptr<StoredTableNode> _stored_table_node;
 };
 
+TEST_F(StoredTableNodeTest, Description) { EXPECT_EQ(_stored_table_node->description(), "[StoredTable] Name: 't_a'"); }
+
+TEST_F(StoredTableNodeTest, ColumnsHaveNoInputIDs) {
+  for (auto column_id : _stored_table_node->output_column_ids_to_input_column_ids()) {
+    EXPECT_EQ(column_id, INVALID_COLUMN_ID);
+  }
+}
+
 TEST_F(StoredTableNodeTest, ColumnIdForColumnIdentifier) {
   EXPECT_EQ(_stored_table_node->get_column_id_by_named_column_reference({"a", std::nullopt}), 0);
   EXPECT_EQ(_stored_table_node->get_column_id_by_named_column_reference({"a", {"t_a"}}), 0);
@@ -29,6 +38,27 @@ TEST_F(StoredTableNodeTest, ColumnIdForColumnIdentifier) {
   EXPECT_EQ(_stored_table_node->find_column_id_by_named_column_reference({"c", {"t_a"}}), std::nullopt);
   EXPECT_EQ(_stored_table_node->find_column_id_by_named_column_reference({"c", {"garbage"}}), std::nullopt);
   EXPECT_EQ(_stored_table_node->find_column_id_by_named_column_reference({"b", {"garbage"}}), std::nullopt);
+}
+
+TEST_F(StoredTableNodeTest, OwnOutputColumnIDs) {
+  auto column_ids = _stored_table_node->get_output_column_ids_for_table("t_a");
+
+  EXPECT_EQ(column_ids.size(), 2u);
+  EXPECT_EQ(column_ids[0], ColumnID{0});
+  EXPECT_EQ(column_ids[1], ColumnID{1});
+}
+
+TEST_F(StoredTableNodeTest, VerboseColumnNames) {
+  EXPECT_EQ(_stored_table_node->get_verbose_column_name(ColumnID{0}), "t_a.a");
+  EXPECT_EQ(_stored_table_node->get_verbose_column_name(ColumnID{1}), "t_a.b");
+}
+
+TEST_F(StoredTableNodeTest, VerboseColumnNamesWithAlias) {
+  const auto node_with_alias = std::make_shared<StoredTableNode>(*_stored_table_node);
+  node_with_alias->set_alias(std::string("foo"));
+
+  EXPECT_EQ(node_with_alias->get_verbose_column_name(ColumnID{0}), "(t_a AS foo).a");
+  EXPECT_EQ(node_with_alias->get_verbose_column_name(ColumnID{1}), "(t_a AS foo).b");
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/union_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/union_node_test.cpp
@@ -1,0 +1,99 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/stored_table_node.hpp"
+#include "optimizer/abstract_syntax_tree/union_node.hpp"
+
+namespace opossum {
+
+class UnionNodeTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    StorageManager::get().add_table("table_a", load_table("src/test/tables/int_int.tbl", 2));
+    StorageManager::get().add_table("table_b", load_table("src/test/tables/int_float.tbl", 2));
+
+    _table_node_a = std::make_shared<StoredTableNode>("table_a");
+    _table_node_b = std::make_shared<StoredTableNode>("table_b");
+
+    _union_node = std::make_shared<UnionNode>(UnionMode::Positions);
+    _union_node->set_left_child(_table_node_a);
+    _union_node->set_right_child(_table_node_b);
+  }
+
+  std::shared_ptr<StoredTableNode> _table_node_a, _table_node_b;
+  std::shared_ptr<UnionNode> _union_node;
+};
+
+TEST_F(UnionNodeTest, Description) { EXPECT_EQ(_union_node->description(), "[UnionNode] Mode: UnionPositions"); }
+
+TEST_F(UnionNodeTest, StatisticsNotImplemented) {
+  EXPECT_THROW(_union_node->derive_statistics_from(_table_node_a, _table_node_b), std::exception);
+}
+
+TEST_F(UnionNodeTest, OutputColumnMapping) {
+  auto column_ids = _union_node->output_column_ids_to_input_column_ids();
+
+  EXPECT_EQ(column_ids.size(), 2u);
+  EXPECT_EQ(column_ids[0], ColumnID{0});
+  EXPECT_EQ(column_ids[1], ColumnID{1});
+}
+
+TEST_F(UnionNodeTest, MismatchingColumnNames) {
+  StorageManager::get().add_table("table_c", load_table("src/test/tables/string_int.tbl", 2));
+
+  auto table_node_c = std::make_shared<StoredTableNode>("table_c");
+  auto invalid_union = std::make_shared<UnionNode>(UnionMode::Positions);
+  invalid_union->set_left_child(_table_node_a);
+  invalid_union->set_right_child(table_node_c);
+
+  EXPECT_THROW(invalid_union->get_verbose_column_name(ColumnID{0}), std::exception);
+}
+
+TEST_F(UnionNodeTest, KnowsNoTables) {
+  EXPECT_FALSE(_union_node->knows_table("table_a"));
+  EXPECT_FALSE(_union_node->knows_table("table_b"));
+  EXPECT_FALSE(_union_node->knows_table("any_table"));
+}
+
+TEST_F(UnionNodeTest, DISABLED_VerboseColumnNames) {
+  /* 
+   * Currently the verbose column names of the inputs need to be *exactly* the same.
+   * That is why we need to use the same input table for left AND right input.
+   * This is probably a logical error in `UnionNode::get_verbose_column_name`.
+   */
+
+  auto verbose_union = std::make_shared<UnionNode>(UnionMode::Positions);
+  verbose_union->set_left_child(_table_node_a);
+  verbose_union->set_right_child(_table_node_b);
+
+  EXPECT_EQ(verbose_union->get_verbose_column_name(ColumnID{0}), "a");
+  EXPECT_EQ(verbose_union->get_verbose_column_name(ColumnID{1}), "b");
+}
+
+TEST_F(UnionNodeTest, DISABLED_FindingColumnReferences) {
+  /*
+   * Resolving names does not seem to work properly. On one hand, it is required to have two input tables
+   * with exactly the same name and alias for `get_verbose_column_name` to work, but on the other hand,
+   * `find_column_id_by_named_column_reference` requires column names to be different on each side.
+   */
+
+  // finding column named "a"
+  EXPECT_EQ(_union_node->get_column_id_by_named_column_reference({"a", std::nullopt}), ColumnID{0});
+  EXPECT_EQ(_union_node->get_column_id_by_named_column_reference({"a", {"table_a"}}), ColumnID{0});
+  EXPECT_EQ(_union_node->get_column_id_by_named_column_reference({"a", {"table_b"}}), ColumnID{0});
+
+  // finding column named "b"
+  EXPECT_EQ(_union_node->get_column_id_by_named_column_reference({"b", std::nullopt}), ColumnID{1});
+  EXPECT_EQ(_union_node->get_column_id_by_named_column_reference({"b", {"table_a"}}), ColumnID{1});
+  EXPECT_EQ(_union_node->get_column_id_by_named_column_reference({"b", {"table_b"}}), ColumnID{1});
+
+  // invalid names
+  EXPECT_EQ(_union_node->find_column_id_by_named_column_reference({"c", std::nullopt}), std::nullopt);
+  EXPECT_EQ(_union_node->find_column_id_by_named_column_reference({"c", {"table_a"}}), std::nullopt);
+  EXPECT_EQ(_union_node->find_column_id_by_named_column_reference({"c", {"table_b"}}), std::nullopt);
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/union_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/union_node_test.cpp
@@ -33,6 +33,10 @@ TEST_F(UnionNodeTest, StatisticsNotImplemented) {
   EXPECT_THROW(_union_node->derive_statistics_from(_table_node_a, _table_node_b), std::exception);
 }
 
+TEST_F(UnionNodeTest, NoInputTableColumn) {
+  EXPECT_THROW(_union_node->get_output_column_ids_for_table("table_a"), std::exception);
+}
+
 TEST_F(UnionNodeTest, OutputColumnMapping) {
   auto column_ids = _union_node->output_column_ids_to_input_column_ids();
 

--- a/src/test/optimizer/abstract_syntax_tree/update_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/update_node_test.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 #include "gtest/gtest.h"
 

--- a/src/test/optimizer/abstract_syntax_tree/update_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/update_node_test.cpp
@@ -1,0 +1,25 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/update_node.hpp"
+
+namespace opossum {
+
+class UpdateNodeTest : public BaseTest {
+ protected:
+  void SetUp() override {
+    std::vector<std::shared_ptr<Expression>> update_expressions;
+    _update_node = std::make_shared<UpdateNode>("table_a", update_expressions);
+  }
+
+  std::shared_ptr<UpdateNode> _update_node;
+};
+
+TEST_F(UpdateNodeTest, Description) { EXPECT_EQ(_update_node->description(), "[Update] Table: 'table_a'"); }
+
+TEST_F(UpdateNodeTest, TableName) { EXPECT_EQ(_update_node->table_name(), "table_a"); }
+
+}  // namespace opossum

--- a/src/test/optimizer/abstract_syntax_tree/validate_node_test.cpp
+++ b/src/test/optimizer/abstract_syntax_tree/validate_node_test.cpp
@@ -1,0 +1,20 @@
+#include <memory>
+
+#include "gtest/gtest.h"
+
+#include "base_test.hpp"
+
+#include "optimizer/abstract_syntax_tree/validate_node.hpp"
+
+namespace opossum {
+
+class ValidateNodeTest : public BaseTest {
+ protected:
+  void SetUp() override { _validate_node = std::make_shared<ValidateNode>(); }
+
+  std::shared_ptr<ValidateNode> _validate_node;
+};
+
+TEST_F(ValidateNodeTest, Description) { EXPECT_EQ(_validate_node->description(), "[Validate]"); }
+
+}  // namespace opossum

--- a/src/test/optimizer/ast_to_operator_translator_test.cpp
+++ b/src/test/optimizer/ast_to_operator_translator_test.cpp
@@ -12,6 +12,8 @@
 #include "operators/join_hash.hpp"
 #include "operators/join_sort_merge.hpp"
 #include "operators/limit.hpp"
+#include "operators/maintenance/show_columns.hpp"
+#include "operators/maintenance/show_tables.hpp"
 #include "operators/projection.hpp"
 #include "operators/sort.hpp"
 #include "operators/table_scan.hpp"
@@ -21,6 +23,8 @@
 #include "optimizer/abstract_syntax_tree/limit_node.hpp"
 #include "optimizer/abstract_syntax_tree/predicate_node.hpp"
 #include "optimizer/abstract_syntax_tree/projection_node.hpp"
+#include "optimizer/abstract_syntax_tree/show_columns_node.hpp"
+#include "optimizer/abstract_syntax_tree/show_tables_node.hpp"
 #include "optimizer/abstract_syntax_tree/sort_node.hpp"
 #include "optimizer/abstract_syntax_tree/stored_table_node.hpp"
 #include "storage/storage_manager.hpp"
@@ -123,6 +127,24 @@ TEST_F(ASTToOperatorTranslatorTest, JoinNode) {
   EXPECT_EQ(join_op->column_ids(), join_node->join_column_ids());
   EXPECT_EQ(join_op->scan_type(), ScanType::OpEquals);
   EXPECT_EQ(join_op->mode(), JoinMode::Outer);
+}
+
+TEST_F(ASTToOperatorTranslatorTest, ShowTablesNode) {
+  const auto show_tables_node = std::make_shared<ShowTablesNode>();
+  const auto op = ASTToOperatorTranslator{}.translate_node(show_tables_node);
+
+  const auto show_tables_op = std::dynamic_pointer_cast<ShowTables>(op);
+  ASSERT_TRUE(show_tables_op);
+  EXPECT_EQ(show_tables_op->name(), "ShowTables");
+}
+
+TEST_F(ASTToOperatorTranslatorTest, ShowColumnsNode) {
+  const auto show_column_node = std::make_shared<ShowColumnsNode>("table_a");
+  const auto op = ASTToOperatorTranslator{}.translate_node(show_column_node);
+
+  const auto show_columns_op = std::dynamic_pointer_cast<ShowColumns>(op);
+  ASSERT_TRUE(show_columns_op);
+  EXPECT_EQ(show_columns_op->name(), "ShowColumns");
 }
 
 TEST_F(ASTToOperatorTranslatorTest, AggregateNodeNoArithmetics) {


### PR DESCRIPTION
I noticed that the AST Node classes were lacking test coverage so this PR will fix that.

As a result, the overall test coverage should reach 90.1% which means a green badge.

Note: `DummyTableNode` had most of its virtual methods removed because they are not needed.