### PR TITLE
Remove BaseColumn::write_string_representation

### DIFF
--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -6,9 +6,13 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <sstream>
+#include <algorithm>
+#include <iterator>
 
 #include "storage/reference_column.hpp"
 #include "utils/assert.hpp"
+#include "type_cast.hpp"
 
 namespace opossum {
 Difference::Difference(const std::shared_ptr<const AbstractOperator> left_in,
@@ -29,23 +33,27 @@ std::shared_ptr<const Table> Difference::_on_execute() {
 
   // 1. We create a set of all right input rows as concatenated strings.
 
-  std::unordered_set<std::string> right_input_row_set(_input_table_right()->row_count());
+  auto right_input_row_set = std::unordered_set<std::string>(_input_table_right()->row_count());
 
   // Iterating over all chunks and for each chunk over all columns
   for (ChunkID chunk_id{0}; chunk_id < _input_table_right()->chunk_count(); chunk_id++) {
     const Chunk& chunk = _input_table_right()->get_chunk(chunk_id);
     // creating a temporary row representation with strings to be filled column wise
-    auto string_row_vector = std::vector<std::string>(chunk.size());
+    auto string_row_vector = std::vector<std::stringstream>(chunk.size());
     for (ColumnID column_id{0}; column_id < _input_table_right()->column_count(); column_id++) {
       const auto base_column = chunk.get_column(column_id);
 
       // filling the row vector with all values from this column
+      auto row_string_buffer = std::stringstream{};
       for (ChunkOffset chunk_offset = 0; chunk_offset < base_column->size(); chunk_offset++) {
-        base_column->write_string_representation(string_row_vector[chunk_offset], chunk_offset);
+        const auto value = (*base_column)[chunk_offset];
+        append_string_representation(string_row_vector[chunk_offset], value);
       }
     }
+
     // Remove duplicate rows by adding all rows to a unordered set
-    right_input_row_set.insert(string_row_vector.begin(), string_row_vector.end());
+    std::transform(string_row_vector.cbegin(), string_row_vector.cend(),
+        std::inserter(right_input_row_set, right_input_row_set.end()), [](auto& x) { return x.str(); });
   }
 
   // 2. Now we check for each chunk of the left input which rows can be added to the output
@@ -89,11 +97,13 @@ std::shared_ptr<const Table> Difference::_on_execute() {
     // for all offsets check if the row can be added to the output
     for (ChunkOffset chunk_offset = 0; chunk_offset < in_chunk.size(); chunk_offset++) {
       // creating string representation off the row at chunk_offset
-      std::string row_string;
+      auto row_string_buffer = std::stringstream{};
       for (ColumnID column_id{0}; column_id < _input_table_left()->column_count(); column_id++) {
-        auto base_column = in_chunk.get_column(column_id);
-        base_column->write_string_representation(row_string, chunk_offset);
+        const auto base_column = in_chunk.get_column(column_id);
+        const auto value = (*base_column)[chunk_offset];
+        append_string_representation(row_string_buffer, value);
       }
+      const auto row_string = row_string_buffer.str();
 
       // we check if the recently created row_string is contained in the left_input_row_set
       auto search = right_input_row_set.find(row_string);
@@ -113,6 +123,17 @@ std::shared_ptr<const Table> Difference::_on_execute() {
   }
 
   return output;
+}
+
+void Difference::append_string_representation(std::ostream& row_string_buffer, const AllTypeVariant value) {
+  const auto string_value = type_cast<std::string>(value);
+  const auto length = static_cast<uint32_t>(string_value.length());
+
+  // write value as string
+  row_string_buffer << string_value;
+
+  // write byte representation of length
+  row_string_buffer.write(reinterpret_cast<const char*>(&length), sizeof(length));
 }
 
 }  // namespace opossum

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -1,18 +1,18 @@
 #include "difference.hpp"
 
+#include <algorithm>
+#include <iterator>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
-#include <sstream>
-#include <algorithm>
-#include <iterator>
 
 #include "storage/reference_column.hpp"
-#include "utils/assert.hpp"
 #include "type_cast.hpp"
+#include "utils/assert.hpp"
 
 namespace opossum {
 Difference::Difference(const std::shared_ptr<const AbstractOperator> left_in,
@@ -53,7 +53,7 @@ std::shared_ptr<const Table> Difference::_on_execute() {
 
     // Remove duplicate rows by adding all rows to a unordered set
     std::transform(string_row_vector.cbegin(), string_row_vector.cend(),
-        std::inserter(right_input_row_set, right_input_row_set.end()), [](auto& x) { return x.str(); });
+                   std::inserter(right_input_row_set, right_input_row_set.end()), [](auto& x) { return x.str(); });
   }
 
   // 2. Now we check for each chunk of the left input which rows can be added to the output

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -46,6 +46,8 @@ std::shared_ptr<const Table> Difference::_on_execute() {
       // filling the row vector with all values from this column
       auto row_string_buffer = std::stringstream{};
       for (ChunkOffset chunk_offset = 0; chunk_offset < base_column->size(); chunk_offset++) {
+        // Previously we called a virtual method of the BaseColumn interface here.
+        // It was replaced with a call to the subscript operator as that is equally slow.
         const auto value = (*base_column)[chunk_offset];
         append_string_representation(string_row_vector[chunk_offset], value);
       }
@@ -100,6 +102,9 @@ std::shared_ptr<const Table> Difference::_on_execute() {
       auto row_string_buffer = std::stringstream{};
       for (ColumnID column_id{0}; column_id < _input_table_left()->column_count(); column_id++) {
         const auto base_column = in_chunk.get_column(column_id);
+
+        // Previously a virtual method of the BaseColumn interface was called here.
+        // It was replaced with a call to the subscript operator as that is equally slow.
         const auto value = (*base_column)[chunk_offset];
         append_string_representation(row_string_buffer, value);
       }

--- a/src/lib/operators/difference.hpp
+++ b/src/lib/operators/difference.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 #include "abstract_read_only_operator.hpp"
 #include "types.hpp"

--- a/src/lib/operators/difference.hpp
+++ b/src/lib/operators/difference.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <sstream>
 
 #include "abstract_read_only_operator.hpp"
 #include "types.hpp"
@@ -22,7 +23,10 @@ class Difference : public AbstractReadOnlyOperator {
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;
 
  protected:
-  void initialize_chunk(const size_t chunk_id);
   std::shared_ptr<const Table> _on_execute() override;
+
+ private:
+  void initialize_chunk(const size_t chunk_id);
+  void append_string_representation(std::ostream& row_string_buffer, const AllTypeVariant value);
 };
 }  // namespace opossum

--- a/src/lib/storage/base_column.hpp
+++ b/src/lib/storage/base_column.hpp
@@ -35,9 +35,6 @@ class BaseColumn : private Noncopyable {
   // calls the column-specific handler in an operator (visitor pattern)
   virtual void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const = 0;
 
-  // writes the length and value at the chunk_offset to the end of row_string
-  virtual void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const = 0;
-
   // copies one of its own values to a different ValueColumn - mainly used for materialization
   // we cannot always use the materialize method below because sort results might come from different BaseColumns
   virtual void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const = 0;

--- a/src/lib/storage/dictionary_column.cpp
+++ b/src/lib/storage/dictionary_column.cpp
@@ -135,23 +135,6 @@ void DictionaryColumn<T>::visit(ColumnVisitable& visitable, std::shared_ptr<Colu
 }
 
 template <typename T>
-void DictionaryColumn<T>::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
-  std::stringstream buffer;
-  // buffering value at chunk_offset
-  auto value_id = _attribute_vector->get(chunk_offset);
-  Assert(value_id != NULL_VALUE_ID, "This operation does not support NULL values.");
-
-  T value = _dictionary->at(value_id);
-  buffer << value;
-  uint32_t length = buffer.str().length();
-  // writing byte representation of length
-  buffer.write(reinterpret_cast<const char*>(&length), sizeof(length));
-
-  // appending the new string to the already present string
-  row_string += buffer.str();
-}
-
-template <typename T>
 void DictionaryColumn<T>::copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const {
   auto& output_column = static_cast<ValueColumn<T>&>(value_column);
   auto& values_out = output_column.values();

--- a/src/lib/storage/dictionary_column.hpp
+++ b/src/lib/storage/dictionary_column.hpp
@@ -76,9 +76,6 @@ class DictionaryColumn : public BaseDictionaryColumn {
   // visitor pattern, see base_column.hpp
   void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
 
-  // writes the length and value at the chunk_offset to the end off row_string
-  void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const override;
-
   // copies one of its own values to a different ValueColumn - mainly used for materialization
   // we cannot always use the materialize method below because sort results might come from different BaseColumns
   void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const override;

--- a/src/lib/storage/reference_column.cpp
+++ b/src/lib/storage/reference_column.cpp
@@ -45,16 +45,6 @@ void ReferenceColumn::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVi
   visitable.handle_reference_column(*this, std::move(context));
 }
 
-// writes the length and value at the chunk_offset to the end off row_string
-void ReferenceColumn::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
-  // retrieving the chunk_id for the given chunk_offset
-  auto row_id = (*_pos_list).at(chunk_offset);
-  // call the equivalent function of the referenced value column
-  _referenced_table->get_chunk(row_id.chunk_id)
-      .get_column(_referenced_column_id)
-      ->write_string_representation(row_string, chunk_offset);
-}
-
 // copies one of its own values to a different ValueColumn - mainly used for materialization
 // we cannot always use the materialize method below because sort results might come from different BaseColumns
 void ReferenceColumn::copy_value_to_value_column(BaseColumn&, ChunkOffset) const {

--- a/src/lib/storage/reference_column.hpp
+++ b/src/lib/storage/reference_column.hpp
@@ -79,9 +79,6 @@ class ReferenceColumn : public BaseColumn {
   // visitor pattern, see base_column.hpp
   void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
 
-  // writes the length and value at the chunk_offset to the end off row_string
-  void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const override;
-
   template <typename ContextClass>
   void visit_dereferenced(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> ctx) const {
     /*

--- a/src/lib/storage/value_column.cpp
+++ b/src/lib/storage/value_column.cpp
@@ -145,23 +145,6 @@ void ValueColumn<T>::visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVis
 }
 
 template <typename T>
-void ValueColumn<T>::write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const {
-  std::stringstream buffer;
-
-  bool is_null = is_nullable() && (*_null_values)[chunk_offset];
-  Assert(!is_null, "This operation does not support NULL values.");
-
-  // buffering value at chunk_offset
-  buffer << _values[chunk_offset];
-  uint32_t length = buffer.str().length();
-  // writing byte representation of length
-  buffer.write(reinterpret_cast<const char*>(&length), sizeof(length));
-
-  // appending the new string to the already present string
-  row_string += buffer.str();
-}
-
-template <typename T>
 void ValueColumn<T>::copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const {
   auto& output_column = static_cast<ValueColumn<T>&>(value_column);
 

--- a/src/lib/storage/value_column.hpp
+++ b/src/lib/storage/value_column.hpp
@@ -60,9 +60,6 @@ class ValueColumn : public BaseValueColumn {
   // Visitor pattern, see base_column.hpp
   void visit(ColumnVisitable& visitable, std::shared_ptr<ColumnVisitableContext> context = nullptr) const override;
 
-  // Write the length and value at the chunk_offset to the end of row_string.
-  void write_string_representation(std::string& row_string, const ChunkOffset chunk_offset) const override;
-
   // Copy own value to a different ValueColumn - mainly used for materialization.
   // We cannot always use the materialize method below because sort results might come from different BaseColumns.
   void copy_value_to_value_column(BaseColumn& value_column, ChunkOffset chunk_offset) const override;


### PR DESCRIPTION
addresses #599 
  
I left `Difference` basically untouched.

Note: Since `BaseColumn::write_string_representation` was a virtual method, it was just as fast as the subscript operator. I replaced this method with a call to `base_column[]` + a few more lines. 
  