### PR TITLE
First round of argument refactoring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,7 @@ Avoid exception handling. Because Hyrise is not a product, we do not have to rec
 - Don't write `this->` if you don't have to
 - Use C++11 for loops when possible: `for (const auto& item : items) {...}`
 - When creating a vector where you know the size beforehand, use `reserve` to avoid unnecessary resizes and allocations
+- Use [these flowcharts](https://github.com/hyrise/hyrise/wiki/Code-Style) to decide how to accept arguments (e.g., reference, pointer, ...).
 
 ## Naming Conventions
 - Files: lowercase separated by underscores, e.g., abstract_operator.cpp

--- a/src/benchmarklib/CMakeLists.txt
+++ b/src/benchmarklib/CMakeLists.txt
@@ -19,7 +19,7 @@ set(
     tpch/constants.hpp
     tpch/text_field_generator.cpp
     tpch/text_field_generator.hpp
-    tpch/tpch_grammer.cpp
+    tpch/tpch_grammar.cpp
     tpch/tpch_grammar.hpp
     tpch/tpch_queries.cpp
     tpch/tpch_queries.hpp

--- a/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
+++ b/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
@@ -51,8 +51,8 @@ class AbstractBenchmarkTableGenerator {
    * @param generator_function  a lambda function to generate a vector of values for this column
    */
   template <typename T>
-  void add_column(std::shared_ptr<opossum::Table> table, std::string name,
-                  std::shared_ptr<std::vector<size_t>> cardinalities,
+  void add_column(const std::shared_ptr<opossum::Table>& table, std::string name,
+                  const std::shared_ptr<std::vector<size_t>>& cardinalities,
                   const std::function<std::vector<T>(std::vector<size_t>)>& generator_function) {
     /**
      * We have to add Chunks when we add the first column.
@@ -161,8 +161,8 @@ class AbstractBenchmarkTableGenerator {
    * @param generator_function  a lambda function to generate a value for this column
    */
   template <typename T>
-  void add_column(std::shared_ptr<opossum::Table> table, std::string name,
-                  std::shared_ptr<std::vector<size_t>> cardinalities,
+  void add_column(const std::shared_ptr<opossum::Table>& table, std::string name,
+                  const std::shared_ptr<std::vector<size_t>>& cardinalities,
                   const std::function<T(std::vector<size_t>)>& generator_function) {
     const std::function<std::vector<T>(std::vector<size_t>)> wrapped_generator_function =
         [generator_function](std::vector<size_t> indices) { return std::vector<T>({generator_function(indices)}); };

--- a/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
+++ b/src/benchmarklib/benchmark_utilities/abstract_benchmark_table_generator.hpp
@@ -52,7 +52,7 @@ class AbstractBenchmarkTableGenerator {
    */
   template <typename T>
   void add_column(const std::shared_ptr<opossum::Table>& table, std::string name,
-                  const std::shared_ptr<std::vector<size_t>>& cardinalities,
+                  const std::vector<size_t>& cardinalities,
                   const std::function<std::vector<T>(std::vector<size_t>)>& generator_function) {
     /**
      * We have to add Chunks when we add the first column.
@@ -69,7 +69,7 @@ class AbstractBenchmarkTableGenerator {
      * For the CUSTOMER table this calculates 1*10*3000
      */
     auto loop_count =
-        std::accumulate(std::begin(*cardinalities), std::end(*cardinalities), 1u, std::multiplies<size_t>());
+        std::accumulate(std::begin(cardinalities), std::end(cardinalities), 1u, std::multiplies<size_t>());
 
     tbb::concurrent_vector<T> column;
     column.reserve(_chunk_size);
@@ -80,7 +80,7 @@ class AbstractBenchmarkTableGenerator {
     size_t row_index = 0;
 
     for (size_t loop_index = 0; loop_index < loop_count; loop_index++) {
-      std::vector<size_t> indices(cardinalities->size());
+      std::vector<size_t> indices(cardinalities.size());
 
       /**
        * Calculate indices for internal loops
@@ -93,10 +93,10 @@ class AbstractBenchmarkTableGenerator {
        * WAREHOUSE_ID | DISTRICT_ID | CUSTOMER_ID
        * indices[0]   | indices[1]  | indices[2]
        */
-      for (size_t loop = 0; loop < cardinalities->size(); loop++) {
-        auto divisor = std::accumulate(std::begin(*cardinalities) + loop + 1, std::end(*cardinalities), 1u,
+      for (size_t loop = 0; loop < cardinalities.size(); loop++) {
+        auto divisor = std::accumulate(std::begin(cardinalities) + loop + 1, std::end(cardinalities), 1u,
                                        std::multiplies<size_t>());
-        indices[loop] = (loop_index / divisor) % cardinalities->at(loop);
+        indices[loop] = (loop_index / divisor) % cardinalities.at(loop);
       }
 
       /**
@@ -162,7 +162,7 @@ class AbstractBenchmarkTableGenerator {
    */
   template <typename T>
   void add_column(const std::shared_ptr<opossum::Table>& table, std::string name,
-                  const std::shared_ptr<std::vector<size_t>>& cardinalities,
+                  const std::vector<size_t>& cardinalities,
                   const std::function<T(std::vector<size_t>)>& generator_function) {
     const std::function<std::vector<T>(std::vector<size_t>)> wrapped_generator_function =
         [generator_function](std::vector<size_t> indices) { return std::vector<T>({generator_function(indices)}); };

--- a/src/benchmarklib/benchmark_utilities/random_generator.hpp
+++ b/src/benchmarklib/benchmark_utilities/random_generator.hpp
@@ -20,7 +20,7 @@ class RandomGenerator {
    * @return            a random number
    */
   template <class IntType = uint32_t, typename LowerType, typename UpperType>
-  IntType random_number(LowerType lower, UpperType upper) {
+  IntType random_number(const LowerType lower, const UpperType upper) {
     std::uniform_int_distribution<IntType> dist(lower, upper);
     return dist(engine);
   }
@@ -32,7 +32,7 @@ class RandomGenerator {
    * @param id_length       maximum number in the set
    * @return                a set of unique numbers
    */
-  std::set<size_t> select_unique_ids(size_t num_unique, size_t id_length) {
+  std::set<size_t> select_unique_ids(const size_t num_unique, const size_t id_length) {
     std::set<size_t> rows;
     opossum::Assert(num_unique <= id_length, "There are not enough ids to be selected!");
     for (size_t i = 0; i < num_unique; ++i) {

--- a/src/benchmarklib/tpcc/helper.cpp
+++ b/src/benchmarklib/tpcc/helper.cpp
@@ -10,7 +10,7 @@
 namespace tpcc {
 
 void execute_tasks_with_context(std::vector<std::shared_ptr<opossum::OperatorTask>>& tasks,
-                                std::shared_ptr<opossum::TransactionContext> t_context) {
+                                const std::shared_ptr<opossum::TransactionContext>& t_context) {
   for (auto& task : tasks) {
     task->get_operator()->set_transaction_context(t_context);
   }

--- a/src/benchmarklib/tpcc/helper.hpp
+++ b/src/benchmarklib/tpcc/helper.hpp
@@ -19,7 +19,7 @@ class ValueColumn;
 namespace tpcc {
 
 void execute_tasks_with_context(std::vector<std::shared_ptr<opossum::OperatorTask>>& tasks,
-                                std::shared_ptr<opossum::TransactionContext> t_context);
+                                const std::shared_ptr<opossum::TransactionContext>& t_context);
 
 template <typename T>
 std::shared_ptr<opossum::ValueColumn<T>> create_single_value_column(T value) {

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_items_table() {
       std::make_shared<opossum::NodeQueueScheduler>(opossum::Topology::create_numa_topology(10)));
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{NUM_ITEMS});
+  auto cardinalities = std::vector<size_t>(std::initializer_list<size_t>{NUM_ITEMS});
 
   /**
    * indices[0] = item
@@ -69,7 +69,7 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_items_table() {
 std::shared_ptr<opossum::Table> TpccTableGenerator::generate_warehouse_table() {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{_warehouse_size});
+  auto cardinalities = std::vector<size_t>(std::initializer_list<size_t>{_warehouse_size});
 
   /**
    * indices[0] = warehouse
@@ -102,8 +102,7 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_warehouse_table() {
 std::shared_ptr<opossum::Table> TpccTableGenerator::generate_stock_table() {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities =
-      std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{_warehouse_size, NUM_STOCK_ITEMS});
+  auto cardinalities = std::vector<size_t>(std::initializer_list<size_t>{_warehouse_size, NUM_STOCK_ITEMS});
 
   /**
    * indices[0] = warehouse
@@ -143,8 +142,7 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_stock_table() {
 std::shared_ptr<opossum::Table> TpccTableGenerator::generate_district_table() {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(
-      std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE});
+  auto cardinalities = std::vector<size_t>(std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE});
 
   /**
    * indices[0] = warehouse
@@ -178,7 +176,7 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_district_table() {
 std::shared_ptr<opossum::Table> TpccTableGenerator::generate_customer_table() {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(
+  auto cardinalities = std::vector<size_t>(
       std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_CUSTOMERS_PER_DISTRICT});
 
   /**
@@ -230,7 +228,7 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_customer_table() {
 std::shared_ptr<opossum::Table> TpccTableGenerator::generate_history_table() {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{
+  auto cardinalities = std::vector<size_t>(std::initializer_list<size_t>{
       _warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_CUSTOMERS_PER_DISTRICT, NUM_HISTORY_ENTRIES});
 
   /**
@@ -256,8 +254,8 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_order_table(
     TpccTableGenerator::order_line_counts_type order_line_counts) {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(
-      std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_ORDERS});
+  auto cardinalities =
+      std::vector<size_t>(std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_ORDERS});
 
   /**
    * indices[0] = warehouse
@@ -331,7 +329,7 @@ std::vector<T> TpccTableGenerator::generate_inner_order_line_column(
 
 template <typename T>
 void TpccTableGenerator::add_order_line_column(std::shared_ptr<opossum::Table> table, std::string name,
-                                               std::shared_ptr<std::vector<size_t>> cardinalities,
+                                               const std::vector<size_t>& cardinalities,
                                                TpccTableGenerator::order_line_counts_type order_line_counts,
                                                const std::function<T(std::vector<size_t>)>& generator_function) {
   const std::function<std::vector<T>(std::vector<size_t>)> wrapped_generator_function =
@@ -345,8 +343,8 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_order_line_table(
     TpccTableGenerator::order_line_counts_type order_line_counts) {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(
-      std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_ORDERS});
+  auto cardinalities =
+      std::vector<size_t>(std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_ORDERS});
 
   /**
    * indices[0] = warehouse
@@ -387,8 +385,8 @@ std::shared_ptr<opossum::Table> TpccTableGenerator::generate_order_line_table(
 std::shared_ptr<opossum::Table> TpccTableGenerator::generate_new_order_table() {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
 
-  auto cardinalities = std::make_shared<std::vector<size_t>>(
-      std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_ORDERS});
+  auto cardinalities =
+      std::vector<size_t>(std::initializer_list<size_t>{_warehouse_size, NUM_DISTRICTS_PER_WAREHOUSE, NUM_ORDERS});
 
   /**
    * indices[0] = warehouse

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -68,8 +68,7 @@ class TpccTableGenerator : public benchmark_utilities::AbstractBenchmarkTableGen
 
   template <typename T>
   void add_order_line_column(std::shared_ptr<opossum::Table> table, std::string name,
-                             std::shared_ptr<std::vector<size_t>> cardinalities,
-                             order_line_counts_type order_line_counts,
+                             const std::vector<size_t>& cardinalities, order_line_counts_type order_line_counts,
                              const std::function<T(std::vector<size_t>)>& generator_function);
 
   TpccRandomGenerator _random_gen;

--- a/src/benchmarklib/tpch/text_field_generator.cpp
+++ b/src/benchmarklib/tpch/text_field_generator.cpp
@@ -16,7 +16,7 @@ TextFieldGenerator::TextFieldGenerator(benchmark_utilities::RandomGenerator rand
       _grammar(TpchGrammar(random_generator)),
       _text(_grammar.random_text(300'000'000)) {}
 
-std::string TextFieldGenerator::text_string(size_t lower_length, size_t upper_length) {
+std::string TextFieldGenerator::text_string(const size_t lower_length, const size_t upper_length) {
   auto length = _random_gen.random_number(lower_length, upper_length);
   auto start = _random_gen.random_number(0, _text.size() - length);
   return _text.substr(start, length);
@@ -28,8 +28,8 @@ std::string TextFieldGenerator::text_string(size_t lower_length, size_t upper_le
  * of at least 64 characters. The length of the string should be between lower_length
  * and upper_length (inclusive).
  */
-std::string TextFieldGenerator::v_string(size_t lower_length, size_t upper_length) {
-  size_t length = _random_gen.random_number(lower_length, upper_length);
+std::string TextFieldGenerator::v_string(const size_t lower_length, const size_t upper_length) {
+  const size_t length = _random_gen.random_number(lower_length, upper_length);
   std::string s;
   s.reserve(length);
   for (size_t i = 0; i < length; i++) {
@@ -75,7 +75,7 @@ std::string TextFieldGenerator::v_string(size_t lower_length, size_t upper_lengt
  * The phone number string is obtained by concatenating the following sub-strings:
  * country_code, "-", local_number1, "-", local_number2, "-", local_number3
  */
-std::string TextFieldGenerator::generate_phone_number(uint32_t nationkey) {
+std::string TextFieldGenerator::generate_phone_number(const uint32_t nationkey) {
   std::stringstream ss;
   auto country_code = nationkey + 10;
   ss << country_code << "-" << _random_gen.random_number(100, 999) << "-" << _random_gen.random_number(100, 999);
@@ -83,7 +83,7 @@ std::string TextFieldGenerator::generate_phone_number(uint32_t nationkey) {
   return ss.str();
 }
 
-std::string TextFieldGenerator::pad_int_with_zeroes(size_t number, size_t length) {
+std::string TextFieldGenerator::pad_int_with_zeroes(const size_t number, const size_t length) {
   std::stringstream ss;
   ss << std::setfill('0') << std::setw(length) << number;
   return ss.str();

--- a/src/benchmarklib/tpch/text_field_generator.hpp
+++ b/src/benchmarklib/tpch/text_field_generator.hpp
@@ -21,11 +21,11 @@ class TextFieldGenerator {
    */
   explicit TextFieldGenerator(benchmark_utilities::RandomGenerator random_generator);
 
-  std::string text_string(size_t lower_length, size_t upper_length);
-  std::string v_string(size_t lower_length, size_t upper_length);
-  std::string generate_phone_number(uint32_t nationkey);
+  std::string text_string(const size_t lower_length, const size_t upper_length);
+  std::string v_string(const size_t lower_length, const size_t upper_length);
+  std::string generate_phone_number(const uint32_t nationkey);
 
-  static std::string pad_int_with_zeroes(size_t number, size_t length);
+  static std::string pad_int_with_zeroes(const size_t number, const size_t length);
 
   std::string generate_name_of_part();
   std::string generate_type_of_part();

--- a/src/benchmarklib/tpch/tpch_grammar.cpp
+++ b/src/benchmarklib/tpch/tpch_grammar.cpp
@@ -46,7 +46,7 @@ namespace tpch {
 
 TpchGrammar::TpchGrammar(benchmark_utilities::RandomGenerator generator) : _random_gen(generator) {}
 
-std::string TpchGrammar::random_text(std::streampos min_size) {
+std::string TpchGrammar::random_text(const std::streampos min_size) {
   std::stringstream text = sentence();
   while (text.tellp() < min_size) {
     text << " " << sentence().rdbuf();

--- a/src/benchmarklib/tpch/tpch_grammar.hpp
+++ b/src/benchmarklib/tpch/tpch_grammar.hpp
@@ -16,7 +16,7 @@ class TpchGrammar {
  public:
   explicit TpchGrammar(benchmark_utilities::RandomGenerator generator);
 
-  std::string random_text(std::streampos min_size);
+  std::string random_text(const std::streampos min_size);
 
   std::string random_word(const std::vector<std::string>& word_vector);
 

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -214,7 +214,7 @@ TpchTableGenerator::order_lines_type TpchTableGenerator::generate_order_lines() 
 }
 
 std::shared_ptr<opossum::Table> TpchTableGenerator::generate_orders_table(
-    TpchTableGenerator::order_lines_type order_lines) {
+    const TpchTableGenerator::order_lines_type order_lines) {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
   size_t table_size = NUM_ORDERS_PER_CUSTOMER * _scale_factor * NUM_CUSTOMERS;
   auto cardinalities = std::make_shared<std::vector<size_t>>(std::initializer_list<size_t>{table_size});
@@ -272,7 +272,7 @@ std::shared_ptr<opossum::Table> TpchTableGenerator::generate_orders_table(
 }
 
 std::shared_ptr<opossum::Table> TpchTableGenerator::generate_lineitems_table(
-    TpchTableGenerator::order_lines_type order_lines) {
+    const TpchTableGenerator::order_lines_type order_lines) {
   auto table = std::make_shared<opossum::Table>(_chunk_size);
   size_t table_size = 0;
   std::vector<OrderLine> flattened_orderlines;

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -43,13 +43,13 @@ class TpchTableGenerator : public benchmark_utilities::AbstractBenchmarkTableGen
 
   std::shared_ptr<opossum::Table> generate_customers_table();
 
-  typedef std::shared_ptr<std::vector<std::vector<OrderLine>>> order_lines_type;
+  typedef std::vector<std::vector<OrderLine>> OrderLines;
 
-  order_lines_type generate_order_lines();
+  OrderLines generate_order_lines();
 
-  std::shared_ptr<opossum::Table> generate_orders_table(const order_lines_type order_lines);
+  std::shared_ptr<opossum::Table> generate_orders_table(const OrderLines& order_lines);
 
-  std::shared_ptr<opossum::Table> generate_lineitems_table(const order_lines_type order_lines);
+  std::shared_ptr<opossum::Table> generate_lineitems_table(const OrderLines& order_lines);
 
   std::shared_ptr<opossum::Table> generate_nations_table();
 

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -47,9 +47,9 @@ class TpchTableGenerator : public benchmark_utilities::AbstractBenchmarkTableGen
 
   order_lines_type generate_order_lines();
 
-  std::shared_ptr<opossum::Table> generate_orders_table(order_lines_type order_lines);
+  std::shared_ptr<opossum::Table> generate_orders_table(const order_lines_type order_lines);
 
-  std::shared_ptr<opossum::Table> generate_lineitems_table(order_lines_type order_lines);
+  std::shared_ptr<opossum::Table> generate_lineitems_table(const order_lines_type order_lines);
 
   std::shared_ptr<opossum::Table> generate_nations_table();
 

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -341,7 +341,7 @@ void Console::load_history(const std::string& history_file) {
   }
 }
 
-void Console::out(const std::string& output, bool console_print) {
+void Console::out(const std::string& output, const bool console_print) {
   if (console_print) {
     _out << output;
   }
@@ -350,7 +350,7 @@ void Console::out(const std::string& output, bool console_print) {
   _log.flush();
 }
 
-void Console::out(std::shared_ptr<const Table> table, uint32_t flags) {
+void Console::out(const std::shared_ptr<const Table>& table, const uint32_t flags) {
   int size_y, size_x;
   rl_get_screen_size(&size_y, &size_x);
 

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -67,7 +67,7 @@ class Console {
    * @param output        The text that should be printed.
    * @param console_print If set to false, then \p output gets printed ONLY to the log_file.
    */
-  void out(const std::string& output, bool console_print = true);
+  void out(const std::string& output, const bool console_print = true);
 
   /*
    * Outputs a table, either directly to the _out stream if it is small enough, or using pagination.
@@ -75,7 +75,7 @@ class Console {
    * @param output The output table.
    * @param flags  Flags for the Print operator.
    */
-  void out(std::shared_ptr<const Table> table, uint32_t flags = 0);
+  void out(const std::shared_ptr<const Table>& table, const uint32_t flags = 0);
 
   /*
    * Handler for SIGINT signal (caused by CTRL-C key sequence).

--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -117,7 +117,7 @@ void Pagination::display() {
   endwin();
 }
 
-void Pagination::_print_page(size_t first_line) {
+void Pagination::_print_page(const size_t first_line) {
   clear();
 
   for (size_t i = first_line; i < first_line + _size_y; ++i) {

--- a/src/bin/console/pagination.hpp
+++ b/src/bin/console/pagination.hpp
@@ -26,7 +26,7 @@ class Pagination {
    *
    * @param first_line Line which should be started from, i.e. which will be the first line on the screen.
    */
-  void _print_page(size_t first_line);
+  void _print_page(const size_t first_line);
 
   /*
    * Prints the help screen, which shows all available commands.

--- a/src/lib/concurrency/commit_context.cpp
+++ b/src/lib/concurrency/commit_context.cpp
@@ -11,7 +11,8 @@ CommitID CommitContext::commit_id() const { return _commit_id; }
 
 bool CommitContext::is_pending() const { return _pending; }
 
-void CommitContext::make_pending(const TransactionID transaction_id, std::function<void(TransactionID)> callback) {
+void CommitContext::make_pending(const TransactionID transaction_id,
+                                 const std::function<void(TransactionID)> callback) {
   _pending = true;
 
   if (callback) {

--- a/src/lib/concurrency/commit_context.hpp
+++ b/src/lib/concurrency/commit_context.hpp
@@ -29,7 +29,7 @@ class CommitContext : private Noncopyable {
    *
    * @param callback called when transaction is committed
    */
-  void make_pending(const TransactionID transaction_id, std::function<void(TransactionID)> callback = nullptr);
+  void make_pending(const TransactionID transaction_id, const std::function<void(TransactionID)> callback = nullptr);
 
   /**
    * Calls the callback of make_pending

--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -96,7 +96,7 @@ bool TransactionContext::commit() {
   return true;
 }
 
-void TransactionContext::register_read_write_operator(const std::shared_ptr<AbstractReadWriteOperator>& op) {
+void TransactionContext::register_read_write_operator(std::shared_ptr<AbstractReadWriteOperator> op) {
   _rw_operators.push_back(op);
 }
 

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -95,7 +95,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
    * @param callback called when transaction is actually committed
    * @return false if called a second time
    */
-  bool commit_async(std::function<void(TransactionID)> callback);
+  bool commit_async(const std::function<void(TransactionID)> callback);
 
   /**
    * Commits the transaction.
@@ -110,7 +110,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
    * Add an operator to the list of read-write operators.
    * Update must not call this because it consists of a Delete and an Insert, which call this themselves.
    */
-  void register_read_write_operator(std::shared_ptr<AbstractReadWriteOperator> op) { _rw_operators.push_back(op); }
+  void register_read_write_operator(const std::shared_ptr<AbstractReadWriteOperator>& op);
 
   /**
    * @defgroup Update the counter of active operators
@@ -159,7 +159,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
    *
    * @param callback called when transaction is committed
    */
-  void _mark_as_pending_and_try_commit(std::function<void(TransactionID)> callback);
+  void _mark_as_pending_and_try_commit(const std::function<void(TransactionID)> callback);
 
   /**@}*/
 
@@ -169,7 +169,8 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
    * Throws an exception if the transition fails and
    * has not been already in phase to_phase or end_phase.
    */
-  bool _transition(TransactionPhase from_phase, TransactionPhase to_phase, TransactionPhase end_phase);
+  bool _transition(const TransactionPhase from_phase, const TransactionPhase to_phase,
+                   const TransactionPhase end_phase);
 
  private:
   const TransactionID _transaction_id;

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -110,7 +110,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
    * Add an operator to the list of read-write operators.
    * Update must not call this because it consists of a Delete and an Insert, which call this themselves.
    */
-  void register_read_write_operator(const std::shared_ptr<AbstractReadWriteOperator>& op);
+  void register_read_write_operator(std::shared_ptr<AbstractReadWriteOperator> op);
 
   /**
    * @defgroup Update the counter of active operators

--- a/src/lib/import_export/csv_converter.hpp
+++ b/src/lib/import_export/csv_converter.hpp
@@ -28,7 +28,7 @@ class BaseCsvConverter {
   virtual ~BaseCsvConverter() = default;
 
   // Converts value to the underlying data type and saves it at the given position.
-  virtual void insert(std::string& value, ChunkOffset position) = 0;
+  virtual void insert(std::string& modifiable_value, const ChunkOffset position) = 0;
 
   // Returns the Column which contains the previously converted values.
   // After the call of finish, no other operation should be called.
@@ -46,31 +46,31 @@ class BaseCsvConverter {
 template <typename T>
 class CsvConverter : public BaseCsvConverter {
  public:
-  explicit CsvConverter(ChunkOffset size, const ParseConfig& config = {}, bool is_nullable = false)
+  explicit CsvConverter(const ChunkOffset size, const ParseConfig& config = {}, const bool is_nullable = false)
       : _parsed_values(size), _null_values(size, false), _is_nullable(is_nullable), _config(config) {}
 
-  void insert(std::string& value, ChunkOffset position) override {
-    if (_is_nullable && value.length() == 0) {
+  void insert(std::string& modifiable_value, const ChunkOffset position) override {
+    if (_is_nullable && modifiable_value.length() == 0) {
       _null_values[position] = true;
       return;
     }
-    Assert(boost::to_lower_copy(value) != ParseConfig::NULL_STRING,
+    Assert(boost::to_lower_copy(modifiable_value) != ParseConfig::NULL_STRING,
            "Unquoted null found in CSV file. Either quote it for string literal \"null\" or leave field empty.");
 
     // clang-format off
     if constexpr(std::is_same_v<T, std::string>) {
-      unescape(value, _config);
+      unescape(modifiable_value, _config);
     } else {  // NOLINT
       // clang-format on
       if (_config.reject_quoted_nonstrings) {
-        Assert(value == unescape_copy(value, _config),
-               "Unexpected quoted string " + value + " encountered in non-string column");
+        Assert(modifiable_value == unescape_copy(modifiable_value, _config),
+               "Unexpected quoted string " + modifiable_value + " encountered in non-string column");
       } else {
-        unescape(value, _config);
+        unescape(modifiable_value, _config);
       }
     }
 
-    _parsed_values[position] = _get_conversion_function()(value);
+    _parsed_values[position] = _get_conversion_function()(modifiable_value);
   }
 
   std::unique_ptr<BaseColumn> finish() override {
@@ -92,7 +92,7 @@ class CsvConverter : public BaseCsvConverter {
   tbb::concurrent_vector<T> _parsed_values;
   tbb::concurrent_vector<bool> _null_values;
   const bool _is_nullable;
-  ParseConfig _config;
+  const ParseConfig _config;
 };
 
 template <>

--- a/src/lib/import_export/csv_parser.hpp
+++ b/src/lib/import_export/csv_parser.hpp
@@ -49,7 +49,7 @@ class CsvParser {
    * csv_content.
    * @returns                False if \p csv_content is empty or chunk_size set to 0, True otherwise.
    */
-  bool _find_fields_in_chunk(std::string_view csv_content, const Table& table, std::vector<size_t>& field_ends);
+  bool _find_fields_in_chunk(const std::string_view csv_content, const Table& table, std::vector<size_t>& field_ends);
 
   /*
    * @param      csv_chunk  String_view on one chunk of the CSV.
@@ -57,13 +57,14 @@ class CsvParser {
    * @param      table      Empty table created by _process_meta_file.
    * @param[out] chunk      Empty chunk, to be filled with fields found in \p csv_chunk.
    */
-  void _parse_into_chunk(std::string_view csv_chunk, const std::vector<size_t>& field_ends, const Table& table,
-                         Chunk& chunk);
+  static void _parse_into_chunk(const CsvMeta& csv_meta, const std::string_view csv_chunk,
+                                const std::vector<size_t>& field_ends, const Table& table,
+                                const std::shared_ptr<Chunk>& chunk);
 
   /*
    * @param field The field that needs to be modified to be RFC 4180 compliant.
    */
-  void _sanitize_field(std::string& field);
+  static void _sanitize_field(const CsvMeta& csv_meta, std::string& field);
 
   // CSV meta information like chunk_size, column information, delimitor/seperator charactere, etc.
   CsvMeta _meta;

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -16,7 +16,7 @@ namespace opossum {
 
 class TableStatistics;
 
-AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type) : _type(node_type) {}
+AbstractLQPNode::AbstractLQPNode(const LQPNodeType node_type) : _type(node_type) {}
 
 std::vector<std::shared_ptr<AbstractLQPNode>> AbstractLQPNode::parents() const {
   std::vector<std::shared_ptr<AbstractLQPNode>> parents;
@@ -45,7 +45,7 @@ void AbstractLQPNode::clear_parents() {
   }
 }
 
-LQPChildSide AbstractLQPNode::get_child_side(const std::shared_ptr<AbstractLQPNode>& parent) const {
+LQPChildSide AbstractLQPNode::get_child_side(const std::shared_ptr<const AbstractLQPNode>& parent) const {
   if (parent->_children[0].get() == this) {
     return LQPChildSide::Left;
   } else if (parent->_children[1].get() == this) {
@@ -81,12 +81,12 @@ void AbstractLQPNode::set_right_child(const std::shared_ptr<AbstractLQPNode>& ri
   set_child(LQPChildSide::Right, right);
 }
 
-std::shared_ptr<AbstractLQPNode> AbstractLQPNode::child(LQPChildSide side) const {
+std::shared_ptr<AbstractLQPNode> AbstractLQPNode::child(const LQPChildSide side) const {
   const auto child_index = static_cast<int>(side);
   return _children[child_index];
 }
 
-void AbstractLQPNode::set_child(LQPChildSide side, const std::shared_ptr<AbstractLQPNode>& child) {
+void AbstractLQPNode::set_child(const LQPChildSide side, const std::shared_ptr<AbstractLQPNode>& child) {
   // We need a reference to _children[child_index], so not calling this->child(side)
   auto& current_child = _children[static_cast<int>(side)];
 
@@ -285,7 +285,7 @@ void AbstractLQPNode::print(std::ostream& out) const {
   _print_impl(out, levels, id_by_node, id_counter);
 }
 
-std::string AbstractLQPNode::get_verbose_column_name(ColumnID column_id) const {
+std::string AbstractLQPNode::get_verbose_column_name(const ColumnID column_id) const {
   DebugAssert(!right_child(), "Node with right child needs to override this function.");
 
   /**

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -39,7 +39,7 @@ enum class LQPNodeType {
 enum class LQPChildSide { Left, Right };
 
 struct NamedColumnReference {
-  std::string column_name;
+  const std::string column_name;
   std::optional<std::string> table_name = std::nullopt;
 
   std::string as_string() const;
@@ -64,7 +64,7 @@ struct NamedColumnReference {
  */
 class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
  public:
-  explicit AbstractLQPNode(LQPNodeType node_type);
+  explicit AbstractLQPNode(const LQPNodeType node_type);
 
   // @{
   /**
@@ -88,7 +88,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
    * @pre this has a parent
    * @return whether this is its parents left or right child.
    */
-  LQPChildSide get_child_side(const std::shared_ptr<AbstractLQPNode>& parent) const;
+  LQPChildSide get_child_side(const std::shared_ptr<const AbstractLQPNode>& parent) const;
 
   /**
    * @returns {get_child_side(parents()[0], ..., get_child_side(parents()[n-1])}
@@ -101,9 +101,9 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   std::shared_ptr<AbstractLQPNode> right_child() const;
   void set_right_child(const std::shared_ptr<AbstractLQPNode>& right);
 
-  std::shared_ptr<AbstractLQPNode> child(LQPChildSide side) const;
+  std::shared_ptr<AbstractLQPNode> child(const LQPChildSide side) const;
 
-  void set_child(LQPChildSide side, const std::shared_ptr<AbstractLQPNode>& child);
+  void set_child(const LQPChildSide side, const std::shared_ptr<AbstractLQPNode>& child);
   // @}
 
   LQPNodeType type() const;
@@ -244,7 +244,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
    * Generate a name for a column that contains all aliases it went through as well as the name of the table that it
    * originally came from, if any
    */
-  virtual std::string get_verbose_column_name(ColumnID column_id) const;
+  virtual std::string get_verbose_column_name(const ColumnID column_id) const;
 
   /**
    * @returns {get_verbose_column_name(0), ..., get_verbose_column_name(n-1)}
@@ -260,7 +260,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   virtual void _on_child_changed() {}
 
   // Used to easily differentiate between node types without pointer casts.
-  LQPNodeType _type;
+  const LQPNodeType _type;
 
   /**
    * Each subtree can be a subselect. A subselect can be given an alias:

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -16,8 +16,8 @@ namespace opossum {
 AggregateNode::AggregateNode(std::vector<std::shared_ptr<Expression>>&& aggregate_expressions,
                              std::vector<ColumnID>&& groupby_column_ids)
     : AbstractLQPNode(LQPNodeType::Aggregate),
-      _aggregate_expressions(aggregate_expressions),
-      _groupby_column_ids(groupby_column_ids) {
+      _aggregate_expressions(std::move(aggregate_expressions)),
+      _groupby_column_ids(std::move(groupby_column_ids)) {
   for ([[gnu::unused]] const auto& expression : aggregate_expressions) {
     DebugAssert(expression->type() == ExpressionType::Function, "Aggregate expression must be a function.");
   }

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -21,8 +21,8 @@ class Expression;
  */
 class AggregateNode : public AbstractLQPNode {
  public:
-  explicit AggregateNode(const std::vector<std::shared_ptr<Expression>>& aggregates,
-                         const std::vector<ColumnID>& groupby_column_ids);
+  explicit AggregateNode(std::vector<std::shared_ptr<Expression>>&& aggregates,
+                         std::vector<ColumnID>&& groupby_column_ids);
 
   const std::vector<std::shared_ptr<Expression>>& aggregate_expressions() const;
   const std::vector<ColumnID>& groupby_column_ids() const;
@@ -49,20 +49,20 @@ class AggregateNode : public AbstractLQPNode {
    *
    * NOTE: These functions will possibly result in a full recursive traversal of the ancestors of this node.
    */
-  std::optional<ColumnID> find_column_id_for_expression(const std::shared_ptr<Expression>& expression) const;
-  ColumnID get_column_id_for_expression(const std::shared_ptr<Expression>& expression) const;
+  std::optional<ColumnID> find_column_id_for_expression(const std::shared_ptr<const Expression>& expression) const;
+  ColumnID get_column_id_for_expression(const std::shared_ptr<const Expression>& expression) const;
   // @}
 
   std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
 
-  std::string get_verbose_column_name(ColumnID column_id) const override;
+  std::string get_verbose_column_name(const ColumnID column_id) const override;
 
  protected:
   void _on_child_changed() override;
 
  private:
-  std::vector<std::shared_ptr<Expression>> _aggregate_expressions;
-  std::vector<ColumnID> _groupby_column_ids;
+  const std::vector<std::shared_ptr<Expression>> _aggregate_expressions;
+  const std::vector<ColumnID> _groupby_column_ids;
 
   mutable std::optional<std::vector<std::string>> _output_column_names;
 

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -11,7 +11,7 @@
 
 namespace opossum {
 
-InsertNode::InsertNode(const std::string table_name) : AbstractLQPNode(LQPNodeType::Insert), _table_name(table_name) {}
+InsertNode::InsertNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Insert), _table_name(table_name) {}
 
 std::string InsertNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -13,7 +13,7 @@ namespace opossum {
  */
 class InsertNode : public AbstractLQPNode {
  public:
-  explicit InsertNode(const std::string table_name);
+  explicit InsertNode(const std::string& table_name);
 
   std::string description() const override;
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -200,7 +200,7 @@ const std::optional<ScanType>& JoinNode::scan_type() const { return _scan_type; 
 
 JoinMode JoinNode::join_mode() const { return _join_mode; }
 
-std::string JoinNode::get_verbose_column_name(ColumnID column_id) const {
+std::string JoinNode::get_verbose_column_name(const ColumnID column_id) const {
   Assert(left_child() && right_child(), "Can't generate column names without children being set");
 
   if (column_id < left_child()->output_column_count()) {

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -40,15 +40,15 @@ class JoinNode : public AbstractLQPNode {
   std::optional<ColumnID> find_column_id_by_named_column_reference(
       const NamedColumnReference& named_column_reference) const override;
 
-  std::string get_verbose_column_name(ColumnID column_id) const override;
+  std::string get_verbose_column_name(const ColumnID column_id) const override;
 
  protected:
   void _on_child_changed() override;
 
  private:
-  JoinMode _join_mode;
-  std::optional<std::pair<ColumnID, ColumnID>> _join_column_ids;
-  std::optional<ScanType> _scan_type;
+  const JoinMode _join_mode;
+  const std::optional<std::pair<ColumnID, ColumnID>> _join_column_ids;
+  const std::optional<ScanType> _scan_type;
 
   mutable std::optional<std::vector<std::string>> _output_column_names;
 

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -175,7 +175,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_aggregate_node(
    *  TODO(anybody): this might result in the same columns being created multiple times. Improve.
    */
   if (need_projection) {
-    Projection::ColumnExpressions column_expressions = Expression::create_columns(groupby_columns);
+    auto column_expressions = Expression::create_columns(groupby_columns);
     column_expressions.reserve(groupby_columns.size() + aggregate_expressions.size());
 
     // The Projection will only select columns used in the Aggregate, i.e., GROUP BY columns and expressions.
@@ -310,7 +310,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_dummy_table_node(
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_by_node_type(
-    LQPNodeType type, const std::shared_ptr<AbstractLQPNode>& node) const {
+    const LQPNodeType type, const std::shared_ptr<AbstractLQPNode>& node) const {
   switch (type) {
     // SQL operators
     case LQPNodeType::StoredTable:

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -20,7 +20,7 @@ class LQPTranslator final : private Noncopyable {
   std::shared_ptr<AbstractOperator> translate_node(const std::shared_ptr<AbstractLQPNode>& node) const;
 
  private:
-  std::shared_ptr<AbstractOperator> _translate_by_node_type(LQPNodeType type,
+  std::shared_ptr<AbstractOperator> _translate_by_node_type(const LQPNodeType type,
                                                             const std::shared_ptr<AbstractLQPNode>& node) const;
 
   // SQL operators

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -28,7 +28,7 @@ const std::vector<ColumnID>& MockNode::output_column_ids_to_input_column_ids() c
 
 const std::vector<std::string>& MockNode::output_column_names() const { return _output_column_names; }
 
-std::string MockNode::get_verbose_column_name(ColumnID column_id) const {
+std::string MockNode::get_verbose_column_name(const ColumnID column_id) const {
   // Aliasing a MockNode doesn't really make sense, but let's stay covered
   if (_table_alias) {
     return *_table_alias + "." + output_column_names()[column_id];

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -22,7 +22,7 @@ class MockNode : public AbstractLQPNode {
   const std::vector<std::string>& output_column_names() const override;
 
   std::string description() const override;
-  std::string get_verbose_column_name(ColumnID column_id) const override;
+  std::string get_verbose_column_name(const ColumnID column_id) const override;
 
  private:
   std::vector<std::string> _output_column_names;

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -12,8 +12,8 @@
 
 namespace opossum {
 
-PredicateNode::PredicateNode(const ColumnID column_id, const ScanType scan_type, const AllParameterVariant& value,
-                             const std::optional<AllTypeVariant>& value2)
+PredicateNode::PredicateNode(const ColumnID column_id, const ScanType scan_type, const AllParameterVariant value,
+                             const std::optional<AllTypeVariant> value2)
     : AbstractLQPNode(LQPNodeType::Predicate),
       _column_id(column_id),
       _scan_type(scan_type),

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -23,8 +23,8 @@ class TableStatistics;
  */
 class PredicateNode : public AbstractLQPNode {
  public:
-  PredicateNode(const ColumnID column_id, const ScanType scan_type, const AllParameterVariant& value,
-                const std::optional<AllTypeVariant>& value2 = std::nullopt);
+  PredicateNode(const ColumnID column_id, const ScanType scan_type, const AllParameterVariant value,
+                const std::optional<AllTypeVariant> value2 = std::nullopt);
 
   std::string description() const override;
 

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -14,7 +14,7 @@
 namespace opossum {
 
 ProjectionNode::ProjectionNode(std::vector<std::shared_ptr<Expression>>&& column_expressions)
-    : AbstractLQPNode(LQPNodeType::Projection), _column_expressions(column_expressions) {}
+    : AbstractLQPNode(LQPNodeType::Projection), _column_expressions(std::move(column_expressions)) {}
 
 std::string ProjectionNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -13,7 +13,7 @@
 
 namespace opossum {
 
-ProjectionNode::ProjectionNode(const std::vector<std::shared_ptr<Expression>>& column_expressions)
+ProjectionNode::ProjectionNode(std::vector<std::shared_ptr<Expression>>&& column_expressions)
     : AbstractLQPNode(LQPNodeType::Projection), _column_expressions(column_expressions) {}
 
 std::string ProjectionNode::description() const {
@@ -162,7 +162,7 @@ std::vector<ColumnID> ProjectionNode::get_output_column_ids_for_table(const std:
   return output_column_ids_for_table;
 }
 
-std::string ProjectionNode::get_verbose_column_name(ColumnID column_id) const {
+std::string ProjectionNode::get_verbose_column_name(const ColumnID column_id) const {
   DebugAssert(left_child(), "Need input to generate name");
   DebugAssert(column_id < _column_expressions.size(), "ColumnID out of range");
 

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -18,7 +18,7 @@ struct ColumnID;
  */
 class ProjectionNode : public AbstractLQPNode {
  public:
-  explicit ProjectionNode(const std::vector<std::shared_ptr<Expression>>& column_expressions);
+  explicit ProjectionNode(std::vector<std::shared_ptr<Expression>>&& column_expressions);
 
   const std::vector<std::shared_ptr<Expression>>& column_expressions() const;
 
@@ -31,7 +31,7 @@ class ProjectionNode : public AbstractLQPNode {
 
   std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
 
-  std::string get_verbose_column_name(ColumnID column_id) const override;
+  std::string get_verbose_column_name(const ColumnID column_id) const override;
 
  protected:
   void _on_child_changed() override;

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -12,7 +12,7 @@ namespace opossum {
 OrderByDefinition::OrderByDefinition(const ColumnID column_id, const OrderByMode order_by_mode)
     : column_id(column_id), order_by_mode(order_by_mode) {}
 
-SortNode::SortNode(const std::vector<OrderByDefinition>& order_by_definitions)
+SortNode::SortNode(std::vector<OrderByDefinition>&& order_by_definitions)
     : AbstractLQPNode(LQPNodeType::Sort), _order_by_definitions(order_by_definitions) {}
 
 std::string SortNode::description() const {

--- a/src/lib/logical_query_plan/sort_node.hpp
+++ b/src/lib/logical_query_plan/sort_node.hpp
@@ -24,7 +24,7 @@ struct OrderByDefinition {
  */
 class SortNode : public AbstractLQPNode {
  public:
-  explicit SortNode(const std::vector<OrderByDefinition>& order_by_definitions);
+  explicit SortNode(std::vector<OrderByDefinition>&& order_by_definitions);
 
   std::string description() const override;
 

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -86,7 +86,7 @@ std::vector<ColumnID> StoredTableNode::get_output_column_ids_for_table(const std
   return column_ids;
 }
 
-std::string StoredTableNode::get_verbose_column_name(ColumnID column_id) const {
+std::string StoredTableNode::get_verbose_column_name(const ColumnID column_id) const {
   if (_table_alias) {
     return "(" + _table_name + " AS " + *_table_alias + ")." + output_column_names()[column_id];
   }

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -37,7 +37,7 @@ class StoredTableNode : public AbstractLQPNode {
   std::optional<ColumnID> find_column_id_by_named_column_reference(
       const NamedColumnReference& named_column_reference) const override;
 
-  std::string get_verbose_column_name(ColumnID column_id) const override;
+  std::string get_verbose_column_name(const ColumnID column_id) const override;
 
  protected:
   void _on_child_changed() override;

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -16,7 +16,7 @@ UnionMode UnionNode::union_mode() const { return _union_mode; }
 
 std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.at(_union_mode); }
 
-std::string UnionNode::get_verbose_column_name(ColumnID column_id) const {
+std::string UnionNode::get_verbose_column_name(const ColumnID column_id) const {
   Assert(left_child() && right_child(), "Need children to determine Column name");
   Assert(column_id < left_child()->output_column_names().size(), "ColumnID out of range");
   Assert(right_child()->output_column_names().size() == left_child()->output_column_names().size(),

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -17,7 +17,7 @@ class UnionNode : public AbstractLQPNode {
 
   std::string description() const override;
 
-  std::string get_verbose_column_name(ColumnID column_id) const override;
+  std::string get_verbose_column_name(const ColumnID column_id) const override;
 
   const std::vector<std::string>& output_column_names() const override;
   const std::vector<ColumnID>& output_column_ids_to_input_column_ids() const override;

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -12,7 +12,9 @@ namespace opossum {
 class Expression;
 
 UpdateNode::UpdateNode(const std::string& table_name, std::vector<std::shared_ptr<Expression>>&& column_expressions)
-    : AbstractLQPNode(LQPNodeType::Update), _table_name(table_name), _column_expressions(column_expressions) {}
+    : AbstractLQPNode(LQPNodeType::Update),
+      _table_name(table_name),
+      _column_expressions(std::move(column_expressions)) {}
 
 std::string UpdateNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -11,8 +11,7 @@ namespace opossum {
 
 class Expression;
 
-UpdateNode::UpdateNode(const std::string& table_name,
-                       const std::vector<std::shared_ptr<Expression>>& column_expressions)
+UpdateNode::UpdateNode(const std::string& table_name, std::vector<std::shared_ptr<Expression>>&& column_expressions)
     : AbstractLQPNode(LQPNodeType::Update), _table_name(table_name), _column_expressions(column_expressions) {}
 
 std::string UpdateNode::description() const {

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -13,8 +13,7 @@ namespace opossum {
  */
 class UpdateNode : public AbstractLQPNode {
  public:
-  explicit UpdateNode(const std::string& table_name,
-                      const std::vector<std::shared_ptr<Expression>>& column_expressions);
+  explicit UpdateNode(const std::string& table_name, std::vector<std::shared_ptr<Expression>>&& column_expressions);
 
   std::string description() const override;
 

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -59,10 +59,10 @@ struct GroupByContext : ColumnVisitableContext {
         chunk_offsets_in(chunk_offsets) {}
 
   const std::shared_ptr<const Table>& table_in;
-  const ChunkID chunk_id;
+  ChunkID chunk_id;
   const ColumnID column_id;
   const std::shared_ptr<std::vector<AggregateKey>>& hash_keys;
-  const std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets_in;
+  std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets_in;
 };
 
 /*

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -46,7 +46,11 @@ Visitor context for the partitioning/grouping visitor
 struct GroupByContext : ColumnVisitableContext {
   GroupByContext(const std::shared_ptr<const Table>& t, const ChunkID chunk, const ColumnID column,
                  const std::shared_ptr<std::vector<AggregateKey>>& keys)
-      : table_in(t), chunk_id(chunk), column_id(column), hash_keys(keys) {}
+      // TODO(anyone): remove shared_ptr<vector> here and anywhere else where it is not needed
+      : table_in(t),
+        chunk_id(chunk),
+        column_id(column),
+        hash_keys(keys) {}
 
   // constructor for use in ReferenceColumn::visit_dereferenced
   GroupByContext(const std::shared_ptr<BaseColumn>&, const std::shared_ptr<const Table>& referenced_table,

--- a/src/lib/operators/aggregate.hpp
+++ b/src/lib/operators/aggregate.hpp
@@ -102,7 +102,7 @@ class Aggregate : public AbstractReadOnlyOperator {
   template <typename ColumnType>
   static void _create_aggregate_visitor(boost::hana::basic_type<ColumnType> type,
                                         std::shared_ptr<ColumnVisitable>& builder,
-                                        std::shared_ptr<ColumnVisitableContext> context,
+                                        const std::shared_ptr<ColumnVisitableContext>& context,
                                         std::shared_ptr<GroupByContext> groupby_context, AggregateFunction function);
 
   template <typename ColumnType>

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -164,8 +164,8 @@ void ExportBinary::_write_chunk(const std::shared_ptr<const Table>& table, std::
 }
 
 template <typename T>
-void ExportBinary::ExportBinaryVisitor<T>::handle_value_column(const BaseValueColumn& base_column,
-                                                               std::shared_ptr<ColumnVisitableContext> base_context) {
+void ExportBinary::ExportBinaryVisitor<T>::handle_value_column(
+    const BaseValueColumn& base_column, const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<ExportContext>(base_context);
   const auto& column = static_cast<const ValueColumn<T>&>(base_column);
 
@@ -180,7 +180,7 @@ void ExportBinary::ExportBinaryVisitor<T>::handle_value_column(const BaseValueCo
 
 template <typename T>
 void ExportBinary::ExportBinaryVisitor<T>::handle_reference_column(
-    const ReferenceColumn& ref_column, std::shared_ptr<ColumnVisitableContext> base_context) {
+    const ReferenceColumn& ref_column, const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<ExportContext>(base_context);
 
   // We materialize reference columns and save them as value columns
@@ -196,7 +196,7 @@ void ExportBinary::ExportBinaryVisitor<T>::handle_reference_column(
 // handle_reference_column implementation for string columns
 template <>
 void ExportBinary::ExportBinaryVisitor<std::string>::handle_reference_column(
-    const ReferenceColumn& ref_column, std::shared_ptr<ColumnVisitableContext> base_context) {
+    const ReferenceColumn& ref_column, const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<ExportContext>(base_context);
 
   // We materialize reference columns and save them as value columns
@@ -222,7 +222,7 @@ void ExportBinary::ExportBinaryVisitor<std::string>::handle_reference_column(
 
 template <typename T>
 void ExportBinary::ExportBinaryVisitor<T>::handle_dictionary_column(
-    const BaseDictionaryColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) {
+    const BaseDictionaryColumn& base_column, const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<ExportContext>(base_context);
   const auto& column = static_cast<const DictionaryColumn<T>&>(base_column);
 

--- a/src/lib/operators/export_binary.hpp
+++ b/src/lib/operators/export_binary.hpp
@@ -106,7 +106,7 @@ class ExportBinary::ExportBinaryVisitor : public ColumnVisitable {
    *
    */
   void handle_value_column(const BaseValueColumn& base_column,
-                           std::shared_ptr<ColumnVisitableContext> base_context) final;
+                           const std::shared_ptr<ColumnVisitableContext>& base_context) final;
 
   /**
    * Reference Columns are dumped with the following layout, which is similar to value columns:
@@ -128,7 +128,7 @@ class ExportBinary::ExportBinaryVisitor : public ColumnVisitable {
    * @param base_context A context in the form of an ExportContext. Contains a reference to the ofstream.
    */
   void handle_reference_column(const ReferenceColumn& ref_column,
-                               std::shared_ptr<ColumnVisitableContext> base_context) override;
+                               const std::shared_ptr<ColumnVisitableContext>& base_context) override;
   /**
    * Dictionary Columns are dumped with the following layout:
    *
@@ -152,7 +152,7 @@ class ExportBinary::ExportBinaryVisitor : public ColumnVisitable {
    * @param base_context A context in the form of an ExportContext. Contains a reference to the ofstream.
    */
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) override;
+                                const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
  private:
   // Chooses the right FittedAttributeVector depending on the attribute_vector_width and exports it.

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -92,7 +92,7 @@ void ExportCsv::_generate_content_file(const std::shared_ptr<const Table>& table
 template <typename T>
 class ExportCsv::ExportCsvVisitor : public ColumnVisitable {
   void handle_value_column(const BaseValueColumn& base_column,
-                           std::shared_ptr<ColumnVisitableContext> base_context) final {
+                           const std::shared_ptr<ColumnVisitableContext>& base_context) final {
     auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
     const auto& column = static_cast<const ValueColumn<T>&>(base_column);
 
@@ -107,14 +107,14 @@ class ExportCsv::ExportCsvVisitor : public ColumnVisitable {
   }
 
   void handle_reference_column(const ReferenceColumn& ref_column,
-                               std::shared_ptr<ColumnVisitableContext> base_context) final {
+                               const std::shared_ptr<ColumnVisitableContext>& base_context) final {
     auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
 
     context->csv_writer.write(ref_column[context->current_row]);
   }
 
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) final {
+                                const std::shared_ptr<ColumnVisitableContext>& base_context) final {
     auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
     const auto& column = static_cast<const DictionaryColumn<T>&>(base_column);
 

--- a/src/lib/operators/index_column_scan.cpp
+++ b/src/lib/operators/index_column_scan.cpp
@@ -59,7 +59,7 @@ class IndexColumnScan::IndexColumnScanImpl : public AbstractReadOnlyOperatorImpl
 
     // constructor for use in ReferenceColumn::visit_dereferenced
     ScanContext(std::shared_ptr<const BaseColumn>, const std::shared_ptr<const Table> referenced_table,
-                std::shared_ptr<ColumnVisitableContext> base_context, ChunkID chunk_id,
+                const std::shared_ptr<ColumnVisitableContext>& base_context, ChunkID chunk_id,
                 std::shared_ptr<std::vector<ChunkOffset>> chunk_offsets)
         : table_in(referenced_table),
           chunk_id(chunk_id),
@@ -227,7 +227,7 @@ class IndexColumnScan::IndexColumnScanImpl : public AbstractReadOnlyOperatorImpl
   }
 
   void handle_value_column(const BaseValueColumn& base_column,
-                           std::shared_ptr<ColumnVisitableContext> base_context) override {
+                           const std::shared_ptr<ColumnVisitableContext>& base_context) override {
     auto context = std::static_pointer_cast<ScanContext>(base_context);
     const auto& column = static_cast<const ValueColumn<T>&>(base_column);
     Assert(!column.is_nullable(), "Cannot perform IndexColumnScan on nullable column.");
@@ -254,12 +254,12 @@ class IndexColumnScan::IndexColumnScanImpl : public AbstractReadOnlyOperatorImpl
   }
 
   void handle_reference_column(const ReferenceColumn& column,
-                               std::shared_ptr<ColumnVisitableContext> base_context) override {
+                               const std::shared_ptr<ColumnVisitableContext>& base_context) override {
     column.visit_dereferenced<ScanContext>(*this, base_context);
   }
 
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) override {
+                                const std::shared_ptr<ColumnVisitableContext>& base_context) override {
     /*
      ValueID x;
      T A;

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -18,15 +18,16 @@ namespace opossum {
 // We need these classes to perform the dynamic cast into a templated ValueColumn
 class AbstractTypedColumnProcessor {
  public:
-  virtual void resize_vector(std::shared_ptr<BaseColumn> column, size_t new_size) = 0;
-  virtual void copy_data(std::shared_ptr<const BaseColumn> source, size_t source_start_index,
-                         std::shared_ptr<BaseColumn> target, size_t target_start_index, size_t length) = 0;
+  virtual void resize_vector(const std::shared_ptr<BaseColumn>& column, const size_t new_size) = 0;
+  virtual void copy_data(const std::shared_ptr<const BaseColumn>& source, const size_t source_start_index,
+                         const std::shared_ptr<BaseColumn>& target, const size_t target_start_index,
+                         const size_t length) = 0;
 };
 
 template <typename T>
 class TypedColumnProcessor : public AbstractTypedColumnProcessor {
  public:
-  void resize_vector(std::shared_ptr<BaseColumn> column, size_t new_size) override {
+  void resize_vector(const std::shared_ptr<BaseColumn>& column, const size_t new_size) override {
     auto val_column = std::dynamic_pointer_cast<ValueColumn<T>>(column);
     DebugAssert(static_cast<bool>(val_column), "Type mismatch");
     auto& values = val_column->values();
@@ -39,8 +40,9 @@ class TypedColumnProcessor : public AbstractTypedColumnProcessor {
   }
 
   // this copies
-  void copy_data(std::shared_ptr<const BaseColumn> source, size_t source_start_index,
-                 std::shared_ptr<BaseColumn> target, size_t target_start_index, size_t length) override {
+  void copy_data(const std::shared_ptr<const BaseColumn>& source, const size_t source_start_index,
+                 const std::shared_ptr<BaseColumn>& target, const size_t target_start_index,
+                 const size_t length) override {
     auto casted_target = std::dynamic_pointer_cast<ValueColumn<T>>(target);
     DebugAssert(static_cast<bool>(casted_target), "Type mismatch");
     auto& values = casted_target->values();

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -86,9 +86,9 @@ using Hash = uint32_t;
 template <typename LeftType, typename RightType>
 class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
  public:
-  JoinHashImpl(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right,
-               const JoinMode mode, const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type,
-               const bool inputs_swapped)
+  JoinHashImpl(const std::shared_ptr<const AbstractOperator>& left,
+               const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
+               const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type, const bool inputs_swapped)
       : _left(left),
         _right(right),
         _mode(mode),
@@ -139,9 +139,10 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   };
 
   template <typename T>
-  std::shared_ptr<Partition<T>> _materialize_input(const std::shared_ptr<const Table> in_table, ColumnID column_id,
+  std::shared_ptr<Partition<T>> _materialize_input(const std::shared_ptr<const Table>& in_table,
+                                                   const ColumnID column_id,
                                                    std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
-                                                   bool keep_nulls = false) {
+                                                   const bool keep_nulls = false) {
     // list of all elements that will be partitioned
     auto elements = std::make_shared<Partition<T>>();
     elements->resize(in_table->row_count());
@@ -242,10 +243,10 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   }
 
   template <typename T>
-  RadixContainer<T> _partition_radix_parallel(std::shared_ptr<Partition<T>> materialized,
-                                              std::shared_ptr<std::vector<size_t>> chunk_offsets,
-                                              std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
-                                              bool keep_nulls = false) {
+  RadixContainer<T> _partition_radix_parallel(const std::shared_ptr<Partition<T>>& materialized,
+                                              const std::shared_ptr<std::vector<size_t>>& chunk_offsets,
+                                              const std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
+                                              const bool keep_nulls = false) {
     // fan-out
     const size_t num_partitions = 1 << _radix_bits;
 
@@ -527,8 +528,8 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   /*
   Copy the column meta-data from input to output table.
   */
-  static void _copy_table_metadata(const std::shared_ptr<const Table> in_table,
-                                   const std::shared_ptr<Table> out_table) {
+  static void _copy_table_metadata(const std::shared_ptr<const Table>& in_table,
+                                   const std::shared_ptr<Table>& out_table) {
     for (ColumnID column_id{0}; column_id < in_table->column_count(); ++column_id) {
       // TODO(anyone): Refine since not all column are nullable
       out_table->add_column_definition(in_table->column_name(column_id), in_table->column_type(column_id), true);
@@ -683,8 +684,8 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     return _output_table;
   }
 
-  static void write_output_chunks(Chunk& output_chunk, const std::shared_ptr<const Table> input_table,
-                                  PosList& pos_list, bool is_ref_column) {
+  static void write_output_chunks(Chunk& output_chunk, const std::shared_ptr<const Table>& input_table,
+                                  const PosList& pos_list, const bool is_ref_column) {
     if (pos_list.empty()) return;
 
     // Add columns from input table to output chunk

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -567,8 +567,8 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   /**
   * Adds the columns from an input table to the output table
   **/
-  void _add_output_columns(std::shared_ptr<Table> output_table, std::shared_ptr<const Table> input_table,
-                           std::shared_ptr<const PosList> pos_list) {
+  void _add_output_columns(const std::shared_ptr<Table>& output_table, const std::shared_ptr<const Table>& input_table,
+                           const std::shared_ptr<const PosList>& pos_list) {
     auto column_count = input_table->column_count();
     for (ColumnID column_id{0}; column_id < column_count; ++column_id) {
       // Add the column definition
@@ -597,8 +597,9 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   * Turns a pos list that is pointing to reference column entries into a pos list pointing to the original table.
   * This is done because there should not be any reference columns referencing reference columns.
   **/
-  std::shared_ptr<PosList> _dereference_pos_list(std::shared_ptr<const Table> input_table, ColumnID column_id,
-                                                 std::shared_ptr<const PosList> pos_list) {
+  std::shared_ptr<PosList> _dereference_pos_list(const std::shared_ptr<const Table>& input_table,
+                                                 const ColumnID column_id,
+                                                 const std::shared_ptr<const PosList>& pos_list) {
     // Get all the input pos lists so that we only have to pointer cast the columns once
     auto input_pos_lists = std::vector<std::shared_ptr<const PosList>>();
     for (ChunkID chunk_id{0}; chunk_id < input_table->chunk_count(); ++chunk_id) {

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -32,14 +32,15 @@ std::shared_ptr<const Table> Product::_on_execute() {
 
   for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _input_table_left()->chunk_count(); ++chunk_id_left) {
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < _input_table_right()->chunk_count(); ++chunk_id_right) {
-      add_product_of_two_chunks(output, chunk_id_left, chunk_id_right);
+      _add_product_of_two_chunks(output, chunk_id_left, chunk_id_right);
     }
   }
 
   return output;
 }
 
-void Product::add_product_of_two_chunks(std::shared_ptr<Table> output, ChunkID chunk_id_left, ChunkID chunk_id_right) {
+void Product::_add_product_of_two_chunks(const std::shared_ptr<Table>& output, const ChunkID chunk_id_left,
+                                         const ChunkID chunk_id_right) {
   const auto& chunk_left = _input_table_left()->get_chunk(chunk_id_left);
   const auto& chunk_right = _input_table_right()->get_chunk(chunk_id_right);
 

--- a/src/lib/operators/product.hpp
+++ b/src/lib/operators/product.hpp
@@ -23,7 +23,8 @@ class Product : public AbstractReadOnlyOperator {
   const std::string name() const override;
 
  protected:
-  void add_product_of_two_chunks(std::shared_ptr<Table> output, ChunkID chunk_id_left, ChunkID chunk_id_right);
+  void _add_product_of_two_chunks(const std::shared_ptr<Table>& output, const ChunkID chunk_id_left,
+                                  const ChunkID chunk_id_right);
   std::shared_ptr<const Table> _on_execute() override;
 };
 }  // namespace opossum

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<AbstractOperator> Projection::recreate(const std::vector<AllPara
 
 template <typename T>
 void Projection::_create_column(boost::hana::basic_type<T> type, Chunk& chunk, const ChunkID chunk_id,
-                                const std::shared_ptr<Expression>& expression,
+                                const std::shared_ptr<const Expression>& expression,
                                 std::shared_ptr<const Table> input_table_left) {
   // check whether term is a just a simple column and bypass this column
   if (expression->type() == ExpressionType::Column) {
@@ -112,7 +112,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   return output;
 }
 
-const std::string Projection::_get_type_of_expression(const std::shared_ptr<Expression>& expression,
+const std::string Projection::_get_type_of_expression(const std::shared_ptr<const Expression>& expression,
                                                       const std::shared_ptr<const Table>& table) {
   if (expression->type() == ExpressionType::Literal) {
     return type_string_from_all_type_variant(expression->value());
@@ -139,7 +139,8 @@ const std::string Projection::_get_type_of_expression(const std::shared_ptr<Expr
 
 template <typename T>
 const pmr_concurrent_vector<std::optional<T>> Projection::_evaluate_expression(
-    const std::shared_ptr<Expression>& expression, const std::shared_ptr<const Table> table, const ChunkID chunk_id) {
+    const std::shared_ptr<const Expression>& expression, const std::shared_ptr<const Table> table,
+    const ChunkID chunk_id) {
   /**
    * Handle Literal
    * This is only used if the Literal represents a constant column, e.g. in 'SELECT 5 FROM table_a'.

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -60,10 +60,10 @@ class Projection : public AbstractReadOnlyOperator {
 
   template <typename T>
   static void _create_column(boost::hana::basic_type<T> type, Chunk& chunk, const ChunkID chunk_id,
-                             const std::shared_ptr<Expression>& expression,
+                             const std::shared_ptr<const Expression>& expression,
                              std::shared_ptr<const Table> input_table_left);
 
-  static const std::string _get_type_of_expression(const std::shared_ptr<Expression>& expression,
+  static const std::string _get_type_of_expression(const std::shared_ptr<const Expression>& expression,
                                                    const std::shared_ptr<const Table>& table);
 
   /**
@@ -72,7 +72,8 @@ class Projection : public AbstractReadOnlyOperator {
    */
   template <typename T>
   static const pmr_concurrent_vector<std::optional<T>> _evaluate_expression(
-      const std::shared_ptr<Expression>& expression, const std::shared_ptr<const Table> table, const ChunkID chunk_id);
+      const std::shared_ptr<const Expression>& expression, const std::shared_ptr<const Table> table,
+      const ChunkID chunk_id);
 
   /**
    * Operators that all numerical types support.

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
@@ -30,8 +30,8 @@ PosList BaseSingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
   return matches_out;
 }
 
-void BaseSingleColumnTableScanImpl::handle_reference_column(const ReferenceColumn& left_column,
-                                                            std::shared_ptr<ColumnVisitableContext> base_context) {
+void BaseSingleColumnTableScanImpl::handle_reference_column(
+    const ReferenceColumn& left_column, const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   const ChunkID chunk_id = context->_chunk_id;
   auto& matches_out = context->_matches_out;

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.hpp
@@ -30,7 +30,7 @@ class BaseSingleColumnTableScanImpl : public BaseTableScanImpl, public ColumnVis
   PosList scan_chunk(ChunkID chunk_id) override;
 
   void handle_reference_column(const ReferenceColumn& left_column,
-                               std::shared_ptr<ColumnVisitableContext> base_context) override;
+                               const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
  protected:
   /**

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
@@ -16,7 +16,7 @@ IsNullTableScanImpl::IsNullTableScanImpl(std::shared_ptr<const Table> in_table, 
     : BaseSingleColumnTableScanImpl{in_table, left_column_id, scan_type, false} {}
 
 void IsNullTableScanImpl::handle_value_column(const BaseValueColumn& base_column,
-                                              std::shared_ptr<ColumnVisitableContext> base_context) {
+                                              const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
   auto& left_column = static_cast<const BaseValueColumn&>(base_column);
@@ -40,7 +40,7 @@ void IsNullTableScanImpl::handle_value_column(const BaseValueColumn& base_column
 }
 
 void IsNullTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                                   std::shared_ptr<ColumnVisitableContext> base_context) {
+                                                   const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
   auto& left_column = static_cast<const BaseDictionaryColumn&>(base_column);

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
@@ -18,10 +18,10 @@ class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
   IsNullTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const ScanType& scan_type);
 
   void handle_value_column(const BaseValueColumn& base_column,
-                           std::shared_ptr<ColumnVisitableContext> base_context) override;
+                           const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) override;
+                                const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
  private:
   /**

--- a/src/lib/operators/table_scan/like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.cpp
@@ -31,7 +31,7 @@ LikeTableScanImpl::LikeTableScanImpl(std::shared_ptr<const Table> in_table, cons
 }
 
 void LikeTableScanImpl::handle_value_column(const BaseValueColumn& base_column,
-                                            std::shared_ptr<ColumnVisitableContext> base_context) {
+                                            const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   auto& matches_out = context->_matches_out;
   const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
@@ -50,7 +50,7 @@ void LikeTableScanImpl::handle_value_column(const BaseValueColumn& base_column,
 }
 
 void LikeTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                                 std::shared_ptr<ColumnVisitableContext> base_context) {
+                                                 const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   auto& matches_out = context->_matches_out;
   const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;

--- a/src/lib/operators/table_scan/like_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.hpp
@@ -30,10 +30,10 @@ class LikeTableScanImpl : public BaseSingleColumnTableScanImpl {
                     const std::string& right_wildcard);
 
   void handle_value_column(const BaseValueColumn& base_column,
-                           std::shared_ptr<ColumnVisitableContext> base_context) override;
+                           const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) override;
+                                const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
  private:
   /**

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
@@ -20,7 +20,7 @@ SingleColumnTableScanImpl::SingleColumnTableScanImpl(std::shared_ptr<const Table
     : BaseSingleColumnTableScanImpl{in_table, left_column_id, scan_type}, _right_value{right_value} {}
 
 void SingleColumnTableScanImpl::handle_value_column(const BaseValueColumn& base_column,
-                                                    std::shared_ptr<ColumnVisitableContext> base_context) {
+                                                    const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   auto& matches_out = context->_matches_out;
   const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
@@ -47,7 +47,7 @@ void SingleColumnTableScanImpl::handle_value_column(const BaseValueColumn& base_
 }
 
 void SingleColumnTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                                         std::shared_ptr<ColumnVisitableContext> base_context) {
+                                                         const std::shared_ptr<ColumnVisitableContext>& base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   auto& matches_out = context->_matches_out;
   const auto chunk_id = context->_chunk_id;

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
@@ -29,10 +29,10 @@ class SingleColumnTableScanImpl : public BaseSingleColumnTableScanImpl {
                             const ScanType& scan_type, const AllTypeVariant& right_value);
 
   void handle_value_column(const BaseValueColumn& base_column,
-                           std::shared_ptr<ColumnVisitableContext> base_context) override;
+                           const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) override;
+                                const std::shared_ptr<ColumnVisitableContext>& base_context) override;
 
  private:
   /**

--- a/src/lib/optimizer/expression.cpp
+++ b/src/lib/optimizer/expression.cpp
@@ -326,7 +326,7 @@ std::string Expression::to_string(const std::vector<std::string>& input_column_n
 
 const std::vector<std::shared_ptr<Expression>>& Expression::expression_list() const { return _expression_list; }
 
-void Expression::set_expression_list(const std::vector<std::shared_ptr<Expression>>& expression_list) {
+void Expression::set_expression_list(std::vector<std::shared_ptr<Expression>>&& expression_list) {
   _expression_list = expression_list;
 }
 

--- a/src/lib/optimizer/expression.hpp
+++ b/src/lib/optimizer/expression.hpp
@@ -143,7 +143,7 @@ class Expression : public std::enable_shared_from_this<Expression> {
   const std::optional<std::string>& table_name() const;
   const std::optional<std::string>& alias() const;
 
-  void set_expression_list(const std::vector<std::shared_ptr<Expression>>& expression_list);
+  void set_expression_list(std::vector<std::shared_ptr<Expression>>&& expression_list);
 
   void set_alias(const std::string& alias);
 

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -277,7 +277,7 @@ void TableStatistics::_reset_table_ptr() {
 }
 
 float TableStatistics::_calculate_added_null_values_for_outer_join(
-    const float row_count, const std::shared_ptr<BaseColumnStatistics> col_stats,
+    const float row_count, const std::shared_ptr<BaseColumnStatistics>& col_stats,
     const float predicate_column_distinct_count) const {
   float null_value_no = col_stats->null_value_ratio() * row_count;
   if (col_stats->distinct_count() != 0.f) {

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -111,7 +111,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    * @return Number of additional null values for columns of table 2.
    */
   float _calculate_added_null_values_for_outer_join(const float row_count,
-                                                    const std::shared_ptr<BaseColumnStatistics> col_stats,
+                                                    const std::shared_ptr<BaseColumnStatistics>& col_stats,
                                                     const float predicate_column_distinct_count) const;
 
   /**

--- a/src/lib/scheduler/operator_task.cpp
+++ b/src/lib/scheduler/operator_task.cpp
@@ -23,7 +23,7 @@ const std::vector<std::shared_ptr<OperatorTask>> OperatorTask::make_tasks_from_o
   return tasks;
 }
 
-void OperatorTask::_add_tasks_from_operator(std::shared_ptr<AbstractOperator> op,
+void OperatorTask::_add_tasks_from_operator(const std::shared_ptr<AbstractOperator>& op,
                                             std::vector<std::shared_ptr<OperatorTask>>& tasks) {
   auto task = std::make_shared<OperatorTask>(op);
 

--- a/src/lib/scheduler/operator_task.hpp
+++ b/src/lib/scheduler/operator_task.hpp
@@ -30,7 +30,7 @@ class OperatorTask : public AbstractTask {
   /**
    * Create tasks recursively. Called by `make_tasks_from_operator`.
    */
-  static void _add_tasks_from_operator(std::shared_ptr<AbstractOperator> op,
+  static void _add_tasks_from_operator(const std::shared_ptr<AbstractOperator>& op,
                                        std::vector<std::shared_ptr<OperatorTask>>& tasks);
 
  private:

--- a/src/lib/storage/base_column.hpp
+++ b/src/lib/storage/base_column.hpp
@@ -33,7 +33,8 @@ class BaseColumn : private Noncopyable {
   virtual size_t size() const = 0;
 
   // calls the column-specific handler in an operator (visitor pattern)
-  virtual void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const = 0;
+  virtual void visit(ColumnVisitable& visitable,
+                     const std::shared_ptr<ColumnVisitableContext>& context = nullptr) const = 0;
 
   // writes the length and value at the chunk_offset to the end of row_string
   virtual void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const = 0;

--- a/src/lib/storage/column_visitable.hpp
+++ b/src/lib/storage/column_visitable.hpp
@@ -17,11 +17,12 @@ class ColumnVisitableContext {};
 class ColumnVisitable {
  public:
   virtual ~ColumnVisitable() = default;
-  virtual void handle_value_column(const BaseValueColumn& column, std::shared_ptr<ColumnVisitableContext> context) = 0;
+  virtual void handle_value_column(const BaseValueColumn& column,
+                                   const std::shared_ptr<ColumnVisitableContext>& context) = 0;
   virtual void handle_dictionary_column(const BaseDictionaryColumn& column,
-                                        std::shared_ptr<ColumnVisitableContext> context) = 0;
+                                        const std::shared_ptr<ColumnVisitableContext>& context) = 0;
   virtual void handle_reference_column(const ReferenceColumn& column,
-                                       std::shared_ptr<ColumnVisitableContext> context) = 0;
+                                       const std::shared_ptr<ColumnVisitableContext>& context) = 0;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/dictionary_column.cpp
+++ b/src/lib/storage/dictionary_column.cpp
@@ -130,7 +130,8 @@ size_t DictionaryColumn<T>::size() const {
 }
 
 template <typename T>
-void DictionaryColumn<T>::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context) const {
+void DictionaryColumn<T>::visit(ColumnVisitable& visitable,
+                                const std::shared_ptr<ColumnVisitableContext>& context) const {
   visitable.handle_dictionary_column(*this, std::move(context));
 }
 

--- a/src/lib/storage/dictionary_column.hpp
+++ b/src/lib/storage/dictionary_column.hpp
@@ -23,8 +23,7 @@ class DictionaryColumn : public BaseDictionaryColumn {
    * Creates a Dictionary column from a given dictionary and attribute vector.
    * See dictionary_compression.cpp for more.
    */
-  explicit DictionaryColumn(pmr_vector<T>&& dictionary,
-                            const std::shared_ptr<BaseAttributeVector>& attribute_vector);
+  explicit DictionaryColumn(pmr_vector<T>&& dictionary, const std::shared_ptr<BaseAttributeVector>& attribute_vector);
 
   explicit DictionaryColumn(const std::shared_ptr<pmr_vector<T>>& dictionary,
                             const std::shared_ptr<BaseAttributeVector>& attribute_vector);
@@ -75,7 +74,8 @@ class DictionaryColumn : public BaseDictionaryColumn {
   size_t size() const override;
 
   // visitor pattern, see base_column.hpp
-  void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
+  void visit(ColumnVisitable& visitable,
+             const std::shared_ptr<ColumnVisitableContext>& context = nullptr) const override;
 
   // writes the length and value at the chunk_offset to the end off row_string
   void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const override;

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.cpp
@@ -26,8 +26,8 @@ static const uint8_t INVALID_INDEX = 255u;
 
 ARTNode4::ARTNode4(std::vector<std::pair<uint8_t, std::shared_ptr<ARTNode>>>& children) {
   std::sort(children.begin(), children.end(),
-            [](const std::pair<uint8_t, std::shared_ptr<ARTNode>>& left,
-               const std::pair<uint8_t, std::shared_ptr<ARTNode>>& right) { return left.first < right.first; });
+            [](const std::pair<uint8_t, const std::shared_ptr<ARTNode>>& left,
+               const std::pair<uint8_t, const std::shared_ptr<ARTNode>>& right) { return left.first < right.first; });
   _partial_keys.fill(INVALID_INDEX);
   for (uint8_t i = 0u; i < children.size(); ++i) {
     _partial_keys[i] = children[i].first;

--- a/src/lib/storage/reference_column.cpp
+++ b/src/lib/storage/reference_column.cpp
@@ -41,7 +41,7 @@ ColumnID ReferenceColumn::referenced_column_id() const { return _referenced_colu
 
 size_t ReferenceColumn::size() const { return _pos_list->size(); }
 
-void ReferenceColumn::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context) const {
+void ReferenceColumn::visit(ColumnVisitable& visitable, const std::shared_ptr<ColumnVisitableContext>& context) const {
   visitable.handle_reference_column(*this, std::move(context));
 }
 

--- a/src/lib/storage/reference_column.hpp
+++ b/src/lib/storage/reference_column.hpp
@@ -77,7 +77,8 @@ class ReferenceColumn : public BaseColumn {
   ColumnID referenced_column_id() const;
 
   // visitor pattern, see base_column.hpp
-  void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
+  void visit(ColumnVisitable& visitable,
+             const std::shared_ptr<ColumnVisitableContext>& context = nullptr) const override;
 
   // writes the length and value at the chunk_offset to the end off row_string
   void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const override;

--- a/src/lib/storage/value_column.cpp
+++ b/src/lib/storage/value_column.cpp
@@ -140,7 +140,7 @@ size_t ValueColumn<T>::size() const {
 }
 
 template <typename T>
-void ValueColumn<T>::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context) const {
+void ValueColumn<T>::visit(ColumnVisitable& visitable, const std::shared_ptr<ColumnVisitableContext>& context) const {
   visitable.handle_value_column(*this, std::move(context));
 }
 

--- a/src/lib/storage/value_column.hpp
+++ b/src/lib/storage/value_column.hpp
@@ -58,7 +58,8 @@ class ValueColumn : public BaseValueColumn {
   size_t size() const override;
 
   // Visitor pattern, see base_column.hpp
-  void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
+  void visit(ColumnVisitable& visitable,
+             const std::shared_ptr<ColumnVisitableContext>& context = nullptr) const override;
 
   // Write the length and value at the chunk_offset to the end of row_string.
   void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const override;

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -63,8 +63,8 @@ TEST_F(LogicalQueryPlanTest, SimpleParentTest) {
   ASSERT_TRUE(predicate_node->parents().empty());
 
   const std::vector<ColumnID> column_ids = {ColumnID{0}, ColumnID{1}};
-  const auto& expressions = Expression::create_columns(column_ids);
-  const auto projection_node = std::make_shared<ProjectionNode>(expressions);
+  auto expressions = Expression::create_columns(column_ids);
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(expressions));
   projection_node->set_left_child(predicate_node);
 
   ASSERT_EQ(predicate_node->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{projection_node});
@@ -118,8 +118,8 @@ TEST_F(LogicalQueryPlanTest, ChainSameNodesTest) {
   ASSERT_TRUE(predicate_node_2->parents().empty());
 
   const std::vector<ColumnID> column_ids = {ColumnID{0}, ColumnID{1}};
-  const auto& expressions = Expression::create_columns(column_ids);
-  const auto projection_node = std::make_shared<ProjectionNode>(expressions);
+  auto expressions = Expression::create_columns(column_ids);
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(expressions));
   projection_node->set_left_child(predicate_node_2);
 
   ASSERT_EQ(predicate_node_2->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{projection_node});

--- a/src/test/logical_query_plan/update_node_test.cpp
+++ b/src/test/logical_query_plan/update_node_test.cpp
@@ -13,7 +13,7 @@ class UpdateNodeTest : public BaseTest {
  protected:
   void SetUp() override {
     std::vector<std::shared_ptr<Expression>> update_expressions;
-    _update_node = std::make_shared<UpdateNode>("table_a", update_expressions);
+    _update_node = std::make_shared<UpdateNode>("table_a", std::move(update_expressions));
   }
 
   std::shared_ptr<UpdateNode> _update_node;

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -86,7 +86,7 @@ class OperatorsAggregateTest : public BaseTest {
     _table_wrapper_1_1_null_dict->execute();
   }
 
-  void test_output(const std::shared_ptr<AbstractOperator> in, const std::vector<AggregateDefinition>& aggregates,
+  void test_output(const std::shared_ptr<AbstractOperator>& in, const std::vector<AggregateDefinition>& aggregates,
                    const std::vector<ColumnID>& groupby_column_ids, const std::string& file_name, size_t chunk_size,
                    bool test_references = true) {
     // load expected results from file

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -342,31 +342,4 @@ TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
       JoinMode::Left, "src/test/tables/joinoperators/int_join_empty_left.tbl", 1);
 }
 
-// Does not work yet due to problems with RowID implementation (RowIDs need to reference a table)
-TYPED_TEST(JoinEquiTest, DISABLED_JoinOnUnion /* #160 */) {
-  //  Filtering to generate RefColumns
-  auto filtered_left =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_e, ColumnID{0}, ScanType::OpLessThanEquals, 10);
-  filtered_left->execute();
-  auto filtered_left2 =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::OpLessThanEquals, 10);
-  filtered_left2->execute();
-  auto filtered_right =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::OpLessThanEquals, 10);
-  filtered_right->execute();
-  auto filtered_right2 =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::OpLessThanEquals, 10);
-  filtered_right2->execute();
-
-  // Union left and right
-  auto union_left = std::make_shared<opossum::UnionAll>(filtered_left, filtered_left2);
-  union_left->execute();
-  auto union_right = std::make_shared<opossum::UnionAll>(filtered_right, filtered_right2);
-  union_right->execute();
-
-  this->template test_join_output<TypeParam>(
-      union_left, union_right, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
-      JoinMode::Inner, "src/test/tables/joinoperators/expected_join_result_1.tbl", 1);
-}
-
 }  // namespace opossum

--- a/src/test/operators/join_test.hpp
+++ b/src/test/operators/join_test.hpp
@@ -87,8 +87,8 @@ class JoinTest : public BaseTest {
 
   // builds and executes the given Join and checks correctness of the output
   template <typename JoinType>
-  void test_join_output(const std::shared_ptr<const AbstractOperator> left,
-                        const std::shared_ptr<const AbstractOperator> right,
+  void test_join_output(const std::shared_ptr<const AbstractOperator>& left,
+                        const std::shared_ptr<const AbstractOperator>& right,
                         const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type, const JoinMode mode,
                         const std::string& file_name, size_t chunk_size) {
     // load expected results from file

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -158,7 +158,7 @@ class OperatorsTableScanTest : public BaseTest {
     return ref_table;
   }
 
-  void scan_for_null_values(const std::shared_ptr<AbstractOperator> in,
+  void scan_for_null_values(const std::shared_ptr<AbstractOperator>& in,
                             const std::map<ScanType, std::vector<AllTypeVariant>>& tests) {
     for (const auto& test : tests) {
       const auto scan_type = test.first;
@@ -172,7 +172,7 @@ class OperatorsTableScanTest : public BaseTest {
     }
   }
 
-  void ASSERT_COLUMN_EQ(std::shared_ptr<const Table> table, const ColumnID& column_id,
+  void ASSERT_COLUMN_EQ(const std::shared_ptr<const Table>& table, const ColumnID& column_id,
                         std::vector<AllTypeVariant> expected) {
     for (auto chunk_id = ChunkID{0u}; chunk_id < table->chunk_count(); ++chunk_id) {
       const auto& chunk = table->get_chunk(chunk_id);

--- a/src/test/operators/update_test.cpp
+++ b/src/test/operators/update_test.cpp
@@ -19,12 +19,13 @@ namespace opossum {
 class OperatorsUpdateTest : public BaseTest {
  protected:
   void SetUp() override {}
-  void helper(std::shared_ptr<GetTable> table_to_update, std::shared_ptr<GetTable> update_values,
-              std::shared_ptr<Table> expected_result);
+  void helper(const std::shared_ptr<GetTable>& table_to_update, const std::shared_ptr<GetTable>& update_values,
+              const std::shared_ptr<Table>& expected_result);
 };
 
-void OperatorsUpdateTest::helper(std::shared_ptr<GetTable> table_to_update, std::shared_ptr<GetTable> update_values,
-                                 std::shared_ptr<Table> expected_result) {
+void OperatorsUpdateTest::helper(const std::shared_ptr<GetTable>& table_to_update,
+                                 const std::shared_ptr<GetTable>& update_values,
+                                 const std::shared_ptr<Table>& expected_result) {
   auto t_context = TransactionManager::get().new_transaction_context();
 
   // Make input left actually referenced. Projection does NOT generate ReferenceColumns.

--- a/src/test/optimizer/ast_to_operator_translator_test.cpp
+++ b/src/test/optimizer/ast_to_operator_translator_test.cpp
@@ -88,8 +88,8 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryScan) {
 
 TEST_F(LQPTranslatorTest, ProjectionNode) {
   const auto stored_table_node = std::make_shared<StoredTableNode>("table_int_float");
-  const auto expressions = std::vector<std::shared_ptr<Expression>>{Expression::create_column(ColumnID{0}, {"a"})};
-  auto projection_node = std::make_shared<ProjectionNode>(expressions);
+  auto expressions = std::vector<std::shared_ptr<Expression>>{Expression::create_column(ColumnID{0}, {"a"})};
+  auto projection_node = std::make_shared<ProjectionNode>(std::move(expressions));
   projection_node->set_left_child(stored_table_node);
   const auto op = LQPTranslator{}.translate_node(projection_node);
 

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -132,8 +132,8 @@ TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
   predicate_node->set_left_child(cross_join_node);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  auto columns = {Expression::create_column(ColumnID{0})};
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
@@ -166,8 +166,8 @@ TEST_F(JoinDetectionRuleTest, NoPredicate) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  auto columns = {Expression::create_column(ColumnID{0})};
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(cross_join_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
@@ -205,8 +205,8 @@ TEST_F(JoinDetectionRuleTest, NoMatchingPredicate) {
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{1});
   predicate_node->set_left_child(cross_join_node);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
@@ -244,8 +244,8 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
   predicate_node->set_left_child(join_node);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
@@ -297,8 +297,8 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins) {
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
   predicate_node->set_left_child(join_node2);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
@@ -397,8 +397,8 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{4}, ScanType::OpEquals, ColumnID{0});
   predicate_node->set_left_child(join_node2);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
@@ -439,9 +439,9 @@ TEST_F(JoinDetectionRuleTest, NoOptimizationAcrossProjection) {
   join_node->set_left_child(_table_node_a);
   join_node->set_right_child(_table_node_b);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0}),
+  std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0}),
                                                             Expression::create_column(ColumnID{2})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(join_node);
 
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{1});
@@ -479,9 +479,9 @@ TEST_F(JoinDetectionRuleTest, NoJoinDetectionAcrossProjections) {
   join_node->set_left_child(_table_node_a);
   join_node->set_right_child(_table_node_b);
 
-  const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0}),
+  std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0}),
                                                             Expression::create_column(ColumnID{2})};
-  const auto projection_node = std::make_shared<ProjectionNode>(columns);
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(columns));
   projection_node->set_left_child(join_node);
 
   const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{1});

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -123,8 +123,8 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   predicate_node_2->set_left_child(predicate_node_1);
 
   const std::vector<ColumnID> column_ids = {ColumnID{0}, ColumnID{1}};
-  const auto& expressions = Expression::create_columns(column_ids);
-  const auto projection_node = std::make_shared<ProjectionNode>(expressions);
+  auto expressions = Expression::create_columns(column_ids);
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(expressions));
   projection_node->set_left_child(predicate_node_2);
 
   auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
@@ -169,8 +169,8 @@ TEST_F(PredicateReorderingTest, TwoReorderings) {
   predicate_node_3->set_left_child(predicate_node_2);
 
   const std::vector<ColumnID> column_ids = {ColumnID{0}, ColumnID{1}};
-  const auto& expressions = Expression::create_columns(column_ids);
-  const auto projection_node = std::make_shared<ProjectionNode>(expressions);
+  auto expressions = Expression::create_columns(column_ids);
+  const auto projection_node = std::make_shared<ProjectionNode>(std::move(expressions));
   projection_node->set_left_child(predicate_node_3);
 
   projection_node->get_statistics();

--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
@@ -135,7 +135,8 @@ std::shared_ptr<Table> SQLiteWrapper::execute_query(const std::string& sql_query
   return result_table;
 }
 
-void SQLiteWrapper::_create_columns(std::shared_ptr<Table> table, sqlite3_stmt* result_row, int column_count) {
+void SQLiteWrapper::_create_columns(const std::shared_ptr<Table>& table, sqlite3_stmt* const result_row,
+                                    const int column_count) {
   std::vector<bool> col_nullable(column_count, false);
   std::vector<std::string> col_types(column_count, "");
   std::vector<std::string> col_names(column_count, "");
@@ -191,7 +192,8 @@ void SQLiteWrapper::_create_columns(std::shared_ptr<Table> table, sqlite3_stmt* 
   }
 }
 
-void SQLiteWrapper::_add_row(std::shared_ptr<Table> table, sqlite3_stmt* result_row, int column_count) {
+void SQLiteWrapper::_add_row(const std::shared_ptr<Table>& table, sqlite3_stmt* const result_row,
+                             const int column_count) {
   std::vector<AllTypeVariant> row;
 
   for (int i = 0; i < column_count; ++i) {

--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper.hpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper.hpp
@@ -38,12 +38,12 @@ class SQLiteWrapper final {
   /*
    * Creates columns in given opossum table according to an sqlite intermediate statement (one result row).
    */
-  void _create_columns(std::shared_ptr<Table> table, sqlite3_stmt* result_row, int column_count);
+  void _create_columns(const std::shared_ptr<Table>& table, sqlite3_stmt* const result_row, const int column_count);
 
   /*
    * Adds a single row to given opossum table according to an sqlite intermediate statement (one result row).
    */
-  void _add_row(std::shared_ptr<Table> table, sqlite3_stmt* result_row, int column_count);
+  void _add_row(const std::shared_ptr<Table>& table, sqlite3_stmt* const result_row, const int column_count);
 
   sqlite3* _db;
 };

--- a/src/test/storage/single_column_index_test.cpp
+++ b/src/test/storage/single_column_index_test.cpp
@@ -32,7 +32,8 @@ class SingleColumnIndexTest : public BaseTest {
   }
 
   template <class Iterator>
-  static std::vector<AllTypeVariant> result_as_vector(std::shared_ptr<BaseColumn> col, Iterator begin, Iterator end) {
+  static std::vector<AllTypeVariant> result_as_vector(const std::shared_ptr<BaseColumn>& col, Iterator begin,
+                                                      Iterator end) {
     std::vector<AllTypeVariant> result{};
     for (auto iter(std::move(begin)); iter != end; ++iter) {
       result.emplace_back((*col)[*iter]);


### PR DESCRIPTION
This updates argument types to the new guidelines, stopping before src/lib/operators. I will split this in separate PRs, both because it's easier to review and because it's tiresome work...