### PR TITLE
Fix column order in multi-table FROM

### DIFF
--- a/src/benchmarklib/tpch/tpch_queries.cpp
+++ b/src/benchmarklib/tpch/tpch_queries.cpp
@@ -375,9 +375,9 @@ const char* const tpch_query_8 =
  *  3. implicit type conversions for arithmetic operations are not supported
  *    a. changed 1 to 1.0 explicitly
  */
- // TODO(anyone): change order of:
- // FROM supplier, lineitem, partsupp, orders, nation, "part"   back to original
- // FROM "part", supplier, lineitem, partsupp, orders, nation   as soon as join ordering is fixed
+// TODO(anyone): change order of:
+// FROM supplier, lineitem, partsupp, orders, nation, "part"   back to original
+// FROM "part", supplier, lineitem, partsupp, orders, nation   as soon as join ordering is fixed
 const char* const tpch_query_9 =
     R"(SELECT nation, o_year, SUM(amount) as sum_profit FROM (SELECT n_name as nation, o_orderdate as o_year,
       l_extendedprice * (1.0 - l_discount) - ps_supplycost * l_quantity as amount

--- a/src/benchmarklib/tpch/tpch_queries.cpp
+++ b/src/benchmarklib/tpch/tpch_queries.cpp
@@ -375,10 +375,13 @@ const char* const tpch_query_8 =
  *  3. implicit type conversions for arithmetic operations are not supported
  *    a. changed 1 to 1.0 explicitly
  */
+ // TODO(anyone): change order of:
+ // FROM supplier, lineitem, partsupp, orders, nation, "part"   back to original
+ // FROM "part", supplier, lineitem, partsupp, orders, nation   as soon as join ordering is fixed
 const char* const tpch_query_9 =
     R"(SELECT nation, o_year, SUM(amount) as sum_profit FROM (SELECT n_name as nation, o_orderdate as o_year,
       l_extendedprice * (1.0 - l_discount) - ps_supplycost * l_quantity as amount
-      FROM "part", supplier, lineitem, partsupp, orders, nation WHERE s_suppkey = l_suppkey
+      FROM supplier, lineitem, partsupp, orders, nation, "part" WHERE s_suppkey = l_suppkey
       AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND p_partkey = l_partkey AND o_orderkey = l_orderkey
       AND s_nationkey = n_nationkey AND p_name like '%green%') as profit
       GROUP BY nation, o_year ORDER BY nation, o_year DESC;)";

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -138,7 +138,7 @@ const std::vector<std::shared_ptr<AbstractLQPNode>>& SQLPipeline::get_optimized_
   _optimized_logical_plans.reserve(_num_statements);
   for (auto& pipeline : _sql_pipeline_statements) {
     try {
-      _optimized_logical_plans.push_back(pipeline->get_unoptimized_logical_plan());
+      _optimized_logical_plans.push_back(pipeline->get_optimized_logical_plan());
     } catch (const std::exception& exception) {
       _failed_pipeline_statement = pipeline;
 


### PR DESCRIPTION
Updates sql-parser to include newest fixes and adapts a test which relied on an old column order, which has changed with the latest parser bug fix.

Fixes #580.