### PR TITLE
Fix set child

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -132,9 +132,7 @@ void AbstractLQPNode::set_child(LQPChildSide side, const std::shared_ptr<Abstrac
     current_child->_add_parent_pointer(shared_from_this());
   }
 
-  for (auto& parent : parents()) {
-    parent->_child_changed();
-  }
+  _child_changed();
 }
 
 LQPNodeType AbstractLQPNode::type() const { return _type; }

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -83,11 +83,11 @@ std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
     // Doing just `value = boost::get<LQPColumnReference>(value)` triggers a compiler warning in GCC release builds
     // about the assigned value being uninitialized. There seems to be no reason for this and this way seems to be
     // fine... :(
-    value = static_cast<ColumnID::base_type>(get_output_column_id(boost::get<LQPColumnReference>(value)));
+    value = static_cast<ColumnID::base_type>(left_child->get_output_column_id(boost::get<LQPColumnReference>(value)));
   }
 
-  return left_child->get_statistics()->predicate_statistics(get_output_column_id(_column_reference), _scan_type, value,
-                                                            _value2);
+  return left_child->get_statistics()->predicate_statistics(left_child->get_output_column_id(_column_reference),
+                                                            _scan_type, value, _value2);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
After introducing the ~`NamedColumnReference`~ `LQPColumnReference`-refactoring into our branch pushing predicates into the right subtree of a join stopped working.
This was due to the fact that finding a column ID (during the statistics computation, for instance) is essentially computing an offset:

    static_cast<ColumnID>(std::distance(output_column_references.begin(), iter));

See `abstract_lqp_node.cpp:309`. The output column references still contained the result columns of the join despite the nodes had been rewired. For the right hand side this means those indices may be out of the range for the underlying nodes of the predicate when operating on stale state.
The solution is to clear the output column references upon child change to have them recomputed on the correct children node. 
The change posed a problem for computing statistics on predicate nodes detached from the LQP as conducted by the predicate reordering rule. With above change the predicate node was now able to realize that the state needs to be refreshed, however, there are no available child nodes to compute the missing pieces of information from. As a result it should really take the children that are parameters to the statistic computation for reference.
