### PR TITLE
Fix malloc include for macOS

### DIFF
--- a/third_party/tpch-dbgen/bm_utils.c
+++ b/third_party/tpch-dbgen/bm_utils.c
@@ -67,7 +67,7 @@
 #endif            /* HP */
 #include <ctype.h>
 #include <math.h>
-#ifndef _POSIX_SOURCE
+#if !defined(_POSIX_SOURCE) && !defined(__APPLE__)
 #include <malloc.h>
 #endif /* POSIX_SOURCE */
 #include <fcntl.h>


### PR DESCRIPTION
The new `dbgen` wants to include `malloc.h`, but this header does not exist on macOS. Instead, the regular malloc from `stdlib.h` will be used.