### PR TITLE
Views

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -21,17 +21,48 @@ set(
     import_export/csv_parser.hpp
     import_export/csv_writer.cpp
     import_export/csv_writer.hpp
-    operators/table_scan/base_single_column_table_scan_impl.cpp
-    operators/table_scan/base_single_column_table_scan_impl.hpp
-    operators/table_scan/base_table_scan_impl.hpp
-    operators/table_scan/column_comparison_table_scan_impl.cpp
-    operators/table_scan/column_comparison_table_scan_impl.hpp
-    operators/table_scan/is_null_table_scan_impl.cpp
-    operators/table_scan/is_null_table_scan_impl.hpp
-    operators/table_scan/like_table_scan_impl.cpp
-    operators/table_scan/like_table_scan_impl.hpp
-    operators/table_scan/single_column_table_scan_impl.cpp
-    operators/table_scan/single_column_table_scan_impl.hpp
+    logical_query_plan/abstract_lqp_node.cpp
+    logical_query_plan/abstract_lqp_node.hpp
+    logical_query_plan/aggregate_node.cpp
+    logical_query_plan/aggregate_node.hpp
+    logical_query_plan/create_view_node.cpp
+    logical_query_plan/create_view_node.hpp
+    logical_query_plan/delete_node.cpp
+    logical_query_plan/delete_node.hpp
+    logical_query_plan/drop_view_node.cpp
+    logical_query_plan/drop_view_node.hpp
+    logical_query_plan/dummy_table_node.cpp
+    logical_query_plan/dummy_table_node.hpp
+    logical_query_plan/insert_node.cpp
+    logical_query_plan/insert_node.hpp
+    logical_query_plan/join_node.cpp
+    logical_query_plan/join_node.hpp
+    logical_query_plan/limit_node.cpp
+    logical_query_plan/limit_node.hpp
+    logical_query_plan/logical_plan_root_node.cpp
+    logical_query_plan/logical_plan_root_node.hpp
+    logical_query_plan/lqp_translator.cpp
+    logical_query_plan/lqp_translator.hpp
+    logical_query_plan/mock_node.cpp
+    logical_query_plan/mock_node.hpp
+    logical_query_plan/predicate_node.cpp
+    logical_query_plan/predicate_node.hpp
+    logical_query_plan/projection_node.cpp
+    logical_query_plan/projection_node.hpp
+    logical_query_plan/show_columns_node.cpp
+    logical_query_plan/show_columns_node.hpp
+    logical_query_plan/show_tables_node.cpp
+    logical_query_plan/show_tables_node.hpp
+    logical_query_plan/sort_node.cpp
+    logical_query_plan/sort_node.hpp
+    logical_query_plan/stored_table_node.cpp
+    logical_query_plan/stored_table_node.hpp
+    logical_query_plan/union_node.cpp
+    logical_query_plan/union_node.hpp
+    logical_query_plan/update_node.cpp
+    logical_query_plan/update_node.hpp
+    logical_query_plan/validate_node.cpp
+    logical_query_plan/validate_node.hpp
     operators/abstract_join_operator.cpp
     operators/abstract_join_operator.hpp
     operators/abstract_operator.cpp
@@ -62,12 +93,16 @@ set(
     operators/insert.hpp
     operators/join_hash.cpp
     operators/join_hash.hpp
-    operators/join_sort_merge.cpp
-    operators/join_sort_merge.hpp
     operators/join_nested_loop.cpp
     operators/join_nested_loop.hpp
+    operators/join_sort_merge.cpp
+    operators/join_sort_merge.hpp
     operators/limit.cpp
     operators/limit.hpp
+    operators/maintenance/create_view.cpp
+    operators/maintenance/create_view.hpp
+    operators/maintenance/drop_view.cpp
+    operators/maintenance/drop_view.hpp
     operators/maintenance/show_columns.cpp
     operators/maintenance/show_columns.hpp
     operators/maintenance/show_tables.cpp
@@ -82,6 +117,17 @@ set(
     operators/sort.hpp
     operators/table_scan.cpp
     operators/table_scan.hpp
+    operators/table_scan/base_single_column_table_scan_impl.cpp
+    operators/table_scan/base_single_column_table_scan_impl.hpp
+    operators/table_scan/base_table_scan_impl.hpp
+    operators/table_scan/column_comparison_table_scan_impl.cpp
+    operators/table_scan/column_comparison_table_scan_impl.hpp
+    operators/table_scan/is_null_table_scan_impl.cpp
+    operators/table_scan/is_null_table_scan_impl.hpp
+    operators/table_scan/like_table_scan_impl.cpp
+    operators/table_scan/like_table_scan_impl.hpp
+    operators/table_scan/single_column_table_scan_impl.cpp
+    operators/table_scan/single_column_table_scan_impl.hpp
     operators/table_wrapper.cpp
     operators/table_wrapper.hpp
     operators/union_all.cpp
@@ -92,44 +138,6 @@ set(
     operators/update.hpp
     operators/validate.cpp
     operators/validate.hpp
-    logical_query_plan/abstract_lqp_node.cpp
-    logical_query_plan/abstract_lqp_node.hpp
-    logical_query_plan/aggregate_node.cpp
-    logical_query_plan/aggregate_node.hpp
-    logical_query_plan/logical_plan_root_node.cpp
-    logical_query_plan/logical_plan_root_node.hpp
-    logical_query_plan/lqp_translator.hpp
-    logical_query_plan/lqp_translator.cpp
-    logical_query_plan/delete_node.cpp
-    logical_query_plan/delete_node.hpp
-    logical_query_plan/dummy_table_node.cpp
-    logical_query_plan/dummy_table_node.hpp
-    logical_query_plan/join_node.cpp
-    logical_query_plan/join_node.hpp
-    logical_query_plan/insert_node.cpp
-    logical_query_plan/insert_node.hpp
-    logical_query_plan/limit_node.cpp
-    logical_query_plan/limit_node.hpp
-    logical_query_plan/mock_node.cpp
-    logical_query_plan/mock_node.hpp
-    logical_query_plan/predicate_node.cpp
-    logical_query_plan/predicate_node.hpp
-    logical_query_plan/projection_node.cpp
-    logical_query_plan/projection_node.hpp
-    logical_query_plan/show_columns_node.cpp
-    logical_query_plan/show_columns_node.hpp
-    logical_query_plan/show_tables_node.cpp
-    logical_query_plan/show_tables_node.hpp
-    logical_query_plan/sort_node.cpp
-    logical_query_plan/sort_node.hpp
-    logical_query_plan/stored_table_node.cpp
-    logical_query_plan/stored_table_node.hpp
-    logical_query_plan/union_node.cpp
-    logical_query_plan/union_node.hpp
-    logical_query_plan/update_node.cpp
-    logical_query_plan/update_node.hpp
-    logical_query_plan/validate_node.cpp
-    logical_query_plan/validate_node.hpp
     optimizer/base_column_statistics.cpp
     optimizer/base_column_statistics.hpp
     optimizer/column_statistics.cpp
@@ -188,6 +196,8 @@ set(
     sql/sql_translator.hpp
     storage/base_attribute_vector.hpp
     storage/base_column.hpp
+    storage/base_dictionary_column.hpp
+    storage/base_value_column.hpp
     storage/chunk.cpp
     storage/chunk.hpp
     storage/column_visitable.hpp
@@ -208,16 +218,15 @@ set(
     storage/index/group_key/composite_group_key_index.hpp
     storage/index/group_key/group_key_index.cpp
     storage/index/group_key/group_key_index.hpp
-    storage/index/group_key/variable_length_key_base.cpp
-    storage/index/group_key/variable_length_key_base.hpp
     storage/index/group_key/variable_length_key.cpp
     storage/index/group_key/variable_length_key.hpp
+    storage/index/group_key/variable_length_key_base.cpp
+    storage/index/group_key/variable_length_key_base.hpp
     storage/index/group_key/variable_length_key_proxy.cpp
     storage/index/group_key/variable_length_key_proxy.hpp
     storage/index/group_key/variable_length_key_store.cpp
     storage/index/group_key/variable_length_key_store.hpp
     storage/iterables/attribute_vector_iterable.hpp
-    storage/iterables/iterables.hpp
     storage/iterables/base_iterators.hpp
     storage/iterables/chunk_offset_mapping.cpp
     storage/iterables/chunk_offset_mapping.hpp
@@ -225,6 +234,7 @@ set(
     storage/iterables/constant_value_iterable.hpp
     storage/iterables/create_iterable_from_column.hpp
     storage/iterables/dictionary_column_iterable.hpp
+    storage/iterables/iterables.hpp
     storage/iterables/null_value_vector_iterable.hpp
     storage/iterables/reference_column_iterable.hpp
     storage/iterables/value_column_iterable.hpp
@@ -239,16 +249,14 @@ set(
     storage/storage_manager.hpp
     storage/table.cpp
     storage/table.hpp
-    storage/base_dictionary_column.hpp
-    storage/base_value_column.hpp
     storage/value_column.cpp
     storage/value_column.hpp
     tasks/chunk_compression_task.cpp
     tasks/chunk_compression_task.hpp
-    tasks/chunk_migration_task.cpp
-    tasks/chunk_migration_task.hpp
     tasks/chunk_metrics_collection_task.cpp
     tasks/chunk_metrics_collection_task.hpp
+    tasks/chunk_migration_task.cpp
+    tasks/chunk_migration_task.hpp
     tasks/migration_preparation_task.cpp
     tasks/migration_preparation_task.hpp
     type_cast.hpp

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -18,12 +18,12 @@ class TableStatistics;
 
 AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type) : _type(node_type) {}
 
-std::shared_ptr<AbstractLQPNode> AbstractLQPNode::clone() const {
+std::shared_ptr<AbstractLQPNode> AbstractLQPNode::deep_copy() const {
   // We cannot use the copy constructor here, because it does not work with shared_from_this()
-  auto clone = _clone_impl();
-  if (_children[0]) clone->set_left_child(_children[0]->clone());
-  if (_children[1]) clone->set_right_child(_children[1]->clone());
-  return clone;
+  auto deep_copy = _deep_copy_impl();
+  if (_children[0]) deep_copy->set_left_child(_children[0]->deep_copy());
+  if (_children[1]) deep_copy->set_right_child(_children[1]->deep_copy());
+  return deep_copy;
 }
 
 std::vector<std::shared_ptr<AbstractLQPNode>> AbstractLQPNode::parents() const {

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -63,18 +63,16 @@ struct NamedColumnReference {
  * Design decision:
  * We decided to have mutable Nodes for now. By that we can apply rules without creating new nodes for every
  * optimization rule.
+ *
+ * We do not want people to copy an LQP node as a copy would still have the same children. Instead, they should use
+ * deep_copy().
  */
-class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
+class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, private Noncopyable {
  public:
   explicit AbstractLQPNode(LQPNodeType node_type);
 
-  // We do not want people to copy an LQP node as a copy would still have the same children. Instead, they should use
-  // clone().
-  AbstractLQPNode(const AbstractLQPNode&) = delete;
-  AbstractLQPNode& operator=(const AbstractLQPNode&) = delete;
-
   // Creates a deep copy
-  virtual std::shared_ptr<AbstractLQPNode> clone() const;
+  virtual std::shared_ptr<AbstractLQPNode> deep_copy() const;
 
   // @{
   /**
@@ -270,7 +268,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
 
  protected:
   // creates a DEEP copy of the other LQP node. Used for reusing LQPs, e.g., in views.
-  virtual std::shared_ptr<AbstractLQPNode> _clone_impl() const = 0;
+  virtual std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const = 0;
 
   /**
    * In derived nodes, clear all data that depends on children and only set it lazily on request (see, e.g.

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -23,11 +23,11 @@ AggregateNode::AggregateNode(const std::vector<std::shared_ptr<Expression>>& agg
   }
 }
 
-std::shared_ptr<AbstractLQPNode> AggregateNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> AggregateNode::_deep_copy_impl() const {
   std::vector<std::shared_ptr<Expression>> aggregate_expressions;
   aggregate_expressions.reserve(_aggregate_expressions.size());
   for (const auto& expression : _aggregate_expressions) {
-    aggregate_expressions.emplace_back(expression->clone());
+    aggregate_expressions.emplace_back(expression->deep_copy());
   }
 
   return std::make_shared<AggregateNode>(std::move(aggregate_expressions), _groupby_column_ids);

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -23,6 +23,16 @@ AggregateNode::AggregateNode(const std::vector<std::shared_ptr<Expression>>& agg
   }
 }
 
+std::shared_ptr<AbstractLQPNode> AggregateNode::_clone_impl() const {
+  std::vector<std::shared_ptr<Expression>> aggregate_expressions;
+  aggregate_expressions.reserve(_aggregate_expressions.size());
+  for (const auto& expression : _aggregate_expressions) {
+    aggregate_expressions.emplace_back(expression->clone());
+  }
+
+  return std::make_shared<AggregateNode>(std::move(aggregate_expressions), _groupby_column_ids);
+}
+
 const std::vector<std::shared_ptr<Expression>>& AggregateNode::aggregate_expressions() const {
   return _aggregate_expressions;
 }

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -58,7 +58,7 @@ class AggregateNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -58,6 +58,7 @@ class AggregateNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -10,8 +10,8 @@ CreateViewNode::CreateViewNode(const std::string& view_name, std::shared_ptr<con
 std::string CreateViewNode::view_name() const { return _view_name; }
 std::shared_ptr<const AbstractLQPNode> CreateViewNode::lqp() const { return _lqp; }
 
-std::shared_ptr<AbstractLQPNode> CreateViewNode::_clone_impl() const {
-  // no need to clone the _lqp because it is const anyway
+std::shared_ptr<AbstractLQPNode> CreateViewNode::_deep_copy_impl() const {
+  // no need to deep_copy the _lqp because it is const anyway
   return std::make_shared<CreateViewNode>(_view_name, _lqp);
 }
 

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -1,0 +1,20 @@
+#include "create_view_node.hpp"
+
+#include <string>
+
+namespace opossum {
+
+CreateViewNode::CreateViewNode(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp)
+    : AbstractLQPNode(LQPNodeType::CreateView), _view_name(view_name), _lqp(lqp) {}
+
+std::string CreateViewNode::view_name() const { return _view_name; }
+std::shared_ptr<const AbstractLQPNode> CreateViewNode::lqp() const { return _lqp; }
+
+std::shared_ptr<AbstractLQPNode> CreateViewNode::_clone_impl() const {
+  // no need to clone the _lqp because it is const anyway
+  return std::make_shared<CreateViewNode>(_view_name, _lqp);
+}
+
+std::string CreateViewNode::description() const { return "[CreateView]"; }
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -19,7 +19,7 @@ class CreateViewNode : public AbstractLQPNode {
   std::shared_ptr<const AbstractLQPNode> lqp() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   const std::string _view_name;
   const std::shared_ptr<const AbstractLQPNode> _lqp;
 };

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+
+#include "abstract_lqp_node.hpp"
+
+namespace opossum {
+
+/**
+ * This node type represents the CREATE VIEW management command.
+ */
+class CreateViewNode : public AbstractLQPNode {
+ public:
+  explicit CreateViewNode(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp);
+
+  std::string description() const override;
+
+  std::string view_name() const;
+  std::shared_ptr<const AbstractLQPNode> lqp() const;
+
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  const std::string _view_name;
+  const std::shared_ptr<const AbstractLQPNode> _lqp;
+};
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -11,7 +11,7 @@ namespace opossum {
 
 DeleteNode::DeleteNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Delete), _table_name(table_name) {}
 
-std::shared_ptr<AbstractLQPNode> DeleteNode::_clone_impl() const { return std::make_shared<DeleteNode>(_table_name); }
+std::shared_ptr<AbstractLQPNode> DeleteNode::_deep_copy_impl() const { return std::make_shared<DeleteNode>(_table_name); }
 
 std::string DeleteNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -11,7 +11,9 @@ namespace opossum {
 
 DeleteNode::DeleteNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Delete), _table_name(table_name) {}
 
-std::shared_ptr<AbstractLQPNode> DeleteNode::_deep_copy_impl() const { return std::make_shared<DeleteNode>(_table_name); }
+std::shared_ptr<AbstractLQPNode> DeleteNode::_deep_copy_impl() const {
+  return std::make_shared<DeleteNode>(_table_name);
+}
 
 std::string DeleteNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -11,6 +11,8 @@ namespace opossum {
 
 DeleteNode::DeleteNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Delete), _table_name(table_name) {}
 
+std::shared_ptr<AbstractLQPNode> DeleteNode::_clone_impl() const { return std::make_shared<DeleteNode>(_table_name); }
+
 std::string DeleteNode::description() const {
   std::ostringstream desc;
 
@@ -18,6 +20,8 @@ std::string DeleteNode::description() const {
 
   return desc.str();
 }
+
+bool DeleteNode::subtree_is_read_only() const { return false; }
 
 const std::string& DeleteNode::table_name() const { return _table_name; }
 

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -20,7 +20,7 @@ class DeleteNode : public AbstractLQPNode {
   const std::string& table_name() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   const std::string _table_name;
 };
 

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -15,10 +15,12 @@ class DeleteNode : public AbstractLQPNode {
   explicit DeleteNode(const std::string& table_name);
 
   std::string description() const override;
+  bool subtree_is_read_only() const override;
 
   const std::string& table_name() const;
 
  protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
   const std::string _table_name;
 };
 

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -12,7 +12,7 @@ namespace opossum {
 DropViewNode::DropViewNode(const std::string& view_name)
     : AbstractLQPNode(LQPNodeType::DropView), _view_name(view_name) {}
 
-std::shared_ptr<AbstractLQPNode> DropViewNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> DropViewNode::_deep_copy_impl() const {
   return std::make_shared<DropViewNode>(_view_name);
 }
 

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -1,0 +1,31 @@
+#include "drop_view_node.hpp"
+
+#include <algorithm>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "utils/assert.hpp"
+
+namespace opossum {
+
+DropViewNode::DropViewNode(const std::string& view_name)
+    : AbstractLQPNode(LQPNodeType::DropView), _view_name(view_name) {}
+
+std::shared_ptr<AbstractLQPNode> DropViewNode::_clone_impl() const {
+  return std::make_shared<DropViewNode>(_view_name);
+}
+
+std::string DropViewNode::description() const {
+  std::ostringstream desc;
+
+  desc << "[Drop] View: '" << _view_name << "'";
+
+  return desc.str();
+}
+
+bool DropViewNode::subtree_is_read_only() const { return false; }
+
+const std::string& DropViewNode::view_name() const { return _view_name; }
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -2,27 +2,26 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "abstract_lqp_node.hpp"
 
 namespace opossum {
 
 /**
- * Node type to represent insertion of rows into a table.
+ * Node type to represent deleting a view from the StorageManager
  */
-class InsertNode : public AbstractLQPNode {
+class DropViewNode : public AbstractLQPNode {
  public:
-  explicit InsertNode(const std::string table_name);
+  explicit DropViewNode(const std::string& view_name);
 
   std::string description() const override;
   bool subtree_is_read_only() const override;
 
-  const std::string& table_name() const;
+  const std::string& view_name() const;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
-  const std::string _table_name;
+  const std::string _view_name;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -20,7 +20,7 @@ class DropViewNode : public AbstractLQPNode {
   const std::string& view_name() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   const std::string _view_name;
 };
 

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -13,6 +13,8 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {
   _output_column_ids_to_input_column_ids.emplace();
 }
 
+std::shared_ptr<AbstractLQPNode> DummyTableNode::_clone_impl() const { return std::make_shared<DummyTableNode>(); }
+
 std::string DummyTableNode::description() const { return "[DummyTable]"; }
 
 const std::vector<std::string>& DummyTableNode::output_column_names() const { return _output_column_names; }

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -13,7 +13,7 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {
   _output_column_ids_to_input_column_ids.emplace();
 }
 
-std::shared_ptr<AbstractLQPNode> DummyTableNode::_clone_impl() const { return std::make_shared<DummyTableNode>(); }
+std::shared_ptr<AbstractLQPNode> DummyTableNode::_deep_copy_impl() const { return std::make_shared<DummyTableNode>(); }
 
 std::string DummyTableNode::description() const { return "[DummyTable]"; }
 

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -21,6 +21,7 @@ class DummyTableNode : public AbstractLQPNode {
   const std::vector<std::string>& output_column_names() const override;
 
  protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
   std::vector<std::string> _output_column_names;
 };
 

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -21,7 +21,7 @@ class DummyTableNode : public AbstractLQPNode {
   const std::vector<std::string>& output_column_names() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   std::vector<std::string> _output_column_names;
 };
 

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -13,6 +13,8 @@ namespace opossum {
 
 InsertNode::InsertNode(const std::string table_name) : AbstractLQPNode(LQPNodeType::Insert), _table_name(table_name) {}
 
+std::shared_ptr<AbstractLQPNode> InsertNode::_clone_impl() const { return std::make_shared<InsertNode>(_table_name); }
+
 std::string InsertNode::description() const {
   std::ostringstream desc;
 
@@ -20,6 +22,8 @@ std::string InsertNode::description() const {
 
   return desc.str();
 }
+
+bool InsertNode::subtree_is_read_only() const { return false; }
 
 const std::string& InsertNode::table_name() const { return _table_name; }
 

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 InsertNode::InsertNode(const std::string table_name) : AbstractLQPNode(LQPNodeType::Insert), _table_name(table_name) {}
 
-std::shared_ptr<AbstractLQPNode> InsertNode::_clone_impl() const { return std::make_shared<InsertNode>(_table_name); }
+std::shared_ptr<AbstractLQPNode> InsertNode::_deep_copy_impl() const { return std::make_shared<InsertNode>(_table_name); }
 
 std::string InsertNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -13,7 +13,9 @@ namespace opossum {
 
 InsertNode::InsertNode(const std::string table_name) : AbstractLQPNode(LQPNodeType::Insert), _table_name(table_name) {}
 
-std::shared_ptr<AbstractLQPNode> InsertNode::_deep_copy_impl() const { return std::make_shared<InsertNode>(_table_name); }
+std::shared_ptr<AbstractLQPNode> InsertNode::_deep_copy_impl() const {
+  return std::make_shared<InsertNode>(_table_name);
+}
 
 std::string InsertNode::description() const {
   std::ostringstream desc;

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -21,7 +21,7 @@ class InsertNode : public AbstractLQPNode {
   const std::string& table_name() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   const std::string _table_name;
 };
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -31,6 +31,14 @@ JoinNode::JoinNode(const JoinMode join_mode, const std::pair<ColumnID, ColumnID>
               "Specified JoinMode must specify neither column ids nor scan type.");
 }
 
+std::shared_ptr<AbstractLQPNode> JoinNode::_clone_impl() const {
+  if (_join_mode == JoinMode::Cross || _join_mode == JoinMode::Natural) {
+    return std::make_shared<JoinNode>(_join_mode);
+  } else {
+    return std::make_shared<JoinNode>(_join_mode, *_join_column_ids, *_scan_type);
+  }
+}
+
 std::string JoinNode::description() const {
   Assert(left_child() && right_child(), "Can't generate description if children aren't set");
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -31,7 +31,7 @@ JoinNode::JoinNode(const JoinMode join_mode, const std::pair<ColumnID, ColumnID>
               "Specified JoinMode must specify neither column ids nor scan type.");
 }
 
-std::shared_ptr<AbstractLQPNode> JoinNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> JoinNode::_deep_copy_impl() const {
   if (_join_mode == JoinMode::Cross || _join_mode == JoinMode::Natural) {
     return std::make_shared<JoinNode>(_join_mode);
   } else {

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -44,6 +44,7 @@ class JoinNode : public AbstractLQPNode {
 
  protected:
   void _on_child_changed() override;
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
 
  private:
   JoinMode _join_mode;

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -44,7 +44,7 @@ class JoinNode : public AbstractLQPNode {
 
  protected:
   void _on_child_changed() override;
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   JoinMode _join_mode;

--- a/src/lib/logical_query_plan/limit_node.cpp
+++ b/src/lib/logical_query_plan/limit_node.cpp
@@ -6,6 +6,8 @@ namespace opossum {
 
 LimitNode::LimitNode(const size_t num_rows) : AbstractLQPNode(LQPNodeType::Limit), _num_rows(num_rows) {}
 
+std::shared_ptr<AbstractLQPNode> LimitNode::_clone_impl() const { return std::make_shared<LimitNode>(_num_rows); }
+
 std::string LimitNode::description() const { return "[Limit] " + std::to_string(_num_rows) + " rows"; }
 
 size_t LimitNode::num_rows() const { return _num_rows; }

--- a/src/lib/logical_query_plan/limit_node.cpp
+++ b/src/lib/logical_query_plan/limit_node.cpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 LimitNode::LimitNode(const size_t num_rows) : AbstractLQPNode(LQPNodeType::Limit), _num_rows(num_rows) {}
 
-std::shared_ptr<AbstractLQPNode> LimitNode::_clone_impl() const { return std::make_shared<LimitNode>(_num_rows); }
+std::shared_ptr<AbstractLQPNode> LimitNode::_deep_copy_impl() const { return std::make_shared<LimitNode>(_num_rows); }
 
 std::string LimitNode::description() const { return "[Limit] " + std::to_string(_num_rows) + " rows"; }
 

--- a/src/lib/logical_query_plan/limit_node.hpp
+++ b/src/lib/logical_query_plan/limit_node.hpp
@@ -18,7 +18,7 @@ class LimitNode : public AbstractLQPNode {
   size_t num_rows() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   const size_t _num_rows;

--- a/src/lib/logical_query_plan/limit_node.hpp
+++ b/src/lib/logical_query_plan/limit_node.hpp
@@ -17,6 +17,9 @@ class LimitNode : public AbstractLQPNode {
 
   size_t num_rows() const;
 
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+
  private:
   const size_t _num_rows;
 };

--- a/src/lib/logical_query_plan/logical_plan_root_node.cpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.cpp
@@ -8,7 +8,7 @@ namespace opossum {
 
 LogicalPlanRootNode::LogicalPlanRootNode() : AbstractLQPNode(LQPNodeType::Root) {}
 
-std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_deep_copy_impl() const {
   return std::make_shared<LogicalPlanRootNode>();
 }
 

--- a/src/lib/logical_query_plan/logical_plan_root_node.cpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.cpp
@@ -8,6 +8,10 @@ namespace opossum {
 
 LogicalPlanRootNode::LogicalPlanRootNode() : AbstractLQPNode(LQPNodeType::Root) {}
 
+std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_clone_impl() const {
+  return std::make_shared<LogicalPlanRootNode>();
+}
+
 std::string LogicalPlanRootNode::description() const { return "[LogicalPlanRootNode]"; }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -21,7 +21,7 @@ class LogicalPlanRootNode : public AbstractLQPNode {
   std::string description() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -19,6 +19,9 @@ class LogicalPlanRootNode : public AbstractLQPNode {
   LogicalPlanRootNode();
 
   std::string description() const override;
+
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -8,7 +8,9 @@
 #include "abstract_lqp_node.hpp"
 #include "aggregate_node.hpp"
 #include "constant_mappings.hpp"
+#include "create_view_node.hpp"
 #include "delete_node.hpp"
+#include "drop_view_node.hpp"
 #include "dummy_table_node.hpp"
 #include "insert_node.hpp"
 #include "join_node.hpp"
@@ -20,6 +22,8 @@
 #include "operators/join_hash.hpp"
 #include "operators/join_sort_merge.hpp"
 #include "operators/limit.hpp"
+#include "operators/maintenance/create_view.hpp"
+#include "operators/maintenance/drop_view.hpp"
 #include "operators/maintenance/show_columns.hpp"
 #include "operators/maintenance/show_tables.hpp"
 #include "operators/product.hpp"
@@ -303,6 +307,18 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_show_columns_node(
   return std::make_shared<ShowColumns>(show_columns_node->table_name());
 }
 
+std::shared_ptr<AbstractOperator> LQPTranslator::_translate_create_view_node(
+    const std::shared_ptr<AbstractLQPNode>& node) const {
+  const auto create_view_node = std::dynamic_pointer_cast<CreateViewNode>(node);
+  return std::make_shared<CreateView>(create_view_node->view_name(), create_view_node->lqp());
+}
+
+std::shared_ptr<AbstractOperator> LQPTranslator::_translate_drop_view_node(
+    const std::shared_ptr<AbstractLQPNode>& node) const {
+  const auto drop_view_node = std::dynamic_pointer_cast<DropViewNode>(node);
+  return std::make_shared<DropView>(drop_view_node->view_name());
+}
+
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_dummy_table_node(
     const std::shared_ptr<AbstractLQPNode>& node) const {
   return std::make_shared<TableWrapper>(Projection::dummy_table());
@@ -344,6 +360,10 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_by_node_type(
       return _translate_show_tables_node(node);
     case LQPNodeType::ShowColumns:
       return _translate_show_columns_node(node);
+    case LQPNodeType::CreateView:
+      return _translate_create_view_node(node);
+    case LQPNodeType::DropView:
+      return _translate_drop_view_node(node);
 
     default:
       Fail("Unknown node type encountered.");

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -41,6 +41,8 @@ class LQPTranslator final : private Noncopyable {
   // Maintenance operators
   std::shared_ptr<AbstractOperator> _translate_show_tables_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_show_columns_node(const std::shared_ptr<AbstractLQPNode>& node) const;
+  std::shared_ptr<AbstractOperator> _translate_create_view_node(const std::shared_ptr<AbstractLQPNode>& node) const;
+  std::shared_ptr<AbstractOperator> _translate_drop_view_node(const std::shared_ptr<AbstractLQPNode>& node) const;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -22,8 +22,8 @@ MockNode::MockNode(const std::shared_ptr<TableStatistics>& statistics) : Abstrac
   _output_column_ids_to_input_column_ids.emplace(output_column_count(), INVALID_COLUMN_ID);
 }
 
-std::shared_ptr<AbstractLQPNode> MockNode::_clone_impl() const {
-  Fail("Cannot clone MockNodes because we cannot get a deep copy of the statistics");
+std::shared_ptr<AbstractLQPNode> MockNode::_deep_copy_impl() const {
+  Fail("Cannot deep_copy MockNodes because we cannot get a deep copy of the statistics");
   return nullptr;
 }
 

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -22,6 +22,11 @@ MockNode::MockNode(const std::shared_ptr<TableStatistics>& statistics) : Abstrac
   _output_column_ids_to_input_column_ids.emplace(output_column_count(), INVALID_COLUMN_ID);
 }
 
+std::shared_ptr<AbstractLQPNode> MockNode::_clone_impl() const {
+  Fail("Cannot clone MockNodes because we cannot get a deep copy of the statistics");
+  return nullptr;
+}
+
 const std::vector<ColumnID>& MockNode::output_column_ids_to_input_column_ids() const {
   return *_output_column_ids_to_input_column_ids;
 }

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -25,7 +25,7 @@ class MockNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   std::vector<std::string> _output_column_names;

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -24,6 +24,9 @@ class MockNode : public AbstractLQPNode {
   std::string description() const override;
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+
  private:
   std::vector<std::string> _output_column_names;
 };

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -20,7 +20,7 @@ PredicateNode::PredicateNode(const ColumnID column_id, const ScanType scan_type,
       _value(value),
       _value2(value2) {}
 
-std::shared_ptr<AbstractLQPNode> PredicateNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> PredicateNode::_deep_copy_impl() const {
   return std::make_shared<PredicateNode>(_column_id, _scan_type, _value, _value2);
 }
 

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -20,6 +20,10 @@ PredicateNode::PredicateNode(const ColumnID column_id, const ScanType scan_type,
       _value(value),
       _value2(value2) {}
 
+std::shared_ptr<AbstractLQPNode> PredicateNode::_clone_impl() const {
+  return std::make_shared<PredicateNode>(_column_id, _scan_type, _value, _value2);
+}
+
 std::string PredicateNode::description() const {
   /**
    * " a BETWEEN 5 AND c"

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -37,6 +37,9 @@ class PredicateNode : public AbstractLQPNode {
       const std::shared_ptr<AbstractLQPNode>& left_child,
       const std::shared_ptr<AbstractLQPNode>& right_child = nullptr) const override;
 
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+
  private:
   const ColumnID _column_id;
   const ScanType _scan_type;

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -38,7 +38,7 @@ class PredicateNode : public AbstractLQPNode {
       const std::shared_ptr<AbstractLQPNode>& right_child = nullptr) const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   const ColumnID _column_id;

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -36,11 +36,11 @@ std::string ProjectionNode::description() const {
   return desc.str();
 }
 
-std::shared_ptr<AbstractLQPNode> ProjectionNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> ProjectionNode::_deep_copy_impl() const {
   std::vector<std::shared_ptr<Expression>> column_expressions;
   column_expressions.reserve(_column_expressions.size());
   for (const auto& expression : _column_expressions) {
-    column_expressions.emplace_back(expression->clone());
+    column_expressions.emplace_back(expression->deep_copy());
   }
 
   return std::make_shared<ProjectionNode>(std::move(column_expressions));

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -36,6 +36,16 @@ std::string ProjectionNode::description() const {
   return desc.str();
 }
 
+std::shared_ptr<AbstractLQPNode> ProjectionNode::_clone_impl() const {
+  std::vector<std::shared_ptr<Expression>> column_expressions;
+  column_expressions.reserve(_column_expressions.size());
+  for (const auto& expression : _column_expressions) {
+    column_expressions.emplace_back(expression->clone());
+  }
+
+  return std::make_shared<ProjectionNode>(std::move(column_expressions));
+}
+
 const std::vector<std::shared_ptr<Expression>>& ProjectionNode::column_expressions() const {
   return _column_expressions;
 }

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -34,7 +34,7 @@ class ProjectionNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -34,10 +34,11 @@ class ProjectionNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
   void _on_child_changed() override;
 
  private:
-  const std::vector<std::shared_ptr<Expression>> _column_expressions;
+  std::vector<std::shared_ptr<Expression>> _column_expressions;
 
   mutable std::optional<std::vector<std::string>> _output_column_names;
 

--- a/src/lib/logical_query_plan/show_columns_node.cpp
+++ b/src/lib/logical_query_plan/show_columns_node.cpp
@@ -7,6 +7,10 @@ namespace opossum {
 ShowColumnsNode::ShowColumnsNode(const std::string& table_name)
     : AbstractLQPNode(LQPNodeType::ShowColumns), _table_name(table_name) {}
 
+std::shared_ptr<AbstractLQPNode> ShowColumnsNode::_clone_impl() const {
+  return std::make_shared<ShowColumnsNode>(_table_name);
+}
+
 std::string ShowColumnsNode::description() const { return "[ShowColumns] Table: '" + _table_name + "'"; }
 
 const std::string& ShowColumnsNode::table_name() const { return _table_name; }

--- a/src/lib/logical_query_plan/show_columns_node.cpp
+++ b/src/lib/logical_query_plan/show_columns_node.cpp
@@ -7,7 +7,7 @@ namespace opossum {
 ShowColumnsNode::ShowColumnsNode(const std::string& table_name)
     : AbstractLQPNode(LQPNodeType::ShowColumns), _table_name(table_name) {}
 
-std::shared_ptr<AbstractLQPNode> ShowColumnsNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> ShowColumnsNode::_deep_copy_impl() const {
   return std::make_shared<ShowColumnsNode>(_table_name);
 }
 

--- a/src/lib/logical_query_plan/show_columns_node.hpp
+++ b/src/lib/logical_query_plan/show_columns_node.hpp
@@ -18,7 +18,7 @@ class ShowColumnsNode : public AbstractLQPNode {
   const std::string& table_name() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   const std::string _table_name;

--- a/src/lib/logical_query_plan/show_columns_node.hpp
+++ b/src/lib/logical_query_plan/show_columns_node.hpp
@@ -17,6 +17,9 @@ class ShowColumnsNode : public AbstractLQPNode {
 
   const std::string& table_name() const;
 
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+
  private:
   const std::string _table_name;
 };

--- a/src/lib/logical_query_plan/show_tables_node.cpp
+++ b/src/lib/logical_query_plan/show_tables_node.cpp
@@ -6,6 +6,8 @@ namespace opossum {
 
 ShowTablesNode::ShowTablesNode() : AbstractLQPNode(LQPNodeType::ShowTables) {}
 
+std::shared_ptr<AbstractLQPNode> ShowTablesNode::_clone_impl() const { return std::make_shared<ShowTablesNode>(); }
+
 std::string ShowTablesNode::description() const { return "[ShowTables]"; }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/show_tables_node.cpp
+++ b/src/lib/logical_query_plan/show_tables_node.cpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 ShowTablesNode::ShowTablesNode() : AbstractLQPNode(LQPNodeType::ShowTables) {}
 
-std::shared_ptr<AbstractLQPNode> ShowTablesNode::_clone_impl() const { return std::make_shared<ShowTablesNode>(); }
+std::shared_ptr<AbstractLQPNode> ShowTablesNode::_deep_copy_impl() const { return std::make_shared<ShowTablesNode>(); }
 
 std::string ShowTablesNode::description() const { return "[ShowTables]"; }
 

--- a/src/lib/logical_query_plan/show_tables_node.hpp
+++ b/src/lib/logical_query_plan/show_tables_node.hpp
@@ -16,7 +16,7 @@ class ShowTablesNode : public AbstractLQPNode {
   std::string description() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/show_tables_node.hpp
+++ b/src/lib/logical_query_plan/show_tables_node.hpp
@@ -14,6 +14,9 @@ class ShowTablesNode : public AbstractLQPNode {
   ShowTablesNode();
 
   std::string description() const override;
+
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -15,7 +15,7 @@ OrderByDefinition::OrderByDefinition(const ColumnID column_id, const OrderByMode
 SortNode::SortNode(const std::vector<OrderByDefinition>& order_by_definitions)
     : AbstractLQPNode(LQPNodeType::Sort), _order_by_definitions(order_by_definitions) {}
 
-std::shared_ptr<AbstractLQPNode> SortNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> SortNode::_deep_copy_impl() const {
   return std::make_shared<SortNode>(_order_by_definitions);
 }
 

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -15,6 +15,10 @@ OrderByDefinition::OrderByDefinition(const ColumnID column_id, const OrderByMode
 SortNode::SortNode(const std::vector<OrderByDefinition>& order_by_definitions)
     : AbstractLQPNode(LQPNodeType::Sort), _order_by_definitions(order_by_definitions) {}
 
+std::shared_ptr<AbstractLQPNode> SortNode::_clone_impl() const {
+  return std::make_shared<SortNode>(_order_by_definitions);
+}
+
 std::string SortNode::description() const {
   std::ostringstream s;
 

--- a/src/lib/logical_query_plan/sort_node.hpp
+++ b/src/lib/logical_query_plan/sort_node.hpp
@@ -30,6 +30,9 @@ class SortNode : public AbstractLQPNode {
 
   const std::vector<OrderByDefinition>& order_by_definitions() const;
 
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+
  private:
   const std::vector<OrderByDefinition> _order_by_definitions;
 };

--- a/src/lib/logical_query_plan/sort_node.hpp
+++ b/src/lib/logical_query_plan/sort_node.hpp
@@ -31,7 +31,7 @@ class SortNode : public AbstractLQPNode {
   const std::vector<OrderByDefinition>& order_by_definitions() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   const std::vector<OrderByDefinition> _order_by_definitions;

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -23,6 +23,10 @@ StoredTableNode::StoredTableNode(const std::string& table_name)
   _output_column_ids_to_input_column_ids.emplace(output_column_count(), INVALID_COLUMN_ID);
 }
 
+std::shared_ptr<AbstractLQPNode> StoredTableNode::_clone_impl() const {
+  return std::make_shared<StoredTableNode>(_table_name);
+}
+
 std::string StoredTableNode::description() const { return "[StoredTable] Name: '" + _table_name + "'"; }
 
 const std::vector<ColumnID>& StoredTableNode::output_column_ids_to_input_column_ids() const {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -23,7 +23,7 @@ StoredTableNode::StoredTableNode(const std::string& table_name)
   _output_column_ids_to_input_column_ids.emplace(output_column_count(), INVALID_COLUMN_ID);
 }
 
-std::shared_ptr<AbstractLQPNode> StoredTableNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> StoredTableNode::_deep_copy_impl() const {
   return std::make_shared<StoredTableNode>(_table_name);
 }
 

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -40,6 +40,7 @@ class StoredTableNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -40,7 +40,7 @@ class StoredTableNode : public AbstractLQPNode {
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -12,7 +12,7 @@ namespace opossum {
 
 UnionNode::UnionNode(UnionMode union_mode) : AbstractLQPNode(LQPNodeType::Union), _union_mode(union_mode) {}
 
-std::shared_ptr<AbstractLQPNode> UnionNode::_clone_impl() const { return std::make_shared<UnionNode>(_union_mode); }
+std::shared_ptr<AbstractLQPNode> UnionNode::_deep_copy_impl() const { return std::make_shared<UnionNode>(_union_mode); }
 
 UnionMode UnionNode::union_mode() const { return _union_mode; }
 

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -12,6 +12,8 @@ namespace opossum {
 
 UnionNode::UnionNode(UnionMode union_mode) : AbstractLQPNode(LQPNodeType::Union), _union_mode(union_mode) {}
 
+std::shared_ptr<AbstractLQPNode> UnionNode::_clone_impl() const { return std::make_shared<UnionNode>(_union_mode); }
+
 UnionMode UnionNode::union_mode() const { return _union_mode; }
 
 std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.at(_union_mode); }

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -33,6 +33,9 @@ class UnionNode : public AbstractLQPNode {
 
   std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
 
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+
  private:
   UnionMode _union_mode;
 };

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -34,7 +34,7 @@ class UnionNode : public AbstractLQPNode {
   std::vector<ColumnID> get_output_column_ids_for_table(const std::string& table_name) const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 
  private:
   UnionMode _union_mode;

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -5,15 +5,24 @@
 #include <string>
 #include <vector>
 
+#include "optimizer/expression.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {
 
-class Expression;
-
 UpdateNode::UpdateNode(const std::string& table_name,
                        const std::vector<std::shared_ptr<Expression>>& column_expressions)
     : AbstractLQPNode(LQPNodeType::Update), _table_name(table_name), _column_expressions(column_expressions) {}
+
+std::shared_ptr<AbstractLQPNode> UpdateNode::_clone_impl() const {
+  std::vector<std::shared_ptr<Expression>> column_expressions;
+  column_expressions.reserve(_column_expressions.size());
+  for (const auto& expression : _column_expressions) {
+    column_expressions.emplace_back(expression->clone());
+  }
+
+  return std::make_shared<UpdateNode>(_table_name, std::move(_column_expressions));
+}
 
 std::string UpdateNode::description() const {
   std::ostringstream desc;
@@ -22,6 +31,8 @@ std::string UpdateNode::description() const {
 
   return desc.str();
 }
+
+bool UpdateNode::subtree_is_read_only() const { return false; }
 
 const std::vector<std::shared_ptr<Expression>>& UpdateNode::column_expressions() const { return _column_expressions; }
 

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -14,11 +14,11 @@ UpdateNode::UpdateNode(const std::string& table_name,
                        const std::vector<std::shared_ptr<Expression>>& column_expressions)
     : AbstractLQPNode(LQPNodeType::Update), _table_name(table_name), _column_expressions(column_expressions) {}
 
-std::shared_ptr<AbstractLQPNode> UpdateNode::_clone_impl() const {
+std::shared_ptr<AbstractLQPNode> UpdateNode::_deep_copy_impl() const {
   std::vector<std::shared_ptr<Expression>> column_expressions;
   column_expressions.reserve(_column_expressions.size());
   for (const auto& expression : _column_expressions) {
-    column_expressions.emplace_back(expression->clone());
+    column_expressions.emplace_back(expression->deep_copy());
   }
 
   return std::make_shared<UpdateNode>(_table_name, std::move(_column_expressions));

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -17,14 +17,16 @@ class UpdateNode : public AbstractLQPNode {
                       const std::vector<std::shared_ptr<Expression>>& column_expressions);
 
   std::string description() const override;
+  bool subtree_is_read_only() const override;
 
   const std::string& table_name() const;
 
   const std::vector<std::shared_ptr<Expression>>& column_expressions() const;
 
  protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
   const std::string _table_name;
-  const std::vector<std::shared_ptr<Expression>> _column_expressions;
+  std::vector<std::shared_ptr<Expression>> _column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -24,7 +24,7 @@ class UpdateNode : public AbstractLQPNode {
   const std::vector<std::shared_ptr<Expression>>& column_expressions() const;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
   const std::string _table_name;
   std::vector<std::shared_ptr<Expression>> _column_expressions;
 };

--- a/src/lib/logical_query_plan/validate_node.cpp
+++ b/src/lib/logical_query_plan/validate_node.cpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 ValidateNode::ValidateNode() : AbstractLQPNode(LQPNodeType::Validate) {}
 
-std::shared_ptr<AbstractLQPNode> ValidateNode::_clone_impl() const { return std::make_shared<ValidateNode>(); }
+std::shared_ptr<AbstractLQPNode> ValidateNode::_deep_copy_impl() const { return std::make_shared<ValidateNode>(); }
 
 std::string ValidateNode::description() const { return "[Validate]"; }
 

--- a/src/lib/logical_query_plan/validate_node.cpp
+++ b/src/lib/logical_query_plan/validate_node.cpp
@@ -6,6 +6,8 @@ namespace opossum {
 
 ValidateNode::ValidateNode() : AbstractLQPNode(LQPNodeType::Validate) {}
 
+std::shared_ptr<AbstractLQPNode> ValidateNode::_clone_impl() const { return std::make_shared<ValidateNode>(); }
+
 std::string ValidateNode::description() const { return "[Validate]"; }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/validate_node.hpp
+++ b/src/lib/logical_query_plan/validate_node.hpp
@@ -14,6 +14,9 @@ class ValidateNode : public AbstractLQPNode {
   ValidateNode();
 
   std::string description() const override;
+
+ protected:
+  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/validate_node.hpp
+++ b/src/lib/logical_query_plan/validate_node.hpp
@@ -16,7 +16,7 @@ class ValidateNode : public AbstractLQPNode {
   std::string description() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _clone_impl() const override;
+  std::shared_ptr<AbstractLQPNode> _deep_copy_impl() const override;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -16,6 +16,7 @@ const std::string CreateView::name() const { return "CreateView"; }
 
 std::shared_ptr<AbstractOperator> CreateView::recreate(const std::vector<AllParameterVariant>& args) const {
   Fail("This operator cannot be recreated");
+  // ... because it makes no sense to do so.
   return nullptr;
 }
 

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -1,0 +1,28 @@
+#include "create_view.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "storage/storage_manager.hpp"
+
+namespace opossum {
+
+CreateView::CreateView(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp)
+    : _view_name(view_name), _lqp(lqp) {}
+
+const std::string CreateView::name() const { return "CreateView"; }
+
+std::shared_ptr<AbstractOperator> CreateView::recreate(const std::vector<AllParameterVariant>& args) const {
+  Fail("This operator cannot be recreated");
+  return nullptr;
+}
+
+std::shared_ptr<const Table> CreateView::_on_execute() {
+  StorageManager::get().add_view(_view_name, _lqp);
+
+  return std::make_shared<Table>();
+}
+
+}  // namespace opossum

--- a/src/lib/operators/maintenance/create_view.hpp
+++ b/src/lib/operators/maintenance/create_view.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "operators/abstract_read_only_operator.hpp"
+
+namespace opossum {
+
+// maintenance operator for the "CREATE VIEW" sql statement
+class CreateView : public AbstractReadOnlyOperator {
+ public:
+  explicit CreateView(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp);
+
+  const std::string name() const override;
+
+  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
+
+ protected:
+  std::shared_ptr<const Table> _on_execute() override;
+
+ private:
+  const std::string _view_name;
+  const std::shared_ptr<const AbstractLQPNode> _lqp;
+};
+}  // namespace opossum

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -15,6 +15,7 @@ const std::string DropView::name() const { return "DropView"; }
 
 std::shared_ptr<AbstractOperator> DropView::recreate(const std::vector<AllParameterVariant>& args) const {
   Fail("This operator cannot be recreated");
+  // ... because it makes no sense to do so.
   return nullptr;
 }
 

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -1,0 +1,27 @@
+#include "drop_view.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "storage/storage_manager.hpp"
+
+namespace opossum {
+
+DropView::DropView(const std::string& view_name) : _view_name(view_name) {}
+
+const std::string DropView::name() const { return "DropView"; }
+
+std::shared_ptr<AbstractOperator> DropView::recreate(const std::vector<AllParameterVariant>& args) const {
+  Fail("This operator cannot be recreated");
+  return nullptr;
+}
+
+std::shared_ptr<const Table> DropView::_on_execute() {
+  StorageManager::get().drop_view(_view_name);
+
+  return std::make_shared<Table>();
+}
+
+}  // namespace opossum

--- a/src/lib/operators/maintenance/drop_view.hpp
+++ b/src/lib/operators/maintenance/drop_view.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "operators/abstract_read_only_operator.hpp"
+
+namespace opossum {
+
+// maintenance operator for the "CREATE VIEW" sql statement
+class DropView : public AbstractReadOnlyOperator {
+ public:
+  explicit DropView(const std::string& view_name);
+
+  const std::string name() const override;
+
+  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
+
+ protected:
+  std::shared_ptr<const Table> _on_execute() override;
+
+ private:
+  const std::string _view_name;
+};
+}  // namespace opossum

--- a/src/lib/optimizer/expression.cpp
+++ b/src/lib/optimizer/expression.cpp
@@ -17,27 +17,27 @@ namespace opossum {
 
 Expression::Expression(ExpressionType type) : _type(type) {}
 
-std::shared_ptr<Expression> Expression::clone() const {
+std::shared_ptr<Expression> Expression::deep_copy() const {
   // We cannot use the copy constructor here, because it does not work with shared_from_this()
-  auto clone = std::make_shared<Expression>(_type);
-  clone->_value = _value;
-  clone->_aggregate_function = _aggregate_function;
-  clone->_table_name = _table_name;
-  clone->_column_id = _column_id;
-  clone->_alias = _alias;
-  clone->_value_placeholder = _value_placeholder;
+  auto deep_copy = std::make_shared<Expression>(_type);
+  deep_copy->_value = _value;
+  deep_copy->_aggregate_function = _aggregate_function;
+  deep_copy->_table_name = _table_name;
+  deep_copy->_column_id = _column_id;
+  deep_copy->_alias = _alias;
+  deep_copy->_value_placeholder = _value_placeholder;
 
   std::vector<std::shared_ptr<Expression>> expression_list;
   expression_list.reserve(_expression_list.size());
   for (const auto& expression : _expression_list) {
-    expression_list.emplace_back(expression->clone());
+    expression_list.emplace_back(expression->deep_copy());
   }
-  clone->_expression_list = std::move(expression_list);
+  deep_copy->_expression_list = std::move(expression_list);
 
-  if (left_child()) clone->set_left_child(left_child()->clone());
-  if (right_child()) clone->set_right_child(right_child()->clone());
+  if (left_child()) deep_copy->set_left_child(left_child()->deep_copy());
+  if (right_child()) deep_copy->set_right_child(right_child()->deep_copy());
 
-  return clone;
+  return deep_copy;
 }
 
 std::shared_ptr<Expression> Expression::create_column(const ColumnID column_id,

--- a/src/lib/optimizer/expression.hpp
+++ b/src/lib/optimizer/expression.hpp
@@ -23,7 +23,7 @@ class AbstractLQPNode;
  * For now we decided to have a single Expression without further specializations. This goes hand in hand with the
  * approach used in hsql::Expr.
  */
-class Expression : public std::enable_shared_from_this<Expression> {
+class Expression : public std::enable_shared_from_this<Expression>, private Noncopyable {
  public:
   /*
    * This constructor is meant for internal use only and therefore should be private.
@@ -44,10 +44,8 @@ class Expression : public std::enable_shared_from_this<Expression> {
    */
   explicit Expression(ExpressionType type);
 
-  explicit Expression(const Expression&) = delete;
-  Expression& operator=(const Expression&) = delete;
   // creates a DEEP copy of the other expression. Used for reusing LQPs, e.g., in views.
-  std::shared_ptr<Expression> clone() const;
+  std::shared_ptr<Expression> deep_copy() const;
 
   // @{
   /**

--- a/src/lib/optimizer/expression.hpp
+++ b/src/lib/optimizer/expression.hpp
@@ -44,6 +44,11 @@ class Expression : public std::enable_shared_from_this<Expression> {
    */
   explicit Expression(ExpressionType type);
 
+  explicit Expression(const Expression&) = delete;
+  Expression& operator=(const Expression&) = delete;
+  // creates a DEEP copy of the other expression. Used for reusing LQPs, e.g., in views.
+  std::shared_ptr<Expression> clone() const;
+
   // @{
   /**
    * Factory Methods to create Expressions of specific type

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -11,7 +11,9 @@
 #include "constant_mappings.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/create_view_node.hpp"
 #include "logical_query_plan/delete_node.hpp"
+#include "logical_query_plan/drop_view_node.hpp"
 #include "logical_query_plan/dummy_table_node.hpp"
 #include "logical_query_plan/insert_node.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -107,15 +109,19 @@ std::vector<std::shared_ptr<AbstractLQPNode>> SQLTranslator::translate_parse_res
 std::shared_ptr<AbstractLQPNode> SQLTranslator::translate_statement(const hsql::SQLStatement& statement) {
   switch (statement.type()) {
     case hsql::kStmtSelect:
-      return _translate_select((const hsql::SelectStatement&)statement);
+      return _translate_select(static_cast<const hsql::SelectStatement&>(statement));
     case hsql::kStmtInsert:
-      return _translate_insert((const hsql::InsertStatement&)statement);
+      return _translate_insert(static_cast<const hsql::InsertStatement&>(statement));
     case hsql::kStmtDelete:
-      return _translate_delete((const hsql::DeleteStatement&)statement);
+      return _translate_delete(static_cast<const hsql::DeleteStatement&>(statement));
     case hsql::kStmtUpdate:
-      return _translate_update((const hsql::UpdateStatement&)statement);
+      return _translate_update(static_cast<const hsql::UpdateStatement&>(statement));
     case hsql::kStmtShow:
-      return _translate_show((const hsql::ShowStatement&)statement);
+      return _translate_show(static_cast<const hsql::ShowStatement&>(statement));
+    case hsql::kStmtCreate:
+      return _translate_create(static_cast<const hsql::CreateStatement&>(statement));
+    case hsql::kStmtDrop:
+      return _translate_drop(static_cast<const hsql::DropStatement&>(statement));
     default:
       Fail("SQL statement type not supported");
       return {};
@@ -440,7 +446,14 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_table_ref(const hsql:
   std::shared_ptr<AbstractLQPNode> node;
   switch (table.type) {
     case hsql::kTableName:
-      node = _validate_if_active(std::make_shared<StoredTableNode>(table.name));
+      if (StorageManager::get().has_table(table.name)) {
+        node = _validate_if_active(std::make_shared<StoredTableNode>(table.name));
+      } else if (StorageManager::get().has_view(table.name)) {
+        node = StorageManager::get().get_view(table.name);
+        Assert(!_validate || node->subtree_is_validated(), "Trying to add non-validated view to validated query");
+      } else {
+        Fail(std::string("Did not find a table or view with name ") + table.name);
+      }
       break;
     case hsql::kTableSelect:
       node = _translate_select(*table.select);
@@ -920,6 +933,46 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_show(const hsql::Show
       return std::make_shared<ShowColumnsNode>(std::string(show_statement.name));
     default:
       Fail("hsql::ShowType is not supported.");
+  }
+
+  return {};
+}
+
+std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create(const hsql::CreateStatement& create_statement) {
+  switch (create_statement.type) {
+    case hsql::CreateType::kCreateView: {
+      auto view = _translate_select((const hsql::SelectStatement&)*create_statement.select);
+      if (create_statement.viewColumns) {
+        std::vector<std::shared_ptr<Expression>> projections;
+        ColumnID column_id{0};
+        Assert(create_statement.viewColumns->size() == view->output_column_count(),
+               "Number of Columns in CREATE VIEW does not match SELECT statement");
+        for (const auto& alias : *create_statement.viewColumns) {
+          // rename columns so they match the view definition
+          projections.push_back(Expression::create_column(column_id, alias));
+          ++column_id;
+        }
+        auto projection_node = std::make_shared<ProjectionNode>(projections);
+        projection_node->set_left_child(view);
+        view = projection_node;
+      }
+
+      return std::make_shared<CreateViewNode>(create_statement.tableName, view);
+    }
+    default:
+      Fail("hsql::CreateType is not supported.");
+  }
+
+  return {};
+}
+
+std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_drop(const hsql::DropStatement& drop_statement) {
+  switch (drop_statement.type) {
+    case hsql::DropType::kDropView: {
+      return std::make_shared<DropViewNode>(drop_statement.name);
+    }
+    default:
+      Fail("hsql::DropType is not supported.");
   }
 
   return {};

--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -101,6 +101,10 @@ class SQLTranslator final : public Noncopyable {
 
   std::shared_ptr<AbstractLQPNode> _translate_update(const hsql::UpdateStatement& update);
 
+  std::shared_ptr<AbstractLQPNode> _translate_create(const hsql::CreateStatement& update);
+
+  std::shared_ptr<AbstractLQPNode> _translate_drop(const hsql::DropStatement& update);
+
   /**
    * Helper function to avoid code duplication for WHERE and HAVING
    */

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -33,12 +33,12 @@ void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> t
 }
 
 void StorageManager::drop_table(const std::string& name) {
-  auto num_deleted = _tables.erase(name);
+  const auto num_deleted = _tables.erase(name);
   Assert(num_deleted == 1, "Error deleting table " + name + ": _erase() returned " + std::to_string(num_deleted) + ".");
 }
 
 std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const {
-  auto iter = _tables.find(name);
+  const auto iter = _tables.find(name);
   Assert(iter != _tables.end(), "No such table named '" + name + "'");
 
   return iter->second;
@@ -66,15 +66,15 @@ void StorageManager::add_view(const std::string& name, std::shared_ptr<const Abs
 }
 
 void StorageManager::drop_view(const std::string& name) {
-  auto num_deleted = _views.erase(name);
+  const auto num_deleted = _views.erase(name);
   Assert(num_deleted == 1, "Error deleting view " + name + ": _erase() returned " + std::to_string(num_deleted) + ".");
 }
 
 std::shared_ptr<AbstractLQPNode> StorageManager::get_view(const std::string& name) const {
-  auto iter = _views.find(name);
+  const auto iter = _views.find(name);
   Assert(iter != _views.end(), "No such view named '" + name + "'");
 
-  return iter->second->clone();
+  return iter->second->deep_copy();
 }
 
 bool StorageManager::has_view(const std::string& name) const { return _views.count(name); }

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "logical_query_plan/abstract_lqp_node.hpp"
 #include "operators/export_csv.hpp"
 #include "operators/table_wrapper.hpp"
 #include "optimizer/table_statistics.hpp"
@@ -21,13 +22,14 @@ StorageManager& StorageManager::get() {
 
 void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> table) {
   Assert(_tables.find(name) == _tables.end(), "A table with the name " + name + " already exists");
+  Assert(_views.find(name) == _views.end(), "Cannot add table " + name + " - a view with the same name already exists");
 
   for (ChunkID chunk_id{0}; chunk_id < table->chunk_count(); chunk_id++) {
     Assert(table->get_chunk(chunk_id).has_mvcc_columns(), "Table must have MVCC columns.");
   }
 
   table->set_table_statistics(std::make_shared<TableStatistics>(table));
-  _tables.insert(std::make_pair(name, std::move(table)));
+  _tables.emplace(name, std::move(table));
 }
 
 void StorageManager::drop_table(const std::string& name) {
@@ -55,6 +57,39 @@ std::vector<std::string> StorageManager::table_names() const {
   return table_names;
 }
 
+void StorageManager::add_view(const std::string& name, std::shared_ptr<const AbstractLQPNode> view) {
+  Assert(_tables.find(name) == _tables.end(),
+         "Cannot add view " + name + " - a table with the same name already exists");
+  Assert(_views.find(name) == _views.end(), "A view with the name " + name + " already exists");
+
+  _views.emplace(name, std::move(view));
+}
+
+void StorageManager::drop_view(const std::string& name) {
+  auto num_deleted = _views.erase(name);
+  Assert(num_deleted == 1, "Error deleting view " + name + ": _erase() returned " + std::to_string(num_deleted) + ".");
+}
+
+std::shared_ptr<AbstractLQPNode> StorageManager::get_view(const std::string& name) const {
+  auto iter = _views.find(name);
+  Assert(iter != _views.end(), "No such view named '" + name + "'");
+
+  return iter->second->clone();
+}
+
+bool StorageManager::has_view(const std::string& name) const { return _views.count(name); }
+
+std::vector<std::string> StorageManager::view_names() const {
+  std::vector<std::string> view_names;
+  view_names.reserve(_views.size());
+
+  for (const auto& view_item : _views) {
+    view_names.emplace_back(view_item.first);
+  }
+
+  return view_names;
+}
+
 void StorageManager::print(std::ostream& out) const {
   out << "==================" << std::endl;
   out << "===== Tables =====" << std::endl << std::endl;
@@ -64,6 +99,14 @@ void StorageManager::print(std::ostream& out) const {
     out << " (" << table.second->column_count() << " columns, " << table.second->row_count() << " rows in "
         << table.second->chunk_count() << " chunks)";
     out << std::endl << std::endl;
+  }
+
+  out << "==================" << std::endl;
+  out << "===== Views ======" << std::endl << std::endl;
+
+  for (auto const& view : _views) {
+    out << "==== view >> " << view.first << " <<";
+    out << std::endl;
   }
 }
 

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -11,6 +11,7 @@
 namespace opossum {
 
 class Table;
+class AbstractLQPNode;
 
 // The StorageManager is a singleton that maintains all tables
 // by mapping table names to table instances.
@@ -33,6 +34,21 @@ class StorageManager : private Noncopyable {
   // returns a list of all table names
   std::vector<std::string> table_names() const;
 
+  // adds a view to the storage manager
+  void add_view(const std::string& name, std::shared_ptr<const AbstractLQPNode> view);
+
+  // removes the view from the storage manger
+  void drop_view(const std::string& name);
+
+  // returns the view instance with the given name
+  std::shared_ptr<AbstractLQPNode> get_view(const std::string& name) const;
+
+  // returns whether the storage manager holds a table with the given name
+  bool has_view(const std::string& name) const;
+
+  // returns a list of all view names
+  std::vector<std::string> view_names() const;
+
   // prints information about all tables in the storage manager (name, #columns, #rows, #chunks)
   void print(std::ostream& out = std::cout) const;
 
@@ -52,5 +68,6 @@ class StorageManager : private Noncopyable {
   StorageManager& operator=(StorageManager&&) = default;
 
   std::map<std::string, std::shared_ptr<Table>> _tables;
+  std::map<std::string, std::shared_ptr<const AbstractLQPNode>> _views;
 };
 }  // namespace opossum

--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -102,7 +102,7 @@ TEST_F(AggregateNodeTest, ColumnIdForExpression) {
 }
 
 TEST_F(AggregateNodeTest, AliasedSubqueryTest) {
-  const auto aggregate_node_with_alias = std::make_shared<AggregateNode>(*_aggregate_node);
+  const auto aggregate_node_with_alias = _aggregate_node->clone();
   aggregate_node_with_alias->set_alias(std::string("foo"));
 
   EXPECT_TRUE(aggregate_node_with_alias->knows_table("foo"));

--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -102,7 +102,7 @@ TEST_F(AggregateNodeTest, ColumnIdForExpression) {
 }
 
 TEST_F(AggregateNodeTest, AliasedSubqueryTest) {
-  const auto aggregate_node_with_alias = _aggregate_node->clone();
+  const auto aggregate_node_with_alias = _aggregate_node->deep_copy();
   aggregate_node_with_alias->set_alias(std::string("foo"));
 
   EXPECT_TRUE(aggregate_node_with_alias->knows_table("foo"));

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -67,7 +67,7 @@ TEST_F(JoinNodeTest, ColumnIdForColumnIdentifier) {
 }
 
 TEST_F(JoinNodeTest, AliasedSubqueryTest) {
-  const auto join_node_with_alias = std::make_shared<JoinNode>(*_join_node);
+  const auto join_node_with_alias = _join_node->clone();
   join_node_with_alias->set_alias({"foo"});
 
   EXPECT_TRUE(join_node_with_alias->knows_table("foo"));

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -67,7 +67,7 @@ TEST_F(JoinNodeTest, ColumnIdForColumnIdentifier) {
 }
 
 TEST_F(JoinNodeTest, AliasedSubqueryTest) {
-  const auto join_node_with_alias = _join_node->clone();
+  const auto join_node_with_alias = _join_node->deep_copy();
   join_node_with_alias->set_alias({"foo"});
 
   EXPECT_TRUE(join_node_with_alias->knows_table("foo"));

--- a/src/test/logical_query_plan/projection_node_test.cpp
+++ b/src/test/logical_query_plan/projection_node_test.cpp
@@ -54,7 +54,7 @@ TEST_F(ProjectionNodeTest, ColumnIdForColumnIdentifier) {
 }
 
 TEST_F(ProjectionNodeTest, AliasedSubqueryTest) {
-  const auto projection_node_with_alias = std::make_shared<ProjectionNode>(*_projection_node);
+  const auto projection_node_with_alias = _projection_node->clone();
   projection_node_with_alias->set_alias({"foo"});
 
   EXPECT_TRUE(projection_node_with_alias->knows_table("foo"));

--- a/src/test/logical_query_plan/projection_node_test.cpp
+++ b/src/test/logical_query_plan/projection_node_test.cpp
@@ -54,7 +54,7 @@ TEST_F(ProjectionNodeTest, ColumnIdForColumnIdentifier) {
 }
 
 TEST_F(ProjectionNodeTest, AliasedSubqueryTest) {
-  const auto projection_node_with_alias = _projection_node->clone();
+  const auto projection_node_with_alias = _projection_node->deep_copy();
   projection_node_with_alias->set_alias({"foo"});
 
   EXPECT_TRUE(projection_node_with_alias->knows_table("foo"));

--- a/src/test/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/logical_query_plan/stored_table_node_test.cpp
@@ -52,7 +52,7 @@ TEST_F(StoredTableNodeTest, UnknownTableColumns) {
 }
 
 TEST_F(StoredTableNodeTest, AliasTableColumns) {
-  const auto alias_table_node = _stored_table_node->clone();
+  const auto alias_table_node = _stored_table_node->deep_copy();
   alias_table_node->set_alias({"foo"});
 
   auto column_ids = alias_table_node->get_output_column_ids_for_table("foo");
@@ -68,7 +68,7 @@ TEST_F(StoredTableNodeTest, VerboseColumnNames) {
 }
 
 TEST_F(StoredTableNodeTest, VerboseColumnNamesWithAlias) {
-  const auto node_with_alias = _stored_table_node->clone();
+  const auto node_with_alias = _stored_table_node->deep_copy();
   node_with_alias->set_alias(std::string("foo"));
 
   EXPECT_EQ(node_with_alias->get_verbose_column_name(ColumnID{0}), "(t_a AS foo).a");

--- a/src/test/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/logical_query_plan/stored_table_node_test.cpp
@@ -52,7 +52,7 @@ TEST_F(StoredTableNodeTest, UnknownTableColumns) {
 }
 
 TEST_F(StoredTableNodeTest, AliasTableColumns) {
-  const auto alias_table_node = std::make_shared<StoredTableNode>(*_stored_table_node);
+  const auto alias_table_node = _stored_table_node->clone();
   alias_table_node->set_alias({"foo"});
 
   auto column_ids = alias_table_node->get_output_column_ids_for_table("foo");
@@ -68,7 +68,7 @@ TEST_F(StoredTableNodeTest, VerboseColumnNames) {
 }
 
 TEST_F(StoredTableNodeTest, VerboseColumnNamesWithAlias) {
-  const auto node_with_alias = std::make_shared<StoredTableNode>(*_stored_table_node);
+  const auto node_with_alias = _stored_table_node->clone();
   node_with_alias->set_alias(std::string("foo"));
 
   EXPECT_EQ(node_with_alias->get_verbose_column_name(ColumnID{0}), "(t_a AS foo).a");

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -130,3 +130,4 @@ SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 4
 -- VIEWS disabled because of #367
 -- CREATE VIEW count_view1 AS SELECT a, COUNT(DISTINCT b) FROM groupby_int_1gb_1agg_null GROUP BY a; SELECT * FROM count_view;
 -- CREATE VIEW count_view2 AS SELECT a, COUNT(DISTINCT b) FROM groupby_int_1gb_1agg_null GROUP BY a; SELECT * FROM count_view WHERE a > 10;
+-- CREATE VIEW count_view3 (foo, bar) AS SELECT a, COUNT(DISTINCT b) FROM groupby_int_1gb_1agg_null GROUP BY a; SELECT * FROM count_view WHERE a > 10;

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -126,3 +126,7 @@ INSERT INTO int_int_for_insert_1 (b, a) SELECT 3, 1 FROM int_int_for_insert_1; S
 INSERT INTO int_int_for_insert_1 SELECT * FROM int_int3 WHERE a = 1 AND b = 3; INSERT INTO int_int_for_insert_1 SELECT * FROM int_int3 WHERE a = 13; INSERT INTO int_int_for_insert_1 (a, b) SELECT a, b FROM int_int3 WHERE a = 6; SELECT * FROM int_int_for_insert_1;
 
 SELECT a, b, MAX(c), AVG(d) FROM groupby_int_2gb_2agg GROUP BY a, b HAVING b > 457 OR b = 1234 OR b = 12345;
+
+-- VIEWS disabled because of #367
+-- CREATE VIEW count_view1 AS SELECT a, COUNT(DISTINCT b) FROM groupby_int_1gb_1agg_null GROUP BY a; SELECT * FROM count_view;
+-- CREATE VIEW count_view2 AS SELECT a, COUNT(DISTINCT b) FROM groupby_int_1gb_1agg_null GROUP BY a; SELECT * FROM count_view WHERE a > 10;

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -5,12 +5,13 @@
 #include "../base_test.hpp"
 #include "gtest/gtest.h"
 
+#include "../lib/logical_query_plan/stored_table_node.hpp"
 #include "../lib/storage/storage_manager.hpp"
 #include "../lib/storage/table.hpp"
 
 namespace opossum {
 
-class StorageStorageManagerTest : public BaseTest {
+class StorageManagerTest : public BaseTest {
  protected:
   void SetUp() override {
     auto& sm = StorageManager::get();
@@ -19,10 +20,22 @@ class StorageStorageManagerTest : public BaseTest {
 
     sm.add_table("first_table", t1);
     sm.add_table("second_table", t2);
+
+    auto v1 = std::make_shared<StoredTableNode>("first_table");
+    auto v2 = std::make_shared<StoredTableNode>("second_table");
+
+    sm.add_view("first_view", std::move(v1));
+    sm.add_view("second_view", std::move(v2));
   }
 };
 
-TEST_F(StorageStorageManagerTest, GetTable) {
+TEST_F(StorageManagerTest, AddTableTwice) {
+  auto& sm = StorageManager::get();
+  EXPECT_THROW(sm.add_table("first_table", std::make_shared<Table>()), std::exception);
+  EXPECT_THROW(sm.add_table("first_view", std::make_shared<Table>()), std::exception);
+}
+
+TEST_F(StorageManagerTest, GetTable) {
   auto& sm = StorageManager::get();
   auto t3 = sm.get_table("first_table");
   auto t4 = sm.get_table("second_table");
@@ -31,21 +44,57 @@ TEST_F(StorageStorageManagerTest, GetTable) {
   EXPECT_EQ(sm.table_names(), names);
 }
 
-TEST_F(StorageStorageManagerTest, DropTable) {
+TEST_F(StorageManagerTest, DropTable) {
   auto& sm = StorageManager::get();
   sm.drop_table("first_table");
   EXPECT_THROW(sm.get_table("first_table"), std::exception);
   EXPECT_THROW(sm.drop_table("first_table"), std::exception);
 }
 
-TEST_F(StorageStorageManagerTest, DoesNotHaveTable) {
+TEST_F(StorageManagerTest, DoesNotHaveTable) {
   auto& sm = StorageManager::get();
   EXPECT_EQ(sm.has_table("third_table"), false);
 }
 
-TEST_F(StorageStorageManagerTest, HasTable) {
+TEST_F(StorageManagerTest, HasTable) {
   auto& sm = StorageManager::get();
   EXPECT_EQ(sm.has_table("first_table"), true);
+}
+
+TEST_F(StorageManagerTest, AddViewTwice) {
+  auto& sm = StorageManager::get();
+  EXPECT_THROW(sm.add_view("first_table", std::make_shared<StoredTableNode>("first_table")), std::exception);
+  EXPECT_THROW(sm.add_view("first_view", std::make_shared<StoredTableNode>("first_table")), std::exception);
+}
+
+TEST_F(StorageManagerTest, GetView) {
+  auto& sm = StorageManager::get();
+  auto v3 = sm.get_view("first_view");
+  auto v4 = sm.get_view("second_view");
+  EXPECT_THROW(sm.get_view("third_view"), std::exception);
+}
+
+TEST_F(StorageManagerTest, DropView) {
+  auto& sm = StorageManager::get();
+  sm.drop_view("first_view");
+  EXPECT_THROW(sm.get_view("first_view"), std::exception);
+  EXPECT_THROW(sm.drop_view("first_view"), std::exception);
+}
+
+TEST_F(StorageManagerTest, ResetView) {
+  StorageManager::reset();
+  auto& sm = StorageManager::get();
+  EXPECT_THROW(sm.get_view("first_view"), std::exception);
+}
+
+TEST_F(StorageManagerTest, DoesNotHaveView) {
+  auto& sm = StorageManager::get();
+  EXPECT_EQ(sm.has_view("third_view"), false);
+}
+
+TEST_F(StorageManagerTest, HasView) {
+  auto& sm = StorageManager::get();
+  EXPECT_EQ(sm.has_view("first_view"), true);
 }
 
 }  // namespace opossum

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -98,7 +98,7 @@ INSTANTIATE_TEST_CASE_P(TPCHTestInstances, TPCHTest, ::testing::Values(
   // 11, /* Enable once we support IN */
   // 12, /* Enable once we support nested expressions in Join Condition */
   // 13, /* Enable once we support Case */
-  // 14, /* We do not support Views yet */
+  // 14, /* Enable once we support Subselects in WHERE condition */
   // 15, /* Enable once we support Subselects in WHERE condition */
   // 16, /* Enable once we support Subselects in WHERE condition */
   // 17, /* Enable once we support Subselects in WHERE condition */


### PR DESCRIPTION
Let's try this again, shall we?

The tests in the sqlite runner are still disabled. This is because of #367: When we have two SQL queries in one string, they get translated at the same time. If the first one changes the data layout, the second one will not see the change during translation.

fixes #461 