### PR TITLE
Use underline for order_line and new_order

### DIFF
--- a/src/benchmark/tpcc/delivery_benchmark.cpp
+++ b/src/benchmark/tpcc/delivery_benchmark.cpp
@@ -32,7 +32,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      * FROM new_order
      * WHERE no_d_id = :d_id AND no_w_id = :w_id ORDER BY no_o_id ASC;
      */
-    auto gt = std::make_shared<GetTable>("NEW-ORDER");
+    auto gt = std::make_shared<GetTable>("NEW_ORDER");
 
     auto ts1 = std::make_shared<TableScan>(gt, ColumnID{1} /* "NO_D_ID" */, ScanType::OpEquals, d_id);
     auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{2} /* "NO_W_ID" */, ScanType::OpEquals, w_id);
@@ -68,11 +68,11 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      * FROM new_order
      * WHERE CURRENT OF c_no;
      */
-    auto gt = std::make_shared<GetTable>("NEW-ORDER");
+    auto gt = std::make_shared<GetTable>("NEW_ORDER");
 
     auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "NO_O_ID" */, ScanType::OpEquals, no_o_id);
     auto val = std::make_shared<Validate>(ts1);
-    auto delete_op = std::make_shared<Delete>("NEW-ORDER", val);
+    auto delete_op = std::make_shared<Delete>("NEW_ORDER", val);
 
     auto t_gt = std::make_shared<OperatorTask>(gt);
     auto t_ts1 = std::make_shared<OperatorTask>(ts1);
@@ -169,7 +169,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      * SET ol_delivery_d = :datetime
      * WHERE ol_o_id = :no_o_id AND ol_d_id = :d_id AND ol_w_id = :w_id;
      */
-    auto gt = std::make_shared<GetTable>("ORDER-LINE");
+    auto gt = std::make_shared<GetTable>("ORDER_LINE");
 
     auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::OpEquals, no_o_id);
     auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::OpEquals, d_id);
@@ -182,7 +182,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
 
     Projection::ColumnExpressions values = {Expression::create_literal(std::to_string(datetime), {"OL_DELIVERY_D"})};
     auto updated_rows = std::make_shared<Projection>(val, values);
-    auto update = std::make_shared<Update>("ORDER-LINE", projection, updated_rows);
+    auto update = std::make_shared<Update>("ORDER_LINE", projection, updated_rows);
 
     auto t_gt = std::make_shared<OperatorTask>(gt);
     auto t_ts1 = std::make_shared<OperatorTask>(ts1);
@@ -212,7 +212,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      * FROM order_line
      * WHERE ol_o_id = :no_o_id AND ol_d_id = :d_id AND ol_w_id = :w_id;
      */
-    auto gt = std::make_shared<GetTable>("ORDER-LINE");
+    auto gt = std::make_shared<GetTable>("ORDER_LINE");
 
     auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::OpEquals, no_o_id);
     auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::OpEquals, d_id);

--- a/src/benchmarklib/tpcc/new_order.cpp
+++ b/src/benchmarklib/tpcc/new_order.cpp
@@ -348,7 +348,7 @@ TaskVector NewOrderRefImpl::get_create_new_order_tasks(const int32_t o_id, const
    * VALUES (?, ?, ?);
    */
 
-  auto target_table_name = std::string("NEW-ORDER");
+  auto target_table_name = std::string("NEW_ORDER");
   const auto original_table = opossum::StorageManager::get().get_table(target_table_name);
 
   auto new_table = std::make_shared<opossum::Table>();
@@ -514,7 +514,7 @@ TaskVector NewOrderRefImpl::get_create_order_line_tasks(const int32_t ol_o_id, c
    *  VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
    */
 
-  auto target_table_name = std::string("ORDER-LINE");
+  auto target_table_name = std::string("ORDER_LINE");
   const auto original_table = opossum::StorageManager::get().get_table(target_table_name);
 
   auto new_table = std::make_shared<opossum::Table>();

--- a/src/benchmarklib/tpcc/order_status.cpp
+++ b/src/benchmarklib/tpcc/order_status.cpp
@@ -249,7 +249,7 @@ TaskVector OrderStatusRefImpl::get_order_lines(const int o_id, const int d_id, c
    * FROM order_line
    * WHERE ol_o_id=:o_id AND ol_d_id=:d_id AND ol_w_id=:w_id;
    */
-  auto gt_order_lines = std::make_shared<opossum::GetTable>("ORDER-LINE");
+  auto gt_order_lines = std::make_shared<opossum::GetTable>("ORDER_LINE");
   auto validate = std::make_shared<opossum::Validate>(gt_order_lines);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{0} /* "OL_O_ID" */,

--- a/src/benchmarklib/tpcc/readme.md
+++ b/src/benchmarklib/tpcc/readme.md
@@ -2,7 +2,7 @@
 
 TPC-C is a transactional benchmark framework focusing on queries that typically select or update only a few rows
 from a table. The given schema consists of nine tables, namely WAREHOUSE, ITEMS, STOCK, DISTRICT, CUSTOMER, HISTORY,
-ORDER, ORDER-LINE, and NEW_ORDER. With all these tables TPC-C represents an enterprise system
+ORDER, ORDER_LINE, and NEW_ORDER. With all these tables TPC-C represents an enterprise system
 that handles incoming orders from customers for items.
 
 The definition of TPC-C provides a set of rules how to implement the benchmark correctly,

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -303,9 +303,9 @@ TpccTableGenerator::order_line_counts_type TpccTableGenerator::generate_order_li
 }
 
 /**
- * Generates a column for the 'ORDER-LINE' table. This is used in the specialization of add_column to insert vectors.
- * In contrast to other tables the ORDER-LINE table is NOT defined by saying, there are 10 order-line per order,
- * but instead there 5 to 15 order-lines per order.
+ * Generates a column for the 'ORDER_LINE' table. This is used in the specialization of add_column to insert vectors.
+ * In contrast to other tables the ORDER_LINE table is NOT defined by saying, there are 10 order_lines per order,
+ * but instead there 5 to 15 order_lines per order.
  * @tparam T
  * @param indices
  * @param order_line_counts
@@ -425,8 +425,8 @@ std::map<std::string, std::shared_ptr<opossum::Table>> TpccTableGenerator::gener
                                                                  {"CUSTOMER", customer_table.get()},
                                                                  {"HISTORY", history_table.get()},
                                                                  {"ORDER", order_table.get()},
-                                                                 {"ORDER-LINE", order_line_table.get()},
-                                                                 {"NEW-ORDER", new_order_table.get()}});
+                                                                 {"ORDER_LINE", order_line_table.get()},
+                                                                 {"NEW_ORDER", new_order_table.get()}});
 }
 
 /*
@@ -443,12 +443,12 @@ TpccTableGeneratorFunctions TpccTableGenerator::tpcc_table_generator_functions()
       {"CUSTOMER", []() { return tpcc::TpccTableGenerator().generate_customer_table(); }},
       {"HISTORY", []() { return tpcc::TpccTableGenerator().generate_history_table(); }},
       {"ORDER", []() { return tpcc::TpccTableGenerator().generate_new_order_table(); }},
-      {"NEW-ORDER",
+      {"NEW_ORDER",
        []() {
          auto order_line_counts = tpcc::TpccTableGenerator().generate_order_line_counts();
          return tpcc::TpccTableGenerator().generate_order_table(order_line_counts);
        }},
-      {"ORDER-LINE", []() {
+      {"ORDER_LINE", []() {
          auto order_line_counts = tpcc::TpccTableGenerator().generate_order_line_counts();
          return tpcc::TpccTableGenerator().generate_order_line_table(order_line_counts);
        }}};

--- a/src/scripts/tpcc_sqlite_driver.py
+++ b/src/scripts/tpcc_sqlite_driver.py
@@ -1,5 +1,5 @@
 """
-    Loads the Tables (NEW-ORDER.csv, ...) into SQLite and performs the transactions specified in
+    Loads the Tables (NEW_ORDER.csv, ...) into SQLite and performs the transactions specified in
     tpcc_{distribution}_requests.json in SQLite. The results of the SELECT queries will be saved as a JSON file
     tpcc_{distribution}_results.json like this:
 
@@ -26,7 +26,7 @@
     "w_tax_rate": 0.1716
   }
 
-  After all Transactions have been performed, the tables will be exported as CSVs (RESULT_NEW-ORDER.csv, ...)
+  After all Transactions have been performed, the tables will be exported as CSVs (RESULT_NEW_ORDER.csv, ...)
 """
 
 import argparse
@@ -43,10 +43,10 @@ TPCC_TABLES = {
     ("DISTRICT","DISTRICT"),
     ("CUSTOMER","CUSTOMER"),
     ("ORDER", "ORDERS"),
-    ("NEW-ORDER", "NEW_ORDER"),
+    ("NEW_ORDER", "NEW_ORDER"),
     ("ITEM","ITEM"),
     ("STOCK","STOCK"),
-    ("ORDER-LINE", "ORDER_LINE")
+    ("ORDER_LINE", "ORDER_LINE")
 }
 
 def execute_sql(cur, statement, params=()):

--- a/src/test/tpc/tpcc_ref_test.cpp
+++ b/src/test/tpc/tpcc_ref_test.cpp
@@ -111,8 +111,8 @@ class TpccRefTest : public BaseTest {
 
  protected:
   void SetUp() override {
-    const auto TABLE_NAMES = {"CUSTOMER",   "DISTRICT", "HISTORY", "ITEM",     "NEW-ORDER",
-                              "ORDER-LINE", "ORDER",    "STOCK",   "WAREHOUSE"};
+    const auto TABLE_NAMES = {"CUSTOMER",   "DISTRICT", "HISTORY", "ITEM",     "NEW_ORDER",
+                              "ORDER_LINE", "ORDER",    "STOCK",   "WAREHOUSE"};
 
     CsvParser parser;
 


### PR DESCRIPTION
Until now, we used `ORDER-LINE` and `NEW-ORDER` as names for these TPCC tables. Some parts of the TPCC documentation use these names, but the reference implementation and documentation of statement level uses a naming version with underlines. Thereby, we can avoid to set the table names in quotes. 