### PR TITLE
Fix build on macOS

### DIFF
--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "all_parameter_variant.hpp"


### PR DESCRIPTION
An include is missing in abstract_operator.hpp