### PR TITLE
Remove Op prefix

### DIFF
--- a/src/benchmark/operators/projection_benchmark.cpp
+++ b/src/benchmark/operators/projection_benchmark.cpp
@@ -18,7 +18,7 @@ class OperatorsProjectionBenchmark : public BenchmarkBasicFixture {
     _column_type = state.range(1);
 
     _table_ref =
-        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::OpGreaterThanEquals, 0);  // all
+        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 0);  // all
     _table_ref->execute();
 
     _tables.emplace_back(_table_wrapper_a);  // 0

--- a/src/benchmark/operators/table_scan_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_benchmark.cpp
@@ -11,11 +11,11 @@ namespace opossum {
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstant)(benchmark::State& state) {
   clear_cache();
 
-  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::OpGreaterThanEquals, 7);
+  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan =
-        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::OpGreaterThanEquals, 7);
+        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
     table_scan->execute();
   }
 }
@@ -23,34 +23,34 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstant)(benchmark::State
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstantOnDict)(benchmark::State& state) {
   clear_cache();
   auto warm_up =
-      std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThanEquals, 7);
+      std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan =
-        std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThanEquals, 7);
+        std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
     table_scan->execute();
   }
 }
 
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariable)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, ColumnID{1});
+  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, ColumnID{1});
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */,
-                                                  ScanType::OpGreaterThanEquals, ColumnID{1} /* "b" */);
+                                                  ScanType::GreaterThanEquals, ColumnID{1} /* "b" */);
     table_scan->execute();
   }
 }
 
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariableOnDict)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThanEquals,
+  auto warm_up = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals,
                                              ColumnID{1} /* "b" */);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */,
-                                                  ScanType::OpGreaterThanEquals, ColumnID{1} /* "b" */);
+                                                  ScanType::GreaterThanEquals, ColumnID{1} /* "b" */);
     table_scan->execute();
   }
 }

--- a/src/benchmark/tpcc/delivery_benchmark.cpp
+++ b/src/benchmark/tpcc/delivery_benchmark.cpp
@@ -34,9 +34,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("NEW_ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{1} /* "NO_D_ID" */, ScanType::OpEquals, d_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{2} /* "NO_W_ID" */, ScanType::OpEquals, w_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{0} /* "NO_O_ID" */, ScanType::OpGreaterThan, -1);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{1} /* "NO_D_ID" */, ScanType::Equals, d_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{2} /* "NO_W_ID" */, ScanType::Equals, w_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{0} /* "NO_O_ID" */, ScanType::GreaterThan, -1);
     auto val = std::make_shared<Validate>(ts3);
 
     Projection::ColumnExpressions columns = {Expression::create_column(ColumnID{0} /* "NO_O_ID" */)};
@@ -70,7 +70,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("NEW_ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "NO_O_ID" */, ScanType::OpEquals, no_o_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "NO_O_ID" */, ScanType::Equals, no_o_id);
     auto val = std::make_shared<Validate>(ts1);
     auto delete_op = std::make_shared<Delete>("NEW_ORDER", val);
 
@@ -94,9 +94,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, ScanType::OpEquals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, ScanType::OpEquals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, ScanType::OpEquals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, ScanType::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, ScanType::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, ScanType::Equals, w_id);
     auto val = std::make_shared<Validate>(ts3);
 
     Projection::ColumnExpressions columns = {Expression::create_column(ColumnID{3} /* "O_C_ID" */)};
@@ -127,9 +127,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, ScanType::OpEquals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, ScanType::OpEquals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, ScanType::OpEquals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, ScanType::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, ScanType::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, ScanType::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 
@@ -171,9 +171,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER_LINE");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::OpEquals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::OpEquals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, ScanType::OpEquals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, ScanType::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 
@@ -214,9 +214,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER_LINE");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::OpEquals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::OpEquals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, ScanType::OpEquals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, ScanType::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 
@@ -249,9 +249,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("CUSTOMER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "C_ID" */, ScanType::OpEquals, c_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "C_D_ID" */, ScanType::OpEquals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "C_W_ID" */, ScanType::OpEquals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "C_ID" */, ScanType::Equals, c_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "C_D_ID" */, ScanType::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "C_W_ID" */, ScanType::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 

--- a/src/benchmarklib/tpcc/new_order.cpp
+++ b/src/benchmarklib/tpcc/new_order.cpp
@@ -166,17 +166,17 @@ TaskVector NewOrderRefImpl::get_get_customer_and_warehouse_tax_rate_tasks(const 
   const auto c_v = std::make_shared<opossum::Validate>(c_gt);
 
   const auto c_ts1 =
-      std::make_shared<opossum::TableScan>(c_v, opossum::ColumnID{2} /* "C_W_ID" */, opossum::ScanType::OpEquals, w_id);
+      std::make_shared<opossum::TableScan>(c_v, opossum::ColumnID{2} /* "C_W_ID" */, opossum::ScanType::Equals, w_id);
 
   const auto c_ts2 = std::make_shared<opossum::TableScan>(c_ts1, opossum::ColumnID{1} /* "C_D_ID" */,
-                                                          opossum::ScanType::OpEquals, d_id);
+                                                          opossum::ScanType::Equals, d_id);
 
   const auto c_ts3 =
-      std::make_shared<opossum::TableScan>(c_ts2, opossum::ColumnID{0} /* "C_ID" */, opossum::ScanType::OpEquals, c_id);
+      std::make_shared<opossum::TableScan>(c_ts2, opossum::ColumnID{0} /* "C_ID" */, opossum::ScanType::Equals, c_id);
 
   const auto w_gt = std::make_shared<opossum::GetTable>("WAREHOUSE");
   const auto w_ts =
-      std::make_shared<opossum::TableScan>(w_gt, opossum::ColumnID{0} /* "W_ID" */, opossum::ScanType::OpEquals, w_id);
+      std::make_shared<opossum::TableScan>(w_gt, opossum::ColumnID{0} /* "W_ID" */, opossum::ScanType::Equals, w_id);
 
   // Both operators should have exactly one row -> Product operator should have smallest overhead.
   const auto join = std::make_shared<opossum::Product>(c_ts3, w_ts);
@@ -229,9 +229,9 @@ TaskVector NewOrderRefImpl::get_get_district_tasks(const int32_t d_id, const int
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::ScanType::OpEquals, d_id);
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::ScanType::Equals, d_id);
   const auto ts2 =
-      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::ScanType::OpEquals, w_id);
+      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::ScanType::Equals, w_id);
 
   const auto proj = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions(
@@ -267,9 +267,9 @@ TaskVector NewOrderRefImpl::get_increment_next_order_id_tasks(const int32_t d_id
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::ScanType::OpEquals, d_id);
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::ScanType::Equals, d_id);
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */,
-                                                        opossum::ScanType::OpEquals, d_w_id);
+                                                        opossum::ScanType::Equals, d_w_id);
 
   const auto original_rows = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions({opossum::Expression::create_column(opossum::ColumnID{10})}));
@@ -384,7 +384,7 @@ TaskVector NewOrderRefImpl::get_get_item_info_tasks(const int32_t ol_i_id) {
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   //  "I_ID"
-  const auto ts = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0}, opossum::ScanType::OpEquals, ol_i_id);
+  const auto ts = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0}, opossum::ScanType::Equals, ol_i_id);
 
   const auto proj = std::make_shared<opossum::Projection>(
       ts, opossum::Projection::ColumnExpressions({opossum::Expression::create_column(opossum::ColumnID{3}),
@@ -420,9 +420,9 @@ TaskVector NewOrderRefImpl::get_get_stock_info_tasks(const int32_t ol_i_id, cons
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */,
-                                                        opossum::ScanType::OpEquals, ol_i_id);
+                                                        opossum::ScanType::Equals, ol_i_id);
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "S_W_ID" */,
-                                                        opossum::ScanType::OpEquals, ol_supply_w_id);
+                                                        opossum::ScanType::Equals, ol_supply_w_id);
 
   std::string s_dist_xx = d_id < 10 ? "S_DIST_0" + std::to_string(d_id) : "S_DIST_" + std::to_string(d_id);
 
@@ -467,10 +467,10 @@ TaskVector NewOrderRefImpl::get_update_stock_tasks(const int32_t s_quantity, con
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */,
-                                                        opossum::ScanType::OpEquals, ol_i_id);
+                                                        opossum::ScanType::Equals, ol_i_id);
 
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "S_W_ID" */,
-                                                        opossum::ScanType::OpEquals, ol_supply_w_id);
+                                                        opossum::ScanType::Equals, ol_supply_w_id);
 
   const auto original_rows = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions({opossum::Expression::create_column(opossum::ColumnID{2})}));

--- a/src/benchmarklib/tpcc/order_status.cpp
+++ b/src/benchmarklib/tpcc/order_status.cpp
@@ -113,13 +113,13 @@ TaskVector OrderStatusRefImpl::get_customer_by_name(const std::string c_last, co
   auto validate = std::make_shared<opossum::Validate>(gt_customer);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{5} /* "C_LAST" */,
-                                                           opossum::ScanType::OpEquals, c_last);
+                                                           opossum::ScanType::Equals, c_last);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "C_D_ID" */,
-                                                            opossum::ScanType::OpEquals, c_d_id);
+                                                            opossum::ScanType::Equals, c_d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "C_W_ID" */,
-                                                           opossum::ScanType::OpEquals, c_w_id);
+                                                           opossum::ScanType::Equals, c_w_id);
 
   auto projection = std::make_shared<opossum::Projection>(
       third_filter, opossum::Projection::ColumnExpressions(
@@ -160,13 +160,13 @@ TaskVector OrderStatusRefImpl::get_customer_by_id(const int c_id, const int c_d_
   auto validate = std::make_shared<opossum::Validate>(gt_customer);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{0} /* "C_ID" */,
-                                                           opossum::ScanType::OpEquals, c_id);
+                                                           opossum::ScanType::Equals, c_id);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "C_D_ID" */,
-                                                            opossum::ScanType::OpEquals, c_d_id);
+                                                            opossum::ScanType::Equals, c_d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "C_W_ID" */,
-                                                           opossum::ScanType::OpEquals, c_w_id);
+                                                           opossum::ScanType::Equals, c_w_id);
 
   auto projection = std::make_shared<opossum::Projection>(
       third_filter, opossum::Projection::ColumnExpressions(
@@ -203,13 +203,13 @@ TaskVector OrderStatusRefImpl::get_orders(const int o_c_id, const int o_d_id, co
   auto validate = std::make_shared<opossum::Validate>(gt_orders);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{3} /* "O_C_ID" */,
-                                                           opossum::ScanType::OpEquals, o_c_id);
+                                                           opossum::ScanType::Equals, o_c_id);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "O_D_ID" */,
-                                                            opossum::ScanType::OpEquals, o_d_id);
+                                                            opossum::ScanType::Equals, o_d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "O_W_ID" */,
-                                                           opossum::ScanType::OpEquals, o_w_id);
+                                                           opossum::ScanType::Equals, o_w_id);
 
   // "O_ID", "O_CARRIER_ID", "O_ENTRY_D"
   auto projection = std::make_shared<opossum::Projection>(
@@ -253,13 +253,13 @@ TaskVector OrderStatusRefImpl::get_order_lines(const int o_id, const int d_id, c
   auto validate = std::make_shared<opossum::Validate>(gt_order_lines);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{0} /* "OL_O_ID" */,
-                                                           opossum::ScanType::OpEquals, o_id);
+                                                           opossum::ScanType::Equals, o_id);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "OL_D_ID" */,
-                                                            opossum::ScanType::OpEquals, d_id);
+                                                            opossum::ScanType::Equals, d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "OL_W_ID" */,
-                                                           opossum::ScanType::OpEquals, w_id);
+                                                           opossum::ScanType::Equals, w_id);
 
   auto projection = std::make_shared<opossum::Projection>(
       third_filter, opossum::Projection::ColumnExpressions(

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -21,17 +21,17 @@ boost::bimap<L, R> make_bimap(std::initializer_list<typename boost::bimap<L, R>:
 }
 
 const boost::bimap<ScanType, std::string> scan_type_to_string = make_bimap<ScanType, std::string>({
-    {ScanType::OpEquals, "="},
-    {ScanType::OpNotEquals, "!="},
-    {ScanType::OpLessThan, "<"},
-    {ScanType::OpLessThanEquals, "<="},
-    {ScanType::OpGreaterThan, ">"},
-    {ScanType::OpGreaterThanEquals, ">="},
-    {ScanType::OpBetween, "BETWEEN"},
-    {ScanType::OpLike, "LIKE"},
-    {ScanType::OpNotLike, "NOT LIKE"},
-    {ScanType::OpIsNull, "IS NULL"},
-    {ScanType::OpIsNotNull, "IS NOT NULL"},
+    {ScanType::Equals, "="},
+    {ScanType::NotEquals, "!="},
+    {ScanType::LessThan, "<"},
+    {ScanType::LessThanEquals, "<="},
+    {ScanType::GreaterThan, ">"},
+    {ScanType::GreaterThanEquals, ">="},
+    {ScanType::Between, "BETWEEN"},
+    {ScanType::Like, "LIKE"},
+    {ScanType::NotLike, "NOT LIKE"},
+    {ScanType::IsNull, "IS NULL"},
+    {ScanType::IsNotNull, "IS NOT NULL"},
 });
 
 const std::unordered_map<ExpressionType, std::string> expression_type_to_string = {

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -61,14 +61,14 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
   const auto input_operator = translate_node(node->left_child());
   auto table_scan_node = std::dynamic_pointer_cast<PredicateNode>(node);
 
-  if (table_scan_node->scan_type() == ScanType::OpBetween) {
+  if (table_scan_node->scan_type() == ScanType::Between) {
     DebugAssert(static_cast<bool>(table_scan_node->value2()), "Scan type BETWEEN requires a second value");
     PerformanceWarning("TableScan executes BETWEEN as two separate selects");
 
     auto table_scan1 = std::make_shared<TableScan>(input_operator, table_scan_node->column_id(),
-                                                   ScanType::OpGreaterThanEquals, table_scan_node->value());
+                                                   ScanType::GreaterThanEquals, table_scan_node->value());
 
-    return std::make_shared<TableScan>(table_scan1, table_scan_node->column_id(), ScanType::OpLessThanEquals,
+    return std::make_shared<TableScan>(table_scan1, table_scan_node->column_id(), ScanType::LessThanEquals,
                                        *table_scan_node->value2());
   }
 
@@ -124,7 +124,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_join_node(
   DebugAssert(static_cast<bool>(join_node->join_column_ids()), "Cannot translate Join without join column ids.");
   DebugAssert(static_cast<bool>(join_node->scan_type()), "Cannot translate Join without ScanType.");
 
-  if (*join_node->scan_type() == ScanType::OpEquals && join_node->join_mode() != JoinMode::Outer) {
+  if (*join_node->scan_type() == ScanType::Equals && join_node->join_mode() != JoinMode::Outer) {
     return std::make_shared<JoinHash>(input_left_operator, input_right_operator, join_node->join_mode(),
                                       *(join_node->join_column_ids()), *(join_node->scan_type()));
   }

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -78,12 +78,12 @@ std::shared_ptr<JobTask> IndexScan::_create_job_and_schedule(const ChunkID chunk
 }
 
 void IndexScan::_validate_input() {
-  Assert(_scan_type != ScanType::OpLike, "Scan type not supported by index scan.");
-  Assert(_scan_type != ScanType::OpNotLike, "Scan type not supported by index scan.");
+  Assert(_scan_type != ScanType::Like, "Scan type not supported by index scan.");
+  Assert(_scan_type != ScanType::NotLike, "Scan type not supported by index scan.");
 
   Assert(_left_column_ids.size() == _right_values.size(),
          "Count mismatch: left column IDs and right values don’t have same size.");
-  if (_scan_type == ScanType::OpBetween) {
+  if (_scan_type == ScanType::Between) {
     Assert(_left_column_ids.size() == _right_values2.size(),
            "Count mismatch: left column IDs and right values don’t have same size.");
   }
@@ -104,12 +104,12 @@ PosList IndexScan::_scan_chunk(const ChunkID chunk_id) {
   Assert(index != nullptr, "Index of specified type not found for column (vector).");
 
   switch (_scan_type) {
-    case ScanType::OpEquals: {
+    case ScanType::Equals: {
       range_begin = index->lower_bound(_right_values);
       range_end = index->upper_bound(_right_values);
       break;
     }
-    case ScanType::OpNotEquals: {
+    case ScanType::NotEquals: {
       // first, get all values less than the search value
       range_begin = index->cbegin();
       range_end = index->lower_bound(_right_values);
@@ -122,27 +122,27 @@ PosList IndexScan::_scan_chunk(const ChunkID chunk_id) {
       range_end = index->cend();
       break;
     }
-    case ScanType::OpLessThan: {
+    case ScanType::LessThan: {
       range_begin = index->cbegin();
       range_end = index->lower_bound(_right_values);
       break;
     }
-    case ScanType::OpLessThanEquals: {
+    case ScanType::LessThanEquals: {
       range_begin = index->cbegin();
       range_end = index->upper_bound(_right_values);
       break;
     }
-    case ScanType::OpGreaterThan: {
+    case ScanType::GreaterThan: {
       range_begin = index->upper_bound(_right_values);
       range_end = index->cend();
       break;
     }
-    case ScanType::OpGreaterThanEquals: {
+    case ScanType::GreaterThanEquals: {
       range_begin = index->lower_bound(_right_values);
       range_end = index->cend();
       break;
     }
-    case ScanType::OpBetween: {
+    case ScanType::Between: {
       range_begin = index->lower_bound(_right_values);
       range_end = index->upper_bound(_right_values2);
       break;

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -26,7 +26,7 @@ JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator> left,
                    const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                    const std::pair<ColumnID, ColumnID>& column_ids, const ScanType scan_type)
     : AbstractJoinOperator(left, right, mode, column_ids, scan_type) {
-  DebugAssert(scan_type == ScanType::OpEquals, "Operator not supported by Hash Join.");
+  DebugAssert(scan_type == ScanType::Equals, "Operator not supported by Hash Join.");
 }
 
 const std::string JoinHash::name() const { return "JoinHash"; }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -157,7 +157,7 @@ void TableScan::_on_cleanup() { _impl.reset(); }
 void TableScan::_init_scan() {
   DebugAssert(_in_table->chunk_count() > 0u, "Input table must contain at least 1 chunk.");
 
-  if (_scan_type == ScanType::OpLike || _scan_type == ScanType::OpNotLike) {
+  if (_scan_type == ScanType::Like || _scan_type == ScanType::NotLike) {
     const auto left_column_type = _in_table->column_type(_left_column_id);
     Assert((left_column_type == DataType::String), "LIKE operator only applicable on string columns.");
 
@@ -174,7 +174,7 @@ void TableScan::_init_scan() {
     return;
   }
 
-  if (_scan_type == ScanType::OpIsNull || _scan_type == ScanType::OpIsNotNull) {
+  if (_scan_type == ScanType::IsNull || _scan_type == ScanType::IsNotNull) {
     _impl = std::make_unique<IsNullTableScanImpl>(_in_table, _left_column_id, _scan_type);
     return;
   }

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
@@ -53,10 +53,10 @@ void IsNullTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& b
 
 bool IsNullTableScanImpl::_matches_all(const BaseValueColumn& column) {
   switch (_scan_type) {
-    case ScanType::OpIsNull:
+    case ScanType::IsNull:
       return false;
 
-    case ScanType::OpIsNotNull:
+    case ScanType::IsNotNull:
       return !column.is_nullable();
 
     default:
@@ -67,10 +67,10 @@ bool IsNullTableScanImpl::_matches_all(const BaseValueColumn& column) {
 
 bool IsNullTableScanImpl::_matches_none(const BaseValueColumn& column) {
   switch (_scan_type) {
-    case ScanType::OpIsNull:
+    case ScanType::IsNull:
       return !column.is_nullable();
 
-    case ScanType::OpIsNotNull:
+    case ScanType::IsNotNull:
       return false;
 
     default:

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
@@ -41,10 +41,10 @@ class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
   template <typename Functor>
   void _resolve_scan_type(const Functor& func) {
     switch (_scan_type) {
-      case ScanType::OpIsNull:
+      case ScanType::IsNull:
         return func([](const bool is_null) { return is_null; });
 
-      case ScanType::OpIsNotNull:
+      case ScanType::IsNotNull:
         return func([](const bool is_null) { return !is_null; });
 
       default:

--- a/src/lib/operators/table_scan/like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.cpp
@@ -24,7 +24,7 @@ LikeTableScanImpl::LikeTableScanImpl(std::shared_ptr<const Table> in_table, cons
                                      const ScanType scan_type, const std::string& right_wildcard)
     : BaseSingleColumnTableScanImpl{in_table, left_column_id, scan_type},
       _right_wildcard{right_wildcard},
-      _invert_results(scan_type == ScanType::OpNotLike) {
+      _invert_results(scan_type == ScanType::NotLike) {
   // convert the given SQL-like search term into a c++11 regex to use it for the actual matching
   auto regex_string = _sqllike_to_regex(_right_wildcard);
   _regex = std::regex{regex_string, std::regex_constants::icase};  // case insensitivity

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
@@ -25,7 +25,7 @@ PosList SingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
     /**
      * Comparing anything with NULL (without using IS [NOT] NULL) will result in NULL.
      * Therefore, these scans will always return an empty position list.
-     * Because OpIsNull/OpIsNotNull are handled separately in IsNullTableScanImpl, 
+     * Because OpIsNull/OpIsNotNull are handled separately in IsNullTableScanImpl,
      * we can assume that comparing with NULLs here will always return nothing.
      */
     return PosList{};
@@ -129,14 +129,14 @@ void SingleColumnTableScanImpl::handle_dictionary_column(const BaseDictionaryCol
 
 ValueID SingleColumnTableScanImpl::_get_search_value_id(const BaseDictionaryColumn& column) {
   switch (_scan_type) {
-    case ScanType::OpEquals:
-    case ScanType::OpNotEquals:
-    case ScanType::OpLessThan:
-    case ScanType::OpGreaterThanEquals:
+    case ScanType::Equals:
+    case ScanType::NotEquals:
+    case ScanType::LessThan:
+    case ScanType::GreaterThanEquals:
       return column.lower_bound(_right_value);
 
-    case ScanType::OpLessThanEquals:
-    case ScanType::OpGreaterThan:
+    case ScanType::LessThanEquals:
+    case ScanType::GreaterThan:
       return column.upper_bound(_right_value);
 
     default:
@@ -148,18 +148,18 @@ ValueID SingleColumnTableScanImpl::_get_search_value_id(const BaseDictionaryColu
 bool SingleColumnTableScanImpl::_right_value_matches_all(const BaseDictionaryColumn& column,
                                                          const ValueID search_value_id) {
   switch (_scan_type) {
-    case ScanType::OpEquals:
+    case ScanType::Equals:
       return search_value_id != column.upper_bound(_right_value) && column.unique_values_count() == size_t{1u};
 
-    case ScanType::OpNotEquals:
+    case ScanType::NotEquals:
       return search_value_id == column.upper_bound(_right_value);
 
-    case ScanType::OpLessThan:
-    case ScanType::OpLessThanEquals:
+    case ScanType::LessThan:
+    case ScanType::LessThanEquals:
       return search_value_id == INVALID_VALUE_ID;
 
-    case ScanType::OpGreaterThanEquals:
-    case ScanType::OpGreaterThan:
+    case ScanType::GreaterThanEquals:
+    case ScanType::GreaterThan:
       return search_value_id == ValueID{0u};
 
     default:
@@ -171,18 +171,18 @@ bool SingleColumnTableScanImpl::_right_value_matches_all(const BaseDictionaryCol
 bool SingleColumnTableScanImpl::_right_value_matches_none(const BaseDictionaryColumn& column,
                                                           const ValueID search_value_id) {
   switch (_scan_type) {
-    case ScanType::OpEquals:
+    case ScanType::Equals:
       return search_value_id == column.upper_bound(_right_value);
 
-    case ScanType::OpNotEquals:
+    case ScanType::NotEquals:
       return search_value_id == column.upper_bound(_right_value) && column.unique_values_count() == size_t{1u};
 
-    case ScanType::OpLessThan:
-    case ScanType::OpLessThanEquals:
+    case ScanType::LessThan:
+    case ScanType::LessThanEquals:
       return search_value_id == ValueID{0u};
 
-    case ScanType::OpGreaterThan:
-    case ScanType::OpGreaterThanEquals:
+    case ScanType::GreaterThan:
+    case ScanType::GreaterThanEquals:
       return search_value_id == INVALID_VALUE_ID;
 
     default:

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
@@ -51,21 +51,21 @@ class SingleColumnTableScanImpl : public BaseSingleColumnTableScanImpl {
   template <typename Functor>
   void _with_operator_for_dict_column_scan(const ScanType scan_type, const Functor& func) {
     switch (scan_type) {
-      case ScanType::OpEquals:
+      case ScanType::Equals:
         func(std::equal_to<void>{});
         return;
 
-      case ScanType::OpNotEquals:
+      case ScanType::NotEquals:
         func(std::not_equal_to<void>{});
         return;
 
-      case ScanType::OpLessThan:
-      case ScanType::OpLessThanEquals:
+      case ScanType::LessThan:
+      case ScanType::LessThanEquals:
         func(std::less<void>{});
         return;
 
-      case ScanType::OpGreaterThan:
-      case ScanType::OpGreaterThanEquals:
+      case ScanType::GreaterThan:
+      case ScanType::GreaterThanEquals:
         func(std::greater_equal<void>{});
         return;
 

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -38,11 +38,11 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const Col
     return shared_from_this();
   }
 
-  if (scan_type == ScanType::OpLike || scan_type == ScanType::OpNotLike) {
+  if (scan_type == ScanType::Like || scan_type == ScanType::NotLike) {
     // simple heuristic:
     auto clone = std::make_shared<TableStatistics>(*this);
     auto selectivity = DEFAULT_LIKE_SELECTIVITY;
-    if (scan_type == ScanType::OpNotLike) selectivity = 1.0 - selectivity;
+    if (scan_type == ScanType::NotLike) selectivity = 1.0 - selectivity;
     clone->_row_count = _row_count * selectivity;
     return clone;
   }

--- a/src/lib/type_comparison.hpp
+++ b/src/lib/type_comparison.hpp
@@ -99,22 +99,22 @@ value_greater(L l, R r) {
 template <typename Functor>
 void with_comparator(const ScanType scan_type, const Functor& func) {
   switch (scan_type) {
-    case ScanType::OpEquals:
+    case ScanType::Equals:
       return func(std::equal_to<void>{});
 
-    case ScanType::OpNotEquals:
+    case ScanType::NotEquals:
       return func(std::not_equal_to<void>{});
 
-    case ScanType::OpLessThan:
+    case ScanType::LessThan:
       return func(std::less<void>{});
 
-    case ScanType::OpLessThanEquals:
+    case ScanType::LessThanEquals:
       return func(std::less_equal<void>{});
 
-    case ScanType::OpGreaterThan:
+    case ScanType::GreaterThan:
       return func(std::greater<void>{});
 
-    case ScanType::OpGreaterThanEquals:
+    case ScanType::GreaterThanEquals:
       return func(std::greater_equal<void>{});
 
     default:

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -162,17 +162,17 @@ class ValuePlaceholder {
 
 // TODO(anyone): integrate and replace with ExpressionType
 enum class ScanType {
-  OpEquals,
-  OpNotEquals,
-  OpLessThan,
-  OpLessThanEquals,
-  OpGreaterThan,
-  OpGreaterThanEquals,
-  OpBetween,  // Currently, OpBetween is not handled by a single scan. The LQPTranslator creates two scans.
-  OpLike,
-  OpNotLike,
-  OpIsNull,
-  OpIsNotNull
+  Equals,
+  NotEquals,
+  LessThan,
+  LessThanEquals,
+  GreaterThan,
+  GreaterThanEquals,
+  Between,  // Currently, OpBetween is not handled by a single scan. The LQPTranslator creates two scans.
+  Like,
+  NotLike,
+  IsNull,
+  IsNotNull
 };
 
 enum class ExpressionType {

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -26,7 +26,7 @@ class JoinNodeTest : public BaseTest {
     _join_node->set_right_child(_stored_table_node_b);
 
     _inner_join_node =
-        std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(ColumnID{0}, ColumnID{1}), ScanType::OpEquals);
+        std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(ColumnID{0}, ColumnID{1}), ScanType::Equals);
     _inner_join_node->set_left_child(_stored_table_node_a);
     _inner_join_node->set_right_child(_stored_table_node_b);
   }

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -54,7 +54,7 @@ TEST_F(LogicalQueryPlanTest, SimpleParentTest) {
   ASSERT_EQ(table_node->right_child(), nullptr);
   ASSERT_TRUE(table_node->parents().empty());
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, "a");
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, "a");
   predicate_node->set_left_child(table_node);
 
   ASSERT_EQ(table_node->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{predicate_node});
@@ -78,7 +78,7 @@ TEST_F(LogicalQueryPlanTest, SimpleParentTest) {
 TEST_F(LogicalQueryPlanTest, SimpleClearParentsTest) {
   const auto table_node = std::make_shared<StoredTableNode>("a");
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, "a");
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, "a");
   predicate_node->set_left_child(table_node);
 
   ASSERT_EQ(table_node->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{predicate_node});
@@ -101,7 +101,7 @@ TEST_F(LogicalQueryPlanTest, ChainSameNodesTest) {
   ASSERT_EQ(table_node->right_child(), nullptr);
   ASSERT_TRUE(table_node->parents().empty());
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, "a");
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, "a");
   predicate_node->set_left_child(table_node);
 
   ASSERT_EQ(table_node->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{predicate_node});
@@ -109,7 +109,7 @@ TEST_F(LogicalQueryPlanTest, ChainSameNodesTest) {
   ASSERT_EQ(predicate_node->right_child(), nullptr);
   ASSERT_TRUE(predicate_node->parents().empty());
 
-  const auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpEquals, "b");
+  const auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::Equals, "b");
   predicate_node_2->set_left_child(predicate_node);
 
   ASSERT_EQ(predicate_node->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{predicate_node_2});
@@ -130,7 +130,7 @@ TEST_F(LogicalQueryPlanTest, ChainSameNodesTest) {
 
 TEST_F(LogicalQueryPlanTest, TwoInputsTest) {
   const auto join_node = std::make_shared<JoinNode>(
-      JoinMode::Inner, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}), ScanType::OpEquals);
+      JoinMode::Inner, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}), ScanType::Equals);
 
   ASSERT_EQ(join_node->left_child(), nullptr);
   ASSERT_EQ(join_node->right_child(), nullptr);
@@ -152,7 +152,7 @@ TEST_F(LogicalQueryPlanTest, TwoInputsTest) {
 
 TEST_F(LogicalQueryPlanTest, AliasedSubqueryTest) {
   const auto table_node = std::make_shared<StoredTableNode>("a");
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, "a");
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, "a");
   predicate_node->set_left_child(table_node);
   predicate_node->set_alias(std::string("foo"));
 

--- a/src/test/logical_query_plan/predicate_node_test.cpp
+++ b/src/test/logical_query_plan/predicate_node_test.cpp
@@ -21,19 +21,19 @@ class PredicateNodeTest : public BaseTest {
 };
 
 TEST_F(PredicateNodeTest, Descriptions) {
-  auto predicate_a = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, 5);
+  auto predicate_a = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, 5);
   predicate_a->set_left_child(_table_node);
   EXPECT_EQ(predicate_a->description(), "[Predicate] table_a.i = 5");
 
-  auto predicate_b = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpNotEquals, 2.5);
+  auto predicate_b = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::NotEquals, 2.5);
   predicate_b->set_left_child(_table_node);
   EXPECT_EQ(predicate_b->description(), "[Predicate] table_a.f != 2.5");
 
-  auto predicate_c = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::OpBetween, 2.5, 10.0);
+  auto predicate_c = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::Between, 2.5, 10.0);
   predicate_c->set_left_child(_table_node);
   EXPECT_EQ(predicate_c->description(), "[Predicate] table_a.d BETWEEN 2.5 AND 10");
 
-  auto predicate_d = std::make_shared<PredicateNode>(ColumnID{3}, ScanType::OpEquals, "test");
+  auto predicate_d = std::make_shared<PredicateNode>(ColumnID{3}, ScanType::Equals, "test");
   predicate_d->set_left_child(_table_node);
   EXPECT_EQ(predicate_d->description(), "[Predicate] table_a.s = test");
 }

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -117,7 +117,7 @@ class OperatorsAggregateTest : public BaseTest {
 
       if (ref != INVALID_COLUMN_ID) {
         // also try a TableScan on every involved column
-        input = std::make_shared<TableScan>(in, ref, ScanType::OpGreaterThanEquals, 0);
+        input = std::make_shared<TableScan>(in, ref, ScanType::GreaterThanEquals, 0);
         input->execute();
       }
 
@@ -474,7 +474,7 @@ TEST_F(OperatorsAggregateTest, DictionarySingleAggregateCountWithNull) {
  */
 
 TEST_F(OperatorsAggregateTest, SingleAggregateMaxOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1, ColumnID{0}, ScanType::OpLessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1, ColumnID{0}, ScanType::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Max}}, {ColumnID{0}},
@@ -482,7 +482,7 @@ TEST_F(OperatorsAggregateTest, SingleAggregateMaxOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, TwoGroupbyAndTwoAggregateMinAvgOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_2, ColumnID{0}, ScanType::OpLessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_2, ColumnID{0}, ScanType::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{2}, AggregateFunction::Min}, {ColumnID{3}, AggregateFunction::Avg}},
@@ -491,7 +491,7 @@ TEST_F(OperatorsAggregateTest, TwoGroupbyAndTwoAggregateMinAvgOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, TwoGroupbySumOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_1, ColumnID{0}, ScanType::OpLessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_1, ColumnID{0}, ScanType::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{2}, AggregateFunction::Sum}}, {ColumnID{0}, ColumnID{1}},
@@ -499,7 +499,7 @@ TEST_F(OperatorsAggregateTest, TwoGroupbySumOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, TwoAggregateSumAvgOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_2, ColumnID{0}, ScanType::OpLessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_2, ColumnID{0}, ScanType::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Sum}, {ColumnID{2}, AggregateFunction::Avg}},
@@ -507,7 +507,7 @@ TEST_F(OperatorsAggregateTest, TwoAggregateSumAvgOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, DictionarySingleAggregateMinOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1_dict, ColumnID{0}, ScanType::OpLessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1_dict, ColumnID{0}, ScanType::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Min}}, {ColumnID{0}},
@@ -516,7 +516,7 @@ TEST_F(OperatorsAggregateTest, DictionarySingleAggregateMinOnRef) {
 
 TEST_F(OperatorsAggregateTest, JoinThenAggregate) {
   auto join = std::make_shared<JoinHash>(_table_wrapper_3_1, _table_wrapper_3_2, JoinMode::Inner,
-                                         std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                         std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->test_output(join, {}, {ColumnID{0}, ColumnID{3}}, "src/test/tables/aggregateoperator/join_2gb_0agg/result.tbl",
@@ -526,7 +526,7 @@ TEST_F(OperatorsAggregateTest, JoinThenAggregate) {
 TEST_F(OperatorsAggregateTest, OuterJoinThenAggregate) {
   auto join =
       std::make_shared<JoinNestedLoop>(_table_wrapper_join_1, _table_wrapper_join_2, JoinMode::Outer,
-                                       std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpLessThan);
+                                       std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::LessThan);
   join->execute();
 
   this->test_output(join, {{ColumnID{1}, AggregateFunction::Min}}, {ColumnID{0}},

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -43,7 +43,7 @@ void OperatorsDeleteTest::helper(bool commit) {
   auto transaction_context = TransactionManager::get().new_transaction_context();
 
   // Selects two out of three rows.
-  auto table_scan = std::make_shared<TableScan>(_gt, ColumnID{0}, ScanType::OpGreaterThan, "456.7");
+  auto table_scan = std::make_shared<TableScan>(_gt, ColumnID{0}, ScanType::GreaterThan, "456.7");
 
   table_scan->execute();
 
@@ -93,9 +93,9 @@ TEST_F(OperatorsDeleteTest, DetectDirtyWrite) {
   auto t1_context = TransactionManager::get().new_transaction_context();
   auto t2_context = TransactionManager::get().new_transaction_context();
 
-  auto table_scan1 = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::OpEquals, "123");
-  auto expected_result = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::OpNotEquals, "123");
-  auto table_scan2 = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::OpLessThan, "1234");
+  auto table_scan1 = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::Equals, "123");
+  auto expected_result = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::NotEquals, "123");
+  auto table_scan2 = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::LessThan, "1234");
 
   table_scan1->execute();
   expected_result->execute();

--- a/src/test/operators/export_binary_test.cpp
+++ b/src/test/operators/export_binary_test.cpp
@@ -218,7 +218,7 @@ TEST_F(OperatorsExportBinaryTest, AllTypesReferenceColumn) {
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
   table_wrapper->execute();
 
-  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{1}, ScanType::OpNotEquals, 5);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{1}, ScanType::NotEquals, 5);
   scan->execute();
 
   auto ex = std::make_shared<opossum::ExportBinary>(scan, filename);

--- a/src/test/operators/export_csv_test.cpp
+++ b/src/test/operators/export_csv_test.cpp
@@ -135,7 +135,7 @@ TEST_F(OperatorsExportCsvTest, ReferenceColumn) {
 
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
   table_wrapper->execute();
-  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::OpLessThan, 5);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::LessThan, 5);
   scan->execute();
   auto ex = std::make_shared<opossum::ExportCsv>(scan, filename);
   ex->execute();

--- a/src/test/operators/index_scan_test.cpp
+++ b/src/test/operators/index_scan_test.cpp
@@ -94,13 +94,13 @@ TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanOnDataTable) {
   const auto right_values2 = std::vector<AllTypeVariant>{AllTypeVariant{9}};
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = {104};
-  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpLessThan] = {100, 102};
-  tests[ScanType::OpLessThanEquals] = {100, 102, 104};
-  tests[ScanType::OpGreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpGreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpBetween] = {104, 106, 108};
+  tests[ScanType::Equals] = {104};
+  tests[ScanType::NotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::LessThan] = {100, 102};
+  tests[ScanType::LessThanEquals] = {100, 102, 104};
+  tests[ScanType::GreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::GreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::Between] = {104, 106, 108};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids, test.first,
@@ -120,12 +120,12 @@ TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanValueGreaterThanMaxDictionary
   const auto right_values2 = std::vector<AllTypeVariant>{AllTypeVariant{34}};
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = no_rows;
-  tests[ScanType::OpNotEquals] = all_rows;
-  tests[ScanType::OpLessThan] = all_rows;
-  tests[ScanType::OpLessThanEquals] = all_rows;
-  tests[ScanType::OpGreaterThan] = no_rows;
-  tests[ScanType::OpGreaterThanEquals] = no_rows;
+  tests[ScanType::Equals] = no_rows;
+  tests[ScanType::NotEquals] = all_rows;
+  tests[ScanType::LessThan] = all_rows;
+  tests[ScanType::LessThanEquals] = all_rows;
+  tests[ScanType::GreaterThan] = no_rows;
+  tests[ScanType::GreaterThanEquals] = no_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids, test.first,
@@ -144,12 +144,12 @@ TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanValueLessThanMinDictionaryVal
   const auto right_values2 = std::vector<AllTypeVariant>{AllTypeVariant{34}};
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = no_rows;
-  tests[ScanType::OpNotEquals] = all_rows;
-  tests[ScanType::OpLessThan] = no_rows;
-  tests[ScanType::OpLessThanEquals] = no_rows;
-  tests[ScanType::OpGreaterThan] = all_rows;
-  tests[ScanType::OpGreaterThanEquals] = all_rows;
+  tests[ScanType::Equals] = no_rows;
+  tests[ScanType::NotEquals] = all_rows;
+  tests[ScanType::LessThan] = no_rows;
+  tests[ScanType::LessThanEquals] = no_rows;
+  tests[ScanType::GreaterThan] = all_rows;
+  tests[ScanType::GreaterThanEquals] = all_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids, test.first,
@@ -164,7 +164,7 @@ TYPED_TEST(OperatorsIndexScanTest, OperatorName) {
   const auto right_values = std::vector<AllTypeVariant>(this->_column_ids.size(), AllTypeVariant{0});
 
   auto scan = std::make_shared<opossum::IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids,
-                                                   ScanType::OpGreaterThanEquals, right_values);
+                                                   ScanType::GreaterThanEquals, right_values);
 
   EXPECT_EQ(scan->name(), "IndexScan");
 }
@@ -173,7 +173,7 @@ TYPED_TEST(OperatorsIndexScanTest, InvalidIndexTypeThrows) {
   const auto right_values = std::vector<AllTypeVariant>(this->_column_ids.size(), AllTypeVariant{0});
 
   auto scan = std::make_shared<opossum::IndexScan>(this->_table_wrapper, ColumnIndexType::Invalid, this->_column_ids,
-                                                   ScanType::OpGreaterThan, right_values);
+                                                   ScanType::GreaterThan, right_values);
   EXPECT_THROW(scan->execute(), std::logic_error);
 }
 

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -23,7 +23,7 @@
 namespace opossum {
 
 /*
-This contains the tests for Join implementations that only implement ScanType::OpEquals.
+This contains the tests for Join implementations that only implement ScanType::Equals.
 */
 
 template <typename T>
@@ -37,26 +37,26 @@ TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
   if (!IS_DEBUG) return;
   EXPECT_THROW(
       std::make_shared<JoinHash>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
-                                 std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpGreaterThan),
+                                 std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::GreaterThan),
       std::logic_error);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
+      ScanType::Equals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinOnString) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Left, "src/test/tables/joinoperators/string_left_join.tbl", 1);
+      ScanType::Equals, JoinMode::Left, "src/test/tables/joinoperators/string_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
+      ScanType::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, OuterJoin) {
@@ -65,280 +65,280 @@ TYPED_TEST(JoinEquiTest, OuterJoin) {
   }
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+      ScanType::Equals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinOnString) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/string_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerValueDictJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictValueJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerValueDictRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictValueRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefDictJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefDictJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinBig) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoinFilteredBig) {
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_c->execute();
-  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::OpGreaterThanEquals, 6);
+  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::GreaterThanEquals, 6);
   scan_d->execute();
 
   this->template test_join_output<TypeParam>(scan_c, scan_d, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, SelfJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_a, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Self, "src/test/tables/joinoperators/int_self_join.tbl", 1);
+      ScanType::Equals, JoinMode::Self, "src/test/tables/joinoperators/int_self_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndDictionaryColumns) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c_dict, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndReferenceColumns) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeft) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner,
-                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, scan_c, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals, JoinMode::Inner,
+      join, scan_c, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_ref_ref_ref_left.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceRight) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner,
-                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_c, join, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals, JoinMode::Inner,
+      scan_c, join, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_ref_ref_ref_right.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeftFiltered) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::OpGreaterThan, 6);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::GreaterThan, 6);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner,
-                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, scan_c, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals, JoinMode::Inner,
+      join, scan_c, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_ref_ref_ref_left_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnValue) {
   auto join = std::make_shared<TypeParam>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Inner,
-                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_multijoin_val_val_val_left.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnRefOuter) {
   auto join = std::make_shared<TypeParam>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Left,
-                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_multijoin_val_val_val_leftouter.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MixNestedLoopAndHash) {
   auto join =
       std::make_shared<JoinNestedLoop>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Left,
-                                       std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                       std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_multijoin_nlj_hash.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MixHashAndNestedLoop) {
   auto join = std::make_shared<JoinHash>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Left,
-                                         std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                         std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      join, this->_table_wrapper_h, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_multijoin_nlj_hash.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      this->_table_wrapper_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoinEmptyRefColumn) {
   // scan that returns no rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::Equals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Right, "src/test/tables/joinoperators/int_join_empty.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
   // scan that returns no rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::Equals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_b, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      this->_table_wrapper_b, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Left, "src/test/tables/joinoperators/int_join_empty_left.tbl", 1);
 }
 
@@ -346,16 +346,16 @@ TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
 TYPED_TEST(JoinEquiTest, DISABLED_JoinOnUnion /* #160 */) {
   //  Filtering to generate RefColumns
   auto filtered_left =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_e, ColumnID{0}, ScanType::OpLessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_e, ColumnID{0}, ScanType::LessThanEquals, 10);
   filtered_left->execute();
   auto filtered_left2 =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::OpLessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::LessThanEquals, 10);
   filtered_left2->execute();
   auto filtered_right =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::OpLessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::LessThanEquals, 10);
   filtered_right->execute();
   auto filtered_right2 =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::OpLessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::LessThanEquals, 10);
   filtered_right2->execute();
 
   // Union left and right
@@ -365,7 +365,7 @@ TYPED_TEST(JoinEquiTest, DISABLED_JoinOnUnion /* #160 */) {
   union_right->execute();
 
   this->template test_join_output<TypeParam>(
-      union_left, union_right, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      union_left, union_right, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/expected_join_result_1.tbl", 1);
 }
 

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -21,7 +21,7 @@ namespace opossum {
 
 /*
 This contains the tests for Join implementations that
-implement all operators, not just ScanType::OpEquals.
+implement all operators, not just ScanType::Equals.
 */
 
 template <typename T>
@@ -35,222 +35,222 @@ TYPED_TEST(JoinFullTest, CrossJoin) {
   if (!IS_DEBUG) return;
 
   EXPECT_THROW(std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Cross,
-                                           std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals),
+                                           std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals),
                std::logic_error);
 }
 
 TYPED_TEST(JoinFullTest, LeftJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
+      ScanType::Equals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, LeftJoinOnString) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Left, "src/test/tables/joinoperators/string_left_join.tbl", 1);
+      ScanType::Equals, JoinMode::Left, "src/test/tables/joinoperators/string_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, RightJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
+      ScanType::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinOnString) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/string_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinSingleChunk) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_e, this->_table_wrapper_f, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_single_chunk.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_single_chunk.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::OpGreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinBig) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c, this->_table_wrapper_d, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFilteredBig) {
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_c->execute();
-  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::OpGreaterThanEquals, 6);
+  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::GreaterThanEquals, 6);
   scan_d->execute();
 
   this->template test_join_output<TypeParam>(scan_c, scan_d, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{1}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+      ScanType::Equals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoinWithNull) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_m, this->_table_wrapper_n, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join_null.tbl", 1);
+      ScanType::Equals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoinDict) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+      ScanType::Equals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SelfJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_a, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Self, "src/test/tables/joinoperators/int_self_join.tbl", 1);
+      ScanType::Equals, JoinMode::Self, "src/test/tables/joinoperators/int_self_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
+      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
+      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoinDict) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
+      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
+      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_j, this->_table_wrapper_i, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join_2.tbl", 1);
+      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerOuterJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_k, this->_table_wrapper_l, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThan, JoinMode::Outer, "src/test/tables/joinoperators/int_smaller_outer_join.tbl", 1);
+      ScanType::LessThan, JoinMode::Outer, "src/test/tables/joinoperators/int_smaller_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_smallerequal_inner_join.tbl", 1);
+      ScanType::LessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_smallerequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
                                              std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-                                             ScanType::OpLessThanEquals, JoinMode::Inner,
+                                             ScanType::LessThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_smallerequal_inner_join.tbl", 1);
 }
 
@@ -258,64 +258,64 @@ TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_j, this->_table_wrapper_i,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpLessThanEquals, JoinMode::Inner,
+                                             ScanType::LessThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_smallerequal_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualOuterJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_k, this->_table_wrapper_l, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThanEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_smallerequal_outer_join.tbl", 1);
+      ScanType::LessThanEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_smallerequal_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoin) {
   // Joining two Integer Column
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
+      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
+      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoinDict) {
   // Joining two Integer Column
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
+      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
+      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_i, this->_table_wrapper_j, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpGreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join_2.tbl", 1);
+      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterOuterJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_l, this->_table_wrapper_k, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpGreaterThan, JoinMode::Outer, "src/test/tables/joinoperators/int_greater_outer_join.tbl", 1);
+      ScanType::GreaterThan, JoinMode::Outer, "src/test/tables/joinoperators/int_greater_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             ScanType::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
                                              std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             ScanType::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
 }
 
@@ -323,20 +323,20 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoinDict) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             ScanType::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             ScanType::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualOuterJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_l, this->_table_wrapper_k,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpGreaterThanEquals, JoinMode::Outer,
+                                             ScanType::GreaterThanEquals, JoinMode::Outer,
                                              "src/test/tables/joinoperators/int_greaterequal_outer_join.tbl", 1);
 }
 
@@ -344,7 +344,7 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_i, this->_table_wrapper_j,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpGreaterThanEquals, JoinMode::Inner,
+                                             ScanType::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_greaterequal_inner_join_2.tbl", 1);
 }
 
@@ -352,74 +352,74 @@ TYPED_TEST(JoinFullTest, NotEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
+      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
+      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, NotEqualInnerJoinDict) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
+      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{1}, ColumnID{1}),
-      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
+      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnMixedValueAndDictionaryColumns) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_c_dict, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndValue) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      scan_a, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnValueAndReferenceColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThan, 100);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThan, 100);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpNotEquals,
+      this->_table_wrapper_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::NotEquals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinLessThanOnDictAndDict) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpLessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_leq_dict.tbl", 1);
+      ScanType::LessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_leq_dict.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndDict) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_a, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals,
+      scan_a, this->_table_wrapper_b_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnDictAndReferenceColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::OpGreaterThan, 100);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThan, 100);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpNotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
+      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
 }
 
 }  // namespace opossum

--- a/src/test/operators/join_null_test.cpp
+++ b/src/test/operators/join_null_test.cpp
@@ -54,95 +54,95 @@ TYPED_TEST_CASE(JoinNullTest, JoinNullTypes);
 TYPED_TEST(JoinNullTest, InnerJoinWithNull) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_a_null, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_a_null_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNull2) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_m, this->_table_wrapper_n, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullDict2) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_m_dict, this->_table_wrapper_n_dict, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
+      ScanType::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullRef2) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(scan_a, scan_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Inner,
+                                             ScanType::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_null_ref.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsOuter) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_null, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
+      ScanType::Equals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsOuterDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Left,
+                                             ScanType::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsInner) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_b, this->_table_wrapper_a_null, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
+      ScanType::Equals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsInnerDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Left,
+                                             ScanType::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsOuter) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_b, this->_table_wrapper_a_null, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
+      ScanType::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsOuterDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Right,
+                                             ScanType::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsInner) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_null, this->_table_wrapper_b, std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-      ScanType::OpEquals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
+      ScanType::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsInnerDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Right,
+                                             ScanType::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, SelfJoinWithNullDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_a_null_dict,
                                              std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}),
-                                             ScanType::OpEquals, JoinMode::Self,
+                                             ScanType::Equals, JoinMode::Self,
                                              "src/test/tables/joinoperators/int_float_with_null_self_join.tbl", 1);
 }
 

--- a/src/test/operators/join_semi_anti_test.cpp
+++ b/src/test/operators/join_semi_anti_test.cpp
@@ -40,45 +40,45 @@ class JoinSemiAntiTest : public JoinTest {
 };
 
 TEST_F(JoinSemiAntiTest, SemiJoin) {
-  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, ScanType::OpEquals,
+  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, ScanType::Equals,
                              JoinMode::Semi, "src/test/tables/int.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, SemiJoinRefColumns) {
-  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
 
-  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
-  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, ScanType::OpEquals, JoinMode::Semi,
+  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, ScanType::Equals, JoinMode::Semi,
                              "src/test/tables/int.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, SemiJoinBig) {
   test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}},
-                             ScanType::OpEquals, JoinMode::Semi, "src/test/tables/joinoperators/semi_result.tbl", 1);
+                             ScanType::Equals, JoinMode::Semi, "src/test/tables/joinoperators/semi_result.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoin) {
-  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, ScanType::OpEquals,
+  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, ScanType::Equals,
                              JoinMode::Anti, "src/test/tables/joinoperators/anti_int4.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoinRefColumns) {
-  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_a->execute();
 
-  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan_b->execute();
 
-  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, ScanType::OpEquals, JoinMode::Anti,
+  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, ScanType::Equals, JoinMode::Anti,
                              "src/test/tables/joinoperators/anti_int4.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoinBig) {
   test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}},
-                             ScanType::OpEquals, JoinMode::Anti, "src/test/tables/joinoperators/anti_result.tbl", 1);
+                             ScanType::Equals, JoinMode::Anti, "src/test/tables/joinoperators/anti_result.tbl", 1);
 }
 
 }  // namespace opossum

--- a/src/test/operators/limit_test.cpp
+++ b/src/test/operators/limit_test.cpp
@@ -70,7 +70,7 @@ TEST_F(OperatorsLimitTest, Limit1ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit1ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_1();
@@ -83,7 +83,7 @@ TEST_F(OperatorsLimitTest, Limit2ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit2ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_2();
@@ -96,7 +96,7 @@ TEST_F(OperatorsLimitTest, Limit4ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit4ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_4();
@@ -109,7 +109,7 @@ TEST_F(OperatorsLimitTest, Limit10ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit10ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_10();

--- a/src/test/operators/product_test.cpp
+++ b/src/test/operators/product_test.cpp
@@ -39,7 +39,7 @@ TEST_F(OperatorsProductTest, ValueColumns) {
 
 TEST_F(OperatorsProductTest, ReferenceAndValueColumns) {
   auto table_scan =
-      std::make_shared<opossum::TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+      std::make_shared<opossum::TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
   table_scan->execute();
 
   auto product = std::make_shared<Product>(table_scan, _table_wrapper_b);

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -249,7 +249,7 @@ TEST_F(OperatorsProjectionTest, VariableArithmeticWithRefProjection) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_int_int_addition.tbl", 2);
 
   // creates ref_columns
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper_int_dict, ColumnID{0}, ScanType::OpGreaterThan, "0");
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper_int_dict, ColumnID{0}, ScanType::GreaterThan, "0");
   table_scan->execute();
 
   auto projection = std::make_shared<Projection>(table_scan, _sum_a_b_c_expr);
@@ -277,7 +277,7 @@ TEST_F(OperatorsProjectionTest, ValueColumnCount) {
 
 // TODO(anyone): refactor test
 TEST_F(OperatorsProjectionTest, ReferenceColumnCount) {
-  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpEquals, 1234);
+  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::Equals, 1234);
   scan->execute();
 
   auto projection_1 = std::make_shared<opossum::Projection>(scan, _a_b_expr);

--- a/src/test/operators/recreation_test.cpp
+++ b/src/test/operators/recreation_test.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(RecreationTestJoin, RecreationJoin) {
 
   // build and execute join
   auto join = std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
-                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                          std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   EXPECT_NE(join, nullptr) << "Could not build Join";
   join->execute();
   EXPECT_TABLE_EQ_UNORDERED(join->get_output(), expected_result);
@@ -147,7 +147,7 @@ TEST_F(RecreationTest, RecreationTableScan) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
 
   // build and execute table scan
-  auto scan = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  auto scan = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -57,7 +57,7 @@ TEST_F(OperatorsSortTest, AscendingSortOFilteredColumn) {
   auto input = std::make_shared<TableWrapper>(load_table("src/test/tables/int_float.tbl", 1));
   input->execute();
 
-  auto scan = std::make_shared<TableScan>(input, ColumnID{0}, ScanType::OpNotEquals, 123);
+  auto scan = std::make_shared<TableScan>(input, ColumnID{0}, ScanType::NotEquals, 123);
   scan->execute();
 
   auto sort = std::make_shared<Sort>(scan, ColumnID{0}, OrderByMode::Ascending, 2u);
@@ -208,7 +208,7 @@ TEST_F(OperatorsSortTest, SortTableWithRefandValueColumns) {
   table_wrapper1->execute();
   table_wrapper2->execute();
 
-  auto ts2 = std::make_shared<TableScan>(table_wrapper2, ColumnID{0}, ScanType::OpGreaterThan, 12);
+  auto ts2 = std::make_shared<TableScan>(table_wrapper2, ColumnID{0}, ScanType::GreaterThan, 12);
   ts2->execute();
 
   auto union_all = std::make_shared<UnionAll>(table_wrapper1, ts2);

--- a/src/test/operators/table_scan_like_test.cpp
+++ b/src/test/operators/table_scan_like_test.cpp
@@ -46,37 +46,37 @@ class OperatorsTableScanLikeTest : public BaseTest {
 };
 
 /*
-    Tests for operator ScanType::OpLike
+    Tests for operator ScanType::Like
     The **%** sign is used to define wildcards (missing letters) both before and after the search pattern.
     We expect the operator to be run on a string column using a string value with wildcard.
 */
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNonStringColumn) {
-  auto scan = std::make_shared<TableScan>(_gt, ColumnID{0}, ScanType::OpLike, "%test");
+  auto scan = std::make_shared<TableScan>(_gt, ColumnID{0}, ScanType::Like, "%test");
   EXPECT_THROW(scan->execute(), std::exception);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNonStringValue) {
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, 1234);
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, 1234);
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 1u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyString) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeCaseInsensitivity) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "dAmpF%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "dAmpF%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
@@ -84,132 +84,132 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeCaseInsensitivity) {
 TEST_F(OperatorsTableScanLikeTest, ScanLikeUnderscoreWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 
-// ScanType::OpLike - Starting
+// ScanType::Like - Starting
 TEST_F(OperatorsTableScanLikeTest, ScanLike_Starting) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "Dampf%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "Dampf%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeStartingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "Dampf%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "Dampf%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeStartingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::OpGreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::OpLike, "Dampf%");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "Dampf%");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
-// ScanType::OpLike - Ending
+// ScanType::Like - Ending
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEnding) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "%gesellschaft");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%gesellschaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEndingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "%gesellschaft");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%gesellschaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEndingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::OpGreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::OpLike, "%gesellschaft");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "%gesellschaft");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
 
-// ScanType::OpLike - Containing Wildcard
+// ScanType::Like - Containing Wildcard
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing_wildcard.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "Schiff%schaft");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "Schiff%schaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 
-// ScanType::OpLike - Containing
+// ScanType::Like - Containing
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContaining) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "%schifffahrtsgesellschaft%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "%schifffahrtsgesellschaft%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::OpGreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::OpLike, "%schifffahrtsgesellschaft%");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "%schifffahrtsgesellschaft%");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
-// ScanType::OpLike - Not Found
+// ScanType::Like - Not Found
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFound) {
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpLike, "%not_there%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%not_there%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFoundOnDictColumn) {
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpLike, "%not_there%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%not_there%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFoundOnReferencedDictColumn) {
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::OpGreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::OpLike, "%not_there%");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "%not_there%");
   scan2->execute();
   EXPECT_EQ(scan2->get_output()->row_count(), 0u);
 }
-// ScanType::OpNotLike
+// ScanType::NotLike
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyString) {
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpNotLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::NotLike, "%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyStringOnDict) {
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpNotLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::NotLike, "%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRows) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpNotLike, "%foo%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::NotLike, "%foo%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRowsOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpNotLike, "%foo%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::NotLike, "%foo%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
@@ -217,14 +217,14 @@ TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRowsOnDict) {
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_not_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::OpNotLike, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::NotLike, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcardOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_not_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::OpNotLike, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::NotLike, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -206,17 +206,17 @@ class OperatorsTableScanTest : public BaseTest {
 TEST_F(OperatorsTableScanTest, DoubleScan) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered.tbl", 2);
 
-  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
   scan_1->execute();
 
-  auto scan_2 = std::make_shared<TableScan>(scan_1, ColumnID{1}, ScanType::OpLessThan, 457.9);
+  auto scan_2 = std::make_shared<TableScan>(scan_1, ColumnID{1}, ScanType::LessThan, 457.9);
   scan_2->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_2->get_output(), expected_result);
 }
 
 TEST_F(OperatorsTableScanTest, EmptyResultScan) {
-  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, 90000);
+  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, 90000);
   scan_1->execute();
 
   for (auto i = ChunkID{0}; i < scan_1->get_output()->chunk_count(); i++)
@@ -226,7 +226,7 @@ TEST_F(OperatorsTableScanTest, EmptyResultScan) {
 TEST_F(OperatorsTableScanTest, SingleScanReturnsCorrectRowCount) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
 
-  auto scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  auto scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
   scan->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
@@ -236,20 +236,20 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = {104};
-  tests[ScanType::OpNotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpLessThan] = {100, 102};
-  tests[ScanType::OpLessThanEquals] = {100, 102, 104};
-  tests[ScanType::OpGreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpGreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpBetween] = {};  // Will throw
-  tests[ScanType::OpIsNull] = {};
-  tests[ScanType::OpIsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::Equals] = {104};
+  tests[ScanType::NotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::LessThan] = {100, 102};
+  tests[ScanType::LessThanEquals] = {100, 102, 104};
+  tests[ScanType::GreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::GreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::Between] = {};  // Will throw
+  tests[ScanType::IsNull] = {};
+  tests[ScanType::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 4);
 
-    if (test.first == ScanType::OpBetween) {
+    if (test.first == ScanType::Between) {
       EXPECT_THROW(scan->execute(), std::logic_error);
       continue;
     }
@@ -264,23 +264,23 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = {104};
-  tests[ScanType::OpNotEquals] = {100, 102, 106};
-  tests[ScanType::OpLessThan] = {100, 102};
-  tests[ScanType::OpLessThanEquals] = {100, 102, 104};
-  tests[ScanType::OpGreaterThan] = {106};
-  tests[ScanType::OpGreaterThanEquals] = {104, 106};
-  tests[ScanType::OpBetween] = {};  // Will throw
-  tests[ScanType::OpIsNull] = {};
-  tests[ScanType::OpIsNotNull] = {100, 102, 104, 106};
+  tests[ScanType::Equals] = {104};
+  tests[ScanType::NotEquals] = {100, 102, 106};
+  tests[ScanType::LessThan] = {100, 102};
+  tests[ScanType::LessThanEquals] = {100, 102, 104};
+  tests[ScanType::GreaterThan] = {106};
+  tests[ScanType::GreaterThanEquals] = {104, 106};
+  tests[ScanType::Between] = {};  // Will throw
+  tests[ScanType::IsNull] = {};
+  tests[ScanType::IsNotNull] = {100, 102, 104, 106};
 
   for (const auto& test : tests) {
-    auto scan1 = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{1}, ScanType::OpLessThan, 108);
+    auto scan1 = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{1}, ScanType::LessThan, 108);
     scan1->execute();
 
     auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{0}, test.first, 4);
 
-    if (test.first == ScanType::OpBetween) {
+    if (test.first == ScanType::Between) {
       EXPECT_THROW(scan2->execute(), std::logic_error);
       continue;
     }
@@ -295,7 +295,7 @@ TEST_F(OperatorsTableScanTest, ScanPartiallyCompressed) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered.tbl", 2);
 
   auto table_wrapper = get_table_op_part_dict();
-  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::OpLessThan, 10);
+  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::LessThan, 10);
   scan_1->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_1->get_output(), expected_result);
@@ -305,7 +305,7 @@ TEST_F(OperatorsTableScanTest, ScanWeirdPosList) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered_onlyodd.tbl", 2);
 
   auto table_wrapper = get_table_op_filtered();
-  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::OpLessThan, 10);
+  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::LessThan, 10);
   scan_1->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_1->get_output(), expected_result);
@@ -316,12 +316,12 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValu
   const auto no_rows = std::vector<AllTypeVariant>{};
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = no_rows;
-  tests[ScanType::OpNotEquals] = all_rows;
-  tests[ScanType::OpLessThan] = all_rows;
-  tests[ScanType::OpLessThanEquals] = all_rows;
-  tests[ScanType::OpGreaterThan] = no_rows;
-  tests[ScanType::OpGreaterThanEquals] = no_rows;
+  tests[ScanType::Equals] = no_rows;
+  tests[ScanType::NotEquals] = all_rows;
+  tests[ScanType::LessThan] = all_rows;
+  tests[ScanType::LessThanEquals] = all_rows;
+  tests[ScanType::GreaterThan] = no_rows;
+  tests[ScanType::GreaterThanEquals] = no_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 30);
@@ -336,12 +336,12 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) 
   const auto no_rows = std::vector<AllTypeVariant>{};
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = no_rows;
-  tests[ScanType::OpNotEquals] = all_rows;
-  tests[ScanType::OpLessThan] = no_rows;
-  tests[ScanType::OpLessThanEquals] = no_rows;
-  tests[ScanType::OpGreaterThan] = all_rows;
-  tests[ScanType::OpGreaterThanEquals] = all_rows;
+  tests[ScanType::Equals] = no_rows;
+  tests[ScanType::NotEquals] = all_rows;
+  tests[ScanType::LessThan] = no_rows;
+  tests[ScanType::LessThanEquals] = no_rows;
+  tests[ScanType::GreaterThan] = all_rows;
+  tests[ScanType::GreaterThanEquals] = all_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0} /* "a" */, test.first, -10);
@@ -358,7 +358,7 @@ TEST_F(OperatorsTableScanTest, ScanOnIntValueColumnWithFloatColumnWithNullValues
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -372,7 +372,7 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntValueColumnWithFloatColumnWith
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -387,7 +387,7 @@ TEST_F(OperatorsTableScanTest, ScanOnIntDictColumnWithFloatColumnWithNullValues)
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -402,7 +402,7 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntDictColumnWithFloatColumnWithN
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::OpGreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -413,14 +413,14 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
   // scanning for a value that is around the dictionary's bounds
 
   std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::OpEquals] = {100};
-  tests[ScanType::OpLessThan] = {};
-  tests[ScanType::OpLessThanEquals] = {100};
-  tests[ScanType::OpGreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpGreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpNotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::OpIsNull] = {};
-  tests[ScanType::OpIsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::Equals] = {100};
+  tests[ScanType::LessThan] = {};
+  tests[ScanType::LessThanEquals] = {100};
+  tests[ScanType::GreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::GreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::NotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[ScanType::IsNull] = {};
+  tests[ScanType::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);
@@ -431,12 +431,12 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
 }
 
 TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThan, 12345);
+  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, 12345);
   scan_1->execute();
   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(0));
 
   // scan_1 produced an empty result
-  auto scan_2 = std::make_shared<opossum::TableScan>(scan_1, ColumnID{1}, ScanType::OpEquals, 456.7);
+  auto scan_2 = std::make_shared<opossum::TableScan>(scan_1, ColumnID{1}, ScanType::Equals, 456.7);
   scan_2->execute();
 
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(0));
@@ -445,7 +445,7 @@ TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
 TEST_F(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
   // 2**8 + 1 values require a data type of 16bit.
   const auto table_wrapper_dict_16 = get_table_op_with_n_dict_entries((1 << 8) + 1);
-  auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, ScanType::OpGreaterThan, 200);
+  auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, ScanType::GreaterThan, 200);
   scan_1->execute();
 
   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(57));
@@ -453,14 +453,14 @@ TEST_F(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
   // 2**16 + 1 values require a data type of 32bit.
   const auto table_wrapper_dict_32 = get_table_op_with_n_dict_entries((1 << 16) + 1);
   auto scan_2 =
-      std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::OpGreaterThan, 65500);
+      std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::GreaterThan, 65500);
   scan_2->execute();
 
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
 }
 
 TEST_F(OperatorsTableScanTest, OperatorName) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
 
   EXPECT_EQ(scan_1->name(), "TableScan");
 }
@@ -470,7 +470,7 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnValueColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::OpIsNull, {12, 123}}, {ScanType::OpIsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -483,7 +483,7 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnDictColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::OpIsNull, {12, 123}}, {ScanType::OpIsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -494,8 +494,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnValueColumnWithoutNulls) {
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::OpIsNull, {}},
-                                                                     {ScanType::OpIsNotNull, {12345, 123, 1234}}};
+  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {}},
+                                                                     {ScanType::IsNotNull, {12345, 123, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -506,8 +506,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumnWithoutNu
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::OpIsNull, {}},
-                                                                     {ScanType::OpIsNotNull, {12345, 123, 1234}}};
+  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {}},
+                                                                     {ScanType::IsNotNull, {12345, 123, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -519,7 +519,7 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::OpIsNull, {12, 123}}, {ScanType::OpIsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -532,7 +532,7 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedDictColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::OpIsNull, {12, 123}}, {ScanType::OpIsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -543,8 +543,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedValueCo
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::OpIsNull, {123, 1234}},
-                                                                     {ScanType::OpIsNotNull, {12345, NULL_VALUE}}};
+  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {123, 1234}},
+                                                                     {ScanType::IsNotNull, {12345, NULL_VALUE}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -555,16 +555,16 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedDictCol
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::OpIsNull, {123, 1234}},
-                                                                     {ScanType::OpIsNotNull, {12345, NULL_VALUE}}};
+  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {123, 1234}},
+                                                                     {ScanType::IsNotNull, {12345, NULL_VALUE}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
 
 TEST_F(OperatorsTableScanTest, NullSemantics) {
   const auto scan_types =
-      std::vector<ScanType>({ScanType::OpEquals, ScanType::OpNotEquals, ScanType::OpLessThan,
-                             ScanType::OpLessThanEquals, ScanType::OpGreaterThan, ScanType::OpGreaterThanEquals});
+      std::vector<ScanType>({ScanType::Equals, ScanType::NotEquals, ScanType::LessThan,
+                             ScanType::LessThanEquals, ScanType::GreaterThan, ScanType::GreaterThanEquals});
 
   for (auto scan_type : scan_types) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_null, ColumnID{0}, scan_type, NULL_VALUE);

--- a/src/test/operators/union_positions_test.cpp
+++ b/src/test/operators/union_positions_test.cpp
@@ -36,8 +36,8 @@ TEST_F(UnionPositionsTest, SelfUnionSimple) {
 
   auto get_table_a_op = std::make_shared<GetTable>("10_ints");
   auto get_table_b_op = std::make_shared<GetTable>("10_ints");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::OpGreaterThan, 24);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::OpGreaterThan, 24);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::GreaterThan, 24);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::GreaterThan, 24);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op});
 
@@ -61,8 +61,8 @@ TEST_F(UnionPositionsTest, SelfUnionExlusiveRanges) {
 
   auto get_table_a_op = std::make_shared<GetTable>("10_ints");
   auto get_table_b_op = std::make_shared<GetTable>("10_ints");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::OpLessThan, 10);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::OpGreaterThan, 200);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::LessThan, 10);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::GreaterThan, 200);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -80,8 +80,8 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRanges) {
 
   auto get_table_a_op = std::make_shared<GetTable>("10_ints");
   auto get_table_b_op = std::make_shared<GetTable>("10_ints");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::OpGreaterThan, 20);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::OpLessThan, 100);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::GreaterThan, 20);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::LessThan, 100);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -96,8 +96,8 @@ TEST_F(UnionPositionsTest, EarlyResultLeft) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::OpLessThan, 12346);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::OpLessThan, 0);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::LessThan, 12346);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::LessThan, 0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -114,8 +114,8 @@ TEST_F(UnionPositionsTest, EarlyResultRight) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::OpLessThan, 0);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::OpLessThan, 12346);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::LessThan, 0);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::LessThan, 12346);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -134,8 +134,8 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRangesMultipleColumns) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::OpGreaterThan, 12345);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{1}, ScanType::OpLessThan, 400.0);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::GreaterThan, 12345);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{1}, ScanType::LessThan, 400.0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -181,12 +181,12 @@ TEST_F(UnionPositionsTest, MultipleReferencedTables) {
   auto get_table_c_op = std::make_shared<GetTable>("int_float4");
   auto get_table_d_op = std::make_shared<GetTable>("int_int");
   auto join_a = std::make_shared<JoinNestedLoop>(get_table_a_op, get_table_b_op, JoinMode::Inner,
-                                                 std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                                 std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   auto join_b = std::make_shared<JoinNestedLoop>(get_table_c_op, get_table_d_op, JoinMode::Inner,
-                                                 std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                                 std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
 
-  auto table_scan_a_op = std::make_shared<TableScan>(join_a, ColumnID{3}, ScanType::OpGreaterThanEquals, 2);
-  auto table_scan_b_op = std::make_shared<TableScan>(join_b, ColumnID{1}, ScanType::OpLessThan, 457.0);
+  auto table_scan_a_op = std::make_shared<TableScan>(join_a, ColumnID{3}, ScanType::GreaterThanEquals, 2);
+  auto table_scan_b_op = std::make_shared<TableScan>(join_b, ColumnID{1}, ScanType::LessThan, 457.0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, get_table_c_op, get_table_d_op, join_a, join_b, table_scan_a_op,

--- a/src/test/operators/update_test.cpp
+++ b/src/test/operators/update_test.cpp
@@ -28,7 +28,7 @@ void OperatorsUpdateTest::helper(std::shared_ptr<GetTable> table_to_update, std:
   auto t_context = TransactionManager::get().new_transaction_context();
 
   // Make input left actually referenced. Projection does NOT generate ReferenceColumns.
-  auto ref_table = std::make_shared<TableScan>(table_to_update, ColumnID{0}, ScanType::OpGreaterThan, 0);
+  auto ref_table = std::make_shared<TableScan>(table_to_update, ColumnID{0}, ScanType::GreaterThan, 0);
   ref_table->set_transaction_context(t_context);
   ref_table->execute();
 
@@ -162,7 +162,7 @@ TEST_F(OperatorsUpdateTest, MissingChunks) {
   gt->execute();
 
   // table scan will leave out first two chunks
-  auto table_scan1 = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::OpEquals, "12345");
+  auto table_scan1 = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::Equals, "12345");
   table_scan1->set_transaction_context(t_context);
   table_scan1->execute();
 

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -69,7 +69,7 @@ TEST_F(OperatorsValidateTest, ScanValidate) {
 
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/validate_output_validated_scanned.tbl", 2u);
 
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::OpGreaterThanEquals, 2);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 2);
   table_scan->set_transaction_context(context);
   table_scan->execute();
 

--- a/src/test/optimizer/ast_to_operator_translator_test.cpp
+++ b/src/test/optimizer/ast_to_operator_translator_test.cpp
@@ -52,34 +52,34 @@ TEST_F(LQPTranslatorTest, StoredTableNode) {
 
 TEST_F(LQPTranslatorTest, PredicateNodeUnaryScan) {
   const auto stored_table_node = std::make_shared<StoredTableNode>("table_int_float");
-  auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, 42);
+  auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, 42);
   predicate_node->set_left_child(stored_table_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
   const auto table_scan_op = std::dynamic_pointer_cast<TableScan>(op);
   ASSERT_TRUE(table_scan_op);
   EXPECT_EQ(table_scan_op->left_column_id(), ColumnID{0} /* "a" */);
-  EXPECT_EQ(table_scan_op->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(table_scan_op->scan_type(), ScanType::Equals);
   EXPECT_EQ(table_scan_op->right_parameter(), AllParameterVariant(42));
 }
 
 TEST_F(LQPTranslatorTest, PredicateNodeBinaryScan) {
   const auto stored_table_node = std::make_shared<StoredTableNode>("table_int_float");
   auto predicate_node =
-      std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpBetween, AllParameterVariant(42), AllTypeVariant(1337));
+      std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Between, AllParameterVariant(42), AllTypeVariant(1337));
   predicate_node->set_left_child(stored_table_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
   const auto table_scan_op2 = std::dynamic_pointer_cast<TableScan>(op);
   ASSERT_TRUE(table_scan_op2);
   EXPECT_EQ(table_scan_op2->left_column_id(), ColumnID{0} /* "a" */);
-  EXPECT_EQ(table_scan_op2->scan_type(), ScanType::OpLessThanEquals);
+  EXPECT_EQ(table_scan_op2->scan_type(), ScanType::LessThanEquals);
   EXPECT_EQ(table_scan_op2->right_parameter(), AllParameterVariant(1337));
 
   const auto table_scan_op = std::dynamic_pointer_cast<const TableScan>(table_scan_op2->input_left());
   ASSERT_TRUE(table_scan_op);
   EXPECT_EQ(table_scan_op->left_column_id(), ColumnID{0} /* "a" */);
-  EXPECT_EQ(table_scan_op->scan_type(), ScanType::OpGreaterThanEquals);
+  EXPECT_EQ(table_scan_op->scan_type(), ScanType::GreaterThanEquals);
   EXPECT_EQ(table_scan_op->right_parameter(), AllParameterVariant(42));
 }
 
@@ -113,7 +113,7 @@ TEST_F(LQPTranslatorTest, JoinNode) {
   const auto stored_table_node_left = std::make_shared<StoredTableNode>("table_int_float");
   const auto stored_table_node_right = std::make_shared<StoredTableNode>("table_int_float2");
   auto join_node =
-      std::make_shared<JoinNode>(JoinMode::Outer, std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+      std::make_shared<JoinNode>(JoinMode::Outer, std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join_node->set_left_child(stored_table_node_left);
   join_node->set_right_child(stored_table_node_right);
   const auto op = LQPTranslator{}.translate_node(join_node);
@@ -121,7 +121,7 @@ TEST_F(LQPTranslatorTest, JoinNode) {
   const auto join_op = std::dynamic_pointer_cast<JoinSortMerge>(op);
   ASSERT_TRUE(join_op);
   EXPECT_EQ(join_op->column_ids(), join_node->join_column_ids());
-  EXPECT_EQ(join_op->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(join_op->scan_type(), ScanType::Equals);
   EXPECT_EQ(join_op->mode(), JoinMode::Outer);
 }
 
@@ -222,16 +222,16 @@ TEST_F(LQPTranslatorTest, AggregateNodeWithArithmetics) {
 
 TEST_F(LQPTranslatorTest, MultipleNodesHierarchy) {
   const auto stored_table_node_left = std::make_shared<StoredTableNode>("table_int_float");
-  auto predicate_node_left = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, AllParameterVariant(42));
+  auto predicate_node_left = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, AllParameterVariant(42));
   predicate_node_left->set_left_child(stored_table_node_left);
 
   const auto stored_table_node_right = std::make_shared<StoredTableNode>("table_int_float2");
   auto predicate_node_right =
-      std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, AllParameterVariant(30.0));
+      std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, AllParameterVariant(30.0));
   predicate_node_right->set_left_child(stored_table_node_right);
 
   auto join_node =
-      std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+      std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
   join_node->set_left_child(predicate_node_left);
   join_node->set_right_child(predicate_node_right);
 
@@ -242,11 +242,11 @@ TEST_F(LQPTranslatorTest, MultipleNodesHierarchy) {
 
   const auto predicate_op_left = std::dynamic_pointer_cast<const TableScan>(join_op->input_left());
   ASSERT_TRUE(predicate_op_left);
-  EXPECT_EQ(predicate_op_left->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(predicate_op_left->scan_type(), ScanType::Equals);
 
   const auto predicate_op_right = std::dynamic_pointer_cast<const TableScan>(join_op->input_right());
   ASSERT_TRUE(predicate_op_right);
-  EXPECT_EQ(predicate_op_right->scan_type(), ScanType::OpGreaterThan);
+  EXPECT_EQ(predicate_op_right->scan_type(), ScanType::GreaterThan);
 
   const auto get_table_op_left = std::dynamic_pointer_cast<const GetTable>(predicate_op_left->input_left());
   ASSERT_TRUE(get_table_op_left);

--- a/src/test/optimizer/column_statistics_test.cpp
+++ b/src/test/optimizer/column_statistics_test.cpp
@@ -106,7 +106,7 @@ class ColumnStatisticsTest : public BaseTest {
 };
 
 TEST_F(ColumnStatisticsTest, NotEqualTest) {
-  ScanType scan_type = ScanType::OpNotEquals;
+  ScanType scan_type = ScanType::NotEquals;
 
   std::vector<float> selectivities{1.f, 5.f / 6.f, 5.f / 6.f, 5.f / 6.f, 1.f};
   predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities);
@@ -116,7 +116,7 @@ TEST_F(ColumnStatisticsTest, NotEqualTest) {
 }
 
 TEST_F(ColumnStatisticsTest, EqualsTest) {
-  ScanType scan_type = ScanType::OpEquals;
+  ScanType scan_type = ScanType::Equals;
 
   std::vector<float> selectivities{0.f, 1.f / 6.f, 1.f / 6.f, 1.f / 6.f, 0.f};
   predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities);
@@ -126,7 +126,7 @@ TEST_F(ColumnStatisticsTest, EqualsTest) {
 }
 
 TEST_F(ColumnStatisticsTest, LessThanTest) {
-  ScanType scan_type = ScanType::OpLessThan;
+  ScanType scan_type = ScanType::LessThan;
 
   std::vector<float> selectivities_int{0.f, 0.f, 1.f / 3.f, 5.f / 6.f, 1.f};
   predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
@@ -137,7 +137,7 @@ TEST_F(ColumnStatisticsTest, LessThanTest) {
 }
 
 TEST_F(ColumnStatisticsTest, LessEqualThanTest) {
-  ScanType scan_type = ScanType::OpLessThanEquals;
+  ScanType scan_type = ScanType::LessThanEquals;
 
   std::vector<float> selectivities_int{0.f, 1.f / 6.f, 1.f / 2.f, 1.f, 1.f};
   predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
@@ -148,7 +148,7 @@ TEST_F(ColumnStatisticsTest, LessEqualThanTest) {
 }
 
 TEST_F(ColumnStatisticsTest, GreaterThanTest) {
-  ScanType scan_type = ScanType::OpGreaterThan;
+  ScanType scan_type = ScanType::GreaterThan;
 
   std::vector<float> selectivities_int{1.f, 5.f / 6.f, 1.f / 2.f, 0.f, 0.f};
   predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
@@ -159,7 +159,7 @@ TEST_F(ColumnStatisticsTest, GreaterThanTest) {
 }
 
 TEST_F(ColumnStatisticsTest, GreaterEqualThanTest) {
-  ScanType scan_type = ScanType::OpGreaterThanEquals;
+  ScanType scan_type = ScanType::GreaterThanEquals;
 
   std::vector<float> selectivities_int{1.f, 1.f, 2.f / 3.f, 1.f / 6.f, 0.f};
   predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
@@ -170,7 +170,7 @@ TEST_F(ColumnStatisticsTest, GreaterEqualThanTest) {
 }
 
 TEST_F(ColumnStatisticsTest, BetweenTest) {
-  ScanType scan_type = ScanType::OpBetween;
+  ScanType scan_type = ScanType::Between;
 
   std::vector<std::pair<int32_t, int32_t>> int_values{{-1, 0}, {-1, 2}, {1, 2}, {0, 7}, {5, 6}, {5, 8}, {7, 8}};
   std::vector<float> selectivities_int{0.f, 1.f / 3.f, 1.f / 3.f, 1.f, 1.f / 3.f, 1.f / 3.f, 0.f};
@@ -187,7 +187,7 @@ TEST_F(ColumnStatisticsTest, BetweenTest) {
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureNotEqualsTest) {
-  ScanType scan_type = ScanType::OpNotEquals;
+  ScanType scan_type = ScanType::NotEquals;
 
   auto result_container_int =
       _column_statistics_int->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
@@ -207,7 +207,7 @@ TEST_F(ColumnStatisticsTest, StoredProcedureNotEqualsTest) {
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureEqualsTest) {
-  ScanType scan_type = ScanType::OpEquals;
+  ScanType scan_type = ScanType::Equals;
 
   auto result_container_int =
       _column_statistics_int->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
@@ -228,7 +228,7 @@ TEST_F(ColumnStatisticsTest, StoredProcedureEqualsTest) {
 
 TEST_F(ColumnStatisticsTest, StoredProcedureOpenEndedTest) {
   // OpLessThan, OpGreaterThan, OpLessThanEquals, OpGreaterThanEquals are same for stored procedures
-  ScanType scan_type = ScanType::OpLessThan;
+  ScanType scan_type = ScanType::LessThan;
 
   auto result_container_int =
       _column_statistics_int->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
@@ -248,7 +248,7 @@ TEST_F(ColumnStatisticsTest, StoredProcedureOpenEndedTest) {
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureBetweenTest) {
-  ScanType scan_type = ScanType::OpBetween;
+  ScanType scan_type = ScanType::Between;
 
   // selectivities = selectivities from LessEqualThan / 0.3f
 
@@ -264,7 +264,7 @@ TEST_F(ColumnStatisticsTest, StoredProcedureBetweenTest) {
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
-  ScanType scan_type = ScanType::OpEquals;
+  ScanType scan_type = ScanType::Equals;
 
   auto col_stat1 = std::make_shared<ColumnStatistics<int>>(ColumnID(0), 10.f, 0, 10);
   auto col_stat2 = std::make_shared<ColumnStatistics<int>>(ColumnID(1), 10.f, -10, 20);
@@ -288,7 +288,7 @@ TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {
-  ScanType scan_type = ScanType::OpLessThan;
+  ScanType scan_type = ScanType::LessThan;
 
   auto col_stat1 = std::make_shared<ColumnStatistics<int>>(ColumnID(0), 10.f, 1, 20);
   auto col_stat2 = std::make_shared<ColumnStatistics<int>>(ColumnID(1), 30.f, 11, 40);
@@ -316,8 +316,8 @@ TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {
 
 TEST_F(ColumnStatisticsTest, TwoColumnsRealDataTest) {
   // test selectivity calculations for all scan types and all column combinations of int_equal_distribution.tbl
-  std::vector<ScanType> scan_types{ScanType::OpEquals, ScanType::OpNotEquals, ScanType::OpLessThan,
-                                   ScanType::OpLessThanEquals, ScanType::OpGreaterThan};
+  std::vector<ScanType> scan_types{ScanType::Equals, ScanType::NotEquals, ScanType::LessThan,
+                                   ScanType::LessThanEquals, ScanType::GreaterThan};
   for (auto scan_type : scan_types) {
     predict_selectivities_and_compare(_table_uniform_distribution, _column_statistics_uniform_columns, scan_type);
   }
@@ -329,7 +329,7 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   _column_statistics_float->set_null_value_ratio(0.5f);  // non-null value ratio: 0.5
   _column_statistics_string->set_null_value_ratio(1.f);  // non-null value ratio: 0
 
-  auto scan_type = ScanType::OpEquals;
+  auto scan_type = ScanType::Equals;
   auto result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(1));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f / 6.f);
   result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(2.f));
@@ -337,7 +337,7 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("a"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::OpNotEquals;
+  scan_type = ScanType::NotEquals;
   result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(1));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 5.f / 6.f);
   result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(2.f));
@@ -345,7 +345,7 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("a"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::OpLessThan;
+  scan_type = ScanType::LessThan;
   result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 2.f / 6.f);
   result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3.f));
@@ -353,7 +353,7 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("c"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::OpGreaterThanEquals;
+  scan_type = ScanType::GreaterThanEquals;
   result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 4.f / 6.f);
   result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3.f));
@@ -361,7 +361,7 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("c"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::OpBetween;
+  scan_type = ScanType::Between;
   result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(2), AllTypeVariant(4));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 3.f / 6.f);
   result =
@@ -381,11 +381,11 @@ TEST_F(ColumnStatisticsTest, NonNullRatioTwoColumnTest) {
   stats_1->set_null_value_ratio(0.2);   // non-null value ratio: 0.8
   stats_2->set_null_value_ratio(0.15);  // non-null value ratio: 0.85
 
-  auto scan_type = ScanType::OpEquals;
+  auto scan_type = ScanType::Equals;
   auto result = stats_0->estimate_selectivity_for_two_column_predicate(scan_type, stats_1);
   EXPECT_FLOAT_EQ(result.selectivity, 0.9f * 0.8f * 0.5f / 3.f);
 
-  scan_type = ScanType::OpLessThan;
+  scan_type = ScanType::LessThan;
   result = stats_1->estimate_selectivity_for_two_column_predicate(scan_type, stats_2);
   EXPECT_FLOAT_EQ(result.selectivity, 0.8f * 0.85f * (1.f / 3.f + 1.f / 3.f * 1.f / 2.f));
 }

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -87,13 +87,13 @@ TEST_F(JoinDetectionRuleTest, SimpleDetectionTest) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{2});
   predicate_node->set_left_child(cross_join_node);
 
   // Apply rule
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output, ScanType::OpEquals, ColumnID{0}, ColumnID{0});
+  ASSERT_INNER_JOIN_NODE(output, ScanType::Equals, ColumnID{0}, ColumnID{0});
 
   EXPECT_EQ(output->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->right_child()->type(), LQPNodeType::StoredTable);
@@ -129,7 +129,7 @@ TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{2});
   predicate_node->set_left_child(cross_join_node);
 
   const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
@@ -141,7 +141,7 @@ TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child(), ScanType::OpEquals, ColumnID{0}, ColumnID{0});
+  ASSERT_INNER_JOIN_NODE(output->left_child(), ScanType::Equals, ColumnID{0}, ColumnID{0});
 
   EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->left_child()->right_child()->type(), LQPNodeType::StoredTable);
@@ -202,7 +202,7 @@ TEST_F(JoinDetectionRuleTest, NoMatchingPredicate) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{1});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{1});
   predicate_node->set_left_child(cross_join_node);
 
   const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
@@ -237,11 +237,11 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
    */
 
   const auto join_node =
-      std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(ColumnID{1}, ColumnID{1}), ScanType::OpEquals);
+      std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(ColumnID{1}, ColumnID{1}), ScanType::Equals);
   join_node->set_left_child(_table_node_a);
   join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{2});
   predicate_node->set_left_child(join_node);
 
   const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
@@ -252,7 +252,7 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
   EXPECT_EQ(output->left_child()->type(), LQPNodeType::Predicate);
-  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), ScanType::OpEquals, ColumnID{1}, ColumnID{1});
+  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), ScanType::Equals, ColumnID{1}, ColumnID{1});
   EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
 }
@@ -294,7 +294,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins) {
   join_node2->set_left_child(join_node1);
   join_node2->set_right_child(_table_node_c);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{2});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{2});
   predicate_node->set_left_child(join_node2);
 
   const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
@@ -310,7 +310,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins) {
   EXPECT_EQ(first_join_node->join_mode(), JoinMode::Cross);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), ScanType::OpEquals, ColumnID{0}, ColumnID{0});
+  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), ScanType::Equals, ColumnID{0}, ColumnID{0});
 
   EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
@@ -340,7 +340,7 @@ TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
    */
   const auto join_node1 = std::make_shared<JoinNode>(JoinMode::Cross);
   const auto join_node2 = std::make_shared<JoinNode>(JoinMode::Cross);
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::OpEquals, ColumnID{5});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::Equals, ColumnID{5});
 
   predicate_node->set_left_child(join_node1);
   join_node1->set_left_child(_table_node_a);
@@ -352,7 +352,7 @@ TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
 
   EXPECT_EQ(output, join_node1);
   EXPECT_EQ(output->left_child(), _table_node_a);
-  ASSERT_INNER_JOIN_NODE(output->right_child(), ScanType::OpEquals, ColumnID{0}, ColumnID{1});
+  ASSERT_INNER_JOIN_NODE(output->right_child(), ScanType::Equals, ColumnID{0}, ColumnID{1});
   EXPECT_EQ(output->right_child()->left_child(), _table_node_b);
   EXPECT_EQ(output->right_child()->right_child(), _table_node_c);
 }
@@ -394,7 +394,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
   join_node2->set_left_child(join_node1);
   join_node2->set_right_child(_table_node_c);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{4}, ScanType::OpEquals, ColumnID{0});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{4}, ScanType::Equals, ColumnID{0});
   predicate_node->set_left_child(join_node2);
 
   const std::vector<std::shared_ptr<Expression>> columns = {Expression::create_column(ColumnID{0})};
@@ -406,7 +406,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child(), ScanType::OpEquals, ColumnID{0}, ColumnID{0});
+  ASSERT_INNER_JOIN_NODE(output->left_child(), ScanType::Equals, ColumnID{0}, ColumnID{0});
 
   EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::Join);
   const auto second_join_node = std::dynamic_pointer_cast<JoinNode>(output->left_child()->left_child());
@@ -444,7 +444,7 @@ TEST_F(JoinDetectionRuleTest, NoOptimizationAcrossProjection) {
   const auto projection_node = std::make_shared<ProjectionNode>(columns);
   projection_node->set_left_child(join_node);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{1});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{1});
   predicate_node->set_left_child(projection_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
@@ -484,7 +484,7 @@ TEST_F(JoinDetectionRuleTest, NoJoinDetectionAcrossProjections) {
   const auto projection_node = std::make_shared<ProjectionNode>(columns);
   projection_node->set_left_child(join_node);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpEquals, ColumnID{1});
+  const auto predicate_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, ColumnID{1});
   predicate_node->set_left_child(projection_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -67,10 +67,10 @@ TEST_F(PredicateReorderingTest, SimpleReorderingTest) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   predicate_node_1->get_statistics();
@@ -88,13 +88,13 @@ TEST_F(PredicateReorderingTest, MoreComplexReorderingTest) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
-  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::OpGreaterThan, 90);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::GreaterThan, 90);
   predicate_node_2->set_left_child(predicate_node_1);
 
   predicate_node_2->get_statistics();
@@ -113,13 +113,13 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
-  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::OpGreaterThan, 90);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::GreaterThan, 90);
   predicate_node_2->set_left_child(predicate_node_1);
 
   const std::vector<ColumnID> column_ids = {ColumnID{0}, ColumnID{1}};
@@ -127,10 +127,10 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   const auto projection_node = std::make_shared<ProjectionNode>(expressions);
   projection_node->set_left_child(predicate_node_2);
 
-  auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
+  auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 10);
   predicate_node_3->set_left_child(projection_node);
 
-  auto predicate_node_4 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 50);
+  auto predicate_node_4 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 50);
   predicate_node_4->set_left_child(predicate_node_3);
 
   predicate_node_4->get_statistics();
@@ -153,19 +153,19 @@ TEST_F(PredicateReorderingTest, TwoReorderings) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto sort_node = std::make_shared<SortNode>(std::vector<OrderByDefinition>{{ColumnID{0}, OrderByMode::Ascending}});
   sort_node->set_left_child(predicate_node_1);
 
-  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::OpGreaterThan, 90);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{2}, ScanType::GreaterThan, 90);
   predicate_node_2->set_left_child(sort_node);
 
-  auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 50);
+  auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 50);
   predicate_node_3->set_left_child(predicate_node_2);
 
   const std::vector<ColumnID> column_ids = {ColumnID{0}, ColumnID{1}};
@@ -195,10 +195,10 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
 
   // Setup first LQP
   // predicate_node_1 -> predicate_node_0 -> stored_table_node
-  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpLessThan, 20);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::LessThan, 20);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 458.5);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 458.5);
   predicate_node_1->set_left_child(predicate_node_0);
 
   predicate_node_1->get_statistics();
@@ -207,10 +207,10 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
 
   // Setup second LQP
   // predicate_node_3 -> predicate_node_2 -> stored_table_node
-  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::OpGreaterThan, 458.5);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::GreaterThan, 458.5);
   predicate_node_2->set_left_child(stored_table_node);
 
-  auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpLessThan, 20);
+  auto predicate_node_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::LessThan, 20);
   predicate_node_3->set_left_child(predicate_node_2);
 
   predicate_node_3->get_statistics();
@@ -257,11 +257,11 @@ TEST_F(PredicateReorderingTest, PredicatesAsRightChild) {
       std::make_shared<TableStatistics>(100, std::vector<std::shared_ptr<BaseColumnStatistics>>{column_statistics});
 
   auto cross_node = std::make_shared<JoinNode>(JoinMode::Cross);
-  auto predicate_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 80);
-  auto predicate_1 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 60);
-  auto predicate_2 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 90);
-  auto predicate_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 50);
-  auto predicate_4 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 30);
+  auto predicate_0 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 80);
+  auto predicate_1 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 60);
+  auto predicate_2 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 90);
+  auto predicate_3 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 50);
+  auto predicate_4 = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 30);
   auto table_0 = std::make_shared<MockNode>(table_statistics);
   auto table_1 = std::make_shared<MockNode>(table_statistics);
 
@@ -308,8 +308,8 @@ TEST_F(PredicateReorderingTest, PredicatesWithMultipleParents) {
       std::make_shared<TableStatistics>(100, std::vector<std::shared_ptr<BaseColumnStatistics>>{column_statistics});
 
   auto union_node = std::make_shared<UnionNode>(UnionMode::Positions);
-  auto predicate_a_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 90);
-  auto predicate_b_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::OpGreaterThan, 10);
+  auto predicate_a_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 90);
+  auto predicate_b_node = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::GreaterThan, 10);
   auto table_node = std::make_shared<MockNode>(table_statistics);
 
   union_node->set_left_child(predicate_a_node);

--- a/src/test/optimizer/table_statistics_join_test.cpp
+++ b/src/test/optimizer/table_statistics_join_test.cpp
@@ -72,8 +72,8 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and column
   // combinations of int_equal_distribution.tbl
   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
-  std::vector<ScanType> scan_types{ScanType::OpEquals,         ScanType::OpNotEquals,   ScanType::OpLessThan,
-                                   ScanType::OpLessThanEquals, ScanType::OpGreaterThan, ScanType::OpGreaterThanEquals};
+  std::vector<ScanType> scan_types{ScanType::Equals,         ScanType::NotEquals,   ScanType::LessThan,
+                                   ScanType::LessThanEquals, ScanType::GreaterThan, ScanType::GreaterThanEquals};
 
   // 3 dimensional table of cached row count results
   // [ join_modes index ][ scan_types index ][ column combination index = 4 * col1_index + col2_index ]
@@ -114,9 +114,9 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
 //   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and
 //   // column combinations of int_equal_distribution.tbl
 //   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
-//   std::vector<ScanType> scan_types{ScanType::OpEquals,         ScanType::OpNotEquals,   ScanType::OpLessThan,
-//                                    ScanType::OpLessThanEquals, ScanType::OpGreaterThan,
-//                                    ScanType::OpGreaterThanEquals};
+//   std::vector<ScanType> scan_types{ScanType::Equals,         ScanType::NotEquals,   ScanType::LessThan,
+//                                    ScanType::LessThanEquals, ScanType::GreaterThan,
+//                                    ScanType::GreaterThanEquals};
 
 //   for (const auto join_mode : join_modes) {
 //     for (const auto scan_type : scan_types) {
@@ -136,14 +136,14 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
   // column combinations of int_equal_distribution.tbl
 
-  // Currently, the statistics component produces in some cases for a two column predicate with ScanType::OpLessThan
-  // and ScanType::OpGreaterThan a column statistics with a too high distinct count. (See comment column_statistics.hpp
+  // Currently, the statistics component produces in some cases for a two column predicate with ScanType::LessThan
+  // and ScanType::GreaterThan a column statistics with a too high distinct count. (See comment column_statistics.hpp
   // for details). Null value calculations depend on the calculated distinct counts of the columns. Therefore, tests
   // for the mentioned scan types with null values are skipped.
 
   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
-  std::vector<ScanType> scan_types{ScanType::OpEquals, ScanType::OpNotEquals, ScanType::OpLessThanEquals,
-                                   ScanType::OpGreaterThanEquals};  // ScanType::OpLessThan, ScanType::OpGreaterThan,
+  std::vector<ScanType> scan_types{ScanType::Equals, ScanType::NotEquals, ScanType::LessThanEquals,
+                                   ScanType::GreaterThanEquals};  // ScanType::LessThan, ScanType::GreaterThan,
 
   // 3 dimensional table of cached row count results
   // [ join_modes index ][ scan_types index ][ column combination index = 4 * col1_index + col2_index ]
@@ -189,14 +189,14 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
 //   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
 //   // column combinations of int_equal_distribution.tbl
 
-//   // Currently, the statistics component produces in some cases for a two column predicate with ScanType::OpLessThan
-//   // and ScanType::OpGreaterThan a column statistics with a too high distinct count. (See comment
+//   // Currently, the statistics component produces in some cases for a two column predicate with ScanType::LessThan
+//   // and ScanType::GreaterThan a column statistics with a too high distinct count. (See comment
 //   // column_statistics.hpp for details). Null value calculations depend on the calculated distinct counts of the
 //   // columns. Therefore, tests for the mentioned scan types with null values are skipped.
 
 //   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
-//   std::vector<ScanType> scan_types{ScanType::OpEquals, ScanType::OpNotEquals, ScanType::OpLessThanEquals,
-//                                    ScanType::OpGreaterThanEquals};
+//   std::vector<ScanType> scan_types{ScanType::Equals, ScanType::NotEquals, ScanType::LessThanEquals,
+//                                    ScanType::GreaterThanEquals};
 
 //   for (const auto join_mode : join_modes) {
 //     for (const auto scan_type : scan_types) {

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -40,12 +40,12 @@ class TableStatisticsTest : public BaseTest {
     table_wrapper->execute();
 
     std::shared_ptr<TableScan> table_scan;
-    if (scan_type == ScanType::OpBetween) {
+    if (scan_type == ScanType::Between) {
       auto first_table_scan =
-          std::make_shared<TableScan>(table_wrapper, column_id, ScanType::OpGreaterThanEquals, value);
+          std::make_shared<TableScan>(table_wrapper, column_id, ScanType::GreaterThanEquals, value);
       first_table_scan->execute();
 
-      table_scan = std::make_shared<TableScan>(first_table_scan, column_id, ScanType::OpLessThanEquals, *value2);
+      table_scan = std::make_shared<TableScan>(first_table_scan, column_id, ScanType::LessThanEquals, *value2);
     } else {
       table_scan = std::make_shared<TableScan>(table_wrapper, column_id, scan_type, value);
     }
@@ -103,7 +103,7 @@ TEST_F(TableStatisticsTest, GetTableTest) {
 }
 
 TEST_F(TableStatisticsTest, NotEqualTest) {
-  ScanType scan_type = ScanType::OpNotEquals;
+  ScanType scan_type = ScanType::NotEquals;
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
   check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, _float_values);
   check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, _double_values);
@@ -111,7 +111,7 @@ TEST_F(TableStatisticsTest, NotEqualTest) {
 }
 
 TEST_F(TableStatisticsTest, EqualsTest) {
-  ScanType scan_type = ScanType::OpEquals;
+  ScanType scan_type = ScanType::Equals;
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
   check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, _float_values);
   check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, _double_values);
@@ -119,7 +119,7 @@ TEST_F(TableStatisticsTest, EqualsTest) {
 }
 
 TEST_F(TableStatisticsTest, LessThanTest) {
-  ScanType scan_type = ScanType::OpLessThan;
+  ScanType scan_type = ScanType::LessThan;
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
   //  table statistics assigns for floating point values greater and greater equals same selectivity
   std::vector<float> custom_float_values{0.f, 1.f, 5.1f, 7.f};
@@ -131,7 +131,7 @@ TEST_F(TableStatisticsTest, LessThanTest) {
 }
 
 TEST_F(TableStatisticsTest, LessEqualThanTest) {
-  ScanType scan_type = ScanType::OpLessThanEquals;
+  ScanType scan_type = ScanType::LessThanEquals;
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
   std::vector<float> custom_float_values{0.f, 1.9f, 5.f, 7.f};
   check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, custom_float_values);
@@ -142,7 +142,7 @@ TEST_F(TableStatisticsTest, LessEqualThanTest) {
 }
 
 TEST_F(TableStatisticsTest, GreaterThanTest) {
-  ScanType scan_type = ScanType::OpGreaterThan;
+  ScanType scan_type = ScanType::GreaterThan;
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
   //  table statistics assigns for floating point values greater and greater equals same selectivity
   std::vector<float> custom_float_values{0.f, 1.5f, 6.f, 7.f};
@@ -154,7 +154,7 @@ TEST_F(TableStatisticsTest, GreaterThanTest) {
 }
 
 TEST_F(TableStatisticsTest, GreaterEqualThanTest) {
-  ScanType scan_type = ScanType::OpGreaterThanEquals;
+  ScanType scan_type = ScanType::GreaterThanEquals;
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
   std::vector<float> custom_float_values{0.f, 1.f, 5.1f, 7.f};
   check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, custom_float_values);
@@ -165,7 +165,7 @@ TEST_F(TableStatisticsTest, GreaterEqualThanTest) {
 }
 
 TEST_F(TableStatisticsTest, BetweenTest) {
-  ScanType scan_type = ScanType::OpBetween;
+  ScanType scan_type = ScanType::Between;
   std::vector<std::pair<int32_t, int32_t>> int_values{{-1, 0}, {-1, 2}, {1, 2}, {0, 7}, {5, 6}, {5, 8}, {7, 8}};
   check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, int_values);
   std::vector<std::pair<float, float>> float_values{{-1.f, 0.f}, {-1.f, 1.9f}, {1.f, 1.9f}, {0.f, 7.f},
@@ -181,9 +181,9 @@ TEST_F(TableStatisticsTest, BetweenTest) {
 }
 
 TEST_F(TableStatisticsTest, MultipleColumnTableScans) {
-  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{2}, ScanType::OpBetween,
+  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{2}, ScanType::Between,
                                                    AllParameterVariant(2.), AllTypeVariant(5.));
-  container = check_statistic_with_table_scan(container, ColumnID{0}, ScanType::OpGreaterThanEquals,
+  container = check_statistic_with_table_scan(container, ColumnID{0}, ScanType::GreaterThanEquals,
                                               AllParameterVariant(4), AllTypeVariant(5));
 }
 
@@ -191,18 +191,18 @@ TEST_F(TableStatisticsTest, NotOverlappingTableScans) {
   /**
    * check that min and max values of columns are set
    */
-  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{3}, ScanType::OpEquals,
+  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{3}, ScanType::Equals,
                                                    AllParameterVariant("f"));
-  check_statistic_with_table_scan(container, ColumnID{3}, ScanType::OpNotEquals, AllParameterVariant("f"));
+  check_statistic_with_table_scan(container, ColumnID{3}, ScanType::NotEquals, AllParameterVariant("f"));
 
-  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{1}, ScanType::OpLessThanEquals,
+  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{1}, ScanType::LessThanEquals,
                                               AllParameterVariant(3.5f));
-  check_statistic_with_table_scan(container, ColumnID{1}, ScanType::OpGreaterThan, AllParameterVariant(3.5f));
+  check_statistic_with_table_scan(container, ColumnID{1}, ScanType::GreaterThan, AllParameterVariant(3.5f));
 
-  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{0}, ScanType::OpLessThan,
+  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{0}, ScanType::LessThan,
                                               AllParameterVariant(4));
-  container = check_statistic_with_table_scan(container, ColumnID{0}, ScanType::OpGreaterThan, AllParameterVariant(2));
-  check_statistic_with_table_scan(container, ColumnID{0}, ScanType::OpEquals, AllParameterVariant(3));
+  container = check_statistic_with_table_scan(container, ColumnID{0}, ScanType::GreaterThan, AllParameterVariant(2));
+  check_statistic_with_table_scan(container, ColumnID{0}, ScanType::Equals, AllParameterVariant(3));
 }
 
 }  // namespace opossum

--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -188,7 +188,7 @@ TEST_F(SchedulerTest, MultipleOperators) {
   StorageManager::get().add_table("table", std::move(test_table));
 
   auto gt = std::make_shared<GetTable>("table");
-  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::OpGreaterThanEquals, 1234);
+  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
 
   auto gt_task = std::make_shared<OperatorTask>(gt);
   auto ts_task = std::make_shared<OperatorTask>(ts);

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -84,7 +84,7 @@ TEST_F(SQLTranslatorTest, DISABLED_ExpressionTest /* #494 */) {
   EXPECT_EQ(ts_node_1->type(), LQPNodeType::Predicate);
   EXPECT_FALSE(ts_node_1->right_child());
   EXPECT_EQ(ts_node_1->column_id(), ColumnID{0});
-  EXPECT_EQ(ts_node_1->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(ts_node_1->scan_type(), ScanType::Equals);
   // TODO(anybody): once this is implemented, the value side has to be checked.
 }
 
@@ -98,7 +98,7 @@ TEST_F(SQLTranslatorTest, TwoColumnFilter) {
   auto ts_node_1 = std::static_pointer_cast<PredicateNode>(result_node->left_child());
   EXPECT_EQ(ts_node_1->type(), LQPNodeType::Predicate);
   EXPECT_FALSE(ts_node_1->right_child());
-  EXPECT_EQ(ts_node_1->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(ts_node_1->scan_type(), ScanType::Equals);
   EXPECT_EQ(ts_node_1->column_id(), ColumnID{0});
   EXPECT_EQ(ts_node_1->value(), AllParameterVariant{ColumnID{1}});
 }
@@ -114,7 +114,7 @@ TEST_F(SQLTranslatorTest, ExpressionStringTest) {
   EXPECT_EQ(ts_node_1->type(), LQPNodeType::Predicate);
   EXPECT_FALSE(ts_node_1->right_child());
   EXPECT_EQ(ts_node_1->column_id(), ColumnID{0});
-  EXPECT_EQ(ts_node_1->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(ts_node_1->scan_type(), ScanType::Equals);
   EXPECT_EQ(ts_node_1->value(), AllParameterVariant{std::string{"b"}});
 }
 
@@ -261,7 +261,7 @@ TEST_F(SQLTranslatorTest, SelectInnerJoin) {
 
   EXPECT_EQ(result_node->left_child()->type(), LQPNodeType::Join);
   auto join_node = std::dynamic_pointer_cast<JoinNode>(result_node->left_child());
-  EXPECT_EQ(join_node->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(join_node->scan_type(), ScanType::Equals);
   EXPECT_EQ(join_node->join_mode(), JoinMode::Inner);
   EXPECT_EQ((*join_node->join_column_ids()).first, ColumnID{0});
   EXPECT_EQ((*join_node->join_column_ids()).second, ColumnID{0});
@@ -283,7 +283,7 @@ TEST_F(SQLTranslatorTest, SelectLeftRightOuterJoins) {
 
     EXPECT_EQ(result_node->left_child()->type(), LQPNodeType::Join);
     auto join_node = std::dynamic_pointer_cast<JoinNode>(result_node->left_child());
-    EXPECT_EQ(join_node->scan_type(), ScanType::OpEquals);
+    EXPECT_EQ(join_node->scan_type(), ScanType::Equals);
     EXPECT_EQ(join_node->join_mode(), mode);
     EXPECT_EQ((*join_node->join_column_ids()).first, ColumnID{0} /* "a" */);
     EXPECT_EQ((*join_node->join_column_ids()).second, ColumnID{0} /* "a" */);
@@ -317,7 +317,7 @@ TEST_F(SQLTranslatorTest, SelectOuterJoin) {
 
   EXPECT_EQ(result_node->left_child()->type(), LQPNodeType::Join);
   auto join_node = std::dynamic_pointer_cast<JoinNode>(result_node->left_child());
-  EXPECT_EQ(join_node->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(join_node->scan_type(), ScanType::Equals);
   EXPECT_EQ(join_node->join_mode(), JoinMode::Outer);
   EXPECT_EQ((*join_node->join_column_ids()).first, ColumnID{0} /* "a" */);
   EXPECT_EQ((*join_node->join_column_ids()).second, ColumnID{0} /* "a" */);
@@ -339,7 +339,7 @@ TEST_F(SQLTranslatorTest, SelectNaturalJoin) {
   auto predicate = std::dynamic_pointer_cast<PredicateNode>(projection_node->left_child());
   EXPECT_FALSE(predicate->right_child());
   EXPECT_EQ(predicate->column_id(), ColumnID{0});
-  EXPECT_EQ(predicate->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(predicate->scan_type(), ScanType::Equals);
   EXPECT_EQ(predicate->value(), AllParameterVariant{ColumnID{2}});
 
   EXPECT_EQ(predicate->left_child()->type(), LQPNodeType::Join);
@@ -555,7 +555,7 @@ TEST_F(SQLTranslatorTest, CreateView) {
   EXPECT_EQ(ts_node_1->type(), LQPNodeType::Predicate);
   EXPECT_FALSE(ts_node_1->right_child());
   EXPECT_EQ(ts_node_1->column_id(), ColumnID{0});
-  EXPECT_EQ(ts_node_1->scan_type(), ScanType::OpEquals);
+  EXPECT_EQ(ts_node_1->scan_type(), ScanType::Equals);
   EXPECT_EQ(ts_node_1->value(), AllParameterVariant{std::string{"b"}});
 }
 

--- a/src/test/tasks/operator_task_test.cpp
+++ b/src/test/tasks/operator_task_test.cpp
@@ -39,7 +39,7 @@ TEST_F(OperatorTaskTest, BasicTasksFromOperatorTest) {
 
 TEST_F(OperatorTaskTest, SingleDependencyTasksFromOperatorTest) {
   auto gt = std::make_shared<GetTable>("table_a");
-  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::OpEquals, 1234);
+  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::Equals, 1234);
 
   auto tasks = OperatorTask::make_tasks_from_operator(ts);
   for (auto& task : tasks) {
@@ -54,7 +54,7 @@ TEST_F(OperatorTaskTest, DoubleDependencyTasksFromOperatorTest) {
   auto gt_a = std::make_shared<GetTable>("table_a");
   auto gt_b = std::make_shared<GetTable>("table_b");
   auto join = std::make_shared<JoinHash>(gt_a, gt_b, JoinMode::Inner,
-                                         std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::OpEquals);
+                                         std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), ScanType::Equals);
 
   auto tasks = OperatorTask::make_tasks_from_operator(join);
   for (auto& task : tasks) {


### PR DESCRIPTION
The Op prefix of `ScanType` values is a relic from the time when ScanType was still a normal `enum` and not `enum class`. It does not have any purpose and should be removed.