### PR TITLE
Fix HashJoin miscounting NULL rows, fixes #538

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -186,7 +186,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
         auto& histogram = static_cast<std::vector<size_t>&>(*histograms[chunk_id]);
 
-        auto materialized_chunk = pmr_vector<std::pair<RowID, T>>();
+        auto materialized_chunk = std::vector<std::pair<RowID, T>>();
 
         // Materialize the chunk
         resolve_column_type<T>(*column, [&, chunk_id, keep_nulls](auto& typed_column) {

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -95,6 +95,11 @@ struct RowID {
   bool operator==(const RowID& other) const {
     return std::tie(chunk_id, chunk_offset) == std::tie(other.chunk_id, other.chunk_offset);
   }
+
+  friend std::ostream& operator<<(std::ostream& o, const RowID& row_id) {
+    o << "RowID(" << row_id.chunk_id << "," << row_id.chunk_offset << ")";
+    return o;
+  }
 };
 
 using WorkerID = uint32_t;

--- a/src/test/operators/join_null_test.cpp
+++ b/src/test/operators/join_null_test.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(JoinNullTest, InnerJoinWithNullDict2) {
       ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
-TYPED_TEST(JoinNullTest, DISABLED_InnerJoinWithNullRef2 /* #538 */) {
+TYPED_TEST(JoinNullTest, InnerJoinWithNullRef2) {
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, ScanType::OpGreaterThanEquals, 0);
   scan_a->execute();
   auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, ScanType::OpGreaterThanEquals, 0);


### PR DESCRIPTION
Also changed the temporary structure from `pmr_vector` to a regular vector. Since it is very temporary, there is no need for the NUMA overhead. First touch should be fine.