### PR TITLE
Improve translation of diamond shapes in LQP

### DIFF
--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -47,7 +47,32 @@
 namespace opossum {
 
 std::shared_ptr<AbstractOperator> LQPTranslator::translate_node(const std::shared_ptr<AbstractLQPNode>& node) const {
-  return _translate_by_node_type(node->type(), node);
+  /**
+   * Translate a node (i.e. call `_translate_by_node_type`) only if it hasn't been translated before, otherwise just
+   * retrieve it from cache
+   *
+   * Without this caching, translating this kind of LQP
+   *
+   *    _____union____
+   *   /              \
+   *  predicate_a     predicate_b
+   *  \                /
+   *   \__predicate_c_/
+   *          |
+   *     table_int_float2
+   *
+   * would result in multiple operators created from predicate_c and thus in performance drops
+   */
+
+  const auto iter = _operator_by_lqp_node.find(node);
+
+  if (iter != _operator_by_lqp_node.end()) {
+    return iter->second;
+  }
+
+  const auto pqp = _translate_by_node_type(node->type(), node);
+  _operator_by_lqp_node.emplace(node, pqp);
+  return pqp;
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_stored_table_node(

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
 
 #include "abstract_lqp_node.hpp"
 #include "all_type_variant.hpp"
@@ -43,6 +44,10 @@ class LQPTranslator final : private Noncopyable {
   std::shared_ptr<AbstractOperator> _translate_show_columns_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_create_view_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_drop_view_node(const std::shared_ptr<AbstractLQPNode>& node) const;
+
+  // Cache operator subtrees by LQP node to avoid executing operators below a diamond shape multiple times
+  mutable std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractOperator>>
+      _operator_by_lqp_node;
 };
 
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -64,7 +64,7 @@ set(
     logical_query_plan/union_node_test.cpp
     logical_query_plan/update_node_test.cpp
     logical_query_plan/validate_node_test.cpp
-    optimizer/ast_to_operator_translator_test.cpp
+    optimizer/lqp_translator_test.cpp
     optimizer/column_statistics_test.cpp
     optimizer/strategy/join_detection_rule_test.cpp
     optimizer/expression_test.cpp

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -316,7 +316,8 @@ TEST_F(LQPTranslatorTest, DiamondShapeSimple) {
   ASSERT_NE(pqp->input_right(), nullptr);
   ASSERT_NE(pqp->input_left()->input_left(), nullptr);
   ASSERT_NE(pqp->input_right()->input_left(), nullptr);
-  ASSERT_EQ(pqp->input_left()->input_left(), pqp->input_right()->input_left());
+  EXPECT_EQ(pqp->input_left()->input_left(), pqp->input_right()->input_left());
+  EXPECT_EQ(pqp->input_left()->input_left()->input_left(), pqp->input_right()->input_left()->input_left());
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -17,6 +17,7 @@
 #include "logical_query_plan/show_tables_node.hpp"
 #include "logical_query_plan/sort_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
+#include "logical_query_plan/union_node.hpp"
 #include "operators/aggregate.hpp"
 #include "operators/get_table.hpp"
 #include "operators/join_hash.hpp"
@@ -268,6 +269,54 @@ TEST_F(LQPTranslatorTest, LimitNode) {
   const auto limit_op = std::dynamic_pointer_cast<Limit>(op);
   ASSERT_TRUE(limit_op);
   EXPECT_EQ(limit_op->num_rows(), num_rows);
+}
+
+TEST_F(LQPTranslatorTest, DiamondShapeSimple) {
+  /**
+   * Test that
+   *
+   *    _____union____
+   *   /              \
+   *  predicate_a     predicate_b
+   *  \                /
+   *   \__predicate_c_/
+   *          |
+   *     table_int_float2
+   *
+   * has a diamond shape in the PQP as well. If it wouldn't have it might look like this:
+   *
+   *    _____union____
+   *   /              \
+   *  predicate_a     predicate_b
+   *      |             |
+   *  predicate_c(1)  predicate_c(2)
+   *      |             |
+   * table_int_float2 table_int_float2
+   *
+   * which is still semantically correct, but would mean predicate_c gets executed twice
+   */
+
+  auto table_node = std::make_shared<StoredTableNode>("table_int_float2");
+  auto predicate_node_a = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, 3);
+  auto predicate_node_b = std::make_shared<PredicateNode>(ColumnID{0}, ScanType::Equals, 4);
+  auto predicate_node_c = std::make_shared<PredicateNode>(ColumnID{1}, ScanType::Equals, 5.0);
+  auto union_node = std::make_shared<UnionNode>(UnionMode::Positions);
+  const auto& lqp = union_node;
+
+  union_node->set_left_child(predicate_node_a);
+  union_node->set_right_child(predicate_node_b);
+  predicate_node_a->set_left_child(predicate_node_c);
+  predicate_node_b->set_left_child(predicate_node_c);
+  predicate_node_c->set_left_child(table_node);
+
+  const auto pqp = LQPTranslator{}.translate_node(lqp);
+
+  ASSERT_NE(pqp, nullptr);
+  ASSERT_NE(pqp->input_left(), nullptr);
+  ASSERT_NE(pqp->input_right(), nullptr);
+  ASSERT_NE(pqp->input_left()->input_left(), nullptr);
+  ASSERT_NE(pqp->input_right()->input_left(), nullptr);
+  ASSERT_EQ(pqp->input_left()->input_left(), pqp->input_right()->input_left());
 }
 
 }  // namespace opossum


### PR DESCRIPTION
```c++
+  /**
+   * Translate a node (i.e. call `_translate_by_node_type`) only if it hasn't been translated before, otherwise just
+   * retrieve it from cache
+   *
+   * Without this caching, translating this kind of LQP
+   *
+   *    _____union____
+   *   /              \
+   *  predicate_a     predicate_b
+   *  \                /
+   *   \__predicate_c_/
+   *          |
+   *     table_int_float2
+   *
+   * would result in multiple operators created from predicate_c and thus in performance drops
+   */
```

Before:
```json
{
  "benchmarks": [
    {
      "cpu_time": 15483563407,
      "items_per_second": 0.0645846128463745,
      "iterations": 1,
      "name": "TPC-H 7",
      "real_time": 15483563407,
      "time_unit": "ns"
    }
  ],
  "context": {
    "benchmark_mode": "IndividualQueries",
    "build_type": "release",
    "chunk_size": 4294967295,
    "date": "2018-01-05 15:53:31",
    "scale_factor": 0.00999999977648258
  }
}
```

Now:
```json
{
  "benchmarks": [
    {
      "cpu_time": 7594633465,
      "items_per_second": 0.131671935319901,
      "iterations": 1,
      "name": "TPC-H 7",
      "real_time": 7594633465,
      "time_unit": "ns"
    }
  ],
  "context": {
    "benchmark_mode": "IndividualQueries",
    "build_type": "release",
    "chunk_size": 4294967295,
    "date": "2018-01-05 15:41:12",
    "scale_factor": 0.00999999977648258
  }
}
```
  