### PR TITLE
Pass correct size to in pmr_concurrent_vector

### DIFF
--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -63,7 +63,7 @@ class pmr_concurrent_vector : public tbb::concurrent_vector<T> {
  public:
   pmr_concurrent_vector(PolymorphicAllocator<T> alloc = {}) : pmr_concurrent_vector(0, alloc) {}  // NOLINT
   pmr_concurrent_vector(size_t n, PolymorphicAllocator<T> alloc = {})                             // NOLINT
-      : pmr_concurrent_vector(0, T{}, alloc) {}
+      : pmr_concurrent_vector(n, T{}, alloc) {}
   pmr_concurrent_vector(size_t n, T val, PolymorphicAllocator<T> alloc = {})  // NOLINT
       : tbb::concurrent_vector<T>(n, val),
         _alloc(alloc) {}


### PR DESCRIPTION
In one of the `pmr_concurrent_vector` constructors the size is not passed on. Instead an empty vector will be created. This PR fixes that.