### PR TITLE
Fix omitted lazy column statistics initialization

### DIFF
--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -22,7 +22,7 @@ MockNode::MockNode(const std::shared_ptr<TableStatistics>& statistics, const std
     : AbstractLQPNode(LQPNodeType::Mock), _constructor_arguments(statistics) {
   set_statistics(statistics);
 
-  for (size_t column_statistics_idx = 0; column_statistics_idx < statistics->column_statistics().size();
+  for (size_t column_statistics_idx = 0; column_statistics_idx < statistics->get_all_column_statistics().size();
        ++column_statistics_idx) {
     _output_column_names.emplace_back("MockCol" + std::to_string(column_statistics_idx));
   }

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -22,7 +22,7 @@ MockNode::MockNode(const std::shared_ptr<TableStatistics>& statistics, const std
     : AbstractLQPNode(LQPNodeType::Mock), _constructor_arguments(statistics) {
   set_statistics(statistics);
 
-  for (size_t column_statistics_idx = 0; column_statistics_idx < statistics->get_all_column_statistics().size();
+  for (size_t column_statistics_idx = 0; column_statistics_idx < statistics->column_statistics().size();
        ++column_statistics_idx) {
     _output_column_names.emplace_back("MockCol" + std::to_string(column_statistics_idx));
   }

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -28,6 +28,8 @@ float TableStatistics::row_count() const { return _row_count; }
 uint64_t TableStatistics::approx_valid_row_count() const { return row_count() - _approx_invalid_row_count; }
 
 const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::column_statistics() const {
+  // Lazily initialize column statistics
+  _create_all_column_statistics();
   return _column_statistics;
 }
 

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -27,7 +27,7 @@ float TableStatistics::row_count() const { return _row_count; }
 
 uint64_t TableStatistics::approx_valid_row_count() const { return row_count() - _approx_invalid_row_count; }
 
-const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::column_statistics() const {
+const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::get_all_column_statistics() {
   // Lazily initialize column statistics
   _create_all_column_statistics();
   return _column_statistics;

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -27,7 +27,7 @@ float TableStatistics::row_count() const { return _row_count; }
 
 uint64_t TableStatistics::approx_valid_row_count() const { return row_count() - _approx_invalid_row_count; }
 
-const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::column_statistics() {
+const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::column_statistics() const {
   // Lazily initialize column statistics
   _create_all_column_statistics();
   return _column_statistics;
@@ -256,7 +256,8 @@ std::shared_ptr<TableStatistics> TableStatistics::generate_predicated_join_stati
 
 void TableStatistics::increment_invalid_row_count(uint64_t count) { _approx_invalid_row_count += count; }
 
-std::shared_ptr<BaseColumnStatistics> TableStatistics::_get_or_generate_column_statistics(const ColumnID column_id) {
+std::shared_ptr<BaseColumnStatistics> TableStatistics::_get_or_generate_column_statistics(
+    const ColumnID column_id) const {
   if (_column_statistics[column_id]) {
     return _column_statistics[column_id];
   }
@@ -270,7 +271,7 @@ std::shared_ptr<BaseColumnStatistics> TableStatistics::_get_or_generate_column_s
   return _column_statistics[column_id];
 }
 
-void TableStatistics::_create_all_column_statistics() {
+void TableStatistics::_create_all_column_statistics() const {
   for (ColumnID column_id{0}; column_id < _column_statistics.size(); ++column_id) {
     _get_or_generate_column_statistics(column_id);
   }

--- a/src/lib/optimizer/table_statistics.cpp
+++ b/src/lib/optimizer/table_statistics.cpp
@@ -27,7 +27,7 @@ float TableStatistics::row_count() const { return _row_count; }
 
 uint64_t TableStatistics::approx_valid_row_count() const { return row_count() - _approx_invalid_row_count; }
 
-const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::get_all_column_statistics() {
+const std::vector<std::shared_ptr<BaseColumnStatistics>>& TableStatistics::column_statistics() {
   // Lazily initialize column statistics
   _create_all_column_statistics();
   return _column_statistics;

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -61,7 +61,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    * Create the TableStatistics by explicitly specifying its underlying data. Intended for statistics tests or to
    * supply mocked statistics to a MockNode
    */
-  TableStatistics(float row_count, const std::vector<std::shared_ptr<BaseColumnStatistics>>& get_all_column_statistics);
+  TableStatistics(float row_count, const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics);
 
   /**
    * Returns the expected row_count of the output of the corresponding operator.
@@ -72,7 +72,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
   // Returns the number of valid rows (using approximate count of deleted rows)
   uint64_t approx_valid_row_count() const;
 
-  const std::vector<std::shared_ptr<BaseColumnStatistics>>& get_all_column_statistics();
+  const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics();
 
   /**
    * Generate table statistics for the operator table scan table scan.

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -61,7 +61,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    * Create the TableStatistics by explicitly specifying its underlying data. Intended for statistics tests or to
    * supply mocked statistics to a MockNode
    */
-  TableStatistics(float row_count, const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics);
+  TableStatistics(float row_count, const std::vector<std::shared_ptr<BaseColumnStatistics>>& get_all_column_statistics);
 
   /**
    * Returns the expected row_count of the output of the corresponding operator.
@@ -72,7 +72,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
   // Returns the number of valid rows (using approximate count of deleted rows)
   uint64_t approx_valid_row_count() const;
 
-  const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics() const;
+  const std::vector<std::shared_ptr<BaseColumnStatistics>>& get_all_column_statistics();
 
   /**
    * Generate table statistics for the operator table scan table scan.

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -72,7 +72,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
   // Returns the number of valid rows (using approximate count of deleted rows)
   uint64_t approx_valid_row_count() const;
 
-  const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics();
+  const std::vector<std::shared_ptr<BaseColumnStatistics>>& column_statistics() const;
 
   /**
    * Generate table statistics for the operator table scan table scan.
@@ -98,9 +98,9 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
   void increment_invalid_row_count(uint64_t count);
 
  protected:
-  std::shared_ptr<BaseColumnStatistics> _get_or_generate_column_statistics(const ColumnID column_id);
+  std::shared_ptr<BaseColumnStatistics> _get_or_generate_column_statistics(const ColumnID column_id) const;
 
-  void _create_all_column_statistics();
+  void _create_all_column_statistics() const;
 
   /**
    * Resets the pointer variable _table after checking that the table is no longer needed. If the pointer is null, all
@@ -151,7 +151,7 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
   // It is simply used as an estimate for the optimizer, and therefore does not need to be exact.
   uint64_t _approx_invalid_row_count{0};
 
-  std::vector<std::shared_ptr<BaseColumnStatistics>> _column_statistics;
+  mutable std::vector<std::shared_ptr<BaseColumnStatistics>> _column_statistics;
 
   friend std::ostream& operator<<(std::ostream& os, TableStatistics& obj);
 };

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -210,4 +210,16 @@ TEST_F(TableStatisticsTest, NotOverlappingTableScans) {
   check_statistic_with_table_scan(container, ColumnID{0}, PredicateCondition::Equals, AllParameterVariant(3));
 }
 
+TEST_F(TableStatisticsTest, DirectlyAccessColumnStatistics) {
+    /**
+     * check that column statistics are generated even without a predicate
+     */
+    auto column_statistics = _table_a_with_statistics.statistics->get_all_column_statistics();
+    EXPECT_EQ(column_statistics.size(), 4u);
+    for (auto col = ColumnID{0}; col < column_statistics.size(); ++col) {
+        EXPECT_TRUE(column_statistics.at(col));
+        EXPECT_FLOAT_EQ(column_statistics.at(col)->distinct_count(), 6.f);
+    }
+}
+
 }  // namespace opossum

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -211,15 +211,15 @@ TEST_F(TableStatisticsTest, NotOverlappingTableScans) {
 }
 
 TEST_F(TableStatisticsTest, DirectlyAccessColumnStatistics) {
-    /**
+  /**
      * check that column statistics are generated even without a predicate
      */
-    auto column_statistics = _table_a_with_statistics.statistics->get_all_column_statistics();
-    EXPECT_EQ(column_statistics.size(), 4u);
-    for (auto col = ColumnID{0}; col < column_statistics.size(); ++col) {
-        EXPECT_TRUE(column_statistics.at(col));
-        EXPECT_FLOAT_EQ(column_statistics.at(col)->distinct_count(), 6.f);
-    }
+  auto column_statistics = _table_a_with_statistics.statistics->get_all_column_statistics();
+  EXPECT_EQ(column_statistics.size(), 4u);
+  for (auto col = ColumnID{0}; col < column_statistics.size(); ++col) {
+    EXPECT_TRUE(column_statistics.at(col));
+    EXPECT_FLOAT_EQ(column_statistics.at(col)->distinct_count(), 6.f);
+  }
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/table_statistics_test.cpp
+++ b/src/test/optimizer/table_statistics_test.cpp
@@ -214,7 +214,7 @@ TEST_F(TableStatisticsTest, DirectlyAccessColumnStatistics) {
   /**
      * check that column statistics are generated even without a predicate
      */
-  auto column_statistics = _table_a_with_statistics.statistics->get_all_column_statistics();
+  auto column_statistics = _table_a_with_statistics.statistics->column_statistics();
   EXPECT_EQ(column_statistics.size(), 4u);
   for (auto col = ColumnID{0}; col < column_statistics.size(); ++col) {
     EXPECT_TRUE(column_statistics.at(col));


### PR DESCRIPTION
The `TableStatistics` lazily generates `ColumnStatistics` currently *only* when querying them with a predicate. This adds the missing lazy initialization logic to the method `TableStatistics::column_statistics()`, **making it non-const**. I also renamed it to `TableStatistics::get_all_column_statistics()` to emphasize that it returns *all* column statistics and not a specific one.

This ignores other shortcomings and is to be seen as a quickfix to a bug.