### PR TITLE
Add Asserts to SQLTranslator when INSERTing mismatch type values

### DIFF
--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -165,7 +165,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_insert(const hsql::In
   };
 
   // Lambda to compare a vector of DataType to the types of a vector of hqsl::Expr
-  auto data_types_match_expr_types = [&](const std::vector<DataType>& data_types, const std::vector<hsql::Expr*>& expressions) {
+  auto data_types_match_expr_types = [&](const std::vector<DataType>& data_types,
+                                         const std::vector<hsql::Expr*>& expressions) {
     auto data_types_it = data_types.begin();
     auto expressions_it = expressions.begin();
 
@@ -211,7 +212,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_insert(const hsql::In
         // when inserting values, simply translate the literal expression
         const auto& hsql_expr = *(*insert.values)[insert_column_index];
 
-        Assert(data_type_matches_expr_type(target_table->column_types()[column_id], hsql_expr), "Insert: Column type mismatch");
+        Assert(data_type_matches_expr_type(target_table->column_types()[column_id], hsql_expr),
+               "Insert: Column type mismatch");
 
         projections[column_id] = HSQLExprTranslator::to_lqp_expression(hsql_expr, nullptr);
       } else {

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -430,7 +430,7 @@ TEST_F(SQLTranslatorTest, InsertValues) {
 }
 
 TEST_F(SQLTranslatorTest, InsertValuesColumnReorder) {
-  const auto query = "INSERT INTO table_a (b, a) VALUES (10, 12.5);";
+  const auto query = "INSERT INTO table_a (b, a) VALUES (12.5, 10);";
   auto result_node = compile_query(query);
 
   EXPECT_EQ(result_node->type(), LQPNodeType::Insert);
@@ -443,9 +443,9 @@ TEST_F(SQLTranslatorTest, InsertValuesColumnReorder) {
 
   auto expressions = projection->column_expressions();
   EXPECT_EQ(expressions[0]->type(), ExpressionType::Literal);
-  EXPECT_EQ(boost::get<float>(expressions[0]->value()), 12.5);
+  EXPECT_EQ(boost::get<int32_t>(expressions[0]->value()), 10);
   EXPECT_EQ(expressions[1]->type(), ExpressionType::Literal);
-  EXPECT_EQ(boost::get<int32_t>(expressions[1]->value()), 10);
+  EXPECT_EQ(boost::get<float>(expressions[1]->value()), 12.5);
 
   EXPECT_EQ(projection->left_child()->type(), LQPNodeType::DummyTable);
 }

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -492,6 +492,14 @@ TEST_F(SQLTranslatorTest, InsertSubquery) {
   EXPECT_EQ(expressions[1]->column_reference(), LQPColumnReference(table_b_node, ColumnID{1}));
 }
 
+TEST_F(SQLTranslatorTest, InsertInvalidDataType) {
+  auto query = "INSERT INTO table_a VALUES (10, 11);";
+  EXPECT_THROW(compile_query(query), std::runtime_error);
+
+  query = "INSERT INTO table_a (b, a) VALUES (10, 12.5);";
+  EXPECT_THROW(compile_query(query), std::runtime_error);
+}
+
 TEST_F(SQLTranslatorTest, Update) {
   const auto query = "UPDATE table_a SET b = 3.2 WHERE a > 1;";
   auto result_node = compile_query(query);


### PR DESCRIPTION
fixes #631. Now throws a "Insert: Column type mismatch" error in `SQLTranslator` when trying to `INSERT` values into columns of a different type.