### PR TITLE
Add TableScan::set_excluded_chunk_ids

### DIFF
--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -29,7 +29,7 @@ class IndexScan : public AbstractReadOnlyOperator {
   /**
    * @brief If set, only the specified chunks will be scanned.
    *
-   * @see TableScann::set_excluded_chunk_ids for usage
+   * @see TableScan::set_excluded_chunk_ids for usage
    */
   void set_included_chunk_ids(const std::vector<ChunkID>& chunk_ids);
 

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -27,7 +27,9 @@ class IndexScan : public AbstractReadOnlyOperator {
   const std::string name() const final;
 
   /**
-   * If set, only the specified chunks will be scanned.
+   * @brief If set, only the specified chunks will be scanned.
+   *
+   * @see TableScann::set_excluded_chunk_ids for usage
    */
   void set_included_chunk_ids(const std::vector<ChunkID>& chunk_ids);
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -5,9 +5,9 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <unordered_set>
 
 #include "all_parameter_variant.hpp"
 #include "constant_mappings.hpp"

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_set>
 
 #include "all_parameter_variant.hpp"
 #include "constant_mappings.hpp"
@@ -36,6 +37,8 @@ TableScan::TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID 
       _right_parameter{right_parameter} {}
 
 TableScan::~TableScan() = default;
+
+void TableScan::set_excluded_chunk_ids(const std::vector<ChunkID>& chunk_ids) { _excluded_chunk_ids = chunk_ids; }
 
 ColumnID TableScan::left_column_id() const { return _left_column_id; }
 
@@ -75,10 +78,14 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
 
   std::mutex output_mutex;
 
+  const auto excluded_chunk_set = std::unordered_set<ChunkID>{_excluded_chunk_ids.cbegin(), _excluded_chunk_ids.cend()};
+
   auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
-  jobs.reserve(_in_table->chunk_count());
+  jobs.reserve(_in_table->chunk_count() - excluded_chunk_set.size());
 
   for (ChunkID chunk_id{0u}; chunk_id < _in_table->chunk_count(); ++chunk_id) {
+    if (excluded_chunk_set.count(chunk_id)) continue;
+
     auto job_task = std::make_shared<JobTask>([=, &output_mutex]() {
       const auto chunk_guard = _in_table->get_chunk_with_access_counting(chunk_id);
       // The actual scan happens in the sub classes of BaseTableScanImpl

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -41,7 +41,6 @@ class TableScan : public AbstractReadOnlyOperator {
   void _on_cleanup() override;
 
   void _init_scan();
-  void _create_job_and_schedule(const ChunkID chunk_id, std::mutex& output_mutex);
 
  private:
   const ColumnID _left_column_id;

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -23,7 +23,17 @@ class TableScan : public AbstractReadOnlyOperator {
   ~TableScan();
 
   /**
-   * If set, the specified chunks will not be scanned.
+   * @brief If set, the specified chunks will not be scanned.
+   *
+   * There are different implementations of table scans.
+   * This is the standard linear scan; another one is
+   * the index scan, which scans a column using an index.
+   * Depending on the situation, it is advantageous to use
+   * the index scan for some chunks and the standard scan for
+   * others. However one has to ensure that all chunks including
+   * newly added are scanned. This is why this scan accepts a list
+   * of excluded chunks while all other scans accept a list of
+   * included chunks.
    */
   void set_excluded_chunk_ids(const std::vector<ChunkID>& chunk_ids);
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -31,9 +31,10 @@ class TableScan : public AbstractReadOnlyOperator {
    * Depending on the situation, it is advantageous to use
    * the index scan for some chunks and the standard scan for
    * others. However one has to ensure that all chunks including
-   * newly added are scanned. This is why this scan accepts a list
-   * of excluded chunks while all other scans accept a list of
-   * included chunks.
+   * newly added are scanned including those that were added
+   * since the optimizer had distributed the chunks between
+   * operators. This is why this scan accepts a list of
+   * excluded chunks and all others a list of included chunks.
    */
   void set_excluded_chunk_ids(const std::vector<ChunkID>& chunk_ids);
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -22,6 +22,11 @@ class TableScan : public AbstractReadOnlyOperator {
 
   ~TableScan();
 
+  /**
+   * If set, the specified chunks will not be scanned.
+   */
+  void set_excluded_chunk_ids(const std::vector<ChunkID>& chunk_ids);
+
   ColumnID left_column_id() const;
   ScanType scan_type() const;
   const AllParameterVariant& right_parameter() const;
@@ -36,11 +41,14 @@ class TableScan : public AbstractReadOnlyOperator {
   void _on_cleanup() override;
 
   void _init_scan();
+  void _create_job_and_schedule(const ChunkID chunk_id, std::mutex& output_mutex);
 
  private:
   const ColumnID _left_column_id;
   const ScanType _scan_type;
   const AllParameterVariant _right_parameter;
+
+  std::vector<ChunkID> _excluded_chunk_ids;
 
   std::shared_ptr<const Table> _in_table;
   std::unique_ptr<BaseTableScanImpl> _impl;

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -451,8 +451,7 @@ TEST_F(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
 
   // 2**16 + 1 values require a data type of 32bit.
   const auto table_wrapper_dict_32 = get_table_op_with_n_dict_entries((1 << 16) + 1);
-  auto scan_2 =
-      std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::GreaterThan, 65500);
+  auto scan_2 = std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::GreaterThan, 65500);
   scan_2->execute();
 
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
@@ -562,8 +561,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedDictCol
 
 TEST_F(OperatorsTableScanTest, NullSemantics) {
   const auto scan_types =
-      std::vector<ScanType>({ScanType::Equals, ScanType::NotEquals, ScanType::LessThan,
-                             ScanType::LessThanEquals, ScanType::GreaterThan, ScanType::GreaterThanEquals});
+      std::vector<ScanType>({ScanType::Equals, ScanType::NotEquals, ScanType::LessThan, ScanType::LessThanEquals,
+                             ScanType::GreaterThan, ScanType::GreaterThanEquals});
 
   for (auto scan_type : scan_types) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_null, ColumnID{0}, scan_type, NULL_VALUE);
@@ -580,7 +579,8 @@ TEST_F(OperatorsTableScanTest, NullSemantics) {
 TEST_F(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
   const auto expected = std::vector<AllTypeVariant>{110, 112, 114, 116, 118, 120, 122, 124};
 
-  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan =
+      std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
   scan->set_excluded_chunk_ids({ChunkID{0u}});
   scan->execute();
 

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -11,7 +11,6 @@
 #include "gtest/gtest.h"
 
 #include "operators/abstract_read_only_operator.hpp"
-#include "operators/print.hpp"
 #include "operators/table_scan.hpp"
 #include "operators/table_wrapper.hpp"
 #include "storage/dictionary_compression.hpp"
@@ -576,6 +575,16 @@ TEST_F(OperatorsTableScanTest, NullSemantics) {
       EXPECT_EQ(scan->get_output()->get_chunk(i).column_count(), 2u);
     }
   }
+}
+
+TEST_F(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
+  const auto expected = std::vector<AllTypeVariant>{110, 112, 114, 116, 118, 120, 122, 124};
+
+  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  scan->set_excluded_chunk_ids({ChunkID{0u}});
+  scan->execute();
+
+  ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, expected);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
This adds the counterpart of IndexScan::set_included_chunk_ids. With this PR it is now possible to scan certain chunks using an index and all others with `TableScan`.

related #73