### PR TITLE
Make AbstractTask::_mark_as_scheduled private

### DIFF
--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -45,12 +45,6 @@ void AbstractTask::set_as_predecessor_of(std::shared_ptr<AbstractTask> successor
 
 void AbstractTask::set_node_id(NodeID node_id) { _node_id = node_id; }
 
-void AbstractTask::mark_as_scheduled() {
-  [[gnu::unused]] auto already_scheduled = _is_scheduled.exchange(true);
-
-  DebugAssert((!already_scheduled), "Task was already scheduled!");
-}
-
 bool AbstractTask::try_mark_as_enqueued() { return !_is_enqueued.exchange(true); }
 
 void AbstractTask::set_done_callback(const std::function<void()>& done_callback) {
@@ -60,7 +54,7 @@ void AbstractTask::set_done_callback(const std::function<void()>& done_callback)
 }
 
 void AbstractTask::schedule(NodeID preferred_node_id, SchedulePriority priority) {
-  mark_as_scheduled();
+  _mark_as_scheduled();
 
   if (CurrentScheduler::is_set()) {
     CurrentScheduler::get()->schedule(shared_from_this(), preferred_node_id, priority);
@@ -110,6 +104,12 @@ void AbstractTask::execute() {
     _done = true;
   }
   _done_condition_variable.notify_all();
+}
+
+void AbstractTask::_mark_as_scheduled() {
+  [[gnu::unused]] auto already_scheduled = _is_scheduled.exchange(true);
+
+  DebugAssert((!already_scheduled), "Task was already scheduled!");
 }
 
 void AbstractTask::_on_predecessor_added() { _predecessor_counter++; }

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -83,9 +83,8 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
   void join();
 
   /**
-   * Atomically marks the Task as scheduled, thus making sure this happens only once
+   * @return The Task was scheduled
    */
-  void mark_as_scheduled();
   bool is_scheduled() const;
 
   /**
@@ -104,6 +103,11 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
   virtual void _on_execute() = 0;
 
  private:
+  /**
+   * Atomically marks the Task as scheduled, thus making sure this happens only once
+   */
+  void _mark_as_scheduled();
+
   /**
    * Blocks the calling thread until the Task finished executing
    */


### PR DESCRIPTION
There is no reason for this method to be public.