### PR TITLE
Fix some join errors 

### DIFF
--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -238,7 +238,11 @@ void JoinNestedLoop::_write_output_chunks(Chunk& output_chunk, const std::shared
           reference_column = std::dynamic_pointer_cast<const ReferenceColumn>(
               input_table->get_chunk(current_chunk_id).get_column(column_id));
         }
-        new_pos_list->push_back(reference_column->pos_list()->at(row.chunk_offset));
+        if (row.chunk_offset == INVALID_CHUNK_OFFSET) {
+          new_pos_list->push_back(RowID{ChunkID{0}, INVALID_CHUNK_OFFSET});
+        } else {
+          new_pos_list->push_back(reference_column->pos_list()->at(row.chunk_offset));
+        }
       }
 
       column = std::make_shared<ReferenceColumn>(reference_column->referenced_table(),

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -610,7 +610,11 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
     // Get the row ids that are referenced
     auto new_pos_list = std::make_shared<PosList>();
     for (const auto& row : *pos_list) {
-      new_pos_list->push_back((*input_pos_lists[row.chunk_id])[row.chunk_offset]);
+      if (row.chunk_offset == INVALID_CHUNK_OFFSET) {
+        new_pos_list->push_back(RowID{ChunkID{0}, INVALID_CHUNK_OFFSET});
+      } else {
+        new_pos_list->push_back((*input_pos_lists[row.chunk_id])[row.chunk_offset]);
+      }
     }
 
     return new_pos_list;

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -129,9 +129,9 @@ class ColumnMaterializer : public ColumnVisitable {
       // value_count is used as an inverted index
       auto rows_with_value = std::vector<std::vector<RowID>>(dict->size());
 
-      // Presize the vectors by assuming a uniform distribution
-      for (size_t index = 0; index < rows_with_value.size(); index++) {
-        rows_with_value[index].resize(value_ids->size() / dict->size());
+      // Reserve correct size of the vectors by assuming a uniform distribution
+      for (auto& row : rows_with_value) {
+        row.reserve(value_ids->size() / dict->size());
       }
 
       // Collect the rows for each value id

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -304,7 +304,7 @@ TYPED_TEST(JoinEquiTest, MixHashAndNestedLoop) {
 
 // TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
-  if (!std::is_same<TypeParam, JoinHash>::value) {
+  if (std::is_same<TypeParam, JoinSortMerge>::value) {
     // todo(anyone): Fix for other joins
     return;
   }
@@ -320,7 +320,7 @@ TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
 
 // TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
-  if (!std::is_same<TypeParam, JoinHash>::value) {
+  if (std::is_same<TypeParam, JoinSortMerge>::value) {
     // todo(anyone): Fix for other joins
     return;
   }
@@ -336,7 +336,7 @@ TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
 
 // TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, RightJoinEmptyRefColumn) {
-  if (!std::is_same<TypeParam, JoinHash>::value) {
+  if (std::is_same<TypeParam, JoinSortMerge>::value) {
     // todo(anyone): Fix for other joins
     return;
   }
@@ -352,7 +352,7 @@ TYPED_TEST(JoinEquiTest, RightJoinEmptyRefColumn) {
 
 // TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
-  if (!std::is_same<TypeParam, JoinHash>::value) {
+  if (std::is_same<TypeParam, JoinSortMerge>::value) {
     // todo(anyone): Fix for other joins
     return;
   }

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -302,13 +302,7 @@ TYPED_TEST(JoinEquiTest, MixHashAndNestedLoop) {
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_multijoin_nlj_hash.tbl", 1);
 }
 
-// TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value) {
-    // todo(anyone): Fix for other joins
-    return;
-  }
-
   // scan that returns all rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_a->execute();
@@ -318,13 +312,7 @@ TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
       JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
-// TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value) {
-    // todo(anyone): Fix for other joins
-    return;
-  }
-
   // scan that returns all rows
   auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_b->execute();
@@ -334,13 +322,7 @@ TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
       JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
-// TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, RightJoinEmptyRefColumn) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value) {
-    // todo(anyone): Fix for other joins
-    return;
-  }
-
   // scan that returns no rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpEquals, 0);
   scan_a->execute();
@@ -350,13 +332,7 @@ TYPED_TEST(JoinEquiTest, RightJoinEmptyRefColumn) {
       JoinMode::Right, "src/test/tables/joinoperators/int_join_empty.tbl", 1);
 }
 
-// TODO(anyone): https://github.com/hyrise/hyrise/issues/306
 TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value) {
-    // todo(anyone): Fix for other joins
-    return;
-  }
-
   // scan that returns no rows
   auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpEquals, 0);
   scan_b->execute();

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -373,9 +373,6 @@ TYPED_TEST(JoinFullTest, JoinOnValueAndReferenceColumn) {
 }
 
 TYPED_TEST(JoinFullTest, JoinLessThanOnDictAndDict) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value) {
-    return;
-  }
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
       ScanType::OpLessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_leq_dict.tbl", 1);
@@ -392,9 +389,6 @@ TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndDict) {
 }
 
 TYPED_TEST(JoinFullTest, JoinOnDictAndReferenceColumn) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value) {
-    return;
-  }
   // scan that returns all rows
   auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThan, 100);
   scan_b->execute();

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -80,9 +80,6 @@ TYPED_TEST(JoinFullTest, InnerJoinSingleChunk) {
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoin) {
-  this->_table_wrapper_a->execute();
-  this->_table_wrapper_b->execute();
-
   // scan that returns all rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_a->execute();
@@ -95,27 +92,18 @@ TYPED_TEST(JoinFullTest, InnerRefJoin) {
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictJoin) {
-  this->_table_wrapper_a->execute();
-  this->_table_wrapper_b_dict->execute();
-
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
       ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueJoin) {
-  this->_table_wrapper_a_dict->execute();
-  this->_table_wrapper_b->execute();
-
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
       ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictRefJoin) {
-  this->_table_wrapper_a->execute();
-  this->_table_wrapper_b_dict->execute();
-
   // scan that returns all rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_a->execute();
@@ -128,9 +116,6 @@ TYPED_TEST(JoinFullTest, InnerValueDictRefJoin) {
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueRefJoin) {
-  this->_table_wrapper_a_dict->execute();
-  this->_table_wrapper_b->execute();
-
   // scan that returns all rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_a->execute();
@@ -143,9 +128,6 @@ TYPED_TEST(JoinFullTest, InnerDictValueRefJoin) {
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFiltered) {
-  this->_table_wrapper_a->execute();
-  this->_table_wrapper_b->execute();
-
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThan, 1000);
   scan_a->execute();
   auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
@@ -157,18 +139,12 @@ TYPED_TEST(JoinFullTest, InnerRefJoinFiltered) {
 }
 
 TYPED_TEST(JoinFullTest, InnerDictJoin) {
-  this->_table_wrapper_a_dict->execute();
-  this->_table_wrapper_b_dict->execute();
-
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
       ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoin) {
-  this->_table_wrapper_a_dict->execute();
-  this->_table_wrapper_b_dict->execute();
-
   // scan that returns all rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_a->execute();
@@ -181,9 +157,6 @@ TYPED_TEST(JoinFullTest, InnerRefDictJoin) {
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoinFiltered) {
-  this->_table_wrapper_a_dict->execute();
-  this->_table_wrapper_b_dict->execute();
-
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThan, 1000);
   scan_a->execute();
   auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
@@ -195,18 +168,12 @@ TYPED_TEST(JoinFullTest, InnerRefDictJoinFiltered) {
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinBig) {
-  this->_table_wrapper_c->execute();
-  this->_table_wrapper_d->execute();
-
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}),
       ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFilteredBig) {
-  this->_table_wrapper_c->execute();
-  this->_table_wrapper_d->execute();
-
   auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
   scan_c->execute();
   auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::OpGreaterThanEquals, 6);
@@ -220,6 +187,12 @@ TYPED_TEST(JoinFullTest, InnerRefJoinFilteredBig) {
 TYPED_TEST(JoinFullTest, OuterJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
+      ScanType::OpEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+}
+
+TYPED_TEST(JoinFullTest, OuterJoinDict) {
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
       ScanType::OpEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
@@ -238,6 +211,18 @@ TYPED_TEST(JoinFullTest, SmallerInnerJoin) {
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
+      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
+}
+
+TYPED_TEST(JoinFullTest, SmallerInnerJoinDict) {
+  // Joining two Integer Columns
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
+      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
+
+  // Joining two Float Columns
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
       ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
 }
 
@@ -293,6 +278,18 @@ TYPED_TEST(JoinFullTest, GreaterInnerJoin) {
       ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
+TYPED_TEST(JoinFullTest, GreaterInnerJoinDict) {
+  // Joining two Integer Column
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
+      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
+
+  // Joining two Float Columns
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
+      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
+}
+
 TYPED_TEST(JoinFullTest, GreaterInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
@@ -315,6 +312,20 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin) {
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
+                                             std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
+                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
+}
+
+TYPED_TEST(JoinFullTest, GreaterEqualInnerJoinDict) {
+  // Joining two Integer Columns
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
+                                             std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
+                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
+
+  // Joining two Float Columns
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
                                              ScanType::OpGreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
@@ -343,6 +354,17 @@ TYPED_TEST(JoinFullTest, NotEqualInnerJoin) {
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
+      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
+}
+
+TYPED_TEST(JoinFullTest, NotEqualInnerJoinDict) {
+  // Joining two Integer Columns
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
+      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
+  // Joining two Float Columns
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
       ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
 }
 

--- a/src/test/tables/joinoperators/int_float_with_null_self_join.tbl
+++ b/src/test/tables/joinoperators/int_float_with_null_self_join.tbl
@@ -1,0 +1,5 @@
+a|b|a|b
+int|float_null|int|float_null
+12345|458.7|12345|458.7
+123|null|123|null
+1234|457.7|1234|457.7


### PR DESCRIPTION
This PR tries to fix some of the errors mentioned in #306 and #314.

  - [x] Fix NestedLoopJoin outer RefColumns
  - [x] Fix SortMergeJoin outer ReColumns
  - [x] Fix SMJ JoinLessThanOnDictAndDict
  - [x] Fix SMJ JoinOnDictAndReferenceColumn