### PR TITLE
Rename tx::last_commit_id to as-of commit id

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -675,8 +675,8 @@ int Console::print_transaction_info(const std::string& input) {
   }
 
   const auto transaction_id = std::to_string(_explicitly_created_transaction_context->transaction_id());
-  const auto last_commit_id = std::to_string(_explicitly_created_transaction_context->last_commit_id());
-  out("Active transaction: { transaction id = " + transaction_id + ", last commit id = " + last_commit_id + " }\n");
+  const auto as_of_commit_id = std::to_string(_explicitly_created_transaction_context->as_of_commit_id());
+  out("Active transaction: { transaction id = " + transaction_id + ", as-of commit id = " + as_of_commit_id + " }\n");
   return ReturnCode::Ok;
 }
 

--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -10,9 +10,9 @@
 
 namespace opossum {
 
-TransactionContext::TransactionContext(const TransactionID transaction_id, const CommitID last_commit_id)
+TransactionContext::TransactionContext(const TransactionID transaction_id, const CommitID as_of_commit_id)
     : _transaction_id{transaction_id},
-      _last_commit_id{last_commit_id},
+      _as_of_commit_id{as_of_commit_id},
       _phase{TransactionPhase::Active},
       _num_active_operators{0} {}
 
@@ -41,7 +41,7 @@ TransactionContext::~TransactionContext() {
 }
 
 TransactionID TransactionContext::transaction_id() const { return _transaction_id; }
-CommitID TransactionContext::last_commit_id() const { return _last_commit_id; }
+CommitID TransactionContext::as_of_commit_id() const { return _as_of_commit_id; }
 
 CommitID TransactionContext::commit_id() const {
   Assert((_commit_context != nullptr), "TransactionContext cid only available after commit context has been created.");

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -51,7 +51,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
   friend class TransactionManager;
 
  public:
-  TransactionContext(const TransactionID transaction_id, const CommitID last_commit_id);
+  TransactionContext(const TransactionID transaction_id, const CommitID as_of_commit_id);
   ~TransactionContext();
 
   /**
@@ -60,10 +60,10 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
   TransactionID transaction_id() const;
 
   /**
-   * The last commit id represents the snapshot in time of the database
+   * The as-of commit id represents the snapshot in time of the database
    * that the transaction is able to see and access.
    */
-  CommitID last_commit_id() const;
+  CommitID as_of_commit_id() const;
 
   /**
    * Only available after TransactionManager::prepare_commit has been called
@@ -171,7 +171,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
 
  private:
   const TransactionID _transaction_id;
-  const CommitID _last_commit_id;
+  const CommitID _as_of_commit_id;
   std::vector<std::shared_ptr<AbstractReadWriteOperator>> _rw_operators;
 
   std::atomic<TransactionPhase> _phase;

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -25,10 +25,11 @@
  * The TransactionManager is a thread-safe singleton that hands out TransactionContexts with monotonically increasing
  * IDs and ensures all transactions are committed in the correct order. It also holds a global last commit ID, which is
  * the commit ID of the last transaction that has been committed. When a new transaction context is created, it retains
- * a copy of the current last commit ID, which represents a snapshot of the database. The last commit ID together with
- * the MVCC columns is used to filter out any changes made after the creation transaction context.
+ * a copy of the current last commit ID, stored as as_of_commit_id, which represents a snapshot of the database. The 
+ * as-of commit ID together with the MVCC columns is used to filter out any changes made after the creation transaction
+ * context.
  *
- * TransactionContext contains data used by a transaction, mainly its ID, the last commit ID explained above, and,
+ * TransactionContext contains data used by a transaction, mainly its ID, the as-of commit ID explained above, and,
  * when it enters the commit phase, the TransactionManager gives it a CommitContext, which contains
  * a new commit ID that is used to make its changes visible to others.
  */

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -13,19 +13,19 @@ namespace opossum {
 
 namespace {
 
-bool is_row_visible(CommitID our_tid, CommitID our_last_cid, ChunkOffset chunk_offset,
+bool is_row_visible(CommitID our_tid, CommitID as_of_commit_id, ChunkOffset chunk_offset,
                     const Chunk::MvccColumns& columns) {
   const auto row_tid = columns.tids[chunk_offset].load();
   const auto begin_cid = columns.begin_cids[chunk_offset];
   const auto end_cid = columns.end_cids[chunk_offset];
 
   // Taken from: https://github.com/hyrise/hyrise/blob/master/docs/documentation/queryexecution/tx.rst
-  // const auto own_insert = (our_tid == row_tid) && !(our_last_cid >= begin_cid) && !(our_last_cid >= end_cid);
-  // const auto past_insert = (our_tid != row_tid) && (our_last_cid >= begin_cid) && !(our_last_cid >= end_cid);
+  // const auto own_insert = (our_tid == row_tid) && !(as_of_commit_id >= begin_cid) && !(as_of_commit_id >= end_cid);
+  // const auto past_insert = (our_tid != row_tid) && (as_of_commit_id >= begin_cid) && !(as_of_commit_id >= end_cid);
   // return own_insert || past_insert;
 
   // since gcc and clang are surprisingly bad at optimizing the above boolean expression, lets do that ourselves
-  return our_last_cid < end_cid && ((our_last_cid >= begin_cid) != (row_tid == our_tid));
+  return as_of_commit_id < end_cid && ((as_of_commit_id >= begin_cid) != (row_tid == our_tid));
 }
 
 }  // namespace
@@ -50,7 +50,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
   auto output = Table::create_with_layout_from(_in_table);
 
   const auto our_tid = transaction_context->transaction_id();
-  const auto our_last_cid = transaction_context->last_commit_id();
+  const auto as_of_commit_id = transaction_context->as_of_commit_id();
 
   for (ChunkID chunk_id{0}; chunk_id < _in_table->chunk_count(); ++chunk_id) {
     const auto& chunk_in = _in_table->get_chunk(chunk_id);
@@ -71,7 +71,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
         const auto& referenced_chunk = referenced_table->get_chunk(row_id.chunk_id);
 
         auto mvcc_columns = referenced_chunk.mvcc_columns();
-        if (is_row_visible(our_tid, our_last_cid, row_id.chunk_offset, *mvcc_columns)) {
+        if (is_row_visible(our_tid, as_of_commit_id, row_id.chunk_offset, *mvcc_columns)) {
           pos_list_out->emplace_back(row_id);
         }
       }
@@ -92,7 +92,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
       // Generate pos_list_out.
       auto chunk_size = chunk_in.size();  // The compiler fails to optimize this in the for clause :(
       for (auto i = 0u; i < chunk_size; i++) {
-        if (is_row_visible(our_tid, our_last_cid, i, *mvcc_columns)) {
+        if (is_row_visible(our_tid, as_of_commit_id, i, *mvcc_columns)) {
           pos_list_out->emplace_back(RowID{chunk_id, i});
         }
       }


### PR DESCRIPTION
I never really liked having a `last_commit_id` in the `TransactionManager` and in the `TransactionContext`. Those two things are somewhat the same but different enough to be confused. In a book I read recently, the one stored in the transaction was called "as-of commit id". I liked that. Should we adopt that name?

Happy to simply close this PR if we decide that we like to keep the current name.