### PR TITLE
Add optimizer rule to create IndexScans

### DIFF
--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -132,7 +132,8 @@ class TpchBenchmark final {
         _scale_factor(scale_factor),
         _max_num_query_runs(max_num_query_runs),
         _max_duration(max_duration),
-        _output_file_path(output_file_path), _enable_mvcc(enable_mvcc),
+        _output_file_path(output_file_path),
+        _enable_mvcc(enable_mvcc),
         _query_results_by_query_id() {}
 
   void run() {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -228,6 +228,7 @@ set(
     storage/index/base_index.cpp
     storage/index/base_index.hpp
     storage/index/column_index_type.hpp
+    storage/index/index_info.hpp
     storage/index/group_key/composite_group_key_index.cpp
     storage/index/group_key/composite_group_key_index.hpp
     storage/index/group_key/group_key_index.cpp

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -154,6 +154,8 @@ set(
     optimizer/optimizer.hpp
     optimizer/strategy/abstract_rule.cpp
     optimizer/strategy/abstract_rule.hpp
+    optimizer/strategy/index_scan_rule.cpp
+    optimizer/strategy/index_scan_rule.hpp
     optimizer/strategy/join_detection_rule.cpp
     optimizer/strategy/join_detection_rule.hpp
     optimizer/strategy/predicate_reordering_rule.cpp

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -86,7 +86,8 @@ std::shared_ptr<TableStatistics> JoinNode::derive_statistics_from(
   } else {
     Assert(_join_column_references,
            "Only cross joins and joins with join column ids supported for generating join statistics");
-    Assert(_predicate_condition, "Only cross joins and joins with predicate condition supported for generating join statistics");
+    Assert(_predicate_condition,
+           "Only cross joins and joins with predicate condition supported for generating join statistics");
 
     ColumnIDPair join_colum_ids{left_child->get_output_column_id(_join_column_references->first),
                                 right_child->get_output_column_id(_join_column_references->second)};

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -18,7 +18,7 @@ namespace opossum {
 
 JoinNode::JoinNode(const JoinMode join_mode) : AbstractLQPNode(LQPNodeType::Join), _join_mode(join_mode) {
   DebugAssert(join_mode == JoinMode::Cross || join_mode == JoinMode::Natural,
-              "Specified JoinMode must also specify column ids and scan type.");
+              "Specified JoinMode must also specify column ids and predicate condition.");
 }
 
 JoinNode::JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references,
@@ -28,7 +28,7 @@ JoinNode::JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_
       _join_column_references(join_column_references),
       _predicate_condition(predicate_condition) {
   DebugAssert(join_mode != JoinMode::Cross && join_mode != JoinMode::Natural,
-              "Specified JoinMode must specify neither column ids nor scan type.");
+              "Specified JoinMode must specify neither column ids nor predicate condition.");
 }
 
 std::shared_ptr<AbstractLQPNode> JoinNode::_deep_copy_impl(
@@ -86,7 +86,7 @@ std::shared_ptr<TableStatistics> JoinNode::derive_statistics_from(
   } else {
     Assert(_join_column_references,
            "Only cross joins and joins with join column ids supported for generating join statistics");
-    Assert(_predicate_condition, "Only cross joins and joins with scan type supported for generating join statistics");
+    Assert(_predicate_condition, "Only cross joins and joins with predicate condition supported for generating join statistics");
 
     ColumnIDPair join_colum_ids{left_child->get_output_column_id(_join_column_references->first),
                                 right_child->get_output_column_id(_join_column_references->second)};

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -145,7 +145,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
    * `X >= a` and one for `X <= b`
    */
   if (predicate_node->predicate_condition() == PredicateCondition::Between) {
-    DebugAssert(static_cast<bool>(predicate_node->value2()), "Scan type BETWEEN requires a second value");
+    DebugAssert(static_cast<bool>(predicate_node->value2()), "Predicate condition BETWEEN requires a second value");
     PerformanceWarning("TableScan executes BETWEEN as two separate scans");
 
     auto table_scan_gt =

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -158,7 +158,6 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
 
     return std::make_shared<UnionPositions>(index_scan, table_scan);
   } else {
-    // Todo(JK): test
     Fail("IndexScan must follow a StoredTableNode. Fail! The optimizer should have dealt with the problem.");
   }
 }

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -97,7 +97,6 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
     value = predicate_node->get_output_column_id(boost::get<const LQPColumnReference>(value));
   }
 
-
   if (predicate_node->scan_type() == ScanType::IndexScan) return _translate_predicate_node_to_index_scan(predicate_node, value, column_id, input_operator);
 
   /**
@@ -131,6 +130,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
     const auto table_name = stored_table_node->table_name();
     const auto table = StorageManager::get().get_table(table_name);
     std::vector<ChunkID> indexed_chunks;
+
     for (ChunkID chunk_id{0u}; chunk_id < table->chunk_count(); ++chunk_id) {
       const auto chunk = table->get_chunk(chunk_id);
       if (chunk->get_index(ColumnIndexType::GroupKey, column_ids)) {

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -101,7 +101,9 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
     if (is_variant(value)) {
       const auto value_variant = boost::get<AllTypeVariant>(value);
       std::vector<ColumnID> column_ids = {column_id};
-      std::vector<AllTypeVariant> values = {value_variant};
+      std::vector<AllTypeVariant> right_values  = {value_variant};
+      std::vector<AllTypeVariant> right_values2 = {};
+      if (predicate_node->value2()) right_values2.emplace_back(*predicate_node->value2());
 
 
       // Currently, we will only use IndexScans, if the predicate node directly follows a StoredTableNode
@@ -116,8 +118,17 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
           }
         }
 
-        auto index_scan = std::make_shared<IndexScan>(input_operator, ColumnIndexType::GroupKey, column_ids, predicate_node->scan_type(), values);
-        auto table_scan = std::make_shared<TableScan>(input_operator, column_id, predicate_node->scan_type(), value);
+        auto index_scan = std::make_shared<IndexScan>(input_operator, ColumnIndexType::GroupKey, column_ids, predicate_node->scan_type(), right_values, right_values2);
+
+        std::shared_ptr<TableScan> table_scan;
+        if (predicate_node->scan_type() == ScanType::Between) {
+          auto table_scan_gt = std::make_shared<TableScan>(input_operator, column_id, ScanType::GreaterThanEquals, value);
+          table_scan_gt->set_excluded_chunk_ids(indexed_chunks);
+
+          table_scan = std::make_shared<TableScan>(table_scan_gt, column_id, ScanType::LessThanEquals, *predicate_node->value2());
+        } else{
+          table_scan = std::make_shared<TableScan>(input_operator, column_id, predicate_node->scan_type(), value);
+        }
 
         index_scan->set_included_chunk_ids(indexed_chunks);
         table_scan->set_excluded_chunk_ids(indexed_chunks);

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -101,10 +101,9 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
     if (is_variant(value)) {
       const auto value_variant = boost::get<AllTypeVariant>(value);
       std::vector<ColumnID> column_ids = {column_id};
-      std::vector<AllTypeVariant> right_values  = {value_variant};
+      std::vector<AllTypeVariant> right_values = {value_variant};
       std::vector<AllTypeVariant> right_values2 = {};
       if (predicate_node->value2()) right_values2.emplace_back(*predicate_node->value2());
-
 
       // Currently, we will only use IndexScans, if the predicate node directly follows a StoredTableNode
       if (auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(predicate_node->left_child())) {
@@ -118,15 +117,18 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
           }
         }
 
-        auto index_scan = std::make_shared<IndexScan>(input_operator, ColumnIndexType::GroupKey, column_ids, predicate_node->scan_type(), right_values, right_values2);
+        auto index_scan = std::make_shared<IndexScan>(input_operator, ColumnIndexType::GroupKey, column_ids,
+                                                      predicate_node->scan_type(), right_values, right_values2);
 
         std::shared_ptr<TableScan> table_scan;
         if (predicate_node->scan_type() == ScanType::Between) {
-          auto table_scan_gt = std::make_shared<TableScan>(input_operator, column_id, ScanType::GreaterThanEquals, value);
+          auto table_scan_gt =
+              std::make_shared<TableScan>(input_operator, column_id, ScanType::GreaterThanEquals, value);
           table_scan_gt->set_excluded_chunk_ids(indexed_chunks);
 
-          table_scan = std::make_shared<TableScan>(table_scan_gt, column_id, ScanType::LessThanEquals, *predicate_node->value2());
-        } else{
+          table_scan = std::make_shared<TableScan>(table_scan_gt, column_id, ScanType::LessThanEquals,
+                                                   *predicate_node->value2());
+        } else {
           table_scan = std::make_shared<TableScan>(input_operator, column_id, predicate_node->scan_type(), value);
         }
 
@@ -134,7 +136,6 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
         table_scan->set_excluded_chunk_ids(indexed_chunks);
 
         return std::make_shared<UnionPositions>(index_scan, table_scan);
-
       }
     }
   }

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -97,7 +97,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
     value = predicate_node->get_output_column_id(boost::get<const LQPColumnReference>(value));
   }
 
-  if (predicate_node->scan_typee() == ScanTypee::IndexScan) {
+  if (predicate_node->scan_type() == ScanType::IndexScan) {
     if (is_variant(value)) {
       const auto value_variant = boost::get<AllTypeVariant>(value);
       std::vector<ColumnID> column_ids = {column_id};

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -97,7 +97,8 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
     value = predicate_node->get_output_column_id(boost::get<const LQPColumnReference>(value));
   }
 
-  if (predicate_node->scan_type() == ScanType::IndexScan) return _translate_predicate_node_to_index_scan(predicate_node, value, column_id, input_operator);
+  if (predicate_node->scan_type() == ScanType::IndexScan)
+    return _translate_predicate_node_to_index_scan(predicate_node, value, column_id, input_operator);
 
   /**
    * The TableScan Operator doesn't support BETWEEN, so for `X BETWEEN a AND b` we create two TableScans: One for
@@ -116,8 +117,12 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node(
   return std::make_shared<TableScan>(input_operator, column_id, predicate_node->predicate_condition(), value);
 }
 
-std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_index_scan(const std::shared_ptr<PredicateNode>& predicate_node, const AllParameterVariant& value, const ColumnID column_id, const std::shared_ptr<AbstractOperator> input_operator) const {
-  DebugAssert(is_variant(value), "We do not support IndexScan on two-column predicates. Fail! The optimizer should have dealt with the problem.");
+std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_index_scan(
+    const std::shared_ptr<PredicateNode>& predicate_node, const AllParameterVariant& value, const ColumnID column_id,
+    const std::shared_ptr<AbstractOperator> input_operator) const {
+  DebugAssert(
+      is_variant(value),
+      "We do not support IndexScan on two-column predicates. Fail! The optimizer should have dealt with the problem.");
 
   const auto value_variant = boost::get<AllTypeVariant>(value);
   const std::vector<ColumnID> column_ids = {column_id};

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "abstract_lqp_node.hpp"
+#include "predicate_node.hpp"
 #include "all_type_variant.hpp"
 #include "operators/abstract_operator.hpp"
 
@@ -29,6 +30,7 @@ class LQPTranslator final : private Noncopyable {
   // SQL operators
   std::shared_ptr<AbstractOperator> _translate_stored_table_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_predicate_node(const std::shared_ptr<AbstractLQPNode>& node) const;
+  std::shared_ptr<AbstractOperator> _translate_predicate_node_to_index_scan(const std::shared_ptr<PredicateNode>& node, const AllParameterVariant& value, const ColumnID column_id, const std::shared_ptr<AbstractOperator> input_operator) const;
   std::shared_ptr<AbstractOperator> _translate_projection_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_sort_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_join_node(const std::shared_ptr<AbstractLQPNode>& node) const;

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -4,9 +4,9 @@
 #include <unordered_map>
 
 #include "abstract_lqp_node.hpp"
-#include "predicate_node.hpp"
 #include "all_type_variant.hpp"
 #include "operators/abstract_operator.hpp"
+#include "predicate_node.hpp"
 
 namespace opossum {
 
@@ -30,7 +30,9 @@ class LQPTranslator final : private Noncopyable {
   // SQL operators
   std::shared_ptr<AbstractOperator> _translate_stored_table_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_predicate_node(const std::shared_ptr<AbstractLQPNode>& node) const;
-  std::shared_ptr<AbstractOperator> _translate_predicate_node_to_index_scan(const std::shared_ptr<PredicateNode>& node, const AllParameterVariant& value, const ColumnID column_id, const std::shared_ptr<AbstractOperator> input_operator) const;
+  std::shared_ptr<AbstractOperator> _translate_predicate_node_to_index_scan(
+      const std::shared_ptr<PredicateNode>& node, const AllParameterVariant& value, const ColumnID column_id,
+      const std::shared_ptr<AbstractOperator> input_operator) const;
   std::shared_ptr<AbstractOperator> _translate_projection_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_sort_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_join_node(const std::shared_ptr<AbstractLQPNode>& node) const;

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -73,6 +73,14 @@ const AllParameterVariant& PredicateNode::value() const { return _value; }
 
 const std::optional<AllTypeVariant>& PredicateNode::value2() const { return _value2; }
 
+ScanTypee PredicateNode::scan_typee() const {
+  return _scan_typee;
+}
+
+void PredicateNode::set_scan_typee(ScanTypee scan_typee) {
+  _scan_typee = scan_typee;
+}
+
 std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
     const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {
   DebugAssert(left_child && !right_child, "PredicateNode need left_child and no right_child");

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -73,13 +73,9 @@ const AllParameterVariant& PredicateNode::value() const { return _value; }
 
 const std::optional<AllTypeVariant>& PredicateNode::value2() const { return _value2; }
 
-ScanTypee PredicateNode::scan_typee() const {
-  return _scan_typee;
-}
+ScanTypee PredicateNode::scan_typee() const { return _scan_typee; }
 
-void PredicateNode::set_scan_typee(ScanTypee scan_typee) {
-  _scan_typee = scan_typee;
-}
+void PredicateNode::set_scan_typee(ScanTypee scan_typee) { _scan_typee = scan_typee; }
 
 std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
     const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -73,9 +73,9 @@ const AllParameterVariant& PredicateNode::value() const { return _value; }
 
 const std::optional<AllTypeVariant>& PredicateNode::value2() const { return _value2; }
 
-ScanTypee PredicateNode::scan_typee() const { return _scan_typee; }
+ScanType PredicateNode::scan_type() const { return _scan_type; }
 
-void PredicateNode::set_scan_typee(ScanTypee scan_typee) { _scan_typee = scan_typee; }
+void PredicateNode::set_scan_type(ScanType scan_type) { _scan_type = scan_type; }
 
 std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
     const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -14,7 +14,7 @@ namespace opossum {
 
 class TableStatistics;
 
-enum class ScanType { TableScan, IndexScan };
+enum class ScanType : uint8_t { TableScan, IndexScan };
 
 /**
  * This node type represents a filter.

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -14,6 +14,8 @@ namespace opossum {
 
 class TableStatistics;
 
+enum class ScanTypee { TableScan, IndexScan };
+
 /**
  * This node type represents a filter.
  * The most common use case is to represent a regular TableScan,
@@ -33,6 +35,9 @@ class PredicateNode : public AbstractLQPNode {
   const AllParameterVariant& value() const;
   const std::optional<AllTypeVariant>& value2() const;
 
+  ScanTypee scan_typee() const;
+  void set_scan_typee(ScanTypee scan_typee);
+
   std::shared_ptr<TableStatistics> derive_statistics_from(
       const std::shared_ptr<AbstractLQPNode>& left_child,
       const std::shared_ptr<AbstractLQPNode>& right_child = nullptr) const override;
@@ -47,6 +52,8 @@ class PredicateNode : public AbstractLQPNode {
   const ScanType _scan_type;
   const AllParameterVariant _value;
   const std::optional<AllTypeVariant> _value2;
+
+  ScanTypee _scan_typee = ScanTypee::TableScan;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -14,7 +14,7 @@ namespace opossum {
 
 class TableStatistics;
 
-enum class ScanTypee { TableScan, IndexScan };
+enum class ScanType { TableScan, IndexScan };
 
 /**
  * This node type represents a filter.
@@ -35,8 +35,8 @@ class PredicateNode : public AbstractLQPNode {
   const AllParameterVariant& value() const;
   const std::optional<AllTypeVariant>& value2() const;
 
-  ScanTypee scan_typee() const;
-  void set_scan_typee(ScanTypee scan_typee);
+  ScanType scan_type() const;
+  void set_scan_type(ScanType scan_type);
 
   std::shared_ptr<TableStatistics> derive_statistics_from(
       const std::shared_ptr<AbstractLQPNode>& left_child,
@@ -53,7 +53,7 @@ class PredicateNode : public AbstractLQPNode {
   const AllParameterVariant _value;
   const std::optional<AllTypeVariant> _value2;
 
-  ScanTypee _scan_typee = ScanTypee::TableScan;
+  ScanType _scan_type = ScanType::TableScan;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -78,8 +78,8 @@ std::shared_ptr<JobTask> IndexScan::_create_job_and_schedule(const ChunkID chunk
 }
 
 void IndexScan::_validate_input() {
-  Assert(_predicate_condition != PredicateCondition::Like, "Scan type not supported by index scan.");
-  Assert(_predicate_condition != PredicateCondition::NotLike, "Scan type not supported by index scan.");
+  Assert(_predicate_condition != PredicateCondition::Like, "Predicate condition not supported by index scan.");
+  Assert(_predicate_condition != PredicateCondition::NotLike, "Predicate condition not supported by index scan.");
 
   Assert(_left_column_ids.size() == _right_values.size(),
          "Count mismatch: left column IDs and right values don’t have same size.");

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -13,9 +13,9 @@
 
 namespace opossum {
 
-IndexScan::IndexScan(std::shared_ptr<AbstractOperator> in, const ColumnIndexType index_type,
+IndexScan::IndexScan(const std::shared_ptr<const AbstractOperator> in, const ColumnIndexType index_type,
                      std::vector<ColumnID> left_column_ids, const ScanType scan_type,
-                     std::vector<AllTypeVariant> right_values, std::vector<AllTypeVariant> right_values2)
+                     const std::vector<AllTypeVariant> right_values, const std::vector<AllTypeVariant> right_values2)
     : AbstractReadOnlyOperator{in},
       _index_type{index_type},
       _left_column_ids{left_column_ids},

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -19,6 +19,8 @@ class JobTask;
  * Note: Scans only the set of chunks passed to the constructor
  */
 class IndexScan : public AbstractReadOnlyOperator {
+ friend class LQPTranslatorTest;
+
  public:
   IndexScan(const std::shared_ptr<const AbstractOperator> in, const ColumnIndexType index_type,
             std::vector<ColumnID> left_column_ids, const ScanType scan_type, const std::vector<AllTypeVariant> right_values,

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -19,12 +19,12 @@ class JobTask;
  * Note: Scans only the set of chunks passed to the constructor
  */
 class IndexScan : public AbstractReadOnlyOperator {
- friend class LQPTranslatorTest;
+  friend class LQPTranslatorTest;
 
  public:
   IndexScan(const std::shared_ptr<const AbstractOperator> in, const ColumnIndexType index_type,
-            std::vector<ColumnID> left_column_ids, const ScanType scan_type, const std::vector<AllTypeVariant> right_values,
-            const std::vector<AllTypeVariant> right_values2 = {});
+            std::vector<ColumnID> left_column_ids, const ScanType scan_type,
+            const std::vector<AllTypeVariant> right_values, const std::vector<AllTypeVariant> right_values2 = {});
 
   const std::string name() const final;
 

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -20,9 +20,9 @@ class JobTask;
  */
 class IndexScan : public AbstractReadOnlyOperator {
  public:
-  IndexScan(std::shared_ptr<AbstractOperator> in, const ColumnIndexType index_type,
-            std::vector<ColumnID> left_column_ids, const ScanType scan_type, std::vector<AllTypeVariant> right_values,
-            std::vector<AllTypeVariant> right_values2 = {});
+  IndexScan(const std::shared_ptr<const AbstractOperator> in, const ColumnIndexType index_type,
+            std::vector<ColumnID> left_column_ids, const ScanType scan_type, const std::vector<AllTypeVariant> right_values,
+            const std::vector<AllTypeVariant> right_values2 = {});
 
   const std::string name() const final;
 

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -18,7 +18,7 @@ namespace opossum {
 
 /*
  * This is a Nested Loop Join implementation completely based on iterables.
- * It supports all current join and scan types, as well as NULL values.
+ * It supports all current join and predicate conditions, as well as NULL values.
  * Because this is a Nested Loop Join, the performance is going to be far inferior to JoinHash and JoinSortMerge,
  * so only use this for testing or benchmarking purposes.
  */

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -45,7 +45,7 @@ JoinSortMerge::JoinSortMerge(const std::shared_ptr<const AbstractOperator> left,
   DebugAssert(op == PredicateCondition::Equals || op == PredicateCondition::LessThan ||
                   op == PredicateCondition::GreaterThan || op == PredicateCondition::LessThanEquals ||
                   op == PredicateCondition::GreaterThanEquals || op == PredicateCondition::NotEquals,
-              "Unsupported scan type");
+              "Unsupported predicate condition");
   DebugAssert(op != PredicateCondition::NotEquals || mode == JoinMode::Inner,
               "Outer joins are not implemented for not-equals joins.");
 }

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -16,6 +16,8 @@ class BaseTableScanImpl;
 class Table;
 
 class TableScan : public AbstractReadOnlyOperator {
+ friend class LQPTranslatorTest;
+
  public:
   TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id, const ScanType scan_type,
             const AllParameterVariant right_parameter);

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -16,7 +16,7 @@ class BaseTableScanImpl;
 class Table;
 
 class TableScan : public AbstractReadOnlyOperator {
- friend class LQPTranslatorTest;
+  friend class LQPTranslatorTest;
 
  public:
   TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id, const ScanType scan_type,

--- a/src/lib/optimizer/column_statistics.cpp
+++ b/src/lib/optimizer/column_statistics.cpp
@@ -450,14 +450,14 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
     return {combined_non_null_ratio * selectivity, new_left_column_stats, new_right_column_stats};
   };
 
-  // Currently the distinct count, min and max calculation is incorrect if predicate condition is OpLessThan or OpGreaterThan and
-  // right column min = left column min or right column max = left column max.
+  // Currently the distinct count, min and max calculation is incorrect if predicate condition is OpLessThan or
+  // OpGreaterThan and right column min = left column min or right column max = left column max.
   //
   // E.g. Two integer columns have 3 distinct values and same min and max value of 1 and 3.
   //
   // Both new left and right column statistics will have the same min and max values of 1 and 3.
-  // However, for predicate condition OpLessThan, the left column max is actually 2 as there is no possibility for 3 < 3.
-  // Additionally, the right column min is actually 2, as there is no possibility for 1 < 1.
+  // However, for predicate condition OpLessThan, the left column max is actually 2 as there is no possibility
+  // for 3 < 3. Additionally, the right column min is actually 2, as there is no possibility for 1 < 1.
   // The same also applies for predicate condition OpGreaterThan vice versa.
   // The smaller range between min and max values of a column will also lead to a smaller distinct count.
   //

--- a/src/lib/optimizer/column_statistics.cpp
+++ b/src/lib/optimizer/column_statistics.cpp
@@ -319,7 +319,7 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
    * will have values below the overlapping range. The same applies to values above the overlapping range. If the max
    * values are not the same, then the column with the larger max value will have values above the overlapping range.
    *
-   * For the different scan types the appropriate ratios of values below, within and above the overlapping range from
+   * For the different predicate conditions the appropriate ratios of values below, within and above the overlapping range from
    * both columns are taken to compute the selectivity.
    *
    * Example estimation:
@@ -342,7 +342,7 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
    * left_overlapping_distinct_count = (1 / 2) * 20 = 10
    * right_overlapping_distinct_count = (1 / 3) * 15 = 5
    *
-   * For scan type equals only the ratios of values in the overlapping range is considered as values. If values could
+   * For predicate condition equals only the ratios of values in the overlapping range is considered as values. If values could
    * match outside the overlapping range, the range would be false as it would be too small. In order to calculate the
    * equal value ratio, the column with fewer distinct values within the overlapping range is determined. In this case
    * this is col_right. Statistics component assumes that for two value sets for the same range the smaller set is
@@ -350,14 +350,14 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
    * column also exist in the left column. The equal value ratio is then calculated by multiplying
    * right_overlapping_ratio (= 1 / 2) with the probability to hit any distinct value of the left column (= 1 / 20):
    * equal_values_ratio = (1 / 2) * (1 / 20) = (1 / 40)
-   * This is also the selectivity for the scan type equals: (1 / 40) = 2.5 %
+   * This is also the selectivity for the predicate condition equals: (1 / 40) = 2.5 %
    *
-   * For scan type less the ratios left_below_overlapping_ratio and right_above_overlapping_ratio are also considered as
+   * For predicate condition less the ratios left_below_overlapping_ratio and right_above_overlapping_ratio are also considered as
    * table entries where the col_left value is below the common range or the col_right value is above it will always be
    * in the result. The probability that both values are within the overlapping range and that col_left < col_right is
    * (probability of col_left != col_right where left and right values are in overlapping range) / 2
    *
-   * The selectivity for scan type less is the sum of different probabilities: // NOLINT
+   * The selectivity for predicate condition less is the sum of different probabilities: // NOLINT
    *    prob. that left value is below overlapping range (= 1 / 2) // NOLINT
    *  + prob. that right value is above overlapping range (= 1 / 3) // NOLINT
    *  - prob. that left value is below overlapping range and right value is above overlapping range (= 1 / 6) // NOLINT
@@ -450,15 +450,15 @@ TwoColumnSelectivityResult ColumnStatistics<ColumnType>::estimate_selectivity_fo
     return {combined_non_null_ratio * selectivity, new_left_column_stats, new_right_column_stats};
   };
 
-  // Currently the distinct count, min and max calculation is incorrect if scan type is OpLessThan or OpGreaterThan and
+  // Currently the distinct count, min and max calculation is incorrect if predicate condition is OpLessThan or OpGreaterThan and
   // right column min = left column min or right column max = left column max.
   //
   // E.g. Two integer columns have 3 distinct values and same min and max value of 1 and 3.
   //
   // Both new left and right column statistics will have the same min and max values of 1 and 3.
-  // However, for scan type OpLessThan, the left column max is actually 2 as there is no possibility for 3 < 3.
+  // However, for predicate condition OpLessThan, the left column max is actually 2 as there is no possibility for 3 < 3.
   // Additionally, the right column min is actually 2, as there is no possibility for 1 < 1.
-  // The same also applies for scan type OpGreaterThan vice versa.
+  // The same also applies for predicate condition OpGreaterThan vice versa.
   // The smaller range between min and max values of a column will also lead to a smaller distinct count.
   //
   // TODO(Anyone): Fix issue mentioned above.

--- a/src/lib/optimizer/column_statistics.hpp
+++ b/src/lib/optimizer/column_statistics.hpp
@@ -86,14 +86,14 @@ class ColumnStatistics : public BaseColumnStatistics {
   float estimate_selectivity_for_range(ColumnType minimum, ColumnType maximum);
 
   /**
-   * Create column statistics and estimate selectivity for predicate with scan type equals and constant value.
+   * Create column statistics and estimate selectivity for predicate with predicate condition equals and constant value.
    * @param value: constant value of aggregate
    * @return Selectivity and new column statistics.
    */
   ColumnSelectivityResult _create_column_stats_for_equals_predicate(ColumnType value);
 
   /**
-   * Create column statistics and estimate selectivity for predicate with scan type not equals and constant value.
+   * Create column statistics and estimate selectivity for predicate with predicate condition not equals and constant value.
    * @param value: constant value of aggregate
    * @return Selectivity and new column statistics.
    */

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -18,19 +18,13 @@ Optimizer Optimizer::create_default_optimizer() {
   Optimizer optimizer{10};
 
   RuleBatch main_batch(RuleBatchExecutionPolicy::Iterative);
-
   main_batch.add_rule(std::make_shared<PredicateReorderingRule>());
   main_batch.add_rule(std::make_shared<JoinDetectionRule>());
-
   optimizer.add_rule_batch(main_batch);
 
-
   RuleBatch final_batch(RuleBatchExecutionPolicy::Once);
-
   final_batch.add_rule(std::make_shared<IndexScanRule>());
-
   optimizer.add_rule_batch(final_batch);
-
 
   return optimizer;
 }

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "logical_query_plan/logical_plan_root_node.hpp"
+#include "strategy/index_scan_rule.hpp"
 #include "strategy/join_detection_rule.hpp"
 #include "strategy/predicate_reordering_rule.hpp"
 
@@ -22,6 +23,14 @@ Optimizer Optimizer::create_default_optimizer() {
   main_batch.add_rule(std::make_shared<JoinDetectionRule>());
 
   optimizer.add_rule_batch(main_batch);
+
+
+  RuleBatch final_batch(RuleBatchExecutionPolicy::Once);
+
+  final_batch.add_rule(std::make_shared<IndexScanRule>());
+
+  optimizer.add_rule_batch(final_batch);
+
 
   return optimizer;
 }

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -22,7 +22,7 @@ std::string IndexScanRule::name() const { return "Index Scan Rule"; }
 
 bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
   if (node->type() == LQPNodeType::Predicate) {
-  auto child = node->left_child();
+    auto child = node->left_child();
 
     if (child->type() == LQPNodeType::StoredTable) {
       auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
@@ -30,20 +30,19 @@ bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
       auto table = StorageManager::get().get_table(stored_table_node->table_name());
 
       auto columns_of_indexes = table->get_columns_of_indexes();
-      for (auto& indexed_columns: columns_of_indexes) {
+      for (auto& indexed_columns : columns_of_indexes) {
         if (_is_index_scan_applicable(indexed_columns, predicate_node)) {
           predicate_node->set_scan_typee(ScanTypee::IndexScan);
         }
       }
     }
-  }// else {
-  return _apply_to_children(node);
-  // }
+  }
 
-  // return true;
+  return _apply_to_children(node);
 }
 
-bool IndexScanRule::_is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns, const std::shared_ptr<PredicateNode>& predicate_node) const {
+bool IndexScanRule::_is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns,
+                                              const std::shared_ptr<PredicateNode>& predicate_node) const {
   if (!_is_single_column_index(indexed_columns)) return false;
 
   // Currently, we do not support two column predicates
@@ -64,40 +63,5 @@ bool IndexScanRule::_is_index_scan_applicable(const std::vector<ColumnID>& index
 inline bool IndexScanRule::_is_single_column_index(const std::vector<ColumnID>& indexed_columns) const {
   return indexed_columns.size() == 1;
 }
-// bool IndexScanRule::_reorder_predicates(std::vector<std::shared_ptr<PredicateNode>>& predicates) const {
-//   // Store original child and parent
-//   auto child = predicates.back()->left_child();
-//   const auto parents = predicates.front()->parents();
-//   const auto child_sides = predicates.front()->get_child_sides();
-
-//   const auto sort_predicate = [&](auto& left, auto& right) {
-//     return left->derive_statistics_from(child)->row_count() > right->derive_statistics_from(child)->row_count();
-//   };
-
-//   if (std::is_sorted(predicates.begin(), predicates.end(), sort_predicate)) {
-//     return false;
-//   }
-
-//   // Untie predicates from LQP, so we can freely retie them
-//   for (auto& predicate : predicates) {
-//     predicate->remove_from_tree();
-//   }
-
-//   // Sort in descending order
-//   std::sort(predicates.begin(), predicates.end(), sort_predicate);
-
-//   // Ensure that nodes are chained correctly
-//   predicates.back()->set_left_child(child);
-
-//   for (size_t parent_idx = 0; parent_idx < parents.size(); ++parent_idx) {
-//     parents[parent_idx]->set_child(child_sides[parent_idx], predicates.front());
-//   }
-
-//   for (size_t predicate_index = 0; predicate_index < predicates.size() - 1; predicate_index++) {
-//     predicates[predicate_index]->set_left_child(predicates[predicate_index + 1]);
-//   }
-
-//   return true;
-// }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -32,7 +32,7 @@ bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
       auto columns_of_indexes = table->get_columns_of_indexes();
       for (auto& indexed_columns : columns_of_indexes) {
         if (_is_index_scan_applicable(indexed_columns, predicate_node)) {
-          predicate_node->set_scan_typee(ScanTypee::IndexScan);
+          predicate_node->set_scan_type(ScanType::IndexScan);
         }
       }
     }

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -52,10 +52,11 @@ bool IndexScanRule::_is_index_scan_applicable(const std::vector<ColumnID>& index
                                               const std::shared_ptr<PredicateNode>& predicate_node) const {
   if (!_is_single_column_index(indexed_columns)) return false;
 
-  // Currently, we do not support two column predicates
+  // Currently, we do not support two-column predicates
   if (is_column_id(predicate_node->value())) return false;
 
-  ColumnID column_id = predicate_node->column_reference().original_column_id();
+  const auto column_id = predicate_node->get_output_column_id(predicate_node->column_reference());
+  // ColumnID column_id = predicate_node->column_reference().original_column_id();
   if (indexed_columns[0] != column_id) return false;
 
   const auto row_count_table = predicate_node->left_child()->derive_statistics_from(nullptr, nullptr)->row_count();

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -1,0 +1,69 @@
+#include "index_scan_rule.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "constant_mappings.hpp"
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "optimizer/table_statistics.hpp"
+#include "utils/assert.hpp"
+
+namespace opossum {
+
+std::string IndexScanRule::name() const { return "Index Scan Rule"; }
+
+bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
+  // auto reordered = false;
+
+  if (node->type() == LQPNodeType::Predicate) {
+    auto parent = node->parents()[0];
+
+    if (parent->type() == LQPNodeType::StoredTable) {
+      std::cout << "d" << std::endl;
+    }
+  }
+
+  return true;
+}
+
+// bool IndexScanRule::_reorder_predicates(std::vector<std::shared_ptr<PredicateNode>>& predicates) const {
+//   // Store original child and parent
+//   auto child = predicates.back()->left_child();
+//   const auto parents = predicates.front()->parents();
+//   const auto child_sides = predicates.front()->get_child_sides();
+
+//   const auto sort_predicate = [&](auto& left, auto& right) {
+//     return left->derive_statistics_from(child)->row_count() > right->derive_statistics_from(child)->row_count();
+//   };
+
+//   if (std::is_sorted(predicates.begin(), predicates.end(), sort_predicate)) {
+//     return false;
+//   }
+
+//   // Untie predicates from LQP, so we can freely retie them
+//   for (auto& predicate : predicates) {
+//     predicate->remove_from_tree();
+//   }
+
+//   // Sort in descending order
+//   std::sort(predicates.begin(), predicates.end(), sort_predicate);
+
+//   // Ensure that nodes are chained correctly
+//   predicates.back()->set_left_child(child);
+
+//   for (size_t parent_idx = 0; parent_idx < parents.size(); ++parent_idx) {
+//     parents[parent_idx]->set_child(child_sides[parent_idx], predicates.front());
+//   }
+
+//   for (size_t predicate_index = 0; predicate_index < predicates.size() - 1; predicate_index++) {
+//     predicates[predicate_index]->set_left_child(predicates[predicate_index + 1]);
+//   }
+
+//   return true;
+// }
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -6,10 +6,14 @@
 #include <string>
 #include <vector>
 
+#include "all_parameter_variant.hpp"
 #include "constant_mappings.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
 #include "optimizer/table_statistics.hpp"
+#include "storage/storage_manager.hpp"
+#include "storage/table.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {
@@ -17,19 +21,49 @@ namespace opossum {
 std::string IndexScanRule::name() const { return "Index Scan Rule"; }
 
 bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
-  // auto reordered = false;
-
   if (node->type() == LQPNodeType::Predicate) {
-    auto parent = node->parents()[0];
+  auto child = node->left_child();
 
-    if (parent->type() == LQPNodeType::StoredTable) {
-      std::cout << "d" << std::endl;
+    if (child->type() == LQPNodeType::StoredTable) {
+      auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
+      auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(child);
+      auto table = StorageManager::get().get_table(stored_table_node->table_name());
+
+      auto columns_of_indexes = table->get_columns_of_indexes();
+      for (auto& indexed_columns: columns_of_indexes) {
+        if (_is_index_scan_applicable(indexed_columns, predicate_node)) {
+          predicate_node->set_scan_typee(ScanTypee::IndexScan);
+        }
+      }
     }
-  }
+  }// else {
+  return _apply_to_children(node);
+  // }
+
+  // return true;
+}
+
+bool IndexScanRule::_is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns, const std::shared_ptr<PredicateNode>& predicate_node) const {
+  if (!_is_single_column_index(indexed_columns)) return false;
+
+  // Currently, we do not support two column predicates
+  if (is_column_id(predicate_node->value())) return false;
+
+  ColumnID column_id = predicate_node->column_reference().original_column_id();
+  if (indexed_columns[0] != column_id) return false;
+
+  auto row_count_table = predicate_node->left_child()->derive_statistics_from(nullptr, nullptr)->row_count();
+  auto row_count_predicate = predicate_node->derive_statistics_from(predicate_node->left_child())->row_count();
+  float selectivity = row_count_predicate / row_count_table;
+
+  if (selectivity > 0.01f) return false;
 
   return true;
 }
 
+inline bool IndexScanRule::_is_single_column_index(const std::vector<ColumnID>& indexed_columns) const {
+  return indexed_columns.size() == 1;
+}
 // bool IndexScanRule::_reorder_predicates(std::vector<std::shared_ptr<PredicateNode>>& predicates) const {
 //   // Store original child and parent
 //   auto child = predicates.back()->left_child();

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -22,7 +22,7 @@ namespace opossum {
 // Access Path Selection in Main-Memory Optimized Data Systems: Should I Scan or Should I Probe?
 constexpr float INDEX_SCAN_SELECTIVITY_THRESHOLD = 0.01f;
 
-// From GroupKeyPaper
+// From GroupKey paper
 constexpr float INDEX_SCAN_ROW_COUNT_THRESHOLD = 1000.0f;
 
 std::string IndexScanRule::name() const { return "Index Scan Rule"; }

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -18,11 +18,13 @@
 
 namespace opossum {
 
-// Kind of arbitrarily chosen, but the following paper suggests something similar
+// Only if we expect num_output_rows <= num_input_rows * selectivity_threshold, the ScanType can be set to IndexScan.
+// This value is kind of arbitrarily chosen, but the following paper suggests something similar:
 // Access Path Selection in Main-Memory Optimized Data Systems: Should I Scan or Should I Probe?
 constexpr float INDEX_SCAN_SELECTIVITY_THRESHOLD = 0.01f;
 
-// From GroupKey paper
+// Only if the number of input rows exceeds num_input_rows, the ScanType can be set to IndexScan.
+// The number is taken from: Fast Lookups for In-Memory Column Stores: Group-Key Indices, Lookup and Maintenance.
 constexpr float INDEX_SCAN_ROW_COUNT_THRESHOLD = 1000.0f;
 
 std::string IndexScanRule::name() const { return "Index Scan Rule"; }

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "abstract_rule.hpp"
+
+namespace opossum {
+
+class AbstractLQPNode;
+class PredicateNode;
+
+/**
+ * This optimizer rule finds chains of adjacent PredicateNodes and sorts them based on the expected cardinality.
+ * By that predicates with a low selectivity are executed first to (hopefully) reduce the size of intermediate results.
+ *
+ * Note:
+ * For now this rule only finds adjacent PredicateNodes, meaning that if there is another node, e.g. a ProjectionNode,
+ * between two
+ * chains of PredicateNodes we won't order all of them, but only each chain separately.
+ * A potential optimization would be to ignore certain intermediate nodes, such as ProjectionNode or SortNode, but
+ * respect
+ * others, such as JoinNode or UnionNode.
+ */
+class IndexScanRule : public AbstractRule {
+ public:
+  std::string name() const override;
+  bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) override;
+};
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "abstract_rule.hpp"
+#include "types.hpp"
 
 namespace opossum {
 
@@ -27,6 +28,10 @@ class IndexScanRule : public AbstractRule {
  public:
   std::string name() const override;
   bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) override;
+
+ protected:
+  bool _is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns, const std::shared_ptr<PredicateNode>& predicate_node) const;
+  inline bool _is_single_column_index(const std::vector<ColumnID>& indexed_columns) const;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -13,16 +13,13 @@ class AbstractLQPNode;
 class PredicateNode;
 
 /**
- * This optimizer rule finds chains of adjacent PredicateNodes and sorts them based on the expected cardinality.
- * By that predicates with a low selectivity are executed first to (hopefully) reduce the size of intermediate results.
+ * This optimizer rule finds PredicateNodes whose children are StoredTableNodes. These PredicateNodes are candidates
+ * for being executed by IndexScans. If the expected selectivity of the predicate falls below a certain threshold the
+ * ScanType of the PredicateNode is set to IndexScan.
  *
  * Note:
- * For now this rule only finds adjacent PredicateNodes, meaning that if there is another node, e.g. a ProjectionNode,
- * between two
- * chains of PredicateNodes we won't order all of them, but only each chain separately.
- * A potential optimization would be to ignore certain intermediate nodes, such as ProjectionNode or SortNode, but
- * respect
- * others, such as JoinNode or UnionNode.
+ * For now this rule is only applicable to single-column indexes and single-column predicates (i.e. WHERE a < b) is
+ * not supported. In addition, chains of IndexScans are not possible since an IndexScan's child must be a GetTable.
  */
 class IndexScanRule : public AbstractRule {
  public:

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -14,13 +14,13 @@ class PredicateNode;
 
 /**
  * This optimizer rule finds PredicateNodes whose children are StoredTableNodes. These PredicateNodes are candidates
- * for being executed by IndexScans. If the expected selectivity of the predicate falls below a certain threshold the
+ * for being executed by IndexScans. If the expected selectivity of the predicate falls below a certain threshold, the
  * ScanType of the PredicateNode is set to IndexScan.
  *
  * Note:
- * For now this rule is only applicable to single-column indexes and multi-column predicates (i.e. WHERE a < b) are
+ * For now this rule is only applicable to single-column indexes. Multi-column predicates (i.e. WHERE a < b) are also
  * not supported. We also assume that if chunks have an index, all of them are of the same type, we do not mix GroupKey
- * and ART indexes. In addition, chains of IndexScans are not possible since an IndexScan's child must be a GetTable.
+ * and ART indexes. In addition, chains of IndexScans are not possible since an IndexScan's input must be a GetTable.
  * Currently, only GroupKeyIndexes are supported.
  */
 

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -18,9 +18,12 @@ class PredicateNode;
  * ScanType of the PredicateNode is set to IndexScan.
  *
  * Note:
- * For now this rule is only applicable to single-column indexes and single-column predicates (i.e. WHERE a < b) is
- * not supported. In addition, chains of IndexScans are not possible since an IndexScan's child must be a GetTable.
+ * For now this rule is only applicable to single-column indexes and multi-column predicates (i.e. WHERE a < b) are
+ * not supported. We also assume that if chunks have an index, all of them are of the same type, we do not mix GroupKey
+ * and ART indexes. In addition, chains of IndexScans are not possible since an IndexScan's child must be a GetTable.
+ * Currently, only GroupKeyIndexes are supported.
  */
+
 class IndexScanRule : public AbstractRule {
  public:
   std::string name() const override;

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -30,7 +30,8 @@ class IndexScanRule : public AbstractRule {
   bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) override;
 
  protected:
-  bool _is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns, const std::shared_ptr<PredicateNode>& predicate_node) const;
+  bool _is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns,
+                                 const std::shared_ptr<PredicateNode>& predicate_node) const;
   inline bool _is_single_column_index(const std::vector<ColumnID>& indexed_columns) const;
 };
 

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "abstract_rule.hpp"
+#include "storage/index/index_info.hpp"
 #include "types.hpp"
 
 namespace opossum {
@@ -30,9 +31,9 @@ class IndexScanRule : public AbstractRule {
   bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) override;
 
  protected:
-  bool _is_index_scan_applicable(const std::vector<ColumnID>& indexed_columns,
+  bool _is_index_scan_applicable(const IndexInfo& indx_info,
                                  const std::shared_ptr<PredicateNode>& predicate_node) const;
-  inline bool _is_single_column_index(const std::vector<ColumnID>& indexed_columns) const;
+  inline bool _is_single_column_index(const IndexInfo& indexed_columns) const;
 };
 
 }  // namespace opossum

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -885,7 +885,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
     /**
      * It should be possible for any predicate to be negated with "NOT",
      * e.g., WHERE NOT a > 5. However, this is currently not supported.
-     * Right now we only use `kOpNot` to detect and set the `OpIsNotNull` scan type.
+     * Right now we only use `kOpNot` to detect and set the `OpIsNotNull` predicate condition.
      */
     Assert(predicate_condition == PredicateCondition::IsNull, "Only IS NULL can be negated");
 

--- a/src/lib/storage/index/index_info.hpp
+++ b/src/lib/storage/index/index_info.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+#include "column_index_type.hpp"
+#include "types.hpp"
+
+namespace opossum {
+
+struct IndexInfo {
+  std::vector<ColumnID> column_ids;
+  std::string name;
+  ColumnIndexType type;
+};
+
+}  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -203,8 +203,6 @@ TableType Table::get_type() const {
   }
 }
 
-std::vector<std::vector<ColumnID>> Table::get_columns_of_indexes() const {
-  return _indexes;
-}
+std::vector<std::vector<ColumnID>> Table::get_columns_of_indexes() const { return _indexes; }
 
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -203,15 +203,8 @@ TableType Table::get_type() const {
   }
 }
 
-std::vector<std::vector<ColumnID>> get_indexes() const {
+std::vector<std::vector<ColumnID>> Table::get_columns_of_indexes() const {
   return _indexes;
-}
-
-template <typename Index>
-void create_index(const std::vector<ColumnID>& column_ids) {
-  for (auto& chunk : _chunks) {
-    chunk->create_index(column_ids);
-  }
 }
 
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -203,6 +203,6 @@ TableType Table::get_type() const {
   }
 }
 
-std::vector<std::vector<ColumnID>> Table::get_columns_of_indexes() const { return _indexes; }
+std::vector<std::vector<ColumnID>> Table::get_column_ids_of_indexes() const { return _indexes; }
 
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -203,4 +203,15 @@ TableType Table::get_type() const {
   }
 }
 
+std::vector<std::vector<ColumnID>> get_indexes() const {
+  return _indexes;
+}
+
+template <typename Index>
+void create_index(const std::vector<ColumnID>& column_ids) {
+  for (auto& chunk : _chunks) {
+    chunk->create_index(column_ids);
+  }
+}
+
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -203,6 +203,6 @@ TableType Table::get_type() const {
   }
 }
 
-std::vector<std::vector<ColumnID>> Table::get_column_ids_of_indexes() const { return _indexes; }
+std::vector<IndexInfo> Table::get_indexes() const { return _indexes; }
 
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -135,10 +135,16 @@ class Table : private Noncopyable {
   TableType get_type() const;
 
   // Todo(JK): what if indexes are deleted during operation
-  std::vector<std::vector<ColumnID>> get_indexes() const;
+  std::vector<std::vector<ColumnID>> get_columns_of_indexes() const;
 
   template <typename Index>
-  void create_index(const std::vector<ColumnID>& column_ids);
+  void create_index(const std::vector<ColumnID>& column_ids) {
+    for (auto& chunk : _chunks) {
+      chunk->create_index<Index>(column_ids);
+    }
+
+    _indexes.emplace_back(column_ids);
+  }
 
  protected:
   const uint32_t _max_chunk_size;

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -9,6 +9,7 @@
 #include "base_column.hpp"
 #include "chunk.hpp"
 #include "proxy_chunk.hpp"
+#include "storage/index/index_info.hpp"
 #include "type_cast.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
@@ -134,15 +135,17 @@ class Table : private Noncopyable {
    */
   TableType get_type() const;
 
-  std::vector<std::vector<ColumnID>> get_column_ids_of_indexes() const;
+  std::vector<IndexInfo> get_indexes() const;
 
   template <typename Index>
-  void create_index(const std::vector<ColumnID>& column_ids) {
+  void create_index(const std::vector<ColumnID>& column_ids, const std::string& name = "") {
+    ColumnIndexType index_type = get_index_type_of<Index>();
+
     for (auto& chunk : _chunks) {
       chunk->create_index<Index>(column_ids);
     }
-
-    _indexes.emplace_back(column_ids);
+    IndexInfo i = {column_ids, name, index_type};
+    _indexes.emplace_back(i);
   }
 
  protected:
@@ -159,6 +162,6 @@ class Table : private Noncopyable {
 
   std::unique_ptr<std::mutex> _append_mutex;
 
-  std::vector<std::vector<ColumnID>> _indexes;
+  std::vector<IndexInfo> _indexes;
 };
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -134,8 +134,7 @@ class Table : private Noncopyable {
    */
   TableType get_type() const;
 
-  // Todo(JK): what if indexes are deleted during operation
-  std::vector<std::vector<ColumnID>> get_columns_of_indexes() const;
+  std::vector<std::vector<ColumnID>> get_column_ids_of_indexes() const;
 
   template <typename Index>
   void create_index(const std::vector<ColumnID>& column_ids) {

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -134,6 +134,12 @@ class Table : private Noncopyable {
    */
   TableType get_type() const;
 
+  // Todo(JK): what if indexes are deleted during operation
+  std::vector<std::vector<ColumnID>> get_indexes() const;
+
+  template <typename Index>
+  void create_index(const std::vector<ColumnID>& column_ids);
+
  protected:
   const uint32_t _max_chunk_size;
   std::vector<std::shared_ptr<Chunk>> _chunks;
@@ -147,5 +153,7 @@ class Table : private Noncopyable {
   std::shared_ptr<TableStatistics> _table_statistics;
 
   std::unique_ptr<std::mutex> _append_mutex;
+
+  std::vector<std::vector<ColumnID>> _indexes;
 };
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -71,6 +71,7 @@ set(
     optimizer/expression_test.cpp
     optimizer/lqp_translator_test.cpp
     optimizer/optimizer_test.cpp
+    optimizer/strategy/index_scan_rule_test.cpp
     optimizer/strategy/join_detection_rule_test.cpp
     optimizer/strategy/predicate_reordering_test.cpp
     optimizer/strategy/strategy_base_test.cpp

--- a/src/test/optimizer/column_statistics_test.cpp
+++ b/src/test/optimizer/column_statistics_test.cpp
@@ -322,7 +322,7 @@ TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsRealDataTest) {
-  // test selectivity calculations for all scan types and all column combinations of int_equal_distribution.tbl
+  // test selectivity calculations for all predicate conditions and all column combinations of int_equal_distribution.tbl
   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
                                                        PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
                                                        PredicateCondition::GreaterThan};

--- a/src/test/optimizer/column_statistics_test.cpp
+++ b/src/test/optimizer/column_statistics_test.cpp
@@ -322,7 +322,8 @@ TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsRealDataTest) {
-  // test selectivity calculations for all predicate conditions and all column combinations of int_equal_distribution.tbl
+  // test selectivity calculations for all predicate conditions and all column combinations of
+  // int_equal_distribution.tbl
   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
                                                        PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
                                                        PredicateCondition::GreaterThan};

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -167,7 +167,8 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
   table->get_chunk(index_chunk_ids[1])->create_index<GroupKeyIndex>(index_column_ids);
 
   auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), ScanType::Between, AllParameterVariant(42), AllTypeVariant(1337));
+      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), ScanType::Between,
+                                      AllParameterVariant(42), AllTypeVariant(1337));
   predicate_node->set_left_child(stored_table_node);
   predicate_node->set_scan_typee(ScanTypee::IndexScan);
   const auto op = LQPTranslator{}.translate_node(predicate_node);

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -133,7 +133,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeIndexScan) {
   auto predicate_node =
       std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), PredicateCondition::Equals, 42);
   predicate_node->set_left_child(stored_table_node);
-  predicate_node->set_scan_typee(ScanTypee::IndexScan);
+  predicate_node->set_scan_type(ScanType::IndexScan);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
   /**
@@ -170,7 +170,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
       std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), PredicateCondition::Between,
                                       AllParameterVariant(42), AllTypeVariant(1337));
   predicate_node->set_left_child(stored_table_node);
-  predicate_node->set_scan_typee(ScanTypee::IndexScan);
+  predicate_node->set_scan_type(ScanType::IndexScan);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
   /**

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -130,8 +130,8 @@ TEST_F(LQPTranslatorTest, PredicateNodeIndexScan) {
   table->get_chunk(index_chunk_ids[0])->create_index<GroupKeyIndex>(index_column_ids);
   table->get_chunk(index_chunk_ids[1])->create_index<GroupKeyIndex>(index_column_ids);
 
-  auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), PredicateCondition::Equals, 42);
+  auto predicate_node = std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}),
+                                                        PredicateCondition::Equals, 42);
   predicate_node->set_left_child(stored_table_node);
   predicate_node->set_scan_type(ScanType::IndexScan);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
@@ -210,11 +210,11 @@ TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNotApplicable) {
   table->get_chunk(index_chunk_ids[0])->create_index<GroupKeyIndex>(index_column_ids);
   table->get_chunk(index_chunk_ids[1])->create_index<GroupKeyIndex>(index_column_ids);
 
-  auto predicate_node =
-      std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}), PredicateCondition::Equals, 42);
+  auto predicate_node = std::make_shared<PredicateNode>(LQPColumnReference(stored_table_node, ColumnID{1}),
+                                                        PredicateCondition::Equals, 42);
   predicate_node->set_left_child(stored_table_node);
-  auto predicate_node2 =
-      std::make_shared<PredicateNode>(LQPColumnReference(predicate_node, ColumnID{0}), PredicateCondition::LessThanEquals, 42);
+  auto predicate_node2 = std::make_shared<PredicateNode>(LQPColumnReference(predicate_node, ColumnID{0}),
+                                                         PredicateCondition::LessThanEquals, 42);
   predicate_node2->set_left_child(predicate_node);
 
   // The optimizer should not set this ScanType in this situation

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -198,7 +198,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
   EXPECT_EQ(table_scan_op2->right_parameter(), AllParameterVariant(42));
 }
 
-TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNonApplicable) {
+TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNotApplicable) {
   /**
    * Build LQP and translate to PQP
    */

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -144,11 +144,11 @@ TEST_F(LQPTranslatorTest, PredicateNodeIndexScan) {
 
   const auto index_scan_op = std::dynamic_pointer_cast<const IndexScan>(op->input_left());
   ASSERT_TRUE(index_scan_op);
-  EXPECT_EQ(this->get_included_chunk_ids(index_scan_op), index_chunk_ids);
+  EXPECT_EQ(get_included_chunk_ids(index_scan_op), index_chunk_ids);
 
   const auto table_scan_op = std::dynamic_pointer_cast<const TableScan>(op->input_right());
   ASSERT_TRUE(table_scan_op);
-  EXPECT_EQ(this->get_excluded_chunk_ids(table_scan_op), index_chunk_ids);
+  EXPECT_EQ(get_excluded_chunk_ids(table_scan_op), index_chunk_ids);
   EXPECT_EQ(table_scan_op->left_column_id(), ColumnID{1} /* "a" */);
   EXPECT_EQ(table_scan_op->predicate_condition(), PredicateCondition::Equals);
   EXPECT_EQ(table_scan_op->right_parameter(), AllParameterVariant(42));
@@ -181,24 +181,25 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
 
   const auto index_scan_op = std::dynamic_pointer_cast<const IndexScan>(op->input_left());
   ASSERT_TRUE(index_scan_op);
-  EXPECT_EQ(this->get_included_chunk_ids(index_scan_op), index_chunk_ids);
+  EXPECT_EQ(get_included_chunk_ids(index_scan_op), index_chunk_ids);
 
   const auto table_scan_op = std::dynamic_pointer_cast<const TableScan>(op->input_right());
   ASSERT_TRUE(table_scan_op);
-  EXPECT_EQ(this->get_excluded_chunk_ids(table_scan_op), index_chunk_ids);
+  EXPECT_EQ(get_excluded_chunk_ids(table_scan_op), index_chunk_ids);
   EXPECT_EQ(table_scan_op->left_column_id(), ColumnID{1} /* "a" */);
   EXPECT_EQ(table_scan_op->predicate_condition(), PredicateCondition::LessThanEquals);
   EXPECT_EQ(table_scan_op->right_parameter(), AllParameterVariant(1337));
 
   const auto table_scan_op2 = std::dynamic_pointer_cast<const TableScan>(table_scan_op->input_left());
   ASSERT_TRUE(table_scan_op2);
-  EXPECT_EQ(this->get_excluded_chunk_ids(table_scan_op2), index_chunk_ids);
+  EXPECT_EQ(get_excluded_chunk_ids(table_scan_op2), index_chunk_ids);
   EXPECT_EQ(table_scan_op2->left_column_id(), ColumnID{1} /* "a" */);
   EXPECT_EQ(table_scan_op2->predicate_condition(), PredicateCondition::GreaterThanEquals);
   EXPECT_EQ(table_scan_op2->right_parameter(), AllParameterVariant(42));
 }
 
 TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNotApplicable) {
+  if (!IS_DEBUG) return;
   /**
    * Build LQP and translate to PQP
    */

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -1,0 +1,74 @@
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "../../base_test.hpp"
+#include "gtest/gtest.h"
+
+#include "abstract_expression.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "optimizer/column_statistics.hpp"
+#include "optimizer/strategy/index_scan_rule.hpp"
+#include "optimizer/strategy/strategy_base_test.hpp"
+#include "optimizer/table_statistics.hpp"
+#include "storage/storage_manager.hpp"
+
+#include "utils/assert.hpp"
+
+#include "logical_query_plan/mock_node.hpp"
+
+namespace opossum {
+
+class TableStatisticsMock : public TableStatistics {
+ public:
+  // we don't need a shared_ptr<Table> for this mock, so just set a nullptr
+  TableStatisticsMock() : TableStatistics(std::make_shared<Table>()) { _row_count = 0; }
+
+  explicit TableStatisticsMock(float row_count) : TableStatistics(std::make_shared<Table>()) { _row_count = row_count; }
+
+  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id, const ScanType scan_type,
+                                                        const AllParameterVariant& value,
+                                                        const std::optional<AllTypeVariant>& value2) override {
+    if (column_id == ColumnID{0}) {
+      return std::make_shared<TableStatisticsMock>(500);
+    }
+    if (column_id == ColumnID{1}) {
+      return std::make_shared<TableStatisticsMock>(200);
+    }
+    if (column_id == ColumnID{2}) {
+      return std::make_shared<TableStatisticsMock>(950);
+    }
+
+    Fail("Tried to access TableStatisticsMock with unexpected column");
+  }
+};
+
+class IndexScanRuleTest : public StrategyBaseTest {
+ protected:
+  void SetUp() override {
+    StorageManager::get().add_table("a", load_table("src/test/tables/int_int_int.tbl", Chunk::MAX_SIZE));
+    _rule = std::make_shared<IndexScanRule>();
+  }
+
+  std::shared_ptr<IndexScanRule> _rule;
+};
+
+TEST_F(IndexScanRuleTest, NoIndexScanWithoutIndex) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>();
+  stored_table_node->set_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+  predicate_node_0->set_left_child(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -15,8 +15,8 @@
 #include "optimizer/strategy/strategy_base_test.hpp"
 #include "optimizer/table_statistics.hpp"
 #include "storage/dictionary_column.hpp"
-#include "storage/index/group_key/group_key_index.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
+#include "storage/index/group_key/group_key_index.hpp"
 #include "storage/storage_manager.hpp"
 
 #include "utils/assert.hpp"
@@ -118,8 +118,8 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithTwoColumnPredicate) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, ColumnID{1});
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          ScanType::GreaterThan, ColumnID{1});
   predicate_node_0->set_left_child(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -71,9 +71,9 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithoutIndex) {
       std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
 }
 
 TEST_F(IndexScanRuleTest, NoIndexScanWithIndexOnOtherColumn) {
@@ -89,9 +89,9 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithIndexOnOtherColumn) {
       std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
 }
 
 TEST_F(IndexScanRuleTest, NoIndexScanWithMultiColumnIndex) {
@@ -107,9 +107,9 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithMultiColumnIndex) {
       std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
 }
 
 TEST_F(IndexScanRuleTest, NoIndexScanWithTwoColumnPredicate) {
@@ -122,9 +122,9 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithTwoColumnPredicate) {
                                                           PredicateCondition::GreaterThan, ColumnID{1});
   predicate_node_0->set_left_child(stored_table_node);
 
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
 }
 
 TEST_F(IndexScanRuleTest, NoIndexScanWithHighSelectivity) {
@@ -140,9 +140,9 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithHighSelectivity) {
       std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
 }
 
 TEST_F(IndexScanRuleTest, IndexScanWithIndex) {
@@ -158,9 +158,9 @@ TEST_F(IndexScanRuleTest, IndexScanWithIndex) {
       std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::IndexScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::IndexScan);
 }
 
 TEST_F(IndexScanRuleTest, IndexScanOnlyOnParentOfStoredTableNode) {
@@ -181,8 +181,8 @@ TEST_F(IndexScanRuleTest, IndexScanOnlyOnParentOfStoredTableNode) {
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);
-  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::IndexScan);
-  EXPECT_EQ(predicate_node_1->scan_typee(), ScanTypee::TableScan);
+  EXPECT_EQ(predicate_node_0->scan_type(), ScanType::IndexScan);
+  EXPECT_EQ(predicate_node_1->scan_type(), ScanType::TableScan);
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -14,6 +14,9 @@
 #include "optimizer/strategy/index_scan_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
 #include "optimizer/table_statistics.hpp"
+#include "storage/dictionary_column.hpp"
+#include "storage/index/group_key/group_key_index.hpp"
+#include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/storage_manager.hpp"
 
 #include "utils/assert.hpp"
@@ -50,6 +53,8 @@ class IndexScanRuleTest : public StrategyBaseTest {
  protected:
   void SetUp() override {
     StorageManager::get().add_table("a", load_table("src/test/tables/int_int_int.tbl", Chunk::MAX_SIZE));
+    DictionaryCompression::compress_table(*StorageManager::get().get_table("a"));
+
     _rule = std::make_shared<IndexScanRule>();
   }
 
@@ -69,6 +74,115 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithoutIndex) {
   EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
   EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+}
+
+TEST_F(IndexScanRuleTest, NoIndexScanWithIndexOnOtherColumn) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto table = StorageManager::get().get_table("a");
+  table->create_index<GroupKeyIndex>({ColumnID{2}});
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>();
+  stored_table_node->set_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, ScanType::GreaterThan, 10);
+  predicate_node_0->set_left_child(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+}
+
+TEST_F(IndexScanRuleTest, NoIndexScanWithMultiColumnIndex) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto table = StorageManager::get().get_table("a");
+  table->create_index<CompositeGroupKeyIndex>({ColumnID{2}, ColumnID{1}});
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>();
+  stored_table_node->set_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 10);
+  predicate_node_0->set_left_child(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+}
+
+TEST_F(IndexScanRuleTest, NoIndexScanWithTwoColumnPredicate) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>();
+  stored_table_node->set_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, ColumnID{1});
+  predicate_node_0->set_left_child(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+}
+
+TEST_F(IndexScanRuleTest, NoIndexScanWithHighSelectivity) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto table = StorageManager::get().get_table("a");
+  table->create_index<GroupKeyIndex>({ColumnID{2}});
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>(80'000);
+  table->set_table_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 10);
+  predicate_node_0->set_left_child(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+}
+
+TEST_F(IndexScanRuleTest, IndexScanWithIndex) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto table = StorageManager::get().get_table("a");
+  table->create_index<GroupKeyIndex>({ColumnID{2}});
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>(1'000'000);
+  table->set_table_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 10);
+  predicate_node_0->set_left_child(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::TableScan);
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::IndexScan);
+}
+
+TEST_F(IndexScanRuleTest, IndexScanOnlyOnParentOfStoredTableNode) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("a");
+
+  auto table = StorageManager::get().get_table("a");
+  table->create_index<GroupKeyIndex>({ColumnID{2}});
+
+  auto statistics_mock = std::make_shared<TableStatisticsMock>(1'000'000);
+  table->set_table_statistics(statistics_mock);
+
+  auto predicate_node_0 =
+      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, ScanType::GreaterThan, 10);
+  predicate_node_0->set_left_child(stored_table_node);
+
+  auto predicate_node_1 =
+      std::make_shared<PredicateNode>(LQPColumnReference{predicate_node_0, ColumnID{1}}, ScanType::LessThan, 15);
+  predicate_node_1->set_left_child(predicate_node_0);
+
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);
+  EXPECT_EQ(predicate_node_0->scan_typee(), ScanTypee::IndexScan);
+  EXPECT_EQ(predicate_node_1->scan_typee(), ScanTypee::TableScan);
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -32,7 +32,8 @@ class TableStatisticsMock : public TableStatistics {
 
   explicit TableStatisticsMock(float row_count) : TableStatistics(std::make_shared<Table>()) { _row_count = row_count; }
 
-  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id, const PredicateCondition predicate_condition,
+  std::shared_ptr<TableStatistics> predicate_statistics(const ColumnID column_id,
+                                                        const PredicateCondition predicate_condition,
                                                         const AllParameterVariant& value,
                                                         const std::optional<AllTypeVariant>& value2) override {
     if (column_id == ColumnID{0}) {
@@ -67,8 +68,8 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithoutIndex) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
@@ -85,8 +86,8 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithIndexOnOtherColumn) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{0}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
@@ -103,8 +104,8 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithMultiColumnIndex) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>();
   stored_table_node->set_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
@@ -136,8 +137,8 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithHighSelectivity) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>(80'000);
   table->set_table_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
@@ -154,8 +155,8 @@ TEST_F(IndexScanRuleTest, IndexScanWithIndex) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>(1'000'000);
   table->set_table_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
@@ -172,12 +173,12 @@ TEST_F(IndexScanRuleTest, IndexScanOnlyOnParentOfStoredTableNode) {
   auto statistics_mock = std::make_shared<TableStatisticsMock>(1'000'000);
   table->set_table_statistics(statistics_mock);
 
-  auto predicate_node_0 =
-      std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
+  auto predicate_node_0 = std::make_shared<PredicateNode>(LQPColumnReference{stored_table_node, ColumnID{2}},
+                                                          PredicateCondition::GreaterThan, 10);
   predicate_node_0->set_left_child(stored_table_node);
 
-  auto predicate_node_1 =
-      std::make_shared<PredicateNode>(LQPColumnReference{predicate_node_0, ColumnID{1}}, PredicateCondition::LessThan, 15);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(LQPColumnReference{predicate_node_0, ColumnID{1}},
+                                                          PredicateCondition::LessThan, 15);
   predicate_node_1->set_left_child(predicate_node_0);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);

--- a/src/test/optimizer/table_statistics_join_test.cpp
+++ b/src/test/optimizer/table_statistics_join_test.cpp
@@ -71,8 +71,8 @@ class TableStatisticsJoinTest : public BaseTest {
 };
 
 TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
-  // test selectivity calculations for join_modes which do not produce null values in the result, predicate conditions and column
-  // combinations of int_equal_distribution.tbl
+  // test selectivity calculations for join_modes which do not produce null values in the result, predicate conditions
+  // and column combinations of int_equal_distribution.tbl
   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
   std::vector<PredicateCondition> predicate_conditions{
       PredicateCondition::Equals,         PredicateCondition::NotEquals,   PredicateCondition::LessThan,
@@ -116,8 +116,8 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
 
 // This is what InnerJoinTest would look like without cached join result size:
 // TEST_F(TableStatisticsJoinTest, InnerJoinRealDataTest) {
-//   // test selectivity calculations for join_modes which do not produce null values in the result, predicate conditions and
-//   // column combinations of int_equal_distribution.tbl
+//   // test selectivity calculations for join_modes which do not produce null values in the result, predicate
+// conditions and column combinations of int_equal_distribution.tbl
 //   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
 //   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
 //                                    PredicateCondition::LessThan, PredicateCondition::LessThanEquals,
@@ -138,8 +138,8 @@ TEST_F(TableStatisticsJoinTest, CrossJoinTest) {
 }
 
 TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
-  // Test selectivity calculations for all join_modes which can produce null values in the result, predicate conditions and
-  // column combinations of int_equal_distribution.tbl
+  // Test selectivity calculations for all join_modes which can produce null values in the result, predicate conditions
+  // and column combinations of int_equal_distribution.tbl
 
   // Currently, the statistics component produces in some cases for a two column predicate with
   // PredicateCondition::LessThan and PredicateCondition::GreaterThan a column statistics with a too high distinct
@@ -194,13 +194,14 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
 
 // This is what OuterJoinsTest would look like without cached join result size:
 // TEST_F(TableStatisticsJoinTest, OuterJoinsRealDataTest) {
-//   // Test selectivity calculations for all join_modes which can produce null values in the result, predicate conditions and
-//   // column combinations of int_equal_distribution.tbl
+//   // Test selectivity calculations for all join_modes which can produce null values in the result, predicate
+//   // conditions and column combinations of int_equal_distribution.tbl
 
 //   // Currently, the statistics component produces in some cases for a two column predicate with
 //   // PredicateCondition::LessThan and PredicateCondition::GreaterThan a column statistics with a too high distinct
 //   // count. (See comment column_statistics.hpp for details). Null value calculations depend on the calculated
-//   // distinct counts of the columns. Therefore, tests for the mentioned predicate conditions with null values are skipped.
+//   // distinct counts of the columns. Therefore, tests for the mentioned predicate conditions with null values are
+//   // skipped.
 
 //   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
 //   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,

--- a/src/test/optimizer/table_statistics_join_test.cpp
+++ b/src/test/optimizer/table_statistics_join_test.cpp
@@ -71,7 +71,7 @@ class TableStatisticsJoinTest : public BaseTest {
 };
 
 TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
-  // test selectivity calculations for join_modes which do not produce null values in the result, scan types and column
+  // test selectivity calculations for join_modes which do not produce null values in the result, predicate conditions and column
   // combinations of int_equal_distribution.tbl
   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
   std::vector<PredicateCondition> predicate_conditions{
@@ -116,7 +116,7 @@ TEST_F(TableStatisticsJoinTest, InnerJoinTest) {
 
 // This is what InnerJoinTest would look like without cached join result size:
 // TEST_F(TableStatisticsJoinTest, InnerJoinRealDataTest) {
-//   // test selectivity calculations for join_modes which do not produce null values in the result, scan types and
+//   // test selectivity calculations for join_modes which do not produce null values in the result, predicate conditions and
 //   // column combinations of int_equal_distribution.tbl
 //   std::vector<JoinMode> join_modes{JoinMode::Inner, JoinMode::Self};
 //   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,
@@ -138,13 +138,13 @@ TEST_F(TableStatisticsJoinTest, CrossJoinTest) {
 }
 
 TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
-  // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
+  // Test selectivity calculations for all join_modes which can produce null values in the result, predicate conditions and
   // column combinations of int_equal_distribution.tbl
 
   // Currently, the statistics component produces in some cases for a two column predicate with
   // PredicateCondition::LessThan and PredicateCondition::GreaterThan a column statistics with a too high distinct
   // count. (See comment column_statistics.hpp for details). Null value calculations depend on the calculated distinct
-  // counts of the columns. Therefore, tests for the mentioned scan types with null values are skipped.
+  // counts of the columns. Therefore, tests for the mentioned predicate conditions with null values are skipped.
 
   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
   std::vector<PredicateCondition> predicate_conditions{
@@ -194,13 +194,13 @@ TEST_F(TableStatisticsJoinTest, OuterJoinsTest) {
 
 // This is what OuterJoinsTest would look like without cached join result size:
 // TEST_F(TableStatisticsJoinTest, OuterJoinsRealDataTest) {
-//   // Test selectivity calculations for all join_modes which can produce null values in the result, scan types and
+//   // Test selectivity calculations for all join_modes which can produce null values in the result, predicate conditions and
 //   // column combinations of int_equal_distribution.tbl
 
 //   // Currently, the statistics component produces in some cases for a two column predicate with
 //   // PredicateCondition::LessThan and PredicateCondition::GreaterThan a column statistics with a too high distinct
 //   // count. (See comment column_statistics.hpp for details). Null value calculations depend on the calculated
-//   // distinct counts of the columns. Therefore, tests for the mentioned scan types with null values are skipped.
+//   // distinct counts of the columns. Therefore, tests for the mentioned predicate conditions with null values are skipped.
 
 //   std::vector<JoinMode> join_modes{JoinMode::Right, JoinMode::Outer, JoinMode::Left};
 //   std::vector<PredicateCondition> predicate_conditions{PredicateCondition::Equals, PredicateCondition::NotEquals,

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -80,7 +80,7 @@ class TableStatisticsTest : public BaseTest {
   }
 
   /**
-   * Predict output sizes of table scans with two values (scan type = OpBetween) and compare with actual output sizes.
+   * Predict output sizes of table scans with two values (predicate condition = OpBetween) and compare with actual output sizes.
    * Does not work with ValuePlaceholder of stored procedures.
    */
   template <typename T>


### PR DESCRIPTION
This adds an optimizer rule to enable the translation of PredicateNodes to IndexScans. We do need IndexScans for one of the seminar topics as well as for other experiments. It is a first basic attempt, we did not include fancy cost models or made use of all the flexibility the chunk layout provides. 

There is an enum with the infamous name `ScanType` added to PredicateNodes. Currently this only holds `TableScan` and `IndexScan`. Later, it might contain further types ,e.g., `JITScan` or `AVX512Scan`.

There are a few things to note:

- This only works with single-column GroupKey indexes
- In case multiple indexes are present on a column of a chunk, there is no mechanism for deciding which index to use
- PredicateNodes can only be translated to IndexScans if their direct child is a StoredTableNode

and also a couple of open questions:

- Do we have a policy regarding adding private methods, which are called from `_translate_X_node` methods, to our LQPTranslator?
- How do we handle the removal of indexes? Should we ignore it for now? Otherwise I see two options:
  - We need a lock mechanism for indexes. The lock would be triggered as soon as inclusion/exclusion lists are written in the LQPTranslator
  - Introducing indexes to the concept of transactions and visibility