### PR TITLE
Add query cache to pipeline

### DIFF
--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -74,9 +74,7 @@ std::shared_ptr<const Table> AbstractOperator::_input_table_left() const { retur
 
 std::shared_ptr<const Table> AbstractOperator::_input_table_right() const { return _input_right->get_output(); }
 
-bool AbstractOperator::transaction_context_is_set() const {
-  return _transaction_context.has_value();
-}
+bool AbstractOperator::transaction_context_is_set() const { return _transaction_context.has_value(); }
 
 std::shared_ptr<TransactionContext> AbstractOperator::transaction_context() const {
   DebugAssert(!transaction_context_is_set() || !_transaction_context->expired(),

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -75,15 +75,13 @@ std::shared_ptr<const Table> AbstractOperator::_input_table_left() const { retur
 std::shared_ptr<const Table> AbstractOperator::_input_table_right() const { return _input_right->get_output(); }
 
 bool AbstractOperator::transaction_context_is_set() const {
-  // https://stackoverflow.com/questions/45507041/how-to-check-if-weak-ptr-is-empty-non-assigned
-  return _transaction_context.owner_before(std::weak_ptr<TransactionContext>{}) ||
-         std::weak_ptr<TransactionContext>{}.owner_before(_transaction_context);
+  return _transaction_context.has_value();
 }
 
 std::shared_ptr<TransactionContext> AbstractOperator::transaction_context() const {
-  DebugAssert(!transaction_context_is_set() || !_transaction_context.expired(),
+  DebugAssert(!transaction_context_is_set() || !_transaction_context->expired(),
               "TransactionContext is expired, but SQL Query Executor should still own it (Operator: " + name() + ")");
-  return _transaction_context.lock();
+  return transaction_context_is_set() ? _transaction_context->lock() : nullptr;
 }
 
 void AbstractOperator::set_transaction_context(std::weak_ptr<TransactionContext> transaction_context) {

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -74,15 +74,15 @@ std::shared_ptr<const Table> AbstractOperator::_input_table_left() const { retur
 
 std::shared_ptr<const Table> AbstractOperator::_input_table_right() const { return _input_right->get_output(); }
 
-std::shared_ptr<TransactionContext> AbstractOperator::transaction_context() const {
+bool AbstractOperator::transaction_context_is_set() const {
   // https://stackoverflow.com/questions/45507041/how-to-check-if-weak-ptr-is-empty-non-assigned
-  DebugAssert(
-      [context = _transaction_context]() {
-        bool transaction_context_set = context.owner_before(std::weak_ptr<TransactionContext>{}) ||
-                                       std::weak_ptr<TransactionContext>{}.owner_before(context);
-        return !transaction_context_set || !context.expired();
-      }(),
-      "TransactionContext is expired, but SQL Query Executor should still own it (Operator: " + name() + ")");
+  return _transaction_context.owner_before(std::weak_ptr<TransactionContext>{}) ||
+         std::weak_ptr<TransactionContext>{}.owner_before(_transaction_context);
+}
+
+std::shared_ptr<TransactionContext> AbstractOperator::transaction_context() const {
+  DebugAssert(!transaction_context_is_set() || !_transaction_context.expired(),
+              "TransactionContext is expired, but SQL Query Executor should still own it (Operator: " + name() + ")");
   return _transaction_context.lock();
 }
 

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -109,7 +109,7 @@ class AbstractOperator : private Noncopyable {
   std::shared_ptr<const Table> _output;
 
   // Weak pointer breaks cyclical dependency between operators and context
-  std::weak_ptr<TransactionContext> _transaction_context;
+  std::optional<std::weak_ptr<TransactionContext>> _transaction_context;
 
   PerformanceData _performance_data;
 

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -49,6 +49,9 @@ class AbstractOperator : private Noncopyable {
   virtual const std::string name() const = 0;
   virtual const std::string description(DescriptionMode description_mode = DescriptionMode::SingleLine) const;
 
+  // This only checks if the operator has/had a transaction context without having to convert the weak_ptr
+  bool transaction_context_is_set() const;
+
   std::shared_ptr<TransactionContext> transaction_context() const;
   void set_transaction_context(std::weak_ptr<TransactionContext> transaction_context);
 

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -11,9 +11,7 @@ AbstractReadWriteOperator::AbstractReadWriteOperator(const std::shared_ptr<const
 
 std::shared_ptr<AbstractOperator> AbstractReadWriteOperator::recreate(
     const std::vector<AllParameterVariant>& args) const {
-  // As of now, we only support caching (and thus, recreation) for SELECTs.
-  // There should be no conceptual problem with R/W though.
-  Fail("ReadWrite operators (here: " + name() + ") can not implement recreation.");
+  Fail("ReadWrite operator '" + name() + "' cannot implement recreation.");
 }
 
 void AbstractReadWriteOperator::execute() {

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -9,11 +9,6 @@ AbstractReadWriteOperator::AbstractReadWriteOperator(const std::shared_ptr<const
                                                      const std::shared_ptr<const AbstractOperator> right)
     : AbstractOperator(left, right), _state{ReadWriteOperatorState::Pending} {}
 
-std::shared_ptr<AbstractOperator> AbstractReadWriteOperator::recreate(
-    const std::vector<AllParameterVariant>& args) const {
-  Fail("ReadWrite operator '" + name() + "' cannot implement recreation.");
-}
-
 void AbstractReadWriteOperator::execute() {
   Assert(static_cast<bool>(transaction_context()),
          "AbstractReadWriteOperator::execute() should never be called without having set the transaction context.");

--- a/src/lib/operators/abstract_read_write_operator.hpp
+++ b/src/lib/operators/abstract_read_write_operator.hpp
@@ -32,7 +32,7 @@ class AbstractReadWriteOperator : public AbstractOperator,
   explicit AbstractReadWriteOperator(const std::shared_ptr<const AbstractOperator> left = nullptr,
                                      const std::shared_ptr<const AbstractOperator> right = nullptr);
 
-  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const final;
+  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
   void execute() override;
 

--- a/src/lib/operators/abstract_read_write_operator.hpp
+++ b/src/lib/operators/abstract_read_write_operator.hpp
@@ -32,8 +32,6 @@ class AbstractReadWriteOperator : public AbstractOperator,
   explicit AbstractReadWriteOperator(const std::shared_ptr<const AbstractOperator> left = nullptr,
                                      const std::shared_ptr<const AbstractOperator> right = nullptr);
 
-  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
-
   void execute() override;
 
   /**

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -122,4 +122,8 @@ bool Delete::_execution_input_valid(const std::shared_ptr<TransactionContext>& c
   return true;
 }
 
+std::shared_ptr<AbstractOperator> Delete::recreate(const std::vector<AllParameterVariant>& args) const {
+  return std::make_shared<Delete>(_table_name, _input_left->recreate());
+}
+
 }  // namespace opossum

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -123,7 +123,7 @@ bool Delete::_execution_input_valid(const std::shared_ptr<TransactionContext>& c
 }
 
 std::shared_ptr<AbstractOperator> Delete::recreate(const std::vector<AllParameterVariant>& args) const {
-  return std::make_shared<Delete>(_table_name, _input_left->recreate());
+  return std::make_shared<Delete>(_table_name, _input_left->recreate(args));
 }
 
 }  // namespace opossum

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -21,6 +21,7 @@ class Delete : public AbstractReadWriteOperator {
   explicit Delete(const std::string& table_name, const std::shared_ptr<const AbstractOperator>& values_to_delete);
 
   const std::string name() const override;
+  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -229,4 +229,8 @@ void Insert::_on_rollback_records() {
   }
 }
 
+std::shared_ptr<AbstractOperator> Insert::recreate(const std::vector<AllParameterVariant>& args) const {
+  return std::make_shared<Insert>(_target_table_name, _input_left->recreate());
+}
+
 }  // namespace opossum

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -230,7 +230,7 @@ void Insert::_on_rollback_records() {
 }
 
 std::shared_ptr<AbstractOperator> Insert::recreate(const std::vector<AllParameterVariant>& args) const {
-  return std::make_shared<Insert>(_target_table_name, _input_left->recreate());
+  return std::make_shared<Insert>(_target_table_name, _input_left->recreate(args));
 }
 
 }  // namespace opossum

--- a/src/lib/operators/insert.hpp
+++ b/src/lib/operators/insert.hpp
@@ -24,6 +24,7 @@ class Insert : public AbstractReadWriteOperator {
   explicit Insert(const std::string& target_table_name, const std::shared_ptr<AbstractOperator>& values_to_insert);
 
   const std::string name() const override;
+  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -128,4 +128,8 @@ bool Update::_execution_input_valid(const std::shared_ptr<TransactionContext>& c
   return true;
 }
 
+std::shared_ptr<AbstractOperator> Update::recreate(const std::vector<AllParameterVariant>& args) const {
+  return std::make_shared<Update>(_table_to_update_name, _input_left->recreate(), _input_right->recreate());
+}
+
 }  // namespace opossum

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -129,7 +129,7 @@ bool Update::_execution_input_valid(const std::shared_ptr<TransactionContext>& c
 }
 
 std::shared_ptr<AbstractOperator> Update::recreate(const std::vector<AllParameterVariant>& args) const {
-  return std::make_shared<Update>(_table_to_update_name, _input_left->recreate(), _input_right->recreate());
+  return std::make_shared<Update>(_table_to_update_name, _input_left->recreate(args), _input_right->recreate(args));
 }
 
 }  // namespace opossum

--- a/src/lib/operators/update.hpp
+++ b/src/lib/operators/update.hpp
@@ -32,6 +32,7 @@ class Update : public AbstractReadWriteOperator {
   ~Update();
 
   const std::string name() const override;
+  std::shared_ptr<AbstractOperator> recreate(const std::vector<AllParameterVariant>& args) const override;
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -59,11 +59,11 @@ SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<TransactionCont
       }
     }
 
+    const auto statement_string_length = statement->stringLength;
     auto parsed_statement = std::make_shared<hsql::SQLParserResult>(statement.release());
     parsed_statement->setIsValid(true);
 
     // Get the statement string from the original query string, so we can pass it to the SQLPipelineStatement
-    const auto statement_string_length = statement->stringLength;
     const auto statement_string = boost::trim_copy(sql.substr(sql_string_offset, statement_string_length));
     sql_string_offset += statement_string_length;
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -284,8 +284,4 @@ std::chrono::microseconds SQLPipeline::execution_time_microseconds() {
   return _execution_time_microseconds;
 }
 
-SQLQueryCache<SQLQueryPlan>& SQLPipeline::get_query_plan_cache() {
-  return SQLPipelineStatement::get_query_plan_cache();
-}
-
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -75,9 +75,6 @@ class SQLPipeline : public Noncopyable {
   // Returns the entire execution time
   std::chrono::microseconds execution_time_microseconds();
 
-  // Returns the query plan cache from the underlying SQLPipelineStatements
-  static SQLQueryCache<SQLQueryPlan>& get_query_plan_cache();
-
  private:
   SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context, bool use_mvcc);
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -33,6 +33,9 @@ class SQLPipeline : public Noncopyable {
   explicit SQLPipeline(const std::string& sql, bool use_mvcc = true);
   SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context);
 
+  // Returns the SQL string for each statement.
+  const std::vector<std::string>& get_sql_strings();
+
   // Returns the parsed SQL string for each statement.
   const std::vector<std::shared_ptr<hsql::SQLParserResult>>& get_parsed_sql_statements();
 
@@ -72,6 +75,9 @@ class SQLPipeline : public Noncopyable {
   // Returns the entire execution time
   std::chrono::microseconds execution_time_microseconds();
 
+  // Returns the query plan cache from the underlying SQLPipelineStatements
+  static SQLQueryCache<SQLQueryPlan>& get_query_plan_cache();
+
  private:
   SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context, bool use_mvcc);
 
@@ -79,6 +85,7 @@ class SQLPipeline : public Noncopyable {
   size_t _num_statements;
 
   // Execution results
+  std::vector<std::string> _sql_strings;
   std::vector<std::shared_ptr<hsql::SQLParserResult>> _parsed_sql_statements;
   std::vector<std::shared_ptr<AbstractLQPNode>> _unoptimized_logical_plans;
   std::vector<std::shared_ptr<AbstractLQPNode>> _optimized_logical_plans;

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -5,6 +5,7 @@
 #include "SQLParserResult.h"
 #include "concurrency/transaction_context.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
+#include "sql/sql_query_cache.hpp"
 #include "sql/sql_query_plan.hpp"
 #include "storage/table.hpp"
 
@@ -33,8 +34,11 @@ class SQLPipelineStatement : public Noncopyable {
 
   // Constructor for creation from SQLParseResult statement.
   // This should be called from SQLPipeline and not by the user directly.
-  SQLPipelineStatement(std::shared_ptr<hsql::SQLParserResult> parsed_sql,
+  SQLPipelineStatement(const std::string& sql, std::shared_ptr<hsql::SQLParserResult> parsed_sql,
                        std::shared_ptr<TransactionContext> transaction_context, bool use_mvcc);
+
+  // Returns the raw SQL string.
+  const std::string& get_sql_string();
 
   // Returns the parsed SQL string.
   const std::shared_ptr<hsql::SQLParserResult>& get_parsed_sql_statement();
@@ -53,6 +57,9 @@ class SQLPipelineStatement : public Noncopyable {
 
   // Executes all tasks, waits for them to finish, and returns the resulting table.
   const std::shared_ptr<const Table>& get_result_table();
+
+  // Returns the query plan cache
+  static SQLQueryCache<SQLQueryPlan>& get_query_plan_cache();
 
   // Returns the TransactionContext that was either passed to or created by the SQLPipelineStatement.
   // This can be a nullptr if no transaction management is wanted.
@@ -85,6 +92,9 @@ class SQLPipelineStatement : public Noncopyable {
   const bool _use_mvcc;
   const bool _auto_commit;
   std::shared_ptr<TransactionContext> _transaction_context;
+
+  // Caching
+  static SQLQueryCache<SQLQueryPlan> _query_plan_cache;
 };
 
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -58,9 +58,6 @@ class SQLPipelineStatement : public Noncopyable {
   // Executes all tasks, waits for them to finish, and returns the resulting table.
   const std::shared_ptr<const Table>& get_result_table();
 
-  // Returns the query plan cache
-  static SQLQueryCache<SQLQueryPlan>& get_query_plan_cache();
-
   // Returns the TransactionContext that was either passed to or created by the SQLPipelineStatement.
   // This can be a nullptr if no transaction management is wanted.
   const std::shared_ptr<TransactionContext>& transaction_context() const;
@@ -92,9 +89,6 @@ class SQLPipelineStatement : public Noncopyable {
   const bool _use_mvcc;
   const bool _auto_commit;
   std::shared_ptr<TransactionContext> _transaction_context;
-
-  // Caching
-  static SQLQueryCache<SQLQueryPlan> _query_plan_cache;
 };
 
 }  // namespace opossum

--- a/src/lib/sql/sql_query_cache.hpp
+++ b/src/lib/sql/sql_query_cache.hpp
@@ -13,7 +13,7 @@
 
 namespace opossum {
 
-static const size_t DefaultCacheCapacity = 1024;
+inline constexpr size_t DefaultCacheCapacity = 1024;
 
 // Cache that stores instances of SQLParserResult.
 // Per-default, uses the GDFS cache as underlying storage.

--- a/src/lib/sql/sql_query_cache.hpp
+++ b/src/lib/sql/sql_query_cache.hpp
@@ -13,14 +13,22 @@
 
 namespace opossum {
 
+static const size_t DefaultCacheCapacity = 1024;
+
 // Cache that stores instances of SQLParserResult.
 // Per-default, uses the GDFS cache as underlying storage.
 template <typename Value, typename Key = std::string>
 class SQLQueryCache {
  public:
-  explicit SQLQueryCache(size_t capacity) : _cache(std::move(std::make_unique<GDFSCache<Key, Value>>(capacity))) {}
+  explicit SQLQueryCache(size_t capacity = DefaultCacheCapacity) :
+    _cache(std::move(std::make_unique<GDFSCache<Key, Value>>(capacity))) {}
 
   virtual ~SQLQueryCache() {}
+
+  static SQLQueryCache& get() {
+    static SQLQueryCache<Value> cache;
+    return cache;
+  }
 
   // Adds or refreshes the cache entry [query, value].
   void set(const Key& query, const Value& value) {

--- a/src/lib/sql/sql_query_cache.hpp
+++ b/src/lib/sql/sql_query_cache.hpp
@@ -20,8 +20,8 @@ static const size_t DefaultCacheCapacity = 1024;
 template <typename Value, typename Key = std::string>
 class SQLQueryCache {
  public:
-  explicit SQLQueryCache(size_t capacity = DefaultCacheCapacity) :
-    _cache(std::move(std::make_unique<GDFSCache<Key, Value>>(capacity))) {}
+  explicit SQLQueryCache(size_t capacity = DefaultCacheCapacity)
+      : _cache(std::move(std::make_unique<GDFSCache<Key, Value>>(capacity))) {}
 
   virtual ~SQLQueryCache() {}
 

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -58,8 +58,7 @@ class SQLPipelineStatementTest : public BaseTest {
     _multi_statement_parse_result = std::make_shared<hsql::SQLParserResult>();
     hsql::SQLParser::parse(_multi_statement_dependant, _multi_statement_parse_result.get());
 
-    // Reset cache
-    SQLPipelineStatement::get_query_plan_cache().clear();
+    SQLQueryCache<SQLQueryPlan>::get().clear();
   }
 
   std::shared_ptr<Table> _table_a;
@@ -455,7 +454,7 @@ TEST_F(SQLPipelineStatementTest, CacheQueryPlan) {
   SQLPipelineStatement sql_pipeline{_select_query_a};
   sql_pipeline.get_result_table();
 
-  const auto& cache = sql_pipeline.get_query_plan_cache();
+  const auto& cache = SQLQueryCache<SQLQueryPlan>::get();
   EXPECT_EQ(cache.size(), 1u);
   EXPECT_TRUE(cache.has(_select_query_a));
 }

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -57,6 +57,9 @@ class SQLPipelineStatementTest : public BaseTest {
 
     _multi_statement_parse_result = std::make_shared<hsql::SQLParserResult>();
     hsql::SQLParser::parse(_multi_statement_dependant, _multi_statement_parse_result.get());
+
+    // Reset cache
+    SQLPipelineStatement::get_query_plan_cache().clear();
   }
 
   std::shared_ptr<Table> _table_a;
@@ -88,12 +91,14 @@ TEST_F(SQLPipelineStatementTest, SimpleCreation) {
   SQLPipelineStatement sql_pipeline{_select_query_a};
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
+  EXPECT_EQ(sql_pipeline.get_sql_string(), _select_query_a);
 }
 
 TEST_F(SQLPipelineStatementTest, SimpleCreationWithoutMVCC) {
   SQLPipelineStatement sql_pipeline{_join_query, false};
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
+  EXPECT_EQ(sql_pipeline.get_sql_string(), _join_query);
 }
 
 TEST_F(SQLPipelineStatementTest, SimpleCreationWithCustomTransactionContext) {
@@ -101,17 +106,18 @@ TEST_F(SQLPipelineStatementTest, SimpleCreationWithCustomTransactionContext) {
   SQLPipelineStatement sql_pipeline{_select_query_a, context};
 
   EXPECT_EQ(sql_pipeline.transaction_context().get(), context.get());
+  EXPECT_EQ(sql_pipeline.get_sql_string(), _select_query_a);
 }
 
 TEST_F(SQLPipelineStatementTest, SimpleParsedCreation) {
-  SQLPipelineStatement sql_pipeline{_select_parse_result, nullptr, true};
+  SQLPipelineStatement sql_pipeline{_select_query_a, _select_parse_result, nullptr, true};
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
   EXPECT_EQ(sql_pipeline.get_parsed_sql_statement().get(), _select_parse_result.get());
 }
 
 TEST_F(SQLPipelineStatementTest, SimpleParsedCreationWithoutMVCC) {
-  SQLPipelineStatement sql_pipeline{_select_parse_result, nullptr, false};
+  SQLPipelineStatement sql_pipeline{_select_query_a, _select_parse_result, nullptr, false};
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
   EXPECT_EQ(sql_pipeline.get_parsed_sql_statement().get(), _select_parse_result.get());
@@ -119,14 +125,15 @@ TEST_F(SQLPipelineStatementTest, SimpleParsedCreationWithoutMVCC) {
 
 TEST_F(SQLPipelineStatementTest, SimpleParsedCreationWithCustomTransactionContext) {
   auto context = TransactionManager::get().new_transaction_context();
-  SQLPipelineStatement sql_pipeline{_select_parse_result, context, true};
+  SQLPipelineStatement sql_pipeline{_select_query_a, _select_parse_result, context, true};
 
   EXPECT_EQ(sql_pipeline.transaction_context().get(), context.get());
   EXPECT_EQ(sql_pipeline.get_parsed_sql_statement().get(), _select_parse_result.get());
 }
 
 TEST_F(SQLPipelineStatementTest, SimpleParsedCreationTooManyStatements) {
-  EXPECT_THROW(SQLPipelineStatement(_multi_statement_parse_result, nullptr, false), std::exception);
+  EXPECT_THROW(SQLPipelineStatement(_multi_statement_dependant, _multi_statement_parse_result, nullptr, false),
+               std::exception);
 }
 
 TEST_F(SQLPipelineStatementTest, GetParsedSQL) {
@@ -442,6 +449,15 @@ TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {
     // Check that the ^ was actually inserted in the error message
     EXPECT_TRUE(error_msg.find('^') != std::string::npos);
   }
+}
+
+TEST_F(SQLPipelineStatementTest, CacheQueryPlan) {
+  SQLPipelineStatement sql_pipeline{_select_query_a};
+  sql_pipeline.get_result_table();
+
+  const auto& cache = sql_pipeline.get_query_plan_cache();
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_TRUE(cache.has(_select_query_a));
 }
 
 }  // namespace opossum

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -56,8 +56,7 @@ class SQLPipelineTest : public BaseTest {
     _join_result->append({12345, 458.7f, 456.7f});
     _join_result->append({12345, 458.7f, 457.7f});
 
-    // Reset cache
-    SQLPipeline::get_query_plan_cache().clear();
+    SQLQueryCache<SQLQueryPlan>::get().clear();
   }
 
   std::shared_ptr<Table> _table_a;
@@ -457,6 +456,7 @@ TEST_F(SQLPipelineTest, RequiresExecutionVariations) {
 }
 
 TEST_F(SQLPipelineTest, CorrectStatementStringSplitting) {
+  // Tests that the string passed into the pipeline is correctly split into the statement substrings
   SQLPipeline select_pipeline{_select_query_a};
   const auto& select_strings = select_pipeline.get_sql_strings();
   EXPECT_EQ(select_strings.size(), 1u);
@@ -500,7 +500,7 @@ TEST_F(SQLPipelineTest, CacheQueryPlanTwice) {
   sql_pipeline2.get_result_table();
 
   // The second part of _multi_statement_query is _select_query_a, which is already cached
-  const auto& cache = sql_pipeline1.get_query_plan_cache();
+  const auto& cache = SQLQueryCache<SQLQueryPlan>::get();
   EXPECT_EQ(cache.size(), 2u);
   EXPECT_TRUE(cache.has(_select_query_a));
   EXPECT_TRUE(cache.has("INSERT INTO table_a VALUES (11, 11.11);"));
@@ -508,12 +508,10 @@ TEST_F(SQLPipelineTest, CacheQueryPlanTwice) {
   SQLPipeline sql_pipeline3{_select_query_a};
   sql_pipeline3.get_result_table();
 
-  // This is the same cache as above, just making sure it really is
-  const auto& same_cache = sql_pipeline3.get_query_plan_cache();
-
-  EXPECT_EQ(same_cache.size(), 2u);
-  EXPECT_TRUE(same_cache.has(_select_query_a));
-  EXPECT_TRUE(same_cache.has("INSERT INTO table_a VALUES (11, 11.11);"));
+  // Make sure the cache hasn't changed
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_TRUE(cache.has(_select_query_a));
+  EXPECT_TRUE(cache.has("INSERT INTO table_a VALUES (11, 11.11);"));
 }
 
 }  // namespace opossum

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -55,6 +55,9 @@ class SQLPipelineTest : public BaseTest {
     _join_result->add_column("bb", DataType::Float);
     _join_result->append({12345, 458.7f, 456.7f});
     _join_result->append({12345, 458.7f, 457.7f});
+
+    // Reset cache
+    SQLPipeline::get_query_plan_cache().clear();
   }
 
   std::shared_ptr<Table> _table_a;
@@ -69,7 +72,7 @@ class SQLPipelineTest : public BaseTest {
       "SELECT table_a.a, table_a.b, table_b.b AS bb FROM table_a, table_b WHERE table_a.a = table_b.a AND table_a.a "
       "> 1000";
   const std::string _multi_statement_query = "INSERT INTO table_a VALUES (11, 11.11); SELECT * FROM table_a";
-  const std::string _multi_statement_dependant = "CREATE VIEW foo AS SELECT * FROM table_a; SELECT * FROM foo;";
+  const std::string _multi_statement_dependent = "CREATE VIEW foo AS SELECT * FROM table_a; SELECT * FROM foo;";
   // VIEW --> VIE
   const std::string _multi_statement_invalid = "CREATE VIE foo AS SELECT * FROM table_a; SELECT * FROM foo;";
 };
@@ -131,7 +134,7 @@ TEST_F(SQLPipelineTest, GetParsedSQLStatements) {
 }
 
 TEST_F(SQLPipelineTest, GetParsedSQLStatementsExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependant};
+  SQLPipeline sql_pipeline{_multi_statement_dependent};
   EXPECT_NO_THROW(sql_pipeline.get_parsed_sql_statements());
 }
 
@@ -168,7 +171,7 @@ TEST_F(SQLPipelineTest, GetUnoptimizedLQPTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetUnoptimizedLQPExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependant};
+  SQLPipeline sql_pipeline{_multi_statement_dependent};
 
   try {
     sql_pipeline.get_unoptimized_logical_plans();
@@ -206,7 +209,7 @@ TEST_F(SQLPipelineTest, GetOptimizedLQPTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetOptimizedLQPExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependant};
+  SQLPipeline sql_pipeline{_multi_statement_dependent};
 
   try {
     sql_pipeline.get_optimized_logical_plans();
@@ -248,7 +251,7 @@ TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetQueryPlansExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependant};
+  SQLPipeline sql_pipeline{_multi_statement_dependent};
   try {
     sql_pipeline.get_query_plans();
     // Fail if this did not throw an exception
@@ -284,7 +287,7 @@ TEST_F(SQLPipelineTest, GetTasksTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetTasksExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependant};
+  SQLPipeline sql_pipeline{_multi_statement_dependent};
 
   try {
     sql_pipeline.get_tasks();
@@ -326,7 +329,7 @@ TEST_F(SQLPipelineTest, GetResultTableTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetResultTableExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependant};
+  SQLPipeline sql_pipeline{_multi_statement_dependent};
   const auto& table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ_UNORDERED(table, _table_a)
@@ -425,7 +428,7 @@ TEST_F(SQLPipelineTest, RequiresExecutionVariations) {
   EXPECT_FALSE(SQLPipeline{_select_query_a}.requires_execution());
   EXPECT_FALSE(SQLPipeline{_join_query}.requires_execution());
   EXPECT_FALSE(SQLPipeline{_multi_statement_query}.requires_execution());
-  EXPECT_TRUE(SQLPipeline{_multi_statement_dependant}.requires_execution());
+  EXPECT_TRUE(SQLPipeline{_multi_statement_dependent}.requires_execution());
 
   const std::string create_view_single = "CREATE VIEW blub AS SELECT * FROM foo;";
   EXPECT_FALSE(SQLPipeline{create_view_single}.requires_execution());
@@ -451,6 +454,66 @@ TEST_F(SQLPipelineTest, RequiresExecutionVariations) {
   const std::string multi_no_exec =
       "SELECT * FROM foo; INSERT INTO foo VALUES (2); SELECT * FROM blub; DELETE FROM foo WHERE a = 2;";
   EXPECT_FALSE(SQLPipeline{multi_no_exec}.requires_execution());
+}
+
+TEST_F(SQLPipelineTest, CorrectStatementStringSplitting) {
+  SQLPipeline select_pipeline{_select_query_a};
+  const auto& select_strings = select_pipeline.get_sql_strings();
+  EXPECT_EQ(select_strings.size(), 1u);
+  EXPECT_EQ(select_strings.at(0), _select_query_a);
+
+  SQLPipeline dependent_pipeline{_multi_statement_query};
+  const auto& dependent_strings = dependent_pipeline.get_sql_strings();
+  EXPECT_EQ(dependent_strings.size(), 2u);
+  // "INSERT INTO table_a VALUES (11, 11.11); SELECT * FROM table_a";
+  EXPECT_EQ(dependent_strings.at(0), "INSERT INTO table_a VALUES (11, 11.11);");
+  EXPECT_EQ(dependent_strings.at(1), "SELECT * FROM table_a");  // leading whitespace should be removed
+
+  // Add newlines, tabd and weird spacing
+  auto spacing_sql = "\n\t\n SELECT\na, b, c,d,e FROM\t(SELECT * FROM foo);    \t  ";
+  SQLPipeline spacing_pipeline{spacing_sql};
+  const auto& spacing_strings = spacing_pipeline.get_sql_strings();
+  EXPECT_EQ(spacing_strings.size(), 1u);
+  EXPECT_EQ(spacing_strings.at(0),
+            "SELECT\na, b, c,d,e FROM\t(SELECT * FROM foo);");  // internal formatting is not done
+
+  auto multi_line_sql = R"(
+  SELECT *
+  FROM foo, bar
+  WHERE foo.x = 17
+    AND bar.y = 25
+  ORDER BY foo.x ASC
+  )";
+  SQLPipeline multi_line_pipeline{multi_line_sql};
+  const auto& multi_line_strings = multi_line_pipeline.get_sql_strings();
+  EXPECT_EQ(multi_line_strings.size(), 1u);
+  EXPECT_EQ(multi_line_strings.at(0),
+            "SELECT *\n  FROM foo, bar\n  WHERE foo.x = 17\n    AND bar.y = 25\n  ORDER BY foo.x ASC");
+}
+
+TEST_F(SQLPipelineTest, CacheQueryPlanTwice) {
+  SQLPipeline sql_pipeline1{_select_query_a};
+  sql_pipeline1.get_result_table();
+
+  // INSERT INTO table_a VALUES (11, 11.11); SELECT * FROM table_a
+  SQLPipeline sql_pipeline2{_multi_statement_query};
+  sql_pipeline2.get_result_table();
+
+  // The second part of _multi_statement_query is _select_query_a, which is already cached
+  const auto& cache = sql_pipeline1.get_query_plan_cache();
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_TRUE(cache.has(_select_query_a));
+  EXPECT_TRUE(cache.has("INSERT INTO table_a VALUES (11, 11.11);"));
+
+  SQLPipeline sql_pipeline3{_select_query_a};
+  sql_pipeline3.get_result_table();
+
+  // This is the same cache as above, just making sure it really is
+  const auto& same_cache = sql_pipeline3.get_query_plan_cache();
+
+  EXPECT_EQ(same_cache.size(), 2u);
+  EXPECT_TRUE(same_cache.has(_select_query_a));
+  EXPECT_TRUE(same_cache.has("INSERT INTO table_a VALUES (11, 11.11);"));
 }
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -60,6 +60,9 @@ class SQLiteTestRunner : public BaseTestWithParam<std::string> {
 
     opossum::CurrentScheduler::set(
         std::make_shared<opossum::NodeQueueScheduler>(opossum::Topology::create_numa_topology()));
+
+    // Clear cache
+    SQLPipeline::get_query_plan_cache().clear();
   }
 
   std::unique_ptr<SQLiteWrapper> _sqlite;

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -61,8 +61,7 @@ class SQLiteTestRunner : public BaseTestWithParam<std::string> {
     opossum::CurrentScheduler::set(
         std::make_shared<opossum::NodeQueueScheduler>(opossum::Topology::create_numa_topology()));
 
-    // Clear cache
-    SQLPipeline::get_query_plan_cache().clear();
+    SQLQueryCache<SQLQueryPlan>::get().clear();
   }
 
   std::unique_ptr<SQLiteWrapper> _sqlite;


### PR DESCRIPTION
This PR adds PQP caching to the `SQLPipeline`. A given SQL string is split into the single statements and then passed to the corresponding `SQLPipelineStatement`. If `get_query_plan()` is called, the pipeline checks whether a PQP exists for the given statement string. If so, the `SQLQueryPlan` is recreated. 

EDIT: on second thought, this will not deal with #304 directly. There seems to be quite a few places that need to be changed to use SQLPipeline, so it makes sense to do that in a separate PR.