### PR TITLE
Rename ScanType to PredicateCondition

### DIFF
--- a/src/benchmark/operators/projection_benchmark.cpp
+++ b/src/benchmark/operators/projection_benchmark.cpp
@@ -18,8 +18,8 @@ class OperatorsProjectionBenchmark : public BenchmarkBasicFixture {
     BenchmarkBasicFixture::SetUp(state);
     _column_type = state.range(1);
 
-    _table_ref =
-        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 0);  // all
+    _table_ref = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */,
+                                             PredicateCondition::GreaterThanEquals, 0);  // all
     _table_ref->execute();
 
     _tables.emplace_back(_table_wrapper_a);  // 0

--- a/src/benchmark/operators/projection_benchmark.cpp
+++ b/src/benchmark/operators/projection_benchmark.cpp
@@ -19,7 +19,7 @@ class OperatorsProjectionBenchmark : public BenchmarkBasicFixture {
     _column_type = state.range(1);
 
     _table_ref =
-        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 0);  // all
+        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 0);  // all
     _table_ref->execute();
 
     _tables.emplace_back(_table_wrapper_a);  // 0

--- a/src/benchmark/operators/table_scan_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_benchmark.cpp
@@ -11,7 +11,8 @@ namespace opossum {
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstant)(benchmark::State& state) {
   clear_cache();
 
-  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
+  auto warm_up =
+      std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan =
@@ -26,27 +27,28 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstantOnDict)(benchmark:
       std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
   warm_up->execute();
   while (state.KeepRunning()) {
-    auto table_scan =
-        std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
+    auto table_scan = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */,
+                                                  PredicateCondition::GreaterThanEquals, 7);
     table_scan->execute();
   }
 }
 
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariable)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, ColumnID{1});
+  auto warm_up =
+      std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, ColumnID{1});
   warm_up->execute();
   while (state.KeepRunning()) {
-    auto table_scan = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals,
-                                                  ColumnID{1} /* "b" */);
+    auto table_scan = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */,
+                                                  PredicateCondition::GreaterThanEquals, ColumnID{1} /* "b" */);
     table_scan->execute();
   }
 }
 
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariableOnDict)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals,
-                                             ColumnID{1} /* "b" */);
+  auto warm_up = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */,
+                                             PredicateCondition::GreaterThanEquals, ColumnID{1} /* "b" */);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */,

--- a/src/benchmark/operators/table_scan_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_benchmark.cpp
@@ -11,11 +11,11 @@ namespace opossum {
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstant)(benchmark::State& state) {
   clear_cache();
 
-  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
+  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan =
-        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
+        std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
     table_scan->execute();
   }
 }
@@ -23,21 +23,21 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstant)(benchmark::State
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanConstantOnDict)(benchmark::State& state) {
   clear_cache();
   auto warm_up =
-      std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
+      std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan =
-        std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals, 7);
+        std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals, 7);
     table_scan->execute();
   }
 }
 
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariable)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, ColumnID{1});
+  auto warm_up = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, ColumnID{1});
   warm_up->execute();
   while (state.KeepRunning()) {
-    auto table_scan = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals,
+    auto table_scan = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals,
                                                   ColumnID{1} /* "b" */);
     table_scan->execute();
   }
@@ -45,12 +45,12 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariable)(benchmark::State
 
 BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_TableScanVariableOnDict)(benchmark::State& state) {
   clear_cache();
-  auto warm_up = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThanEquals,
+  auto warm_up = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThanEquals,
                                              ColumnID{1} /* "b" */);
   warm_up->execute();
   while (state.KeepRunning()) {
     auto table_scan = std::make_shared<TableScan>(_table_dict_wrapper, ColumnID{0} /* "a" */,
-                                                  ScanType::GreaterThanEquals, ColumnID{1} /* "b" */);
+                                                  PredicateCondition::GreaterThanEquals, ColumnID{1} /* "b" */);
     table_scan->execute();
   }
 }

--- a/src/benchmark/tpcc/delivery_benchmark.cpp
+++ b/src/benchmark/tpcc/delivery_benchmark.cpp
@@ -35,9 +35,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("NEW_ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{1} /* "NO_D_ID" */, ScanType::Equals, d_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{2} /* "NO_W_ID" */, ScanType::Equals, w_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{0} /* "NO_O_ID" */, ScanType::GreaterThan, -1);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{1} /* "NO_D_ID" */, PredicateCondition::Equals, d_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{2} /* "NO_W_ID" */, PredicateCondition::Equals, w_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{0} /* "NO_O_ID" */, PredicateCondition::GreaterThan, -1);
     auto val = std::make_shared<Validate>(ts3);
 
     Projection::ColumnExpressions columns = {PQPExpression::create_column(ColumnID{0} /* "NO_O_ID" */)};
@@ -71,7 +71,7 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("NEW_ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "NO_O_ID" */, ScanType::Equals, no_o_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "NO_O_ID" */, PredicateCondition::Equals, no_o_id);
     auto val = std::make_shared<Validate>(ts1);
     auto delete_op = std::make_shared<Delete>("NEW_ORDER", val);
 
@@ -95,9 +95,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, ScanType::Equals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, ScanType::Equals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, ScanType::Equals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, PredicateCondition::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, PredicateCondition::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, PredicateCondition::Equals, w_id);
     auto val = std::make_shared<Validate>(ts3);
 
     Projection::ColumnExpressions columns = {PQPExpression::create_column(ColumnID{3} /* "O_C_ID" */)};
@@ -128,9 +128,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, ScanType::Equals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, ScanType::Equals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, ScanType::Equals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "O_ID" */, PredicateCondition::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "O_D_ID" */, PredicateCondition::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "O_W_ID" */, PredicateCondition::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 
@@ -172,9 +172,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER_LINE");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::Equals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::Equals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, ScanType::Equals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, PredicateCondition::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, PredicateCondition::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, PredicateCondition::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 
@@ -215,9 +215,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("ORDER_LINE");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, ScanType::Equals, no_o_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, ScanType::Equals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, ScanType::Equals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "OL_O_ID" */, PredicateCondition::Equals, no_o_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "OL_D_ID" */, PredicateCondition::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "OL_W_ID" */, PredicateCondition::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 
@@ -250,9 +250,9 @@ class TPCCDeliveryBenchmark : public TPCCBenchmarkFixture {
      */
     auto gt = std::make_shared<GetTable>("CUSTOMER");
 
-    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "C_ID" */, ScanType::Equals, c_id);
-    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "C_D_ID" */, ScanType::Equals, d_id);
-    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "C_W_ID" */, ScanType::Equals, w_id);
+    auto ts1 = std::make_shared<TableScan>(gt, ColumnID{0} /* "C_ID" */, PredicateCondition::Equals, c_id);
+    auto ts2 = std::make_shared<TableScan>(ts1, ColumnID{1} /* "C_D_ID" */, PredicateCondition::Equals, d_id);
+    auto ts3 = std::make_shared<TableScan>(ts2, ColumnID{2} /* "C_W_ID" */, PredicateCondition::Equals, w_id);
 
     auto val = std::make_shared<Validate>(ts3);
 

--- a/src/benchmarklib/tpcc/new_order.cpp
+++ b/src/benchmarklib/tpcc/new_order.cpp
@@ -167,17 +167,17 @@ TaskVector NewOrderRefImpl::get_get_customer_and_warehouse_tax_rate_tasks(const 
   const auto c_v = std::make_shared<opossum::Validate>(c_gt);
 
   const auto c_ts1 =
-      std::make_shared<opossum::TableScan>(c_v, opossum::ColumnID{2} /* "C_W_ID" */, opossum::ScanType::Equals, w_id);
+      std::make_shared<opossum::TableScan>(c_v, opossum::ColumnID{2} /* "C_W_ID" */, opossum::PredicateCondition::Equals, w_id);
 
   const auto c_ts2 =
-      std::make_shared<opossum::TableScan>(c_ts1, opossum::ColumnID{1} /* "C_D_ID" */, opossum::ScanType::Equals, d_id);
+      std::make_shared<opossum::TableScan>(c_ts1, opossum::ColumnID{1} /* "C_D_ID" */, opossum::PredicateCondition::Equals, d_id);
 
   const auto c_ts3 =
-      std::make_shared<opossum::TableScan>(c_ts2, opossum::ColumnID{0} /* "C_ID" */, opossum::ScanType::Equals, c_id);
+      std::make_shared<opossum::TableScan>(c_ts2, opossum::ColumnID{0} /* "C_ID" */, opossum::PredicateCondition::Equals, c_id);
 
   const auto w_gt = std::make_shared<opossum::GetTable>("WAREHOUSE");
   const auto w_ts =
-      std::make_shared<opossum::TableScan>(w_gt, opossum::ColumnID{0} /* "W_ID" */, opossum::ScanType::Equals, w_id);
+      std::make_shared<opossum::TableScan>(w_gt, opossum::ColumnID{0} /* "W_ID" */, opossum::PredicateCondition::Equals, w_id);
 
   // Both operators should have exactly one row -> Product operator should have smallest overhead.
   const auto join = std::make_shared<opossum::Product>(c_ts3, w_ts);
@@ -230,9 +230,9 @@ TaskVector NewOrderRefImpl::get_get_district_tasks(const int32_t d_id, const int
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::ScanType::Equals, d_id);
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::PredicateCondition::Equals, d_id);
   const auto ts2 =
-      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::ScanType::Equals, w_id);
+      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::PredicateCondition::Equals, w_id);
 
   const auto proj = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions(
@@ -268,9 +268,9 @@ TaskVector NewOrderRefImpl::get_increment_next_order_id_tasks(const int32_t d_id
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::ScanType::Equals, d_id);
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::PredicateCondition::Equals, d_id);
   const auto ts2 =
-      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::ScanType::Equals, d_w_id);
+      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::PredicateCondition::Equals, d_w_id);
 
   const auto original_rows = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions({opossum::PQPExpression::create_column(opossum::ColumnID{10})}));
@@ -385,7 +385,7 @@ TaskVector NewOrderRefImpl::get_get_item_info_tasks(const int32_t ol_i_id) {
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   //  "I_ID"
-  const auto ts = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0}, opossum::ScanType::Equals, ol_i_id);
+  const auto ts = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0}, opossum::PredicateCondition::Equals, ol_i_id);
 
   const auto proj = std::make_shared<opossum::Projection>(
       ts, opossum::Projection::ColumnExpressions({opossum::PQPExpression::create_column(opossum::ColumnID{3}),
@@ -421,9 +421,9 @@ TaskVector NewOrderRefImpl::get_get_stock_info_tasks(const int32_t ol_i_id, cons
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */, opossum::ScanType::Equals, ol_i_id);
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */, opossum::PredicateCondition::Equals, ol_i_id);
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "S_W_ID" */,
-                                                        opossum::ScanType::Equals, ol_supply_w_id);
+                                                        opossum::PredicateCondition::Equals, ol_supply_w_id);
 
   std::string s_dist_xx = d_id < 10 ? "S_DIST_0" + std::to_string(d_id) : "S_DIST_" + std::to_string(d_id);
 
@@ -468,10 +468,10 @@ TaskVector NewOrderRefImpl::get_update_stock_tasks(const int32_t s_quantity, con
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */, opossum::ScanType::Equals, ol_i_id);
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */, opossum::PredicateCondition::Equals, ol_i_id);
 
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "S_W_ID" */,
-                                                        opossum::ScanType::Equals, ol_supply_w_id);
+                                                        opossum::PredicateCondition::Equals, ol_supply_w_id);
 
   const auto original_rows = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions({opossum::PQPExpression::create_column(opossum::ColumnID{2})}));

--- a/src/benchmarklib/tpcc/new_order.cpp
+++ b/src/benchmarklib/tpcc/new_order.cpp
@@ -166,18 +166,18 @@ TaskVector NewOrderRefImpl::get_get_customer_and_warehouse_tax_rate_tasks(const 
   const auto c_gt = std::make_shared<opossum::GetTable>("CUSTOMER");
   const auto c_v = std::make_shared<opossum::Validate>(c_gt);
 
-  const auto c_ts1 =
-      std::make_shared<opossum::TableScan>(c_v, opossum::ColumnID{2} /* "C_W_ID" */, opossum::PredicateCondition::Equals, w_id);
+  const auto c_ts1 = std::make_shared<opossum::TableScan>(c_v, opossum::ColumnID{2} /* "C_W_ID" */,
+                                                          opossum::PredicateCondition::Equals, w_id);
 
-  const auto c_ts2 =
-      std::make_shared<opossum::TableScan>(c_ts1, opossum::ColumnID{1} /* "C_D_ID" */, opossum::PredicateCondition::Equals, d_id);
+  const auto c_ts2 = std::make_shared<opossum::TableScan>(c_ts1, opossum::ColumnID{1} /* "C_D_ID" */,
+                                                          opossum::PredicateCondition::Equals, d_id);
 
-  const auto c_ts3 =
-      std::make_shared<opossum::TableScan>(c_ts2, opossum::ColumnID{0} /* "C_ID" */, opossum::PredicateCondition::Equals, c_id);
+  const auto c_ts3 = std::make_shared<opossum::TableScan>(c_ts2, opossum::ColumnID{0} /* "C_ID" */,
+                                                          opossum::PredicateCondition::Equals, c_id);
 
   const auto w_gt = std::make_shared<opossum::GetTable>("WAREHOUSE");
-  const auto w_ts =
-      std::make_shared<opossum::TableScan>(w_gt, opossum::ColumnID{0} /* "W_ID" */, opossum::PredicateCondition::Equals, w_id);
+  const auto w_ts = std::make_shared<opossum::TableScan>(w_gt, opossum::ColumnID{0} /* "W_ID" */,
+                                                         opossum::PredicateCondition::Equals, w_id);
 
   // Both operators should have exactly one row -> Product operator should have smallest overhead.
   const auto join = std::make_shared<opossum::Product>(c_ts3, w_ts);
@@ -229,10 +229,10 @@ TaskVector NewOrderRefImpl::get_get_district_tasks(const int32_t d_id, const int
   const auto gt = std::make_shared<opossum::GetTable>("DISTRICT");
   const auto v = std::make_shared<opossum::Validate>(gt);
 
-  const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::PredicateCondition::Equals, d_id);
-  const auto ts2 =
-      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::PredicateCondition::Equals, w_id);
+  const auto ts1 = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */,
+                                                        opossum::PredicateCondition::Equals, d_id);
+  const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */,
+                                                        opossum::PredicateCondition::Equals, w_id);
 
   const auto proj = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions(
@@ -267,10 +267,10 @@ TaskVector NewOrderRefImpl::get_increment_next_order_id_tasks(const int32_t d_id
   const auto gt = std::make_shared<opossum::GetTable>("DISTRICT");
   const auto v = std::make_shared<opossum::Validate>(gt);
 
-  const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */, opossum::PredicateCondition::Equals, d_id);
-  const auto ts2 =
-      std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */, opossum::PredicateCondition::Equals, d_w_id);
+  const auto ts1 = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "D_ID" */,
+                                                        opossum::PredicateCondition::Equals, d_id);
+  const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "D_W_ID" */,
+                                                        opossum::PredicateCondition::Equals, d_w_id);
 
   const auto original_rows = std::make_shared<opossum::Projection>(
       ts2, opossum::Projection::ColumnExpressions({opossum::PQPExpression::create_column(opossum::ColumnID{10})}));
@@ -385,7 +385,8 @@ TaskVector NewOrderRefImpl::get_get_item_info_tasks(const int32_t ol_i_id) {
   const auto v = std::make_shared<opossum::Validate>(gt);
 
   //  "I_ID"
-  const auto ts = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0}, opossum::PredicateCondition::Equals, ol_i_id);
+  const auto ts =
+      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0}, opossum::PredicateCondition::Equals, ol_i_id);
 
   const auto proj = std::make_shared<opossum::Projection>(
       ts, opossum::Projection::ColumnExpressions({opossum::PQPExpression::create_column(opossum::ColumnID{3}),
@@ -420,8 +421,8 @@ TaskVector NewOrderRefImpl::get_get_stock_info_tasks(const int32_t ol_i_id, cons
   const auto gt = std::make_shared<opossum::GetTable>("STOCK");
   const auto v = std::make_shared<opossum::Validate>(gt);
 
-  const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */, opossum::PredicateCondition::Equals, ol_i_id);
+  const auto ts1 = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */,
+                                                        opossum::PredicateCondition::Equals, ol_i_id);
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "S_W_ID" */,
                                                         opossum::PredicateCondition::Equals, ol_supply_w_id);
 
@@ -467,8 +468,8 @@ TaskVector NewOrderRefImpl::get_update_stock_tasks(const int32_t s_quantity, con
   const auto gt = std::make_shared<opossum::GetTable>("STOCK");
   const auto v = std::make_shared<opossum::Validate>(gt);
 
-  const auto ts1 =
-      std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */, opossum::PredicateCondition::Equals, ol_i_id);
+  const auto ts1 = std::make_shared<opossum::TableScan>(v, opossum::ColumnID{0} /* "S_I_ID" */,
+                                                        opossum::PredicateCondition::Equals, ol_i_id);
 
   const auto ts2 = std::make_shared<opossum::TableScan>(ts1, opossum::ColumnID{1} /* "S_W_ID" */,
                                                         opossum::PredicateCondition::Equals, ol_supply_w_id);

--- a/src/benchmarklib/tpcc/order_status.cpp
+++ b/src/benchmarklib/tpcc/order_status.cpp
@@ -114,13 +114,13 @@ TaskVector OrderStatusRefImpl::get_customer_by_name(const std::string c_last, co
   auto validate = std::make_shared<opossum::Validate>(gt_customer);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{5} /* "C_LAST" */,
-                                                           opossum::ScanType::Equals, c_last);
+                                                           opossum::PredicateCondition::Equals, c_last);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "C_D_ID" */,
-                                                            opossum::ScanType::Equals, c_d_id);
+                                                            opossum::PredicateCondition::Equals, c_d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "C_W_ID" */,
-                                                           opossum::ScanType::Equals, c_w_id);
+                                                           opossum::PredicateCondition::Equals, c_w_id);
 
   auto projection = std::make_shared<opossum::Projection>(
       third_filter, opossum::Projection::ColumnExpressions(
@@ -161,13 +161,13 @@ TaskVector OrderStatusRefImpl::get_customer_by_id(const int c_id, const int c_d_
   auto validate = std::make_shared<opossum::Validate>(gt_customer);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{0} /* "C_ID" */,
-                                                           opossum::ScanType::Equals, c_id);
+                                                           opossum::PredicateCondition::Equals, c_id);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "C_D_ID" */,
-                                                            opossum::ScanType::Equals, c_d_id);
+                                                            opossum::PredicateCondition::Equals, c_d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "C_W_ID" */,
-                                                           opossum::ScanType::Equals, c_w_id);
+                                                           opossum::PredicateCondition::Equals, c_w_id);
 
   auto projection = std::make_shared<opossum::Projection>(
       third_filter, opossum::Projection::ColumnExpressions(
@@ -204,13 +204,13 @@ TaskVector OrderStatusRefImpl::get_orders(const int o_c_id, const int o_d_id, co
   auto validate = std::make_shared<opossum::Validate>(gt_orders);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{3} /* "O_C_ID" */,
-                                                           opossum::ScanType::Equals, o_c_id);
+                                                           opossum::PredicateCondition::Equals, o_c_id);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "O_D_ID" */,
-                                                            opossum::ScanType::Equals, o_d_id);
+                                                            opossum::PredicateCondition::Equals, o_d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "O_W_ID" */,
-                                                           opossum::ScanType::Equals, o_w_id);
+                                                           opossum::PredicateCondition::Equals, o_w_id);
 
   // "O_ID", "O_CARRIER_ID", "O_ENTRY_D"
   auto projection = std::make_shared<opossum::Projection>(
@@ -255,13 +255,13 @@ TaskVector OrderStatusRefImpl::get_order_lines(const int o_id, const int d_id, c
   auto validate = std::make_shared<opossum::Validate>(gt_order_lines);
 
   auto first_filter = std::make_shared<opossum::TableScan>(validate, opossum::ColumnID{0} /* "OL_O_ID" */,
-                                                           opossum::ScanType::Equals, o_id);
+                                                           opossum::PredicateCondition::Equals, o_id);
 
   auto second_filter = std::make_shared<opossum::TableScan>(first_filter, opossum::ColumnID{1} /* "OL_D_ID" */,
-                                                            opossum::ScanType::Equals, d_id);
+                                                            opossum::PredicateCondition::Equals, d_id);
 
   auto third_filter = std::make_shared<opossum::TableScan>(second_filter, opossum::ColumnID{2} /* "OL_W_ID" */,
-                                                           opossum::ScanType::Equals, w_id);
+                                                           opossum::PredicateCondition::Equals, w_id);
 
   auto projection = std::make_shared<opossum::Projection>(
       third_filter, opossum::Projection::ColumnExpressions(

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -20,19 +20,20 @@ boost::bimap<L, R> make_bimap(std::initializer_list<typename boost::bimap<L, R>:
   return boost::bimap<L, R>(list.begin(), list.end());
 }
 
-const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string = make_bimap<PredicateCondition, std::string>({
-    {PredicateCondition::Equals, "="},
-    {PredicateCondition::NotEquals, "!="},
-    {PredicateCondition::LessThan, "<"},
-    {PredicateCondition::LessThanEquals, "<="},
-    {PredicateCondition::GreaterThan, ">"},
-    {PredicateCondition::GreaterThanEquals, ">="},
-    {PredicateCondition::Between, "BETWEEN"},
-    {PredicateCondition::Like, "LIKE"},
-    {PredicateCondition::NotLike, "NOT LIKE"},
-    {PredicateCondition::IsNull, "IS NULL"},
-    {PredicateCondition::IsNotNull, "IS NOT NULL"},
-});
+const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string =
+    make_bimap<PredicateCondition, std::string>({
+        {PredicateCondition::Equals, "="},
+        {PredicateCondition::NotEquals, "!="},
+        {PredicateCondition::LessThan, "<"},
+        {PredicateCondition::LessThanEquals, "<="},
+        {PredicateCondition::GreaterThan, ">"},
+        {PredicateCondition::GreaterThanEquals, ">="},
+        {PredicateCondition::Between, "BETWEEN"},
+        {PredicateCondition::Like, "LIKE"},
+        {PredicateCondition::NotLike, "NOT LIKE"},
+        {PredicateCondition::IsNull, "IS NULL"},
+        {PredicateCondition::IsNotNull, "IS NOT NULL"},
+    });
 
 const std::unordered_map<ExpressionType, std::string> expression_type_to_string = {
     {ExpressionType::Literal, "Literal"},

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -20,18 +20,18 @@ boost::bimap<L, R> make_bimap(std::initializer_list<typename boost::bimap<L, R>:
   return boost::bimap<L, R>(list.begin(), list.end());
 }
 
-const boost::bimap<ScanType, std::string> scan_type_to_string = make_bimap<ScanType, std::string>({
-    {ScanType::Equals, "="},
-    {ScanType::NotEquals, "!="},
-    {ScanType::LessThan, "<"},
-    {ScanType::LessThanEquals, "<="},
-    {ScanType::GreaterThan, ">"},
-    {ScanType::GreaterThanEquals, ">="},
-    {ScanType::Between, "BETWEEN"},
-    {ScanType::Like, "LIKE"},
-    {ScanType::NotLike, "NOT LIKE"},
-    {ScanType::IsNull, "IS NULL"},
-    {ScanType::IsNotNull, "IS NOT NULL"},
+const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string = make_bimap<PredicateCondition, std::string>({
+    {PredicateCondition::Equals, "="},
+    {PredicateCondition::NotEquals, "!="},
+    {PredicateCondition::LessThan, "<"},
+    {PredicateCondition::LessThanEquals, "<="},
+    {PredicateCondition::GreaterThan, ">"},
+    {PredicateCondition::GreaterThanEquals, ">="},
+    {PredicateCondition::Between, "BETWEEN"},
+    {PredicateCondition::Like, "LIKE"},
+    {PredicateCondition::NotLike, "NOT LIKE"},
+    {PredicateCondition::IsNull, "IS NULL"},
+    {PredicateCondition::IsNotNull, "IS NOT NULL"},
 });
 
 const std::unordered_map<ExpressionType, std::string> expression_type_to_string = {

--- a/src/lib/constant_mappings.hpp
+++ b/src/lib/constant_mappings.hpp
@@ -10,7 +10,7 @@
 
 namespace opossum {
 
-extern const boost::bimap<ScanType, std::string> scan_type_to_string;
+extern const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string;
 extern const std::unordered_map<ExpressionType, std::string> expression_type_to_string;
 extern const std::unordered_map<OrderByMode, std::string> order_by_mode_to_string;
 extern const std::unordered_map<hsql::OperatorType, ExpressionType> operator_type_to_expression_type;

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -25,7 +25,8 @@ class JoinNode : public AbstractLQPNode {
   explicit JoinNode(const JoinMode join_mode);
 
   // Constructor for predicated Joins
-  JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references, const PredicateCondition predicate_condition);
+  JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references,
+           const PredicateCondition predicate_condition);
 
   const std::optional<LQPColumnReferencePair>& join_column_references() const;
   const std::optional<PredicateCondition>& predicate_condition() const;

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -25,10 +25,10 @@ class JoinNode : public AbstractLQPNode {
   explicit JoinNode(const JoinMode join_mode);
 
   // Constructor for predicated Joins
-  JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references, const ScanType scan_type);
+  JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references, const PredicateCondition predicate_condition);
 
   const std::optional<LQPColumnReferencePair>& join_column_references() const;
-  const std::optional<ScanType>& scan_type() const;
+  const std::optional<PredicateCondition>& predicate_condition() const;
   JoinMode join_mode() const;
 
   std::string description() const override;
@@ -50,7 +50,7 @@ class JoinNode : public AbstractLQPNode {
  private:
   JoinMode _join_mode;
   std::optional<LQPColumnReferencePair> _join_column_references;
-  std::optional<ScanType> _scan_type;
+  std::optional<PredicateCondition> _predicate_condition;
 
   mutable std::optional<std::vector<std::string>> _output_column_names;
 

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -99,16 +99,16 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
    * The TableScan Operator doesn't support BETWEEN, so for `X BETWEEN a AND b` we create two TableScans: One for
    * `X >= a` and one for `X <= b`
    */
-  if (table_scan_node->scan_type() == ScanType::Between) {
+  if (table_scan_node->predicate_condition() == PredicateCondition::Between) {
     DebugAssert(static_cast<bool>(table_scan_node->value2()), "Scan type BETWEEN requires a second value");
     PerformanceWarning("TableScan executes BETWEEN as two separate scans");
 
-    auto table_scan_gt = std::make_shared<TableScan>(input_operator, column_id, ScanType::GreaterThanEquals, value);
+    auto table_scan_gt = std::make_shared<TableScan>(input_operator, column_id, PredicateCondition::GreaterThanEquals, value);
 
-    return std::make_shared<TableScan>(table_scan_gt, column_id, ScanType::LessThanEquals, *table_scan_node->value2());
+    return std::make_shared<TableScan>(table_scan_gt, column_id, PredicateCondition::LessThanEquals, *table_scan_node->value2());
   }
 
-  return std::make_shared<TableScan>(input_operator, column_id, table_scan_node->scan_type(), value);
+  return std::make_shared<TableScan>(input_operator, column_id, table_scan_node->predicate_condition(), value);
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_projection_node(
@@ -159,19 +159,19 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_join_node(
   }
 
   DebugAssert(static_cast<bool>(join_node->join_column_references()), "Cannot translate Join without columns.");
-  DebugAssert(static_cast<bool>(join_node->scan_type()), "Cannot translate Join without ScanType.");
+  DebugAssert(static_cast<bool>(join_node->predicate_condition()), "Cannot translate Join without PredicateCondition.");
 
   ColumnIDPair join_column_ids;
   join_column_ids.first = join_node->left_child()->get_output_column_id(join_node->join_column_references()->first);
   join_column_ids.second = join_node->right_child()->get_output_column_id(join_node->join_column_references()->second);
 
-  if (*join_node->scan_type() == ScanType::Equals && join_node->join_mode() != JoinMode::Outer) {
+  if (*join_node->predicate_condition() == PredicateCondition::Equals && join_node->join_mode() != JoinMode::Outer) {
     return std::make_shared<JoinHash>(input_left_operator, input_right_operator, join_node->join_mode(),
-                                      join_column_ids, *(join_node->scan_type()));
+                                      join_column_ids, *(join_node->predicate_condition()));
   }
 
   return std::make_shared<JoinSortMerge>(input_left_operator, input_right_operator, join_node->join_mode(),
-                                         join_column_ids, *(join_node->scan_type()));
+                                         join_column_ids, *(join_node->predicate_condition()));
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_aggregate_node(

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -103,9 +103,11 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
     DebugAssert(static_cast<bool>(table_scan_node->value2()), "Scan type BETWEEN requires a second value");
     PerformanceWarning("TableScan executes BETWEEN as two separate scans");
 
-    auto table_scan_gt = std::make_shared<TableScan>(input_operator, column_id, PredicateCondition::GreaterThanEquals, value);
+    auto table_scan_gt =
+        std::make_shared<TableScan>(input_operator, column_id, PredicateCondition::GreaterThanEquals, value);
 
-    return std::make_shared<TableScan>(table_scan_gt, column_id, PredicateCondition::LessThanEquals, *table_scan_node->value2());
+    return std::make_shared<TableScan>(table_scan_gt, column_id, PredicateCondition::LessThanEquals,
+                                       *table_scan_node->value2());
   }
 
   return std::make_shared<TableScan>(input_operator, column_id, table_scan_node->predicate_condition(), value);

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -12,11 +12,11 @@
 
 namespace opossum {
 
-PredicateNode::PredicateNode(const LQPColumnReference& column_reference, const ScanType scan_type,
+PredicateNode::PredicateNode(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition,
                              const AllParameterVariant& value, const std::optional<AllTypeVariant>& value2)
     : AbstractLQPNode(LQPNodeType::Predicate),
       _column_reference(column_reference),
-      _scan_type(scan_type),
+      _predicate_condition(predicate_condition),
       _value(value),
       _value2(value2) {}
 
@@ -25,7 +25,7 @@ std::shared_ptr<AbstractLQPNode> PredicateNode::_deep_copy_impl(
     const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
   DebugAssert(left_child(), "Can't copy without child");
   return std::make_shared<PredicateNode>(
-      adapt_column_reference_to_different_lqp(_column_reference, left_child(), copied_left_child), _scan_type, _value,
+      adapt_column_reference_to_different_lqp(_column_reference, left_child(), copied_left_child), _predicate_condition, _value,
       _value2);
 }
 
@@ -51,7 +51,7 @@ std::string PredicateNode::description() const {
 
   std::ostringstream desc;
 
-  desc << "[Predicate] " << left_operand_desc << " " << scan_type_to_string.left.at(_scan_type);
+  desc << "[Predicate] " << left_operand_desc << " " << predicate_condition_to_string.left.at(_predicate_condition);
   desc << " " << middle_operand_desc << "";
   if (_value2) {
     desc << " AND ";
@@ -67,7 +67,7 @@ std::string PredicateNode::description() const {
 
 const LQPColumnReference& PredicateNode::column_reference() const { return _column_reference; }
 
-ScanType PredicateNode::scan_type() const { return _scan_type; }
+PredicateCondition PredicateNode::predicate_condition() const { return _predicate_condition; }
 
 const AllParameterVariant& PredicateNode::value() const { return _value; }
 
@@ -86,7 +86,7 @@ std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
     value = static_cast<ColumnID::base_type>(get_output_column_id(boost::get<LQPColumnReference>(value)));
   }
 
-  return left_child->get_statistics()->predicate_statistics(get_output_column_id(_column_reference), _scan_type, value,
+  return left_child->get_statistics()->predicate_statistics(get_output_column_id(_column_reference), _predicate_condition, value,
                                                             _value2);
 }
 

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -25,8 +25,8 @@ std::shared_ptr<AbstractLQPNode> PredicateNode::_deep_copy_impl(
     const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
   DebugAssert(left_child(), "Can't copy without child");
   return std::make_shared<PredicateNode>(
-      adapt_column_reference_to_different_lqp(_column_reference, left_child(), copied_left_child), _predicate_condition, _value,
-      _value2);
+      adapt_column_reference_to_different_lqp(_column_reference, left_child(), copied_left_child), _predicate_condition,
+      _value, _value2);
 }
 
 std::string PredicateNode::description() const {
@@ -86,8 +86,8 @@ std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
     value = static_cast<ColumnID::base_type>(get_output_column_id(boost::get<LQPColumnReference>(value)));
   }
 
-  return left_child->get_statistics()->predicate_statistics(get_output_column_id(_column_reference), _predicate_condition, value,
-                                                            _value2);
+  return left_child->get_statistics()->predicate_statistics(get_output_column_id(_column_reference),
+                                                            _predicate_condition, value, _value2);
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -23,8 +23,8 @@ class TableStatistics;
  */
 class PredicateNode : public AbstractLQPNode {
  public:
-  PredicateNode(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value,
-                const std::optional<AllTypeVariant>& value2 = std::nullopt);
+  PredicateNode(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition,
+                const AllParameterVariant& value, const std::optional<AllTypeVariant>& value2 = std::nullopt);
 
   std::string description() const override;
 

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -23,13 +23,13 @@ class TableStatistics;
  */
 class PredicateNode : public AbstractLQPNode {
  public:
-  PredicateNode(const LQPColumnReference& column_reference, const ScanType scan_type, const AllParameterVariant& value,
+  PredicateNode(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value,
                 const std::optional<AllTypeVariant>& value2 = std::nullopt);
 
   std::string description() const override;
 
   const LQPColumnReference& column_reference() const;
-  ScanType scan_type() const;
+  PredicateCondition predicate_condition() const;
   const AllParameterVariant& value() const;
   const std::optional<AllTypeVariant>& value2() const;
 
@@ -44,7 +44,7 @@ class PredicateNode : public AbstractLQPNode {
 
  private:
   const LQPColumnReference _column_reference;
-  const ScanType _scan_type;
+  const PredicateCondition _predicate_condition;
   const AllParameterVariant _value;
   const std::optional<AllTypeVariant> _value2;
 };

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -10,8 +10,8 @@ namespace opossum {
 
 AbstractJoinOperator::AbstractJoinOperator(const std::shared_ptr<const AbstractOperator> left,
                                            const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
-                                           const ColumnIDPair& column_ids, const ScanType scan_type)
-    : AbstractReadOnlyOperator(left, right), _mode(mode), _column_ids(column_ids), _scan_type(scan_type) {
+                                           const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
+    : AbstractReadOnlyOperator(left, right), _mode(mode), _column_ids(column_ids), _predicate_condition(predicate_condition) {
   DebugAssert(mode != JoinMode::Cross && mode != JoinMode::Natural,
               "Specified JoinMode not supported by an AbstractJoin, use Product etc. instead.");
 }
@@ -20,7 +20,7 @@ JoinMode AbstractJoinOperator::mode() const { return _mode; }
 
 const ColumnIDPair& AbstractJoinOperator::column_ids() const { return _column_ids; }
 
-ScanType AbstractJoinOperator::scan_type() const { return _scan_type; }
+PredicateCondition AbstractJoinOperator::predicate_condition() const { return _predicate_condition; }
 
 const std::string AbstractJoinOperator::description(DescriptionMode description_mode) const {
   std::string column_name_left = std::string("Col #") + std::to_string(_column_ids.first);
@@ -32,7 +32,7 @@ const std::string AbstractJoinOperator::description(DescriptionMode description_
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
 
   return name() + separator + "(" + join_mode_to_string.at(_mode) + " Join where " + column_name_left + " " +
-         scan_type_to_string.left.at(_scan_type) + " " + column_name_right + ")";
+         predicate_condition_to_string.left.at(_predicate_condition) + " " + column_name_right + ")";
 }
 
 }  // namespace opossum

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -11,7 +11,10 @@ namespace opossum {
 AbstractJoinOperator::AbstractJoinOperator(const std::shared_ptr<const AbstractOperator> left,
                                            const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                                            const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
-    : AbstractReadOnlyOperator(left, right), _mode(mode), _column_ids(column_ids), _predicate_condition(predicate_condition) {
+    : AbstractReadOnlyOperator(left, right),
+      _mode(mode),
+      _column_ids(column_ids),
+      _predicate_condition(predicate_condition) {
   DebugAssert(mode != JoinMode::Cross && mode != JoinMode::Natural,
               "Specified JoinMode not supported by an AbstractJoin, use Product etc. instead.");
 }

--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -26,17 +26,17 @@ class AbstractJoinOperator : public AbstractReadOnlyOperator {
  public:
   AbstractJoinOperator(const std::shared_ptr<const AbstractOperator> left,
                        const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
-                       const ColumnIDPair& column_ids, const ScanType scan_type);
+                       const ColumnIDPair& column_ids, const PredicateCondition predicate_condition);
 
   JoinMode mode() const;
   const ColumnIDPair& column_ids() const;
-  ScanType scan_type() const;
+  PredicateCondition predicate_condition() const;
   const std::string description(DescriptionMode description_mode) const override;
 
  protected:
   const JoinMode _mode;
   const ColumnIDPair _column_ids;
-  const ScanType _scan_type;
+  const PredicateCondition _predicate_condition;
 
   // Some operators need an internal implementation class, mostly in cases where
   // their execute method depends on a template parameter. An example for this is

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -14,12 +14,12 @@
 namespace opossum {
 
 IndexScan::IndexScan(std::shared_ptr<AbstractOperator> in, const ColumnIndexType index_type,
-                     std::vector<ColumnID> left_column_ids, const ScanType scan_type,
+                     std::vector<ColumnID> left_column_ids, const PredicateCondition predicate_condition,
                      std::vector<AllTypeVariant> right_values, std::vector<AllTypeVariant> right_values2)
     : AbstractReadOnlyOperator{in},
       _index_type{index_type},
       _left_column_ids{left_column_ids},
-      _scan_type{scan_type},
+      _predicate_condition{predicate_condition},
       _right_values{right_values},
       _right_values2{right_values2} {}
 
@@ -78,12 +78,12 @@ std::shared_ptr<JobTask> IndexScan::_create_job_and_schedule(const ChunkID chunk
 }
 
 void IndexScan::_validate_input() {
-  Assert(_scan_type != ScanType::Like, "Scan type not supported by index scan.");
-  Assert(_scan_type != ScanType::NotLike, "Scan type not supported by index scan.");
+  Assert(_predicate_condition != PredicateCondition::Like, "Scan type not supported by index scan.");
+  Assert(_predicate_condition != PredicateCondition::NotLike, "Scan type not supported by index scan.");
 
   Assert(_left_column_ids.size() == _right_values.size(),
          "Count mismatch: left column IDs and right values don’t have same size.");
-  if (_scan_type == ScanType::Between) {
+  if (_predicate_condition == PredicateCondition::Between) {
     Assert(_left_column_ids.size() == _right_values2.size(),
            "Count mismatch: left column IDs and right values don’t have same size.");
   }
@@ -103,13 +103,13 @@ PosList IndexScan::_scan_chunk(const ChunkID chunk_id) {
   const auto index = chunk->get_index(_index_type, _left_column_ids);
   Assert(index != nullptr, "Index of specified type not found for column (vector).");
 
-  switch (_scan_type) {
-    case ScanType::Equals: {
+  switch (_predicate_condition) {
+    case PredicateCondition::Equals: {
       range_begin = index->lower_bound(_right_values);
       range_end = index->upper_bound(_right_values);
       break;
     }
-    case ScanType::NotEquals: {
+    case PredicateCondition::NotEquals: {
       // first, get all values less than the search value
       range_begin = index->cbegin();
       range_end = index->lower_bound(_right_values);
@@ -122,27 +122,27 @@ PosList IndexScan::_scan_chunk(const ChunkID chunk_id) {
       range_end = index->cend();
       break;
     }
-    case ScanType::LessThan: {
+    case PredicateCondition::LessThan: {
       range_begin = index->cbegin();
       range_end = index->lower_bound(_right_values);
       break;
     }
-    case ScanType::LessThanEquals: {
+    case PredicateCondition::LessThanEquals: {
       range_begin = index->cbegin();
       range_end = index->upper_bound(_right_values);
       break;
     }
-    case ScanType::GreaterThan: {
+    case PredicateCondition::GreaterThan: {
       range_begin = index->upper_bound(_right_values);
       range_end = index->cend();
       break;
     }
-    case ScanType::GreaterThanEquals: {
+    case PredicateCondition::GreaterThanEquals: {
       range_begin = index->lower_bound(_right_values);
       range_end = index->cend();
       break;
     }
-    case ScanType::Between: {
+    case PredicateCondition::Between: {
       range_begin = index->lower_bound(_right_values);
       range_end = index->upper_bound(_right_values2);
       break;

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -21,8 +21,8 @@ class JobTask;
 class IndexScan : public AbstractReadOnlyOperator {
  public:
   IndexScan(std::shared_ptr<AbstractOperator> in, const ColumnIndexType index_type,
-            std::vector<ColumnID> left_column_ids, const PredicateCondition predicate_condition, std::vector<AllTypeVariant> right_values,
-            std::vector<AllTypeVariant> right_values2 = {});
+            std::vector<ColumnID> left_column_ids, const PredicateCondition predicate_condition,
+            std::vector<AllTypeVariant> right_values, std::vector<AllTypeVariant> right_values2 = {});
 
   const std::string name() const final;
 

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -21,7 +21,7 @@ class JobTask;
 class IndexScan : public AbstractReadOnlyOperator {
  public:
   IndexScan(std::shared_ptr<AbstractOperator> in, const ColumnIndexType index_type,
-            std::vector<ColumnID> left_column_ids, const ScanType scan_type, std::vector<AllTypeVariant> right_values,
+            std::vector<ColumnID> left_column_ids, const PredicateCondition predicate_condition, std::vector<AllTypeVariant> right_values,
             std::vector<AllTypeVariant> right_values2 = {});
 
   const std::string name() const final;
@@ -43,7 +43,7 @@ class IndexScan : public AbstractReadOnlyOperator {
  private:
   const ColumnIndexType _index_type;
   const std::vector<ColumnID> _left_column_ids;
-  const ScanType _scan_type;
+  const PredicateCondition _predicate_condition;
   const std::vector<AllTypeVariant> _right_values;
   const std::vector<AllTypeVariant> _right_values2;
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -87,7 +87,8 @@ template <typename LeftType, typename RightType>
 class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
  public:
   JoinHashImpl(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right,
-               const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition predicate_condition, const bool inputs_swapped)
+               const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition predicate_condition,
+               const bool inputs_swapped)
       : _left(left),
         _right(right),
         _mode(mode),

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -26,7 +26,7 @@ namespace opossum {
 class JoinHash : public AbstractJoinOperator {
  public:
   JoinHash(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right,
-           const JoinMode mode, const ColumnIDPair& column_ids, const ScanType scan_type);
+           const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition predicate_condition);
 
   const std::string name() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -25,14 +25,14 @@ namespace opossum {
 
 JoinNestedLoop::JoinNestedLoop(const std::shared_ptr<const AbstractOperator> left,
                                const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
-                               const ColumnIDPair& column_ids, const ScanType scan_type)
-    : AbstractJoinOperator(left, right, mode, column_ids, scan_type) {}
+                               const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
+    : AbstractJoinOperator(left, right, mode, column_ids, predicate_condition) {}
 
 const std::string JoinNestedLoop::name() const { return "JoinNestedLoop"; }
 
 std::shared_ptr<AbstractOperator> JoinNestedLoop::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<JoinNestedLoop>(_input_left->recreate(args), _input_right->recreate(args), _mode, _column_ids,
-                                          _scan_type);
+                                          _predicate_condition);
 }
 
 std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
@@ -159,7 +159,7 @@ void JoinNestedLoop::_perform_join() {
 
             iterable_left.with_iterators([&](auto left_it, auto left_end) {
               iterable_right.with_iterators([&](auto right_it, auto right_end) {
-                with_comparator(_scan_type, [&](auto comparator) {
+                with_comparator(_predicate_condition, [&](auto comparator) {
                   this->_join_two_columns(comparator, left_it, left_end, right_it, right_end, chunk_id_left,
                                           chunk_id_right, left_matches);
                 });

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -15,7 +15,7 @@ class JoinNestedLoop : public AbstractJoinOperator {
  public:
   JoinNestedLoop(const std::shared_ptr<const AbstractOperator> left,
                  const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
-                 const ColumnIDPair& column_ids, const ScanType scan_type);
+                 const ColumnIDPair& column_ids, const PredicateCondition predicate_condition);
 
   const std::string name() const override;
   std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args = {}) const override;

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -42,8 +42,9 @@ JoinSortMerge::JoinSortMerge(const std::shared_ptr<const AbstractOperator> left,
   DebugAssert(mode != JoinMode::Cross, "This operator does not support cross joins.");
   DebugAssert(left != nullptr, "The left input operator is null.");
   DebugAssert(right != nullptr, "The right input operator is null.");
-  DebugAssert(op == PredicateCondition::Equals || op == PredicateCondition::LessThan || op == PredicateCondition::GreaterThan ||
-                  op == PredicateCondition::LessThanEquals || op == PredicateCondition::GreaterThanEquals || op == PredicateCondition::NotEquals,
+  DebugAssert(op == PredicateCondition::Equals || op == PredicateCondition::LessThan ||
+                  op == PredicateCondition::GreaterThan || op == PredicateCondition::LessThanEquals ||
+                  op == PredicateCondition::GreaterThanEquals || op == PredicateCondition::NotEquals,
               "Unsupported scan type");
   DebugAssert(op != PredicateCondition::NotEquals || mode == JoinMode::Inner,
               "Outer joins are not implemented for not-equals joins.");
@@ -368,8 +369,9 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   * Determines the smallest value in a sorted materialized table.
   **/
   T& _table_min_value(std::unique_ptr<MaterializedColumnList<T>>& sorted_table) {
-    DebugAssert(_op != PredicateCondition::Equals, "Complete table order is required for _table_min_value which is only " +
-                                             "available in the non-equi case");
+    DebugAssert(
+        _op != PredicateCondition::Equals,
+        "Complete table order is required for _table_min_value which is only " + "available in the non-equi case");
     DebugAssert(sorted_table->size() > 0, "Sorted table has no partitions");
 
     for (auto partition : *sorted_table) {

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -36,22 +36,22 @@ namespace opossum {
 **/
 JoinSortMerge::JoinSortMerge(const std::shared_ptr<const AbstractOperator> left,
                              const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
-                             const ColumnIDPair& column_ids, const ScanType op)
+                             const ColumnIDPair& column_ids, const PredicateCondition op)
     : AbstractJoinOperator(left, right, mode, column_ids, op) {
   // Validate the parameters
   DebugAssert(mode != JoinMode::Cross, "This operator does not support cross joins.");
   DebugAssert(left != nullptr, "The left input operator is null.");
   DebugAssert(right != nullptr, "The right input operator is null.");
-  DebugAssert(op == ScanType::Equals || op == ScanType::LessThan || op == ScanType::GreaterThan ||
-                  op == ScanType::LessThanEquals || op == ScanType::GreaterThanEquals || op == ScanType::NotEquals,
+  DebugAssert(op == PredicateCondition::Equals || op == PredicateCondition::LessThan || op == PredicateCondition::GreaterThan ||
+                  op == PredicateCondition::LessThanEquals || op == PredicateCondition::GreaterThanEquals || op == PredicateCondition::NotEquals,
               "Unsupported scan type");
-  DebugAssert(op != ScanType::NotEquals || mode == JoinMode::Inner,
+  DebugAssert(op != PredicateCondition::NotEquals || mode == JoinMode::Inner,
               "Outer joins are not implemented for not-equals joins.");
 }
 
 std::shared_ptr<AbstractOperator> JoinSortMerge::recreate(const std::vector<AllParameterVariant>& args) const {
   return std::make_shared<JoinSortMerge>(_input_left->recreate(args), _input_right->recreate(args), _mode, _column_ids,
-                                         _scan_type);
+                                         _predicate_condition);
 }
 
 std::shared_ptr<const Table> JoinSortMerge::_on_execute() {
@@ -62,7 +62,7 @@ std::shared_ptr<const Table> JoinSortMerge::_on_execute() {
 
   // Create implementation to compute the join result
   _impl = make_unique_by_data_type<AbstractJoinOperatorImpl, JoinSortMergeImpl>(
-      left_column_type, *this, _column_ids.first, _column_ids.second, _scan_type, _mode);
+      left_column_type, *this, _column_ids.first, _column_ids.second, _predicate_condition, _mode);
 
   return _impl->_on_execute();
 }
@@ -78,7 +78,7 @@ template <typename T>
 class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
  public:
   JoinSortMergeImpl<T>(JoinSortMerge& sort_merge_join, ColumnID left_column_id, ColumnID right_column_id,
-                       const ScanType op, JoinMode mode)
+                       const PredicateCondition op, JoinMode mode)
       : _sort_merge_join{sort_merge_join},
         _left_column_id{left_column_id},
         _right_column_id{right_column_id},
@@ -103,7 +103,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   const ColumnID _left_column_id;
   const ColumnID _right_column_id;
 
-  const ScanType _op;
+  const PredicateCondition _op;
   const JoinMode _mode;
 
   // the cluster count must be a power of two, i.e. 1, 2, 4, 8, 16, ...
@@ -189,7 +189,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   void _join_runs(TableRange left_run, TableRange right_run, CompareResult compare_result) {
     size_t cluster_number = left_run.start.cluster;
     switch (_op) {
-      case ScanType::Equals:
+      case PredicateCondition::Equals:
         if (compare_result == CompareResult::Equal) {
           _emit_all_combinations(cluster_number, left_run, right_run);
         } else if (compare_result == CompareResult::Less) {
@@ -202,7 +202,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
           }
         }
         break;
-      case ScanType::NotEquals:
+      case PredicateCondition::NotEquals:
         if (compare_result == CompareResult::Greater) {
           _emit_all_combinations(cluster_number, left_run.start.to(_end_of_left_table), right_run);
         } else if (compare_result == CompareResult::Equal) {
@@ -212,32 +212,32 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
           _emit_all_combinations(cluster_number, left_run, right_run.start.to(_end_of_right_table));
         }
         break;
-      case ScanType::GreaterThan:
+      case PredicateCondition::GreaterThan:
         if (compare_result == CompareResult::Greater) {
           _emit_all_combinations(cluster_number, left_run.start.to(_end_of_left_table), right_run);
         } else if (compare_result == CompareResult::Equal) {
           _emit_all_combinations(cluster_number, left_run.end.to(_end_of_left_table), right_run);
         }
         break;
-      case ScanType::GreaterThanEquals:
+      case PredicateCondition::GreaterThanEquals:
         if (compare_result == CompareResult::Greater || compare_result == CompareResult::Equal) {
           _emit_all_combinations(cluster_number, left_run.start.to(_end_of_left_table), right_run);
         }
         break;
-      case ScanType::LessThan:
+      case PredicateCondition::LessThan:
         if (compare_result == CompareResult::Less) {
           _emit_all_combinations(cluster_number, left_run, right_run.start.to(_end_of_right_table));
         } else if (compare_result == CompareResult::Equal) {
           _emit_all_combinations(cluster_number, left_run, right_run.end.to(_end_of_right_table));
         }
         break;
-      case ScanType::LessThanEquals:
+      case PredicateCondition::LessThanEquals:
         if (compare_result == CompareResult::Less || compare_result == CompareResult::Equal) {
           _emit_all_combinations(cluster_number, left_run, right_run.start.to(_end_of_right_table));
         }
         break;
       default:
-        throw std::logic_error("Unknown ScanType");
+        throw std::logic_error("Unknown PredicateCondition");
     }
   }
 
@@ -368,7 +368,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   * Determines the smallest value in a sorted materialized table.
   **/
   T& _table_min_value(std::unique_ptr<MaterializedColumnList<T>>& sorted_table) {
-    DebugAssert(_op != ScanType::Equals, "Complete table order is required for _table_min_value which is only " +
+    DebugAssert(_op != PredicateCondition::Equals, "Complete table order is required for _table_min_value which is only " +
                                              "available in the non-equi case");
     DebugAssert(sorted_table->size() > 0, "Sorted table has no partitions");
 
@@ -385,7 +385,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   * Determines the largest value in a sorted materialized table.
   **/
   T& _table_max_value(std::unique_ptr<MaterializedColumnList<T>>& sorted_table) {
-    DebugAssert(_op != ScanType::Equals,
+    DebugAssert(_op != PredicateCondition::Equals,
                 "The table needs to be sorted for _table_max_value which is only " + "the case in the non-equi case");
     DebugAssert(sorted_table->size() > 0, "Sorted table is empty");
 
@@ -450,28 +450,28 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
     auto& left_max_value = _table_max_value(_sorted_left_table);
     auto end_of_right_table = _end_of_table(_sorted_right_table);
 
-    if (_op == ScanType::LessThan) {
+    if (_op == PredicateCondition::LessThan) {
       // Look for the first right value that is bigger than the smallest left value.
       auto result =
           _first_value_that_satisfies(_sorted_right_table, [&](const T& value) { return value > left_min_value; });
       if (result.has_value()) {
         _emit_left_null_combinations(0, TablePosition(0, 0).to(*result));
       }
-    } else if (_op == ScanType::LessThanEquals) {
+    } else if (_op == PredicateCondition::LessThanEquals) {
       // Look for the first right value that is bigger or equal to the smallest left value.
       auto result =
           _first_value_that_satisfies(_sorted_right_table, [&](const T& value) { return value >= left_min_value; });
       if (result.has_value()) {
         _emit_left_null_combinations(0, TablePosition(0, 0).to(*result));
       }
-    } else if (_op == ScanType::GreaterThan) {
+    } else if (_op == PredicateCondition::GreaterThan) {
       // Look for the first right value that is smaller than the biggest left value.
       auto result = _first_value_that_satisfies_reverse(_sorted_right_table,
                                                         [&](const T& value) { return value < left_max_value; });
       if (result.has_value()) {
         _emit_left_null_combinations(0, (*result).to(end_of_right_table));
       }
-    } else if (_op == ScanType::GreaterThanEquals) {
+    } else if (_op == PredicateCondition::GreaterThanEquals) {
       // Look for the first right value that is smaller or equal to the biggest left value.
       auto result = _first_value_that_satisfies_reverse(_sorted_right_table,
                                                         [&](const T& value) { return value <= left_max_value; });
@@ -491,28 +491,28 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
     auto& right_max_value = _table_max_value(_sorted_right_table);
     auto end_of_left_table = _end_of_table(_sorted_left_table);
 
-    if (_op == ScanType::LessThan) {
+    if (_op == PredicateCondition::LessThan) {
       // Look for the last left value that is smaller than the biggest right value.
       auto result = _first_value_that_satisfies_reverse(_sorted_left_table,
                                                         [&](const T& value) { return value < right_max_value; });
       if (result.has_value()) {
         _emit_right_null_combinations(0, (*result).to(end_of_left_table));
       }
-    } else if (_op == ScanType::LessThanEquals) {
+    } else if (_op == PredicateCondition::LessThanEquals) {
       // Look for the last left value that is smaller or equal than the biggest right value.
       auto result = _first_value_that_satisfies_reverse(_sorted_left_table,
                                                         [&](const T& value) { return value <= right_max_value; });
       if (result.has_value()) {
         _emit_right_null_combinations(0, (*result).to(end_of_left_table));
       }
-    } else if (_op == ScanType::GreaterThan) {
+    } else if (_op == PredicateCondition::GreaterThan) {
       // Look for the first left value that is bigger than the smallest right value.
       auto result =
           _first_value_that_satisfies(_sorted_left_table, [&](const T& value) { return value > right_min_value; });
       if (result.has_value()) {
         _emit_right_null_combinations(0, TablePosition(0, 0).to(*result));
       }
-    } else if (_op == ScanType::GreaterThanEquals) {
+    } else if (_op == PredicateCondition::GreaterThanEquals) {
       // Look for the first left value that is bigger or equal to the smallest right value.
       auto result =
           _first_value_that_satisfies(_sorted_left_table, [&](const T& value) { return value >= right_min_value; });
@@ -538,10 +538,10 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
 
     // The outer joins for the non-equi cases
     // Note: Equi outer joins can be integrated into the main algorithm, while these can not.
-    if ((_mode == JoinMode::Left || _mode == JoinMode::Outer) && _op != ScanType::Equals) {
+    if ((_mode == JoinMode::Left || _mode == JoinMode::Outer) && _op != PredicateCondition::Equals) {
       _left_outer_non_equi_join();
     }
-    if ((_mode == JoinMode::Right || _mode == JoinMode::Outer) && _op != ScanType::Equals) {
+    if ((_mode == JoinMode::Right || _mode == JoinMode::Outer) && _op != PredicateCondition::Equals) {
       _right_outer_non_equi_join();
     }
   }
@@ -632,7 +632,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
     bool include_null_right = (_mode == JoinMode::Right || _mode == JoinMode::Outer);
     auto radix_clusterer = RadixClusterSort<T>(
         _sort_merge_join._input_table_left(), _sort_merge_join._input_table_right(), _sort_merge_join._column_ids,
-        _op == ScanType::Equals, include_null_left, include_null_right, _cluster_count);
+        _op == PredicateCondition::Equals, include_null_left, include_null_right, _cluster_count);
     // Sort and cluster the input tables
     auto sort_output = radix_clusterer.execute();
     _sorted_left_table = std::move(sort_output.clusters_left);

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -24,7 +24,7 @@ namespace opossum {
 class JoinSortMerge : public AbstractJoinOperator {
  public:
   JoinSortMerge(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right,
-                const JoinMode mode, const ColumnIDPair& column_ids, const ScanType op);
+                const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition op);
 
   std::shared_ptr<const Table> _on_execute() override;
   void _on_cleanup() override;

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -30,10 +30,10 @@
 namespace opossum {
 
 TableScan::TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id,
-                     const ScanType scan_type, const AllParameterVariant right_parameter)
+                     const PredicateCondition predicate_condition, const AllParameterVariant right_parameter)
     : AbstractReadOnlyOperator{in},
       _left_column_id{left_column_id},
-      _scan_type{scan_type},
+      _predicate_condition{predicate_condition},
       _right_parameter{right_parameter} {}
 
 TableScan::~TableScan() = default;
@@ -42,7 +42,7 @@ void TableScan::set_excluded_chunk_ids(const std::vector<ChunkID>& chunk_ids) { 
 
 ColumnID TableScan::left_column_id() const { return _left_column_id; }
 
-ScanType TableScan::scan_type() const { return _scan_type; }
+PredicateCondition TableScan::predicate_condition() const { return _predicate_condition; }
 
 const AllParameterVariant& TableScan::right_parameter() const { return _right_parameter; }
 
@@ -56,7 +56,7 @@ const std::string TableScan::description(DescriptionMode description_mode) const
   std::string predicate_string = to_string(_right_parameter);
 
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-  return name() + separator + "(" + column_name + " " + scan_type_to_string.left.at(_scan_type) + " " +
+  return name() + separator + "(" + column_name + " " + predicate_condition_to_string.left.at(_predicate_condition) + " " +
          predicate_string + ")";
 }
 
@@ -65,10 +65,10 @@ std::shared_ptr<AbstractOperator> TableScan::recreate(const std::vector<AllParam
   if (is_placeholder(_right_parameter)) {
     const auto index = boost::get<ValuePlaceholder>(_right_parameter).index();
     if (index < args.size()) {
-      return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _scan_type, args[index]);
+      return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _predicate_condition, args[index]);
     }
   }
-  return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _scan_type, _right_parameter);
+  return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _predicate_condition, _right_parameter);
 }
 
 std::shared_ptr<const Table> TableScan::_on_execute() {
@@ -166,7 +166,7 @@ void TableScan::_on_cleanup() { _impl.reset(); }
 void TableScan::_init_scan() {
   DebugAssert(_in_table->chunk_count() > 0u, "Input table must contain at least 1 chunk.");
 
-  if (_scan_type == ScanType::Like || _scan_type == ScanType::NotLike) {
+  if (_predicate_condition == PredicateCondition::Like || _predicate_condition == PredicateCondition::NotLike) {
     const auto left_column_type = _in_table->column_type(_left_column_id);
     Assert((left_column_type == DataType::String), "LIKE operator only applicable on string columns.");
 
@@ -178,24 +178,24 @@ void TableScan::_init_scan() {
 
     const auto right_wildcard = type_cast<std::string>(right_value);
 
-    _impl = std::make_unique<LikeTableScanImpl>(_in_table, _left_column_id, _scan_type, right_wildcard);
+    _impl = std::make_unique<LikeTableScanImpl>(_in_table, _left_column_id, _predicate_condition, right_wildcard);
 
     return;
   }
 
-  if (_scan_type == ScanType::IsNull || _scan_type == ScanType::IsNotNull) {
-    _impl = std::make_unique<IsNullTableScanImpl>(_in_table, _left_column_id, _scan_type);
+  if (_predicate_condition == PredicateCondition::IsNull || _predicate_condition == PredicateCondition::IsNotNull) {
+    _impl = std::make_unique<IsNullTableScanImpl>(_in_table, _left_column_id, _predicate_condition);
     return;
   }
 
   if (is_variant(_right_parameter)) {
     const auto right_value = boost::get<AllTypeVariant>(_right_parameter);
 
-    _impl = std::make_unique<SingleColumnTableScanImpl>(_in_table, _left_column_id, _scan_type, right_value);
+    _impl = std::make_unique<SingleColumnTableScanImpl>(_in_table, _left_column_id, _predicate_condition, right_value);
   } else /* is_column_name(_right_parameter) */ {
     const auto right_column_id = boost::get<ColumnID>(_right_parameter);
 
-    _impl = std::make_unique<ColumnComparisonTableScanImpl>(_in_table, _left_column_id, _scan_type, right_column_id);
+    _impl = std::make_unique<ColumnComparisonTableScanImpl>(_in_table, _left_column_id, _predicate_condition, right_column_id);
   }
 }
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -56,8 +56,8 @@ const std::string TableScan::description(DescriptionMode description_mode) const
   std::string predicate_string = to_string(_right_parameter);
 
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-  return name() + separator + "(" + column_name + " " + predicate_condition_to_string.left.at(_predicate_condition) + " " +
-         predicate_string + ")";
+  return name() + separator + "(" + column_name + " " + predicate_condition_to_string.left.at(_predicate_condition) +
+         " " + predicate_string + ")";
 }
 
 std::shared_ptr<AbstractOperator> TableScan::recreate(const std::vector<AllParameterVariant>& args) const {
@@ -65,10 +65,12 @@ std::shared_ptr<AbstractOperator> TableScan::recreate(const std::vector<AllParam
   if (is_placeholder(_right_parameter)) {
     const auto index = boost::get<ValuePlaceholder>(_right_parameter).index();
     if (index < args.size()) {
-      return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _predicate_condition, args[index]);
+      return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _predicate_condition,
+                                         args[index]);
     }
   }
-  return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _predicate_condition, _right_parameter);
+  return std::make_shared<TableScan>(_input_left->recreate(args), _left_column_id, _predicate_condition,
+                                     _right_parameter);
 }
 
 std::shared_ptr<const Table> TableScan::_on_execute() {
@@ -195,7 +197,8 @@ void TableScan::_init_scan() {
   } else /* is_column_name(_right_parameter) */ {
     const auto right_column_id = boost::get<ColumnID>(_right_parameter);
 
-    _impl = std::make_unique<ColumnComparisonTableScanImpl>(_in_table, _left_column_id, _predicate_condition, right_column_id);
+    _impl = std::make_unique<ColumnComparisonTableScanImpl>(_in_table, _left_column_id, _predicate_condition,
+                                                            right_column_id);
   }
 }
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -17,7 +17,7 @@ class Table;
 
 class TableScan : public AbstractReadOnlyOperator {
  public:
-  TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id, const ScanType scan_type,
+  TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id, const PredicateCondition predicate_condition,
             const AllParameterVariant right_parameter);
 
   ~TableScan();
@@ -39,7 +39,7 @@ class TableScan : public AbstractReadOnlyOperator {
   void set_excluded_chunk_ids(const std::vector<ChunkID>& chunk_ids);
 
   ColumnID left_column_id() const;
-  ScanType scan_type() const;
+  PredicateCondition predicate_condition() const;
   const AllParameterVariant& right_parameter() const;
 
   const std::string name() const override;
@@ -55,7 +55,7 @@ class TableScan : public AbstractReadOnlyOperator {
 
  private:
   const ColumnID _left_column_id;
-  const ScanType _scan_type;
+  const PredicateCondition _predicate_condition;
   const AllParameterVariant _right_parameter;
 
   std::vector<ChunkID> _excluded_chunk_ids;

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -17,8 +17,8 @@ class Table;
 
 class TableScan : public AbstractReadOnlyOperator {
  public:
-  TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id, const PredicateCondition predicate_condition,
-            const AllParameterVariant right_parameter);
+  TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id,
+            const PredicateCondition predicate_condition, const AllParameterVariant right_parameter);
 
   ~TableScan();
 

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
@@ -14,7 +14,8 @@
 namespace opossum {
 
 BaseSingleColumnTableScanImpl::BaseSingleColumnTableScanImpl(std::shared_ptr<const Table> in_table,
-                                                             const ColumnID left_column_id, const PredicateCondition predicate_condition,
+                                                             const ColumnID left_column_id,
+                                                             const PredicateCondition predicate_condition,
                                                              const bool skip_null_row_ids)
     : BaseTableScanImpl{in_table, left_column_id, predicate_condition}, _skip_null_row_ids{skip_null_row_ids} {}
 

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
@@ -14,9 +14,9 @@
 namespace opossum {
 
 BaseSingleColumnTableScanImpl::BaseSingleColumnTableScanImpl(std::shared_ptr<const Table> in_table,
-                                                             const ColumnID left_column_id, const ScanType scan_type,
+                                                             const ColumnID left_column_id, const PredicateCondition predicate_condition,
                                                              const bool skip_null_row_ids)
-    : BaseTableScanImpl{in_table, left_column_id, scan_type}, _skip_null_row_ids{skip_null_row_ids} {}
+    : BaseTableScanImpl{in_table, left_column_id, predicate_condition}, _skip_null_row_ids{skip_null_row_ids} {}
 
 PosList BaseSingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
   const auto chunk = _in_table->get_chunk(chunk_id);

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.hpp
@@ -25,7 +25,7 @@ class ReferenceColumn;
 class BaseSingleColumnTableScanImpl : public BaseTableScanImpl, public ColumnVisitable {
  public:
   BaseSingleColumnTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
-                                const ScanType scan_type, const bool skip_null_row_ids = true);
+                                const PredicateCondition predicate_condition, const bool skip_null_row_ids = true);
 
   PosList scan_chunk(ChunkID chunk_id) override;
 

--- a/src/lib/operators/table_scan/base_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_table_scan_impl.hpp
@@ -15,8 +15,8 @@ class Table;
  */
 class BaseTableScanImpl {
  public:
-  BaseTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const ScanType scan_type)
-      : _in_table{in_table}, _left_column_id{left_column_id}, _scan_type{scan_type} {}
+  BaseTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const PredicateCondition predicate_condition)
+      : _in_table{in_table}, _left_column_id{left_column_id}, _predicate_condition{predicate_condition} {}
 
   virtual ~BaseTableScanImpl() = default;
 
@@ -62,7 +62,7 @@ class BaseTableScanImpl {
  protected:
   const std::shared_ptr<const Table> _in_table;
   const ColumnID _left_column_id;
-  const ScanType _scan_type;
+  const PredicateCondition _predicate_condition;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan/base_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_table_scan_impl.hpp
@@ -15,7 +15,8 @@ class Table;
  */
 class BaseTableScanImpl {
  public:
-  BaseTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const PredicateCondition predicate_condition)
+  BaseTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
+                    const PredicateCondition predicate_condition)
       : _in_table{in_table}, _left_column_id{left_column_id}, _predicate_condition{predicate_condition} {}
 
   virtual ~BaseTableScanImpl() = default;

--- a/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
@@ -16,7 +16,8 @@
 namespace opossum {
 
 ColumnComparisonTableScanImpl::ColumnComparisonTableScanImpl(std::shared_ptr<const Table> in_table,
-                                                             const ColumnID left_column_id, const PredicateCondition& predicate_condition,
+                                                             const ColumnID left_column_id,
+                                                             const PredicateCondition& predicate_condition,
                                                              const ColumnID right_column_id)
     : BaseTableScanImpl{in_table, left_column_id, predicate_condition}, _right_column_id{right_column_id} {}
 

--- a/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
@@ -16,9 +16,9 @@
 namespace opossum {
 
 ColumnComparisonTableScanImpl::ColumnComparisonTableScanImpl(std::shared_ptr<const Table> in_table,
-                                                             const ColumnID left_column_id, const ScanType& scan_type,
+                                                             const ColumnID left_column_id, const PredicateCondition& predicate_condition,
                                                              const ColumnID right_column_id)
-    : BaseTableScanImpl{in_table, left_column_id, scan_type}, _right_column_id{right_column_id} {}
+    : BaseTableScanImpl{in_table, left_column_id, predicate_condition}, _right_column_id{right_column_id} {}
 
 PosList ColumnComparisonTableScanImpl::scan_chunk(ChunkID chunk_id) {
   const auto chunk = _in_table->get_chunk(chunk_id);
@@ -68,7 +68,7 @@ PosList ColumnComparisonTableScanImpl::scan_chunk(ChunkID chunk_id) {
 
         left_column_iterable.with_iterators([&](auto left_it, auto left_end) {
           right_column_iterable.with_iterators([&](auto right_it, auto right_end) {
-            with_comparator(_scan_type, [&](auto comparator) {
+            with_comparator(_predicate_condition, [&](auto comparator) {
               this->_binary_scan(comparator, left_it, left_end, right_it, chunk_id, matches_out);
             });
           });

--- a/src/lib/operators/table_scan/column_comparison_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_comparison_table_scan_impl.hpp
@@ -25,7 +25,7 @@ class Table;
 class ColumnComparisonTableScanImpl : public BaseTableScanImpl {
  public:
   ColumnComparisonTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
-                                const ScanType& scan_type, const ColumnID right_column_id);
+                                const PredicateCondition& predicate_condition, const ColumnID right_column_id);
 
   PosList scan_chunk(ChunkID chunk_id) override;
 

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.cpp
@@ -12,8 +12,8 @@
 namespace opossum {
 
 IsNullTableScanImpl::IsNullTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
-                                         const ScanType& scan_type)
-    : BaseSingleColumnTableScanImpl{in_table, left_column_id, scan_type, false} {}
+                                         const PredicateCondition& predicate_condition)
+    : BaseSingleColumnTableScanImpl{in_table, left_column_id, predicate_condition, false} {}
 
 void IsNullTableScanImpl::handle_value_column(const BaseValueColumn& base_column,
                                               std::shared_ptr<ColumnVisitableContext> base_context) {
@@ -52,11 +52,11 @@ void IsNullTableScanImpl::handle_dictionary_column(const BaseDictionaryColumn& b
 }
 
 bool IsNullTableScanImpl::_matches_all(const BaseValueColumn& column) {
-  switch (_scan_type) {
-    case ScanType::IsNull:
+  switch (_predicate_condition) {
+    case PredicateCondition::IsNull:
       return false;
 
-    case ScanType::IsNotNull:
+    case PredicateCondition::IsNotNull:
       return !column.is_nullable();
 
     default:
@@ -65,11 +65,11 @@ bool IsNullTableScanImpl::_matches_all(const BaseValueColumn& column) {
 }
 
 bool IsNullTableScanImpl::_matches_none(const BaseValueColumn& column) {
-  switch (_scan_type) {
-    case ScanType::IsNull:
+  switch (_predicate_condition) {
+    case PredicateCondition::IsNull:
       return !column.is_nullable();
 
-    case ScanType::IsNotNull:
+    case PredicateCondition::IsNotNull:
       return false;
 
     default:

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
@@ -15,7 +15,8 @@ class BaseValueColumn;
 
 class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
  public:
-  IsNullTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const PredicateCondition& predicate_condition);
+  IsNullTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
+                      const PredicateCondition& predicate_condition);
 
   void handle_value_column(const BaseValueColumn& base_column,
                            std::shared_ptr<ColumnVisitableContext> base_context) override;

--- a/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/is_null_table_scan_impl.hpp
@@ -15,7 +15,7 @@ class BaseValueColumn;
 
 class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
  public:
-  IsNullTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const ScanType& scan_type);
+  IsNullTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const PredicateCondition& predicate_condition);
 
   void handle_value_column(const BaseValueColumn& base_column,
                            std::shared_ptr<ColumnVisitableContext> base_context) override;
@@ -39,12 +39,12 @@ class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
 
  private:
   template <typename Functor>
-  void _resolve_scan_type(const Functor& func) {
-    switch (_scan_type) {
-      case ScanType::IsNull:
+  void _resolve_predicate_condition(const Functor& func) {
+    switch (_predicate_condition) {
+      case PredicateCondition::IsNull:
         return func([](const bool is_null) { return is_null; });
 
-      case ScanType::IsNotNull:
+      case PredicateCondition::IsNotNull:
         return func([](const bool is_null) { return !is_null; });
 
       default:
@@ -57,7 +57,7 @@ class IsNullTableScanImpl : public BaseSingleColumnTableScanImpl {
     auto& matches_out = context._matches_out;
     const auto chunk_id = context._chunk_id;
 
-    _resolve_scan_type([&](auto comparator) {
+    _resolve_predicate_condition([&](auto comparator) {
       for (; left_it != left_end; ++left_it) {
         const auto left = *left_it;
 

--- a/src/lib/operators/table_scan/like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.cpp
@@ -21,10 +21,10 @@
 namespace opossum {
 
 LikeTableScanImpl::LikeTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
-                                     const ScanType scan_type, const std::string& right_wildcard)
-    : BaseSingleColumnTableScanImpl{in_table, left_column_id, scan_type},
+                                     const PredicateCondition predicate_condition, const std::string& right_wildcard)
+    : BaseSingleColumnTableScanImpl{in_table, left_column_id, predicate_condition},
       _right_wildcard{right_wildcard},
-      _invert_results(scan_type == ScanType::NotLike) {
+      _invert_results(predicate_condition == PredicateCondition::NotLike) {
   // convert the given SQL-like search term into a c++11 regex to use it for the actual matching
   auto regex_string = _sqllike_to_regex(_right_wildcard);
   _regex = std::regex{regex_string, std::regex_constants::icase};  // case insensitivity

--- a/src/lib/operators/table_scan/like_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.hpp
@@ -26,8 +26,8 @@ class Table;
  */
 class LikeTableScanImpl : public BaseSingleColumnTableScanImpl {
  public:
-  LikeTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const PredicateCondition predicate_condition,
-                    const std::string& right_wildcard);
+  LikeTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
+                    const PredicateCondition predicate_condition, const std::string& right_wildcard);
 
   void handle_value_column(const BaseValueColumn& base_column,
                            std::shared_ptr<ColumnVisitableContext> base_context) override;

--- a/src/lib/operators/table_scan/like_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/like_table_scan_impl.hpp
@@ -26,7 +26,7 @@ class Table;
  */
 class LikeTableScanImpl : public BaseSingleColumnTableScanImpl {
  public:
-  LikeTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const ScanType scan_type,
+  LikeTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id, const PredicateCondition predicate_condition,
                     const std::string& right_wildcard);
 
   void handle_value_column(const BaseValueColumn& base_column,

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
@@ -15,7 +15,8 @@
 namespace opossum {
 
 SingleColumnTableScanImpl::SingleColumnTableScanImpl(std::shared_ptr<const Table> in_table,
-                                                     const ColumnID left_column_id, const PredicateCondition& predicate_condition,
+                                                     const ColumnID left_column_id,
+                                                     const PredicateCondition& predicate_condition,
                                                      const AllTypeVariant& right_value)
     : BaseSingleColumnTableScanImpl{in_table, left_column_id, predicate_condition}, _right_value{right_value} {}
 

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
@@ -15,9 +15,9 @@
 namespace opossum {
 
 SingleColumnTableScanImpl::SingleColumnTableScanImpl(std::shared_ptr<const Table> in_table,
-                                                     const ColumnID left_column_id, const ScanType& scan_type,
+                                                     const ColumnID left_column_id, const PredicateCondition& predicate_condition,
                                                      const AllTypeVariant& right_value)
-    : BaseSingleColumnTableScanImpl{in_table, left_column_id, scan_type}, _right_value{right_value} {}
+    : BaseSingleColumnTableScanImpl{in_table, left_column_id, predicate_condition}, _right_value{right_value} {}
 
 PosList SingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
   // early outs for specific NULL semantics
@@ -53,7 +53,7 @@ void SingleColumnTableScanImpl::handle_value_column(const BaseValueColumn& base_
 
     left_column_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
       right_value_iterable.with_iterators([&](auto right_it, auto right_end) {
-        with_comparator(_scan_type, [&](auto comparator) {
+        with_comparator(_predicate_condition, [&](auto comparator) {
           _binary_scan(comparator, left_it, left_end, right_it, chunk_id, matches_out);
         });
       });
@@ -120,7 +120,7 @@ void SingleColumnTableScanImpl::handle_dictionary_column(const BaseDictionaryCol
 
   left_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
     right_iterable.with_iterators([&](auto right_it, auto right_end) {
-      this->_with_operator_for_dict_column_scan(_scan_type, [&](auto comparator) {
+      this->_with_operator_for_dict_column_scan(_predicate_condition, [&](auto comparator) {
         this->_binary_scan(comparator, left_it, left_end, right_it, chunk_id, matches_out);
       });
     });
@@ -128,15 +128,15 @@ void SingleColumnTableScanImpl::handle_dictionary_column(const BaseDictionaryCol
 }
 
 ValueID SingleColumnTableScanImpl::_get_search_value_id(const BaseDictionaryColumn& column) {
-  switch (_scan_type) {
-    case ScanType::Equals:
-    case ScanType::NotEquals:
-    case ScanType::LessThan:
-    case ScanType::GreaterThanEquals:
+  switch (_predicate_condition) {
+    case PredicateCondition::Equals:
+    case PredicateCondition::NotEquals:
+    case PredicateCondition::LessThan:
+    case PredicateCondition::GreaterThanEquals:
       return column.lower_bound(_right_value);
 
-    case ScanType::LessThanEquals:
-    case ScanType::GreaterThan:
+    case PredicateCondition::LessThanEquals:
+    case PredicateCondition::GreaterThan:
       return column.upper_bound(_right_value);
 
     default:
@@ -146,19 +146,19 @@ ValueID SingleColumnTableScanImpl::_get_search_value_id(const BaseDictionaryColu
 
 bool SingleColumnTableScanImpl::_right_value_matches_all(const BaseDictionaryColumn& column,
                                                          const ValueID search_value_id) {
-  switch (_scan_type) {
-    case ScanType::Equals:
+  switch (_predicate_condition) {
+    case PredicateCondition::Equals:
       return search_value_id != column.upper_bound(_right_value) && column.unique_values_count() == size_t{1u};
 
-    case ScanType::NotEquals:
+    case PredicateCondition::NotEquals:
       return search_value_id == column.upper_bound(_right_value);
 
-    case ScanType::LessThan:
-    case ScanType::LessThanEquals:
+    case PredicateCondition::LessThan:
+    case PredicateCondition::LessThanEquals:
       return search_value_id == INVALID_VALUE_ID;
 
-    case ScanType::GreaterThanEquals:
-    case ScanType::GreaterThan:
+    case PredicateCondition::GreaterThanEquals:
+    case PredicateCondition::GreaterThan:
       return search_value_id == ValueID{0u};
 
     default:
@@ -168,19 +168,19 @@ bool SingleColumnTableScanImpl::_right_value_matches_all(const BaseDictionaryCol
 
 bool SingleColumnTableScanImpl::_right_value_matches_none(const BaseDictionaryColumn& column,
                                                           const ValueID search_value_id) {
-  switch (_scan_type) {
-    case ScanType::Equals:
+  switch (_predicate_condition) {
+    case PredicateCondition::Equals:
       return search_value_id == column.upper_bound(_right_value);
 
-    case ScanType::NotEquals:
+    case PredicateCondition::NotEquals:
       return search_value_id == column.upper_bound(_right_value) && column.unique_values_count() == size_t{1u};
 
-    case ScanType::LessThan:
-    case ScanType::LessThanEquals:
+    case PredicateCondition::LessThan:
+    case PredicateCondition::LessThanEquals:
       return search_value_id == ValueID{0u};
 
-    case ScanType::GreaterThan:
-    case ScanType::GreaterThanEquals:
+    case PredicateCondition::GreaterThan:
+    case PredicateCondition::GreaterThanEquals:
       return search_value_id == INVALID_VALUE_ID;
 
     default:

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
@@ -26,7 +26,7 @@ class BaseDictionaryColumn;
 class SingleColumnTableScanImpl : public BaseSingleColumnTableScanImpl {
  public:
   SingleColumnTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
-                            const ScanType& scan_type, const AllTypeVariant& right_value);
+                            const PredicateCondition& predicate_condition, const AllTypeVariant& right_value);
 
   PosList scan_chunk(ChunkID) override;
 
@@ -49,23 +49,23 @@ class SingleColumnTableScanImpl : public BaseSingleColumnTableScanImpl {
   bool _right_value_matches_none(const BaseDictionaryColumn& column, const ValueID search_value_id);
 
   template <typename Functor>
-  void _with_operator_for_dict_column_scan(const ScanType scan_type, const Functor& func) {
-    switch (scan_type) {
-      case ScanType::Equals:
+  void _with_operator_for_dict_column_scan(const PredicateCondition predicate_condition, const Functor& func) {
+    switch (predicate_condition) {
+      case PredicateCondition::Equals:
         func(std::equal_to<void>{});
         return;
 
-      case ScanType::NotEquals:
+      case PredicateCondition::NotEquals:
         func(std::not_equal_to<void>{});
         return;
 
-      case ScanType::LessThan:
-      case ScanType::LessThanEquals:
+      case PredicateCondition::LessThan:
+      case PredicateCondition::LessThanEquals:
         func(std::less<void>{});
         return;
 
-      case ScanType::GreaterThan:
-      case ScanType::GreaterThanEquals:
+      case PredicateCondition::GreaterThan:
+      case PredicateCondition::GreaterThanEquals:
         func(std::greater_equal<void>{});
         return;
 

--- a/src/lib/optimizer/base_column_statistics.hpp
+++ b/src/lib/optimizer/base_column_statistics.hpp
@@ -69,7 +69,8 @@ class BaseColumnStatistics : public std::enable_shared_from_this<BaseColumnStati
    * @return Selectivity and two new column statistics.
    */
   virtual TwoColumnSelectivityResult estimate_selectivity_for_two_column_predicate(
-      const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+      const PredicateCondition predicate_condition,
+      const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) = 0;
 
   /**

--- a/src/lib/optimizer/base_column_statistics.hpp
+++ b/src/lib/optimizer/base_column_statistics.hpp
@@ -48,7 +48,7 @@ class BaseColumnStatistics : public std::enable_shared_from_this<BaseColumnStati
    * @return Selectivity and new column statistics.
    */
   virtual ColumnSelectivityResult estimate_selectivity_for_predicate(
-      const ScanType scan_type, const AllTypeVariant& value,
+      const PredicateCondition predicate_condition, const AllTypeVariant& value,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) = 0;
 
   /**
@@ -58,18 +58,18 @@ class BaseColumnStatistics : public std::enable_shared_from_this<BaseColumnStati
    * @return Selectivity and new column statistics.
    */
   virtual ColumnSelectivityResult estimate_selectivity_for_predicate(
-      const ScanType scan_type, const ValuePlaceholder& value,
+      const PredicateCondition predicate_condition, const ValuePlaceholder& value,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) = 0;
 
   /**
    * Estimate selectivity for predicate on columns.
    * In comparison to predicates with constants, value is another column.
    * For predicate "col_left < col_right", selectivity is calculated in column statistics of col_left with parameters
-   * scan_type = "<" and right_base_column_statistics = col_right statistics.
+   * predicate_condition = "<" and right_base_column_statistics = col_right statistics.
    * @return Selectivity and two new column statistics.
    */
   virtual TwoColumnSelectivityResult estimate_selectivity_for_two_column_predicate(
-      const ScanType scan_type, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+      const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) = 0;
 
   /**

--- a/src/lib/optimizer/column_statistics.cpp
+++ b/src/lib/optimizer/column_statistics.cpp
@@ -177,17 +177,17 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::_create_column_stats_for_n
 
 template <typename ColumnType>
 ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_predicate(
-    const ScanType scan_type, const AllTypeVariant& value, const std::optional<AllTypeVariant>& value2) {
+    const PredicateCondition predicate_condition, const AllTypeVariant& value, const std::optional<AllTypeVariant>& value2) {
   auto casted_value = type_cast<ColumnType>(value);
 
-  switch (scan_type) {
-    case ScanType::Equals: {
+  switch (predicate_condition) {
+    case PredicateCondition::Equals: {
       return _create_column_stats_for_equals_predicate(casted_value);
     }
-    case ScanType::NotEquals: {
+    case PredicateCondition::NotEquals: {
       return _create_column_stats_for_not_equals_predicate(casted_value);
     }
-    case ScanType::LessThan: {
+    case PredicateCondition::LessThan: {
       // distinction between integers and decimals
       // for integers "< value" means that the new max is value <= value - 1
       // for decimals "< value" means that the new max is value <= value - ε
@@ -199,10 +199,10 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_p
       // OpLessThanEquals behaviour is expected instead of OpLessThan
       [[fallthrough]];
     }
-    case ScanType::LessThanEquals: {
+    case PredicateCondition::LessThanEquals: {
       return _create_column_stats_for_range_predicate(_get_or_calculate_min(), casted_value);
     }
-    case ScanType::GreaterThan: {
+    case PredicateCondition::GreaterThan: {
       // distinction between integers and decimals
       // for integers "> value" means that the new min value is >= value + 1
       // for decimals "> value" means that the new min value is >= value + ε
@@ -214,10 +214,10 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_p
       // OpGreaterThanEquals behaviour is expected instead of OpGreaterThan
       [[fallthrough]];
     }
-    case ScanType::GreaterThanEquals: {
+    case PredicateCondition::GreaterThanEquals: {
       return _create_column_stats_for_range_predicate(casted_value, _get_or_calculate_max());
     }
-    case ScanType::Between: {
+    case PredicateCondition::Between: {
       DebugAssert(static_cast<bool>(value2), "Operator BETWEEN should get two parameters, second is missing!");
       auto casted_value2 = type_cast<ColumnType>(*value2);
       return _create_column_stats_for_range_predicate(casted_value, casted_value2);
@@ -231,18 +231,18 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_p
  */
 template <>
 ColumnSelectivityResult ColumnStatistics<std::string>::estimate_selectivity_for_predicate(
-    const ScanType scan_type, const AllTypeVariant& value, const std::optional<AllTypeVariant>& value2) {
+    const PredicateCondition predicate_condition, const AllTypeVariant& value, const std::optional<AllTypeVariant>& value2) {
   // if column has no distinct values, it can only have null values which cannot be selected with this predicate
   if (distinct_count() == 0) {
     return {0.f, _this_without_null_values()};
   }
 
   auto casted_value = type_cast<std::string>(value);
-  switch (scan_type) {
-    case ScanType::Equals: {
+  switch (predicate_condition) {
+    case PredicateCondition::Equals: {
       return _create_column_stats_for_equals_predicate(casted_value);
     }
-    case ScanType::NotEquals: {
+    case PredicateCondition::NotEquals: {
       return _create_column_stats_for_not_equals_predicate(casted_value);
     }
     // TODO(anybody) implement other table-scan operators for string.
@@ -252,33 +252,33 @@ ColumnSelectivityResult ColumnStatistics<std::string>::estimate_selectivity_for_
 
 template <typename ColumnType>
 ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_predicate(
-    const ScanType scan_type, const ValuePlaceholder& value, const std::optional<AllTypeVariant>& value2) {
+    const PredicateCondition predicate_condition, const ValuePlaceholder& value, const std::optional<AllTypeVariant>& value2) {
   // if column has no distinct values, it can only have null values which cannot be selected with this predicate
   if (distinct_count() == 0) {
     return {0.f, _this_without_null_values()};
   }
 
-  switch (scan_type) {
-    case ScanType::Equals: {
+  switch (predicate_condition) {
+    case PredicateCondition::Equals: {
       auto column_statistics =
           std::make_shared<ColumnStatistics>(_column_id, 1, _get_or_calculate_min(), _get_or_calculate_max());
       return {1.f / distinct_count(), column_statistics};
     }
-    case ScanType::NotEquals: {
+    case PredicateCondition::NotEquals: {
       auto column_statistics = std::make_shared<ColumnStatistics>(_column_id, distinct_count() - 1,
                                                                   _get_or_calculate_min(), _get_or_calculate_max());
       return {(distinct_count() - 1.f) / distinct_count(), column_statistics};
     }
-    case ScanType::LessThan:
-    case ScanType::LessThanEquals:
-    case ScanType::GreaterThan:
-    case ScanType::GreaterThanEquals: {
+    case PredicateCondition::LessThan:
+    case PredicateCondition::LessThanEquals:
+    case PredicateCondition::GreaterThan:
+    case PredicateCondition::GreaterThanEquals: {
       auto column_statistics =
           std::make_shared<ColumnStatistics>(_column_id, distinct_count() * DEFAULT_OPEN_ENDED_SELECTIVITY,
                                              _get_or_calculate_min(), _get_or_calculate_max());
       return {_non_null_value_ratio * DEFAULT_OPEN_ENDED_SELECTIVITY, column_statistics};
     }
-    case ScanType::Between: {
+    case PredicateCondition::Between: {
       // since the value2 is known,
       // first, statistics for the operation <= value are calculated
       // then, the open ended selectivity is applied on the result
@@ -307,7 +307,7 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_p
 
 template <typename ColumnType>
 TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_two_column_predicate(
-    const ScanType scan_type, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+    const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
     const std::optional<AllTypeVariant>& value2) {
   /**
    * Calculate expected selectivity by looking at what ratio of values of both columns are in the overlapping value
@@ -422,7 +422,7 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
 
   float combined_non_null_ratio = _non_null_value_ratio * right_stats->_non_null_value_ratio;
 
-  // used for <, <=, > and >= scan_types
+  // used for <, <=, > and >= predicate_conditions
   auto estimate_selectivity_for_open_ended_operators = [&](float values_below_ratio, float values_above_ratio,
                                                            ColumnType new_min, ColumnType new_max,
                                                            bool add_equal_values) -> TwoColumnSelectivityResult {
@@ -459,8 +459,8 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
   //
   // TODO(Anyone): Fix issue mentioned above.
 
-  switch (scan_type) {
-    case ScanType::Equals: {
+  switch (predicate_condition) {
+    case PredicateCondition::Equals: {
       auto overlapping_distinct_count = std::min(left_overlapping_distinct_count, right_overlapping_distinct_count);
 
       auto new_left_column_stats = std::make_shared<ColumnStatistics>(_column_id, overlapping_distinct_count,
@@ -469,7 +469,7 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
           right_stats->_column_id, overlapping_distinct_count, overlapping_range_min, overlapping_range_max);
       return {combined_non_null_ratio * equal_values_ratio, new_left_column_stats, new_right_column_stats};
     }
-    case ScanType::NotEquals: {
+    case PredicateCondition::NotEquals: {
       auto new_left_column_stats = std::make_shared<ColumnStatistics>(_column_id, distinct_count(),
                                                                       _get_or_calculate_min(), _get_or_calculate_max());
       auto new_right_column_stats = std::make_shared<ColumnStatistics>(
@@ -477,27 +477,27 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
           right_stats->_get_or_calculate_max());
       return {combined_non_null_ratio * (1.f - equal_values_ratio), new_left_column_stats, new_right_column_stats};
     }
-    case ScanType::LessThan: {
+    case PredicateCondition::LessThan: {
       return estimate_selectivity_for_open_ended_operators(left_below_overlapping_ratio, right_above_overlapping_ratio,
                                                            _get_or_calculate_min(),
                                                            right_stats->_get_or_calculate_max(), false);
     }
-    case ScanType::LessThanEquals: {
+    case PredicateCondition::LessThanEquals: {
       return estimate_selectivity_for_open_ended_operators(left_below_overlapping_ratio, right_above_overlapping_ratio,
                                                            _get_or_calculate_min(),
                                                            right_stats->_get_or_calculate_max(), true);
     }
-    case ScanType::GreaterThan: {
+    case PredicateCondition::GreaterThan: {
       return estimate_selectivity_for_open_ended_operators(right_below_overlapping_ratio, left_above_overlapping_ratio,
                                                            right_stats->_get_or_calculate_min(),
                                                            _get_or_calculate_max(), false);
     }
-    case ScanType::GreaterThanEquals: {
+    case PredicateCondition::GreaterThanEquals: {
       return estimate_selectivity_for_open_ended_operators(right_below_overlapping_ratio, left_above_overlapping_ratio,
                                                            right_stats->_get_or_calculate_min(),
                                                            _get_or_calculate_max(), true);
     }
-    // case ScanType::Between is not supported for ColumnID as TableScan does not support this
+    // case PredicateCondition::Between is not supported for ColumnID as TableScan does not support this
     default: {
       return {combined_non_null_ratio, _this_without_null_values(), right_stats->_this_without_null_values()};
     }
@@ -509,7 +509,7 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
  */
 template <>
 TwoColumnSelectivityResult ColumnStatistics<std::string>::estimate_selectivity_for_two_column_predicate(
-    const ScanType scan_type, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+    const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
     const std::optional<AllTypeVariant>& value2) {
   // TODO(anybody) implement special case for strings
   auto right_stats = std::dynamic_pointer_cast<ColumnStatistics<std::string>>(right_base_column_statistics);

--- a/src/lib/optimizer/column_statistics.cpp
+++ b/src/lib/optimizer/column_statistics.cpp
@@ -177,7 +177,8 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::_create_column_stats_for_n
 
 template <typename ColumnType>
 ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_predicate(
-    const PredicateCondition predicate_condition, const AllTypeVariant& value, const std::optional<AllTypeVariant>& value2) {
+    const PredicateCondition predicate_condition, const AllTypeVariant& value,
+    const std::optional<AllTypeVariant>& value2) {
   auto casted_value = type_cast<ColumnType>(value);
 
   switch (predicate_condition) {
@@ -231,7 +232,8 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_p
  */
 template <>
 ColumnSelectivityResult ColumnStatistics<std::string>::estimate_selectivity_for_predicate(
-    const PredicateCondition predicate_condition, const AllTypeVariant& value, const std::optional<AllTypeVariant>& value2) {
+    const PredicateCondition predicate_condition, const AllTypeVariant& value,
+    const std::optional<AllTypeVariant>& value2) {
   // if column has no distinct values, it can only have null values which cannot be selected with this predicate
   if (distinct_count() == 0) {
     return {0.f, _this_without_null_values()};
@@ -252,7 +254,8 @@ ColumnSelectivityResult ColumnStatistics<std::string>::estimate_selectivity_for_
 
 template <typename ColumnType>
 ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_predicate(
-    const PredicateCondition predicate_condition, const ValuePlaceholder& value, const std::optional<AllTypeVariant>& value2) {
+    const PredicateCondition predicate_condition, const ValuePlaceholder& value,
+    const std::optional<AllTypeVariant>& value2) {
   // if column has no distinct values, it can only have null values which cannot be selected with this predicate
   if (distinct_count() == 0) {
     return {0.f, _this_without_null_values()};
@@ -307,7 +310,8 @@ ColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_p
 
 template <typename ColumnType>
 TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_for_two_column_predicate(
-    const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+    const PredicateCondition predicate_condition,
+    const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
     const std::optional<AllTypeVariant>& value2) {
   /**
    * Calculate expected selectivity by looking at what ratio of values of both columns are in the overlapping value
@@ -509,7 +513,8 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
  */
 template <>
 TwoColumnSelectivityResult ColumnStatistics<std::string>::estimate_selectivity_for_two_column_predicate(
-    const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+    const PredicateCondition predicate_condition,
+    const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
     const std::optional<AllTypeVariant>& value2) {
   // TODO(anybody) implement special case for strings
   auto right_stats = std::dynamic_pointer_cast<ColumnStatistics<std::string>>(right_base_column_statistics);

--- a/src/lib/optimizer/column_statistics.hpp
+++ b/src/lib/optimizer/column_statistics.hpp
@@ -48,7 +48,8 @@ class ColumnStatistics : public BaseColumnStatistics {
       const std::optional<AllTypeVariant>& value2 = std::nullopt) override;
 
   TwoColumnSelectivityResult estimate_selectivity_for_two_column_predicate(
-      const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+      const PredicateCondition predicate_condition,
+      const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) override;
 
   /**

--- a/src/lib/optimizer/column_statistics.hpp
+++ b/src/lib/optimizer/column_statistics.hpp
@@ -40,15 +40,15 @@ class ColumnStatistics : public BaseColumnStatistics {
   ~ColumnStatistics() override = default;
 
   ColumnSelectivityResult estimate_selectivity_for_predicate(
-      const ScanType scan_type, const AllTypeVariant& value,
+      const PredicateCondition predicate_condition, const AllTypeVariant& value,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) override;
 
   ColumnSelectivityResult estimate_selectivity_for_predicate(
-      const ScanType scan_type, const ValuePlaceholder& value,
+      const PredicateCondition predicate_condition, const ValuePlaceholder& value,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) override;
 
   TwoColumnSelectivityResult estimate_selectivity_for_two_column_predicate(
-      const ScanType scan_type, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
+      const PredicateCondition predicate_condition, const std::shared_ptr<BaseColumnStatistics>& right_base_column_statistics,
       const std::optional<AllTypeVariant>& value2 = std::nullopt) override;
 
   /**

--- a/src/lib/optimizer/strategy/join_detection_rule.cpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.cpp
@@ -34,7 +34,7 @@ bool JoinDetectionRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
 
         auto predicate_node = join_condition->predicate_node;
         const auto new_join_node =
-            std::make_shared<JoinNode>(JoinMode::Inner, join_column_ids, predicate_node->scan_type());
+            std::make_shared<JoinNode>(JoinMode::Inner, join_column_ids, predicate_node->predicate_condition());
 
         /**
          * Place the conditional join where the cross join was and remove the predicate node

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -32,7 +32,7 @@ const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::colum
 }
 
 std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const ColumnID column_id,
-                                                                       const ScanType scan_type,
+                                                                       const PredicateCondition predicate_condition,
                                                                        const AllParameterVariant& value,
                                                                        const std::optional<AllTypeVariant>& value2) {
   auto _row_count = row_count();
@@ -40,11 +40,11 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const Col
     return shared_from_this();
   }
 
-  if (scan_type == ScanType::Like || scan_type == ScanType::NotLike) {
+  if (predicate_condition == PredicateCondition::Like || predicate_condition == PredicateCondition::NotLike) {
     // simple heuristic:
     auto clone = std::make_shared<TableStatistics>(*this);
     auto selectivity = DEFAULT_LIKE_SELECTIVITY;
-    if (scan_type == ScanType::NotLike) selectivity = 1.0 - selectivity;
+    if (predicate_condition == PredicateCondition::NotLike) selectivity = 1.0 - selectivity;
     clone->_row_count = _row_count * selectivity;
     return clone;
   }
@@ -61,7 +61,7 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const Col
     auto old_right_column_stats = _get_or_generate_column_statistics(value_column_id);
 
     auto two_column_statistics_container =
-        old_column_statistics->estimate_selectivity_for_two_column_predicate(scan_type, old_right_column_stats, value2);
+        old_column_statistics->estimate_selectivity_for_two_column_predicate(predicate_condition, old_right_column_stats, value2);
 
     clone->_column_statistics[value_column_id] = two_column_statistics_container.second_column_statistics;
     column_statistics_container = two_column_statistics_container;
@@ -70,7 +70,7 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const Col
     auto casted_value = get<AllTypeVariant>(value);
 
     column_statistics_container =
-        old_column_statistics->estimate_selectivity_for_predicate(scan_type, casted_value, value2);
+        old_column_statistics->estimate_selectivity_for_predicate(predicate_condition, casted_value, value2);
 
   } else {
     DebugAssert(value.type() == typeid(ValuePlaceholder),
@@ -78,7 +78,7 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const Col
     auto casted_value = boost::get<ValuePlaceholder>(value);
 
     column_statistics_container =
-        old_column_statistics->estimate_selectivity_for_predicate(scan_type, casted_value, value2);
+        old_column_statistics->estimate_selectivity_for_predicate(predicate_condition, casted_value, value2);
   }
 
   clone->_column_statistics[column_id] = column_statistics_container.column_statistics;
@@ -115,7 +115,7 @@ std::shared_ptr<TableStatistics> TableStatistics::generate_cross_join_statistics
 
 std::shared_ptr<TableStatistics> TableStatistics::generate_predicated_join_statistics(
     const std::shared_ptr<TableStatistics>& right_table_stats, const JoinMode mode, const ColumnIDPair column_ids,
-    const ScanType scan_type) {
+    const PredicateCondition predicate_condition) {
   DebugAssert(mode != JoinMode::Cross, "Use function generate_cross_join_statistics for cross joins.");
   DebugAssert(mode != JoinMode::Natural, "Natural joins are not supported by statistics component.");
 
@@ -190,7 +190,7 @@ std::shared_ptr<TableStatistics> TableStatistics::generate_predicated_join_stati
   auto& left_col_stats = _column_statistics[column_ids.first];
   auto& right_col_stats = right_table_stats->_column_statistics[column_ids.second];
 
-  auto stats_container = left_col_stats->estimate_selectivity_for_two_column_predicate(scan_type, right_col_stats);
+  auto stats_container = left_col_stats->estimate_selectivity_for_two_column_predicate(predicate_condition, right_col_stats);
 
   // apply predicate selectivity to cross join
   join_table_stats->_row_count *= stats_container.selectivity;

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -60,8 +60,8 @@ std::shared_ptr<TableStatistics> TableStatistics::predicate_statistics(const Col
     const ColumnID value_column_id = boost::get<ColumnID>(value);
     auto old_right_column_stats = _get_or_generate_column_statistics(value_column_id);
 
-    auto two_column_statistics_container =
-        old_column_statistics->estimate_selectivity_for_two_column_predicate(predicate_condition, old_right_column_stats, value2);
+    auto two_column_statistics_container = old_column_statistics->estimate_selectivity_for_two_column_predicate(
+        predicate_condition, old_right_column_stats, value2);
 
     clone->_column_statistics[value_column_id] = two_column_statistics_container.second_column_statistics;
     column_statistics_container = two_column_statistics_container;
@@ -190,7 +190,8 @@ std::shared_ptr<TableStatistics> TableStatistics::generate_predicated_join_stati
   auto& left_col_stats = _column_statistics[column_ids.first];
   auto& right_col_stats = right_table_stats->_column_statistics[column_ids.second];
 
-  auto stats_container = left_col_stats->estimate_selectivity_for_two_column_predicate(predicate_condition, right_col_stats);
+  auto stats_container =
+      left_col_stats->estimate_selectivity_for_two_column_predicate(predicate_condition, right_col_stats);
 
   // apply predicate selectivity to cross join
   join_table_stats->_row_count *= stats_container.selectivity;

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -78,7 +78,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    * Generate table statistics for the operator table scan table scan.
    */
   virtual std::shared_ptr<TableStatistics> predicate_statistics(
-      const ColumnID column_id, const ScanType scan_type, const AllParameterVariant& value,
+      const ColumnID column_id, const PredicateCondition predicate_condition, const AllParameterVariant& value,
       const std::optional<AllTypeVariant>& value2 = std::nullopt);
 
   /**
@@ -92,7 +92,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    */
   virtual std::shared_ptr<TableStatistics> generate_predicated_join_statistics(
       const std::shared_ptr<TableStatistics>& right_table_stats, const JoinMode mode, const ColumnIDPair column_ids,
-      const ScanType scan_type);
+      const PredicateCondition predicate_condition);
 
   // Increases the (approximate) count of invalid rows in the table (caused by deletes).
   void increment_invalid_row_count(uint64_t count);

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -40,23 +40,23 @@
 
 namespace opossum {
 
-ScanType translate_operator_type_to_scan_type(const hsql::OperatorType operator_type) {
-  static const std::unordered_map<const hsql::OperatorType, const ScanType> operator_to_scan_type = {
-      {hsql::kOpEquals, ScanType::Equals},       {hsql::kOpNotEquals, ScanType::NotEquals},
-      {hsql::kOpGreater, ScanType::GreaterThan}, {hsql::kOpGreaterEq, ScanType::GreaterThanEquals},
-      {hsql::kOpLess, ScanType::LessThan},       {hsql::kOpLessEq, ScanType::LessThanEquals},
-      {hsql::kOpBetween, ScanType::Between},     {hsql::kOpLike, ScanType::Like},
-      {hsql::kOpNotLike, ScanType::NotLike},     {hsql::kOpIsNull, ScanType::IsNull}};
+PredicateCondition translate_operator_type_to_predicate_condition(const hsql::OperatorType operator_type) {
+  static const std::unordered_map<const hsql::OperatorType, const PredicateCondition> operator_to_predicate_condition = {
+      {hsql::kOpEquals, PredicateCondition::Equals},       {hsql::kOpNotEquals, PredicateCondition::NotEquals},
+      {hsql::kOpGreater, PredicateCondition::GreaterThan}, {hsql::kOpGreaterEq, PredicateCondition::GreaterThanEquals},
+      {hsql::kOpLess, PredicateCondition::LessThan},       {hsql::kOpLessEq, PredicateCondition::LessThanEquals},
+      {hsql::kOpBetween, PredicateCondition::Between},     {hsql::kOpLike, PredicateCondition::Like},
+      {hsql::kOpNotLike, PredicateCondition::NotLike},     {hsql::kOpIsNull, PredicateCondition::IsNull}};
 
-  auto it = operator_to_scan_type.find(operator_type);
-  DebugAssert(it != operator_to_scan_type.end(), "Filter expression clause operator is not yet supported.");
+  auto it = operator_to_predicate_condition.find(operator_type);
+  DebugAssert(it != operator_to_predicate_condition.end(), "Filter expression clause operator is not yet supported.");
   return it->second;
 }
 
-ScanType get_scan_type_for_reverse_order(const ScanType scan_type) {
+PredicateCondition get_predicate_condition_for_reverse_order(const PredicateCondition predicate_condition) {
   /**
    * If we switch the sides for the expressions, we might have to change the operator that is used for the predicate.
-   * This function returns the respective ScanType.
+   * This function returns the respective PredicateCondition.
    *
    * Example:
    *     SELECT * FROM t WHERE 1 > a
@@ -66,18 +66,18 @@ ScanType get_scan_type_for_reverse_order(const ScanType scan_type) {
    *     SELECT * FROM t WHERE 1 = a
    *  -> SELECT * FROM t WHERE a = 1
    */
-  static const std::unordered_map<const ScanType, const ScanType> scan_type_for_reverse_order = {
-      {ScanType::GreaterThan, ScanType::LessThan},
-      {ScanType::LessThan, ScanType::GreaterThan},
-      {ScanType::GreaterThanEquals, ScanType::LessThanEquals},
-      {ScanType::LessThanEquals, ScanType::GreaterThanEquals}};
+  static const std::unordered_map<const PredicateCondition, const PredicateCondition> predicate_condition_for_reverse_order = {
+      {PredicateCondition::GreaterThan, PredicateCondition::LessThan},
+      {PredicateCondition::LessThan, PredicateCondition::GreaterThan},
+      {PredicateCondition::GreaterThanEquals, PredicateCondition::LessThanEquals},
+      {PredicateCondition::LessThanEquals, PredicateCondition::GreaterThanEquals}};
 
-  auto it = scan_type_for_reverse_order.find(scan_type);
-  if (it != scan_type_for_reverse_order.end()) {
+  auto it = predicate_condition_for_reverse_order.find(predicate_condition);
+  if (it != predicate_condition_for_reverse_order.end()) {
     return it->second;
   }
 
-  return scan_type;
+  return predicate_condition;
 }
 
 JoinMode translate_join_type_to_join_mode(const hsql::JoinType join_type) {
@@ -360,9 +360,9 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_join(const hsql::Join
                                                    : std::make_pair(*left_in_right_node, *right_in_left_node);
 
   // Joins currently only support one simple condition (i.e., not multiple conditions).
-  auto scan_type = translate_operator_type_to_scan_type(condition.opType);
+  auto predicate_condition = translate_operator_type_to_predicate_condition(condition.opType);
 
-  auto join_node = std::make_shared<JoinNode>(join_mode, column_references, scan_type);
+  auto join_node = std::make_shared<JoinNode>(join_mode, column_references, predicate_condition);
   join_node->set_left_child(left_node);
   join_node->set_right_child(right_node);
 
@@ -395,7 +395,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_natural_join(const hs
   for (const auto& join_column_name : join_column_names) {
     auto left_column_reference = left_node->get_column({join_column_name});
     auto right_column_reference = right_node->get_column({join_column_name});
-    auto predicate = std::make_shared<PredicateNode>(left_column_reference, ScanType::Equals, right_column_reference);
+    auto predicate = std::make_shared<PredicateNode>(left_column_reference, PredicateCondition::Equals, right_column_reference);
     predicate->set_left_child(return_node);
     return_node = predicate;
   }
@@ -874,27 +874,27 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
   auto predicate_negated = (hsql_expr.opType == hsql::kOpNot);
 
   const auto* column_ref_hsql_expr = hsql_expr.expr;
-  ScanType scan_type;
+  PredicateCondition predicate_condition;
 
   if (predicate_negated) {
     Assert(hsql_expr.expr != nullptr, "NOT operator without further expressions");
-    scan_type = translate_operator_type_to_scan_type(hsql_expr.expr->opType);
+    predicate_condition = translate_operator_type_to_predicate_condition(hsql_expr.expr->opType);
 
     /**
      * It should be possible for any predicate to be negated with "NOT",
      * e.g., WHERE NOT a > 5. However, this is currently not supported.
      * Right now we only use `kOpNot` to detect and set the `OpIsNotNull` scan type.
      */
-    Assert(scan_type == ScanType::IsNull, "Only IS NULL can be negated");
+    Assert(predicate_condition == PredicateCondition::IsNull, "Only IS NULL can be negated");
 
-    if (scan_type == ScanType::IsNull) {
-      scan_type = ScanType::IsNotNull;
+    if (predicate_condition == PredicateCondition::IsNull) {
+      predicate_condition = PredicateCondition::IsNotNull;
     }
 
     // change column reference to the correct expression
     column_ref_hsql_expr = hsql_expr.expr->expr;
   } else {
-    scan_type = translate_operator_type_to_scan_type(hsql_expr.opType);
+    predicate_condition = translate_operator_type_to_predicate_condition(hsql_expr.opType);
   }
 
   // Indicates whether to use expr.expr or expr.expr2 as the main column to reference
@@ -908,7 +908,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
 
   std::optional<AllTypeVariant> value2;  // Left uninitialized for predicates that are not BETWEEN
 
-  if (scan_type == ScanType::Between) {
+  if (predicate_condition == PredicateCondition::Between) {
     /**
      * Translate expressions of the form `column_or_aggregate BETWEEN value AND value2`.
      * Both value and value2 can be any kind of literal, while value might also be a column or a placeholder.
@@ -931,7 +931,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
     value2 = boost::get<AllTypeVariant>(value2_all_parameter_variant);
 
     Assert(refers_to_column(*column_ref_hsql_expr), "For BETWEENS, hsql_expr.expr has to refer to a column");
-  } else if (scan_type != ScanType::IsNull && scan_type != ScanType::IsNotNull) {
+  } else if (predicate_condition != PredicateCondition::IsNull && predicate_condition != PredicateCondition::IsNotNull) {
     /**
      * For logical operators (>, >=, <, ...), thanks to the strict interface of PredicateNode/TableScan, we have to
      * determine whether the left (expr.expr) or the right (expr.expr2) expr refers to the Column/AggregateFunction
@@ -942,7 +942,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
     if (!refers_to_column(*hsql_expr.expr)) {
       Assert(refers_to_column(*hsql_expr.expr2), "One side of the expression has to refer to a column.");
       operands_switched = true;
-      scan_type = get_scan_type_for_reverse_order(scan_type);
+      predicate_condition = get_predicate_condition_for_reverse_order(predicate_condition);
     }
 
     value_ref_hsql_expr = operands_switched ? hsql_expr.expr : hsql_expr.expr2;
@@ -950,7 +950,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
   }
 
   AllParameterVariant value;
-  if (scan_type == ScanType::IsNull || scan_type == ScanType::IsNotNull) {
+  if (predicate_condition == PredicateCondition::IsNull || predicate_condition == PredicateCondition::IsNotNull) {
     value = NULL_VALUE;
   } else if (refers_to_column(*value_ref_hsql_expr)) {
     value = resolve_column(*value_ref_hsql_expr);
@@ -965,7 +965,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
    */
   const auto column_id = resolve_column(*column_ref_hsql_expr);
 
-  auto predicate_node = std::make_shared<PredicateNode>(column_id, scan_type, value, value2);
+  auto predicate_node = std::make_shared<PredicateNode>(column_id, predicate_condition, value, value2);
   predicate_node->set_left_child(input_node);
 
   return predicate_node;

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -41,12 +41,12 @@
 namespace opossum {
 
 PredicateCondition translate_operator_type_to_predicate_condition(const hsql::OperatorType operator_type) {
-  static const std::unordered_map<const hsql::OperatorType, const PredicateCondition> operator_to_predicate_condition = {
-      {hsql::kOpEquals, PredicateCondition::Equals},       {hsql::kOpNotEquals, PredicateCondition::NotEquals},
-      {hsql::kOpGreater, PredicateCondition::GreaterThan}, {hsql::kOpGreaterEq, PredicateCondition::GreaterThanEquals},
-      {hsql::kOpLess, PredicateCondition::LessThan},       {hsql::kOpLessEq, PredicateCondition::LessThanEquals},
-      {hsql::kOpBetween, PredicateCondition::Between},     {hsql::kOpLike, PredicateCondition::Like},
-      {hsql::kOpNotLike, PredicateCondition::NotLike},     {hsql::kOpIsNull, PredicateCondition::IsNull}};
+  static const std::unordered_map<const hsql::OperatorType, const PredicateCondition> operator_to_predicate_condition =
+      {{hsql::kOpEquals, PredicateCondition::Equals},       {hsql::kOpNotEquals, PredicateCondition::NotEquals},
+       {hsql::kOpGreater, PredicateCondition::GreaterThan}, {hsql::kOpGreaterEq, PredicateCondition::GreaterThanEquals},
+       {hsql::kOpLess, PredicateCondition::LessThan},       {hsql::kOpLessEq, PredicateCondition::LessThanEquals},
+       {hsql::kOpBetween, PredicateCondition::Between},     {hsql::kOpLike, PredicateCondition::Like},
+       {hsql::kOpNotLike, PredicateCondition::NotLike},     {hsql::kOpIsNull, PredicateCondition::IsNull}};
 
   auto it = operator_to_predicate_condition.find(operator_type);
   DebugAssert(it != operator_to_predicate_condition.end(), "Filter expression clause operator is not yet supported.");
@@ -66,11 +66,12 @@ PredicateCondition get_predicate_condition_for_reverse_order(const PredicateCond
    *     SELECT * FROM t WHERE 1 = a
    *  -> SELECT * FROM t WHERE a = 1
    */
-  static const std::unordered_map<const PredicateCondition, const PredicateCondition> predicate_condition_for_reverse_order = {
-      {PredicateCondition::GreaterThan, PredicateCondition::LessThan},
-      {PredicateCondition::LessThan, PredicateCondition::GreaterThan},
-      {PredicateCondition::GreaterThanEquals, PredicateCondition::LessThanEquals},
-      {PredicateCondition::LessThanEquals, PredicateCondition::GreaterThanEquals}};
+  static const std::unordered_map<const PredicateCondition, const PredicateCondition>
+      predicate_condition_for_reverse_order = {
+          {PredicateCondition::GreaterThan, PredicateCondition::LessThan},
+          {PredicateCondition::LessThan, PredicateCondition::GreaterThan},
+          {PredicateCondition::GreaterThanEquals, PredicateCondition::LessThanEquals},
+          {PredicateCondition::LessThanEquals, PredicateCondition::GreaterThanEquals}};
 
   auto it = predicate_condition_for_reverse_order.find(predicate_condition);
   if (it != predicate_condition_for_reverse_order.end()) {
@@ -395,7 +396,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_natural_join(const hs
   for (const auto& join_column_name : join_column_names) {
     auto left_column_reference = left_node->get_column({join_column_name});
     auto right_column_reference = right_node->get_column({join_column_name});
-    auto predicate = std::make_shared<PredicateNode>(left_column_reference, PredicateCondition::Equals, right_column_reference);
+    auto predicate =
+        std::make_shared<PredicateNode>(left_column_reference, PredicateCondition::Equals, right_column_reference);
     predicate->set_left_child(return_node);
     return_node = predicate;
   }
@@ -931,7 +933,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
     value2 = boost::get<AllTypeVariant>(value2_all_parameter_variant);
 
     Assert(refers_to_column(*column_ref_hsql_expr), "For BETWEENS, hsql_expr.expr has to refer to a column");
-  } else if (predicate_condition != PredicateCondition::IsNull && predicate_condition != PredicateCondition::IsNotNull) {
+  } else if (predicate_condition != PredicateCondition::IsNull &&
+             predicate_condition != PredicateCondition::IsNotNull) {
     /**
      * For logical operators (>, >=, <, ...), thanks to the strict interface of PredicateNode/TableScan, we have to
      * determine whether the left (expr.expr) or the right (expr.expr2) expr refers to the Column/AggregateFunction

--- a/src/lib/type_comparison.hpp
+++ b/src/lib/type_comparison.hpp
@@ -97,24 +97,24 @@ value_greater(L l, R r) {
 
 // Function that calls a given functor with the correct std comparator
 template <typename Functor>
-void with_comparator(const ScanType scan_type, const Functor& func) {
-  switch (scan_type) {
-    case ScanType::Equals:
+void with_comparator(const PredicateCondition predicate_condition, const Functor& func) {
+  switch (predicate_condition) {
+    case PredicateCondition::Equals:
       return func(std::equal_to<void>{});
 
-    case ScanType::NotEquals:
+    case PredicateCondition::NotEquals:
       return func(std::not_equal_to<void>{});
 
-    case ScanType::LessThan:
+    case PredicateCondition::LessThan:
       return func(std::less<void>{});
 
-    case ScanType::LessThanEquals:
+    case PredicateCondition::LessThanEquals:
       return func(std::less_equal<void>{});
 
-    case ScanType::GreaterThan:
+    case PredicateCondition::GreaterThan:
       return func(std::greater<void>{});
 
-    case ScanType::GreaterThanEquals:
+    case PredicateCondition::GreaterThanEquals:
       return func(std::greater_equal<void>{});
 
     default:

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -164,7 +164,7 @@ class ValuePlaceholder {
 };
 
 // TODO(anyone): integrate and replace with ExpressionType
-enum class ScanType {
+enum class PredicateCondition {
   Equals,
   NotEquals,
   LessThan,

--- a/src/test/gtest_main.cpp
+++ b/src/test/gtest_main.cpp
@@ -14,11 +14,11 @@ namespace filesystem = std::experimental::filesystem;
 
 void create_test_data_directory(std::optional<std::string>& prefix) {
   opossum::Assert(!filesystem::exists(opossum::test_data_path),
-    "Cannot create directory for test data: \"" + opossum::test_data_path +"\" already exists.");
+                  "Cannot create directory for test data: \"" + opossum::test_data_path + "\" already exists.");
 
   if (prefix) {
     opossum::Assert(filesystem::exists("./" + *prefix),
-      "Cannot create directory for test data because \"" + *prefix + "\" does not exist");
+                    "Cannot create directory for test data because \"" + *prefix + "\" does not exist");
   }
 
   filesystem::create_directory(opossum::test_data_path);
@@ -37,7 +37,6 @@ int main(int argc, char** argv) {
 
   opossum::PerformanceWarningDisabler pwd;
   ::testing::InitGoogleTest(&argc, argv);
-
 
   std::optional<std::string> prefix;
   if (argc > 1) {

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -30,7 +30,8 @@ class JoinNodeTest : public BaseTest {
     _join_node->set_left_child(_mock_node_a);
     _join_node->set_right_child(_mock_node_b);
 
-    _inner_join_node = std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
+    _inner_join_node =
+        std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
     _inner_join_node->set_left_child(_mock_node_a);
     _inner_join_node->set_right_child(_mock_node_b);
   }

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -30,7 +30,7 @@ class JoinNodeTest : public BaseTest {
     _join_node->set_left_child(_mock_node_a);
     _join_node->set_right_child(_mock_node_b);
 
-    _inner_join_node = std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_t_a_a, _t_b_y), ScanType::Equals);
+    _inner_join_node = std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
     _inner_join_node->set_left_child(_mock_node_a);
     _inner_join_node->set_right_child(_mock_node_b);
   }

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -39,7 +39,8 @@ class LogicalQueryPlanTest : public BaseTest {
     _predicate_node_a = std::make_shared<PredicateNode>(_t_a_a, PredicateCondition::Equals, 42);
     _predicate_node_b = std::make_shared<PredicateNode>(_t_a_b, PredicateCondition::Equals, 1337);
     _projection_node = std::make_shared<ProjectionNode>(LQPExpression::create_columns({_t_a_a, _t_a_b}));
-    _join_node = std::make_shared<JoinNode>(JoinMode::Inner, LQPColumnReferencePair{_t_a_a, _t_b_a}, PredicateCondition::Equals);
+    _join_node =
+        std::make_shared<JoinNode>(JoinMode::Inner, LQPColumnReferencePair{_t_a_a, _t_b_a}, PredicateCondition::Equals);
 
     /**
      * Init complex graph.
@@ -60,7 +61,8 @@ class LogicalQueryPlanTest : public BaseTest {
     _nodes[7] = std::make_shared<MockNode>(MockNode::ColumnDefinitions{{{DataType::Int, "b"}}});
     _nodes[0] = std::make_shared<JoinNode>(JoinMode::Cross);
     _nodes[1] = std::make_shared<JoinNode>(JoinMode::Cross);
-    _nodes[2] = std::make_shared<PredicateNode>(LQPColumnReference{_nodes[6], ColumnID{0}}, PredicateCondition::Equals, 42);
+    _nodes[2] =
+        std::make_shared<PredicateNode>(LQPColumnReference{_nodes[6], ColumnID{0}}, PredicateCondition::Equals, 42);
     _nodes[3] = std::make_shared<JoinNode>(JoinMode::Cross);
     _nodes[4] = std::make_shared<JoinNode>(JoinMode::Cross);
     _nodes[5] = std::make_shared<JoinNode>(JoinMode::Cross);

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -36,10 +36,10 @@ class LogicalQueryPlanTest : public BaseTest {
     _t_b_a = LQPColumnReference{_mock_node_b, ColumnID{0}};
     _t_b_b = LQPColumnReference{_mock_node_b, ColumnID{1}};
 
-    _predicate_node_a = std::make_shared<PredicateNode>(_t_a_a, ScanType::Equals, 42);
-    _predicate_node_b = std::make_shared<PredicateNode>(_t_a_b, ScanType::Equals, 1337);
+    _predicate_node_a = std::make_shared<PredicateNode>(_t_a_a, PredicateCondition::Equals, 42);
+    _predicate_node_b = std::make_shared<PredicateNode>(_t_a_b, PredicateCondition::Equals, 1337);
     _projection_node = std::make_shared<ProjectionNode>(LQPExpression::create_columns({_t_a_a, _t_a_b}));
-    _join_node = std::make_shared<JoinNode>(JoinMode::Inner, LQPColumnReferencePair{_t_a_a, _t_b_a}, ScanType::Equals);
+    _join_node = std::make_shared<JoinNode>(JoinMode::Inner, LQPColumnReferencePair{_t_a_a, _t_b_a}, PredicateCondition::Equals);
 
     /**
      * Init complex graph.
@@ -60,7 +60,7 @@ class LogicalQueryPlanTest : public BaseTest {
     _nodes[7] = std::make_shared<MockNode>(MockNode::ColumnDefinitions{{{DataType::Int, "b"}}});
     _nodes[0] = std::make_shared<JoinNode>(JoinMode::Cross);
     _nodes[1] = std::make_shared<JoinNode>(JoinMode::Cross);
-    _nodes[2] = std::make_shared<PredicateNode>(LQPColumnReference{_nodes[6], ColumnID{0}}, ScanType::Equals, 42);
+    _nodes[2] = std::make_shared<PredicateNode>(LQPColumnReference{_nodes[6], ColumnID{0}}, PredicateCondition::Equals, 42);
     _nodes[3] = std::make_shared<JoinNode>(JoinMode::Cross);
     _nodes[4] = std::make_shared<JoinNode>(JoinMode::Cross);
     _nodes[5] = std::make_shared<JoinNode>(JoinMode::Cross);
@@ -312,7 +312,7 @@ TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
       std::make_shared<MockNode>(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}});
   auto join_node = std::make_shared<JoinNode>(JoinMode::Cross);
   auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference{mock_node_b, ColumnID{0}}, ScanType::Equals, 3);
+      std::make_shared<PredicateNode>(LQPColumnReference{mock_node_b, ColumnID{0}}, PredicateCondition::Equals, 3);
 
   const auto column_reference_a = LQPColumnReference{mock_node_a, ColumnID{1}};
   const auto column_reference_b = LQPColumnReference{mock_node_b, ColumnID{0}};

--- a/src/test/logical_query_plan/predicate_node_test.cpp
+++ b/src/test/logical_query_plan/predicate_node_test.cpp
@@ -21,7 +21,8 @@ class PredicateNodeTest : public BaseTest {
 };
 
 TEST_F(PredicateNodeTest, Descriptions) {
-  auto predicate_a = std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{0}}, PredicateCondition::Equals, 5);
+  auto predicate_a =
+      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{0}}, PredicateCondition::Equals, 5);
   predicate_a->set_left_child(_table_node);
   EXPECT_EQ(predicate_a->description(), "[Predicate] table_a.i = 5");
 
@@ -30,8 +31,8 @@ TEST_F(PredicateNodeTest, Descriptions) {
   predicate_b->set_left_child(_table_node);
   EXPECT_EQ(predicate_b->description(), "[Predicate] table_a.f != 2.5");
 
-  auto predicate_c =
-      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{2}}, PredicateCondition::Between, 2.5, 10.0);
+  auto predicate_c = std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{2}},
+                                                     PredicateCondition::Between, 2.5, 10.0);
   predicate_c->set_left_child(_table_node);
   EXPECT_EQ(predicate_c->description(), "[Predicate] table_a.d BETWEEN 2.5 AND 10");
 

--- a/src/test/logical_query_plan/predicate_node_test.cpp
+++ b/src/test/logical_query_plan/predicate_node_test.cpp
@@ -21,22 +21,22 @@ class PredicateNodeTest : public BaseTest {
 };
 
 TEST_F(PredicateNodeTest, Descriptions) {
-  auto predicate_a = std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{0}}, ScanType::Equals, 5);
+  auto predicate_a = std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{0}}, PredicateCondition::Equals, 5);
   predicate_a->set_left_child(_table_node);
   EXPECT_EQ(predicate_a->description(), "[Predicate] table_a.i = 5");
 
   auto predicate_b =
-      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{1}}, ScanType::NotEquals, 2.5);
+      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{1}}, PredicateCondition::NotEquals, 2.5);
   predicate_b->set_left_child(_table_node);
   EXPECT_EQ(predicate_b->description(), "[Predicate] table_a.f != 2.5");
 
   auto predicate_c =
-      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{2}}, ScanType::Between, 2.5, 10.0);
+      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{2}}, PredicateCondition::Between, 2.5, 10.0);
   predicate_c->set_left_child(_table_node);
   EXPECT_EQ(predicate_c->description(), "[Predicate] table_a.d BETWEEN 2.5 AND 10");
 
   auto predicate_d =
-      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{3}}, ScanType::Equals, "test");
+      std::make_shared<PredicateNode>(LQPColumnReference{_table_node, ColumnID{3}}, PredicateCondition::Equals, "test");
   predicate_d->set_left_child(_table_node);
   EXPECT_EQ(predicate_d->description(), "[Predicate] table_a.s = test");
 }

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -507,7 +507,8 @@ TEST_F(OperatorsAggregateTest, TwoAggregateSumAvgOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, DictionarySingleAggregateMinOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1_dict, ColumnID{0}, PredicateCondition::LessThan, "100");
+  auto filtered =
+      std::make_shared<TableScan>(_table_wrapper_1_1_dict, ColumnID{0}, PredicateCondition::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Min}}, {ColumnID{0}},

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -117,7 +117,7 @@ class OperatorsAggregateTest : public BaseTest {
 
       if (ref != INVALID_COLUMN_ID) {
         // also try a TableScan on every involved column
-        input = std::make_shared<TableScan>(in, ref, ScanType::GreaterThanEquals, 0);
+        input = std::make_shared<TableScan>(in, ref, PredicateCondition::GreaterThanEquals, 0);
         input->execute();
       }
 
@@ -474,7 +474,7 @@ TEST_F(OperatorsAggregateTest, DictionarySingleAggregateCountWithNull) {
  */
 
 TEST_F(OperatorsAggregateTest, SingleAggregateMaxOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1, ColumnID{0}, ScanType::LessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1, ColumnID{0}, PredicateCondition::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Max}}, {ColumnID{0}},
@@ -482,7 +482,7 @@ TEST_F(OperatorsAggregateTest, SingleAggregateMaxOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, TwoGroupbyAndTwoAggregateMinAvgOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_2, ColumnID{0}, ScanType::LessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_2, ColumnID{0}, PredicateCondition::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{2}, AggregateFunction::Min}, {ColumnID{3}, AggregateFunction::Avg}},
@@ -491,7 +491,7 @@ TEST_F(OperatorsAggregateTest, TwoGroupbyAndTwoAggregateMinAvgOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, TwoGroupbySumOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_1, ColumnID{0}, ScanType::LessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_2_1, ColumnID{0}, PredicateCondition::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{2}, AggregateFunction::Sum}}, {ColumnID{0}, ColumnID{1}},
@@ -499,7 +499,7 @@ TEST_F(OperatorsAggregateTest, TwoGroupbySumOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, TwoAggregateSumAvgOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_2, ColumnID{0}, ScanType::LessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_2, ColumnID{0}, PredicateCondition::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Sum}, {ColumnID{2}, AggregateFunction::Avg}},
@@ -507,7 +507,7 @@ TEST_F(OperatorsAggregateTest, TwoAggregateSumAvgOnRef) {
 }
 
 TEST_F(OperatorsAggregateTest, DictionarySingleAggregateMinOnRef) {
-  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1_dict, ColumnID{0}, ScanType::LessThan, "100");
+  auto filtered = std::make_shared<TableScan>(_table_wrapper_1_1_dict, ColumnID{0}, PredicateCondition::LessThan, "100");
   filtered->execute();
 
   this->test_output(filtered, {{ColumnID{1}, AggregateFunction::Min}}, {ColumnID{0}},
@@ -516,7 +516,7 @@ TEST_F(OperatorsAggregateTest, DictionarySingleAggregateMinOnRef) {
 
 TEST_F(OperatorsAggregateTest, JoinThenAggregate) {
   auto join = std::make_shared<JoinHash>(_table_wrapper_3_1, _table_wrapper_3_2, JoinMode::Inner,
-                                         ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                         ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();
 
   this->test_output(join, {}, {ColumnID{0}, ColumnID{3}}, "src/test/tables/aggregateoperator/join_2gb_0agg/result.tbl",
@@ -525,7 +525,7 @@ TEST_F(OperatorsAggregateTest, JoinThenAggregate) {
 
 TEST_F(OperatorsAggregateTest, OuterJoinThenAggregate) {
   auto join = std::make_shared<JoinNestedLoop>(_table_wrapper_join_1, _table_wrapper_join_2, JoinMode::Outer,
-                                               ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThan);
+                                               ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan);
   join->execute();
 
   this->test_output(join, {{ColumnID{1}, AggregateFunction::Min}}, {ColumnID{0}},

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -44,7 +44,7 @@ void OperatorsDeleteTest::helper(bool commit) {
   auto transaction_context = TransactionManager::get().new_transaction_context();
 
   // Selects two out of three rows.
-  auto table_scan = std::make_shared<TableScan>(_gt, ColumnID{0}, ScanType::GreaterThan, "456.7");
+  auto table_scan = std::make_shared<TableScan>(_gt, ColumnID{0}, PredicateCondition::GreaterThan, "456.7");
 
   table_scan->execute();
 
@@ -95,9 +95,9 @@ TEST_F(OperatorsDeleteTest, DetectDirtyWrite) {
   auto t1_context = TransactionManager::get().new_transaction_context();
   auto t2_context = TransactionManager::get().new_transaction_context();
 
-  auto table_scan1 = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::Equals, "123");
-  auto expected_result = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::NotEquals, "123");
-  auto table_scan2 = std::make_shared<TableScan>(_gt, ColumnID{1}, ScanType::LessThan, "1234");
+  auto table_scan1 = std::make_shared<TableScan>(_gt, ColumnID{1}, PredicateCondition::Equals, "123");
+  auto expected_result = std::make_shared<TableScan>(_gt, ColumnID{1}, PredicateCondition::NotEquals, "123");
+  auto table_scan2 = std::make_shared<TableScan>(_gt, ColumnID{1}, PredicateCondition::LessThan, "1234");
 
   table_scan1->execute();
   expected_result->execute();

--- a/src/test/operators/export_binary_test.cpp
+++ b/src/test/operators/export_binary_test.cpp
@@ -217,7 +217,7 @@ TEST_F(OperatorsExportBinaryTest, AllTypesReferenceColumn) {
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
   table_wrapper->execute();
 
-  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{1}, ScanType::NotEquals, 5);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{1}, PredicateCondition::NotEquals, 5);
   scan->execute();
 
   auto ex = std::make_shared<opossum::ExportBinary>(scan, filename);

--- a/src/test/operators/export_csv_test.cpp
+++ b/src/test/operators/export_csv_test.cpp
@@ -134,7 +134,7 @@ TEST_F(OperatorsExportCsvTest, ReferenceColumn) {
 
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
   table_wrapper->execute();
-  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::LessThan, 5);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, PredicateCondition::LessThan, 5);
   scan->execute();
   auto ex = std::make_shared<opossum::ExportCsv>(scan, filename);
   ex->execute();

--- a/src/test/operators/index_scan_test.cpp
+++ b/src/test/operators/index_scan_test.cpp
@@ -93,14 +93,14 @@ TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanOnDataTable) {
   const auto right_values = std::vector<AllTypeVariant>{AllTypeVariant{4}};
   const auto right_values2 = std::vector<AllTypeVariant>{AllTypeVariant{9}};
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = {104};
-  tests[ScanType::NotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::LessThan] = {100, 102};
-  tests[ScanType::LessThanEquals] = {100, 102, 104};
-  tests[ScanType::GreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::GreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::Between] = {104, 106, 108};
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = {104};
+  tests[PredicateCondition::NotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::LessThan] = {100, 102};
+  tests[PredicateCondition::LessThanEquals] = {100, 102, 104};
+  tests[PredicateCondition::GreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::GreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::Between] = {104, 106, 108};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids, test.first,
@@ -119,13 +119,13 @@ TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanValueGreaterThanMaxDictionary
   const auto right_values = std::vector<AllTypeVariant>{AllTypeVariant{30}};
   const auto right_values2 = std::vector<AllTypeVariant>{AllTypeVariant{34}};
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = no_rows;
-  tests[ScanType::NotEquals] = all_rows;
-  tests[ScanType::LessThan] = all_rows;
-  tests[ScanType::LessThanEquals] = all_rows;
-  tests[ScanType::GreaterThan] = no_rows;
-  tests[ScanType::GreaterThanEquals] = no_rows;
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = no_rows;
+  tests[PredicateCondition::NotEquals] = all_rows;
+  tests[PredicateCondition::LessThan] = all_rows;
+  tests[PredicateCondition::LessThanEquals] = all_rows;
+  tests[PredicateCondition::GreaterThan] = no_rows;
+  tests[PredicateCondition::GreaterThanEquals] = no_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids, test.first,
@@ -143,13 +143,13 @@ TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanValueLessThanMinDictionaryVal
   const auto right_values = std::vector<AllTypeVariant>{AllTypeVariant{-10}};
   const auto right_values2 = std::vector<AllTypeVariant>{AllTypeVariant{34}};
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = no_rows;
-  tests[ScanType::NotEquals] = all_rows;
-  tests[ScanType::LessThan] = no_rows;
-  tests[ScanType::LessThanEquals] = no_rows;
-  tests[ScanType::GreaterThan] = all_rows;
-  tests[ScanType::GreaterThanEquals] = all_rows;
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = no_rows;
+  tests[PredicateCondition::NotEquals] = all_rows;
+  tests[PredicateCondition::LessThan] = no_rows;
+  tests[PredicateCondition::LessThanEquals] = no_rows;
+  tests[PredicateCondition::GreaterThan] = all_rows;
+  tests[PredicateCondition::GreaterThanEquals] = all_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids, test.first,
@@ -164,7 +164,7 @@ TYPED_TEST(OperatorsIndexScanTest, OperatorName) {
   const auto right_values = std::vector<AllTypeVariant>(this->_column_ids.size(), AllTypeVariant{0});
 
   auto scan = std::make_shared<opossum::IndexScan>(this->_table_wrapper, this->_index_type, this->_column_ids,
-                                                   ScanType::GreaterThanEquals, right_values);
+                                                   PredicateCondition::GreaterThanEquals, right_values);
 
   EXPECT_EQ(scan->name(), "IndexScan");
 }
@@ -173,7 +173,7 @@ TYPED_TEST(OperatorsIndexScanTest, InvalidIndexTypeThrows) {
   const auto right_values = std::vector<AllTypeVariant>(this->_column_ids.size(), AllTypeVariant{0});
 
   auto scan = std::make_shared<opossum::IndexScan>(this->_table_wrapper, ColumnIndexType::Invalid, this->_column_ids,
-                                                   ScanType::GreaterThan, right_values);
+                                                   PredicateCondition::GreaterThan, right_values);
   EXPECT_THROW(scan->execute(), std::logic_error);
 }
 

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -42,20 +42,20 @@ TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
 
 TYPED_TEST(JoinEquiTest, LeftJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/int_left_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/string_left_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Left, "src/test/tables/joinoperators/string_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
-                                             "src/test/tables/joinoperators/int_right_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, OuterJoin) {
@@ -63,138 +63,156 @@ TYPED_TEST(JoinEquiTest, OuterJoin) {
     return;
   }
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
-                                             "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/string_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerValueDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictValueJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerValueDictRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictValueRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoinFiltered) {
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefDictJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefDictJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinBig) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_c, this->_table_wrapper_d, ColumnIDPair(ColumnID{0}, ColumnID{1}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoinFilteredBig) {
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_c =
+      std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
-  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, PredicateCondition::GreaterThanEquals, 6);
+  auto scan_d =
+      std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, PredicateCondition::GreaterThanEquals, 6);
   scan_d->execute();
 
-  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, SelfJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_a,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Self,
-                                             "src/test/tables/joinoperators/int_self_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Self, "src/test/tables/joinoperators/int_self_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndDictionaryColumns) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndReferenceColumns) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
@@ -204,11 +222,14 @@ TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndReferenceColumns) {
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeft) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_c =
+      std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
@@ -222,11 +243,14 @@ TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeft) {
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceRight) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_c =
+      std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
@@ -242,9 +266,11 @@ TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeftFiltered) {
   // scan that returns all rows
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThan, 6);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_c =
+      std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
@@ -298,7 +324,8 @@ TYPED_TEST(JoinEquiTest, MixHashAndNestedLoop) {
 
 TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
@@ -308,7 +335,8 @@ TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
 
 TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -23,7 +23,7 @@
 namespace opossum {
 
 /*
-This contains the tests for Join implementations that only implement ScanType::Equals.
+This contains the tests for Join implementations that only implement PredicateCondition::Equals.
 */
 
 template <typename T>
@@ -36,25 +36,25 @@ TYPED_TEST_CASE(JoinEquiTest, JoinEquiTypes);
 TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
   if (!IS_DEBUG) return;
   EXPECT_THROW(std::make_shared<JoinHash>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
-                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::GreaterThan),
+                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan),
                std::logic_error);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/string_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Right,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
@@ -63,276 +63,276 @@ TYPED_TEST(JoinEquiTest, OuterJoin) {
     return;
   }
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Outer,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
                                              "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerValueDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictValueJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerValueDictRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictValueRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefDictJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefDictJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinBig) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{1}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, InnerRefJoinFilteredBig) {
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
-  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::GreaterThanEquals, 6);
+  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, PredicateCondition::GreaterThanEquals, 6);
   scan_d->execute();
 
-  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, SelfJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_a,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Self,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Self,
                                              "src/test/tables/joinoperators/int_self_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndDictionaryColumns) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, JoinOnMixedValueAndReferenceColumns) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Inner,
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeft) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                          ScanType::Equals);
+                                          PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, scan_c, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+      join, scan_c, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_ref_ref_ref_left.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceRight) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                          ScanType::Equals);
+                                          PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      scan_c, join, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+      scan_c, join, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_ref_ref_ref_right.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnReferenceLeftFiltered) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::GreaterThan, 6);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::GreaterThan, 6);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
 
   auto join = std::make_shared<TypeParam>(scan_a, scan_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                          ScanType::Equals);
+                                          PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, scan_c, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+      join, scan_c, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_ref_ref_ref_left_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnValue) {
   auto join = std::make_shared<TypeParam>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Inner,
-                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, this->_table_wrapper_h, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+      join, this->_table_wrapper_h, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_val_val_val_left.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MultiJoinOnRefOuter) {
   auto join = std::make_shared<TypeParam>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Left,
-                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(
-      join, this->_table_wrapper_h, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+      join, this->_table_wrapper_h, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_multijoin_val_val_val_leftouter.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MixNestedLoopAndHash) {
   auto join = std::make_shared<JoinNestedLoop>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Left,
-                                               ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                               ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(join, this->_table_wrapper_h, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Inner,
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_multijoin_nlj_hash.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, MixHashAndNestedLoop) {
   auto join = std::make_shared<JoinHash>(this->_table_wrapper_f, this->_table_wrapper_g, JoinMode::Left,
-                                         ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                         ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();
 
   this->template test_join_output<TypeParam>(join, this->_table_wrapper_h, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Inner,
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_multijoin_nlj_hash.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoinRefColumn) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Right,
+                                             PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinRefColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Left,
+                                             PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, RightJoinEmptyRefColumn) {
   // scan that returns no rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::Equals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::Equals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Right,
+                                             PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_join_empty.tbl", 1);
 }
 
 TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
   // scan that returns no rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::Equals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::Equals, 0);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(this->_table_wrapper_b, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Left,
+                                             PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_join_empty_left.tbl", 1);
 }
 
@@ -340,16 +340,16 @@ TYPED_TEST(JoinEquiTest, LeftJoinEmptyRefColumn) {
 TYPED_TEST(JoinEquiTest, DISABLED_JoinOnUnion /* #160 */) {
   //  Filtering to generate RefColumns
   auto filtered_left =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_e, ColumnID{0}, ScanType::LessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_e, ColumnID{0}, PredicateCondition::LessThanEquals, 10);
   filtered_left->execute();
   auto filtered_left2 =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_f, ColumnID{0}, ScanType::LessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_f, ColumnID{0}, PredicateCondition::LessThanEquals, 10);
   filtered_left2->execute();
   auto filtered_right =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_g, ColumnID{0}, ScanType::LessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_g, ColumnID{0}, PredicateCondition::LessThanEquals, 10);
   filtered_right->execute();
   auto filtered_right2 =
-      std::make_shared<opossum::TableScan>(this->_table_wrapper_h, ColumnID{0}, ScanType::LessThanEquals, 10);
+      std::make_shared<opossum::TableScan>(this->_table_wrapper_h, ColumnID{0}, PredicateCondition::LessThanEquals, 10);
   filtered_right2->execute();
 
   // Union left and right
@@ -359,7 +359,7 @@ TYPED_TEST(JoinEquiTest, DISABLED_JoinOnUnion /* #160 */) {
   union_right->execute();
 
   this->template test_join_output<TypeParam>(union_left, union_right, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Inner,
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/expected_join_result_1.tbl", 1);
 }
 

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -21,7 +21,7 @@ namespace opossum {
 
 /*
 This contains the tests for Join implementations that
-implement all operators, not just ScanType::Equals.
+implement all operators, not just PredicateCondition::Equals.
 */
 
 template <typename T>
@@ -35,180 +35,180 @@ TYPED_TEST(JoinFullTest, CrossJoin) {
   if (!IS_DEBUG) return;
 
   EXPECT_THROW(std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Cross,
-                                           ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals),
+                                           ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals),
                std::logic_error);
 }
 
 TYPED_TEST(JoinFullTest, LeftJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, LeftJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/string_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, RightJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Right,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinSingleChunk) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_e, this->_table_wrapper_f,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_single_chunk.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, ScanType::GreaterThan, 1000);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinBig) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{1}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFilteredBig) {
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
-  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, ScanType::GreaterThanEquals, 6);
+  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, PredicateCondition::GreaterThanEquals, 6);
   scan_d->execute();
 
-  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Outer,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
                                              "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoinWithNull) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_m, this->_table_wrapper_n,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Outer,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
                                              "src/test/tables/joinoperators/int_outer_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoinDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Outer,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
                                              "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SelfJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_a,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Self,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Self,
                                              "src/test/tables/joinoperators/int_self_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThan,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan,
       JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), ScanType::LessThan,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::LessThan,
       JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
 }
 
@@ -216,61 +216,61 @@ TYPED_TEST(JoinFullTest, SmallerInnerJoinDict) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
+      PredicateCondition::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{1}, ColumnID{1}),
-      ScanType::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
+      PredicateCondition::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThan,
+      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan,
       JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerOuterJoin) {
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThan,
+      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan,
       JoinMode::Outer, "src/test/tables/joinoperators/int_smaller_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThanEquals,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_smallerequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), ScanType::LessThanEquals,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::LessThanEquals,
       JoinMode::Inner, "src/test/tables/joinoperators/float_smallerequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThanEquals,
+      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_smallerequal_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualOuterJoin) {
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::LessThanEquals,
+      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
       JoinMode::Outer, "src/test/tables/joinoperators/int_smallerequal_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoin) {
   // Joining two Integer Column
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::GreaterThan,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
       JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), ScanType::GreaterThan,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThan,
       JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
@@ -278,24 +278,24 @@ TYPED_TEST(JoinFullTest, GreaterInnerJoinDict) {
   // Joining two Integer Column
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
+      PredicateCondition::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{1}, ColumnID{1}),
-      ScanType::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
+      PredicateCondition::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_i, this->_table_wrapper_j, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::GreaterThan,
+      this->_table_wrapper_i, this->_table_wrapper_j, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
       JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterOuterJoin) {
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_l, this->_table_wrapper_k, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::GreaterThan,
+      this->_table_wrapper_l, this->_table_wrapper_k, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
       JoinMode::Outer, "src/test/tables/joinoperators/int_greater_outer_join.tbl", 1);
 }
 
@@ -303,11 +303,11 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::GreaterThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
+      PredicateCondition::GreaterThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), ScanType::GreaterThanEquals,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThanEquals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
 }
@@ -316,11 +316,11 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoinDict) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::GreaterThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
+      PredicateCondition::GreaterThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), ScanType::GreaterThanEquals,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThanEquals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
 }
@@ -328,13 +328,13 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoinDict) {
 TYPED_TEST(JoinFullTest, GreaterEqualOuterJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_l, this->_table_wrapper_k, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::GreaterThanEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_greaterequal_outer_join.tbl", 1);
+      PredicateCondition::GreaterThanEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_greaterequal_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_i, this->_table_wrapper_j,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::GreaterThanEquals,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThanEquals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_greaterequal_inner_join_2.tbl", 1);
 }
@@ -342,11 +342,11 @@ TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin2) {
 TYPED_TEST(JoinFullTest, NotEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::NotEquals,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::NotEquals,
       JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), ScanType::NotEquals,
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::NotEquals,
       JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
 }
 
@@ -354,62 +354,62 @@ TYPED_TEST(JoinFullTest, NotEqualInnerJoinDict) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
+      PredicateCondition::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{1}, ColumnID{1}),
-      ScanType::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
+      PredicateCondition::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnMixedValueAndDictionaryColumns) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndValue) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::Equals, JoinMode::Inner,
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnValueAndReferenceColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThan, 100);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThan, 100);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-                                             ScanType::NotEquals, JoinMode::Inner,
+                                             PredicateCondition::NotEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinLessThanOnDictAndDict) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      ScanType::LessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_leq_dict.tbl", 1);
+      PredicateCondition::LessThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_leq_dict.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndDict) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnDictAndReferenceColumn) {
   // scan that returns all rows
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, ScanType::GreaterThan, 100);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThan, 100);
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a_dict, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::NotEquals, JoinMode::Inner,
+      this->_table_wrapper_a_dict, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::NotEquals, JoinMode::Inner,
       "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
 }
 

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -41,175 +41,192 @@ TYPED_TEST(JoinFullTest, CrossJoin) {
 
 TYPED_TEST(JoinFullTest, LeftJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/int_left_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Left, "src/test/tables/joinoperators/int_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, LeftJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/string_left_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Left, "src/test/tables/joinoperators/string_left_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, RightJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
-                                             "src/test/tables/joinoperators/int_right_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Right, "src/test/tables/joinoperators/int_right_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinOnString) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/string_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinSingleChunk) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_e, this->_table_wrapper_f,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join_single_chunk.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_e, this->_table_wrapper_f, ColumnIDPair(ColumnID{1}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_single_chunk.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerValueDictRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictValueRefJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFiltered) {
   auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerDictJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoin) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefDictJoinFiltered) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a_dict, ColumnID{0}, PredicateCondition::GreaterThan, 1000);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_b_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerJoinBig) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_c, this->_table_wrapper_d,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_c, this->_table_wrapper_d, ColumnIDPair(ColumnID{0}, ColumnID{1}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_string_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, InnerRefJoinFilteredBig) {
-  auto scan_c = std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_c =
+      std::make_shared<TableScan>(this->_table_wrapper_c, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_c->execute();
-  auto scan_d = std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, PredicateCondition::GreaterThanEquals, 6);
+  auto scan_d =
+      std::make_shared<TableScan>(this->_table_wrapper_d, ColumnID{1}, PredicateCondition::GreaterThanEquals, 6);
   scan_d->execute();
 
-  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_c, scan_d, ColumnIDPair(ColumnID{0}, ColumnID{1}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_string_inner_join_filtered.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
-                                             "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoinWithNull) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_m, this->_table_wrapper_n,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
-                                             "src/test/tables/joinoperators/int_outer_join_null.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_m, this->_table_wrapper_n, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, OuterJoinDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Outer,
-                                             "src/test/tables/joinoperators/int_outer_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Outer, "src/test/tables/joinoperators/int_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SelfJoin) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_a,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Self,
-                                             "src/test/tables/joinoperators/int_self_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Self, "src/test/tables/joinoperators/int_self_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::LessThan,
-      JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}),
+      PredicateCondition::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/float_smaller_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerInnerJoinDict) {
@@ -227,51 +244,56 @@ TYPED_TEST(JoinFullTest, SmallerInnerJoinDict) {
 TYPED_TEST(JoinFullTest, SmallerInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join_2.tbl", 1);
+      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::LessThan, JoinMode::Inner, "src/test/tables/joinoperators/int_smaller_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerOuterJoin) {
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan,
-      JoinMode::Outer, "src/test/tables/joinoperators/int_smaller_outer_join.tbl", 1);
+      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::LessThan, JoinMode::Outer, "src/test/tables/joinoperators/int_smaller_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin) {
   // Joining two Integer Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_smallerequal_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
+                                             JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_smallerequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::LessThanEquals,
-      JoinMode::Inner, "src/test/tables/joinoperators/float_smallerequal_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::LessThanEquals,
+                                             JoinMode::Inner,
+                                             "src/test/tables/joinoperators/float_smallerequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin2) {
   // Joining two Integer Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_j, this->_table_wrapper_i, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_smallerequal_inner_join_2.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_j, this->_table_wrapper_i,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
+                                             JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_smallerequal_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualOuterJoin) {
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_k, this->_table_wrapper_l, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
-      JoinMode::Outer, "src/test/tables/joinoperators/int_smallerequal_outer_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_k, this->_table_wrapper_l,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThanEquals,
+                                             JoinMode::Outer,
+                                             "src/test/tables/joinoperators/int_smallerequal_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoin) {
   // Joining two Integer Column
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
 
   // Joining two Float Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThan,
-      JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThan,
+                                             JoinMode::Inner,
+                                             "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoinDict) {
@@ -281,73 +303,78 @@ TYPED_TEST(JoinFullTest, GreaterInnerJoinDict) {
       PredicateCondition::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join.tbl", 1);
 
   // Joining two Float Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{1}, ColumnID{1}),
-      PredicateCondition::GreaterThan, JoinMode::Inner, "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThan,
+                                             JoinMode::Inner,
+                                             "src/test/tables/joinoperators/float_greater_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterInnerJoin2) {
   // Joining two Integer Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_i, this->_table_wrapper_j, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_greater_inner_join_2.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_i, this->_table_wrapper_j,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
+                                             JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_greater_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterOuterJoin) {
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_l, this->_table_wrapper_k, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan,
-      JoinMode::Outer, "src/test/tables/joinoperators/int_greater_outer_join.tbl", 1);
+      this->_table_wrapper_l, this->_table_wrapper_k, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::GreaterThan, JoinMode::Outer, "src/test/tables/joinoperators/int_greater_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin) {
   // Joining two Integer Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      PredicateCondition::GreaterThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::GreaterThanEquals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThanEquals,
-                                             JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}),
+                                             PredicateCondition::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualInnerJoinDict) {
   // Joining two Integer Columns
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      PredicateCondition::GreaterThanEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::GreaterThanEquals, JoinMode::Inner,
+                                             "src/test/tables/joinoperators/int_greaterequal_inner_join.tbl", 1);
 
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::GreaterThanEquals,
-                                             JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{1}, ColumnID{1}),
+                                             PredicateCondition::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/float_greaterequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualOuterJoin) {
-  this->template test_join_output<TypeParam>(
-      this->_table_wrapper_l, this->_table_wrapper_k, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      PredicateCondition::GreaterThanEquals, JoinMode::Outer, "src/test/tables/joinoperators/int_greaterequal_outer_join.tbl", 1);
+  this->template test_join_output<TypeParam>(this->_table_wrapper_l, this->_table_wrapper_k,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::GreaterThanEquals, JoinMode::Outer,
+                                             "src/test/tables/joinoperators/int_greaterequal_outer_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, GreaterEqualInnerJoin2) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(this->_table_wrapper_i, this->_table_wrapper_j,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThanEquals,
-                                             JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::GreaterThanEquals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_greaterequal_inner_join_2.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, NotEqualInnerJoin) {
   // Joining two Integer Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::NotEquals,
-      JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/int_notequal_inner_join.tbl", 1);
   // Joining two Float Columns
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}), PredicateCondition::NotEquals,
-      JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
+      this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{1}, ColumnID{1}),
+      PredicateCondition::NotEquals, JoinMode::Inner, "src/test/tables/joinoperators/float_notequal_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, NotEqualInnerJoinDict) {
@@ -363,13 +390,14 @@ TYPED_TEST(JoinFullTest, NotEqualInnerJoinDict) {
 
 TYPED_TEST(JoinFullTest, JoinOnMixedValueAndDictionaryColumns) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_c_dict, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndValue) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
@@ -395,12 +423,13 @@ TYPED_TEST(JoinFullTest, JoinLessThanOnDictAndDict) {
 
 TYPED_TEST(JoinFullTest, JoinOnReferenceColumnAndDict) {
   // scan that returns all rows
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
   this->template test_join_output<TypeParam>(scan_a, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, JoinOnDictAndReferenceColumn) {
@@ -409,8 +438,8 @@ TYPED_TEST(JoinFullTest, JoinOnDictAndReferenceColumn) {
   scan_b->execute();
 
   this->template test_join_output<TypeParam>(
-      this->_table_wrapper_a_dict, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::NotEquals, JoinMode::Inner,
-      "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
+      this->_table_wrapper_a_dict, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::NotEquals,
+      JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_neq.tbl", 1);
 }
 
 }  // namespace opossum

--- a/src/test/operators/join_null_test.cpp
+++ b/src/test/operators/join_null_test.cpp
@@ -52,92 +52,94 @@ using JoinNullTypes = ::testing::Types<JoinHash, JoinSortMerge, JoinNestedLoop>;
 TYPED_TEST_CASE(JoinNullTest, JoinNullTypes);
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNull) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_a_null,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a, this->_table_wrapper_a_null, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullDict) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_dict, this->_table_wrapper_a_null_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNull2) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_m, this->_table_wrapper_n,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_m, this->_table_wrapper_n, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullDict2) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_m_dict, this->_table_wrapper_n_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
-                                             "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_m_dict, this->_table_wrapper_n_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Inner, "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullRef2) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_a =
+      std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan_b =
+      std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
-                                             JoinMode::Inner,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                             PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_null_ref.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsOuter) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsOuterDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
+                                             JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsInner) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_b, this->_table_wrapper_a_null,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_b, this->_table_wrapper_a_null, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsInnerDict) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
-                                             "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Left, "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsOuter) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_b, this->_table_wrapper_a_null,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
-                                             "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_b, this->_table_wrapper_a_null, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsOuterDict) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
-                                             "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsInner) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_a_null, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
-                                             "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_null, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsInnerDict) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
-                                             "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Right, "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, SelfJoinWithNullDict) {
-  this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Self,
-                                             "src/test/tables/joinoperators/int_float_with_null_self_join.tbl", 1);
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_a_null_dict, this->_table_wrapper_a_null_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::Equals, JoinMode::Self, "src/test/tables/joinoperators/int_float_with_null_self_join.tbl", 1);
 }
 
 }  // namespace opossum

--- a/src/test/operators/join_null_test.cpp
+++ b/src/test/operators/join_null_test.cpp
@@ -53,90 +53,90 @@ TYPED_TEST_CASE(JoinNullTest, JoinNullTypes);
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNull) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_a_null,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_float_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNull2) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_m, this->_table_wrapper_n,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullDict2) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_m_dict, this->_table_wrapper_n_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Inner,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNullRef2) {
-  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(this->_table_wrapper_m, ColumnID{1}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
-  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(this->_table_wrapper_n, ColumnID{1}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals,
+  this->template test_join_output<TypeParam>(scan_a, scan_b, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals,
                                              JoinMode::Inner,
                                              "src/test/tables/joinoperators/int_inner_join_null_ref.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsOuter) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsOuterDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsInner) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_b, this->_table_wrapper_a_null,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, LeftJoinWithNullAsInnerDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Left,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Left,
                                              "src/test/tables/joinoperators/int_left_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsOuter) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_b, this->_table_wrapper_a_null,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Right,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsOuterDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_b_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Right,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsInner) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null, this->_table_wrapper_b,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Right,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, RightJoinWithNullAsInnerDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_b_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Right,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Right,
                                              "src/test/tables/joinoperators/int_right_join_null_inner.tbl", 1);
 }
 
 TYPED_TEST(JoinNullTest, SelfJoinWithNullDict) {
   this->template test_join_output<TypeParam>(this->_table_wrapper_a_null_dict, this->_table_wrapper_a_null_dict,
-                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals, JoinMode::Self,
+                                             ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, JoinMode::Self,
                                              "src/test/tables/joinoperators/int_float_with_null_self_join.tbl", 1);
 }
 

--- a/src/test/operators/join_semi_anti_test.cpp
+++ b/src/test/operators/join_semi_anti_test.cpp
@@ -40,44 +40,44 @@ class JoinSemiAntiTest : public JoinTest {
 };
 
 TEST_F(JoinSemiAntiTest, SemiJoin) {
-  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, ScanType::Equals,
+  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals,
                              JoinMode::Semi, "src/test/tables/int.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, SemiJoinRefColumns) {
-  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
-  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, ScanType::Equals, JoinMode::Semi,
+  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals, JoinMode::Semi,
                              "src/test/tables/int.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, SemiJoinBig) {
-  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}}, ScanType::Equals,
+  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals,
                              JoinMode::Semi, "src/test/tables/joinoperators/semi_result.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoin) {
-  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, ScanType::Equals,
+  test_join_output<JoinHash>(_table_wrapper_k, _table_wrapper_a, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals,
                              JoinMode::Anti, "src/test/tables/joinoperators/anti_int4.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoinRefColumns) {
-  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_a = std::make_shared<TableScan>(_table_wrapper_k, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_a->execute();
 
-  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+  auto scan_b = std::make_shared<TableScan>(_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan_b->execute();
 
-  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, ScanType::Equals, JoinMode::Anti,
+  test_join_output<JoinHash>(scan_a, scan_b, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals, JoinMode::Anti,
                              "src/test/tables/joinoperators/anti_int4.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoinBig) {
-  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}}, ScanType::Equals,
+  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals,
                              JoinMode::Anti, "src/test/tables/joinoperators/anti_result.tbl", 1);
 }
 

--- a/src/test/operators/join_semi_anti_test.cpp
+++ b/src/test/operators/join_semi_anti_test.cpp
@@ -56,8 +56,9 @@ TEST_F(JoinSemiAntiTest, SemiJoinRefColumns) {
 }
 
 TEST_F(JoinSemiAntiTest, SemiJoinBig) {
-  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals,
-                             JoinMode::Semi, "src/test/tables/joinoperators/semi_result.tbl", 1);
+  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}},
+                             PredicateCondition::Equals, JoinMode::Semi,
+                             "src/test/tables/joinoperators/semi_result.tbl", 1);
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoin) {
@@ -77,8 +78,9 @@ TEST_F(JoinSemiAntiTest, AntiJoinRefColumns) {
 }
 
 TEST_F(JoinSemiAntiTest, AntiJoinBig) {
-  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals,
-                             JoinMode::Anti, "src/test/tables/joinoperators/anti_result.tbl", 1);
+  test_join_output<JoinHash>(_table_wrapper_semi_a, _table_wrapper_semi_b, {ColumnID{0}, ColumnID{0}},
+                             PredicateCondition::Equals, JoinMode::Anti,
+                             "src/test/tables/joinoperators/anti_result.tbl", 1);
 }
 
 }  // namespace opossum

--- a/src/test/operators/join_test.hpp
+++ b/src/test/operators/join_test.hpp
@@ -91,14 +91,14 @@ class JoinTest : public BaseTest {
   template <typename JoinType>
   void test_join_output(const std::shared_ptr<const AbstractOperator> left,
                         const std::shared_ptr<const AbstractOperator> right, const ColumnIDPair& column_ids,
-                        const ScanType scan_type, const JoinMode mode, const std::string& file_name,
+                        const PredicateCondition predicate_condition, const JoinMode mode, const std::string& file_name,
                         size_t chunk_size) {
     // load expected results from file
     std::shared_ptr<Table> expected_result = load_table(file_name, chunk_size);
     EXPECT_NE(expected_result, nullptr) << "Could not load expected result table";
 
     // build and execute join
-    auto join = std::make_shared<JoinType>(left, right, mode, column_ids, scan_type);
+    auto join = std::make_shared<JoinType>(left, right, mode, column_ids, predicate_condition);
     EXPECT_NE(join, nullptr) << "Could not build Join";
     join->execute();
 

--- a/src/test/operators/limit_test.cpp
+++ b/src/test/operators/limit_test.cpp
@@ -70,7 +70,7 @@ TEST_F(OperatorsLimitTest, Limit1ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit1ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_1();
@@ -83,7 +83,7 @@ TEST_F(OperatorsLimitTest, Limit2ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit2ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_2();
@@ -96,7 +96,7 @@ TEST_F(OperatorsLimitTest, Limit4ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit4ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_4();
@@ -109,7 +109,7 @@ TEST_F(OperatorsLimitTest, Limit10ValueColumn) {
 
 TEST_F(OperatorsLimitTest, Limit10ReferenceColumn) {
   // Filter accepts all rows in table.
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, -1);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, -1);
   table_scan->execute();
   _input_operator = table_scan;
   test_limit_10();

--- a/src/test/operators/physical_query_plan_test.cpp
+++ b/src/test/operators/physical_query_plan_test.cpp
@@ -16,8 +16,8 @@ TEST_F(PhysicalQueryPlanTest, Print) {
   StorageManager::get().add_table("int_int_int_100", load_table("src/test/tables/sqlite/int_int_int_100.tbl", 20));
 
   auto get_table = std::make_shared<GetTable>("int_int_int_100");
-  auto table_scan_a = std::make_shared<TableScan>(get_table, ColumnID{0}, ScanType::GreaterThan, 20);
-  auto table_scan_b = std::make_shared<TableScan>(get_table, ColumnID{1}, ScanType::GreaterThan, 30);
+  auto table_scan_a = std::make_shared<TableScan>(get_table, ColumnID{0}, PredicateCondition::GreaterThan, 20);
+  auto table_scan_b = std::make_shared<TableScan>(get_table, ColumnID{1}, PredicateCondition::GreaterThan, 30);
   auto union_positions = std::make_shared<UnionPositions>(table_scan_a, table_scan_b);
 
   std::stringstream stream;

--- a/src/test/operators/product_test.cpp
+++ b/src/test/operators/product_test.cpp
@@ -39,7 +39,7 @@ TEST_F(OperatorsProductTest, ValueColumns) {
 
 TEST_F(OperatorsProductTest, ReferenceAndValueColumns) {
   auto table_scan =
-      std::make_shared<opossum::TableScan>(_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
+      std::make_shared<opossum::TableScan>(_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
   table_scan->execute();
 
   auto product = std::make_shared<Product>(table_scan, _table_wrapper_b);

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -273,7 +273,7 @@ TEST_F(OperatorsProjectionTest, VariableArithmeticWithRefProjection) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_int_int_addition.tbl", 2);
 
   // creates ref_columns
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper_int_dict, ColumnID{0}, ScanType::GreaterThan, "0");
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper_int_dict, ColumnID{0}, PredicateCondition::GreaterThan, "0");
   table_scan->execute();
 
   auto projection = std::make_shared<Projection>(table_scan, _sum_a_b_c_expr);
@@ -301,7 +301,7 @@ TEST_F(OperatorsProjectionTest, ValueColumnCount) {
 
 // TODO(anyone): refactor test
 TEST_F(OperatorsProjectionTest, ReferenceColumnCount) {
-  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::Equals, 1234);
+  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::Equals, 1234);
   scan->execute();
 
   auto projection_1 = std::make_shared<opossum::Projection>(scan, _a_b_expr);

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -273,7 +273,8 @@ TEST_F(OperatorsProjectionTest, VariableArithmeticWithRefProjection) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_int_int_addition.tbl", 2);
 
   // creates ref_columns
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper_int_dict, ColumnID{0}, PredicateCondition::GreaterThan, "0");
+  auto table_scan =
+      std::make_shared<TableScan>(_table_wrapper_int_dict, ColumnID{0}, PredicateCondition::GreaterThan, "0");
   table_scan->execute();
 
   auto projection = std::make_shared<Projection>(table_scan, _sum_a_b_c_expr);

--- a/src/test/operators/recreation_test.cpp
+++ b/src/test/operators/recreation_test.cpp
@@ -58,7 +58,7 @@ TYPED_TEST(RecreationTestJoin, RecreationJoin) {
 
   // build and execute join
   auto join = std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
-                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   EXPECT_NE(join, nullptr) << "Could not build Join";
   join->execute();
   EXPECT_TABLE_EQ_UNORDERED(join->get_output(), expected_result);
@@ -147,7 +147,7 @@ TEST_F(RecreationTest, RecreationTableScan) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
 
   // build and execute table scan
-  auto scan = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
+  auto scan = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 

--- a/src/test/operators/recreation_test.cpp
+++ b/src/test/operators/recreation_test.cpp
@@ -147,7 +147,8 @@ TEST_F(RecreationTest, RecreationTableScan) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
 
   // build and execute table scan
-  auto scan = std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
+  auto scan =
+      std::make_shared<TableScan>(this->_table_wrapper_a, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -57,7 +57,7 @@ TEST_F(OperatorsSortTest, AscendingSortOFilteredColumn) {
   auto input = std::make_shared<TableWrapper>(load_table("src/test/tables/int_float.tbl", 1));
   input->execute();
 
-  auto scan = std::make_shared<TableScan>(input, ColumnID{0}, ScanType::NotEquals, 123);
+  auto scan = std::make_shared<TableScan>(input, ColumnID{0}, PredicateCondition::NotEquals, 123);
   scan->execute();
 
   auto sort = std::make_shared<Sort>(scan, ColumnID{0}, OrderByMode::Ascending, 2u);
@@ -208,7 +208,7 @@ TEST_F(OperatorsSortTest, SortTableWithRefandValueColumns) {
   table_wrapper1->execute();
   table_wrapper2->execute();
 
-  auto ts2 = std::make_shared<TableScan>(table_wrapper2, ColumnID{0}, ScanType::GreaterThan, 12);
+  auto ts2 = std::make_shared<TableScan>(table_wrapper2, ColumnID{0}, PredicateCondition::GreaterThan, 12);
   ts2->execute();
 
   auto union_all = std::make_shared<UnionAll>(table_wrapper1, ts2);

--- a/src/test/operators/table_scan_like_test.cpp
+++ b/src/test/operators/table_scan_like_test.cpp
@@ -46,37 +46,37 @@ class OperatorsTableScanLikeTest : public BaseTest {
 };
 
 /*
-    Tests for operator ScanType::Like
+    Tests for operator PredicateCondition::Like
     The **%** sign is used to define wildcards (missing letters) both before and after the search pattern.
     We expect the operator to be run on a string column using a string value with wildcard.
 */
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNonStringColumn) {
-  auto scan = std::make_shared<TableScan>(_gt, ColumnID{0}, ScanType::Like, "%test");
+  auto scan = std::make_shared<TableScan>(_gt, ColumnID{0}, PredicateCondition::Like, "%test");
   EXPECT_THROW(scan->execute(), std::exception);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNonStringValue) {
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, 1234);
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, 1234);
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 1u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyString) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeCaseInsensitivity) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "dAmpF%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "dAmpF%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
@@ -84,132 +84,132 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeCaseInsensitivity) {
 TEST_F(OperatorsTableScanLikeTest, ScanLikeUnderscoreWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 
-// ScanType::Like - Starting
+// PredicateCondition::Like - Starting
 TEST_F(OperatorsTableScanLikeTest, ScanLike_Starting) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "Dampf%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "Dampf%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeStartingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "Dampf%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "Dampf%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeStartingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "Dampf%");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "Dampf%");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
-// ScanType::Like - Ending
+// PredicateCondition::Like - Ending
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEnding) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%gesellschaft");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%gesellschaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEndingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%gesellschaft");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%gesellschaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEndingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "%gesellschaft");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "%gesellschaft");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
 
-// ScanType::Like - Containing Wildcard
+// PredicateCondition::Like - Containing Wildcard
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing_wildcard.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "Schiff%schaft");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "Schiff%schaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 
-// ScanType::Like - Containing
+// PredicateCondition::Like - Containing
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContaining) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%schifffahrtsgesellschaft%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%schifffahrtsgesellschaft%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "%schifffahrtsgesellschaft%");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
-// ScanType::Like - Not Found
+// PredicateCondition::Like - Not Found
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFound) {
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::Like, "%not_there%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%not_there%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFoundOnDictColumn) {
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::Like, "%not_there%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%not_there%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFoundOnReferencedDictColumn) {
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, ScanType::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
-  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, ScanType::Like, "%not_there%");
+  auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "%not_there%");
   scan2->execute();
   EXPECT_EQ(scan2->get_output()->row_count(), 0u);
 }
-// ScanType::NotLike
+// PredicateCondition::NotLike
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyString) {
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::NotLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::NotLike, "%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyStringOnDict) {
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::NotLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::NotLike, "%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRows) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::NotLike, "%foo%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::NotLike, "%foo%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRowsOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::NotLike, "%foo%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::NotLike, "%foo%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
@@ -217,14 +217,14 @@ TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRowsOnDict) {
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcard) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_not_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, ScanType::NotLike, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::NotLike, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcardOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_not_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, ScanType::NotLike, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::NotLike, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }

--- a/src/test/operators/table_scan_like_test.cpp
+++ b/src/test/operators/table_scan_like_test.cpp
@@ -150,13 +150,15 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingWildcard) {
 // PredicateCondition::Like - Containing
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContaining) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
+  auto scan =
+      std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
+  auto scan =
+      std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -161,12 +161,12 @@ class OperatorsTableScanTest : public BaseTest {
   }
 
   void scan_for_null_values(const std::shared_ptr<AbstractOperator> in,
-                            const std::map<ScanType, std::vector<AllTypeVariant>>& tests) {
+                            const std::map<PredicateCondition, std::vector<AllTypeVariant>>& tests) {
     for (const auto& test : tests) {
-      const auto scan_type = test.first;
+      const auto predicate_condition = test.first;
       const auto& expected = test.second;
 
-      auto scan = std::make_shared<opossum::TableScan>(in, ColumnID{1} /* "b" */, scan_type, NULL_VALUE);
+      auto scan = std::make_shared<opossum::TableScan>(in, ColumnID{1} /* "b" */, predicate_condition, NULL_VALUE);
       scan->execute();
 
       const auto expected_result = std::vector<AllTypeVariant>{{12, 123}};
@@ -205,17 +205,17 @@ class OperatorsTableScanTest : public BaseTest {
 TEST_F(OperatorsTableScanTest, DoubleScan) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered.tbl", 2);
 
-  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
+  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
   scan_1->execute();
 
-  auto scan_2 = std::make_shared<TableScan>(scan_1, ColumnID{1}, ScanType::LessThan, 457.9);
+  auto scan_2 = std::make_shared<TableScan>(scan_1, ColumnID{1}, PredicateCondition::LessThan, 457.9);
   scan_2->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_2->get_output(), expected_result);
 }
 
 TEST_F(OperatorsTableScanTest, EmptyResultScan) {
-  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, 90000);
+  auto scan_1 = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, 90000);
   scan_1->execute();
 
   for (auto i = ChunkID{0}; i < scan_1->get_output()->chunk_count(); i++)
@@ -225,7 +225,7 @@ TEST_F(OperatorsTableScanTest, EmptyResultScan) {
 TEST_F(OperatorsTableScanTest, SingleScanReturnsCorrectRowCount) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_filtered2.tbl", 1);
 
-  auto scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
+  auto scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
   scan->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
@@ -234,21 +234,21 @@ TEST_F(OperatorsTableScanTest, SingleScanReturnsCorrectRowCount) {
 TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = {104};
-  tests[ScanType::NotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::LessThan] = {100, 102};
-  tests[ScanType::LessThanEquals] = {100, 102, 104};
-  tests[ScanType::GreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::GreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::Between] = {};  // Will throw
-  tests[ScanType::IsNull] = {};
-  tests[ScanType::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = {104};
+  tests[PredicateCondition::NotEquals] = {100, 102, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::LessThan] = {100, 102};
+  tests[PredicateCondition::LessThanEquals] = {100, 102, 104};
+  tests[PredicateCondition::GreaterThan] = {106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::GreaterThanEquals] = {104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::Between] = {};  // Will throw
+  tests[PredicateCondition::IsNull] = {};
+  tests[PredicateCondition::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 4);
 
-    if (test.first == ScanType::Between) {
+    if (test.first == PredicateCondition::Between) {
       EXPECT_THROW(scan->execute(), std::logic_error);
       continue;
     }
@@ -262,24 +262,24 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumn) {
 TEST_F(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = {104};
-  tests[ScanType::NotEquals] = {100, 102, 106};
-  tests[ScanType::LessThan] = {100, 102};
-  tests[ScanType::LessThanEquals] = {100, 102, 104};
-  tests[ScanType::GreaterThan] = {106};
-  tests[ScanType::GreaterThanEquals] = {104, 106};
-  tests[ScanType::Between] = {};  // Will throw
-  tests[ScanType::IsNull] = {};
-  tests[ScanType::IsNotNull] = {100, 102, 104, 106};
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = {104};
+  tests[PredicateCondition::NotEquals] = {100, 102, 106};
+  tests[PredicateCondition::LessThan] = {100, 102};
+  tests[PredicateCondition::LessThanEquals] = {100, 102, 104};
+  tests[PredicateCondition::GreaterThan] = {106};
+  tests[PredicateCondition::GreaterThanEquals] = {104, 106};
+  tests[PredicateCondition::Between] = {};  // Will throw
+  tests[PredicateCondition::IsNull] = {};
+  tests[PredicateCondition::IsNotNull] = {100, 102, 104, 106};
 
   for (const auto& test : tests) {
-    auto scan1 = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{1}, ScanType::LessThan, 108);
+    auto scan1 = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{1}, PredicateCondition::LessThan, 108);
     scan1->execute();
 
     auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{0}, test.first, 4);
 
-    if (test.first == ScanType::Between) {
+    if (test.first == PredicateCondition::Between) {
       EXPECT_THROW(scan2->execute(), std::logic_error);
       continue;
     }
@@ -294,7 +294,7 @@ TEST_F(OperatorsTableScanTest, ScanPartiallyCompressed) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered.tbl", 2);
 
   auto table_wrapper = get_table_op_part_dict();
-  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::LessThan, 10);
+  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, PredicateCondition::LessThan, 10);
   scan_1->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_1->get_output(), expected_result);
@@ -304,7 +304,7 @@ TEST_F(OperatorsTableScanTest, ScanWeirdPosList) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered_onlyodd.tbl", 2);
 
   auto table_wrapper = get_table_op_filtered();
-  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, ScanType::LessThan, 10);
+  auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, PredicateCondition::LessThan, 10);
   scan_1->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_1->get_output(), expected_result);
@@ -314,13 +314,13 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValu
   const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   const auto no_rows = std::vector<AllTypeVariant>{};
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = no_rows;
-  tests[ScanType::NotEquals] = all_rows;
-  tests[ScanType::LessThan] = all_rows;
-  tests[ScanType::LessThanEquals] = all_rows;
-  tests[ScanType::GreaterThan] = no_rows;
-  tests[ScanType::GreaterThanEquals] = no_rows;
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = no_rows;
+  tests[PredicateCondition::NotEquals] = all_rows;
+  tests[PredicateCondition::LessThan] = all_rows;
+  tests[PredicateCondition::LessThanEquals] = all_rows;
+  tests[PredicateCondition::GreaterThan] = no_rows;
+  tests[PredicateCondition::GreaterThanEquals] = no_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 30);
@@ -334,13 +334,13 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) 
   const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   const auto no_rows = std::vector<AllTypeVariant>{};
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = no_rows;
-  tests[ScanType::NotEquals] = all_rows;
-  tests[ScanType::LessThan] = no_rows;
-  tests[ScanType::LessThanEquals] = no_rows;
-  tests[ScanType::GreaterThan] = all_rows;
-  tests[ScanType::GreaterThanEquals] = all_rows;
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = no_rows;
+  tests[PredicateCondition::NotEquals] = all_rows;
+  tests[PredicateCondition::LessThan] = no_rows;
+  tests[PredicateCondition::LessThanEquals] = no_rows;
+  tests[PredicateCondition::GreaterThan] = all_rows;
+  tests[PredicateCondition::GreaterThanEquals] = all_rows;
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_even_dict, ColumnID{0} /* "a" */, test.first, -10);
@@ -357,7 +357,7 @@ TEST_F(OperatorsTableScanTest, ScanOnIntValueColumnWithFloatColumnWithNullValues
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -371,7 +371,7 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntValueColumnWithFloatColumnWith
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -386,7 +386,7 @@ TEST_F(OperatorsTableScanTest, ScanOnIntDictColumnWithFloatColumnWithNullValues)
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -401,7 +401,7 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntDictColumnWithFloatColumnWithN
   table_wrapper->execute();
 
   auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, ScanType::GreaterThan, ColumnID{1} /* "b" */);
+      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -411,15 +411,15 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntDictColumnWithFloatColumnWithN
 TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
   // scanning for a value that is around the dictionary's bounds
 
-  std::map<ScanType, std::vector<AllTypeVariant>> tests;
-  tests[ScanType::Equals] = {100};
-  tests[ScanType::LessThan] = {};
-  tests[ScanType::LessThanEquals] = {100};
-  tests[ScanType::GreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::GreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::NotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
-  tests[ScanType::IsNull] = {};
-  tests[ScanType::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
+  tests[PredicateCondition::Equals] = {100};
+  tests[PredicateCondition::LessThan] = {};
+  tests[PredicateCondition::LessThanEquals] = {100};
+  tests[PredicateCondition::GreaterThan] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::GreaterThanEquals] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::NotEquals] = {102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
+  tests[PredicateCondition::IsNull] = {};
+  tests[PredicateCondition::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
     auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, test.first, 0);
@@ -430,12 +430,12 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
 }
 
 TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThan, 12345);
+  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, 12345);
   scan_1->execute();
   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(0));
 
   // scan_1 produced an empty result
-  auto scan_2 = std::make_shared<opossum::TableScan>(scan_1, ColumnID{1}, ScanType::Equals, 456.7);
+  auto scan_2 = std::make_shared<opossum::TableScan>(scan_1, ColumnID{1}, PredicateCondition::Equals, 456.7);
   scan_2->execute();
 
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(0));
@@ -444,21 +444,21 @@ TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
 TEST_F(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
   // 2**8 + 1 values require a data type of 16bit.
   const auto table_wrapper_dict_16 = get_table_op_with_n_dict_entries((1 << 8) + 1);
-  auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, ScanType::GreaterThan, 200);
+  auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, PredicateCondition::GreaterThan, 200);
   scan_1->execute();
 
   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(57));
 
   // 2**16 + 1 values require a data type of 32bit.
   const auto table_wrapper_dict_32 = get_table_op_with_n_dict_entries((1 << 16) + 1);
-  auto scan_2 = std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, ScanType::GreaterThan, 65500);
+  auto scan_2 = std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, PredicateCondition::GreaterThan, 65500);
   scan_2->execute();
 
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
 }
 
 TEST_F(OperatorsTableScanTest, OperatorName) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
+  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
 
   EXPECT_EQ(scan_1->name(), "TableScan");
 }
@@ -467,8 +467,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnValueColumn) {
   auto table_wrapper = std::make_shared<TableWrapper>(load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4));
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -480,8 +480,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnDictColumn) {
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -492,8 +492,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnValueColumnWithoutNulls) {
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {}},
-                                                                     {ScanType::IsNotNull, {12345, 123, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {}},
+                                                                     {PredicateCondition::IsNotNull, {12345, 123, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -504,8 +504,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumnWithoutNu
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {}},
-                                                                     {ScanType::IsNotNull, {12345, 123, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {}},
+                                                                     {PredicateCondition::IsNotNull, {12345, 123, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -516,8 +516,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumn) {
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -529,8 +529,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedDictColumn) {
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{
-      {ScanType::IsNull, {12, 123}}, {ScanType::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -541,8 +541,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedValueCo
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {123, 1234}},
-                                                                     {ScanType::IsNotNull, {12345, NULL_VALUE}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {123, 1234}},
+                                                                     {PredicateCondition::IsNotNull, {12345, NULL_VALUE}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -553,19 +553,19 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedDictCol
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<ScanType, std::vector<AllTypeVariant>>{{ScanType::IsNull, {123, 1234}},
-                                                                     {ScanType::IsNotNull, {12345, NULL_VALUE}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {123, 1234}},
+                                                                     {PredicateCondition::IsNotNull, {12345, NULL_VALUE}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
 
 TEST_F(OperatorsTableScanTest, NullSemantics) {
-  const auto scan_types =
-      std::vector<ScanType>({ScanType::Equals, ScanType::NotEquals, ScanType::LessThan, ScanType::LessThanEquals,
-                             ScanType::GreaterThan, ScanType::GreaterThanEquals});
+  const auto predicate_conditions =
+      std::vector<PredicateCondition>({PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
+                             PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals});
 
-  for (auto scan_type : scan_types) {
-    auto scan = std::make_shared<TableScan>(_table_wrapper_null, ColumnID{0}, scan_type, NULL_VALUE);
+  for (auto predicate_condition : predicate_conditions) {
+    auto scan = std::make_shared<TableScan>(_table_wrapper_null, ColumnID{0}, predicate_condition, NULL_VALUE);
     scan->execute();
 
     EXPECT_EQ(scan->get_output()->row_count(), 0u);
@@ -580,7 +580,7 @@ TEST_F(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
   const auto expected = std::vector<AllTypeVariant>{110, 112, 114, 116, 118, 120, 122, 124};
 
   auto scan =
-      std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, ScanType::GreaterThanEquals, 0);
+      std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
   scan->set_excluded_chunk_ids({ChunkID{0u}});
   scan->execute();
 

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -356,8 +356,8 @@ TEST_F(OperatorsTableScanTest, ScanOnIntValueColumnWithFloatColumnWithNullValues
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
   table_wrapper->execute();
 
-  auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan,
+                                          ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -370,8 +370,8 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntValueColumnWithFloatColumnWith
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan,
+                                          ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -385,8 +385,8 @@ TEST_F(OperatorsTableScanTest, ScanOnIntDictColumnWithFloatColumnWithNullValues)
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
   table_wrapper->execute();
 
-  auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan,
+                                          ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -400,8 +400,8 @@ TEST_F(OperatorsTableScanTest, ScanOnReferencedIntDictColumnWithFloatColumnWithN
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  auto scan =
-      std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan, ColumnID{1} /* "b" */);
+  auto scan = std::make_shared<TableScan>(table_wrapper, ColumnID{0} /* "a" */, PredicateCondition::GreaterThan,
+                                          ColumnID{1} /* "b" */);
   scan->execute();
 
   const auto expected = std::vector<AllTypeVariant>{12345, 1234, 12345, 1234};
@@ -430,7 +430,8 @@ TEST_F(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
 }
 
 TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, 12345);
+  auto scan_1 =
+      std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThan, 12345);
   scan_1->execute();
   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(0));
 
@@ -444,21 +445,24 @@ TEST_F(OperatorsTableScanTest, ScanWithEmptyInput) {
 TEST_F(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
   // 2**8 + 1 values require a data type of 16bit.
   const auto table_wrapper_dict_16 = get_table_op_with_n_dict_entries((1 << 8) + 1);
-  auto scan_1 = std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, PredicateCondition::GreaterThan, 200);
+  auto scan_1 =
+      std::make_shared<opossum::TableScan>(table_wrapper_dict_16, ColumnID{0}, PredicateCondition::GreaterThan, 200);
   scan_1->execute();
 
   EXPECT_EQ(scan_1->get_output()->row_count(), static_cast<size_t>(57));
 
   // 2**16 + 1 values require a data type of 32bit.
   const auto table_wrapper_dict_32 = get_table_op_with_n_dict_entries((1 << 16) + 1);
-  auto scan_2 = std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, PredicateCondition::GreaterThan, 65500);
+  auto scan_2 =
+      std::make_shared<opossum::TableScan>(table_wrapper_dict_32, ColumnID{0}, PredicateCondition::GreaterThan, 65500);
   scan_2->execute();
 
   EXPECT_EQ(scan_2->get_output()->row_count(), static_cast<size_t>(37));
 }
 
 TEST_F(OperatorsTableScanTest, OperatorName) {
-  auto scan_1 = std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
+  auto scan_1 =
+      std::make_shared<opossum::TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
 
   EXPECT_EQ(scan_1->name(), "TableScan");
 }
@@ -468,7 +472,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnValueColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
-      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {PredicateCondition::IsNull, {12, 123}},
+      {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -481,7 +486,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnDictColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
-      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {PredicateCondition::IsNull, {12, 123}},
+      {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -492,8 +498,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnValueColumnWithoutNulls) {
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {}},
-                                                                     {PredicateCondition::IsNotNull, {12345, 123, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {}}, {PredicateCondition::IsNotNull, {12345, 123, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -504,8 +510,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumnWithoutNu
   auto table_wrapper = std::make_shared<TableWrapper>(to_referencing_table(table));
   table_wrapper->execute();
 
-  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {}},
-                                                                     {PredicateCondition::IsNotNull, {12345, 123, 1234}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {}}, {PredicateCondition::IsNotNull, {12345, 123, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -517,7 +523,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
-      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {PredicateCondition::IsNull, {12, 123}},
+      {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -530,7 +537,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesOnReferencedDictColumn) {
   table_wrapper->execute();
 
   const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
-      {PredicateCondition::IsNull, {12, 123}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
+      {PredicateCondition::IsNull, {12, 123}},
+      {PredicateCondition::IsNotNull, {12345, NULL_VALUE, 1234, 12345, 12, 1234}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -541,8 +549,8 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedValueCo
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {123, 1234}},
-                                                                     {PredicateCondition::IsNotNull, {12345, NULL_VALUE}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {123, 1234}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
@@ -553,16 +561,16 @@ TEST_F(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedDictCol
   auto table_wrapper = std::make_shared<TableWrapper>(table);
   table_wrapper->execute();
 
-  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{{PredicateCondition::IsNull, {123, 1234}},
-                                                                     {PredicateCondition::IsNotNull, {12345, NULL_VALUE}}};
+  const auto tests = std::map<PredicateCondition, std::vector<AllTypeVariant>>{
+      {PredicateCondition::IsNull, {123, 1234}}, {PredicateCondition::IsNotNull, {12345, NULL_VALUE}}};
 
   scan_for_null_values(table_wrapper, tests);
 }
 
 TEST_F(OperatorsTableScanTest, NullSemantics) {
-  const auto predicate_conditions =
-      std::vector<PredicateCondition>({PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
-                             PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals});
+  const auto predicate_conditions = std::vector<PredicateCondition>(
+      {PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThan,
+       PredicateCondition::LessThanEquals, PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals});
 
   for (auto predicate_condition : predicate_conditions) {
     auto scan = std::make_shared<TableScan>(_table_wrapper_null, ColumnID{0}, predicate_condition, NULL_VALUE);
@@ -579,8 +587,8 @@ TEST_F(OperatorsTableScanTest, NullSemantics) {
 TEST_F(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
   const auto expected = std::vector<AllTypeVariant>{110, 112, 114, 116, 118, 120, 122, 124};
 
-  auto scan =
-      std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0}, PredicateCondition::GreaterThanEquals, 0);
+  auto scan = std::make_shared<opossum::TableScan>(_table_wrapper_even_dict, ColumnID{0},
+                                                   PredicateCondition::GreaterThanEquals, 0);
   scan->set_excluded_chunk_ids({ChunkID{0u}});
   scan->execute();
 

--- a/src/test/operators/union_positions_test.cpp
+++ b/src/test/operators/union_positions_test.cpp
@@ -134,7 +134,8 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRangesMultipleColumns) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::GreaterThan, 12345);
+  auto table_scan_a_op =
+      std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::GreaterThan, 12345);
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{1}, PredicateCondition::LessThan, 400.0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 

--- a/src/test/operators/union_positions_test.cpp
+++ b/src/test/operators/union_positions_test.cpp
@@ -36,8 +36,8 @@ TEST_F(UnionPositionsTest, SelfUnionSimple) {
 
   auto get_table_a_op = std::make_shared<GetTable>("10_ints");
   auto get_table_b_op = std::make_shared<GetTable>("10_ints");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::GreaterThan, 24);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::GreaterThan, 24);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::GreaterThan, 24);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, PredicateCondition::GreaterThan, 24);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op});
 
@@ -61,8 +61,8 @@ TEST_F(UnionPositionsTest, SelfUnionExlusiveRanges) {
 
   auto get_table_a_op = std::make_shared<GetTable>("10_ints");
   auto get_table_b_op = std::make_shared<GetTable>("10_ints");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::LessThan, 10);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::GreaterThan, 200);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::LessThan, 10);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, PredicateCondition::GreaterThan, 200);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -80,8 +80,8 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRanges) {
 
   auto get_table_a_op = std::make_shared<GetTable>("10_ints");
   auto get_table_b_op = std::make_shared<GetTable>("10_ints");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::GreaterThan, 20);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::LessThan, 100);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::GreaterThan, 20);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, PredicateCondition::LessThan, 100);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -96,8 +96,8 @@ TEST_F(UnionPositionsTest, EarlyResultLeft) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::LessThan, 12346);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::LessThan, 0);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::LessThan, 12346);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, PredicateCondition::LessThan, 0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -114,8 +114,8 @@ TEST_F(UnionPositionsTest, EarlyResultRight) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::LessThan, 0);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, ScanType::LessThan, 12346);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::LessThan, 0);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{0}, PredicateCondition::LessThan, 12346);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -134,8 +134,8 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRangesMultipleColumns) {
 
   auto get_table_a_op = std::make_shared<GetTable>("int_float4");
   auto get_table_b_op = std::make_shared<GetTable>("int_float4");
-  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, ScanType::GreaterThan, 12345);
-  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{1}, ScanType::LessThan, 400.0);
+  auto table_scan_a_op = std::make_shared<TableScan>(get_table_a_op, ColumnID{0}, PredicateCondition::GreaterThan, 12345);
+  auto table_scan_b_op = std::make_shared<TableScan>(get_table_b_op, ColumnID{1}, PredicateCondition::LessThan, 400.0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, table_scan_a_op, table_scan_b_op, union_unique_op});
@@ -181,12 +181,12 @@ TEST_F(UnionPositionsTest, MultipleReferencedTables) {
   auto get_table_c_op = std::make_shared<GetTable>("int_float4");
   auto get_table_d_op = std::make_shared<GetTable>("int_int");
   auto join_a = std::make_shared<JoinNestedLoop>(get_table_a_op, get_table_b_op, JoinMode::Inner,
-                                                 std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                                 std::make_pair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   auto join_b = std::make_shared<JoinNestedLoop>(get_table_c_op, get_table_d_op, JoinMode::Inner,
-                                                 std::make_pair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+                                                 std::make_pair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
 
-  auto table_scan_a_op = std::make_shared<TableScan>(join_a, ColumnID{3}, ScanType::GreaterThanEquals, 2);
-  auto table_scan_b_op = std::make_shared<TableScan>(join_b, ColumnID{1}, ScanType::LessThan, 457.0);
+  auto table_scan_a_op = std::make_shared<TableScan>(join_a, ColumnID{3}, PredicateCondition::GreaterThanEquals, 2);
+  auto table_scan_b_op = std::make_shared<TableScan>(join_b, ColumnID{1}, PredicateCondition::LessThan, 457.0);
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
 
   _execute_all({get_table_a_op, get_table_b_op, get_table_c_op, get_table_d_op, join_a, join_b, table_scan_a_op,

--- a/src/test/operators/update_test.cpp
+++ b/src/test/operators/update_test.cpp
@@ -39,7 +39,7 @@ void OperatorsUpdateTest::helper(std::shared_ptr<GetTable> table_to_update, std:
   auto t_context = TransactionManager::get().new_transaction_context();
 
   // Make input left actually referenced. Projection does NOT generate ReferenceColumns.
-  auto ref_table = std::make_shared<TableScan>(table_to_update, ColumnID{0}, ScanType::GreaterThan, 0);
+  auto ref_table = std::make_shared<TableScan>(table_to_update, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   ref_table->set_transaction_context(t_context);
   ref_table->execute();
 
@@ -158,7 +158,7 @@ TEST_F(OperatorsUpdateTest, MissingChunks) {
   gt->execute();
 
   // table scan will leave out first two chunks
-  auto table_scan1 = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::Equals, "12345");
+  auto table_scan1 = std::make_shared<TableScan>(gt, ColumnID{0}, PredicateCondition::Equals, "12345");
   table_scan1->set_transaction_context(t_context);
   table_scan1->execute();
 

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -69,7 +69,7 @@ TEST_F(OperatorsValidateTest, ScanValidate) {
 
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/validate_output_validated_scanned.tbl", 2u);
 
-  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, ScanType::GreaterThanEquals, 2);
+  auto table_scan = std::make_shared<TableScan>(_table_wrapper, ColumnID{0}, PredicateCondition::GreaterThanEquals, 2);
   table_scan->set_transaction_context(context);
   table_scan->execute();
 

--- a/src/test/optimizer/column_statistics_test.cpp
+++ b/src/test/optimizer/column_statistics_test.cpp
@@ -40,7 +40,8 @@ class ColumnStatisticsTest : public BaseTest {
                                          const std::vector<float>& expected_selectivities) {
     auto expected_selectivities_itr = expected_selectivities.begin();
     for (const auto& value : values) {
-      auto result_container = column_statistic->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(value));
+      auto result_container =
+          column_statistic->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(value));
       EXPECT_FLOAT_EQ(result_container.selectivity, *expected_selectivities_itr++);
     }
   }
@@ -56,7 +57,8 @@ class ColumnStatisticsTest : public BaseTest {
       for (ColumnID::base_type column_2 = 0; column_2 < column_statistics.size() && column_1 != column_2; ++column_2) {
         auto result_container = column_statistics[column_1]->estimate_selectivity_for_two_column_predicate(
             predicate_condition, column_statistics[column_2]);
-        auto table_scan = std::make_shared<TableScan>(table_wrapper, ColumnID{column_1}, predicate_condition, ColumnID{column_2});
+        auto table_scan =
+            std::make_shared<TableScan>(table_wrapper, ColumnID{column_1}, predicate_condition, ColumnID{column_2});
         table_scan->execute();
         auto result_row_count = table_scan->get_output()->row_count();
         EXPECT_FLOAT_EQ(result_container.selectivity,
@@ -68,7 +70,8 @@ class ColumnStatisticsTest : public BaseTest {
   // For BETWEEN
   template <typename T>
   void predict_selectivities_and_compare(const std::shared_ptr<ColumnStatistics<T>>& column_statistic,
-                                         const PredicateCondition predicate_condition, const std::vector<std::pair<T, T>>& values,
+                                         const PredicateCondition predicate_condition,
+                                         const std::vector<std::pair<T, T>>& values,
                                          const std::vector<float>& expected_selectivities) {
     auto expected_selectivities_itr = expected_selectivities.begin();
     for (const auto& value_pair : values) {
@@ -84,8 +87,8 @@ class ColumnStatisticsTest : public BaseTest {
       const std::vector<T>& values2, const std::vector<float>& expected_selectivities) {
     auto expected_selectivities_itr = expected_selectivities.begin();
     for (const auto& value2 : values2) {
-      auto result_container =
-          column_statistic->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0), AllTypeVariant(value2));
+      auto result_container = column_statistic->estimate_selectivity_for_predicate(
+          predicate_condition, ValuePlaceholder(0), AllTypeVariant(value2));
       EXPECT_FLOAT_EQ(result_container.selectivity, *expected_selectivities_itr++);
     }
   }
@@ -133,7 +136,8 @@ TEST_F(ColumnStatisticsTest, LessThanTest) {
 
   std::vector<float> selectivities_float{0.f, 0.f, 0.4f, 1.f, 1.f};
   predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values,
+                                    selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, LessEqualThanTest) {
@@ -144,7 +148,8 @@ TEST_F(ColumnStatisticsTest, LessEqualThanTest) {
 
   std::vector<float> selectivities_float{0.f, 0.f, 0.4f, 1.f, 1.f};
   predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values,
+                                    selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, GreaterThanTest) {
@@ -155,7 +160,8 @@ TEST_F(ColumnStatisticsTest, GreaterThanTest) {
 
   std::vector<float> selectivities_float{1.f, 1.f, 0.6f, 0.f, 0.f};
   predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values,
+                                    selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, GreaterEqualThanTest) {
@@ -166,7 +172,8 @@ TEST_F(ColumnStatisticsTest, GreaterEqualThanTest) {
 
   std::vector<float> selectivities_float{1.f, 1.f, 0.6f, 0.f, 0.f};
   predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values,
+                                    selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, BetweenTest) {
@@ -259,8 +266,8 @@ TEST_F(ColumnStatisticsTest, StoredProcedureBetweenTest) {
   std::vector<float> selectivities_float{0.f, 0.f, 2.f / 15.f, 1.f / 3.f, 1.f / 3.f};
   predict_selectivities_for_stored_procedures_and_compare(_column_statistics_float, predicate_condition, _float_values,
                                                           selectivities_float);
-  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_double, predicate_condition, _double_values,
-                                                          selectivities_float);
+  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_double, predicate_condition,
+                                                          _double_values, selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
@@ -316,10 +323,12 @@ TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {
 
 TEST_F(ColumnStatisticsTest, TwoColumnsRealDataTest) {
   // test selectivity calculations for all scan types and all column combinations of int_equal_distribution.tbl
-  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
-                                   PredicateCondition::GreaterThan};
+  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
+                                                       PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
+                                                       PredicateCondition::GreaterThan};
   for (auto predicate_condition : predicate_conditions) {
-    predict_selectivities_and_compare(_table_uniform_distribution, _column_statistics_uniform_columns, predicate_condition);
+    predict_selectivities_and_compare(_table_uniform_distribution, _column_statistics_uniform_columns,
+                                      predicate_condition);
   }
 }
 
@@ -362,10 +371,11 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
   predicate_condition = PredicateCondition::Between;
-  result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(2), AllTypeVariant(4));
+  result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(2),
+                                                                      AllTypeVariant(4));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 3.f / 6.f);
-  result =
-      _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(4.f), AllTypeVariant(6.f));
+  result = _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(4.f),
+                                                                        AllTypeVariant(6.f));
   EXPECT_FLOAT_EQ(result.selectivity, 0.5f * 2.f / 5.f);
   result = _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant("c"),
                                                                          AllTypeVariant("d"));

--- a/src/test/optimizer/column_statistics_test.cpp
+++ b/src/test/optimizer/column_statistics_test.cpp
@@ -36,11 +36,11 @@ class ColumnStatisticsTest : public BaseTest {
   // For single value scans (i.e. all but BETWEEN)
   template <typename T>
   void predict_selectivities_and_compare(const std::shared_ptr<ColumnStatistics<T>>& column_statistic,
-                                         const ScanType scan_type, const std::vector<T>& values,
+                                         const PredicateCondition predicate_condition, const std::vector<T>& values,
                                          const std::vector<float>& expected_selectivities) {
     auto expected_selectivities_itr = expected_selectivities.begin();
     for (const auto& value : values) {
-      auto result_container = column_statistic->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(value));
+      auto result_container = column_statistic->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(value));
       EXPECT_FLOAT_EQ(result_container.selectivity, *expected_selectivities_itr++);
     }
   }
@@ -48,15 +48,15 @@ class ColumnStatisticsTest : public BaseTest {
   // For two column scans (type of value1 is ColumnID)
   void predict_selectivities_and_compare(const std::shared_ptr<Table>& table,
                                          const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics,
-                                         const ScanType scan_type) {
+                                         const PredicateCondition predicate_condition) {
     auto table_wrapper = std::make_shared<TableWrapper>(table);
     table_wrapper->execute();
     auto row_count = table->row_count();
     for (ColumnID::base_type column_1 = 0; column_1 < column_statistics.size(); ++column_1) {
       for (ColumnID::base_type column_2 = 0; column_2 < column_statistics.size() && column_1 != column_2; ++column_2) {
         auto result_container = column_statistics[column_1]->estimate_selectivity_for_two_column_predicate(
-            scan_type, column_statistics[column_2]);
-        auto table_scan = std::make_shared<TableScan>(table_wrapper, ColumnID{column_1}, scan_type, ColumnID{column_2});
+            predicate_condition, column_statistics[column_2]);
+        auto table_scan = std::make_shared<TableScan>(table_wrapper, ColumnID{column_1}, predicate_condition, ColumnID{column_2});
         table_scan->execute();
         auto result_row_count = table_scan->get_output()->row_count();
         EXPECT_FLOAT_EQ(result_container.selectivity,
@@ -68,24 +68,24 @@ class ColumnStatisticsTest : public BaseTest {
   // For BETWEEN
   template <typename T>
   void predict_selectivities_and_compare(const std::shared_ptr<ColumnStatistics<T>>& column_statistic,
-                                         const ScanType scan_type, const std::vector<std::pair<T, T>>& values,
+                                         const PredicateCondition predicate_condition, const std::vector<std::pair<T, T>>& values,
                                          const std::vector<float>& expected_selectivities) {
     auto expected_selectivities_itr = expected_selectivities.begin();
     for (const auto& value_pair : values) {
       auto result_container = column_statistic->estimate_selectivity_for_predicate(
-          scan_type, AllTypeVariant(value_pair.first), AllTypeVariant(value_pair.second));
+          predicate_condition, AllTypeVariant(value_pair.first), AllTypeVariant(value_pair.second));
       EXPECT_FLOAT_EQ(result_container.selectivity, *expected_selectivities_itr++);
     }
   }
 
   template <typename T>
   void predict_selectivities_for_stored_procedures_and_compare(
-      const std::shared_ptr<ColumnStatistics<T>>& column_statistic, const ScanType scan_type,
+      const std::shared_ptr<ColumnStatistics<T>>& column_statistic, const PredicateCondition predicate_condition,
       const std::vector<T>& values2, const std::vector<float>& expected_selectivities) {
     auto expected_selectivities_itr = expected_selectivities.begin();
     for (const auto& value2 : values2) {
       auto result_container =
-          column_statistic->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0), AllTypeVariant(value2));
+          column_statistic->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0), AllTypeVariant(value2));
       EXPECT_FLOAT_EQ(result_container.selectivity, *expected_selectivities_itr++);
     }
   }
@@ -106,171 +106,171 @@ class ColumnStatisticsTest : public BaseTest {
 };
 
 TEST_F(ColumnStatisticsTest, NotEqualTest) {
-  ScanType scan_type = ScanType::NotEquals;
+  PredicateCondition predicate_condition = PredicateCondition::NotEquals;
 
   std::vector<float> selectivities{1.f, 5.f / 6.f, 5.f / 6.f, 5.f / 6.f, 1.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities);
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, _float_values, selectivities);
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, _double_values, selectivities);
-  predict_selectivities_and_compare(_column_statistics_string, scan_type, _string_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, _int_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_string, predicate_condition, _string_values, selectivities);
 }
 
 TEST_F(ColumnStatisticsTest, EqualsTest) {
-  ScanType scan_type = ScanType::Equals;
+  PredicateCondition predicate_condition = PredicateCondition::Equals;
 
   std::vector<float> selectivities{0.f, 1.f / 6.f, 1.f / 6.f, 1.f / 6.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities);
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, _float_values, selectivities);
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, _double_values, selectivities);
-  predict_selectivities_and_compare(_column_statistics_string, scan_type, _string_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, _int_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities);
+  predict_selectivities_and_compare(_column_statistics_string, predicate_condition, _string_values, selectivities);
 }
 
 TEST_F(ColumnStatisticsTest, LessThanTest) {
-  ScanType scan_type = ScanType::LessThan;
+  PredicateCondition predicate_condition = PredicateCondition::LessThan;
 
   std::vector<float> selectivities_int{0.f, 0.f, 1.f / 3.f, 5.f / 6.f, 1.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, _int_values, selectivities_int);
 
   std::vector<float> selectivities_float{0.f, 0.f, 0.4f, 1.f, 1.f};
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, LessEqualThanTest) {
-  ScanType scan_type = ScanType::LessThanEquals;
+  PredicateCondition predicate_condition = PredicateCondition::LessThanEquals;
 
   std::vector<float> selectivities_int{0.f, 1.f / 6.f, 1.f / 2.f, 1.f, 1.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, _int_values, selectivities_int);
 
   std::vector<float> selectivities_float{0.f, 0.f, 0.4f, 1.f, 1.f};
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, GreaterThanTest) {
-  ScanType scan_type = ScanType::GreaterThan;
+  PredicateCondition predicate_condition = PredicateCondition::GreaterThan;
 
   std::vector<float> selectivities_int{1.f, 5.f / 6.f, 1.f / 2.f, 0.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, _int_values, selectivities_int);
 
   std::vector<float> selectivities_float{1.f, 1.f, 0.6f, 0.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, GreaterEqualThanTest) {
-  ScanType scan_type = ScanType::GreaterThanEquals;
+  PredicateCondition predicate_condition = PredicateCondition::GreaterThanEquals;
 
   std::vector<float> selectivities_int{1.f, 1.f, 2.f / 3.f, 1.f / 6.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, _int_values, selectivities_int);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, _int_values, selectivities_int);
 
   std::vector<float> selectivities_float{1.f, 1.f, 0.6f, 0.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, _float_values, selectivities_float);
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, _double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, _float_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, _double_values, selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, BetweenTest) {
-  ScanType scan_type = ScanType::Between;
+  PredicateCondition predicate_condition = PredicateCondition::Between;
 
   std::vector<std::pair<int32_t, int32_t>> int_values{{-1, 0}, {-1, 2}, {1, 2}, {0, 7}, {5, 6}, {5, 8}, {7, 8}};
   std::vector<float> selectivities_int{0.f, 1.f / 3.f, 1.f / 3.f, 1.f, 1.f / 3.f, 1.f / 3.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_int, scan_type, int_values, selectivities_int);
+  predict_selectivities_and_compare(_column_statistics_int, predicate_condition, int_values, selectivities_int);
 
   std::vector<std::pair<float, float>> float_values{{-1.f, 0.f}, {-1.f, 2.f}, {1.f, 2.f}, {0.f, 7.f},
                                                     {5.f, 6.f},  {5.f, 8.f},  {7.f, 8.f}};
   std::vector<float> selectivities_float{0.f, 1.f / 5.f, 1.f / 5.f, 1.f, 1.f / 5.f, 1.f / 5.f, 0.f};
-  predict_selectivities_and_compare(_column_statistics_float, scan_type, float_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_float, predicate_condition, float_values, selectivities_float);
 
   std::vector<std::pair<double, double>> double_values{{-1., 0.}, {-1., 2.}, {1., 2.}, {0., 7.},
                                                        {5., 6.},  {5., 8.},  {7., 8.}};
-  predict_selectivities_and_compare(_column_statistics_double, scan_type, double_values, selectivities_float);
+  predict_selectivities_and_compare(_column_statistics_double, predicate_condition, double_values, selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureNotEqualsTest) {
-  ScanType scan_type = ScanType::NotEquals;
+  PredicateCondition predicate_condition = PredicateCondition::NotEquals;
 
   auto result_container_int =
-      _column_statistics_int->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_int.selectivity, 5.f / 6.f);
 
   auto result_container_float =
-      _column_statistics_float->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_float.selectivity, 5.f / 6.f);
 
   auto result_container_double =
-      _column_statistics_double->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_double->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_double.selectivity, 5.f / 6.f);
 
   auto result_container_string =
-      _column_statistics_string->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_string.selectivity, 5.f / 6.f);
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureEqualsTest) {
-  ScanType scan_type = ScanType::Equals;
+  PredicateCondition predicate_condition = PredicateCondition::Equals;
 
   auto result_container_int =
-      _column_statistics_int->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_int.selectivity, 1.f / 6.f);
 
   auto result_container_float =
-      _column_statistics_float->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_float.selectivity, 1.f / 6.f);
 
   auto result_container_double =
-      _column_statistics_double->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_double->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_double.selectivity, 1.f / 6.f);
 
   auto result_container_string =
-      _column_statistics_string->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_string.selectivity, 1.f / 6.f);
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureOpenEndedTest) {
   // OpLessThan, OpGreaterThan, OpLessThanEquals, OpGreaterThanEquals are same for stored procedures
-  ScanType scan_type = ScanType::LessThan;
+  PredicateCondition predicate_condition = PredicateCondition::LessThan;
 
   auto result_container_int =
-      _column_statistics_int->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_int.selectivity, 1.f / 3.f);
 
   auto result_container_float =
-      _column_statistics_float->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_float.selectivity, 1.f / 3.f);
 
   auto result_container_double =
-      _column_statistics_double->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_double->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_double.selectivity, 1.f / 3.f);
 
   auto result_container_string =
-      _column_statistics_string->estimate_selectivity_for_predicate(scan_type, ValuePlaceholder(0));
+      _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, ValuePlaceholder(0));
   EXPECT_FLOAT_EQ(result_container_string.selectivity, 1.f / 3.f);
 }
 
 TEST_F(ColumnStatisticsTest, StoredProcedureBetweenTest) {
-  ScanType scan_type = ScanType::Between;
+  PredicateCondition predicate_condition = PredicateCondition::Between;
 
   // selectivities = selectivities from LessEqualThan / 0.3f
 
   std::vector<float> selectivities_int{0.f, 1.f / 18.f, 1.f / 6.f, 1.f / 3.f, 1.f / 3.f};
-  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_int, scan_type, _int_values,
+  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_int, predicate_condition, _int_values,
                                                           selectivities_int);
 
   std::vector<float> selectivities_float{0.f, 0.f, 2.f / 15.f, 1.f / 3.f, 1.f / 3.f};
-  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_float, scan_type, _float_values,
+  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_float, predicate_condition, _float_values,
                                                           selectivities_float);
-  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_double, scan_type, _double_values,
+  predict_selectivities_for_stored_procedures_and_compare(_column_statistics_double, predicate_condition, _double_values,
                                                           selectivities_float);
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
-  ScanType scan_type = ScanType::Equals;
+  PredicateCondition predicate_condition = PredicateCondition::Equals;
 
   auto col_stat1 = std::make_shared<ColumnStatistics<int>>(ColumnID(0), 10.f, 0, 10);
   auto col_stat2 = std::make_shared<ColumnStatistics<int>>(ColumnID(1), 10.f, -10, 20);
 
-  auto result1 = col_stat1->estimate_selectivity_for_two_column_predicate(scan_type, col_stat2);
-  auto result2 = col_stat2->estimate_selectivity_for_two_column_predicate(scan_type, col_stat1);
+  auto result1 = col_stat1->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat2);
+  auto result2 = col_stat2->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat1);
   float expected_selectivity = (11.f / 31.f) / 10.f;
 
   EXPECT_FLOAT_EQ(result1.selectivity, expected_selectivity);
@@ -279,8 +279,8 @@ TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
   auto col_stat3 = std::make_shared<ColumnStatistics<float>>(ColumnID(0), 10.f, 0.f, 10.f);
   auto col_stat4 = std::make_shared<ColumnStatistics<float>>(ColumnID(1), 3.f, -10.f, 20.f);
 
-  auto result3 = col_stat3->estimate_selectivity_for_two_column_predicate(scan_type, col_stat4);
-  auto result4 = col_stat4->estimate_selectivity_for_two_column_predicate(scan_type, col_stat3);
+  auto result3 = col_stat3->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat4);
+  auto result4 = col_stat4->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat3);
   expected_selectivity = (10.f / 30.f) / 10.f;
 
   EXPECT_FLOAT_EQ(result3.selectivity, expected_selectivity);
@@ -288,38 +288,38 @@ TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {
-  ScanType scan_type = ScanType::LessThan;
+  PredicateCondition predicate_condition = PredicateCondition::LessThan;
 
   auto col_stat1 = std::make_shared<ColumnStatistics<int>>(ColumnID(0), 10.f, 1, 20);
   auto col_stat2 = std::make_shared<ColumnStatistics<int>>(ColumnID(1), 30.f, 11, 40);
 
-  auto result1 = col_stat1->estimate_selectivity_for_two_column_predicate(scan_type, col_stat2);
+  auto result1 = col_stat1->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat2);
   auto expected_selectivity = ((10.f / 20.f) * (10.f / 30.f) - 0.5f * 1.f / 30.f) * 0.5f + (10.f / 20.f) +
                               (20.f / 30.f) - (10.f / 20.f) * (20.f / 30.f);
   EXPECT_FLOAT_EQ(result1.selectivity, expected_selectivity);
 
-  auto result2 = col_stat2->estimate_selectivity_for_two_column_predicate(scan_type, col_stat1);
+  auto result2 = col_stat2->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat1);
   expected_selectivity = ((10.f / 20.f) * (10.f / 30.f) - 0.5f * 1.f / 30.f) * 0.5f;
   EXPECT_FLOAT_EQ(result2.selectivity, expected_selectivity);
 
   auto col_stat3 = std::make_shared<ColumnStatistics<float>>(ColumnID(0), 6.f, 0, 10);
   auto col_stat4 = std::make_shared<ColumnStatistics<float>>(ColumnID(1), 12.f, -10, 30);
 
-  auto result3 = col_stat3->estimate_selectivity_for_two_column_predicate(scan_type, col_stat4);
+  auto result3 = col_stat3->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat4);
   expected_selectivity = ((10.f / 10.f) * (10.f / 40.f) - 1.f / (4 * 6)) * 0.5f + (20.f / 40.f);
   EXPECT_FLOAT_EQ(result3.selectivity, expected_selectivity);
 
-  auto result4 = col_stat4->estimate_selectivity_for_two_column_predicate(scan_type, col_stat3);
+  auto result4 = col_stat4->estimate_selectivity_for_two_column_predicate(predicate_condition, col_stat3);
   expected_selectivity = ((10.f / 10.f) * (10.f / 40.f) - 1.f / (4 * 6)) * 0.5f + (10.f / 40.f);
   EXPECT_FLOAT_EQ(result4.selectivity, expected_selectivity);
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsRealDataTest) {
   // test selectivity calculations for all scan types and all column combinations of int_equal_distribution.tbl
-  std::vector<ScanType> scan_types{ScanType::Equals, ScanType::NotEquals, ScanType::LessThan, ScanType::LessThanEquals,
-                                   ScanType::GreaterThan};
-  for (auto scan_type : scan_types) {
-    predict_selectivities_and_compare(_table_uniform_distribution, _column_statistics_uniform_columns, scan_type);
+  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
+                                   PredicateCondition::GreaterThan};
+  for (auto predicate_condition : predicate_conditions) {
+    predict_selectivities_and_compare(_table_uniform_distribution, _column_statistics_uniform_columns, predicate_condition);
   }
 }
 
@@ -329,45 +329,45 @@ TEST_F(ColumnStatisticsTest, NonNullRatioOneColumnTest) {
   _column_statistics_float->set_null_value_ratio(0.5f);  // non-null value ratio: 0.5
   _column_statistics_string->set_null_value_ratio(1.f);  // non-null value ratio: 0
 
-  auto scan_type = ScanType::Equals;
-  auto result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(1));
+  auto predicate_condition = PredicateCondition::Equals;
+  auto result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(1));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f / 6.f);
-  result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(2.f));
+  result = _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(2.f));
   EXPECT_FLOAT_EQ(result.selectivity, 0.5f / 6.f);
-  result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("a"));
+  result = _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant("a"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::NotEquals;
-  result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(1));
+  predicate_condition = PredicateCondition::NotEquals;
+  result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(1));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 5.f / 6.f);
-  result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(2.f));
+  result = _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(2.f));
   EXPECT_FLOAT_EQ(result.selectivity, 0.5f * 5.f / 6.f);
-  result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("a"));
+  result = _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant("a"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::LessThan;
-  result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3));
+  predicate_condition = PredicateCondition::LessThan;
+  result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(3));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 2.f / 6.f);
-  result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3.f));
+  result = _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(3.f));
   EXPECT_FLOAT_EQ(result.selectivity, 0.5f * 2.f / 5.f);
-  result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("c"));
+  result = _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant("c"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::GreaterThanEquals;
-  result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3));
+  predicate_condition = PredicateCondition::GreaterThanEquals;
+  result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(3));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 4.f / 6.f);
-  result = _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(3.f));
+  result = _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(3.f));
   EXPECT_FLOAT_EQ(result.selectivity, 0.5f * 3.f / 5.f);
-  result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("c"));
+  result = _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant("c"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 
-  scan_type = ScanType::Between;
-  result = _column_statistics_int->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(2), AllTypeVariant(4));
+  predicate_condition = PredicateCondition::Between;
+  result = _column_statistics_int->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(2), AllTypeVariant(4));
   EXPECT_FLOAT_EQ(result.selectivity, 0.75f * 3.f / 6.f);
   result =
-      _column_statistics_float->estimate_selectivity_for_predicate(scan_type, AllTypeVariant(4.f), AllTypeVariant(6.f));
+      _column_statistics_float->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant(4.f), AllTypeVariant(6.f));
   EXPECT_FLOAT_EQ(result.selectivity, 0.5f * 2.f / 5.f);
-  result = _column_statistics_string->estimate_selectivity_for_predicate(scan_type, AllTypeVariant("c"),
+  result = _column_statistics_string->estimate_selectivity_for_predicate(predicate_condition, AllTypeVariant("c"),
                                                                          AllTypeVariant("d"));
   EXPECT_FLOAT_EQ(result.selectivity, 0.f);
 }
@@ -381,12 +381,12 @@ TEST_F(ColumnStatisticsTest, NonNullRatioTwoColumnTest) {
   stats_1->set_null_value_ratio(0.2);   // non-null value ratio: 0.8
   stats_2->set_null_value_ratio(0.15);  // non-null value ratio: 0.85
 
-  auto scan_type = ScanType::Equals;
-  auto result = stats_0->estimate_selectivity_for_two_column_predicate(scan_type, stats_1);
+  auto predicate_condition = PredicateCondition::Equals;
+  auto result = stats_0->estimate_selectivity_for_two_column_predicate(predicate_condition, stats_1);
   EXPECT_FLOAT_EQ(result.selectivity, 0.9f * 0.8f * 0.5f / 3.f);
 
-  scan_type = ScanType::LessThan;
-  result = stats_1->estimate_selectivity_for_two_column_predicate(scan_type, stats_2);
+  predicate_condition = PredicateCondition::LessThan;
+  result = stats_1->estimate_selectivity_for_two_column_predicate(predicate_condition, stats_2);
   EXPECT_FLOAT_EQ(result.selectivity, 0.8f * 0.85f * (1.f / 3.f + 1.f / 3.f * 1.f / 2.f));
 }
 

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -64,7 +64,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeUnaryScan) {
    */
   const auto stored_table_node = std::make_shared<StoredTableNode>("table_int_float");
   auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), ScanType::Equals, 42);
+      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), PredicateCondition::Equals, 42);
   predicate_node->set_left_child(stored_table_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
@@ -74,7 +74,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeUnaryScan) {
   const auto table_scan_op = std::dynamic_pointer_cast<TableScan>(op);
   ASSERT_TRUE(table_scan_op);
   EXPECT_EQ(table_scan_op->left_column_id(), ColumnID{1} /* "a" */);
-  EXPECT_EQ(table_scan_op->scan_type(), ScanType::Equals);
+  EXPECT_EQ(table_scan_op->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(table_scan_op->right_parameter(), AllParameterVariant(42));
 }
 
@@ -84,7 +84,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryScan) {
    */
   const auto stored_table_node = std::make_shared<StoredTableNode>("table_int_float");
   auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{0}), ScanType::Between,
+      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{0}), PredicateCondition::Between,
                                       AllParameterVariant(42), AllTypeVariant(1337));
   predicate_node->set_left_child(stored_table_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
@@ -95,13 +95,13 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryScan) {
   const auto table_scan_op2 = std::dynamic_pointer_cast<TableScan>(op);
   ASSERT_TRUE(table_scan_op2);
   EXPECT_EQ(table_scan_op2->left_column_id(), ColumnID{0} /* "a" */);
-  EXPECT_EQ(table_scan_op2->scan_type(), ScanType::LessThanEquals);
+  EXPECT_EQ(table_scan_op2->predicate_condition(), PredicateCondition::LessThanEquals);
   EXPECT_EQ(table_scan_op2->right_parameter(), AllParameterVariant(1337));
 
   const auto table_scan_op = std::dynamic_pointer_cast<const TableScan>(table_scan_op2->input_left());
   ASSERT_TRUE(table_scan_op);
   EXPECT_EQ(table_scan_op->left_column_id(), ColumnID{0} /* "a" */);
-  EXPECT_EQ(table_scan_op->scan_type(), ScanType::GreaterThanEquals);
+  EXPECT_EQ(table_scan_op->predicate_condition(), PredicateCondition::GreaterThanEquals);
   EXPECT_EQ(table_scan_op->right_parameter(), AllParameterVariant(42));
 }
 
@@ -151,7 +151,7 @@ TEST_F(LQPTranslatorTest, JoinNode) {
   auto join_node = std::make_shared<JoinNode>(JoinMode::Outer,
                                               std::make_pair(LQPColumnReference(stored_table_node_left, ColumnID{1}),
                                                              LQPColumnReference(stored_table_node_right, ColumnID{0})),
-                                              ScanType::Equals);
+                                              PredicateCondition::Equals);
   join_node->set_left_child(stored_table_node_left);
   join_node->set_right_child(stored_table_node_right);
   const auto op = LQPTranslator{}.translate_node(join_node);
@@ -162,7 +162,7 @@ TEST_F(LQPTranslatorTest, JoinNode) {
   const auto join_op = std::dynamic_pointer_cast<JoinSortMerge>(op);
   ASSERT_TRUE(join_op);
   EXPECT_EQ(join_op->column_ids(), ColumnIDPair(ColumnID{1}, ColumnID{0}));
-  EXPECT_EQ(join_op->scan_type(), ScanType::Equals);
+  EXPECT_EQ(join_op->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(join_op->mode(), JoinMode::Outer);
 }
 
@@ -293,18 +293,18 @@ TEST_F(LQPTranslatorTest, MultipleNodesHierarchy) {
    */
   const auto stored_table_node_left = std::make_shared<StoredTableNode>("table_int_float");
   auto predicate_node_left = std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node_left, ColumnID{0}),
-                                                             ScanType::Equals, AllParameterVariant(42));
+                                                             PredicateCondition::Equals, AllParameterVariant(42));
   predicate_node_left->set_left_child(stored_table_node_left);
 
   const auto stored_table_node_right = std::make_shared<StoredTableNode>("table_int_float2");
   auto predicate_node_right = std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node_right, ColumnID{1}),
-                                                              ScanType::GreaterThan, AllParameterVariant(30.0));
+                                                              PredicateCondition::GreaterThan, AllParameterVariant(30.0));
   predicate_node_right->set_left_child(stored_table_node_right);
 
   auto join_node = std::make_shared<JoinNode>(
       JoinMode::Inner, LQPColumnReferencePair(LQPColumnReference(stored_table_node_left, ColumnID{0}),
                                               LQPColumnReference(stored_table_node_right, ColumnID{0})),
-      ScanType::Equals);
+      PredicateCondition::Equals);
   join_node->set_left_child(predicate_node_left);
   join_node->set_right_child(predicate_node_right);
 
@@ -318,11 +318,11 @@ TEST_F(LQPTranslatorTest, MultipleNodesHierarchy) {
 
   const auto predicate_op_left = std::dynamic_pointer_cast<const TableScan>(join_op->input_left());
   ASSERT_TRUE(predicate_op_left);
-  EXPECT_EQ(predicate_op_left->scan_type(), ScanType::Equals);
+  EXPECT_EQ(predicate_op_left->predicate_condition(), PredicateCondition::Equals);
 
   const auto predicate_op_right = std::dynamic_pointer_cast<const TableScan>(join_op->input_right());
   ASSERT_TRUE(predicate_op_right);
-  EXPECT_EQ(predicate_op_right->scan_type(), ScanType::GreaterThan);
+  EXPECT_EQ(predicate_op_right->predicate_condition(), PredicateCondition::GreaterThan);
 
   const auto get_table_op_left = std::dynamic_pointer_cast<const GetTable>(predicate_op_left->input_left());
   ASSERT_TRUE(get_table_op_left);
@@ -379,11 +379,11 @@ TEST_F(LQPTranslatorTest, DiamondShapeSimple) {
 
   auto table_node = std::make_shared<StoredTableNode>("table_int_float2");
   auto predicate_node_a =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, ScanType::Equals, 3);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, PredicateCondition::Equals, 3);
   auto predicate_node_b =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, ScanType::Equals, 4);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, PredicateCondition::Equals, 4);
   auto predicate_node_c =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{1}}, ScanType::Equals, 5.0);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{1}}, PredicateCondition::Equals, 5.0);
   auto union_node = std::make_shared<UnionNode>(UnionMode::Positions);
   const auto& lqp = union_node;
 

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -63,8 +63,8 @@ TEST_F(LQPTranslatorTest, PredicateNodeUnaryScan) {
    * Build LQP and translate to PQP
    */
   const auto stored_table_node = std::make_shared<StoredTableNode>("table_int_float");
-  auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), PredicateCondition::Equals, 42);
+  auto predicate_node = std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}),
+                                                        PredicateCondition::Equals, 42);
   predicate_node->set_left_child(stored_table_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
@@ -297,8 +297,9 @@ TEST_F(LQPTranslatorTest, MultipleNodesHierarchy) {
   predicate_node_left->set_left_child(stored_table_node_left);
 
   const auto stored_table_node_right = std::make_shared<StoredTableNode>("table_int_float2");
-  auto predicate_node_right = std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node_right, ColumnID{1}),
-                                                              PredicateCondition::GreaterThan, AllParameterVariant(30.0));
+  auto predicate_node_right =
+      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node_right, ColumnID{1}),
+                                      PredicateCondition::GreaterThan, AllParameterVariant(30.0));
   predicate_node_right->set_left_child(stored_table_node_right);
 
   auto join_node = std::make_shared<JoinNode>(

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -248,7 +248,8 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
    * isn't manipulated.
    */
 
-  const auto join_node = std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_a_b, _b_b), PredicateCondition::Equals);
+  const auto join_node =
+      std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_a_b, _b_b), PredicateCondition::Equals);
   join_node->set_left_child(_table_node_a);
   join_node->set_right_child(_table_node_b);
 

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -97,13 +97,13 @@ TEST_F(JoinDetectionRuleTest, SimpleDetectionTest) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _b_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _b_a);
   predicate_node->set_left_child(cross_join_node);
 
   // Apply rule
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output, ScanType::Equals, _a_a, _b_a);
+  ASSERT_INNER_JOIN_NODE(output, PredicateCondition::Equals, _a_a, _b_a);
 
   ASSERT_NE(output->left_child(), nullptr);
   ASSERT_NE(output->right_child(), nullptr);
@@ -141,7 +141,7 @@ TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _b_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _b_a);
   predicate_node->set_left_child(cross_join_node);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
@@ -153,7 +153,7 @@ TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child(), ScanType::Equals, _a_a, _b_a);
+  ASSERT_INNER_JOIN_NODE(output->left_child(), PredicateCondition::Equals, _a_a, _b_a);
 
   EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->left_child()->right_child()->type(), LQPNodeType::StoredTable);
@@ -214,7 +214,7 @@ TEST_F(JoinDetectionRuleTest, NoMatchingPredicate) {
   cross_join_node->set_left_child(_table_node_a);
   cross_join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _a_b);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _a_b);
   predicate_node->set_left_child(cross_join_node);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
@@ -248,11 +248,11 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
    * isn't manipulated.
    */
 
-  const auto join_node = std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_a_b, _b_b), ScanType::Equals);
+  const auto join_node = std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_a_b, _b_b), PredicateCondition::Equals);
   join_node->set_left_child(_table_node_a);
   join_node->set_right_child(_table_node_b);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _b_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _b_a);
   predicate_node->set_left_child(join_node);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
@@ -263,7 +263,7 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
   EXPECT_EQ(output->left_child()->type(), LQPNodeType::Predicate);
-  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), ScanType::Equals, _a_b, _b_b);
+  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), PredicateCondition::Equals, _a_b, _b_b);
   EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
 }
@@ -305,7 +305,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins) {
   join_node2->set_left_child(join_node1);
   join_node2->set_right_child(_table_node_c);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _b_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _b_a);
   predicate_node->set_left_child(join_node2);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
@@ -321,7 +321,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins) {
   EXPECT_EQ(first_join_node->join_mode(), JoinMode::Cross);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), ScanType::Equals, _a_a, _b_a);
+  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), PredicateCondition::Equals, _a_a, _b_a);
 
   EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
   EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
@@ -351,7 +351,7 @@ TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
    */
   const auto join_node1 = std::make_shared<JoinNode>(JoinMode::Cross);
   const auto join_node2 = std::make_shared<JoinNode>(JoinMode::Cross);
-  const auto predicate_node = std::make_shared<PredicateNode>(_b_a, ScanType::Equals, _c_b);
+  const auto predicate_node = std::make_shared<PredicateNode>(_b_a, PredicateCondition::Equals, _c_b);
 
   predicate_node->set_left_child(join_node1);
   join_node1->set_left_child(_table_node_a);
@@ -363,7 +363,7 @@ TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
 
   EXPECT_EQ(output, join_node1);
   EXPECT_EQ(output->left_child(), _table_node_a);
-  ASSERT_INNER_JOIN_NODE(output->right_child(), ScanType::Equals, _b_a, _c_b);
+  ASSERT_INNER_JOIN_NODE(output->right_child(), PredicateCondition::Equals, _b_a, _c_b);
   EXPECT_EQ(output->right_child()->left_child(), _table_node_b);
   EXPECT_EQ(output->right_child()->right_child(), _table_node_c);
 }
@@ -405,7 +405,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
   join_node2->set_left_child(join_node1);
   join_node2->set_right_child(_table_node_c);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_c_a, ScanType::Equals, _a_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_c_a, PredicateCondition::Equals, _a_a);
   predicate_node->set_left_child(join_node2);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
@@ -417,7 +417,7 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child(), ScanType::Equals, _a_a, _c_a);
+  ASSERT_INNER_JOIN_NODE(output->left_child(), PredicateCondition::Equals, _a_a, _c_a);
 
   EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::Join);
   const auto second_join_node = std::dynamic_pointer_cast<JoinNode>(output->left_child()->left_child());
@@ -455,7 +455,7 @@ TEST_F(JoinDetectionRuleTest, NoOptimizationAcrossProjection) {
   const auto projection_node = std::make_shared<ProjectionNode>(columns);
   projection_node->set_left_child(join_node);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _b_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _b_a);
   predicate_node->set_left_child(projection_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
@@ -495,7 +495,7 @@ TEST_F(JoinDetectionRuleTest, NoJoinDetectionAcrossProjections) {
   const auto projection_node = std::make_shared<ProjectionNode>(columns);
   projection_node->set_left_child(join_node);
 
-  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, ScanType::Equals, _b_a);
+  const auto predicate_node = std::make_shared<PredicateNode>(_a_a, PredicateCondition::Equals, _b_a);
   predicate_node->set_left_child(projection_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -33,7 +33,7 @@ class TableStatisticsMock : public TableStatistics {
 
   explicit TableStatisticsMock(float row_count) : TableStatistics(std::make_shared<Table>()) { _row_count = row_count; }
 
-  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id, const ScanType scan_type,
+  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id, const PredicateCondition predicate_condition,
                                                         const AllParameterVariant& value,
                                                         const std::optional<AllTypeVariant>& value2) override {
     if (column_id == ColumnID{0}) {
@@ -67,11 +67,11 @@ TEST_F(PredicateReorderingTest, SimpleReorderingTest) {
   stored_table_node->set_statistics(statistics_mock);
 
   auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, ScanType::GreaterThan, 50);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);
@@ -88,15 +88,15 @@ TEST_F(PredicateReorderingTest, MoreComplexReorderingTest) {
   stored_table_node->set_statistics(statistics_mock);
 
   auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 5);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 5);
   predicate_node_0->set_left_child(stored_table_node);
 
   auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, ScanType::GreaterThan, 1);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 1);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 9);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 9);
   predicate_node_2->set_left_child(predicate_node_1);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_2);
@@ -113,15 +113,15 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   stored_table_node->set_statistics(statistics_mock);
 
   auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, ScanType::GreaterThan, 50);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 90);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 90);
   predicate_node_2->set_left_child(predicate_node_1);
 
   const auto& expressions = LQPExpression::create_columns(
@@ -130,11 +130,11 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   projection_node->set_left_child(predicate_node_2);
 
   auto predicate_node_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
   predicate_node_3->set_left_child(projection_node);
 
   auto predicate_node_4 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, ScanType::GreaterThan, 50);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
   predicate_node_4->set_left_child(predicate_node_3);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_4);
@@ -156,11 +156,11 @@ TEST_F(PredicateReorderingTest, TwoReorderings) {
   stored_table_node->set_statistics(statistics_mock);
 
   auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, ScanType::GreaterThan, 50);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto sort_node = std::make_shared<SortNode>(
@@ -168,11 +168,11 @@ TEST_F(PredicateReorderingTest, TwoReorderings) {
   sort_node->set_left_child(predicate_node_1);
 
   auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 90);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 90);
   predicate_node_2->set_left_child(sort_node);
 
   auto predicate_node_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, ScanType::GreaterThan, 50);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
   predicate_node_3->set_left_child(predicate_node_2);
 
   const auto& expressions = LQPExpression::create_columns(
@@ -201,11 +201,11 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
   // Setup first LQP
   // predicate_node_1 -> predicate_node_0 -> stored_table_node
   auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::LessThan, 20);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 20);
   predicate_node_0->set_left_child(stored_table_node);
 
   auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::LessThan, 40);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 40);
   predicate_node_1->set_left_child(predicate_node_0);
 
   predicate_node_1->get_statistics();
@@ -215,11 +215,11 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
   // Setup second LQP
   // predicate_node_3 -> predicate_node_2 -> stored_table_node
   auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::LessThan, 40);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 40);
   predicate_node_2->set_left_child(stored_table_node);
 
   auto predicate_node_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::LessThan, 20);
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 20);
   predicate_node_3->set_left_child(predicate_node_2);
 
   auto reordered_1 = StrategyBaseTest::apply_rule(_rule, predicate_node_3);
@@ -259,15 +259,15 @@ TEST_F(PredicateReorderingTest, PredicatesAsRightChild) {
   auto table_1 = std::make_shared<MockNode>(table_statistics);
   auto cross_node = std::make_shared<JoinNode>(JoinMode::Cross);
   auto predicate_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_0, ColumnID{0}}, ScanType::GreaterThan, 80);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_0, ColumnID{0}}, PredicateCondition::GreaterThan, 80);
   auto predicate_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_0, ColumnID{0}}, ScanType::GreaterThan, 60);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_0, ColumnID{0}}, PredicateCondition::GreaterThan, 60);
   auto predicate_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_1, ColumnID{0}}, ScanType::GreaterThan, 90);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_1, ColumnID{0}}, PredicateCondition::GreaterThan, 90);
   auto predicate_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_1, ColumnID{0}}, ScanType::GreaterThan, 50);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_1, ColumnID{0}}, PredicateCondition::GreaterThan, 50);
   auto predicate_4 =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_1, ColumnID{0}}, ScanType::GreaterThan, 30);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_1, ColumnID{0}}, PredicateCondition::GreaterThan, 30);
 
   predicate_1->set_left_child(table_0);
   predicate_0->set_left_child(predicate_1);
@@ -314,9 +314,9 @@ TEST_F(PredicateReorderingTest, PredicatesWithMultipleParents) {
   auto table_node = std::make_shared<MockNode>(table_statistics);
   auto union_node = std::make_shared<UnionNode>(UnionMode::Positions);
   auto predicate_a_node =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, ScanType::GreaterThan, 90);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 90);
   auto predicate_b_node =
-      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+      std::make_shared<PredicateNode>(LQPColumnReference{table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
 
   union_node->set_left_child(predicate_a_node);
   union_node->set_right_child(predicate_b_node);

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -33,7 +33,8 @@ class TableStatisticsMock : public TableStatistics {
 
   explicit TableStatisticsMock(float row_count) : TableStatistics(std::make_shared<Table>()) { _row_count = row_count; }
 
-  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id, const PredicateCondition predicate_condition,
+  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id,
+                                                        const PredicateCondition predicate_condition,
                                                         const AllParameterVariant& value,
                                                         const std::optional<AllTypeVariant>& value2) override {
     if (column_id == ColumnID{0}) {
@@ -66,12 +67,12 @@ TEST_F(PredicateReorderingTest, SimpleReorderingTest) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}},
+                                                          PredicateCondition::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);
@@ -87,16 +88,16 @@ TEST_F(PredicateReorderingTest, MoreComplexReorderingTest) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 5);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 5);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 1);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}},
+                                                          PredicateCondition::GreaterThan, 1);
   predicate_node_1->set_left_child(predicate_node_0);
 
-  auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 9);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 9);
   predicate_node_2->set_left_child(predicate_node_1);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_2);
@@ -112,16 +113,16 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}},
+                                                          PredicateCondition::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
-  auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 90);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 90);
   predicate_node_2->set_left_child(predicate_node_1);
 
   const auto& expressions = LQPExpression::create_columns(
@@ -129,12 +130,12 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
   const auto projection_node = std::make_shared<ProjectionNode>(expressions);
   projection_node->set_left_child(predicate_node_2);
 
-  auto predicate_node_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_3 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_3->set_left_child(projection_node);
 
-  auto predicate_node_4 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
+  auto predicate_node_4 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}},
+                                                          PredicateCondition::GreaterThan, 50);
   predicate_node_4->set_left_child(predicate_node_3);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_4);
@@ -155,24 +156,24 @@ TEST_F(PredicateReorderingTest, TwoReorderings) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}},
+                                                          PredicateCondition::GreaterThan, 50);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto sort_node = std::make_shared<SortNode>(
       std::vector<OrderByDefinition>{{LQPColumnReference{stored_table_node, ColumnID{0}}, OrderByMode::Ascending}});
   sort_node->set_left_child(predicate_node_1);
 
-  auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 90);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 90);
   predicate_node_2->set_left_child(sort_node);
 
-  auto predicate_node_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
+  auto predicate_node_3 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{1}},
+                                                          PredicateCondition::GreaterThan, 50);
   predicate_node_3->set_left_child(predicate_node_2);
 
   const auto& expressions = LQPExpression::create_columns(
@@ -200,12 +201,12 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
 
   // Setup first LQP
   // predicate_node_1 -> predicate_node_0 -> stored_table_node
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 20);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::LessThan, 20);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 40);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::LessThan, 40);
   predicate_node_1->set_left_child(predicate_node_0);
 
   predicate_node_1->get_statistics();
@@ -214,12 +215,12 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
 
   // Setup second LQP
   // predicate_node_3 -> predicate_node_2 -> stored_table_node
-  auto predicate_node_2 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 40);
+  auto predicate_node_2 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::LessThan, 40);
   predicate_node_2->set_left_child(stored_table_node);
 
-  auto predicate_node_3 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 20);
+  auto predicate_node_3 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::LessThan, 20);
   predicate_node_3->set_left_child(predicate_node_2);
 
   auto reordered_1 = StrategyBaseTest::apply_rule(_rule, predicate_node_3);

--- a/src/test/optimizer/table_statistics_join_test.cpp
+++ b/src/test/optimizer/table_statistics_join_test.cpp
@@ -40,7 +40,8 @@ class TableStatisticsJoinTest : public BaseTest {
         auto column_ids = std::make_pair(ColumnID{column_1}, ColumnID{column_2});
         auto join_stats = table_with_statistics.statistics->generate_predicated_join_statistics(
             table_with_statistics.statistics, mode, column_ids, predicate_condition);
-        auto join = std::make_shared<JoinNestedLoop>(table_wrapper, table_wrapper, mode, column_ids, predicate_condition);
+        auto join =
+            std::make_shared<JoinNestedLoop>(table_wrapper, table_wrapper, mode, column_ids, predicate_condition);
         join->execute();
         auto result = join->get_output();
         EXPECT_FLOAT_EQ(result->row_count(), join_stats->row_count());
@@ -53,7 +54,8 @@ class TableStatisticsJoinTest : public BaseTest {
    * compared to predicted row count.
    */
   void predict_join_row_counts_and_compare(const TableWithStatistics& table_with_statistics, const JoinMode mode,
-                                           const PredicateCondition predicate_condition, const std::vector<uint32_t> row_counts) {
+                                           const PredicateCondition predicate_condition,
+                                           const std::vector<uint32_t> row_counts) {
     for (ColumnID::base_type column_1 = 0; column_1 < table_with_statistics.table->column_count(); ++column_1) {
       for (ColumnID::base_type column_2 = 0; column_2 < table_with_statistics.table->column_count(); ++column_2) {
         auto column_ids = std::make_pair(ColumnID{column_1}, ColumnID{column_2});
@@ -72,8 +74,9 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and column
   // combinations of int_equal_distribution.tbl
   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
-  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals,         PredicateCondition::NotEquals,   PredicateCondition::LessThan,
-                                   PredicateCondition::LessThanEquals, PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals};
+  std::vector<PredicateCondition> predicate_conditions{
+      PredicateCondition::Equals,         PredicateCondition::NotEquals,   PredicateCondition::LessThan,
+      PredicateCondition::LessThanEquals, PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals};
 
   // 3 dimensional table of cached row count results
   // [ join_modes index ][ predicate_conditions index ][ column combination index = 4 * col1_index + col2_index ]
@@ -102,9 +105,11 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
       }};
 
   for (auto join_modes_index = 0u; join_modes_index < join_modes.size(); ++join_modes_index) {
-    for (auto predicate_conditions_index = 0u; predicate_conditions_index < predicate_conditions.size(); ++predicate_conditions_index) {
+    for (auto predicate_conditions_index = 0u; predicate_conditions_index < predicate_conditions.size();
+         ++predicate_conditions_index) {
       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_modes[join_modes_index],
-                                          predicate_conditions[predicate_conditions_index], row_counts[join_modes_index][predicate_conditions_index]);
+                                          predicate_conditions[predicate_conditions_index],
+                                          row_counts[join_modes_index][predicate_conditions_index]);
     }
   }
 }
@@ -114,10 +119,10 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
 //   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and
 //   // column combinations of int_equal_distribution.tbl
 //   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
-//   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals,         PredicateCondition::NotEquals,   PredicateCondition::LessThan,
-//                                    PredicateCondition::LessThanEquals, PredicateCondition::GreaterThan,
-//                                    PredicateCondition::GreaterThanEquals};
-
+//   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
+//                                    PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
+//                                    PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals};
+//
 //   for (const auto join_mode : join_modes) {
 //     for (const auto predicate_condition : predicate_conditions) {
 //       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_mode, predicate_condition);
@@ -136,14 +141,15 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
   // column combinations of int_equal_distribution.tbl
 
-  // Currently, the statistics component produces in some cases for a two column predicate with PredicateCondition::LessThan
-  // and PredicateCondition::GreaterThan a column statistics with a too high distinct count. (See comment column_statistics.hpp
-  // for details). Null value calculations depend on the calculated distinct counts of the columns. Therefore, tests
-  // for the mentioned scan types with null values are skipped.
+  // Currently, the statistics component produces in some cases for a two column predicate with
+  // PredicateCondition::LessThan and PredicateCondition::GreaterThan a column statistics with a too high distinct
+  // count. (See comment column_statistics.hpp for details). Null value calculations depend on the calculated distinct
+  // counts of the columns. Therefore, tests for the mentioned scan types with null values are skipped.
 
   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
-  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThanEquals,
-                                   PredicateCondition::GreaterThanEquals};  // PredicateCondition::LessThan, PredicateCondition::GreaterThan,
+  std::vector<PredicateCondition> predicate_conditions{
+      PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThanEquals,
+      PredicateCondition::GreaterThanEquals};  // PredicateCondition::LessThan, PredicateCondition::GreaterThan,
 
   // 3 dimensional table of cached row count results
   // [ join_modes index ][ predicate_conditions index ][ column combination index = 4 * col1_index + col2_index ]
@@ -177,9 +183,11 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
       }};
 
   for (auto join_modes_index = 0u; join_modes_index < join_modes.size(); ++join_modes_index) {
-    for (auto predicate_conditions_index = 0u; predicate_conditions_index < predicate_conditions.size(); ++predicate_conditions_index) {
+    for (auto predicate_conditions_index = 0u; predicate_conditions_index < predicate_conditions.size();
+         ++predicate_conditions_index) {
       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_modes[join_modes_index],
-                                          predicate_conditions[predicate_conditions_index], row_counts[join_modes_index][predicate_conditions_index]);
+                                          predicate_conditions[predicate_conditions_index],
+                                          row_counts[join_modes_index][predicate_conditions_index]);
     }
   }
 }
@@ -189,14 +197,14 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
 //   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
 //   // column combinations of int_equal_distribution.tbl
 
-//   // Currently, the statistics component produces in some cases for a two column predicate with PredicateCondition::LessThan
-//   // and PredicateCondition::GreaterThan a column statistics with a too high distinct count. (See comment
-//   // column_statistics.hpp for details). Null value calculations depend on the calculated distinct counts of the
-//   // columns. Therefore, tests for the mentioned scan types with null values are skipped.
+//   // Currently, the statistics component produces in some cases for a two column predicate with
+//   // PredicateCondition::LessThan and PredicateCondition::GreaterThan a column statistics with a too high distinct
+//   // count. (See comment column_statistics.hpp for details). Null value calculations depend on the calculated
+//   // distinct counts of the columns. Therefore, tests for the mentioned scan types with null values are skipped.
 
 //   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
-//   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThanEquals,
-//                                    PredicateCondition::GreaterThanEquals};
+//   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
+//   PredicateCondition::LessThanEquals, PredicateCondition::GreaterThanEquals};
 
 //   for (const auto join_mode : join_modes) {
 //     for (const auto predicate_condition : predicate_conditions) {

--- a/src/test/optimizer/table_statistics_join_test.cpp
+++ b/src/test/optimizer/table_statistics_join_test.cpp
@@ -32,15 +32,15 @@ class TableStatisticsJoinTest : public BaseTest {
    * compared to predicted row count.
    */
   void predict_join_row_counts_and_compare(const TableWithStatistics& table_with_statistics, const JoinMode mode,
-                                           const ScanType scan_type) {
+                                           const PredicateCondition predicate_condition) {
     auto table_wrapper = std::make_shared<TableWrapper>(table_with_statistics.table);
     table_wrapper->execute();
     for (ColumnID::base_type column_1 = 0; column_1 < table_with_statistics.table->column_count(); ++column_1) {
       for (ColumnID::base_type column_2 = 0; column_2 < table_with_statistics.table->column_count(); ++column_2) {
         auto column_ids = std::make_pair(ColumnID{column_1}, ColumnID{column_2});
         auto join_stats = table_with_statistics.statistics->generate_predicated_join_statistics(
-            table_with_statistics.statistics, mode, column_ids, scan_type);
-        auto join = std::make_shared<JoinNestedLoop>(table_wrapper, table_wrapper, mode, column_ids, scan_type);
+            table_with_statistics.statistics, mode, column_ids, predicate_condition);
+        auto join = std::make_shared<JoinNestedLoop>(table_wrapper, table_wrapper, mode, column_ids, predicate_condition);
         join->execute();
         auto result = join->get_output();
         EXPECT_FLOAT_EQ(result->row_count(), join_stats->row_count());
@@ -53,12 +53,12 @@ class TableStatisticsJoinTest : public BaseTest {
    * compared to predicted row count.
    */
   void predict_join_row_counts_and_compare(const TableWithStatistics& table_with_statistics, const JoinMode mode,
-                                           const ScanType scan_type, const std::vector<uint32_t> row_counts) {
+                                           const PredicateCondition predicate_condition, const std::vector<uint32_t> row_counts) {
     for (ColumnID::base_type column_1 = 0; column_1 < table_with_statistics.table->column_count(); ++column_1) {
       for (ColumnID::base_type column_2 = 0; column_2 < table_with_statistics.table->column_count(); ++column_2) {
         auto column_ids = std::make_pair(ColumnID{column_1}, ColumnID{column_2});
         auto join_stats = table_with_statistics.statistics->generate_predicated_join_statistics(
-            table_with_statistics.statistics, mode, column_ids, scan_type);
+            table_with_statistics.statistics, mode, column_ids, predicate_condition);
         auto cached_row_count = row_counts.at(table_with_statistics.table->column_count() * column_1 + column_2);
         EXPECT_FLOAT_EQ(cached_row_count, join_stats->row_count());
       }
@@ -72,11 +72,11 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and column
   // combinations of int_equal_distribution.tbl
   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
-  std::vector<ScanType> scan_types{ScanType::Equals,         ScanType::NotEquals,   ScanType::LessThan,
-                                   ScanType::LessThanEquals, ScanType::GreaterThan, ScanType::GreaterThanEquals};
+  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals,         PredicateCondition::NotEquals,   PredicateCondition::LessThan,
+                                   PredicateCondition::LessThanEquals, PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals};
 
   // 3 dimensional table of cached row count results
-  // [ join_modes index ][ scan_types index ][ column combination index = 4 * col1_index + col2_index ]
+  // [ join_modes index ][ predicate_conditions index ][ column combination index = 4 * col1_index + col2_index ]
   const std::vector<std::vector<std::vector<uint32_t>>> row_counts{
       {
           {5400, 5400, 5400, 5400, 5400, 10800, 10800, 4320, 5400, 10800, 16200, 6480, 5400, 4320, 6480, 6480},
@@ -102,9 +102,9 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
       }};
 
   for (auto join_modes_index = 0u; join_modes_index < join_modes.size(); ++join_modes_index) {
-    for (auto scan_types_index = 0u; scan_types_index < scan_types.size(); ++scan_types_index) {
+    for (auto predicate_conditions_index = 0u; predicate_conditions_index < predicate_conditions.size(); ++predicate_conditions_index) {
       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_modes[join_modes_index],
-                                          scan_types[scan_types_index], row_counts[join_modes_index][scan_types_index]);
+                                          predicate_conditions[predicate_conditions_index], row_counts[join_modes_index][predicate_conditions_index]);
     }
   }
 }
@@ -114,13 +114,13 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
 //   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and
 //   // column combinations of int_equal_distribution.tbl
 //   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
-//   std::vector<ScanType> scan_types{ScanType::Equals,         ScanType::NotEquals,   ScanType::LessThan,
-//                                    ScanType::LessThanEquals, ScanType::GreaterThan,
-//                                    ScanType::GreaterThanEquals};
+//   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals,         PredicateCondition::NotEquals,   PredicateCondition::LessThan,
+//                                    PredicateCondition::LessThanEquals, PredicateCondition::GreaterThan,
+//                                    PredicateCondition::GreaterThanEquals};
 
 //   for (const auto join_mode : join_modes) {
-//     for (const auto scan_type : scan_types) {
-//       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_mode, scan_type);
+//     for (const auto predicate_condition : predicate_conditions) {
+//       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_mode, predicate_condition);
 //     }
 //   }
 // }
@@ -136,17 +136,17 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
   // column combinations of int_equal_distribution.tbl
 
-  // Currently, the statistics component produces in some cases for a two column predicate with ScanType::LessThan
-  // and ScanType::GreaterThan a column statistics with a too high distinct count. (See comment column_statistics.hpp
+  // Currently, the statistics component produces in some cases for a two column predicate with PredicateCondition::LessThan
+  // and PredicateCondition::GreaterThan a column statistics with a too high distinct count. (See comment column_statistics.hpp
   // for details). Null value calculations depend on the calculated distinct counts of the columns. Therefore, tests
   // for the mentioned scan types with null values are skipped.
 
   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
-  std::vector<ScanType> scan_types{ScanType::Equals, ScanType::NotEquals, ScanType::LessThanEquals,
-                                   ScanType::GreaterThanEquals};  // ScanType::LessThan, ScanType::GreaterThan,
+  std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThanEquals,
+                                   PredicateCondition::GreaterThanEquals};  // PredicateCondition::LessThan, PredicateCondition::GreaterThan,
 
   // 3 dimensional table of cached row count results
-  // [ join_modes index ][ scan_types index ][ column combination index = 4 * col1_index + col2_index ]
+  // [ join_modes index ][ predicate_conditions index ][ column combination index = 4 * col1_index + col2_index ]
   const std::vector<std::vector<std::vector<uint32_t>>> row_counts{
       {
           {5400, 5400, 5400, 5400, 5490, 10800, 10800, 4428, 5520, 10860, 16200, 6588, 5430, 4380, 6480, 6480},
@@ -177,9 +177,9 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
       }};
 
   for (auto join_modes_index = 0u; join_modes_index < join_modes.size(); ++join_modes_index) {
-    for (auto scan_types_index = 0u; scan_types_index < scan_types.size(); ++scan_types_index) {
+    for (auto predicate_conditions_index = 0u; predicate_conditions_index < predicate_conditions.size(); ++predicate_conditions_index) {
       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_modes[join_modes_index],
-                                          scan_types[scan_types_index], row_counts[join_modes_index][scan_types_index]);
+                                          predicate_conditions[predicate_conditions_index], row_counts[join_modes_index][predicate_conditions_index]);
     }
   }
 }
@@ -189,18 +189,18 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
 //   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
 //   // column combinations of int_equal_distribution.tbl
 
-//   // Currently, the statistics component produces in some cases for a two column predicate with ScanType::LessThan
-//   // and ScanType::GreaterThan a column statistics with a too high distinct count. (See comment
+//   // Currently, the statistics component produces in some cases for a two column predicate with PredicateCondition::LessThan
+//   // and PredicateCondition::GreaterThan a column statistics with a too high distinct count. (See comment
 //   // column_statistics.hpp for details). Null value calculations depend on the calculated distinct counts of the
 //   // columns. Therefore, tests for the mentioned scan types with null values are skipped.
 
 //   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
-//   std::vector<ScanType> scan_types{ScanType::Equals, ScanType::NotEquals, ScanType::LessThanEquals,
-//                                    ScanType::GreaterThanEquals};
+//   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals, PredicateCondition::LessThanEquals,
+//                                    PredicateCondition::GreaterThanEquals};
 
 //   for (const auto join_mode : join_modes) {
-//     for (const auto scan_type : scan_types) {
-//       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_mode, scan_type);
+//     for (const auto predicate_condition : predicate_conditions) {
+//       predict_join_row_counts_and_compare(_table_uniform_distribution_with_stats, join_mode, predicate_condition);
 //     }
 //   }
 // }

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -33,7 +33,8 @@ class TableStatisticsTest : public BaseTest {
    * Predict output size of one TableScan with statistics and compare with actual output size of an actual TableScan.
    */
   TableWithStatistics check_statistic_with_table_scan(const TableWithStatistics& table_with_statistics,
-                                                      const ColumnID column_id, const PredicateCondition predicate_condition,
+                                                      const ColumnID column_id,
+                                                      const PredicateCondition predicate_condition,
                                                       const AllParameterVariant value,
                                                       const std::optional<AllTypeVariant> value2 = std::nullopt) {
     auto table_wrapper = std::make_shared<TableWrapper>(table_with_statistics.table);
@@ -41,10 +42,12 @@ class TableStatisticsTest : public BaseTest {
 
     std::shared_ptr<TableScan> table_scan;
     if (predicate_condition == PredicateCondition::Between) {
-      auto first_table_scan = std::make_shared<TableScan>(table_wrapper, column_id, PredicateCondition::GreaterThanEquals, value);
+      auto first_table_scan =
+          std::make_shared<TableScan>(table_wrapper, column_id, PredicateCondition::GreaterThanEquals, value);
       first_table_scan->execute();
 
-      table_scan = std::make_shared<TableScan>(first_table_scan, column_id, PredicateCondition::LessThanEquals, *value2);
+      table_scan =
+          std::make_shared<TableScan>(first_table_scan, column_id, PredicateCondition::LessThanEquals, *value2);
     } else {
       table_scan = std::make_shared<TableScan>(table_wrapper, column_id, predicate_condition, value);
     }
@@ -71,7 +74,8 @@ class TableStatisticsTest : public BaseTest {
   void check_column_with_values(const TableWithStatistics& table_with_statistics, const ColumnID column_id,
                                 const PredicateCondition predicate_condition, const std::vector<T>& values) {
     for (const auto& value : values) {
-      check_statistic_with_table_scan(table_with_statistics, column_id, predicate_condition, AllParameterVariant(value));
+      check_statistic_with_table_scan(table_with_statistics, column_id, predicate_condition,
+                                      AllParameterVariant(value));
     }
   }
 
@@ -81,7 +85,8 @@ class TableStatisticsTest : public BaseTest {
    */
   template <typename T>
   void check_column_with_values(const TableWithStatistics& table_with_statistics, const ColumnID column_id,
-                                const PredicateCondition predicate_condition, const std::vector<std::pair<T, T>>& values) {
+                                const PredicateCondition predicate_condition,
+                                const std::vector<std::pair<T, T>>& values) {
     for (const auto& value_pair : values) {
       check_statistic_with_table_scan(table_with_statistics, column_id, predicate_condition,
                                       AllParameterVariant(value_pair.first), AllTypeVariant(value_pair.second));
@@ -200,7 +205,8 @@ TEST_F(TableStatisticsTest, NotOverlappingTableScans) {
 
   container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{0}, PredicateCondition::LessThan,
                                               AllParameterVariant(4));
-  container = check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::GreaterThan, AllParameterVariant(2));
+  container =
+      check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::GreaterThan, AllParameterVariant(2));
   check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::Equals, AllParameterVariant(3));
 }
 

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -33,25 +33,25 @@ class TableStatisticsTest : public BaseTest {
    * Predict output size of one TableScan with statistics and compare with actual output size of an actual TableScan.
    */
   TableWithStatistics check_statistic_with_table_scan(const TableWithStatistics& table_with_statistics,
-                                                      const ColumnID column_id, const ScanType scan_type,
+                                                      const ColumnID column_id, const PredicateCondition predicate_condition,
                                                       const AllParameterVariant value,
                                                       const std::optional<AllTypeVariant> value2 = std::nullopt) {
     auto table_wrapper = std::make_shared<TableWrapper>(table_with_statistics.table);
     table_wrapper->execute();
 
     std::shared_ptr<TableScan> table_scan;
-    if (scan_type == ScanType::Between) {
-      auto first_table_scan = std::make_shared<TableScan>(table_wrapper, column_id, ScanType::GreaterThanEquals, value);
+    if (predicate_condition == PredicateCondition::Between) {
+      auto first_table_scan = std::make_shared<TableScan>(table_wrapper, column_id, PredicateCondition::GreaterThanEquals, value);
       first_table_scan->execute();
 
-      table_scan = std::make_shared<TableScan>(first_table_scan, column_id, ScanType::LessThanEquals, *value2);
+      table_scan = std::make_shared<TableScan>(first_table_scan, column_id, PredicateCondition::LessThanEquals, *value2);
     } else {
-      table_scan = std::make_shared<TableScan>(table_wrapper, column_id, scan_type, value);
+      table_scan = std::make_shared<TableScan>(table_wrapper, column_id, predicate_condition, value);
     }
     table_scan->execute();
 
     auto post_table_scan_statistics =
-        table_with_statistics.statistics->predicate_statistics(column_id, scan_type, value, value2);
+        table_with_statistics.statistics->predicate_statistics(column_id, predicate_condition, value, value2);
     TableWithStatistics output;
     output.table = table_scan->get_output();
     output.statistics = post_table_scan_statistics;
@@ -69,9 +69,9 @@ class TableStatisticsTest : public BaseTest {
    */
   template <typename T>
   void check_column_with_values(const TableWithStatistics& table_with_statistics, const ColumnID column_id,
-                                const ScanType scan_type, const std::vector<T>& values) {
+                                const PredicateCondition predicate_condition, const std::vector<T>& values) {
     for (const auto& value : values) {
-      check_statistic_with_table_scan(table_with_statistics, column_id, scan_type, AllParameterVariant(value));
+      check_statistic_with_table_scan(table_with_statistics, column_id, predicate_condition, AllParameterVariant(value));
     }
   }
 
@@ -81,9 +81,9 @@ class TableStatisticsTest : public BaseTest {
    */
   template <typename T>
   void check_column_with_values(const TableWithStatistics& table_with_statistics, const ColumnID column_id,
-                                const ScanType scan_type, const std::vector<std::pair<T, T>>& values) {
+                                const PredicateCondition predicate_condition, const std::vector<std::pair<T, T>>& values) {
     for (const auto& value_pair : values) {
-      check_statistic_with_table_scan(table_with_statistics, column_id, scan_type,
+      check_statistic_with_table_scan(table_with_statistics, column_id, predicate_condition,
                                       AllParameterVariant(value_pair.first), AllTypeVariant(value_pair.second));
     }
   }
@@ -102,87 +102,87 @@ TEST_F(TableStatisticsTest, GetTableTest) {
 }
 
 TEST_F(TableStatisticsTest, NotEqualTest) {
-  ScanType scan_type = ScanType::NotEquals;
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, _float_values);
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, _double_values);
-  check_column_with_values(_table_a_with_statistics, ColumnID{3}, scan_type, _string_values);
+  PredicateCondition predicate_condition = PredicateCondition::NotEquals;
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, _int_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, _float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, _double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{3}, predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, EqualsTest) {
-  ScanType scan_type = ScanType::Equals;
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, _float_values);
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, _double_values);
-  check_column_with_values(_table_a_with_statistics, ColumnID{3}, scan_type, _string_values);
+  PredicateCondition predicate_condition = PredicateCondition::Equals;
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, _int_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, _float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, _double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{3}, predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, LessThanTest) {
-  ScanType scan_type = ScanType::LessThan;
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
+  PredicateCondition predicate_condition = PredicateCondition::LessThan;
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, _int_values);
   //  table statistics assigns for floating point values greater and greater equals same selectivity
   std::vector<float> custom_float_values{0.f, 1.f, 5.1f, 7.f};
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, custom_float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, custom_float_values);
   std::vector<double> custom_double_values{0., 1., 5.1, 7.};
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, custom_double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, custom_double_values);
   //  table statistics for string columns not implemented for less table scans
-  //  check_column_with_values(_table_a_with_statistics, "s", scan_type, _string_values);
+  //  check_column_with_values(_table_a_with_statistics, "s", predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, LessEqualThanTest) {
-  ScanType scan_type = ScanType::LessThanEquals;
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
+  PredicateCondition predicate_condition = PredicateCondition::LessThanEquals;
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, _int_values);
   std::vector<float> custom_float_values{0.f, 1.9f, 5.f, 7.f};
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, custom_float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, custom_float_values);
   std::vector<double> custom_double_values{0., 1.9, 5., 7.};
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, custom_double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, custom_double_values);
   //  table statistics for string columns not implemented for less equal table scans
-  //  check_column_with_values(_table_a_with_statistics, "s", scan_type, _string_values);
+  //  check_column_with_values(_table_a_with_statistics, "s", predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, GreaterThanTest) {
-  ScanType scan_type = ScanType::GreaterThan;
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
+  PredicateCondition predicate_condition = PredicateCondition::GreaterThan;
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, _int_values);
   //  table statistics assigns for floating point values greater and greater equals same selectivity
   std::vector<float> custom_float_values{0.f, 1.5f, 6.f, 7.f};
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, custom_float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, custom_float_values);
   std::vector<double> custom_double_values{0., 1.5, 6., 7.};
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, custom_double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, custom_double_values);
   //  table statistics for string columns not implemented for greater equal table scans
-  //  check_column_with_values(_table_a_with_statistics, "s", scan_type, _string_values);
+  //  check_column_with_values(_table_a_with_statistics, "s", predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, GreaterEqualThanTest) {
-  ScanType scan_type = ScanType::GreaterThanEquals;
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, _int_values);
+  PredicateCondition predicate_condition = PredicateCondition::GreaterThanEquals;
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, _int_values);
   std::vector<float> custom_float_values{0.f, 1.f, 5.1f, 7.f};
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, custom_float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, custom_float_values);
   std::vector<double> custom_double_values{0., 1., 5.1, 7.};
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, custom_double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, custom_double_values);
   //  table statistics for string columns not implemented for greater equal table scans
-  //  check_column_with_values(_table_a_with_statistics, "s", scan_type, _string_values);
+  //  check_column_with_values(_table_a_with_statistics, "s", predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, BetweenTest) {
-  ScanType scan_type = ScanType::Between;
+  PredicateCondition predicate_condition = PredicateCondition::Between;
   std::vector<std::pair<int32_t, int32_t>> int_values{{-1, 0}, {-1, 2}, {1, 2}, {0, 7}, {5, 6}, {5, 8}, {7, 8}};
-  check_column_with_values(_table_a_with_statistics, ColumnID{0}, scan_type, int_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{0}, predicate_condition, int_values);
   std::vector<std::pair<float, float>> float_values{{-1.f, 0.f}, {-1.f, 1.9f}, {1.f, 1.9f}, {0.f, 7.f},
                                                     {5.1f, 6.f}, {5.1f, 8.f},  {7.f, 8.f}};
-  check_column_with_values(_table_a_with_statistics, ColumnID{1}, scan_type, float_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{1}, predicate_condition, float_values);
   std::vector<std::pair<double, double>> double_values{{-1., 0.}, {-1., 1.9}, {1., 1.9}, {0., 7.},
                                                        {5.1, 6.}, {5.1, 8.},  {7., 8.}};
-  check_column_with_values(_table_a_with_statistics, ColumnID{2}, scan_type, double_values);
+  check_column_with_values(_table_a_with_statistics, ColumnID{2}, predicate_condition, double_values);
   std::vector<std::pair<std::string, std::string>> string_values{{"a", "a"}, {"a", "c"}, {"a", "b"}, {"a", "h"},
                                                                  {"f", "g"}, {"f", "i"}, {"h", "i"}};
   //  table statistics for string columns not implemented for between table scans
-  //  check_column_with_values(_table_a_with_statistics, "s", scan_type, _string_values);
+  //  check_column_with_values(_table_a_with_statistics, "s", predicate_condition, _string_values);
 }
 
 TEST_F(TableStatisticsTest, MultipleColumnTableScans) {
-  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{2}, ScanType::Between,
+  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{2}, PredicateCondition::Between,
                                                    AllParameterVariant(2.), AllTypeVariant(5.));
-  container = check_statistic_with_table_scan(container, ColumnID{0}, ScanType::GreaterThanEquals,
+  container = check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::GreaterThanEquals,
                                               AllParameterVariant(4), AllTypeVariant(5));
 }
 
@@ -190,18 +190,18 @@ TEST_F(TableStatisticsTest, NotOverlappingTableScans) {
   /**
    * check that min and max values of columns are set
    */
-  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{3}, ScanType::Equals,
+  auto container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{3}, PredicateCondition::Equals,
                                                    AllParameterVariant("f"));
-  check_statistic_with_table_scan(container, ColumnID{3}, ScanType::NotEquals, AllParameterVariant("f"));
+  check_statistic_with_table_scan(container, ColumnID{3}, PredicateCondition::NotEquals, AllParameterVariant("f"));
 
-  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{1}, ScanType::LessThanEquals,
+  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{1}, PredicateCondition::LessThanEquals,
                                               AllParameterVariant(3.5f));
-  check_statistic_with_table_scan(container, ColumnID{1}, ScanType::GreaterThan, AllParameterVariant(3.5f));
+  check_statistic_with_table_scan(container, ColumnID{1}, PredicateCondition::GreaterThan, AllParameterVariant(3.5f));
 
-  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{0}, ScanType::LessThan,
+  container = check_statistic_with_table_scan(_table_a_with_statistics, ColumnID{0}, PredicateCondition::LessThan,
                                               AllParameterVariant(4));
-  container = check_statistic_with_table_scan(container, ColumnID{0}, ScanType::GreaterThan, AllParameterVariant(2));
-  check_statistic_with_table_scan(container, ColumnID{0}, ScanType::Equals, AllParameterVariant(3));
+  container = check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::GreaterThan, AllParameterVariant(2));
+  check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::Equals, AllParameterVariant(3));
 }
 
 }  // namespace opossum

--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -188,7 +188,7 @@ TEST_F(SchedulerTest, MultipleOperators) {
   StorageManager::get().add_table("table", std::move(test_table));
 
   auto gt = std::make_shared<GetTable>("table");
-  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::GreaterThanEquals, 1234);
+  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, PredicateCondition::GreaterThanEquals, 1234);
 
   auto gt_task = std::make_shared<OperatorTask>(gt);
   auto ts_task = std::make_shared<OperatorTask>(ts);

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -77,7 +77,7 @@ TEST_F(SQLTranslatorTest, DISABLED_ExpressionTest /* #494 */) {
   const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(result_node->left_child());
   EXPECT_FALSE(predicate_node->right_child());
   EXPECT_EQ(predicate_node->column_reference(), LQPColumnReference(predicate_node->left_child(), ColumnID{0}));
-  EXPECT_EQ(predicate_node->scan_type(), ScanType::Equals);
+  EXPECT_EQ(predicate_node->predicate_condition(), PredicateCondition::Equals);
   // TODO(anybody): once this is implemented, the value side has to be checked.
 }
 
@@ -91,7 +91,7 @@ TEST_F(SQLTranslatorTest, TwoColumnFilter) {
   ASSERT_EQ(result_node->left_child()->type(), LQPNodeType::Predicate);
   auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(result_node->left_child());
   EXPECT_FALSE(predicate_node->right_child());
-  EXPECT_EQ(predicate_node->scan_type(), ScanType::Equals);
+  EXPECT_EQ(predicate_node->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(predicate_node->column_reference(), LQPColumnReference(predicate_node->left_child(), ColumnID{0}));
   EXPECT_EQ(predicate_node->value(),
             AllParameterVariant(LQPColumnReference(predicate_node->left_child(), ColumnID{1})));
@@ -111,7 +111,7 @@ TEST_F(SQLTranslatorTest, ExpressionStringTest) {
   EXPECT_EQ(predicate_node->type(), LQPNodeType::Predicate);
   EXPECT_FALSE(predicate_node->right_child());
   EXPECT_EQ(predicate_node->column_reference(), LQPColumnReference(predicate_node->left_child(), ColumnID{0}));
-  EXPECT_EQ(predicate_node->scan_type(), ScanType::Equals);
+  EXPECT_EQ(predicate_node->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(predicate_node->value(), AllParameterVariant{std::string{"b"}});
 }
 
@@ -278,7 +278,7 @@ TEST_F(SQLTranslatorTest, SelectInnerJoin) {
   const auto table_a_node = result_node->left_child()->left_child();
   const auto table_b_node = result_node->left_child()->right_child();
 
-  EXPECT_EQ(join_node->scan_type(), ScanType::Equals);
+  EXPECT_EQ(join_node->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(join_node->join_mode(), JoinMode::Inner);
   EXPECT_EQ(join_node->join_column_references()->first, LQPColumnReference(table_a_node, ColumnID{0}));
   EXPECT_EQ(join_node->join_column_references()->second, LQPColumnReference(table_b_node, ColumnID{0}));
@@ -315,7 +315,7 @@ TEST_P(SQLTranslatorJoinTest, SelectLeftRightOuterJoins) {
   const auto table_a_node = join_node->left_child();
   const auto table_b_node = join_node->right_child();
 
-  EXPECT_EQ(join_node->scan_type(), ScanType::Equals);
+  EXPECT_EQ(join_node->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(join_node->join_mode(), mode);
   EXPECT_EQ(join_node->join_column_references()->first, LQPColumnReference(table_a_node, ColumnID{0}));
   EXPECT_EQ(join_node->join_column_references()->second, LQPColumnReference(table_b_node, ColumnID{0}));
@@ -378,7 +378,7 @@ TEST_F(SQLTranslatorTest, SelectNaturalJoin) {
 
   EXPECT_FALSE(predicate_node->right_child());
   EXPECT_EQ(predicate_node->column_reference(), LQPColumnReference(table_a_node, ColumnID{0}));
-  EXPECT_EQ(predicate_node->scan_type(), ScanType::Equals);
+  EXPECT_EQ(predicate_node->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(predicate_node->value(), AllParameterVariant{LQPColumnReference(table_b_node, ColumnID{0})});
 }
 
@@ -394,7 +394,7 @@ TEST_F(SQLTranslatorTest, SelectCrossJoin) {
   EXPECT_EQ(result_node->left_child()->type(), LQPNodeType::Predicate);
   EXPECT_EQ(result_node->left_child()->left_child()->type(), LQPNodeType::Join);
   auto join_node = std::dynamic_pointer_cast<JoinNode>(result_node->left_child()->left_child());
-  EXPECT_FALSE(join_node->scan_type());
+  EXPECT_FALSE(join_node->predicate_condition());
   EXPECT_EQ(join_node->join_mode(), JoinMode::Cross);
 }
 
@@ -603,7 +603,7 @@ TEST_F(SQLTranslatorTest, CreateView) {
   const auto table_a_node = ts_node_1->left_child();
 
   EXPECT_EQ(ts_node_1->column_reference(), LQPColumnReference(table_a_node, ColumnID{0}));
-  EXPECT_EQ(ts_node_1->scan_type(), ScanType::Equals);
+  EXPECT_EQ(ts_node_1->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(ts_node_1->value(), AllParameterVariant{std::string{"b"}});
 }
 

--- a/src/test/tasks/operator_task_test.cpp
+++ b/src/test/tasks/operator_task_test.cpp
@@ -39,7 +39,7 @@ TEST_F(OperatorTaskTest, BasicTasksFromOperatorTest) {
 
 TEST_F(OperatorTaskTest, SingleDependencyTasksFromOperatorTest) {
   auto gt = std::make_shared<GetTable>("table_a");
-  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, ScanType::Equals, 1234);
+  auto ts = std::make_shared<TableScan>(gt, ColumnID{0}, PredicateCondition::Equals, 1234);
 
   auto tasks = OperatorTask::make_tasks_from_operator(ts);
   for (auto& task : tasks) {
@@ -54,7 +54,7 @@ TEST_F(OperatorTaskTest, DoubleDependencyTasksFromOperatorTest) {
   auto gt_a = std::make_shared<GetTable>("table_a");
   auto gt_b = std::make_shared<GetTable>("table_b");
   auto join =
-      std::make_shared<JoinHash>(gt_a, gt_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}), ScanType::Equals);
+      std::make_shared<JoinHash>(gt_a, gt_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
 
   auto tasks = OperatorTask::make_tasks_from_operator(join);
   for (auto& task : tasks) {

--- a/src/test/tasks/operator_task_test.cpp
+++ b/src/test/tasks/operator_task_test.cpp
@@ -53,8 +53,8 @@ TEST_F(OperatorTaskTest, SingleDependencyTasksFromOperatorTest) {
 TEST_F(OperatorTaskTest, DoubleDependencyTasksFromOperatorTest) {
   auto gt_a = std::make_shared<GetTable>("table_a");
   auto gt_b = std::make_shared<GetTable>("table_b");
-  auto join =
-      std::make_shared<JoinHash>(gt_a, gt_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
+  auto join = std::make_shared<JoinHash>(gt_a, gt_b, JoinMode::Inner, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+                                         PredicateCondition::Equals);
 
   auto tasks = OperatorTask::make_tasks_from_operator(join);
   for (auto& task : tasks) {

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -256,13 +256,13 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
   return true;
 }
 
-void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, ScanType scan_type,
+void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, PredicateCondition predicate_condition,
                             const LQPColumnReference& left_column_reference,
                             const LQPColumnReference& right_column_reference) {
   ASSERT_EQ(node->type(), LQPNodeType::Join);  // Can't cast otherwise
   auto join_node = std::dynamic_pointer_cast<JoinNode>(node);
   ASSERT_EQ(join_node->join_mode(), JoinMode::Inner);  // Can't access join_column_ids() otherwise
-  EXPECT_EQ(join_node->scan_type(), scan_type);
+  EXPECT_EQ(join_node->predicate_condition(), predicate_condition);
   EXPECT_EQ(join_node->join_column_references(), std::make_pair(left_column_reference, right_column_reference));
 }
 

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -47,7 +47,7 @@ bool check_table_equal(const std::shared_ptr<const Table>& opossum_table,
 
 // @}
 
-void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, ScanType scan_type,
+void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, PredicateCondition predicate_condition,
                             const LQPColumnReference& left_column_reference,
                             const LQPColumnReference& right_column_reference);
 


### PR DESCRIPTION
This renames `ScanType` which holds values like `Equals` or `LessThan` to `PredicateCondition` because this better reflects the actual meaning. In addition, `ScanType` is going to be used for the specific implementation that does execute the scanning, e.g., `TableScan`, `IndexScan`, `JITScan`.