### PR TITLE
Add method to remove an index from a chunk

### DIFF
--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -140,6 +140,14 @@ std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
   return get_index(index_type, columns);
 }
 
+void Chunk::remove_index(std::shared_ptr<BaseIndex> index)
+{
+    auto it = std::find(_indices.cbegin(), _indices.cend(), index);
+    if (it == _indices.cend()) Fail("Trying to remove a non-existing index");
+
+    _indices.erase(it);
+}
+
 bool Chunk::references_exactly_one_table() const {
   if (column_count() == 0) return false;
 

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
 
 void Chunk::remove_index(std::shared_ptr<BaseIndex> index) {
   auto it = std::find(_indices.cbegin(), _indices.cend(), index);
-  if (it == _indices.cend()) Fail("Trying to remove a non-existing index");
+  DebugAssert(it != _indices.cend(), "Trying to remove a non-existing index");
   _indices.erase(it);
 }
 

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -140,12 +140,10 @@ std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
   return get_index(index_type, columns);
 }
 
-void Chunk::remove_index(std::shared_ptr<BaseIndex> index)
-{
-    auto it = std::find(_indices.cbegin(), _indices.cend(), index);
-    if (it == _indices.cend()) Fail("Trying to remove a non-existing index");
-
-    _indices.erase(it);
+void Chunk::remove_index(std::shared_ptr<BaseIndex> index) {
+  auto it = std::find(_indices.cbegin(), _indices.cend(), index);
+  if (it == _indices.cend()) Fail("Trying to remove a non-existing index");
+  _indices.erase(it);
 }
 
 bool Chunk::references_exactly_one_table() const {

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -198,6 +198,8 @@ class Chunk : private Noncopyable {
     return create_index<Index>(columns);
   }
 
+  void remove_index(std::shared_ptr<BaseIndex> index);
+
   void migrate(boost::container::pmr::memory_resource* memory_source);
 
   std::shared_ptr<AccessCounter> access_counter() const { return _access_counter; }

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -141,12 +141,12 @@ TEST_F(StorageChunkTest, GetIndicesByColumnIDs) {
   auto index_int_str =
       c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
 
-  auto ind_col_0 = c->get_indices(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto ind_col_0 = c->get_indices(std::vector<ColumnID>{ColumnID{0}});
   // Make sure it finds both the single-column index as well as the multi-column index
   EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int), ind_col_0.cend());
   EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int_str), ind_col_0.cend());
 
-  auto ind_col_1 = c->get_indices(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto ind_col_1 = c->get_indices(std::vector<ColumnID>{ColumnID{1}});
   // Make sure it only finds the single-column index
   EXPECT_NE(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_str), ind_col_1.cend());
   EXPECT_EQ(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_int_str), ind_col_1.cend());
@@ -160,12 +160,12 @@ TEST_F(StorageChunkTest, GetIndicesByColumnPointers) {
   auto index_int_str =
       c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
 
-  auto ind_col_0 = c->get_indices(std::vector<ColumnID>{ColumnID{0}});
+  auto ind_col_0 = c->get_indices(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
   // Make sure it finds both the single-column index as well as the multi-column index
   EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int), ind_col_0.cend());
   EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int_str), ind_col_0.cend());
 
-  auto ind_col_1 = c->get_indices(std::vector<ColumnID>{ColumnID{1}});
+  auto ind_col_1 = c->get_indices(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
   // Make sure it only finds the single-column index
   EXPECT_NE(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_str), ind_col_1.cend());
   EXPECT_EQ(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_int_str), ind_col_1.cend());

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -6,8 +6,9 @@
 #include "../lib/resolve_type.hpp"
 #include "../lib/storage/base_column.hpp"
 #include "../lib/storage/chunk.hpp"
-#include "../lib/types.hpp"
+#include "../lib/storage/index/group_key/composite_group_key_index.hpp"
 #include "../lib/storage/index/group_key/group_key_index.hpp"
+#include "../lib/types.hpp"
 
 namespace opossum {
 
@@ -74,15 +75,122 @@ TEST_F(StorageChunkTest, UnknownColumnType) {
   }
 }
 
-TEST_F(StorageChunkTest, AddIndex) {
+TEST_F(StorageChunkTest, AddIndexByColumnID) {
   c->add_column(dc_int);
   c->add_column(dc_str);
   auto index_int = c->create_index<GroupKeyIndex>(std::vector<ColumnID>{ColumnID{0}});
   auto index_str = c->create_index<GroupKeyIndex>(std::vector<ColumnID>{ColumnID{0}});
-  auto index_int_str = c->create_index<GroupKeyIndex>(std::vector<ColumnID>{ColumnID{0}, ColumnID{1}});
+  auto index_int_str = c->create_index<CompositeGroupKeyIndex>(std::vector<ColumnID>{ColumnID{0}, ColumnID{1}});
   EXPECT_TRUE(index_int);
   EXPECT_TRUE(index_str);
   EXPECT_TRUE(index_int_str);
+}
+
+TEST_F(StorageChunkTest, AddIndexByColumnPointer) {
+  c->add_column(dc_int);
+  c->add_column(dc_str);
+  auto index_int = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto index_str = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto index_int_str =
+      c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
+  EXPECT_TRUE(index_int);
+  EXPECT_TRUE(index_str);
+  EXPECT_TRUE(index_int_str);
+}
+
+TEST_F(StorageChunkTest, GetIndexByColumnID) {
+  c->add_column(dc_int);
+  c->add_column(dc_str);
+  auto index_int = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto index_str = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto index_int_str =
+      c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
+
+  EXPECT_EQ(c->get_index(ColumnIndexType::GroupKey, std::vector<ColumnID>{ColumnID{0}}), index_int);
+  EXPECT_EQ(c->get_index(ColumnIndexType::CompositeGroupKey, std::vector<ColumnID>{ColumnID{0}}), index_int_str);
+  EXPECT_EQ(c->get_index(ColumnIndexType::CompositeGroupKey, std::vector<ColumnID>{ColumnID{0}, ColumnID{1}}),
+            index_int_str);
+  EXPECT_EQ(c->get_index(ColumnIndexType::GroupKey, std::vector<ColumnID>{ColumnID{1}}), index_str);
+  EXPECT_EQ(c->get_index(ColumnIndexType::CompositeGroupKey, std::vector<ColumnID>{ColumnID{1}}), nullptr);
+}
+
+TEST_F(StorageChunkTest, GetIndexByColumnPointer) {
+  c->add_column(dc_int);
+  c->add_column(dc_str);
+  auto index_int = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto index_str = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto index_int_str =
+      c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
+
+  EXPECT_EQ(c->get_index(ColumnIndexType::GroupKey, std::vector<std::shared_ptr<const BaseColumn>>{dc_int}), index_int);
+  EXPECT_EQ(c->get_index(ColumnIndexType::CompositeGroupKey, std::vector<std::shared_ptr<const BaseColumn>>{dc_int}),
+            index_int_str);
+  EXPECT_EQ(
+      c->get_index(ColumnIndexType::CompositeGroupKey, std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str}),
+      index_int_str);
+  EXPECT_EQ(c->get_index(ColumnIndexType::GroupKey, std::vector<std::shared_ptr<const BaseColumn>>{dc_str}), index_str);
+  EXPECT_EQ(c->get_index(ColumnIndexType::CompositeGroupKey, std::vector<std::shared_ptr<const BaseColumn>>{dc_str}),
+            nullptr);
+}
+
+TEST_F(StorageChunkTest, GetIndicesByColumnIDs) {
+  c->add_column(dc_int);
+  c->add_column(dc_str);
+  auto index_int = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto index_str = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto index_int_str =
+      c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
+
+  auto ind_col_0 = c->get_indices(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  // Make sure it finds both the single-column index as well as the multi-column index
+  EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int), ind_col_0.cend());
+  EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int_str), ind_col_0.cend());
+
+  auto ind_col_1 = c->get_indices(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  // Make sure it only finds the single-column index
+  EXPECT_NE(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_str), ind_col_1.cend());
+  EXPECT_EQ(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_int_str), ind_col_1.cend());
+}
+
+TEST_F(StorageChunkTest, GetIndicesByColumnPointers) {
+  c->add_column(dc_int);
+  c->add_column(dc_str);
+  auto index_int = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto index_str = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto index_int_str =
+      c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
+
+  auto ind_col_0 = c->get_indices(std::vector<ColumnID>{ColumnID{0}});
+  // Make sure it finds both the single-column index as well as the multi-column index
+  EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int), ind_col_0.cend());
+  EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int_str), ind_col_0.cend());
+
+  auto ind_col_1 = c->get_indices(std::vector<ColumnID>{ColumnID{1}});
+  // Make sure it only finds the single-column index
+  EXPECT_NE(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_str), ind_col_1.cend());
+  EXPECT_EQ(std::find(ind_col_1.cbegin(), ind_col_1.cend(), index_int_str), ind_col_1.cend());
+}
+
+TEST_F(StorageChunkTest, RemoveIndex) {
+  c->add_column(dc_int);
+  c->add_column(dc_str);
+  auto index_int = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int});
+  auto index_str = c->create_index<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_str});
+  auto index_int_str =
+      c->create_index<CompositeGroupKeyIndex>(std::vector<std::shared_ptr<const BaseColumn>>{dc_int, dc_str});
+
+  c->remove_index(index_int);
+  auto ind_col_0 = c->get_indices(std::vector<ColumnID>{ColumnID{0}});
+  EXPECT_EQ(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int), ind_col_0.cend());
+  EXPECT_NE(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int_str), ind_col_0.cend());
+
+  c->remove_index(index_int_str);
+  ind_col_0 = c->get_indices(std::vector<ColumnID>{ColumnID{0}});
+  EXPECT_EQ(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_int_str), ind_col_0.cend());
+
+  c->remove_index(index_str);
+  auto ind_col_1 = c->get_indices(std::vector<ColumnID>{ColumnID{1}});
+  EXPECT_EQ(std::find(ind_col_0.cbegin(), ind_col_0.cend(), index_str), ind_col_0.cend());
 }
 
 }  // namespace opossum


### PR DESCRIPTION
This adds a method to remove an existing index from a chunk. This functionality is needed for the *self-driving database* project.

Possible discussion topics:

- Argument: I picked `std::shared_ptr<BaseIndex>` because that is also the parameter returned from `Chunk::get_index`.
- Naming: I chose *remove* index over *drop* index as this is an operation on a storage container.
- Testing: I did not find any tests for the index operations of `Chunk`.