### PR TITLE
Fix numeric_limits for strong typedefs

### DIFF
--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -17,45 +17,45 @@
  *  - std::hash specialization
  */
 
-#define STRONG_TYPEDEF(T, D)                                                                                        \
-  namespace opossum {                                                                                               \
-  struct D : boost::totally_ordered1<D, boost::totally_ordered2<D, T>> {                                            \
-    typedef T base_type;                                                                                            \
-    T t;                                                                                                            \
-    constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {}   \
-    D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                                \
-    D(const D& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                    \
-    D& operator=(const D& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                           \
-      t = other.t;                                                                                                  \
-      return *this;                                                                                                 \
-    }                                                                                                               \
-    D& operator=(const T& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                           \
-      t = other;                                                                                                    \
-      return *this;                                                                                                 \
-    }                                                                                                               \
-    operator const T&() const { return t; }                                                                         \
-    operator T&() { return t; }                                                                                     \
-    bool operator==(const D& other) const { return t == other.t; }                                                  \
-    bool operator<(const D& other) const { return t < other.t; }                                                    \
-  };                                                                                                                \
-  } /* NOLINT */                                                                                                    \
-                                                                                                                    \
-  namespace std {                                                                                                   \
-  template <>                                                                                                       \
-  struct hash<::opossum::D> : public unary_function<::opossum::D, size_t> {                                         \
-    size_t operator()(const ::opossum::D& x) const { return hash<T>{}(x); }                                         \
-  };                                                                                                                \
-  } /* NOLINT */                                                                                                    \
-                                                                                                                    \
-  namespace std {                                                                                                   \
-    template <>                                                                                                     \
-    struct numeric_limits<::opossum::D> {                                                                           \
-      static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> min() {                          \
-        return ::opossum::D(numeric_limits<T>::min());                                                              \
-      }                                                                                                             \
-      static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> max() {                          \
-        return ::opossum::D(numeric_limits<T>::max());                                                              \
-      }                                                                                                             \
-    };                                                                                                              \
-  } /* NOLINT */                                                                                                    \
+#define STRONG_TYPEDEF(T, D)                                                                                      \
+  namespace opossum {                                                                                             \
+  struct D : boost::totally_ordered1<D, boost::totally_ordered2<D, T>> {                                          \
+    typedef T base_type;                                                                                          \
+    T t;                                                                                                          \
+    constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {} \
+    D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                              \
+    D(const D& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                  \
+    D& operator=(const D& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                         \
+      t = other.t;                                                                                                \
+      return *this;                                                                                               \
+    }                                                                                                             \
+    D& operator=(const T& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                         \
+      t = other;                                                                                                  \
+      return *this;                                                                                               \
+    }                                                                                                             \
+    operator const T&() const { return t; }                                                                       \
+    operator T&() { return t; }                                                                                   \
+    bool operator==(const D& other) const { return t == other.t; }                                                \
+    bool operator<(const D& other) const { return t < other.t; }                                                  \
+  };                                                                                                              \
+  } /* NOLINT */                                                                                                  \
+                                                                                                                  \
+  namespace std {                                                                                                 \
+  template <>                                                                                                     \
+  struct hash<::opossum::D> : public unary_function<::opossum::D, size_t> {                                       \
+    size_t operator()(const ::opossum::D& x) const { return hash<T>{}(x); }                                       \
+  };                                                                                                              \
+  } /* NOLINT */                                                                                                  \
+                                                                                                                  \
+  namespace std {                                                                                                 \
+    template <>                                                                                                   \
+    struct numeric_limits<::opossum::D> {                                                                         \
+      static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> min() {                        \
+        return ::opossum::D(numeric_limits<T>::min());                                                            \
+      }                                                                                                           \
+      static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> max() {                        \
+        return ::opossum::D(numeric_limits<T>::max());                                                            \
+      }                                                                                                           \
+    };                                                                                                            \
+  } /* NOLINT */                                                                                                  \
   static_assert(true, "End call of macro with a semicolon")

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -41,14 +41,12 @@
   } /* NOLINT */                                                                                                  \
                                                                                                                   \
   namespace std {                                                                                                 \
-  template <>                                                                                                     \
-  struct hash<::opossum::D> : public unary_function<::opossum::D, size_t> {                                       \
-    size_t operator()(const ::opossum::D& x) const { return hash<T>{}(x); }                                       \
-  };                                                                                                              \
-  } /* NOLINT */                                                                                                  \
-                                                                                                                  \
-  namespace std {                                                                                                 \
     template <>                                                                                                   \
+    struct hash<::opossum::D> : public unary_function<::opossum::D, size_t> {                                     \
+      size_t operator()(const ::opossum::D& x) const { return hash<T>{}(x); }                                     \
+    };                                                                                                            \
+    template <>                                                                                                   \
+                                                                                                                  \
     struct numeric_limits<::opossum::D> {                                                                         \
       static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> min() {                        \
         return ::opossum::D(numeric_limits<T>::min());                                                            \

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -7,6 +7,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 
 #include <functional>
+#include <limits>
 
 /*
  * This is an extension of boost's BOOST_STRONG_TYPEDEF.
@@ -16,33 +17,45 @@
  *  - std::hash specialization
  */
 
-#define STRONG_TYPEDEF(T, D)                                                                                      \
-  namespace opossum {                                                                                             \
-  struct D : boost::totally_ordered1<D, boost::totally_ordered2<D, T>> {                                          \
-    typedef T base_type;                                                                                          \
-    T t;                                                                                                          \
-    constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {} \
-    D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                              \
-    D(const D& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                  \
-    D& operator=(const D& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                         \
-      t = other.t;                                                                                                \
-      return *this;                                                                                               \
-    }                                                                                                             \
-    D& operator=(const T& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                         \
-      t = other;                                                                                                  \
-      return *this;                                                                                               \
-    }                                                                                                             \
-    operator const T&() const { return t; }                                                                       \
-    operator T&() { return t; }                                                                                   \
-    bool operator==(const D& other) const { return t == other.t; }                                                \
-    bool operator<(const D& other) const { return t < other.t; }                                                  \
-  };                                                                                                              \
-  } /* NOLINT */                                                                                                  \
-                                                                                                                  \
-  namespace std {                                                                                                 \
-  template <>                                                                                                     \
-  struct hash<::opossum::D> : public unary_function<::opossum::D, size_t> {                                       \
-    size_t operator()(const ::opossum::D& x) const { return hash<T>{}(x); }                                       \
-  };                                                                                                              \
-  } /* NOLINT */                                                                                                  \
+#define STRONG_TYPEDEF(T, D)                                                                                        \
+  namespace opossum {                                                                                               \
+  struct D : boost::totally_ordered1<D, boost::totally_ordered2<D, T>> {                                            \
+    typedef T base_type;                                                                                            \
+    T t;                                                                                                            \
+    constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {}   \
+    D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                                \
+    D(const D& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                    \
+    D& operator=(const D& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                           \
+      t = other.t;                                                                                                  \
+      return *this;                                                                                                 \
+    }                                                                                                               \
+    D& operator=(const T& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                           \
+      t = other;                                                                                                    \
+      return *this;                                                                                                 \
+    }                                                                                                               \
+    operator const T&() const { return t; }                                                                         \
+    operator T&() { return t; }                                                                                     \
+    bool operator==(const D& other) const { return t == other.t; }                                                  \
+    bool operator<(const D& other) const { return t < other.t; }                                                    \
+  };                                                                                                                \
+  } /* NOLINT */                                                                                                    \
+                                                                                                                    \
+  namespace std {                                                                                                   \
+  template <>                                                                                                       \
+  struct hash<::opossum::D> : public unary_function<::opossum::D, size_t> {                                         \
+    size_t operator()(const ::opossum::D& x) const { return hash<T>{}(x); }                                         \
+  };                                                                                                                \
+  } /* NOLINT */                                                                                                    \
+                                                                                                                    \
+  namespace std {                                                                                                   \
+    template <>                                                                                                     \
+    struct numeric_limits<::opossum::D> {                                                                           \
+      static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> min() {                          \
+        return ::opossum::D(numeric_limits<T>::min());                                                              \
+      }                                                                                                             \
+      static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> max() {                          \
+        return ::opossum::D(numeric_limits<T>::max());                                                              \
+      }                                                                                                             \
+    };                                                                                                              \
+  } /* NOLINT */                                                                                                    \
   static_assert(true, "End call of macro with a semicolon")


### PR DESCRIPTION
It was brought up in the seminar that `numeric_limits` behaves weirdly for strong typedefs:
```
  std::cout << std::numeric_limits<opossum::ChunkID>::min() << std::endl;
  std::cout << std::numeric_limits<opossum::ChunkID>::max() << std::endl;
```

No idea what the standards committee was thinking when they made all of those methods return 0 for unknown types. This PR fixes that for strong typedefs.

If you now call methods of `numeric_limits` that the strong typedef does not forward, you will now get an error:

```
/Users/markus/Projekte/Opossum/Git/src/bin/playground.cpp: In function 'int main()':
/Users/markus/Projekte/Opossum/Git/src/bin/playground.cpp:8:55: error: 'lowest' is not a member of 'std::numeric_limits<opossum::ChunkID>'
   std::cout << std::numeric_limits<opossum::ChunkID>::lowest() << std::endl;
                                                       ^~~
```