### PR TITLE
397 Improve EXPECT_TABLE_EQ error output

### DIFF
--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -158,9 +158,9 @@ void ExportBinary::_write_chunk(const std::shared_ptr<const Table>& table, std::
   _export_value(ofstream, static_cast<ChunkOffset>(chunk.size()));
 
   // Iterating over all columns of this chunk and exporting them
-  for (ColumnID col_id{0}; col_id < chunk.column_count(); col_id++) {
-    auto visitor = make_unique_by_data_type<ColumnVisitable, ExportBinaryVisitor>(table->column_type(col_id));
-    chunk.get_column(col_id)->visit(*visitor, context);
+  for (ColumnID column_id{0}; column_id < chunk.column_count(); column_id++) {
+    auto visitor = make_unique_by_data_type<ColumnVisitable, ExportBinaryVisitor>(table->column_type(column_id));
+    chunk.get_column(column_id)->visit(*visitor, context);
   }
 }
 

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -100,8 +100,9 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
   return stream.str();
 }
 
-template <typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
+template <typename T>
 bool almost_equals(T left_val, T right_val, opossum::FloatComparisonMode float_comparison_mode) {
+  static_assert(std::is_floating_point_v<T>, "Values must be have floating point type.");
   if (float_comparison_mode == opossum::FloatComparisonMode::AbsoluteDifference) {
     return std::fabs(left_val - right_val) < EPSILON;
   } else {

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -92,6 +92,15 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
   return stream.str();
 }
 
+template<typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
+bool near(T left_val, T right_val, opossum::FloatComparisonMode float_comparison_mode) {
+  if (float_comparison_mode == opossum::FloatComparisonMode::AbsoluteDifference) {
+    return std::fabs(left_val - right_val) < EPSILON;
+  } else {
+    return std::fabs(left_val - right_val) < std::fabs(right_val * EPSILON);
+  }
+}
+
 }  // namespace
 
 
@@ -207,20 +216,12 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
         auto left_val = type_cast<float>(opossum_matrix[row][col]);
         auto right_val = type_cast<float>(expected_matrix[row][col]);
 
-        if (float_comparison_mode == FloatComparisonMode::AbsoluteDifference) {
-          expect_true(std::fabs(left_val - right_val) < EPSILON, row, col);
-        } else {
-          expect_true(std::fabs(left_val - right_val) < std::fabs(right_val * EPSILON), row, col);
-        }
+        expect_true(near(left_val, right_val, float_comparison_mode), row, col);
       } else if (opossum_table->column_type(col) == DataType::Double) {
         auto left_val = type_cast<double>(opossum_matrix[row][col]);
         auto right_val = type_cast<double>(expected_matrix[row][col]);
 
-        if (float_comparison_mode == FloatComparisonMode::AbsoluteDifference) {
-          expect_true(std::fabs(left_val - right_val) < EPSILON, row, col);
-        } else {
-          expect_true(std::fabs(left_val - right_val) < std::fabs(right_val * EPSILON), row, col);
-        }
+        expect_true(near(left_val, right_val, float_comparison_mode), row, col);
       } else {
         if (type_cmp_mode == TypeCmpMode::Lenient &&
             (opossum_table->column_type(col) == DataType::Int || opossum_table->column_type(col) == DataType::Long)) {

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -13,13 +13,26 @@
 #include "storage/table.hpp"
 #include "storage/value_column.hpp"
 
+#define ANSI_COLOR_RED "\x1B[31m"
+#define ANSI_COLOR_GREEN "\x1B[32m"
+#define ANSI_COLOR_YELLOW "\x1B[33m"
+#define ANSI_COLOR_RESET "\x1B[0m"
+
+#define EPSILON 0.0001
+
 namespace {
 
 using Matrix = std::vector<std::vector<opossum::AllTypeVariant>>;
 
 Matrix _table_to_matrix(const std::shared_ptr<const opossum::Table>& t) {
-  // initialize matrix with table sizes
-  Matrix matrix(t->row_count(), std::vector<opossum::AllTypeVariant>(t->column_count()));
+  // initialize matrix with table sizes, including column names/types
+  Matrix matrix(t->row_count() + 2, std::vector<opossum::AllTypeVariant>(t->column_count()));
+
+  // set column names/types
+  for (opossum::ColumnID col_id{0}; col_id < t->column_count(); ++col_id) {
+    matrix[0][col_id] = t->column_name(col_id);
+    matrix[1][col_id] = opossum::data_type_to_string.left.at(t->column_type(col_id));
+  }
 
   // set values
   unsigned row_offset = 0;
@@ -33,7 +46,7 @@ Matrix _table_to_matrix(const std::shared_ptr<const opossum::Table>& t) {
       const auto column = chunk.get_column(col_id);
 
       for (opossum::ChunkOffset chunk_offset = 0; chunk_offset < chunk.size(); ++chunk_offset) {
-        matrix[row_offset + chunk_offset][col_id] = (*column)[chunk_offset];
+        matrix[row_offset + chunk_offset + 2][col_id] = (*column)[chunk_offset];
       }
     }
     row_offset += chunk.size();
@@ -42,19 +55,45 @@ Matrix _table_to_matrix(const std::shared_ptr<const opossum::Table>& t) {
   return matrix;
 }
 
-std::string _matrix_to_string(const std::string& title, const Matrix& m) {
+std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<uint64_t, uint16_t>>& highlight_cells, const std::string& highlight_color) {
   std::stringstream stream;
-  stream << "-------" << title << "-------" << std::endl;
-  for (unsigned row = 0; row < m.size(); row++) {
-    for (opossum::ColumnID col{0}; col < m[row].size(); col++) {
-      stream << std::setw(8) << m[row][col] << " ";
+  bool highlight;
+  bool previous_row_highlighted = false;
+  for (unsigned row = 0; row < matrix.size(); row++) {
+    highlight = false;
+    auto it = std::find_if( highlight_cells.begin(), highlight_cells.end(), [&](const std::pair<uint64_t, uint16_t>& element){ return element.first == row;} );
+    if (it != highlight_cells.end()) {
+      highlight = true;
+      if (!previous_row_highlighted) {
+        stream << "<<<<<" << std::endl;
+        previous_row_highlighted = true;
+      }
+    } else {
+      previous_row_highlighted = false;
+    }
+    if (row >= 2) {
+      stream << std::setw(4) << std::to_string(row - 2);
+    } else {
+      stream << std::setw(4) << " ";
+    }
+    for (opossum::ColumnID col{0}; col < matrix[row].size(); col++) {
+      std::string field = boost::lexical_cast<std::string>(matrix[row][col]);
+      std::string coloring = "";
+      if (highlight) {
+        coloring = ANSI_COLOR_YELLOW;
+        if (it->second == col) {
+          coloring = highlight_color;
+        }
+      }
+      stream << coloring << std::setw(8) << field << ANSI_COLOR_RESET << " ";
     }
     stream << std::endl;
   }
-  stream << "---------------------------" << std::endl;
   return stream.str();
 }
+
 }  // namespace
+
 
 namespace opossum {
 
@@ -64,22 +103,32 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   auto opossum_matrix = _table_to_matrix(opossum_table);
   auto expected_matrix = _table_to_matrix(expected_table);
 
-  const auto generate_table_comparison = [&]() {
+  std::string error_type = "";
+  std::string error_msg = "";
+
+  const auto generate_table_comparison = [&](const std::vector<std::pair<uint64_t, uint16_t>>& highlighted_cells = {}) {
     std::stringstream stream;
     stream << "========= Tables are not equal =========" << std::endl;
-    stream << _matrix_to_string("Actual Result", opossum_matrix);
-    stream << std::endl;
-    stream << _matrix_to_string("Expected Result", expected_matrix);
-    stream << "========================================" << std::endl;
+    stream << "------- Actual Result -------" << std::endl;
+    stream << _matrix_to_string(opossum_matrix, highlighted_cells, ANSI_COLOR_RED);
+    stream << "-----------------------------" << std::endl << std::endl;
+    stream << "------- Expected Result -------" << std::endl;
+    stream << _matrix_to_string(expected_matrix, highlighted_cells, ANSI_COLOR_GREEN);
+    stream << "-------------------------------" << std::endl;
+    stream << "========================================" << std::endl << std::endl;
+    stream << "Type of error: " << error_type << std::endl;
+    stream << error_msg << std::endl;
     return stream.str();
   };
 
   // compare schema of tables
   //  - column count
   if (opossum_table->column_count() != expected_table->column_count()) {
-    std::cout << generate_table_comparison() << "Number of columns is different. " << std::endl
-              << "Actual result: " << opossum_table->column_count()
-              << ", Expected result: " << expected_table->column_count();
+    error_type = "Column count mismatch";
+    error_msg = "Actual number of columns: " + std::to_string(opossum_table->column_count()) + "\n"
+              + "Expected number of columns: " + std::to_string(expected_table->column_count());
+
+    std::cout << generate_table_comparison() << std::endl;
     return false;
   }
 
@@ -103,15 +152,21 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
       }
     }
 
-    if (left_col_type != right_col_type || opossum_table->column_name(col_id) != expected_table->column_name(col_id)) {
-      const auto opossum_column_data_type = data_type_to_string.left.at(opossum_table->column_type(col_id));
-      const auto expected_column_data_type = data_type_to_string.left.at(expected_table->column_type(col_id));
+    if (opossum_table->column_name(col_id) != expected_table->column_name(col_id)) {
+      error_type = "Column name mismatch (column " + std::to_string(col_id) + ")";
+      error_msg = "Actual column name: " + opossum_table->column_name(col_id) + "\n"
+              + "Expected column name: " + expected_table->column_name(col_id);
 
-      std::cout << generate_table_comparison() << "Table schema is different."
-                << "Column with ID " << col_id << " is different" << std::endl
-                << "Got: " << opossum_table->column_name(col_id) << " (" << opossum_column_data_type << ")" << std::endl
-                << "Expected: " << expected_table->column_name(col_id) << " (" << expected_column_data_type << ")"
-                << std::endl;
+      std::cout << generate_table_comparison({{0, col_id}}) << std::endl;
+      return false;
+    }
+
+    if (left_col_type != right_col_type) {
+      error_type = "Column type mismatch (column " + std::to_string(col_id) + ")";
+      error_msg = "Actual column type: " + data_type_to_string.left.at(opossum_table->column_type(col_id)) + "\n"
+              + "Expected column type: " + data_type_to_string.left.at(expected_table->column_type(col_id));
+
+      std::cout << generate_table_comparison({{1, col_id}}) << std::endl;
       return false;
     }
   }
@@ -119,67 +174,73 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   // compare content of tables
   //  - row count for fast failure
   if (opossum_table->row_count() != expected_table->row_count()) {
-    std::cout << "Number of rows is different." << std::endl
-              << "Got: " << opossum_table->row_count() << " rows" << std::endl
-              << "Expected: " << expected_table->row_count() << " rows" << std::endl
-              << generate_table_comparison() << std::endl;
+    error_type = "Row count mismatch";
+    error_msg = "Actual number of rows: " + std::to_string(opossum_table->row_count()) + "\n"
+              + "Expected number of rows: " + std::to_string(expected_table->row_count());
+
+    std::cout << generate_table_comparison() << std::endl;
     return false;
   }
 
   // sort if order does not matter
   if (order_sensitivity == OrderSensitivity::No) {
-    std::sort(opossum_matrix.begin(), opossum_matrix.end());
-    std::sort(expected_matrix.begin(), expected_matrix.end());
+    // skip header when sorting
+    std::sort(opossum_matrix.begin() + 2, opossum_matrix.end());
+    std::sort(expected_matrix.begin() + 2, expected_matrix.end());
   }
 
-  for (unsigned row = 0; row < opossum_matrix.size(); row++)
+  bool has_error = false;
+  std::vector<std::pair<uint64_t, uint16_t>> mismatched_cells{};
+
+  const auto expect_true = [&has_error, &mismatched_cells](bool statement, uint64_t row, uint16_t col) {
+    if (!statement) {
+      has_error = true;
+      mismatched_cells.push_back({row, col});
+    }
+  };
+
+  for (unsigned row = 2; row < opossum_matrix.size(); row++)
     for (ColumnID col{0}; col < opossum_matrix[row].size(); col++) {
       if (variant_is_null(opossum_matrix[row][col]) || variant_is_null(expected_matrix[row][col])) {
-        EXPECT_TRUE(variant_is_null(opossum_matrix[row][col]) && variant_is_null(expected_matrix[row][col]));
+        expect_true(variant_is_null(opossum_matrix[row][col]) && variant_is_null(expected_matrix[row][col]), row, col);
       } else if (opossum_table->column_type(col) == DataType::Float) {
         auto left_val = type_cast<float>(opossum_matrix[row][col]);
         auto right_val = type_cast<float>(expected_matrix[row][col]);
 
-        if (type_cmp_mode == TypeCmpMode::Strict) {
-          EXPECT_EQ(expected_table->column_type(col), DataType::Float);
-        } else {
-          EXPECT_TRUE(expected_table->column_type(col) == DataType::Float ||
-                      expected_table->column_type(col) == DataType::Double);
-        }
         if (float_comparison_mode == FloatComparisonMode::AbsoluteDifference) {
-          EXPECT_NEAR(left_val, right_val, 0.0001) << "Row/Col:" << row << "/" << col;
+          expect_true(std::fabs(left_val - right_val) < EPSILON, row, col);
         } else {
-          EXPECT_REL_NEAR(left_val, right_val, 0.0001) << "Row/Col:" << row << "/" << col;
+          expect_true(std::fabs(left_val - right_val) < std::fabs(right_val * EPSILON), row, col);
         }
       } else if (opossum_table->column_type(col) == DataType::Double) {
         auto left_val = type_cast<double>(opossum_matrix[row][col]);
         auto right_val = type_cast<double>(expected_matrix[row][col]);
 
-        if (type_cmp_mode == TypeCmpMode::Strict) {
-          EXPECT_EQ(expected_table->column_type(col), DataType::Double);
-        } else {
-          EXPECT_TRUE(expected_table->column_type(col) == DataType::Float ||
-                      expected_table->column_type(col) == DataType::Double);
-        }
         if (float_comparison_mode == FloatComparisonMode::AbsoluteDifference) {
-          EXPECT_NEAR(left_val, right_val, 0.0001) << "Row/Col:" << row << "/" << col;
+          expect_true(std::fabs(left_val - right_val) < EPSILON, row, col);
         } else {
-          EXPECT_REL_NEAR(left_val, right_val, 0.0001) << "Row/Col:" << row << "/" << col;
+          expect_true(std::fabs(left_val - right_val) < std::fabs(right_val * EPSILON), row, col);
         }
       } else {
         if (type_cmp_mode == TypeCmpMode::Lenient &&
             (opossum_table->column_type(col) == DataType::Int || opossum_table->column_type(col) == DataType::Long)) {
           auto left_val = type_cast<int64_t>(opossum_matrix[row][col]);
           auto right_val = type_cast<int64_t>(expected_matrix[row][col]);
-          EXPECT_EQ(left_val, right_val) << "Row:" << row + 1 << " Col:" << col + 1;
+          expect_true(left_val == right_val, row, col);
         } else {
-          EXPECT_EQ(opossum_matrix[row][col], expected_matrix[row][col]) << "Row:" << row + 1 << " Col:" << col + 1;
+          expect_true(opossum_matrix[row][col] == expected_matrix[row][col], row, col);
         }
       }
     }
 
-  if (::testing::Test::HasFailure()) {
-    std::cout << generate_table_comparison();
+  if (has_error) {
+    error_type = "Cell data mismatch";
+    error_msg = "Mismatched cells (row,column): ";
+    for (auto cell : mismatched_cells) {
+      error_msg += "(" + std::to_string(cell.first - 2) + "," + std::to_string(cell.second) + ") ";
+    }
+
+    std::cout << generate_table_comparison(mismatched_cells) << std::endl;
     return false;
   }
 

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -15,7 +15,8 @@
 
 #define ANSI_COLOR_RED "\x1B[31m"
 #define ANSI_COLOR_GREEN "\x1B[32m"
-#define ANSI_COLOR_YELLOW "\x1B[33m"
+#define ANSI_COLOR_BG_RED "\x1B[41m"
+#define ANSI_COLOR_BG_GREEN "\x1B[42m"
 #define ANSI_COLOR_RESET "\x1B[0m"
 
 #define EPSILON 0.0001
@@ -59,6 +60,12 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
   std::stringstream stream;
   bool highlight;
   bool previous_row_highlighted = false;
+
+  std::string highlight_color_bg = ANSI_COLOR_BG_RED;
+  if (highlight_color == ANSI_COLOR_GREEN) {
+    highlight_color_bg = ANSI_COLOR_BG_GREEN;
+  }
+  
   for (unsigned row = 0; row < matrix.size(); row++) {
     highlight = false;
     auto it = std::find_if( highlight_cells.begin(), highlight_cells.end(), [&](const std::pair<uint64_t, uint16_t>& element){ return element.first == row;} );
@@ -71,19 +78,20 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
     } else {
       previous_row_highlighted = false;
     }
+    std::string coloring = "";
+    if (highlight) {
+      coloring = highlight_color_bg;
+    }
     if (row >= 2) {
-      stream << std::setw(4) << std::to_string(row - 2);
+      stream << coloring << std::setw(4) << std::to_string(row - 2) << ANSI_COLOR_RESET;
     } else {
-      stream << std::setw(4) << " ";
+      stream << coloring << std::setw(4) << "    " << ANSI_COLOR_RESET;
     }
     for (opossum::ColumnID col{0}; col < matrix[row].size(); col++) {
       std::string field = boost::lexical_cast<std::string>(matrix[row][col]);
-      std::string coloring = "";
-      if (highlight) {
-        coloring = ANSI_COLOR_YELLOW;
-        if (it->second == col) {
-          coloring = highlight_color;
-        }
+      coloring = "";
+      if (highlight && it->second == col) {
+        coloring = highlight_color;
       }
       stream << coloring << std::setw(8) << field << ANSI_COLOR_RESET << " ";
     }

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -65,7 +65,7 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
   if (highlight_color == ANSI_COLOR_GREEN) {
     highlight_color_bg = ANSI_COLOR_BG_GREEN;
   }
-  
+
   for (unsigned row = 0; row < matrix.size(); row++) {
     highlight = false;
     auto it = std::find_if( highlight_cells.begin(), highlight_cells.end(), [&](const std::pair<uint64_t, uint16_t>& element){ return element.first == row;} );
@@ -78,6 +78,8 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
     } else {
       previous_row_highlighted = false;
     }
+
+    // Highlight row number with background color
     std::string coloring = "";
     if (highlight) {
       coloring = highlight_color_bg;
@@ -87,13 +89,15 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
     } else {
       stream << coloring << std::setw(4) << "    " << ANSI_COLOR_RESET;
     }
+
+    // Highlicht each (applicable) cell with highlight color
     for (opossum::ColumnID col{0}; col < matrix[row].size(); col++) {
-      std::string field = boost::lexical_cast<std::string>(matrix[row][col]);
+      std::string cell = boost::lexical_cast<std::string>(matrix[row][col]);
       coloring = "";
       if (highlight && it->second == col) {
         coloring = highlight_color;
       }
-      stream << coloring << std::setw(8) << field << ANSI_COLOR_RESET << " ";
+      stream << coloring << std::setw(8) << cell << ANSI_COLOR_RESET << " ";
     }
     stream << std::endl;
   }

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -56,13 +56,15 @@ Matrix _table_to_matrix(const std::shared_ptr<const opossum::Table>& t) {
   return matrix;
 }
 
-std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<uint64_t, uint16_t>>& highlight_cells, const std::string& highlight_color, const std::string& highlight_color_bg) {
+std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<uint64_t, uint16_t>>& highlight_cells,
+                              const std::string& highlight_color, const std::string& highlight_color_bg) {
   std::stringstream stream;
   bool previous_row_highlighted = false;
 
   for (auto row_id = size_t{0}; row_id < matrix.size(); row_id++) {
     auto highlight = false;
-    auto it = std::find_if(highlight_cells.begin(), highlight_cells.end(), [&](const auto& element) { return element.first == row_id; });
+    auto it = std::find_if(highlight_cells.begin(), highlight_cells.end(),
+                           [&](const auto& element) { return element.first == row_id; });
     if (it != highlight_cells.end()) {
       highlight = true;
       if (!previous_row_highlighted) {
@@ -118,7 +120,7 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   auto expected_matrix = _table_to_matrix(expected_table);
 
   const auto print_table_comparison = [&](const std::string& error_type, const std::string& error_msg,
-                                             const std::vector<std::pair<uint64_t, uint16_t>>& highlighted_cells = {}) {
+                                          const std::vector<std::pair<uint64_t, uint16_t>>& highlighted_cells = {}) {
     std::cout << "========= Tables are not equal =========" << std::endl;
     std::cout << "------- Actual Result -------" << std::endl;
     std::cout << _matrix_to_string(opossum_matrix, highlighted_cells, ANSI_COLOR_RED, ANSI_COLOR_BG_RED);
@@ -214,7 +216,9 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   for (auto row_id = size_t{2}; row_id < opossum_matrix.size(); row_id++)
     for (auto col_id = ColumnID{0}; col_id < opossum_matrix[row_id].size(); col_id++) {
       if (variant_is_null(opossum_matrix[row_id][col_id]) || variant_is_null(expected_matrix[row_id][col_id])) {
-        highlight_if(!(variant_is_null(opossum_matrix[row_id][col_id]) && variant_is_null(expected_matrix[row_id][col_id])), row_id, col_id);
+        highlight_if(
+            !(variant_is_null(opossum_matrix[row_id][col_id]) && variant_is_null(expected_matrix[row_id][col_id])),
+            row_id, col_id);
       } else if (opossum_table->column_type(col_id) == DataType::Float) {
         auto left_val = type_cast<float>(opossum_matrix[row_id][col_id]);
         auto right_val = type_cast<float>(expected_matrix[row_id][col_id]);
@@ -226,8 +230,8 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
 
         highlight_if(!almost_equals(left_val, right_val, float_comparison_mode), row_id, col_id);
       } else {
-        if (type_cmp_mode == TypeCmpMode::Lenient &&
-            (opossum_table->column_type(col_id) == DataType::Int || opossum_table->column_type(col_id) == DataType::Long)) {
+        if (type_cmp_mode == TypeCmpMode::Lenient && (opossum_table->column_type(col_id) == DataType::Int ||
+                                                      opossum_table->column_type(col_id) == DataType::Long)) {
           auto left_val = type_cast<int64_t>(opossum_matrix[row_id][col_id]);
           auto right_val = type_cast<int64_t>(expected_matrix[row_id][col_id]);
           highlight_if(left_val != right_val, row_id, col_id);

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -56,7 +56,8 @@ Matrix _table_to_matrix(const std::shared_ptr<const opossum::Table>& t) {
   return matrix;
 }
 
-std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<uint64_t, uint16_t>>& highlight_cells, const std::string& highlight_color) {
+std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<uint64_t, uint16_t>>& highlight_cells,
+                              const std::string& highlight_color) {
   std::stringstream stream;
   bool highlight;
   bool previous_row_highlighted = false;
@@ -68,7 +69,8 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
 
   for (unsigned row = 0; row < matrix.size(); row++) {
     highlight = false;
-    auto it = std::find_if( highlight_cells.begin(), highlight_cells.end(), [&](const std::pair<uint64_t, uint16_t>& element){ return element.first == row;} );
+    auto it = std::find_if(highlight_cells.begin(), highlight_cells.end(),
+                           [&](const std::pair<uint64_t, uint16_t>& element) { return element.first == row; });
     if (it != highlight_cells.end()) {
       highlight = true;
       if (!previous_row_highlighted) {
@@ -104,7 +106,7 @@ std::string _matrix_to_string(const Matrix& matrix, const std::vector<std::pair<
   return stream.str();
 }
 
-template<typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
+template <typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
 bool near(T left_val, T right_val, opossum::FloatComparisonMode float_comparison_mode) {
   if (float_comparison_mode == opossum::FloatComparisonMode::AbsoluteDifference) {
     return std::fabs(left_val - right_val) < EPSILON;
@@ -115,7 +117,6 @@ bool near(T left_val, T right_val, opossum::FloatComparisonMode float_comparison
 
 }  // namespace
 
-
 namespace opossum {
 
 bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
@@ -124,7 +125,8 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   auto opossum_matrix = _table_to_matrix(opossum_table);
   auto expected_matrix = _table_to_matrix(expected_table);
 
-  const auto generate_table_comparison = [&](const std::string& error_type, const std::string& error_msg, const std::vector<std::pair<uint64_t, uint16_t>>& highlighted_cells = {}) {
+  const auto generate_table_comparison = [&](const std::string& error_type, const std::string& error_msg,
+                                             const std::vector<std::pair<uint64_t, uint16_t>>& highlighted_cells = {}) {
     std::stringstream stream;
     stream << "========= Tables are not equal =========" << std::endl;
     stream << "------- Actual Result -------" << std::endl;
@@ -143,8 +145,8 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   //  - column count
   if (opossum_table->column_count() != expected_table->column_count()) {
     const std::string error_type = "Column count mismatch";
-    const std::string error_msg = "Actual number of columns: " + std::to_string(opossum_table->column_count()) + "\n"
-              + "Expected number of columns: " + std::to_string(expected_table->column_count());
+    const std::string error_msg = "Actual number of columns: " + std::to_string(opossum_table->column_count()) + "\n" +
+                                  "Expected number of columns: " + std::to_string(expected_table->column_count());
 
     std::cout << generate_table_comparison(error_type, error_msg) << std::endl;
     return false;
@@ -172,8 +174,8 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
 
     if (opossum_table->column_name(col_id) != expected_table->column_name(col_id)) {
       const std::string error_type = "Column name mismatch (column " + std::to_string(col_id) + ")";
-      const std::string error_msg = "Actual column name: " + opossum_table->column_name(col_id) + "\n"
-              + "Expected column name: " + expected_table->column_name(col_id);
+      const std::string error_msg = "Actual column name: " + opossum_table->column_name(col_id) + "\n" +
+                                    "Expected column name: " + expected_table->column_name(col_id);
 
       std::cout << generate_table_comparison(error_type, error_msg, {{0, col_id}}) << std::endl;
       return false;
@@ -181,8 +183,9 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
 
     if (left_col_type != right_col_type) {
       const std::string error_type = "Column type mismatch (column " + std::to_string(col_id) + ")";
-      const std::string error_msg = "Actual column type: " + data_type_to_string.left.at(opossum_table->column_type(col_id)) + "\n"
-              + "Expected column type: " + data_type_to_string.left.at(expected_table->column_type(col_id));
+      const std::string error_msg =
+          "Actual column type: " + data_type_to_string.left.at(opossum_table->column_type(col_id)) + "\n" +
+          "Expected column type: " + data_type_to_string.left.at(expected_table->column_type(col_id));
 
       std::cout << generate_table_comparison(error_type, error_msg, {{1, col_id}}) << std::endl;
       return false;
@@ -193,8 +196,8 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   //  - row count for fast failure
   if (opossum_table->row_count() != expected_table->row_count()) {
     const std::string error_type = "Row count mismatch";
-    const std::string error_msg = "Actual number of rows: " + std::to_string(opossum_table->row_count()) + "\n"
-              + "Expected number of rows: " + std::to_string(expected_table->row_count());
+    const std::string error_msg = "Actual number of rows: " + std::to_string(opossum_table->row_count()) + "\n" +
+                                  "Expected number of rows: " + std::to_string(expected_table->row_count());
 
     std::cout << generate_table_comparison(error_type, error_msg) << std::endl;
     return false;


### PR DESCRIPTION
#397 
This mainly changes the `check_table_equal() `method in `testing_assert.cpp`. It normalizes the error output after table comparison to:
- print both tables with colored highlights of mismatching cells if applicable
- print the type of error, and the actual and expected value

The highlights in the printed tables are two-fold. The first one is a "<<<<<" preceding the row(s) where the error occured, this makes it easy to locate the row with searching. The second one is a coloring of the affected cell and the row number as well, this makes it easy to spot when scrolling through the output.

This also gets rid of the problem @mrzzzrm mentioned, that a failing EXPECT_TABLE_EQ causes all following EXPECT_TABLE_EQ in the same test to print as well.

I'll attach some example images how it looks like:
![screenshot from 2017-12-20 11-25-19](https://user-images.githubusercontent.com/1871704/34202684-caa7b48c-e578-11e7-8492-a0eec99d68a7.png)
![screenshot from 2017-12-20 11-26-02](https://user-images.githubusercontent.com/1871704/34202685-cac69ac8-e578-11e7-97ac-462bf9f05898.png)
![screenshot from 2017-12-20 11-26-23](https://user-images.githubusercontent.com/1871704/34202686-cadeb928-e578-11e7-9c59-0ea0a6162069.png)
![screenshot from 2017-12-20 11-26-47](https://user-images.githubusercontent.com/1871704/34202687-caf62c02-e578-11e7-901a-88abec627f8f.png)



