### PR TITLE
Fix SQLiteWrapper interpreting 'null' in string_null columns

### DIFF
--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
@@ -63,7 +63,7 @@ void SQLiteWrapper::create_table_from_tbl(const std::string& file, const std::st
     query << "INSERT INTO " << table_name << " VALUES (";
     std::vector<std::string> values = _split<std::string>(line, '|');
     for (size_t i = 0; i < values.size(); i++) {
-      if (col_types[i] == "TEXT") {
+      if (col_types[i] == "TEXT" && values[i] != "null") {
         query << "'" << values[i] << "'";
       } else {
         query << values[i];


### PR DESCRIPTION
When loading a .tbl file into SQLite, the SQLiteWrapper treated a null value in a string_null column as string, not as null.