### PR TITLE
Change default TpchDbGenerator chunk size

### DIFF
--- a/src/benchmarklib/tpch/tpch_db_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_db_generator.hpp
@@ -32,7 +32,7 @@ extern std::unordered_map<opossum::TpchTable, std::string> tpch_table_names;
  */
 class TpchDbGenerator final {
  public:
-  explicit TpchDbGenerator(float scale_factor, uint32_t chunk_size = 0);
+  explicit TpchDbGenerator(float scale_factor, uint32_t chunk_size = Chunk::MAX_SIZE);
 
   std::unordered_map<TpchTable, std::shared_ptr<Table>> generate();
 


### PR DESCRIPTION
Calling `TpchDbGenerator(0.1f)` without an explicit `chunk_size` fails because it passes on a default size of 0, which causes an assert to fail in the table constructor. 