### PR TITLE
Run-Length Encoding

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -211,18 +211,21 @@ set(
     storage/fitted_attribute_vector.hpp
     storage/column_encoders/base_column_encoder.hpp
     storage/column_encoders/deprecated_dictionary_encoder.hpp
-    storage/column_encoders/encoders.hpp
     storage/column_encoders/dictionary_encoder.hpp
+    storage/column_encoders/encoders.hpp
+    storage/column_encoders/run_length_encoder.hpp
     storage/column_encoders/utils.cpp
     storage/column_encoders/utils.hpp
-    storage/encoded_columns/base_encoded_column.cpp
-    storage/encoded_columns/base_encoded_column.hpp
     storage/encoded_columns/base_dictionary_column.cpp
     storage/encoded_columns/base_dictionary_column.hpp
+    storage/encoded_columns/base_encoded_column.cpp
+    storage/encoded_columns/base_encoded_column.hpp
     storage/encoded_columns/column_encoding_type.hpp
-    storage/encoded_columns/encoded_columns.hpp
     storage/encoded_columns/dictionary_column.cpp
     storage/encoded_columns/dictionary_column.hpp
+    storage/encoded_columns/encoded_columns.hpp
+    storage/encoded_columns/run_length_column.cpp
+    storage/encoded_columns/run_length_column.hpp
     storage/encoded_columns/utils.hpp
     storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
     storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -257,6 +260,7 @@ set(
     storage/iterables/null_value_vector_iterable.hpp
     storage/iterables/reference_column_iterable.hpp
     storage/iterables/value_column_iterable.hpp
+    storage/iterables/run_length_column_iterable.hpp
     storage/zero_suppression/base_zero_suppression_decoder.hpp
     storage/zero_suppression/base_zero_suppression_encoder.hpp
     storage/zero_suppression/base_zero_suppression_vector.hpp

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -244,8 +244,8 @@ void ExportBinary::ExportBinaryVisitor<T>::handle_dictionary_column(
 }
 
 template <typename T>
-void ExportBinary::ExportBinaryVisitor<T>::handle_encoded_column(
-    const BaseEncodedColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) {
+void ExportBinary::ExportBinaryVisitor<T>::handle_encoded_column(const BaseEncodedColumn& base_column,
+                                                                 std::shared_ptr<ColumnVisitableContext> base_context) {
   Fail("Binary export not implemented yet for encoded columns.");
 }
 

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -244,6 +244,12 @@ void ExportBinary::ExportBinaryVisitor<T>::handle_dictionary_column(
 }
 
 template <typename T>
+void ExportBinary::ExportBinaryVisitor<T>::handle_encoded_column(
+    const BaseEncodedColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) {
+  Fail("Binary export not implemented yet for encoded columns.");
+}
+
+template <typename T>
 void ExportBinary::ExportBinaryVisitor<T>::_export_attribute_vector(std::ofstream& ofstream,
                                                                     const BaseAttributeVector& attribute_vector) {
   switch (attribute_vector.width()) {

--- a/src/lib/operators/export_binary.hpp
+++ b/src/lib/operators/export_binary.hpp
@@ -157,6 +157,9 @@ class ExportBinary::ExportBinaryVisitor : public ColumnVisitable {
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
                                 std::shared_ptr<ColumnVisitableContext> base_context) override;
 
+  void handle_encoded_column(const BaseEncodedColumn& base_column,
+                             std::shared_ptr<ColumnVisitableContext> base_context) override;
+
  private:
   // Chooses the right FittedAttributeVector depending on the attribute_vector_width and exports it.
   static void _export_attribute_vector(std::ofstream& ofstream, const BaseAttributeVector& attribute_vector);

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -128,7 +128,7 @@ class ExportCsv::ExportCsvVisitor : public ColumnVisitable {
   }
 
   void handle_encoded_column(const BaseEncodedColumn& base_column,
-                                std::shared_ptr<ColumnVisitableContext> base_context) final {
+                             std::shared_ptr<ColumnVisitableContext> base_context) final {
     Fail("CSV export not implemented yet for encoded columns.");
   }
 };

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -126,6 +126,11 @@ class ExportCsv::ExportCsvVisitor : public ColumnVisitable {
                                 std::shared_ptr<ColumnVisitableContext> base_context) final {
     Fail("CSV export not implemented yet for new version of dictionary column.");
   }
+
+  void handle_encoded_column(const BaseEncodedColumn& base_column,
+                                std::shared_ptr<ColumnVisitableContext> base_context) final {
+    Fail("CSV export not implemented yet for encoded columns.");
+  }
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
@@ -65,6 +65,25 @@ void IsNullTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& l
                                       [&](auto left_it, auto left_end) { this->_scan(left_it, left_end, *context); });
 }
 
+void IsNullTableScanImpl::handle_encoded_column(const BaseEncodedColumn& base_column,
+                                                std::shared_ptr<ColumnVisitableContext> base_context) {
+  auto context = std::static_pointer_cast<Context>(base_context);
+  const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
+
+  const auto left_column_type = _in_table->column_type(_left_column_id);
+
+  resolve_data_type(left_column_type, [&](auto type) {
+    using Type = typename decltype(type)::type;
+
+    resolve_encoded_column_type<Type>(base_column, [&](const auto& typed_column) {
+      auto left_column_iterable = create_iterable_from_column(typed_column);
+
+      left_column_iterable.with_iterators(mapped_chunk_offsets.get(),
+                                          [&](auto left_it, auto left_end) { this->_scan(left_it, left_end, *context); });
+    });
+  });
+}
+
 bool IsNullTableScanImpl::_matches_all(const BaseValueColumn& column) {
   switch (_scan_type) {
     case ScanType::IsNull:

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
@@ -78,8 +78,8 @@ void IsNullTableScanImpl::handle_encoded_column(const BaseEncodedColumn& base_co
     resolve_encoded_column_type<Type>(base_column, [&](const auto& typed_column) {
       auto left_column_iterable = create_iterable_from_column(typed_column);
 
-      left_column_iterable.with_iterators(mapped_chunk_offsets.get(),
-                                          [&](auto left_it, auto left_end) { this->_scan(left_it, left_end, *context); });
+      left_column_iterable.with_iterators(
+          mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) { this->_scan(left_it, left_end, *context); });
     });
   });
 }

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
@@ -26,6 +26,9 @@ class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
                                 std::shared_ptr<ColumnVisitableContext> base_context) override;
 
+  void handle_encoded_column(const BaseEncodedColumn& base_column,
+                             std::shared_ptr<ColumnVisitableContext> base_context) override;
+
  private:
   /**
    * @defgroup Methods used for handling value columns

--- a/src/lib/operators/table_scan/like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.cpp
@@ -65,7 +65,7 @@ void LikeTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& bas
 }
 
 void LikeTableScanImpl::handle_encoded_column(const BaseEncodedColumn& base_column,
-                             std::shared_ptr<ColumnVisitableContext> base_context) {
+                                              std::shared_ptr<ColumnVisitableContext> base_context) {
   auto context = std::static_pointer_cast<Context>(base_context);
   auto& matches_out = context->_matches_out;
   const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;

--- a/src/lib/operators/table_scan/like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.cpp
@@ -64,6 +64,25 @@ void LikeTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& bas
   _handle_dictionary_column(left_column, base_context);
 }
 
+void LikeTableScanImpl::handle_encoded_column(const BaseEncodedColumn& base_column,
+                             std::shared_ptr<ColumnVisitableContext> base_context) {
+  auto context = std::static_pointer_cast<Context>(base_context);
+  auto& matches_out = context->_matches_out;
+  const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
+  const auto chunk_id = context->_chunk_id;
+
+  resolve_encoded_column_type<std::string>(base_column, [&](const auto& typed_column) {
+    auto left_iterable = create_iterable_from_column(typed_column);
+    auto right_iterable = ConstantValueIterable<std::regex>{_regex};
+
+    const auto regex_match = [this](const std::string& str) { return std::regex_match(str, _regex) ^ _invert_results; };
+
+    left_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
+      this->_unary_scan(regex_match, left_it, left_end, chunk_id, matches_out);
+    });
+  });
+}
+
 template <typename DictionaryColumnType>
 void LikeTableScanImpl::_handle_dictionary_column(const DictionaryColumnType& left_column,
                                                   std::shared_ptr<ColumnVisitableContext> base_context) {

--- a/src/lib/operators/table_scan/like_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.hpp
@@ -38,6 +38,9 @@ class LikeTableScanImpl : public BaseSingleColumnTableScanImpl {
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
                                 std::shared_ptr<ColumnVisitableContext> base_context) override;
 
+  void handle_encoded_column(const BaseEncodedColumn& base_column,
+                             std::shared_ptr<ColumnVisitableContext> base_context) override;
+
  private:
   /**
    * @defgroup Methods used for handling dictionary columns

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
@@ -40,6 +40,9 @@ class SingleColumnTableScanImpl : public BaseSingleColumnTableScanImpl {
   void handle_dictionary_column(const BaseDictionaryColumn& base_column,
                                 std::shared_ptr<ColumnVisitableContext> base_context) override;
 
+  void handle_encoded_column(const BaseEncodedColumn& base_column,
+                             std::shared_ptr<ColumnVisitableContext> base_context) override;
+
  private:
   /**
    * @defgroup Methods used for handling dictionary columns

--- a/src/lib/storage/column_encoders/column_encoder.template.hpp
+++ b/src/lib/storage/column_encoders/column_encoder.template.hpp
@@ -23,7 +23,7 @@ class ColumnEncoderTemplate : public ColumnEncoder<ColumnEncoderTemplate> {
   static constexpr auto _encoding_type = enum_c<EncodingType, EncodingType::NewEncoding>;
 
   template <typename T>
-  std::shared_ptr<BaseColumn> _encode(const std::shared_ptr<ValueColumn<T>>& value_column) {
+  std::shared_ptr<BaseColumn> _on_encode(const std::shared_ptr<ValueColumn<T>>& value_column) {
     // TODO(you): Implement encoding
   }
 };

--- a/src/lib/storage/column_encoders/encoders.hpp
+++ b/src/lib/storage/column_encoders/encoders.hpp
@@ -6,6 +6,7 @@
 // Include your column encoder file here!
 #include "deprecated_dictionary_encoder.hpp"
 #include "dictionary_encoder.hpp"
+#include "run_length_encoder.hpp"
 
 #include "storage/encoded_columns/column_encoding_type.hpp"
 
@@ -21,6 +22,7 @@ namespace opossum {
 constexpr auto encoder_for_type =
     hana::make_tuple(hana::make_pair(enum_c<EncodingType, EncodingType::DeprecatedDictionary>,
                                      hana::type_c<DeprecatedDictionaryEncoder>),
-                     hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, hana::type_c<DictionaryEncoder>));
+                     hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, hana::type_c<DictionaryEncoder>),
+                     hana::make_pair(enum_c<EncodingType, EncodingType::RunLength>, hana::type_c<RunLengthEncoder>));
 
 }  // namespace opossum

--- a/src/lib/storage/column_encoders/run_length_encoder.hpp
+++ b/src/lib/storage/column_encoders/run_length_encoder.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "base_column_encoder.hpp"
+
+#include "storage/encoded_columns/run_length_column.hpp"
+#include "storage/iterables/value_column_iterable.hpp"
+#include "storage/value_column.hpp"
+#include "types.hpp"
+#include "utils/enum_constant.hpp"
+
+namespace opossum {
+
+class RunLengthEncoder : public ColumnEncoder<RunLengthEncoder> {
+ public:
+  static constexpr auto _encoding_type = enum_c<EncodingType, EncodingType::RunLength>;
+
+  template <typename T>
+  std::shared_ptr<BaseColumn> _on_encode(const std::shared_ptr<ValueColumn<T>>& value_column) {
+    auto null_value = get_null_value<T>();
+
+    const auto alloc = value_column->values().get_allocator();
+
+    auto values = pmr_vector<T>{alloc};
+    auto end_positions = pmr_vector<ChunkOffset>{alloc};
+
+    auto iterable = ValueColumnIterable<T>{*value_column};
+
+    iterable.with_iterators([&](auto it, auto end) {
+      // Init current_value such that it does not equal the first entry
+      auto current_value = it->is_null() ? T{} : null_value;
+      auto current_index = 0u;
+
+      for (; it != end; ++it) {
+        auto column_value = *it;
+
+        const auto prev_value = current_value;
+        current_value = column_value.is_null() ? null_value : column_value.value();
+
+        if (prev_value == current_value) {
+          end_positions.back() = current_index;
+        } else {
+          values.push_back(current_value);
+          end_positions.push_back(current_index);
+        }
+
+        ++current_index;
+      }
+    });
+
+    auto values_ptr = std::allocate_shared<pmr_vector<T>>(alloc, std::move(values));
+    auto end_positions_ptr = std::allocate_shared<pmr_vector<ChunkOffset>>(alloc, std::move(end_positions));
+    return std::allocate_shared<RunLengthColumn<T>>(alloc, values_ptr, end_positions_ptr, null_value);
+  }
+
+ private:
+  // Use quiet NaN as null value for floating point types
+  template <typename T>
+  std::enable_if_t<std::numeric_limits<T>::has_quiet_NaN, T> get_null_value() {
+    return std::numeric_limits<T>::quiet_NaN();
+  }
+
+  // Use bell signal as null value for strings
+  template <typename T>
+  std::enable_if_t<std::is_same_v<std::string, T>, T> get_null_value() {
+    return std::string{'\7'};
+  }
+
+  // Use maximum value as null value for integral types
+  template <typename T>
+  std::enable_if_t<std::is_integral_v<T>, T> get_null_value() {
+    return std::numeric_limits<T>::max();
+  }
+};
+
+}  // namespace opossum

--- a/src/lib/storage/column_visitable.hpp
+++ b/src/lib/storage/column_visitable.hpp
@@ -11,6 +11,7 @@ class BaseColumn;
 class ReferenceColumn;
 class BaseDictionaryColumn;
 class BaseDeprecatedDictionaryColumn;
+class BaseEncodedColumn;
 
 // In cases where an operator has to operate on different column types, we use the visitor pattern.
 // By inheriting from ColumnVisitable, an AbstractOperator(Impl) can implement handle methods for all column
@@ -24,6 +25,8 @@ class ColumnVisitable {
                                         std::shared_ptr<ColumnVisitableContext> context) = 0;
   virtual void handle_dictionary_column(const BaseDictionaryColumn& column,
                                         std::shared_ptr<ColumnVisitableContext> context) = 0;
+  virtual void handle_encoded_column(const BaseEncodedColumn& column,
+                                     std::shared_ptr<ColumnVisitableContext> context) = 0;
   virtual void handle_reference_column(const ReferenceColumn& column,
                                        std::shared_ptr<ColumnVisitableContext> context) = 0;
 };

--- a/src/lib/storage/encoded_columns/base_encoded_column.cpp
+++ b/src/lib/storage/encoded_columns/base_encoded_column.cpp
@@ -1,10 +1,14 @@
 #include "base_encoded_column.hpp"
 
+#include "storage/column_visitable.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {
 
-// Encoded columns are immutable
 void BaseEncodedColumn::append(const AllTypeVariant&) { Fail("Encoded column is immutable."); }
+
+void BaseEncodedColumn::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context) const {
+  visitable.handle_encoded_column(*this, std::move(context));
+}
 
 }  // namespace opossum

--- a/src/lib/storage/encoded_columns/base_encoded_column.hpp
+++ b/src/lib/storage/encoded_columns/base_encoded_column.hpp
@@ -17,6 +17,9 @@ class BaseEncodedColumn : public BaseColumn {
   // Encoded columns are immutable
   void append(const AllTypeVariant&) final;
 
+  // calls the column-specific handler in an operator (visitor pattern)
+  void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
+
   virtual EncodingType encoding_type() const = 0;
 };
 

--- a/src/lib/storage/encoded_columns/column_encoding_type.hpp
+++ b/src/lib/storage/encoded_columns/column_encoding_type.hpp
@@ -16,7 +16,7 @@ namespace opossum {
 
 namespace hana = boost::hana;
 
-enum class EncodingType : uint8_t { Invalid, DeprecatedDictionary, Dictionary };
+enum class EncodingType : uint8_t { Invalid, DeprecatedDictionary, Dictionary, RunLength };
 
 namespace detail {
 
@@ -33,7 +33,8 @@ constexpr auto all_data_types = data_types;
  */
 constexpr auto supported_data_types_for_type =
     hana::make_map(hana::make_pair(enum_c<EncodingType, EncodingType::DeprecatedDictionary>, detail::all_data_types),
-                   hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, detail::all_data_types));
+                   hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, detail::all_data_types),
+                   hana::make_pair(enum_c<EncodingType, EncodingType::RunLength>, detail::all_data_types));
 
 //  Example for an encoding that doesn’t support all data types:
 //  hane::make_pair(enum_c<EncodingType, EncodingType::NewEncoding>, hana::make_tuple(hana::type_t<int32_t, int64_t>))

--- a/src/lib/storage/encoded_columns/encoded_columns.hpp
+++ b/src/lib/storage/encoded_columns/encoded_columns.hpp
@@ -5,6 +5,7 @@
 
 // Include your encoded column file here!
 #include "dictionary_column.hpp"
+#include "run_length_column.hpp"
 #include "storage/deprecated_dictionary_column.hpp"
 
 #include "column_encoding_type.hpp"
@@ -25,6 +26,7 @@ namespace opossum {
 constexpr auto encoded_column_info_for_type =
     hana::make_map(hana::make_pair(enum_c<EncodingType, EncodingType::DeprecatedDictionary>,
                                    hana::type_c<DeprecatedDictionaryColumnInfo>),
-                   hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, hana::type_c<DictionaryColumnInfo>));
+                   hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, hana::type_c<DictionaryColumnInfo>),
+                   hana::make_pair(enum_c<EncodingType, EncodingType::RunLength>, hana::type_c<RunLengthColumnInfo>));
 
 }  // namespace opossum

--- a/src/lib/storage/encoded_columns/run_length_column.cpp
+++ b/src/lib/storage/encoded_columns/run_length_column.cpp
@@ -51,47 +51,6 @@ size_t RunLengthColumn<T>::size() const {
 }
 
 template <typename T>
-void RunLengthColumn<T>::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
-  std::stringstream buffer;
-
-  const auto value = (*this)[chunk_offset];
-
-  bool is_null = variant_is_null(value);
-  Assert(!is_null, "This operation does not support NULL values.");
-
-  // buffering value at chunk_offset
-  buffer << value;
-  const uint32_t length = buffer.str().length();
-
-  // writing byte representation of length
-  buffer.write(reinterpret_cast<const char*>(&length), sizeof(length));
-
-  // appending the new string to the already present string
-  row_string += buffer.str();
-}
-
-template <typename T>
-void RunLengthColumn<T>::copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const {
-  auto& output_column = static_cast<ValueColumn<T>&>(value_column);
-
-  auto& values_out = output_column.values();
-
-  const auto value = (*this)[chunk_offset];
-  const auto is_null = variant_is_null(value);
-
-  if (output_column.is_nullable()) {
-    auto& null_values_out = output_column.null_values();
-
-    null_values_out.push_back(is_null);
-    values_out.push_back(is_null ? T{} : type_cast<T>(value));
-  } else {
-    DebugAssert(!is_null, "Value cannot be null if target column is not nullable.");
-
-    values_out.push_back(type_cast<T>(value));
-  }
-}
-
-template <typename T>
 std::shared_ptr<BaseColumn> RunLengthColumn<T>::copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const {
   auto new_values = pmr_vector<T>{*_values, alloc};
   auto new_end_positions = pmr_vector<ChunkOffset>{*_end_positions, alloc};

--- a/src/lib/storage/encoded_columns/run_length_column.cpp
+++ b/src/lib/storage/encoded_columns/run_length_column.cpp
@@ -1,0 +1,103 @@
+#include "run_length_column.hpp"
+
+#include <algorithm>
+
+#include "storage/value_column.hpp"
+#include "type_cast.hpp"
+#include "utils/assert.hpp"
+#include "utils/performance_warning.hpp"
+
+namespace opossum {
+
+template <typename T>
+RunLengthColumn<T>::RunLengthColumn(const std::shared_ptr<const pmr_vector<T>>& values,
+                                    const std::shared_ptr<const pmr_vector<ChunkOffset>>& end_positions,
+                                    const T null_value)
+    : _values{values}, _end_positions{end_positions}, _null_value{null_value} {}
+
+template <typename T>
+std::shared_ptr<const pmr_vector<T>> RunLengthColumn<T>::values() const { return _values; }
+
+template <typename T>
+std::shared_ptr<const pmr_vector<ChunkOffset>> RunLengthColumn<T>::end_positions() const { return _end_positions; }
+
+template <typename T>
+const T RunLengthColumn<T>::null_value() const { return _null_value; }
+
+template <typename T>
+const AllTypeVariant RunLengthColumn<T>::operator[](const ChunkOffset chunk_offset) const {
+  PerformanceWarning("operator[] used");
+
+  const auto end_position_it = std::lower_bound(_end_positions->cbegin(), _end_positions->cend(), chunk_offset);
+  const auto index = std::distance(_end_positions->cbegin(), end_position_it);
+
+  const auto value = (*_values)[index];
+
+  if (value == _null_value) return NULL_VALUE;
+
+  return AllTypeVariant{value};
+}
+
+template <typename T>
+size_t RunLengthColumn<T>::size() const {
+  DebugAssert(_end_positions->size() > 0u, "Column size is never zero.");
+  return _end_positions->back() + 1u;
+}
+
+template <typename T>
+void RunLengthColumn<T>::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
+  std::stringstream buffer;
+
+  const auto value = (*this)[chunk_offset];
+
+  bool is_null = variant_is_null(value);
+  Assert(!is_null, "This operation does not support NULL values.");
+
+  // buffering value at chunk_offset
+  buffer << value;
+  const uint32_t length = buffer.str().length();
+
+  // writing byte representation of length
+  buffer.write(reinterpret_cast<const char*>(&length), sizeof(length));
+
+  // appending the new string to the already present string
+  row_string += buffer.str();
+}
+
+template <typename T>
+void RunLengthColumn<T>::copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const {
+  auto& output_column = static_cast<ValueColumn<T>&>(value_column);
+
+  auto& values_out = output_column.values();
+
+  const auto value = (*this)[chunk_offset];
+  const auto is_null = variant_is_null(value);
+
+  if (output_column.is_nullable()) {
+    auto& null_values_out = output_column.null_values();
+
+    null_values_out.push_back(is_null);
+    values_out.push_back(is_null ? T{} : type_cast<T>(value));
+  } else {
+    DebugAssert(!is_null, "Value cannot be null if target column is not nullable.");
+
+    values_out.push_back(type_cast<T>(value));
+  }
+}
+
+template <typename T>
+std::shared_ptr<BaseColumn> RunLengthColumn<T>::copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const {
+  auto new_values = pmr_vector<T>{*_values, alloc};
+  auto new_end_positions = pmr_vector<ChunkOffset>{*_end_positions, alloc};
+
+  auto new_values_ptr = std::allocate_shared<pmr_vector<T>>(alloc, std::move(new_values));
+  auto new_end_positions_ptr = std::allocate_shared<pmr_vector<ChunkOffset>>(alloc, std::move(new_end_positions));
+  return std::allocate_shared<RunLengthColumn<T>>(alloc, new_values_ptr, new_end_positions_ptr, _null_value);
+}
+
+template <typename T>
+EncodingType RunLengthColumn<T>::encoding_type() const { return EncodingType::RunLength; }
+
+EXPLICITLY_INSTANTIATE_DATA_TYPES(RunLengthColumn);
+
+}  // namespace opossum

--- a/src/lib/storage/encoded_columns/run_length_column.cpp
+++ b/src/lib/storage/encoded_columns/run_length_column.cpp
@@ -16,13 +16,19 @@ RunLengthColumn<T>::RunLengthColumn(const std::shared_ptr<const pmr_vector<T>>& 
     : _values{values}, _end_positions{end_positions}, _null_value{null_value} {}
 
 template <typename T>
-std::shared_ptr<const pmr_vector<T>> RunLengthColumn<T>::values() const { return _values; }
+std::shared_ptr<const pmr_vector<T>> RunLengthColumn<T>::values() const {
+  return _values;
+}
 
 template <typename T>
-std::shared_ptr<const pmr_vector<ChunkOffset>> RunLengthColumn<T>::end_positions() const { return _end_positions; }
+std::shared_ptr<const pmr_vector<ChunkOffset>> RunLengthColumn<T>::end_positions() const {
+  return _end_positions;
+}
 
 template <typename T>
-const T RunLengthColumn<T>::null_value() const { return _null_value; }
+const T RunLengthColumn<T>::null_value() const {
+  return _null_value;
+}
 
 template <typename T>
 const AllTypeVariant RunLengthColumn<T>::operator[](const ChunkOffset chunk_offset) const {
@@ -96,7 +102,9 @@ std::shared_ptr<BaseColumn> RunLengthColumn<T>::copy_using_allocator(const Polym
 }
 
 template <typename T>
-EncodingType RunLengthColumn<T>::encoding_type() const { return EncodingType::RunLength; }
+EncodingType RunLengthColumn<T>::encoding_type() const {
+  return EncodingType::RunLength;
+}
 
 EXPLICITLY_INSTANTIATE_DATA_TYPES(RunLengthColumn);
 

--- a/src/lib/storage/encoded_columns/run_length_column.hpp
+++ b/src/lib/storage/encoded_columns/run_length_column.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "base_encoded_column.hpp"
+#include "types.hpp"
+
+namespace opossum {
+
+class BaseZeroSuppressionVector;
+
+/**
+ * @brief Column implementing run-length encoding
+ */
+template <typename T>
+class RunLengthColumn : public BaseEncodedColumn {
+ public:
+  explicit RunLengthColumn(const std::shared_ptr<const pmr_vector<T>>& values,
+                           const std::shared_ptr<const pmr_vector<ChunkOffset>>& end_positions,
+                           const T null_value);
+
+  std::shared_ptr<const pmr_vector<T>> values() const;
+  std::shared_ptr<const pmr_vector<ChunkOffset>> end_positions() const;
+
+  // column specific null_value
+  const T null_value() const;
+
+  /**
+   * @defgroup BaseColumn interface
+   * @{
+   */
+
+  const AllTypeVariant operator[](const ChunkOffset chunk_offset) const final;
+
+  size_t size() const final;
+
+  void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const final;
+
+  void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const final;
+
+  std::shared_ptr<BaseColumn> copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const final;
+
+  /**@}*/
+
+  /**
+   * @defgroup BaseEncodedColumn interface
+   * @{
+   */
+
+  EncodingType encoding_type() const final;
+
+  /**@}*/
+
+ protected:
+  const std::shared_ptr<const pmr_vector<T>> _values;
+  const std::shared_ptr<const pmr_vector<ChunkOffset>> _end_positions;
+  const T _null_value;
+};
+
+struct RunLengthColumnInfo {
+  template <typename T>
+  using ColumnTemplate = RunLengthColumn<T>;
+};
+
+}  // namespace opossum

--- a/src/lib/storage/encoded_columns/run_length_column.hpp
+++ b/src/lib/storage/encoded_columns/run_length_column.hpp
@@ -34,10 +34,6 @@ class RunLengthColumn : public BaseEncodedColumn {
 
   size_t size() const final;
 
-  void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const final;
-
-  void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const final;
-
   std::shared_ptr<BaseColumn> copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const final;
 
   /**@}*/

--- a/src/lib/storage/encoded_columns/run_length_column.hpp
+++ b/src/lib/storage/encoded_columns/run_length_column.hpp
@@ -17,8 +17,7 @@ template <typename T>
 class RunLengthColumn : public BaseEncodedColumn {
  public:
   explicit RunLengthColumn(const std::shared_ptr<const pmr_vector<T>>& values,
-                           const std::shared_ptr<const pmr_vector<ChunkOffset>>& end_positions,
-                           const T null_value);
+                           const std::shared_ptr<const pmr_vector<ChunkOffset>>& end_positions, const T null_value);
 
   std::shared_ptr<const pmr_vector<T>> values() const;
   std::shared_ptr<const pmr_vector<ChunkOffset>> end_positions() const;

--- a/src/lib/storage/iterables/chunk_offset_mapping.hpp
+++ b/src/lib/storage/iterables/chunk_offset_mapping.hpp
@@ -13,8 +13,8 @@ namespace opossum {
  * referenced value or dictionary column.
  */
 struct ChunkOffsetMapping {
-  const ChunkOffset into_referencing;  // chunk offset into reference column
-  const ChunkOffset into_referenced;   // used to access values in the referenced data column
+  ChunkOffset into_referencing;  // chunk offset into reference column
+  ChunkOffset into_referenced;   // used to access values in the referenced data column
 };
 
 /**

--- a/src/lib/storage/iterables/create_iterable_from_column.hpp
+++ b/src/lib/storage/iterables/create_iterable_from_column.hpp
@@ -3,6 +3,7 @@
 #include "deprecated_dictionary_column_iterable.hpp"
 #include "dictionary_column_iterable.hpp"
 #include "reference_column_iterable.hpp"
+#include "run_length_column_iterable.hpp"
 #include "value_column_iterable.hpp"
 
 namespace opossum {
@@ -34,6 +35,11 @@ auto create_iterable_from_column(const ReferenceColumn& column) {
 template <typename T>
 auto create_iterable_from_column(const DictionaryColumn<T>& column) {
   return DictionaryColumnIterable<T>{column};
+}
+
+template <typename T>
+auto create_iterable_from_column(const RunLengthColumn<T>& column) {
+  return RunLengthColumnIterable<T>{column};
 }
 
 /**@}*/

--- a/src/lib/storage/iterables/run_length_column_iterable.hpp
+++ b/src/lib/storage/iterables/run_length_column_iterable.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <algorithm>
+
+#include "iterables.hpp"
+
+#include "storage/encoded_columns/run_length_column.hpp"
+
+namespace opossum {
+
+template <typename T>
+class RunLengthColumnIterable : public IndexableIterable<RunLengthColumnIterable<T>> {
+ public:
+  explicit RunLengthColumnIterable(const RunLengthColumn<T>& column) : _column{column} {}
+
+  template <typename Functor>
+  void _on_with_iterators(const Functor& functor) const {
+    auto begin = Iterator{_column.null_value(), _column.values()->cbegin(), _column.end_positions()->cbegin(), 0u};
+    auto end = Iterator{_column.null_value(), _column.values()->cend(), _column.end_positions()->cend(), static_cast<ChunkOffset>(_column.size())};
+
+    functor(begin, end);
+  }
+
+  template <typename Functor>
+  void _on_with_iterators(const ChunkOffsetsList& mapped_chunk_offsets, const Functor& functor) const {
+    auto begin = IndexedIterator{_column.null_value(), *_column.values(), *_column.end_positions(), mapped_chunk_offsets.cbegin()};
+    auto end = IndexedIterator{_column.null_value(), *_column.values(), *_column.end_positions(), mapped_chunk_offsets.cend()};
+
+    functor(begin, end);
+  }
+
+ private:
+  const RunLengthColumn<T>& _column;
+
+ private:
+  class Iterator : public BaseIterator<Iterator, NullableColumnValue<T>> {
+   public:
+    using ValueIterator = typename pmr_vector<T>::const_iterator;
+    using EndPositionIterator = typename pmr_vector<ChunkOffset>::const_iterator;
+
+   public:
+    explicit Iterator(const T null_value, const ValueIterator& value_it, const EndPositionIterator& end_position_it, const ChunkOffset start_position)
+        : _null_value{null_value}, _value_it{value_it}, _end_position_it{end_position_it}, _current_position{start_position} {}
+
+   private:
+    friend class boost::iterator_core_access;  // grants the boost::iterator_facade access to the private interface
+
+    void increment() {
+      ++_current_position;
+
+      if (_current_position > *_end_position_it) {
+        ++_value_it;
+        ++_end_position_it;
+      }
+    }
+
+    bool equal(const Iterator& other) const { return _current_position == other._current_position; }
+
+    NullableColumnValue<T> dereference() const {
+      if (*_value_it == _null_value) { return NullableColumnValue{T{}, true, _current_position}; }
+
+      return NullableColumnValue<T>{*_value_it, false, _current_position};
+    }
+
+   private:
+    const T _null_value;
+    ValueIterator _value_it;
+    EndPositionIterator _end_position_it;
+    ChunkOffset _current_position;
+  };
+
+  class IndexedIterator : public BaseIndexedIterator<IndexedIterator, NullableColumnValue<T>> {
+   public:
+    explicit IndexedIterator(const T null_value, const pmr_vector<T>& values, const pmr_vector<ChunkOffset>& end_positions,
+                             const ChunkOffsetsIterator& chunk_offsets_it)
+        : BaseIndexedIterator<IndexedIterator, NullableColumnValue<T>>{chunk_offsets_it},
+          _null_value{null_value},
+          _values{values},
+          _end_positions{end_positions},
+          _prev_chunk_offset{end_positions.back() + 1u},
+          _prev_index{end_positions.size()} {}
+
+   private:
+    friend class boost::iterator_core_access;  // grants the boost::iterator_facade access to the private interface
+
+    NullableColumnValue<T> dereference() const {
+      const auto& chunk_offsets = this->chunk_offsets();
+
+      if (chunk_offsets.into_referenced == INVALID_CHUNK_OFFSET)
+        return NullableColumnValue<T>{T{}, true, chunk_offsets.into_referencing};
+
+      const auto current_chunk_offset = chunk_offsets.into_referenced;
+      const auto less_than_current = [current = current_chunk_offset](ChunkOffset offset) { return offset < current; };
+
+      auto end_position_it = _end_positions.cend();
+      if (current_chunk_offset < _prev_chunk_offset) {
+        end_position_it = std::lower_bound(_end_positions.cbegin(), _end_positions.cbegin() + _prev_index, current_chunk_offset);
+      } else {
+        end_position_it = std::find_if_not(_end_positions.cbegin() + _prev_index, _end_positions.cend(),
+                                           less_than_current);
+      }
+
+      const auto current_index = std::distance(_end_positions.cbegin(), end_position_it);
+
+      const auto value = _values[current_index];
+      const auto is_null = (value == _null_value);
+
+      _prev_chunk_offset = current_chunk_offset;
+      _prev_index = current_index;
+
+      return NullableColumnValue<T>{value, is_null, chunk_offsets.into_referencing};
+    }
+
+   private:
+    const T _null_value;
+    const pmr_vector<T>& _values;
+    const pmr_vector<ChunkOffset>& _end_positions;
+
+    mutable ChunkOffset _prev_chunk_offset;
+    mutable size_t _prev_index;
+  };
+};
+
+}  // namespace opossum

--- a/src/lib/storage/iterables/run_length_column_iterable.hpp
+++ b/src/lib/storage/iterables/run_length_column_iterable.hpp
@@ -16,15 +16,18 @@ class RunLengthColumnIterable : public IndexableIterable<RunLengthColumnIterable
   template <typename Functor>
   void _on_with_iterators(const Functor& functor) const {
     auto begin = Iterator{_column.null_value(), _column.values()->cbegin(), _column.end_positions()->cbegin(), 0u};
-    auto end = Iterator{_column.null_value(), _column.values()->cend(), _column.end_positions()->cend(), static_cast<ChunkOffset>(_column.size())};
+    auto end = Iterator{_column.null_value(), _column.values()->cend(), _column.end_positions()->cend(),
+                        static_cast<ChunkOffset>(_column.size())};
 
     functor(begin, end);
   }
 
   template <typename Functor>
   void _on_with_iterators(const ChunkOffsetsList& mapped_chunk_offsets, const Functor& functor) const {
-    auto begin = IndexedIterator{_column.null_value(), *_column.values(), *_column.end_positions(), mapped_chunk_offsets.cbegin()};
-    auto end = IndexedIterator{_column.null_value(), *_column.values(), *_column.end_positions(), mapped_chunk_offsets.cend()};
+    auto begin = IndexedIterator{_column.null_value(), *_column.values(), *_column.end_positions(),
+                                 mapped_chunk_offsets.cbegin()};
+    auto end =
+        IndexedIterator{_column.null_value(), *_column.values(), *_column.end_positions(), mapped_chunk_offsets.cend()};
 
     functor(begin, end);
   }
@@ -39,8 +42,12 @@ class RunLengthColumnIterable : public IndexableIterable<RunLengthColumnIterable
     using EndPositionIterator = typename pmr_vector<ChunkOffset>::const_iterator;
 
    public:
-    explicit Iterator(const T null_value, const ValueIterator& value_it, const EndPositionIterator& end_position_it, const ChunkOffset start_position)
-        : _null_value{null_value}, _value_it{value_it}, _end_position_it{end_position_it}, _current_position{start_position} {}
+    explicit Iterator(const T null_value, const ValueIterator& value_it, const EndPositionIterator& end_position_it,
+                      const ChunkOffset start_position)
+        : _null_value{null_value},
+          _value_it{value_it},
+          _end_position_it{end_position_it},
+          _current_position{start_position} {}
 
    private:
     friend class boost::iterator_core_access;  // grants the boost::iterator_facade access to the private interface
@@ -57,7 +64,9 @@ class RunLengthColumnIterable : public IndexableIterable<RunLengthColumnIterable
     bool equal(const Iterator& other) const { return _current_position == other._current_position; }
 
     NullableColumnValue<T> dereference() const {
-      if (*_value_it == _null_value) { return NullableColumnValue{T{}, true, _current_position}; }
+      if (*_value_it == _null_value) {
+        return NullableColumnValue{T{}, true, _current_position};
+      }
 
       return NullableColumnValue<T>{*_value_it, false, _current_position};
     }
@@ -71,8 +80,8 @@ class RunLengthColumnIterable : public IndexableIterable<RunLengthColumnIterable
 
   class IndexedIterator : public BaseIndexedIterator<IndexedIterator, NullableColumnValue<T>> {
    public:
-    explicit IndexedIterator(const T null_value, const pmr_vector<T>& values, const pmr_vector<ChunkOffset>& end_positions,
-                             const ChunkOffsetsIterator& chunk_offsets_it)
+    explicit IndexedIterator(const T null_value, const pmr_vector<T>& values,
+                             const pmr_vector<ChunkOffset>& end_positions, const ChunkOffsetsIterator& chunk_offsets_it)
         : BaseIndexedIterator<IndexedIterator, NullableColumnValue<T>>{chunk_offsets_it},
           _null_value{null_value},
           _values{values},
@@ -94,10 +103,11 @@ class RunLengthColumnIterable : public IndexableIterable<RunLengthColumnIterable
 
       auto end_position_it = _end_positions.cend();
       if (current_chunk_offset < _prev_chunk_offset) {
-        end_position_it = std::lower_bound(_end_positions.cbegin(), _end_positions.cbegin() + _prev_index, current_chunk_offset);
+        end_position_it =
+            std::lower_bound(_end_positions.cbegin(), _end_positions.cbegin() + _prev_index, current_chunk_offset);
       } else {
-        end_position_it = std::find_if_not(_end_positions.cbegin() + _prev_index, _end_positions.cend(),
-                                           less_than_current);
+        end_position_it =
+            std::find_if_not(_end_positions.cbegin() + _prev_index, _end_positions.cend(), less_than_current);
       }
 
       const auto current_index = std::distance(_end_positions.cbegin(), end_position_it);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(
     storage/composite_group_key_index_test.cpp
     storage/deprecated_dictionary_column_test.cpp
     storage/dictionary_column_test.cpp
+    storage/encoded_column_test.cpp
     storage/group_key_index_test.cpp
     storage/iterables_test.cpp
     storage/multi_column_index_test.cpp

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -596,11 +596,11 @@ TEST_P(OperatorsTableScanTest, NullSemantics) {
   }
 }
 
-TEST_F(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
+TEST_P(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
   const auto expected = std::vector<AllTypeVariant>{110, 112, 114, 116, 118, 120, 122, 124};
 
   auto scan =
-      std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+      std::make_shared<opossum::TableScan>(get_table_op_even_dict(), ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan->set_excluded_chunk_ids({ChunkID{0u}});
   scan->execute();
 

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -19,10 +19,9 @@ namespace opossum {
 
 namespace hana = boost::hana;
 
-using EncodingTypes =
-    ::testing::Types<enum_constant<EncodingType, EncodingType::Dictionary>,
-                     enum_constant<EncodingType, EncodingType::DeprecatedDictionary>,
-                     enum_constant<EncodingType, EncodingType::RunLength>>;
+using EncodingTypes = ::testing::Types<enum_constant<EncodingType, EncodingType::Dictionary>,
+                                       enum_constant<EncodingType, EncodingType::DeprecatedDictionary>,
+                                       enum_constant<EncodingType, EncodingType::RunLength>>;
 
 template <typename EncodingTypeT>
 class EncodedColumnTest : public BaseTest {
@@ -93,7 +92,8 @@ class EncodedColumnTest : public BaseTest {
   }
 
   template <typename T>
-  std::shared_ptr<EncodedColumnType<T>> encode_value_column(DataType data_type, const std::shared_ptr<ValueColumn<T>>& value_column) {
+  std::shared_ptr<EncodedColumnType<T>> encode_value_column(DataType data_type,
+                                                            const std::shared_ptr<ValueColumn<T>>& value_column) {
     return std::dynamic_pointer_cast<EncodedColumnType<T>>(encode_column(encoding_type_t(), data_type, value_column));
   }
 };

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -1,0 +1,191 @@
+#include <boost/hana/at_key.hpp>
+
+#include <memory>
+#include <random>
+
+#include "base_test.hpp"
+#include "gtest/gtest.h"
+
+#include "storage/column_encoders/utils.hpp"
+#include "storage/encoded_columns/column_encoding_type.hpp"
+#include "storage/encoded_columns/encoded_columns.hpp"
+#include "storage/iterables/create_iterable_from_column.hpp"
+#include "storage/value_column.hpp"
+
+#include "types.hpp"
+#include "utils/enum_constant.hpp"
+
+namespace opossum {
+
+namespace hana = boost::hana;
+
+using EncodingTypes =
+    ::testing::Types<enum_constant<EncodingType, EncodingType::Dictionary>,
+                     enum_constant<EncodingType, EncodingType::DeprecatedDictionary>,
+                     enum_constant<EncodingType, EncodingType::RunLength>>;
+
+template <typename EncodingTypeT>
+class EncodedColumnTest : public BaseTest {
+ protected:
+  static constexpr auto encoding_type_t = EncodingTypeT{};
+  static constexpr auto column_info_t = hana::at_key(encoded_column_info_for_type, encoding_type_t);
+
+  using ColumnInfoType = typename decltype(column_info_t)::type;
+
+  template <typename T>
+  using EncodedColumnType = typename ColumnInfoType::template ColumnTemplate<T>;
+
+ protected:
+  static constexpr auto row_count = 200u;
+
+ protected:
+  std::shared_ptr<ValueColumn<int32_t>> create_int_value_column() {
+    auto values = pmr_concurrent_vector<int32_t>(row_count);
+
+    std::default_random_engine engine{};
+    std::uniform_int_distribution<int32_t> dist{0u, 10u};
+
+    for (auto& elem : values) {
+      elem = dist(engine);
+    }
+
+    return std::make_shared<ValueColumn<int32_t>>(std::move(values));
+  }
+
+  std::shared_ptr<ValueColumn<int32_t>> create_int_w_null_value_column() {
+    auto values = pmr_concurrent_vector<int32_t>(row_count);
+    auto null_values = pmr_concurrent_vector<bool>(row_count);
+
+    std::default_random_engine engine{};
+    std::uniform_int_distribution<int32_t> dist{0u, 10u};
+    std::bernoulli_distribution bernoulli_dist{0.3};
+
+    for (auto i = 0u; i < row_count; ++i) {
+      values[i] = dist(engine);
+      null_values[i] = bernoulli_dist(engine);
+    }
+
+    return std::make_shared<ValueColumn<int32_t>>(std::move(values), std::move(null_values));
+  }
+
+  ChunkOffsetsList create_sequential_chunk_offsets_list() {
+    auto list = ChunkOffsetsList{};
+
+    std::default_random_engine engine{};
+    std::bernoulli_distribution bernoulli_dist{0.5};
+
+    for (auto into_referencing = 0u, into_referenced = 0u; into_referenced < row_count; ++into_referenced) {
+      if (bernoulli_dist(engine)) {
+        list.push_back({into_referencing++, into_referenced});
+      }
+    }
+
+    return list;
+  }
+
+  ChunkOffsetsList create_random_access_chunk_offsets_list() {
+    auto list = create_sequential_chunk_offsets_list();
+
+    std::default_random_engine engine{};
+    std::shuffle(list.begin(), list.end(), engine);
+
+    return list;
+  }
+
+  template <typename T>
+  std::shared_ptr<EncodedColumnType<T>> encode_value_column(DataType data_type, const std::shared_ptr<ValueColumn<T>>& value_column) {
+    return std::dynamic_pointer_cast<EncodedColumnType<T>>(encode_column(encoding_type_t(), data_type, value_column));
+  }
+};
+
+TYPED_TEST_CASE(EncodedColumnTest, EncodingTypes);
+
+TYPED_TEST(EncodedColumnTest, SequenciallyReadNotNullableIntColumn) {
+  auto value_column = this->create_int_value_column();
+  auto encoded_column = this->encode_value_column(DataType::Int, value_column);
+
+  EXPECT_EQ(value_column->size(), encoded_column->size());
+
+  auto value_column_iterable = create_iterable_from_column(*value_column);
+  auto encoded_column_iterable = create_iterable_from_column(*encoded_column);
+
+  value_column_iterable.with_iterators([&](auto value_column_it, auto value_column_end) {
+    encoded_column_iterable.with_iterators([&](auto encoded_column_it, auto encoded_column_end) {
+      for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it) {
+        EXPECT_EQ(value_column_it->value(), encoded_column_it->value());
+      }
+    });
+  });
+}
+
+TYPED_TEST(EncodedColumnTest, SequenciallyReadNullableIntColumn) {
+  auto value_column = this->create_int_w_null_value_column();
+  auto encoded_column = this->encode_value_column(DataType::Int, value_column);
+
+  EXPECT_EQ(value_column->size(), encoded_column->size());
+
+  auto value_column_iterable = create_iterable_from_column(*value_column);
+  auto encoded_column_iterable = create_iterable_from_column(*encoded_column);
+
+  value_column_iterable.with_iterators([&](auto value_column_it, auto value_column_end) {
+    encoded_column_iterable.with_iterators([&](auto encoded_column_it, auto encoded_column_end) {
+      for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it) {
+        EXPECT_EQ(value_column_it->is_null(), encoded_column_it->is_null());
+
+        if (!value_column_it->is_null()) {
+          EXPECT_EQ(value_column_it->value(), encoded_column_it->value());
+        }
+      }
+    });
+  });
+}
+
+TYPED_TEST(EncodedColumnTest, SequanciallyReadNullableIntColumnWithChunkOffsetsList) {
+  auto value_column = this->create_int_w_null_value_column();
+  auto encoded_column = this->encode_value_column(DataType::Int, value_column);
+
+  EXPECT_EQ(value_column->size(), encoded_column->size());
+
+  auto value_column_iterable = create_iterable_from_column(*value_column);
+  auto encoded_column_iterable = create_iterable_from_column(*encoded_column);
+
+  auto chunk_offsets_list = this->create_sequential_chunk_offsets_list();
+
+  value_column_iterable.with_iterators(&chunk_offsets_list, [&](auto value_column_it, auto value_column_end) {
+    encoded_column_iterable.with_iterators(&chunk_offsets_list, [&](auto encoded_column_it, auto encoded_column_end) {
+      for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it) {
+        EXPECT_EQ(value_column_it->is_null(), encoded_column_it->is_null());
+
+        if (!value_column_it->is_null()) {
+          EXPECT_EQ(value_column_it->value(), encoded_column_it->value());
+        }
+      }
+    });
+  });
+}
+
+TYPED_TEST(EncodedColumnTest, SequanciallyReadNullableIntColumnWithShuffledChunkOffsetsList) {
+  auto value_column = this->create_int_w_null_value_column();
+  auto encoded_column = this->encode_value_column(DataType::Int, value_column);
+
+  EXPECT_EQ(value_column->size(), encoded_column->size());
+
+  auto value_column_iterable = create_iterable_from_column(*value_column);
+  auto encoded_column_iterable = create_iterable_from_column(*encoded_column);
+
+  auto chunk_offsets_list = this->create_random_access_chunk_offsets_list();
+
+  value_column_iterable.with_iterators(&chunk_offsets_list, [&](auto value_column_it, auto value_column_end) {
+    encoded_column_iterable.with_iterators(&chunk_offsets_list, [&](auto encoded_column_it, auto encoded_column_end) {
+      for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it) {
+        EXPECT_EQ(value_column_it->is_null(), encoded_column_it->is_null());
+
+        if (!value_column_it->is_null()) {
+          EXPECT_EQ(value_column_it->value(), encoded_column_it->value());
+        }
+      }
+    });
+  });
+}
+
+}  // namespace opossum


### PR DESCRIPTION
**Follow-up PR to #566**

This is an example pull request which adds Run-Length Encoding. It’s a pull request on top of #566 in order to show how the new framework facilitates adding new compression schemes. Commit e765e052054884c423cf56bd774cb5d92e80f94c contains everything that is specific to the new compression scheme (about 400 lines, 4 files added, 5 files touched (only very few lines)). It took around 5 hours to write this and fix bugs. I think some code wasn’t really necessary and is partially duplicated from other columns (see #599). I added a bit more (additions to visitor interface + tests) in the other two commits. Those things needed to be done only once.
  