### PR TITLE
Truncate long strings in Print

### DIFF
--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -127,6 +127,7 @@ std::vector<uint16_t> Print::_column_string_widths(uint16_t min, uint16_t max, s
 
 std::string Print::_truncate_cell(const AllTypeVariant& cell, uint16_t max_width) const {
   auto cell_str = type_cast<std::string>(cell);
+  DebugAssert(max_width > 3, "Cannot truncate string with '...' at end with max_width <= 3");
   if (cell_str.length() > max_width) {
     return cell_str.substr(0, max_width - 3) + "...";
   }

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -23,7 +23,8 @@ class Print : public AbstractReadOnlyOperator {
   static void print(std::shared_ptr<const Table> table, uint32_t flags = 0, std::ostream& out = std::cout);
 
  protected:
-  std::vector<uint16_t> column_string_widths(uint16_t min, uint16_t max, std::shared_ptr<const Table> t) const;
+  std::vector<uint16_t> _column_string_widths(uint16_t min, uint16_t max, std::shared_ptr<const Table> t) const;
+  std::string _truncate_cell(const AllTypeVariant& cell, uint16_t max_width) const;
   std::shared_ptr<const Table> _on_execute() override;
 
   // stream to print the result

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -45,6 +45,10 @@ class PrintWrapper : public Print {
   std::vector<uint16_t> test_column_string_widths(uint16_t min, uint16_t max) {
     return _column_string_widths(min, max, tab);
   }
+
+  std::string test_truncate_cell(const AllTypeVariant& cell, uint16_t max_width) {
+    return _truncate_cell(cell, max_width);
+  }
 };
 
 TEST_F(OperatorsPrintTest, EmptyTable) {
@@ -125,6 +129,21 @@ TEST_F(OperatorsPrintTest, OperatorName) {
 }
 
 TEST_F(OperatorsPrintTest, TruncateLongValue) {
+  auto print_wrap = std::make_shared<PrintWrapper>(gt);
+
+  auto cell = AllTypeVariant{"abcdefghijklmnopqrstuvwxyz"};
+
+  auto truncated_cell_20 = print_wrap->test_truncate_cell(cell, 20);
+  EXPECT_EQ(truncated_cell_20, "abcdefghijklmnopq...");
+
+  auto truncated_cell_30 = print_wrap->test_truncate_cell(cell, 30);
+  EXPECT_EQ(truncated_cell_30, "abcdefghijklmnopqrstuvwxyz");
+
+  auto truncated_cell_10 = print_wrap->test_truncate_cell(cell, 10);
+  EXPECT_EQ(truncated_cell_10, "abcdefg...");
+}
+
+TEST_F(OperatorsPrintTest, TruncateLongValueInOutput) {
   auto tab = StorageManager::get().get_table(table_name);
 
   tab->append({0, "abcdefghijklmnopqrstuvwxyz"});
@@ -136,7 +155,7 @@ TEST_F(OperatorsPrintTest, TruncateLongValue) {
   printer->execute();
 
   auto output_str = output.str();
-  EXPECT_TRUE(output_str.find("abcdefghijklmnopq...") != std::string::npos);
+  EXPECT_TRUE(output_str.find("|abcdefghijklmnopq...|") != std::string::npos);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
We now truncate strings that are longer than a certain max width in `Print`.

Now:
```
=== Columns
|c_custkey|            c_name|           c_address|
|      int|            string|              string|
=== Chunk 0 ===
|        1|Customer#000000001|   IVhzIApeRb ot,c,E|
|        2|Customer#000000002|XSTf4,NCwDVaWNe6t...|
|        3|Customer#000000003|        MG9kdTD2WBHm|
|        4|Customer#000000004|         XxVSJsLAGtn|
|        5|Customer#000000005|KvpyuHCplrB84WgAi...|
|        6|Customer#000000006|sKZz0CsnMD7mp4Xd0...|
|        7|Customer#000000007|TcGe5gaZNgVePxU5k...|
|        8|Customer#000000008|I0B10bB0AymmC, 0P...|
|        9|Customer#000000009|xKiAFTjUsCuxfeleN...|
```

Before:
```
=== Columns
|c_custkey|            c_name|           c_address|
|      int|            string|              string|
=== Chunk 0 ===
|        1|Customer#000000001|   IVhzIApeRb ot,c,E|
|        2|Customer#000000002|XSTf4,NCwDVaWNe6tcxvxcvxv|
|        3|Customer#000000003|        MG9kdTD2WBHm|
|        4|Customer#000000004|         XxVSJsLAGtn|
|        5|Customer#000000005|KvpyuHCplrB84WgAixcvxcvxcvxcvxcvxcvxcv|
|        6|Customer#000000006|sKZz0CsnMD7mp4Xd0xcvcxvcxvxcv|
|        7|Customer#000000007|TcGe5gaZNgVePxU5k1d4|
|        8|Customer#000000008|I0B10bB0AymmC, 0Pdffsdv|
|        9|Customer#000000009|xKiAFTjUsCuxfeleNasd|
```