### PR TITLE
Remove Table::approx_valid_row_count()

### DIFF
--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -64,11 +64,6 @@ void Delete::_on_commit_records(const CommitID cid) {
   }
 }
 
-void Delete::_finish_commit() {
-  const auto num_rows_deleted = _input_table_left()->row_count();
-  _table->inc_invalid_row_count(num_rows_deleted);
-}
-
 void Delete::_on_rollback_records() {
   for (const auto& pos_list : _pos_lists) {
     for (const auto& row_id : *pos_list) {

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -25,7 +25,6 @@ class Delete : public AbstractReadWriteOperator {
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;
   void _on_commit_records(const CommitID cid) override;
-  void _finish_commit() override;
   void _on_rollback_records() override;
 
  private:

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -76,8 +76,6 @@ void Table::append(std::vector<AllTypeVariant> values) {
   _chunks.back().append(values);
 }
 
-void Table::inc_invalid_row_count(uint64_t count) { _approx_invalid_row_count += count; }
-
 void Table::create_new_chunk() {
   // Create chunk with mvcc columns
   Chunk new_chunk{ChunkUseMvcc::Yes};
@@ -100,8 +98,6 @@ uint64_t Table::row_count() const {
   }
   return ret;
 }
-
-uint64_t Table::approx_valid_row_count() const { return row_count() - _approx_invalid_row_count; }
 
 ChunkID Table::chunk_count() const { return static_cast<ChunkID>(_chunks.size()); }
 

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -136,7 +136,7 @@ class Table : private Noncopyable {
  protected:
   const uint32_t _max_chunk_size;
   std::vector<Chunk> _chunks;
-  
+
   // these should be const strings, but having a vector of const values is a C++17 feature
   // that is not yet completely implemented in all compilers
   std::vector<std::string> _column_names;

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -45,14 +45,7 @@ class Table : private Noncopyable {
 
   // Returns the number of rows.
   // This number includes invalidated (deleted) rows.
-  // Use approx_valid_row_count() for an approximate count of valid rows instead.
   uint64_t row_count() const;
-
-  // Returns the number of valid rows (using approximate count of deleted rows)
-  uint64_t approx_valid_row_count() const;
-
-  // Increases the (approximate) count of invalid rows in the table (caused by deletes).
-  void inc_invalid_row_count(uint64_t count);
 
   // returns the number of chunks (cannot exceed ChunkID (uint32_t))
   ChunkID chunk_count() const;
@@ -143,12 +136,7 @@ class Table : private Noncopyable {
  protected:
   const uint32_t _max_chunk_size;
   std::vector<Chunk> _chunks;
-
-  // Stores the number of invalid (deleted) rows.
-  // This is currently not an atomic due to performance considerations.
-  // It is simply used as an estimate for the optimizer, and therefore does not need to be exact.
-  uint64_t _approx_invalid_row_count{0};
-
+  
   // these should be const strings, but having a vector of const values is a C++17 feature
   // that is not yet completely implemented in all compilers
   std::vector<std::string> _column_names;

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -56,22 +56,13 @@ void OperatorsDeleteTest::helper(bool commit) {
   EXPECT_EQ(_table->get_chunk(ChunkID{0}).mvcc_columns()->tids.at(1u), 0u);
   EXPECT_EQ(_table->get_chunk(ChunkID{0}).mvcc_columns()->tids.at(2u), transaction_context->transaction_id());
 
-  // Table has three rows initially.
-  EXPECT_EQ(_table->approx_valid_row_count(), 3u);
-
   auto expected_end_cid = CommitID{0u};
   if (commit) {
     transaction_context->commit();
     expected_end_cid = transaction_context->commit_id();
-
-    // Delete successful, one row left.
-    EXPECT_EQ(_table->approx_valid_row_count(), 1u);
   } else {
     transaction_context->rollback();
     expected_end_cid = Chunk::MAX_COMMIT_ID;
-
-    // Delete rolled back, three rows left.
-    EXPECT_EQ(_table->approx_valid_row_count(), 3u);
   }
 
   EXPECT_EQ(_table->get_chunk(ChunkID{0}).mvcc_columns()->end_cids.at(0u), expected_end_cid);

--- a/src/test/operators/update_test.cpp
+++ b/src/test/operators/update_test.cpp
@@ -67,7 +67,6 @@ void OperatorsUpdateTest::helper(std::shared_ptr<GetTable> table_to_update, std:
   // Approximation should be exact here because we do not have ti deal with parallelism issues in tests.
   auto updated_table = std::make_shared<GetTable>("updateTestTable");
   updated_table->execute();
-  EXPECT_EQ(updated_table->get_output()->approx_valid_row_count(), original_row_count);
 
   // The total row count (valid + invalid) should have increased by the number of rows that were updated.
   EXPECT_EQ(updated_table->get_output()->row_count(), original_row_count + updated_rows_count);


### PR DESCRIPTION
This wasn't used anywhere. If we ever need it again, add it to TableStatistics, not the Table itself.

(Am disgusted by the complexity of the interface of such basic classes like Chunk and Table, need to vent.)