### PR TITLE
Fix TPCC benchmark

### DIFF
--- a/src/benchmark/tpcc/delivery_benchmark.cpp
+++ b/src/benchmark/tpcc/delivery_benchmark.cpp
@@ -42,7 +42,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
     Projection::ColumnExpressions columns = {Expression::create_column(ColumnID{0} /* "NO_O_ID" */)};
     auto projection = std::make_shared<Projection>(val, columns);
 
-    auto sort = std::make_shared<Sort>(projection, ColumnID{0} /* "NO_O_ID" */, OrderByMode::Ascending, 0);
+    auto sort = std::make_shared<Sort>(projection, ColumnID{0} /* "NO_O_ID" */, OrderByMode::Ascending);
 
     auto t_gt = std::make_shared<OperatorTask>(gt);
     auto t_ts1 = std::make_shared<OperatorTask>(ts1);


### PR DESCRIPTION
A call to the SortOperator utilized the old value for maximum chunk sizes `0` which leads to a failing benchmark because of this [assert](https://github.com/hyrise/hyrise/blob/master/src/lib/storage/table.cpp#L52)