### PR TITLE
 AST printing and multiple parents; OR in HAVING

### DIFF
--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,26 +1,6 @@
 #include <iostream>
-#include <optimizer/abstract_syntax_tree/abstract_ast_node.hpp>
-#include <sql/sql_to_ast_translator.hpp>
-#include <storage/storage_manager.hpp>
-#include <utils/load_table.hpp>
-
-#include "SQLParser.h"
-#include "SQLParserResult.h"
 
 int main() {
-  opossum::StorageManager::get().add_table(
-      "groupby_int_2gb_2agg",
-      opossum::load_table("src/test/tables/aggregateoperator/groupby_int_2gb_2agg/input.tbl", 0));
-
-  auto query =
-      "SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;";
-
-  hsql::SQLParserResult result;
-  hsql::SQLParser::parse(query, &result);
-
-  auto nodes = opossum::SQLToASTTranslator(false).translate_parse_result(result);
-
-  nodes[0]->print();
-
+  std::cout << "Hello world!" << std::endl;
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -8,16 +8,17 @@
 #include "SQLParserResult.h"
 
 int main() {
-  opossum::StorageManager::get().add_table("groupby_int_2gb_2agg", opossum::load_table("src/test/tables/aggregateoperator/groupby_int_2gb_2agg/input.tbl", 0));
+  opossum::StorageManager::get().add_table(
+      "groupby_int_2gb_2agg",
+      opossum::load_table("src/test/tables/aggregateoperator/groupby_int_2gb_2agg/input.tbl", 0));
 
-  auto query = "SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;";
+  auto query =
+      "SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;";
 
   hsql::SQLParserResult result;
   hsql::SQLParser::parse(query, &result);
 
   auto nodes = opossum::SQLToASTTranslator(false).translate_parse_result(result);
-
-
 
   nodes[0]->print();
 

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,6 +1,25 @@
 #include <iostream>
+#include <optimizer/abstract_syntax_tree/abstract_ast_node.hpp>
+#include <sql/sql_to_ast_translator.hpp>
+#include <storage/storage_manager.hpp>
+#include <utils/load_table.hpp>
+
+#include "SQLParser.h"
+#include "SQLParserResult.h"
 
 int main() {
-  std::cout << "Hello world!" << std::endl;
+  opossum::StorageManager::get().add_table("groupby_int_2gb_2agg", opossum::load_table("src/test/tables/aggregateoperator/groupby_int_2gb_2agg/input.tbl", 0));
+
+  auto query = "SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;";
+
+  hsql::SQLParserResult result;
+  hsql::SQLParser::parse(query, &result);
+
+  auto nodes = opossum::SQLToASTTranslator(false).translate_parse_result(result);
+
+
+
+  nodes[0]->print();
+
   return 0;
 }

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "types.hpp"
@@ -333,10 +334,8 @@ std::optional<NamedColumnReference> AbstractASTNode::_resolve_local_alias(const 
   return reference;
 }
 
-
-void AbstractASTNode::_print_impl(std::ostream& out,
-                                  std::vector<bool> & levels,
-                                  std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t> & id_by_node,
+void AbstractASTNode::_print_impl(std::ostream& out, std::vector<bool>& levels,
+                                  std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t>& id_by_node,
                                   size_t id_counter) const {
   const auto max_level = levels.empty() ? 0 : levels.size() - 1;
   for (size_t level = 0; level < max_level; ++level) {

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.cpp
@@ -279,32 +279,11 @@ void AbstractASTNode::replace_with(const std::shared_ptr<AbstractASTNode>& repla
 
 void AbstractASTNode::set_alias(const std::optional<std::string>& table_alias) { _table_alias = table_alias; }
 
-void AbstractASTNode::print(std::ostream& out, std::vector<bool> levels) const {
-  const auto max_level = levels.empty() ? 0 : levels.size() - 1;
-  for (size_t level = 0; level < max_level; ++level) {
-    if (levels[level]) {
-      out << " | ";
-    } else {
-      out << "   ";
-    }
-  }
+void AbstractASTNode::print(std::ostream& out) const {
+  std::vector<bool> levels;
+  std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t> id_by_node;
 
-  if (!levels.empty()) {
-    out << " \\_";
-  }
-  out << description() << std::endl;
-
-  levels.emplace_back(right_child() != nullptr);
-
-  if (left_child()) {
-    left_child()->print(out, levels);
-  }
-  if (right_child()) {
-    levels.back() = false;
-    right_child()->print(out, levels);
-  }
-
-  levels.pop_back();
+  _print_impl(out, levels, id_by_node, 0);
 }
 
 std::string AbstractASTNode::get_verbose_column_name(ColumnID column_id) const {
@@ -352,6 +331,55 @@ std::optional<NamedColumnReference> AbstractASTNode::_resolve_local_alias(const 
     }
   }
   return reference;
+}
+
+
+void AbstractASTNode::_print_impl(std::ostream& out,
+                                  std::vector<bool> & levels,
+                                  std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t> & id_by_node,
+                                  size_t id_counter) const {
+  const auto max_level = levels.empty() ? 0 : levels.size() - 1;
+  for (size_t level = 0; level < max_level; ++level) {
+    if (levels[level]) {
+      out << " | ";
+    } else {
+      out << "   ";
+    }
+  }
+
+  if (!levels.empty()) {
+    out << " \\_";
+  }
+
+  /**
+   * Check whether the node has been printed before
+   */
+  const auto iter = id_by_node.find(shared_from_this());
+  if (iter != id_by_node.end()) {
+    out << "Recurring Node --> [" << iter->second << "]" << std::endl;
+    return;
+  }
+
+  const auto this_node_id = id_counter;
+  id_counter++;
+  id_by_node.emplace(shared_from_this(), this_node_id);
+
+  /**
+   *
+   */
+  out << "[" << this_node_id << "] " << description() << std::endl;
+
+  levels.emplace_back(right_child() != nullptr);
+
+  if (left_child()) {
+    left_child()->_print_impl(out, levels, id_by_node, id_counter);
+  }
+  if (right_child()) {
+    levels.back() = false;
+    right_child()->_print_impl(out, levels, id_by_node, id_counter);
+  }
+
+  levels.pop_back();
 }
 
 void AbstractASTNode::_child_changed() {

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
@@ -225,7 +225,7 @@ class AbstractASTNode : public std::enable_shared_from_this<AbstractASTNode> {
   /**
    * Prints this node and all its descendants formatted as a tree
    */
-  void print(std::ostream& out = std::cout, std::vector<bool> levels = {}) const;
+  void print(std::ostream& out = std::cout) const;
 
   /**
    * Returns a string describing this node, but nothing about its children.
@@ -287,6 +287,14 @@ class AbstractASTNode : public std::enable_shared_from_this<AbstractASTNode> {
    * Reset statistics, call _on_child_changed() for node specific behaviour and call _child_changed() on parents
    */
   void _child_changed();
+
+  /**
+   * Actual impl of AbstractASTNode::print(). AbstractASTNode::print() just creates the `levels` and `id_by_node`
+   * instances used during the recursion.
+   */
+  void _print_impl(std::ostream& out,
+                   std::vector<bool> & levels,
+                   std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t> & id_by_node, size_t id_counter) const;
 
   // @{
   /**

--- a/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
+++ b/src/lib/optimizer/abstract_syntax_tree/abstract_ast_node.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "types.hpp"
@@ -292,9 +293,9 @@ class AbstractASTNode : public std::enable_shared_from_this<AbstractASTNode> {
    * Actual impl of AbstractASTNode::print(). AbstractASTNode::print() just creates the `levels` and `id_by_node`
    * instances used during the recursion.
    */
-  void _print_impl(std::ostream& out,
-                   std::vector<bool> & levels,
-                   std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t> & id_by_node, size_t id_counter) const;
+  void _print_impl(std::ostream& out, std::vector<bool>& levels,
+                   std::unordered_map<std::shared_ptr<const AbstractASTNode>, size_t>& id_by_node,
+                   size_t id_counter) const;
 
   // @{
   /**

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -120,5 +120,4 @@ INSERT INTO int_int_for_insert_1 (b, a) SELECT 3, 1 FROM int_int_for_insert_1; S
 -- INSERT ... INTO ... (with regular queries)
 INSERT INTO int_int_for_insert_1 SELECT * FROM int_int3 WHERE a = 1 AND b = 3; INSERT INTO int_int_for_insert_1 SELECT * FROM int_int3 WHERE a = 13; INSERT INTO int_int_for_insert_1 (a, b) SELECT a, b FROM int_int3 WHERE a = 6; SELECT * FROM int_int_for_insert_1;
 
--- TODO: Fails
--- SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;
+SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;


### PR DESCRIPTION
Fix #444
Fix #328

`SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING MAX(c) > 457 OR MAX(c) = 1234 OR b = 12345;`

now gets printed as

```
[0] [Projection] MAX(groupby_int_2gb_2agg.c), AVG(groupby_int_2gb_2agg.d), groupby_int_2gb_2agg.a, groupby_int_2gb_2agg.b
 \_[1] [UnionNode] Mode: UnionPositions
    \_[2] [UnionNode] Mode: UnionPositions
    |  \_[3] [Predicate] groupby_int_2gb_2agg.a > 457
    |  |  \_[4] [Aggregate] MAX(groupby_int_2gb_2agg.c), AVG(groupby_int_2gb_2agg.d) GROUP BY [groupby_int_2gb_2agg.a, groupby_int_2gb_2agg.b]
    |  |     \_[5] [StoredTable] Name: 'groupby_int_2gb_2agg'
    |  \_[3] [Predicate] groupby_int_2gb_2agg.a = 1234
    |     \_Recurring Node --> [4]
    \_[2] [Predicate] AVG(groupby_int_2gb_2agg.d) = 12345
       \_Recurring Node --> [4]
```