### PR TITLE
RuleBatches

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -158,6 +158,8 @@ set(
     optimizer/strategy/join_detection_rule.hpp
     optimizer/strategy/predicate_reordering_rule.cpp
     optimizer/strategy/predicate_reordering_rule.hpp
+    optimizer/strategy/rule_batch.cpp
+    optimizer/strategy/rule_batch.hpp
     optimizer/table_statistics.cpp
     optimizer/table_statistics.hpp
     planviz/abstract_visualizer.hpp

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -9,11 +9,11 @@
 namespace opossum {
 
 const Optimizer& Optimizer::get() {
-  static Optimizer optimizer{createDefaultOptimizer()};
+  static Optimizer optimizer{create_default_optimizer()};
   return optimizer;
 }
 
-Optimizer Optimizer::createDefaultOptimizer() {
+Optimizer Optimizer::create_default_optimizer() {
   Optimizer optimizer{10};
 
   RuleBatch main_batch(RuleBatchExecutionPolicy::Iterative);
@@ -26,13 +26,9 @@ Optimizer Optimizer::createDefaultOptimizer() {
   return optimizer;
 }
 
-Optimizer::Optimizer(const uint32_t max_num_iterations):
-  _max_num_iterations(max_num_iterations)
-{}
+Optimizer::Optimizer(const uint32_t max_num_iterations) : _max_num_iterations(max_num_iterations) {}
 
-void Optimizer::add_rule_batch(RuleBatch rule_batch) {
-  _rule_batches.emplace_back(std::move(rule_batch));
-}
+void Optimizer::add_rule_batch(RuleBatch rule_batch) { _rule_batches.emplace_back(std::move(rule_batch)); }
 
 std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<AbstractLQPNode>& input) const {
   // Add explicit root node, so the rules can freely change the tree below it without having to maintain a root node

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -9,13 +9,29 @@
 namespace opossum {
 
 const Optimizer& Optimizer::get() {
-  static Optimizer optimizer;
+  static Optimizer optimizer{createDefaultOptimizer()};
   return optimizer;
 }
 
-Optimizer::Optimizer() {
-  _rules.emplace_back(std::make_shared<PredicateReorderingRule>());
-  _rules.emplace_back(std::make_shared<JoinDetectionRule>());
+Optimizer Optimizer::createDefaultOptimizer() {
+  Optimizer optimizer{10};
+
+  RuleBatch main_batch(RuleBatchExecutionPolicy::Iterative);
+
+  main_batch.add_rule(std::make_shared<PredicateReorderingRule>());
+  main_batch.add_rule(std::make_shared<JoinDetectionRule>());
+
+  optimizer.add_rule_batch(main_batch);
+
+  return optimizer;
+}
+
+Optimizer::Optimizer(const uint32_t max_num_iterations):
+  _max_num_iterations(max_num_iterations)
+{}
+
+void Optimizer::add_rule_batch(RuleBatch rule_batch) {
+  _rule_batches.emplace_back(std::move(rule_batch));
 }
 
 std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<AbstractLQPNode>& input) const {
@@ -24,18 +40,22 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<Abstr
   const auto root_node = std::make_shared<LogicalPlanRootNode>();
   root_node->set_left_child(input);
 
-  /**
-   * Apply all optimization over and over until all of them stopped changing the LQP or the max number of
-   * iterations is reached
-   */
-  for (uint32_t iter_index = 0; iter_index < _max_num_iterations; ++iter_index) {
-    auto ast_changed = false;
+  for (const auto& rule_batch : _rule_batches) {
+    switch (rule_batch.execution_policy()) {
+      case RuleBatchExecutionPolicy::Once:
+        rule_batch.apply_rules_to(root_node);
+        break;
 
-    for (const auto& rule : _rules) {
-      ast_changed |= rule->apply_to(root_node);
+      case RuleBatchExecutionPolicy::Iterative:
+        /**
+         * Apply all optimization over and over until all of them stopped changing the LQP or the max number of
+         * iterations is reached
+         */
+        for (uint32_t iter_index = 0; iter_index < _max_num_iterations; ++iter_index) {
+          if (!rule_batch.apply_rules_to(root_node)) break;
+        }
+        break;
     }
-
-    if (!ast_changed) break;
   }
 
   // Remove LogicalPlanRootNode

--- a/src/lib/optimizer/optimizer.hpp
+++ b/src/lib/optimizer/optimizer.hpp
@@ -11,7 +11,12 @@ class AbstractRule;
 class AbstractLQPNode;
 
 /**
- * Applies (currently: all) optimization rules to an LQP.
+ * Applies optimization rules to an LQP. Rules are organized in RuleBatches which can be added to the Optimizer using
+ * add_rule_batch(). On each invocation of optimize(), these Batches are applied in the same order as they were added
+ * to the Optimizer.
+ *
+ * By default, you can use Optimizer::get() to retrieve the global default Optimizer, but it is also possible to create
+ * and configure a custom Optimizer.
  */
 class Optimizer final {
  public:

--- a/src/lib/optimizer/optimizer.hpp
+++ b/src/lib/optimizer/optimizer.hpp
@@ -3,6 +3,8 @@
 #include <memory>
 #include <vector>
 
+#include "optimizer/strategy/rule_batch.hpp"
+
 namespace opossum {
 
 class AbstractRule;
@@ -15,12 +17,16 @@ class Optimizer final {
  public:
   static const Optimizer& get();
 
-  Optimizer();
+  static Optimizer createDefaultOptimizer();
+
+  explicit Optimizer(const uint32_t max_num_iterations);
+
+  void add_rule_batch(RuleBatch rule_batch);
 
   std::shared_ptr<AbstractLQPNode> optimize(const std::shared_ptr<AbstractLQPNode>& input) const;
 
  private:
-  std::vector<std::shared_ptr<AbstractRule>> _rules;
+  std::vector<RuleBatch> _rule_batches;
 
   // Rather arbitrary right now, atm all rules should be done after one iteration
   uint32_t _max_num_iterations = 10;

--- a/src/lib/optimizer/optimizer.hpp
+++ b/src/lib/optimizer/optimizer.hpp
@@ -17,7 +17,7 @@ class Optimizer final {
  public:
   static const Optimizer& get();
 
-  static Optimizer createDefaultOptimizer();
+  static Optimizer create_default_optimizer();
 
   explicit Optimizer(const uint32_t max_num_iterations);
 

--- a/src/lib/optimizer/strategy/rule_batch.cpp
+++ b/src/lib/optimizer/strategy/rule_batch.cpp
@@ -4,21 +4,13 @@
 
 namespace opossum {
 
-RuleBatch::RuleBatch(RuleBatchExecutionPolicy execution_policy):
-  _execution_policy(execution_policy)
-{}
+RuleBatch::RuleBatch(RuleBatchExecutionPolicy execution_policy) : _execution_policy(execution_policy) {}
 
-RuleBatchExecutionPolicy RuleBatch::execution_policy() const {
-  return _execution_policy;
-}
+RuleBatchExecutionPolicy RuleBatch::execution_policy() const { return _execution_policy; }
 
-const std::vector<std::shared_ptr<AbstractRule>>& RuleBatch::rules() const {
-  return _rules;
-}
+const std::vector<std::shared_ptr<AbstractRule>>& RuleBatch::rules() const { return _rules; }
 
-void RuleBatch::add_rule(const std::shared_ptr<AbstractRule>& rule) {
-  _rules.emplace_back(rule);
-}
+void RuleBatch::add_rule(const std::shared_ptr<AbstractRule>& rule) { _rules.emplace_back(rule); }
 
 bool RuleBatch::apply_rules_to(const std::shared_ptr<AbstractLQPNode>& root_node) const {
   auto lqp_changed = false;

--- a/src/lib/optimizer/strategy/rule_batch.cpp
+++ b/src/lib/optimizer/strategy/rule_batch.cpp
@@ -1,0 +1,33 @@
+#include "rule_batch.hpp"
+
+#include "abstract_rule.hpp"
+
+namespace opossum {
+
+RuleBatch::RuleBatch(RuleBatchExecutionPolicy execution_policy):
+  _execution_policy(execution_policy)
+{}
+
+RuleBatchExecutionPolicy RuleBatch::execution_policy() const {
+  return _execution_policy;
+}
+
+const std::vector<std::shared_ptr<AbstractRule>>& RuleBatch::rules() const {
+  return _rules;
+}
+
+void RuleBatch::add_rule(const std::shared_ptr<AbstractRule>& rule) {
+  _rules.emplace_back(rule);
+}
+
+bool RuleBatch::apply_rules_to(const std::shared_ptr<AbstractLQPNode>& root_node) const {
+  auto lqp_changed = false;
+
+  for (auto& rule : _rules) {
+    lqp_changed |= rule->apply_to(root_node);
+  }
+
+  return lqp_changed;
+}
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/rule_batch.hpp
+++ b/src/lib/optimizer/strategy/rule_batch.hpp
@@ -26,5 +26,4 @@ class RuleBatch final {
   const RuleBatchExecutionPolicy _execution_policy;
   std::vector<std::shared_ptr<AbstractRule>> _rules;
 };
-
-}
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/rule_batch.hpp
+++ b/src/lib/optimizer/strategy/rule_batch.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace opossum {
+
+class AbstractRule;
+class AbstractLQPNode;
+
+enum class RuleBatchExecutionPolicy { Once, Iterative };
+
+// Enables the "grouping" of Optimizer Rules into Batches and the ordering of these Batches.
+class RuleBatch final {
+ public:
+  explicit RuleBatch(RuleBatchExecutionPolicy execution_policy);
+
+  RuleBatchExecutionPolicy execution_policy() const;
+  const std::vector<std::shared_ptr<AbstractRule>>& rules() const;
+
+  void add_rule(const std::shared_ptr<AbstractRule>& rule);
+
+  bool apply_rules_to(const std::shared_ptr<AbstractLQPNode>& root_node) const;
+
+ private:
+  const RuleBatchExecutionPolicy _execution_policy;
+  std::vector<std::shared_ptr<AbstractRule>> _rules;
+};
+
+}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -70,6 +70,7 @@ set(
     optimizer/column_statistics_test.cpp
     optimizer/expression_test.cpp
     optimizer/lqp_translator_test.cpp
+    optimizer/optimizer_test.cpp
     optimizer/strategy/join_detection_rule_test.cpp
     optimizer/strategy/predicate_reordering_test.cpp
     optimizer/strategy/strategy_base_test.cpp

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -1,0 +1,55 @@
+#include "gtest/gtest.h"
+
+#include "optimizer/optimizer.hpp"
+#include "optimizer/strategy/abstract_rule.hpp"
+#include "logical_query_plan/mock_node.hpp"
+
+namespace opossum {
+
+class OptimizerTest: public ::testing::Test {};
+
+struct MockRule : public AbstractRule {
+  explicit MockRule(size_t num_iterations): num_iterations(num_iterations) {}
+
+  std::string name() const override {
+    return "MockNode";
+  }
+
+  bool apply_to(const std::shared_ptr<AbstractLQPNode>& root) override {
+    num_iterations = num_iterations > 0 ? num_iterations - 1 : 0;
+    return num_iterations != 0;
+  }
+
+  uint32_t num_iterations;
+};
+
+TEST_F(OptimizerTest, RuleBatches) {
+  auto iterative_rule_a = std::make_shared<MockRule>(4u);
+  auto iterative_rule_b = std::make_shared<MockRule>(8u);
+  auto iterative_rule_c = std::make_shared<MockRule>(12u);
+  auto iterative_rule_d = std::make_shared<MockRule>(7u);
+
+  RuleBatch iterative_batch(RuleBatchExecutionPolicy::Iterative);
+  iterative_batch.add_rule(iterative_rule_a);
+  iterative_batch.add_rule(iterative_rule_b);
+  iterative_batch.add_rule(iterative_rule_c);
+
+  RuleBatch once_batch(RuleBatchExecutionPolicy::Once);
+  once_batch.add_rule(iterative_rule_d);
+
+  Optimizer optimizer{10};
+  optimizer.add_rule_batch(iterative_batch);
+  optimizer.add_rule_batch(once_batch);
+
+  auto lqp = std::make_shared<MockNode>(MockNode::ColumnDefinitions{{DataType::Int, "a"}});
+
+  optimizer.optimize(lqp);
+
+  EXPECT_EQ(iterative_rule_a->num_iterations, 0u);
+  EXPECT_EQ(iterative_rule_b->num_iterations, 0u);
+  EXPECT_EQ(iterative_rule_c->num_iterations, 2u);
+
+  EXPECT_EQ(iterative_rule_d->num_iterations, 6u);
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -1,19 +1,17 @@
 #include "gtest/gtest.h"
 
+#include "logical_query_plan/mock_node.hpp"
 #include "optimizer/optimizer.hpp"
 #include "optimizer/strategy/abstract_rule.hpp"
-#include "logical_query_plan/mock_node.hpp"
 
 namespace opossum {
 
-class OptimizerTest: public ::testing::Test {};
+class OptimizerTest : public ::testing::Test {};
 
 struct MockRule : public AbstractRule {
-  explicit MockRule(size_t num_iterations): num_iterations(num_iterations) {}
+  explicit MockRule(size_t num_iterations) : num_iterations(num_iterations) {}
 
-  std::string name() const override {
-    return "MockNode";
-  }
+  std::string name() const override { return "MockNode"; }
 
   bool apply_to(const std::shared_ptr<AbstractLQPNode>& root) override {
     num_iterations = num_iterations > 0 ? num_iterations - 1 : 0;


### PR DESCRIPTION
A RuleBatch can either be iterative, i.e. it executes the Rules until they stop changing the LQP, or execute their rules just once.

Details (per-batch `max_num_iterations`, batch names...) might be tweaked once actual batches arrive, but this should provide the template for those who wish to work with rule batches