### PR TITLE
Add asserts for unsupported null values operations

### DIFF
--- a/src/lib/storage/base_column.hpp
+++ b/src/lib/storage/base_column.hpp
@@ -35,7 +35,7 @@ class BaseColumn : private Noncopyable {
   // calls the column-specific handler in an operator (visitor pattern)
   virtual void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const = 0;
 
-  // writes the length and value at the chunk_offset to the end off row_string
+  // writes the length and value at the chunk_offset to the end of row_string
   virtual void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const = 0;
 
   // copies one of its own values to a different ValueColumn - mainly used for materialization

--- a/src/lib/storage/dictionary_column.cpp
+++ b/src/lib/storage/dictionary_column.cpp
@@ -129,7 +129,10 @@ template <typename T>
 void DictionaryColumn<T>::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
   std::stringstream buffer;
   // buffering value at chunk_offset
-  T value = _dictionary->at(_attribute_vector->get(chunk_offset));
+  auto value_id = _attribute_vector->get(chunk_offset);
+  Assert(value_id != NULL_VALUE_ID, "This operation does not support NULL values.");
+
+  T value = _dictionary->at(value_id);
   buffer << value;
   uint32_t length = buffer.str().length();
   // writing byte representation of length

--- a/src/lib/storage/value_column.cpp
+++ b/src/lib/storage/value_column.cpp
@@ -131,6 +131,10 @@ void ValueColumn<T>::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVis
 template <typename T>
 void ValueColumn<T>::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
   std::stringstream buffer;
+
+  bool is_null = is_nullable() && (*_null_values)[chunk_offset];
+  Assert(!is_null, "This operation does not support NULL values.");
+
   // buffering value at chunk_offset
   buffer << _values[chunk_offset];
   uint32_t length = buffer.str().length();


### PR DESCRIPTION
Addresses @mrks comment in #13. We will just not support null values in `Difference` and `IndexColumnScan` for now.

closes #13