### PR TITLE
Feedback needed: Semantic LQP comparison

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -27,6 +27,8 @@ set(
     logical_query_plan/aggregate_node.hpp
     logical_query_plan/lqp_column_reference.cpp
     logical_query_plan/lqp_column_reference.hpp
+    logical_query_plan/compare_lqps.cpp
+    logical_query_plan/compare_lqps.hpp
     logical_query_plan/create_view_node.cpp
     logical_query_plan/create_view_node.hpp
     logical_query_plan/delete_node.cpp

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -25,6 +25,8 @@ set(
     logical_query_plan/abstract_lqp_node.hpp
     logical_query_plan/aggregate_node.cpp
     logical_query_plan/aggregate_node.hpp
+    logical_query_plan/build_lqps.cpp
+    logical_query_plan/build_lqps.hpp
     logical_query_plan/lqp_column_reference.cpp
     logical_query_plan/lqp_column_reference.hpp
     logical_query_plan/compare_lqps.cpp

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -17,6 +17,9 @@ namespace opossum {
 
 class TableStatistics;
 
+QualifiedColumnName::QualifiedColumnName(const std::string& column_name, const std::optional<std::string>& table_name):
+  column_name(column_name), table_name(table_name) {}
+
 AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type) : _type(node_type) {}
 
 std::shared_ptr<AbstractLQPNode> AbstractLQPNode::deep_copy() const {
@@ -266,6 +269,12 @@ LQPColumnReference AbstractLQPNode::get_column(const QualifiedColumnName& qualif
   DebugAssert(colum_origin, "Couldn't resolve column origin of " + qualified_column_name.as_string());
   return *colum_origin;
 }
+//
+//LQPColumnReference AbstractLQPNode::get_column(const std::string& column_name) const {
+//  const auto iter = std::find(output_column_names().begin(), output_column_names().end(), column_name);
+//  DebugAssert(iter != output_column_names().end(), "Couldn't find column " + column_name);
+//  return LQPColumnReference{shared_from_this(), static_cast<ColumnID>(std::distance(output_column_names().begin(), iter))};
+//}
 
 std::shared_ptr<const AbstractLQPNode> AbstractLQPNode::find_table_name_origin(const std::string& table_name) const {
   // If this node has an ALIAS that matches the table_name, this is the node we're looking for

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -42,6 +42,8 @@ enum class LQPNodeType {
 enum class LQPChildSide { Left, Right };
 
 struct QualifiedColumnName {
+  QualifiedColumnName(const std::string& column_name, const std::optional<std::string>& table_name = std::nullopt);
+
   std::string column_name;
   std::optional<std::string> table_name = std::nullopt;
 
@@ -171,10 +173,15 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   std::optional<LQPColumnReference> find_column(const QualifiedColumnName& qualified_column_name) const;
 
   /**
-   * Convenience method for (*find_column_reference_by_qualified_column_name()), DebugAssert()s that the
+   * Convenience method for (*find_column()), DebugAssert()s that the
    * qualified_column_name could be resolved
    */
   LQPColumnReference get_column(const QualifiedColumnName& qualified_column_name) const;
+
+//  /**
+//   * @returns column with the specified name
+////   */
+////  LQPColumnReference get_column(const std::string& column_name) const;
 
   /**
    * @return the StoredTableNode that is called table_name or any that carries it as an alias in this subtree.

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -25,7 +25,7 @@ namespace opossum {
 class AggregateNode : public AbstractLQPNode {
  public:
   explicit AggregateNode(const std::vector<std::shared_ptr<LQPExpression>>& aggregates,
-                         const std::vector<LQPColumnReference>& groupy_column_references);
+                         const std::vector<LQPColumnReference>& groupby_column_references);
 
   const std::vector<std::shared_ptr<LQPExpression>>& aggregate_expressions() const;
   const std::vector<LQPColumnReference>& groupby_column_references() const;

--- a/src/lib/logical_query_plan/build_lqps.cpp
+++ b/src/lib/logical_query_plan/build_lqps.cpp
@@ -1,0 +1,44 @@
+#include "build_lqps.hpp"
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/create_view_node.hpp"
+#include "logical_query_plan/delete_node.hpp"
+#include "logical_query_plan/drop_view_node.hpp"
+#include "logical_query_plan/dummy_table_node.hpp"
+#include "logical_query_plan/insert_node.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/limit_node.hpp"
+#include "logical_query_plan/logical_plan_root_node.hpp"
+#include "logical_query_plan/mock_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/show_columns_node.hpp"
+#include "logical_query_plan/show_tables_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "logical_query_plan/union_node.hpp"
+#include "logical_query_plan/update_node.hpp"
+#include "logical_query_plan/validate_node.hpp"
+
+namespace opossum {
+
+std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::shared_ptr<AbstractLQPNode>& child) {
+  return make_predicate_node(column_reference, predicate_condition, value, std::nullopt)
+}
+
+std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const AllTypeVariant& value2, const std::shared_ptr<AbstractLQPNode>& child) {
+  const auto predicate_node =  std::make_shared<PredicateNode>(column_reference, predicate_condition, value, value2);
+  predicate_node->set_left_child(child);
+  return predicate_node;
+}
+
+std::shared_ptr<ProjectionNode> make_star_projection_node(const std::shared_ptr<AbstractLQPNode>& child) {
+
+}
+
+std::shared_ptr<StoredTableNode> make_stored_table_node(const std::string& table_name, const std::optional<std::string>& alias) {
+
+}
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/build_lqps.cpp
+++ b/src/lib/logical_query_plan/build_lqps.cpp
@@ -50,4 +50,47 @@ std::shared_ptr<StoredTableNode> make_stored_table_node(const std::string& table
   return stored_table_node;
 }
 
+std::shared_ptr<SortNode> make_sort_node(const OrderByDefinitions& order_by_definitions, const std::shared_ptr<AbstractLQPNode>& child) {
+  const auto sort_node = std::make_shared<SortNode>(order_by_definitions);
+  sort_node->set_left_child(child);
+  return sort_node;
+}
+
+std::shared_ptr<JoinNode> make_join_node(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references,
+                                         const PredicateCondition predicate_condition, const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) {
+  const auto join_node = std::make_shared<JoinNode>(join_mode, join_column_references, predicate_condition);
+  join_node->set_left_child(left_child);
+  join_node->set_right_child(right_child);
+  return join_node;
+}
+
+std::shared_ptr<JoinNode> make_join_node(const JoinMode join_mode, const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) {
+  const auto join_node = std::make_shared<JoinNode>(join_mode);
+  join_node->set_left_child(left_child);
+  join_node->set_right_child(right_child);
+  return join_node;
+}
+
+std::shared_ptr<LimitNode> make_limit_node(const size_t num_rows, const std::shared_ptr<AbstractLQPNode>& child) {
+  const auto limit_node = std::make_shared<LimitNode>(num_rows);
+  limit_node->set_left_child(child);
+  return limit_node;
+}
+
+std::shared_ptr<InsertNode> make_insert_node(const std::string& table_name, const std::shared_ptr<AbstractLQPNode>& child) {
+  const auto insert_node = std::make_shared<InsertNode>(table_name);
+  insert_node->set_left_child(child);
+  return insert_node;
+}
+
+std::shared_ptr<UpdateNode> make_update_node(const std::string& table_name, const std::vector<std::shared_ptr<LQPExpression>>& column_expressions, const std::shared_ptr<AbstractLQPNode>& child) {
+  const auto update_node = std::make_shared<UpdateNode>(table_name, column_expressions);
+  update_node->set_left_child(child);
+  return update_node;
+}
+
+std::shared_ptr<CreateViewNode> make_create_view_node(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp) {
+  return std::make_shared<CreateViewNode>(view_name, lqp);
+}
+
 }  // namespace opossum

--- a/src/lib/logical_query_plan/build_lqps.cpp
+++ b/src/lib/logical_query_plan/build_lqps.cpp
@@ -24,21 +24,30 @@
 namespace opossum {
 
 std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::shared_ptr<AbstractLQPNode>& child) {
-  return make_predicate_node(column_reference, predicate_condition, value, std::nullopt)
+  return make_predicate_node(column_reference, predicate_condition, value, std::nullopt, child);
 }
 
-std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const AllTypeVariant& value2, const std::shared_ptr<AbstractLQPNode>& child) {
+std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::optional<AllTypeVariant>& value2, const std::shared_ptr<AbstractLQPNode>& child) {
   const auto predicate_node =  std::make_shared<PredicateNode>(column_reference, predicate_condition, value, value2);
   predicate_node->set_left_child(child);
   return predicate_node;
 }
 
 std::shared_ptr<ProjectionNode> make_star_projection_node(const std::shared_ptr<AbstractLQPNode>& child) {
+  std::vector<std::shared_ptr<LQPExpression>> expressions = LQPExpression::create_columns(child->output_column_references());
+  return make_projection_node(expressions, child);
+}
 
+std::shared_ptr<ProjectionNode> make_projection_node(const std::vector<std::shared_ptr<LQPExpression>>& column_expressions, const std::shared_ptr<AbstractLQPNode>& child) {
+  const auto projection_node = std::make_shared<ProjectionNode>(column_expressions);
+  projection_node->set_left_child(child);
+  return projection_node;
 }
 
 std::shared_ptr<StoredTableNode> make_stored_table_node(const std::string& table_name, const std::optional<std::string>& alias) {
-
+  const auto stored_table_node = std::make_shared<StoredTableNode>(table_name);
+  stored_table_node->set_alias(alias);
+  return stored_table_node;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/build_lqps.hpp
+++ b/src/lib/logical_query_plan/build_lqps.hpp
@@ -10,13 +10,15 @@
 namespace opossum {
 
 class AbstractLQPNode;
+class LQPExpression;
 class ProjectionNode;
 class PredicateNode;
 class StoredTableNode;
 
 std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::shared_ptr<AbstractLQPNode>& child);
-std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const AllTypeVariant& value2, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::optional<AllTypeVariant>& value2, const std::shared_ptr<AbstractLQPNode>& child);
 std::shared_ptr<ProjectionNode> make_star_projection_node(const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<ProjectionNode> make_projection_node(const std::vector<std::shared_ptr<LQPExpression>>& column_expressions, const std::shared_ptr<AbstractLQPNode>& child);
 std::shared_ptr<StoredTableNode> make_stored_table_node(const std::string& table_name, const std::optional<std::string>& alias = std::nullopt);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/build_lqps.hpp
+++ b/src/lib/logical_query_plan/build_lqps.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <memory>
+
+#include "types.hpp"
+#include "all_parameter_variant.hpp"
+#include "all_type_variant.hpp"
+#include "lqp_column_reference.hpp"
+
+namespace opossum {
+
+class AbstractLQPNode;
+class ProjectionNode;
+class PredicateNode;
+class StoredTableNode;
+
+std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const AllTypeVariant& value2, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<ProjectionNode> make_star_projection_node(const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<StoredTableNode> make_stored_table_node(const std::string& table_name, const std::optional<std::string>& alias = std::nullopt);
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/build_lqps.hpp
+++ b/src/lib/logical_query_plan/build_lqps.hpp
@@ -6,19 +6,33 @@
 #include "all_parameter_variant.hpp"
 #include "all_type_variant.hpp"
 #include "lqp_column_reference.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
 
 namespace opossum {
 
 class AbstractLQPNode;
+class CreateViewNode;
+class InsertNode;
+class LimitNode;
 class LQPExpression;
 class ProjectionNode;
 class PredicateNode;
 class StoredTableNode;
+class UpdateNode;
 
 std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::shared_ptr<AbstractLQPNode>& child);
 std::shared_ptr<PredicateNode> make_predicate_node(const LQPColumnReference& column_reference, const PredicateCondition predicate_condition, const AllParameterVariant& value, const std::optional<AllTypeVariant>& value2, const std::shared_ptr<AbstractLQPNode>& child);
 std::shared_ptr<ProjectionNode> make_star_projection_node(const std::shared_ptr<AbstractLQPNode>& child);
 std::shared_ptr<ProjectionNode> make_projection_node(const std::vector<std::shared_ptr<LQPExpression>>& column_expressions, const std::shared_ptr<AbstractLQPNode>& child);
 std::shared_ptr<StoredTableNode> make_stored_table_node(const std::string& table_name, const std::optional<std::string>& alias = std::nullopt);
+std::shared_ptr<SortNode> make_sort_node(const OrderByDefinitions& order_by_definitions, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<JoinNode> make_join_node(const JoinMode join_mode, const LQPColumnReferencePair& join_column_references,
+                                         const PredicateCondition predicate_condition, const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child);
+std::shared_ptr<JoinNode> make_join_node(const JoinMode join_mode, const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child);
+std::shared_ptr<LimitNode> make_limit_node(const size_t num_rows, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<InsertNode> make_insert_node(const std::string& table_name, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<UpdateNode> make_update_node(const std::string& table_name, const std::vector<std::shared_ptr<LQPExpression>>& column_expressions, const std::shared_ptr<AbstractLQPNode>& child);
+std::shared_ptr<CreateViewNode> make_create_view_node(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/compare_lqps.cpp
+++ b/src/lib/logical_query_plan/compare_lqps.cpp
@@ -84,7 +84,7 @@ bool SemanticLQPCompare::_semantical_traverse(const std::shared_ptr<const Abstra
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const AggregateNode>& lhs, const std::shared_ptr<const AggregateNode>& rhs) {
-  return _compare_expressions(lhs->aggregate_expressions(), rhs->aggregate_expressions()) && _compare_column_references(lhs->groupby_column_references(), rhs->groupby_column_references());
+  return _compare_expressions(lhs, lhs->aggregate_expressions(), rhs, rhs->aggregate_expressions()) && _compare_column_references(lhs, lhs->groupby_column_references(), rhs, rhs->groupby_column_references());
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const CreateViewNode>& lhs, const std::shared_ptr<const CreateViewNode>& rhs) {
@@ -113,7 +113,8 @@ bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const Joi
 
   if (!lhs->join_column_references().has_value()) return true;
 
-  return _compare_column_references(lhs->join_column_references()->first, rhs->join_column_references()->first) &&  _compare_column_references(lhs->join_column_references()->second, rhs->join_column_references()->second);
+  return _compare_column_references(lhs, lhs->join_column_references()->first, rhs, rhs->join_column_references()->first) &&
+  _compare_column_references(lhs, lhs->join_column_references()->second, rhs, rhs->join_column_references()->second);
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const LimitNode>& lhs, const std::shared_ptr<const LimitNode>& rhs) {
@@ -121,11 +122,11 @@ bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const Lim
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const PredicateNode>& lhs, const std::shared_ptr<const PredicateNode>& rhs) {
-  if (!_compare_column_references(lhs->column_reference(), rhs->column_reference())) return false;
+  if (!_compare_column_references(lhs, lhs->column_reference(), rhs, rhs->column_reference())) return false;
   if (lhs->scan_type() != rhs->scan_type()) return false;
   if (is_lqp_column_reference(lhs->value()) != is_lqp_column_reference(rhs->value())) return false;
   if (is_lqp_column_reference(lhs->value())) {
-    if (_compare_column_references(boost::get<LQPColumnReference>(lhs->value()), boost::get<LQPColumnReference>(rhs->value()))) return false;
+    if (_compare_column_references(lhs, boost::get<LQPColumnReference>(lhs->value()), rhs, boost::get<LQPColumnReference>(rhs->value()))) return false;
   } else {
     if (lhs->value() != rhs->value()) return false;
   }
@@ -134,7 +135,7 @@ bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const Pre
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const ProjectionNode>& lhs, const std::shared_ptr<const ProjectionNode>& rhs) {
-  return _compare_expressions(lhs->column_expressions(), rhs->column_expressions());
+  return _compare_expressions(lhs, lhs->column_expressions(), rhs, rhs->column_expressions());
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const LogicalPlanRootNode>& lhs, const std::shared_ptr<const LogicalPlanRootNode>& rhs) {
@@ -151,26 +152,94 @@ bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const Sho
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const SortNode>& lhs, const std::shared_ptr<const SortNode>& rhs) {
   if (lhs->order_by_definitions().size() != rhs->order_by_definitions().size()) return false;
+
+  for (size_t definition_idx = 0; definition_idx < rhs->order_by_definitions().size(); ++definition_idx) {
+    if (lhs->order_by_definitions()[definition_idx].order_by_mode != rhs->order_by_definitions()[definition_idx].order_by_mode) return false;
+    if (_compare_column_references(lhs, lhs->order_by_definitions()[definition_idx].column_reference, rhs, rhs->order_by_definitions()[definition_idx].column_reference)) return false;
+  }
+
+  return true;
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const StoredTableNode>& lhs, const std::shared_ptr<const StoredTableNode>& rhs) {
-
+  return lhs->table_name() == rhs->table_name();
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const UpdateNode>& lhs, const std::shared_ptr<const UpdateNode>& rhs) {
-
+  return lhs->table_name() == rhs->table_name() && _compare_expressions(lhs, lhs->column_expressions(), rhs, rhs->column_expressions());
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const UnionNode>& lhs, const std::shared_ptr<const UnionNode>& rhs) {
-
+  return lhs->union_mode() == rhs->union_mode();
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const ValidateNode>& lhs, const std::shared_ptr<const ValidateNode>& rhs) {
-
+  return true;
 }
 
 bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const MockNode>& lhs, const std::shared_ptr<const MockNode>& rhs) {
+  return lhs->constructor_arguments() == rhs->constructor_arguments();
+//  if (lhs->constructor_arguments().which() != rhs->constructor_arguments().which()) return false;
+//
+//  if (lhs->constructor_arguments().type() == typeid(MockNode::ColumnDefinitions)) {
+//    return boost::get<MockNode::ColumnDefinitions>(lhs->constructor_arguments()) ==
+//  } else if (lhs->constructor_arguments().type() == typeid(std::shared_ptr<TableStatistics>)) {
+//
+//  } else {
+//    Fail("Constructor arguments comparison not implemented for this type.")
+//  }
+}
 
+bool SemanticLQPCompare::_compare_expressions(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::vector<std::shared_ptr<LQPExpression>>& expressions_left,
+                          const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::vector<std::shared_ptr<LQPExpression>>& expressions_right) const {
+  if (expressions_left.size() != expressions_right.size()) return false;
+
+  for (size_t expression_idx = 0; expression_idx < expressions_left.size(); ++expression_idx) {
+    if (!_compare_expressions(lqp_left, expressions_left[expression_idx], lqp_right, expressions_right[expression_idx])) return false;
+  }
+
+  return true;
+}
+
+bool SemanticLQPCompare::_compare_expressions(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::shared_ptr<const LQPExpression>& expression_left,
+                          const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::shared_ptr<const LQPExpression>& expression_right) const {
+  if (static_cast<bool>(expression_left) != static_cast<bool>(expression_right)) return false;
+  if (*expression_left == *expression_right) return true;
+  if (expression_left->type() != expression_right->type()) return false;
+  if (expression_left->aggregate_function_arguments().size() != expression_right->aggregate_function_arguments().size()) return false;
+
+  const auto type = expression_left->type();
+
+  if (type == ExpressionType::Column) {
+    return _compare_column_references(lqp_left, expression_left->column_reference(), lqp_right, expression_right->column_reference());
+  }
+
+  for (size_t arg_idx = 0; arg_idx < expression_left->aggregate_function_arguments().size(); ++arg_idx) {
+    if (!_compare_expressions(lqp_left, expression_left->aggregate_function_arguments()[arg_idx], lqp_right, expression_right->aggregate_function_arguments()[arg_idx])) return false;
+  }
+
+  if (!_compare_expressions(lqp_left, expression_left->left_child(), lqp_right, expression_right->left_child())) return false;
+  if (!_compare_expressions(lqp_right, expression_left->right_child(), lqp_right, expression_right->right_child())) return false;
+
+  return true;
+}
+
+bool SemanticLQPCompare::_compare_column_references(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::vector<LQPColumnReference>& column_references_left,
+                                const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::vector<LQPColumnReference>& column_references_right) const {
+  if (column_references_left.size() != column_references_right.size()) return false;
+  for (size_t column_reference_idx = 0; column_reference_idx < column_references_left.size(); ++column_reference_idx) {
+    if (!_compare_column_references(lqp_left, column_references_left[column_reference_idx], lqp_right, column_references_right[column_reference_idx])) return false;
+  }
+  return true;
+}
+
+bool SemanticLQPCompare:: _compare_column_references(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const LQPColumnReference& column_reference_left,
+                                const std::shared_ptr<const AbstractLQPNode>&lqp_right, const LQPColumnReference& column_reference_right) const {
+  // We just need a temporary ColumnReference which won't be used to manipulate nodes, promised.
+  const auto mutable_lqp_left = std::const_pointer_cast<AbstractLQPNode>(lqp_left);
+  const auto mutable_lqp_right = std::const_pointer_cast<AbstractLQPNode>(lqp_right);
+
+  return AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_right, mutable_lqp_left, mutable_lqp_right) == column_reference_right;
 }
 
 bool lqp_node_types_equal(const std::shared_ptr<const AbstractLQPNode>& lhs,

--- a/src/lib/logical_query_plan/compare_lqps.cpp
+++ b/src/lib/logical_query_plan/compare_lqps.cpp
@@ -239,7 +239,7 @@ bool SemanticLQPCompare:: _compare_column_references(const std::shared_ptr<const
   const auto mutable_lqp_left = std::const_pointer_cast<AbstractLQPNode>(lqp_left);
   const auto mutable_lqp_right = std::const_pointer_cast<AbstractLQPNode>(lqp_right);
 
-  return AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_right, mutable_lqp_left, mutable_lqp_right) == column_reference_right;
+  return AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_left, mutable_lqp_left, mutable_lqp_right) == column_reference_right;
 }
 
 bool lqp_node_types_equal(const std::shared_ptr<const AbstractLQPNode>& lhs,

--- a/src/lib/logical_query_plan/compare_lqps.cpp
+++ b/src/lib/logical_query_plan/compare_lqps.cpp
@@ -57,6 +57,7 @@ bool SemanticLQPCompare::_structural_traverse(const std::shared_ptr<const Abstra
 bool SemanticLQPCompare::_semantical_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs) {
   if (!lhs && !rhs) return true;
   if (!lhs || !rhs) return false;
+  if (lhs == rhs) return true;
 
   auto semantically_equal = false;
 

--- a/src/lib/logical_query_plan/compare_lqps.cpp
+++ b/src/lib/logical_query_plan/compare_lqps.cpp
@@ -1,0 +1,187 @@
+#include "compare_lqps.hpp"
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/create_view_node.hpp"
+#include "logical_query_plan/delete_node.hpp"
+#include "logical_query_plan/drop_view_node.hpp"
+#include "logical_query_plan/dummy_table_node.hpp"
+#include "logical_query_plan/insert_node.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/limit_node.hpp"
+#include "logical_query_plan/logical_plan_root_node.hpp"
+#include "logical_query_plan/mock_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/show_columns_node.hpp"
+#include "logical_query_plan/show_tables_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "logical_query_plan/union_node.hpp"
+#include "logical_query_plan/update_node.hpp"
+#include "logical_query_plan/validate_node.hpp"
+
+namespace opossum {
+
+SemanticLQPCompare::SemanticLQPCompare(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs): _lhs(lhs), _rhs(rhs) {
+
+}
+
+bool SemanticLQPCompare::operator()() {
+  if (!_structural_traverse(_lhs, _rhs)) {
+    return false;
+  }
+
+  return _semantical_traverse(_lhs, _rhs);
+}
+
+bool SemanticLQPCompare::_structural_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs) {
+  if (lhs == nullptr && rhs == nullptr) return true;
+  if (lhs == nullptr || rhs == nullptr) return false;
+
+  if (lhs->type() != rhs->type()) return false;
+
+  // Checks number of columns AND names
+  if (lhs->output_column_names() != rhs->output_column_names()) return false;
+
+  _node_mapping[lhs] = rhs;
+
+  return _structural_traverse(lhs->left_child(), rhs->left_child()) &&
+  _structural_traverse(lhs->right_child(), rhs->right_child());
+}
+
+bool SemanticLQPCompare::_semantical_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs) {
+  if (!lhs) return false; // Implies !rhs
+
+  auto semantically_equal = false;
+
+  switch(lhs->type()) {
+    case LQPNodeType::Aggregate: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const AggregateNode>(lhs), std::dynamic_pointer_cast<const AggregateNode>(rhs)); break;
+    case LQPNodeType::CreateView: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const CreateViewNode>(lhs), std::dynamic_pointer_cast<const CreateViewNode>(rhs)); break;
+    case LQPNodeType::Delete: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const DeleteNode>(lhs), std::dynamic_pointer_cast<const DeleteNode>(rhs)); break;
+    case LQPNodeType::DropView: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const DropViewNode>(lhs), std::dynamic_pointer_cast<const DropViewNode>(rhs)); break;
+    case LQPNodeType::DummyTable: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const DummyTableNode>(lhs), std::dynamic_pointer_cast<const DummyTableNode>(rhs)); break;
+    case LQPNodeType::Insert: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const InsertNode>(lhs), std::dynamic_pointer_cast<const InsertNode>(rhs)); break;
+    case LQPNodeType::Join: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const JoinNode>(lhs), std::dynamic_pointer_cast<const JoinNode>(rhs)); break;
+    case LQPNodeType::Limit: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const LimitNode>(lhs), std::dynamic_pointer_cast<const LimitNode>(rhs)); break;
+    case LQPNodeType::Predicate: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const PredicateNode>(lhs), std::dynamic_pointer_cast<const PredicateNode>(rhs)); break;
+    case LQPNodeType::Projection: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const ProjectionNode>(lhs), std::dynamic_pointer_cast<const ProjectionNode>(rhs)); break;
+    case LQPNodeType::Root: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const LogicalPlanRootNode>(lhs), std::dynamic_pointer_cast<const LogicalPlanRootNode>(rhs)); break;
+    case LQPNodeType::ShowColumns: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const ShowColumnsNode>(lhs), std::dynamic_pointer_cast<const ShowColumnsNode>(rhs)); break;
+    case LQPNodeType::ShowTables: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const ShowTablesNode>(lhs), std::dynamic_pointer_cast<const ShowTablesNode>(rhs)); break;
+    case LQPNodeType::Sort: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const SortNode>(lhs), std::dynamic_pointer_cast<const SortNode>(rhs)); break;
+    case LQPNodeType::StoredTable: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const StoredTableNode>(lhs), std::dynamic_pointer_cast<const StoredTableNode>(rhs)); break;
+    case LQPNodeType::Update: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const UpdateNode>(lhs), std::dynamic_pointer_cast<const UpdateNode>(rhs)); break;
+    case LQPNodeType::Union: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const UnionNode>(lhs), std::dynamic_pointer_cast<const UnionNode>(rhs)); break;
+    case LQPNodeType::Validate: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const ValidateNode>(lhs), std::dynamic_pointer_cast<const ValidateNode>(rhs)); break;
+    case LQPNodeType::Mock: semantically_equal = _are_semantically_equal(std::dynamic_pointer_cast<const MockNode>(lhs), std::dynamic_pointer_cast<const MockNode>(rhs)); break;
+  }
+
+  if (!semantically_equal) return false;
+
+  if (!_semantical_traverse(lhs->left_child(), rhs->left_child())) return false;
+  return _semantical_traverse(lhs->right_child(), rhs->right_child());
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const AggregateNode>& lhs, const std::shared_ptr<const AggregateNode>& rhs) {
+  return _compare_expressions(lhs->aggregate_expressions(), rhs->aggregate_expressions()) && _compare_column_references(lhs->groupby_column_references(), rhs->groupby_column_references());
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const CreateViewNode>& lhs, const std::shared_ptr<const CreateViewNode>& rhs) {
+  return lhs->view_name() == rhs->view_name() && SemanticLQPCompare{lhs->lqp(), rhs->lqp()}();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const DeleteNode>& lhs, const std::shared_ptr<const DeleteNode>& rhs) {
+  return lhs->table_name() == rhs->table_name();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const DropViewNode>& lhs, const std::shared_ptr<const DropViewNode>& rhs) {
+  return lhs->view_name() == rhs->view_name();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const DummyTableNode>& lhs, const std::shared_ptr<const DummyTableNode>& rhs) {
+  return true;
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const InsertNode>& lhs, const std::shared_ptr<const InsertNode>& rhs) {
+  return lhs->table_name() == rhs->table_name();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const JoinNode>& lhs, const std::shared_ptr<const JoinNode>& rhs) {
+  if (lhs->join_mode() != rhs->join_mode() || lhs->scan_type() != rhs->scan_type()) return false;
+  if (lhs->join_column_references().has_value() != rhs->join_column_references().has_value()) return false;
+
+  if (!lhs->join_column_references().has_value()) return true;
+
+  return _compare_column_references(lhs->join_column_references()->first, rhs->join_column_references()->first) &&  _compare_column_references(lhs->join_column_references()->second, rhs->join_column_references()->second);
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const LimitNode>& lhs, const std::shared_ptr<const LimitNode>& rhs) {
+  return lhs->num_rows() == rhs->num_rows();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const PredicateNode>& lhs, const std::shared_ptr<const PredicateNode>& rhs) {
+  if (!_compare_column_references(lhs->column_reference(), rhs->column_reference())) return false;
+  if (lhs->scan_type() != rhs->scan_type()) return false;
+  if (is_lqp_column_reference(lhs->value()) != is_lqp_column_reference(rhs->value())) return false;
+  if (is_lqp_column_reference(lhs->value())) {
+    if (_compare_column_references(boost::get<LQPColumnReference>(lhs->value()), boost::get<LQPColumnReference>(rhs->value()))) return false;
+  } else {
+    if (lhs->value() != rhs->value()) return false;
+  }
+
+  return lhs->value2() != rhs->value2();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const ProjectionNode>& lhs, const std::shared_ptr<const ProjectionNode>& rhs) {
+  return _compare_expressions(lhs->column_expressions(), rhs->column_expressions());
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const LogicalPlanRootNode>& lhs, const std::shared_ptr<const LogicalPlanRootNode>& rhs) {
+  return true;
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const ShowColumnsNode>& lhs, const std::shared_ptr<const ShowColumnsNode>& rhs) {
+  return lhs->table_name() == rhs->table_name();
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const ShowTablesNode>& lhs, const std::shared_ptr<const ShowTablesNode>& rhs) {
+  return true;
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const SortNode>& lhs, const std::shared_ptr<const SortNode>& rhs) {
+  if (lhs->order_by_definitions().size() != rhs->order_by_definitions().size()) return false;
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const StoredTableNode>& lhs, const std::shared_ptr<const StoredTableNode>& rhs) {
+
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const UpdateNode>& lhs, const std::shared_ptr<const UpdateNode>& rhs) {
+
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const UnionNode>& lhs, const std::shared_ptr<const UnionNode>& rhs) {
+
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const ValidateNode>& lhs, const std::shared_ptr<const ValidateNode>& rhs) {
+
+}
+
+bool SemanticLQPCompare::_are_semantically_equal(const std::shared_ptr<const MockNode>& lhs, const std::shared_ptr<const MockNode>& rhs) {
+
+}
+
+bool lqp_node_types_equal(const std::shared_ptr<const AbstractLQPNode>& lhs,
+                          const std::shared_ptr<const AbstractLQPNode>& rhs) {
+  if (lhs == nullptr && rhs == nullptr) return true;
+  if (lhs == nullptr) return false;
+  if (rhs == nullptr) return false;
+
+  if (lhs->type() != rhs->type()) return false;
+  return lqp_node_types_equal(lhs->left_child(), rhs->left_child()) &&
+  lqp_node_types_equal(lhs->right_child(), rhs->right_child());
+}
+
+}

--- a/src/lib/logical_query_plan/compare_lqps.hpp
+++ b/src/lib/logical_query_plan/compare_lqps.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+namespace opossum {
+
+class AbstractLQPNode;
+class AggregateNode;
+class CreateViewNode;
+class DeleteNode;
+class DropViewNode;
+class DummyTableNode;
+class InsertNode;
+class JoinNode;
+class LimitNode;
+class PredicateNode;
+class ProjectionNode;
+class LogicalPlanRootNode;
+class ShowColumnsNode;
+class ShowTablesNode;
+class SortNode;
+class StoredTableNode;
+class UpdateNode;
+class ValidateNode;
+class MockNode;
+class UnionNode;
+
+class SemanticLQPCompare final {
+ public:
+  SemanticLQPCompare(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
+
+  bool operator()();
+
+ private:
+  std::shared_ptr<const AbstractLQPNode> _lhs;
+  std::shared_ptr<const AbstractLQPNode> _rhs;
+
+  std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>> _node_mapping;
+
+  bool _structural_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
+  bool _semantical_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const AggregateNode>& lhs, const std::shared_ptr<const AggregateNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const CreateViewNode>& lhs, const std::shared_ptr<const CreateViewNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const DeleteNode>& lhs, const std::shared_ptr<const DeleteNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const DropViewNode>& lhs, const std::shared_ptr<const DropViewNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const DummyTableNode>& lhs, const std::shared_ptr<const DummyTableNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const InsertNode>& lhs, const std::shared_ptr<const InsertNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const JoinNode>& lhs, const std::shared_ptr<const JoinNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const LimitNode>& lhs, const std::shared_ptr<const LimitNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const PredicateNode>& lhs, const std::shared_ptr<const PredicateNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const ProjectionNode>& lhs, const std::shared_ptr<const ProjectionNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const LogicalPlanRootNode>& lhs, const std::shared_ptr<const LogicalPlanRootNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const ShowColumnsNode>& lhs, const std::shared_ptr<const ShowColumnsNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const ShowTablesNode>& lhs, const std::shared_ptr<const ShowTablesNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const SortNode>& lhs, const std::shared_ptr<const SortNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const StoredTableNode>& lhs, const std::shared_ptr<const StoredTableNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const UpdateNode>& lhs, const std::shared_ptr<const UpdateNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const UnionNode>& lhs, const std::shared_ptr<const UnionNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const ValidateNode>& lhs, const std::shared_ptr<const ValidateNode>& rhs);
+  bool _are_semantically_equal(const std::shared_ptr<const MockNode>& lhs, const std::shared_ptr<const MockNode>& rhs);
+};
+
+bool lqp_node_semantic_compare(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
+
+bool lqp_node_types_equal(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/compare_lqps.hpp
+++ b/src/lib/logical_query_plan/compare_lqps.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 namespace opossum {
 
@@ -25,6 +26,8 @@ class UpdateNode;
 class ValidateNode;
 class MockNode;
 class UnionNode;
+class LQPColumnReference;
+class LQPExpression;
 
 class SemanticLQPCompare final {
  public:
@@ -59,6 +62,16 @@ class SemanticLQPCompare final {
   bool _are_semantically_equal(const std::shared_ptr<const UnionNode>& lhs, const std::shared_ptr<const UnionNode>& rhs);
   bool _are_semantically_equal(const std::shared_ptr<const ValidateNode>& lhs, const std::shared_ptr<const ValidateNode>& rhs);
   bool _are_semantically_equal(const std::shared_ptr<const MockNode>& lhs, const std::shared_ptr<const MockNode>& rhs);
+
+  bool _compare_expressions(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::vector<std::shared_ptr<LQPExpression>>& expressions_left,
+                            const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::vector<std::shared_ptr<LQPExpression>>& expressions_right) const;
+  bool _compare_expressions(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::shared_ptr<const LQPExpression>& expression_left,
+                            const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::shared_ptr<const LQPExpression>& expression_right) const;
+
+  bool _compare_column_references(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::vector<LQPColumnReference>& column_references_left,
+                            const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::vector<LQPColumnReference>& column_references_right) const;
+  bool _compare_column_references(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const LQPColumnReference& column_reference_left,
+                                  const std::shared_ptr<const AbstractLQPNode>&lqp_right, const LQPColumnReference& column_reference_right) const;
 };
 
 bool lqp_node_semantic_compare(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);

--- a/src/lib/logical_query_plan/compare_lqps.hpp
+++ b/src/lib/logical_query_plan/compare_lqps.hpp
@@ -33,6 +33,8 @@ class SemanticLQPCompare final {
  public:
   SemanticLQPCompare(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
 
+  const std::vector<std::pair<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>>>& differing_subtrees() const;
+
   bool operator()();
 
  private:
@@ -40,6 +42,8 @@ class SemanticLQPCompare final {
   std::shared_ptr<const AbstractLQPNode> _rhs;
 
   std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>> _node_mapping;
+
+  std::vector<std::pair<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>>> _differing_subtrees;
 
   bool _structural_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);
   bool _semantical_traverse(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);

--- a/src/lib/logical_query_plan/compare_lqps.hpp
+++ b/src/lib/logical_query_plan/compare_lqps.hpp
@@ -4,6 +4,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "all_parameter_variant.hpp"
+
 namespace opossum {
 
 class AbstractLQPNode;
@@ -67,15 +69,25 @@ class SemanticLQPCompare final {
   bool _are_semantically_equal(const std::shared_ptr<const ValidateNode>& lhs, const std::shared_ptr<const ValidateNode>& rhs);
   bool _are_semantically_equal(const std::shared_ptr<const MockNode>& lhs, const std::shared_ptr<const MockNode>& rhs);
 
-  bool _compare_expressions(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::vector<std::shared_ptr<LQPExpression>>& expressions_left,
-                            const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::vector<std::shared_ptr<LQPExpression>>& expressions_right) const;
-  bool _compare_expressions(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::shared_ptr<const LQPExpression>& expression_left,
-                            const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::shared_ptr<const LQPExpression>& expression_right) const;
+  bool _compare(const std::shared_ptr<const AbstractLQPNode> &lqp_left,
+                const std::vector<std::shared_ptr<LQPExpression>> &expressions_left,
+                const std::shared_ptr<const AbstractLQPNode> &lqp_right,
+                const std::vector<std::shared_ptr<LQPExpression>> &expressions_right) const;
+  bool _compare(const std::shared_ptr<const AbstractLQPNode> &lqp_left,
+                const std::shared_ptr<const LQPExpression> &expression_left,
+                const std::shared_ptr<const AbstractLQPNode> &lqp_right,
+                const std::shared_ptr<const LQPExpression> &expression_right) const;
 
-  bool _compare_column_references(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const std::vector<LQPColumnReference>& column_references_left,
-                            const std::shared_ptr<const AbstractLQPNode>&lqp_right, const std::vector<LQPColumnReference>& column_references_right) const;
-  bool _compare_column_references(const std::shared_ptr<const AbstractLQPNode>&lqp_left, const LQPColumnReference& column_reference_left,
-                                  const std::shared_ptr<const AbstractLQPNode>&lqp_right, const LQPColumnReference& column_reference_right) const;
+  bool _compare(const std::shared_ptr<const AbstractLQPNode> &lqp_left,
+                const std::vector<LQPColumnReference> &column_references_left,
+                const std::shared_ptr<const AbstractLQPNode> &lqp_right,
+                const std::vector<LQPColumnReference> &column_references_right) const;
+  bool _compare(const std::shared_ptr<const AbstractLQPNode> &lqp_left, const LQPColumnReference &column_reference_left,
+                const std::shared_ptr<const AbstractLQPNode> &lqp_right,
+                const LQPColumnReference &column_reference_right) const;
+
+  bool _compare(const AllParameterVariant& lhs, const AllParameterVariant& rhs) const;
+  bool _compare(const AllTypeVariant& lhs, const AllTypeVariant& rhs) const;
 };
 
 bool lqp_node_semantic_compare(const std::shared_ptr<const AbstractLQPNode>& lhs, const std::shared_ptr<const AbstractLQPNode>& rhs);

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -1,6 +1,7 @@
 #include "create_view_node.hpp"
 
 #include <string>
+#include <sstream>
 
 namespace opossum {
 
@@ -8,6 +9,7 @@ CreateViewNode::CreateViewNode(const std::string& view_name, std::shared_ptr<con
     : AbstractLQPNode(LQPNodeType::CreateView), _view_name(view_name), _lqp(lqp) {}
 
 std::string CreateViewNode::view_name() const { return _view_name; }
+
 std::shared_ptr<const AbstractLQPNode> CreateViewNode::lqp() const { return _lqp; }
 
 std::shared_ptr<AbstractLQPNode> CreateViewNode::_deep_copy_impl(
@@ -17,6 +19,15 @@ std::shared_ptr<AbstractLQPNode> CreateViewNode::_deep_copy_impl(
   return std::make_shared<CreateViewNode>(_view_name, _lqp);
 }
 
-std::string CreateViewNode::description() const { return "[CreateView]"; }
+std::string CreateViewNode::description() const {
+  std::stringstream stream;
+  _lqp->print(stream);
+
+  return "[CreateView] Name: '" + _view_name + "' (\n" + stream.str() + ")";
+}
+
+const std::vector<std::string>& CreateViewNode::output_column_names() const {
+  return _output_column_names_dummy;
+}
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -14,6 +14,7 @@ class CreateViewNode : public AbstractLQPNode {
   explicit CreateViewNode(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp);
 
   std::string description() const override;
+  const std::vector<std::string>& output_column_names() const override;
 
   std::string view_name() const;
   std::shared_ptr<const AbstractLQPNode> lqp() const;
@@ -24,6 +25,10 @@ class CreateViewNode : public AbstractLQPNode {
       const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
   const std::string _view_name;
   const std::shared_ptr<const AbstractLQPNode> _lqp;
+
+ private:
+  // Need an instance since we're returning a reference in the getter
+  std::vector<std::string> _output_column_names_dummy;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -28,6 +28,10 @@ std::string DropViewNode::description() const {
 
 bool DropViewNode::subtree_is_read_only() const { return false; }
 
+const std::vector<std::string>& DropViewNode::output_column_names() const {
+  return _output_column_names_dummy;
+}
+
 const std::string& DropViewNode::view_name() const { return _view_name; }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -16,6 +16,7 @@ class DropViewNode : public AbstractLQPNode {
 
   std::string description() const override;
   bool subtree_is_read_only() const override;
+  const std::vector<std::string>& output_column_names() const override;
 
   const std::string& view_name() const;
 
@@ -23,7 +24,12 @@ class DropViewNode : public AbstractLQPNode {
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
       const std::shared_ptr<AbstractLQPNode>& copied_left_child,
       const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+
+ private:
   const std::string _view_name;
+
+  // Need an instance since we're returning a reference in the getter
+  std::vector<std::string> _output_column_names_dummy;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -22,7 +22,7 @@ class InsertNode : public AbstractLQPNode {
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-                                                   const std::shared_ptr<AbstractLQPNode>& copied_child) const override;
+                                                   const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
   const std::string _table_name;
 };
 

--- a/src/lib/logical_query_plan/lqp_expression.cpp
+++ b/src/lib/logical_query_plan/lqp_expression.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 std::shared_ptr<LQPExpression> LQPExpression::create_column(const LQPColumnReference& column_reference,
                                                             const std::optional<std::string>& alias) {
   auto expression = std::make_shared<LQPExpression>(ExpressionType::Column);
-  expression->_column_references = column_reference;
+  expression->_column_reference = column_reference;
   expression->_alias = alias;
 
   return expression;
@@ -37,14 +37,14 @@ std::vector<std::shared_ptr<LQPExpression>> LQPExpression::create_columns(
 }
 
 const LQPColumnReference& LQPExpression::column_reference() const {
-  DebugAssert(_column_references,
+  DebugAssert(_column_reference,
               "Expression " + expression_type_to_string.at(_type) + " does not have a LQPColumnReference");
-  return *_column_references;
+  return *_column_reference;
 }
 
 void LQPExpression::set_column_reference(const LQPColumnReference& column_reference) {
   Assert(_type == ExpressionType::Column, "Can't set an LQPColumnReference on a non-column");
-  _column_references = column_reference;
+  _column_reference = column_reference;
 }
 
 std::string LQPExpression::to_string(const std::optional<std::vector<std::string>>& input_column_names,
@@ -59,10 +59,10 @@ bool LQPExpression::operator==(const LQPExpression& other) const {
   if (!AbstractExpression<LQPExpression>::operator==(other)) {
     return false;
   }
-  return _column_references == other._column_references;
+  return _column_reference == other._column_reference;
 }
 
 void LQPExpression::_deep_copy_impl(const std::shared_ptr<LQPExpression>& copy) const {
-  copy->_column_references = _column_references;
+  copy->_column_reference = _column_reference;
 }
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_expression.cpp
+++ b/src/lib/logical_query_plan/lqp_expression.cpp
@@ -50,7 +50,7 @@ void LQPExpression::set_column_reference(const LQPColumnReference& column_refere
 std::string LQPExpression::to_string(const std::optional<std::vector<std::string>>& input_column_names,
                                      bool is_root) const {
   if (type() == ExpressionType::Column) {
-    return column_reference().description();
+    return column_reference().description() + (_alias ? " AS " + *_alias : std::string{});
   }
   return AbstractExpression<LQPExpression>::to_string(input_column_names, is_root);
 }

--- a/src/lib/logical_query_plan/lqp_expression.hpp
+++ b/src/lib/logical_query_plan/lqp_expression.hpp
@@ -36,6 +36,6 @@ class LQPExpression : public AbstractExpression<LQPExpression> {
   void _deep_copy_impl(const std::shared_ptr<LQPExpression>& copy) const override;
 
  private:
-  std::optional<LQPColumnReference> _column_references;
+  std::optional<LQPColumnReference> _column_reference;
 };
 }  // namespace opossum

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -45,6 +45,10 @@ std::shared_ptr<AbstractLQPNode> MockNode::_deep_copy_impl(
 
 const std::vector<std::string>& MockNode::output_column_names() const { return _output_column_names; }
 
+const boost::variant<MockNode::ColumnDefinitions, std::shared_ptr<TableStatistics>>& MockNode::constructor_arguments() const {
+  return _constructor_arguments;
+}
+
 std::string MockNode::get_verbose_column_name(ColumnID column_id) const {
   // Aliasing a MockNode doesn't really make sense, but let's stay covered
   if (_table_alias) {

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -28,6 +28,8 @@ class MockNode : public AbstractLQPNode {
 
   const std::vector<std::string>& output_column_names() const override;
 
+  const boost::variant<ColumnDefinitions, std::shared_ptr<TableStatistics>>& constructor_arguments() const;
+
   std::string description() const override;
   std::string get_verbose_column_name(ColumnID column_id) const override;
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(
     lib/all_parameter_variant_test.cpp
     lib/all_type_variant_test.cpp
     logical_query_plan/aggregate_node_test.cpp
+    logical_query_plan/compare_lqps_test.cpp
     logical_query_plan/delete_node_test.cpp
     logical_query_plan/dummy_table_node_test.cpp
     logical_query_plan/insert_node_test.cpp

--- a/src/test/logical_query_plan/compare_lqps_test.cpp
+++ b/src/test/logical_query_plan/compare_lqps_test.cpp
@@ -1,0 +1,88 @@
+#include "gtest/gtest.h"
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/create_view_node.hpp"
+#include "logical_query_plan/delete_node.hpp"
+#include "logical_query_plan/drop_view_node.hpp"
+#include "logical_query_plan/dummy_table_node.hpp"
+#include "logical_query_plan/insert_node.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/limit_node.hpp"
+#include "logical_query_plan/logical_plan_root_node.hpp"
+#include "logical_query_plan/mock_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/show_columns_node.hpp"
+#include "logical_query_plan/show_tables_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "logical_query_plan/union_node.hpp"
+#include "logical_query_plan/update_node.hpp"
+#include "logical_query_plan/validate_node.hpp"
+#include "storage/storage_manager.hpp"
+#include "utils/load_table.hpp"
+
+#include "testing_assert.hpp"
+
+namespace {
+
+using namespace opossum;
+
+struct QueryNodes {
+  std::shared_ptr<StoredTableNode> stored_table_node_a;
+  std::shared_ptr<StoredTableNode> stored_table_node_b;
+  std::shared_ptr<PredicateNode> predicate_node_a;
+  std::shared_ptr<PredicateNode> predicate_node_b;
+  std::shared_ptr<UnionNode> union_node;
+};
+
+}
+
+namespace opossum {
+
+class CompareLQPsTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    StorageManager::get().add_table("table_a", load_table("src/test/tables/int_int.tbl", 2));
+    StorageManager::get().add_table("table_b", load_table("src/test/tables/int_int.tbl", 2));
+
+    _init_query_nodes(_query_nodes_lhs);
+    _init_query_nodes(_query_nodes_rhs);
+  }
+
+  void _init_query_nodes(QueryNodes &query_nodes) const {
+    query_nodes.stored_table_node_a = std::make_shared<StoredTableNode>("table_a");
+    query_nodes.stored_table_node_b = std::make_shared<StoredTableNode>("table_b");
+
+    const auto table_a_a = LQPColumnReference{query_nodes.stored_table_node_a, ColumnID{0}};
+    const auto table_b_a = LQPColumnReference{query_nodes.stored_table_node_b, ColumnID{0}};
+
+    query_nodes.predicate_node_a = std::make_shared<PredicateNode>(table_a_a, ScanType::Equals, 42);
+    query_nodes.predicate_node_b = std::make_shared<PredicateNode>(table_b_a, ScanType::GreaterThan, 42);
+    query_nodes.union_node = std::make_shared<UnionNode>(UnionMode::Positions);
+  }
+
+  std::shared_ptr<AbstractLQPNode> _build_query_lqp(QueryNodes &query_nodes) {
+    query_nodes.predicate_node_a->set_left_child(query_nodes.stored_table_node_a);
+    query_nodes.predicate_node_b->set_left_child(query_nodes.stored_table_node_b);
+    query_nodes.union_node->set_left_child(query_nodes.predicate_node_a);
+    query_nodes.union_node->set_right_child(query_nodes.predicate_node_b);
+    return query_nodes.union_node;
+  }
+
+  void _build_query_lqps() {
+    _query_lqp_lhs = _build_query_lqp(_query_nodes_lhs);
+    _query_lqp_rhs = _build_query_lqp(_query_nodes_rhs);
+  }
+
+  QueryNodes _query_nodes_lhs, _query_nodes_rhs;
+  std::shared_ptr<AbstractLQPNode> _query_lqp_lhs, _query_lqp_rhs;
+};
+
+TEST_F(CompareLQPsTest, EqualsTest) {
+  _build_query_lqps();
+  EXPECT_LQP_SEMANTICALLY_EQ(_query_lqp_lhs, _query_lqp_rhs);
+}
+
+}  // namespace opossum

--- a/src/test/logical_query_plan/compare_lqps_test.cpp
+++ b/src/test/logical_query_plan/compare_lqps_test.cpp
@@ -68,11 +68,11 @@ class CompareLQPsTest : public ::testing::Test {
     const auto table_c_a = LQPColumnReference{query_nodes.mock_node_b, ColumnID{0}};
     const auto table_c_b = LQPColumnReference{query_nodes.mock_node_b, ColumnID{1}};
 
-    query_nodes.predicate_node_a = std::make_shared<PredicateNode>(table_a_a, ScanType::LessThan, 41);
-    query_nodes.predicate_node_b = std::make_shared<PredicateNode>(table_a_a, ScanType::GreaterThan, 42);
+    query_nodes.predicate_node_a = std::make_shared<PredicateNode>(table_a_a, PredicateCondition::LessThan, 41);
+    query_nodes.predicate_node_b = std::make_shared<PredicateNode>(table_a_a, PredicateCondition::GreaterThan, 42);
     query_nodes.union_node = std::make_shared<UnionNode>(UnionMode::Positions);
     query_nodes.limit_node = std::make_shared<LimitNode>(10);
-    query_nodes.join_node = std::make_shared<JoinNode>(JoinMode::Inner, LQPColumnReferencePair{table_a_a, table_c_b}, ScanType::Equals);
+    query_nodes.join_node = std::make_shared<JoinNode>(JoinMode::Inner, LQPColumnReferencePair{table_a_a, table_c_b}, PredicateCondition::Equals);
 
     std::vector<std::shared_ptr<LQPExpression>> aggregates{LQPExpression::create_aggregate_function(AggregateFunction::Sum, LQPExpression::create_columns({table_c_a}))};
     std::vector<LQPColumnReference> groupby_column_references{table_c_b};

--- a/src/test/logical_query_plan/projection_node_test.cpp
+++ b/src/test/logical_query_plan/projection_node_test.cpp
@@ -49,7 +49,7 @@ class ProjectionNodeTest : public BaseTest {
 };
 
 TEST_F(ProjectionNodeTest, Description) {
-  EXPECT_EQ(_projection_node->description(), "[Projection] t_a.c, t_a.a, t_a.b, t_a.b + t_a.c, t_a.a + t_a.c");
+  EXPECT_EQ(_projection_node->description(), "[Projection] t_a.c, t_a.a, t_a.b AS alias_for_b, t_a.b + t_a.c, t_a.a + t_a.c");
 }
 
 TEST_F(ProjectionNodeTest, ColumnReferenceByNamedColumnReference) {

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -6,8 +6,9 @@
 #include "SQLParser.h"
 #include "SQLParserResult.h"
 #include "gtest/gtest.h"
-#include "logical_query_plan/join_node.hpp"
 
+#include "logical_query_plan/compare_lqps.hpp"
+#include "logical_query_plan/join_node.hpp"
 #include "operators/abstract_join_operator.hpp"
 #include "operators/print.hpp"
 #include "operators/validate.hpp"
@@ -237,7 +238,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPDoesNotInfluenceUnoptimizedLQP) 
   sql_pipeline.get_optimized_logical_plan();
   const auto& unoptimized_lqp_new = sql_pipeline.get_unoptimized_logical_plan();
 
-  EXPECT_TRUE(subtree_types_are_equal(unoptimized_lqp_new, unoptimized_copy));
+  EXPECT_TRUE(lqp_node_types_equal(unoptimized_lqp_new, unoptimized_copy));
 }
 
 TEST_F(SQLPipelineStatementTest, GetQueryPlan) {

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -49,15 +49,13 @@ TEST_F(SQLTranslatorTest, SelectStarAllTest) {
   const auto query = "SELECT * FROM table_a;";
   const auto result_node = compile_query(query);
 
-  ASSERT_EQ(result_node->type(), LQPNodeType::Projection);
-  ASSERT_TRUE(result_node->left_child());
-  ASSERT_EQ(result_node->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_FALSE(result_node->right_child());
-  EXPECT_FALSE(result_node->left_child()->left_child());
-  ASSERT_EQ(result_node->output_column_references().size(), 2u);
+  auto stored_table_node = std::make_shared<StoredTableNode>("table_a");
+  const auto table_a_a = LQPColumnReference{stored_table_node, ColumnID{0}};
+  const auto table_a_b = LQPColumnReference{stored_table_node, ColumnID{1}};
+  auto projection_node = std::make_shared<ProjectionNode>(LQPExpression::create_columns({table_a_a, table_a_b}));
+  projection_node->set_left_child(stored_table_node);
 
-  EXPECT_EQ(result_node->output_column_references()[0], LQPColumnReference(result_node->left_child(), ColumnID{0}));
-  EXPECT_EQ(result_node->output_column_references()[1], LQPColumnReference(result_node->left_child(), ColumnID{1}));
+  EXPECT_LQP_SEMANTICALLY_EQ(projection_node, result_node);
 }
 
 /*

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -283,15 +283,4 @@ bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPChil
   return false;
 }
 
-bool subtree_types_are_equal(const std::shared_ptr<AbstractLQPNode>& got,
-                             const std::shared_ptr<AbstractLQPNode>& expected) {
-  if (got == nullptr && expected == nullptr) return true;
-  if (got == nullptr) return false;
-  if (expected == nullptr) return false;
-
-  if (got->type() != expected->type()) return false;
-  return subtree_types_are_equal(got->left_child(), expected->left_child()) &&
-         subtree_types_are_equal(got->right_child(), expected->right_child());
-}
-
 }  // namespace opossum

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -56,9 +56,6 @@ void ASSERT_CROSS_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node);
 bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPChildSide child_side,
                    const std::shared_ptr<const AbstractLQPNode>& child);
 
-bool subtree_types_are_equal(const std::shared_ptr<AbstractLQPNode>& got,
-                             const std::shared_ptr<AbstractLQPNode>& expected);
-
 template <typename Functor>
 bool contained_in_lqp(const std::shared_ptr<AbstractLQPNode>& node, Functor contains_fn) {
   if (node == nullptr) return false;

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -6,6 +6,7 @@
 
 #include "gtest/gtest.h"
 
+#include "logical_query_plan/compare_lqps.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "operators/abstract_operator.hpp"
 #include "scheduler/operator_task.hpp"
@@ -126,3 +127,5 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
 
 #define ASSERT_LQP_TIE(parent, child_side, child) \
   if (!opossum::check_lqp_tie(parent, child_side, child)) FAIL();
+
+#define EXPECT_LQP_SEMANTICALLY_EQ(lhs, rhs) EXPECT_TRUE(SemanticLQPCompare(lhs, rhs)());

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -128,4 +128,17 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
 #define ASSERT_LQP_TIE(parent, child_side, child) \
   if (!opossum::check_lqp_tie(parent, child_side, child)) FAIL();
 
-#define EXPECT_LQP_SEMANTICALLY_EQ(lhs, rhs) EXPECT_TRUE(SemanticLQPCompare(lhs, rhs)());
+#define EXPECT_LQP_SEMANTICALLY_EQ(lhs, rhs) {  \
+  SemanticLQPCompare cmp(lhs, rhs); \
+  if (!cmp()) { \
+    std::cout << "Differing subtrees: " << cmp.differing_subtrees().size() << std::endl;\
+    for (const auto& pair : cmp.differing_subtrees()) {\
+      pair.first->print();\
+      std::cout << std::endl;\
+      pair.second->print();\
+      std::cout << std::endl;\
+    }\
+    GTEST_FAIL(); \
+  }\
+} \
+


### PR DESCRIPTION
Fixes #612 

This adds the `EXPECT_LQP_SEMANTICALLY_EQ` macro and the underlying `SemanticLQPCompare` algorithms that make it possible to compare two LQPs for logical [sic] / semantic equality - i.e. returns true for two LQPs that do the exactly the same thing even if they are comprised of different LQP node object instances.

This makes testing the structure of LQPs returned, e.g., by Optimizer Rules or the SQL Translator much easier, as one just builds a "reference LQP" and compares it with the LQP generated by Hyrise:

```c++
  const auto input_lqp =
  make_predicate_node(_mock_node_a, PredicateCondition::Equals, 42,
    make_predicate_node(_mock_node_b, PredicateCondition::GreaterThan, 50,
      make_predicate_node(_mock_node_b, PredicateCondition::GreaterThan, 40,
        make_star_projection_node(
           make_predicate_node(_mock_node_a, PredicateCondition::GreaterThanEquals, 90,
             make_predicate_node(_mock_node_c, PredicateCondition::LessThan, 500,
               _mock_node
  ))))));

  const auto expected_optimized_lqp =
  make_predicate_node(_mock_node_b, PredicateCondition::GreaterThan, 40,
    make_predicate_node(_mock_node_b, PredicateCondition::GreaterThan, 50,
      make_predicate_node(_mock_node_a, PredicateCondition::Equals, 42,
        make_star_projection_node(
          make_predicate_node(_mock_node_c, PredicateCondition::LessThan, 500,
            make_predicate_node(_mock_node_a, PredicateCondition::GreaterThanEquals, 90,
              _mock_node
  ))))));

  const auto reordered_input_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
  EXPECT_LQP_SEMANTICALLY_EQ(reordered_input_lqp, expected_optimized_lqp);
```
If `EXPECT_LQP_SEMANTICALL_EQ` fails, the error message looks like this:

```
Differing subtrees: 1
[0] [Predicate] MockCol2 >= 90
 \_[1] [Predicate] MockCol0 < 500
    \_[2] [MockTable]

[0] [Predicate] MockCol2 < 500
 \_[1] [Predicate] MockCol0 >= 90
    \_[2] [MockTable]
```

In `sql_translator_test.cpp` and `predicate_reordering_test.cpp` you can see the new "style" of testing LQPs in action. I hope you agree it is much easier to read and covers way more checks than the old "style" of explicitly testing selected member fields.

## Feedback needed
This PR still lacks some tests, code cleaness etc. I'm opening it now to get early feedback on some stuff to avoid having to restructure everything on review.

* I expect people to take issue with the builder methods in `build_lqps.hpp` since they mostly just wrap `std::make_shared<...>(...)` and `node->set_left/right` child. Would you rather prefer the LQPNodes to take their children as constructor arguments and replace the calls to `make_..._node()` with `std::make_shared` calls?

* The `SemanticLQPCompare::_are_semantically_equal` functions are tied tightly to the data members in LQP nodes - if one adds members to an LQP node, she/he is likely to miss extending the corresponding `SemanticLQPCompare::_are_semantically_equal` implementation. Would you rather I put `semantically_equal_to()` into the LQP node classes? (e.g. PredicateNode::is_semantically_equal_to(another_predicate_node))
