### PR TITLE
Playground using namespace opossum

### DIFF
--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,5 +1,9 @@
 #include <iostream>
 
+#include "types.hpp"
+
+using namespace opossum;  // NOLINT
+
 int main() {
   std::cout << "Hello world!" << std::endl;
   return 0;

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -5,6 +5,6 @@
 using namespace opossum;  // NOLINT
 
 int main() {
-  std::cout << "Hello world!" << std::endl;
+  std::cout << "Hello world!!" << std::endl;
   return 0;
 }


### PR DESCRIPTION
I type this in EVERY TIME I do something in the playground, so might just have it on master. 
Include types.hpp so the namespace is actually defined and I have a `#include` line to duplicate and adapt to other includes I might need.