### PR TITLE
Allow deep copy of diamond LQPs

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -19,14 +19,22 @@ class TableStatistics;
 
 AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type) : _type(node_type) {}
 
-std::shared_ptr<AbstractLQPNode> AbstractLQPNode::deep_copy() const {
-  auto copied_left_child = left_child() ? left_child()->deep_copy() : std::shared_ptr<AbstractLQPNode>();
-  auto copied_right_child = this->right_child() ? this->right_child()->deep_copy() : std::shared_ptr<AbstractLQPNode>();
+std::shared_ptr<AbstractLQPNode> AbstractLQPNode::deep_copy(
+    std::shared_ptr<std::map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>> previous_copies)
+    const {
+  if (auto it = previous_copies->find(shared_from_this()); it != previous_copies->cend()) {
+    return it->second;
+  }
+
+  auto copied_left_child = left_child() ? left_child()->deep_copy(previous_copies) : nullptr;
+  auto copied_right_child = this->right_child() ? this->right_child()->deep_copy(previous_copies) : nullptr;
 
   // We cannot use the copy constructor here, because it does not work with shared_from_this()
   auto deep_copy = _deep_copy_impl(copied_left_child, copied_right_child);
-  deep_copy->set_left_child(copied_left_child);
-  deep_copy->set_right_child(copied_right_child);
+  if (copied_left_child) deep_copy->set_left_child(copied_left_child);
+  if (copied_right_child) deep_copy->set_right_child(copied_right_child);
+
+  previous_copies->emplace(shared_from_this(), deep_copy);
 
   return deep_copy;
 }

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -73,9 +73,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   explicit AbstractLQPNode(LQPNodeType node_type);
 
   // Creates a deep copy
-  using PreviousCopiesMap = std::map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
-  std::shared_ptr<AbstractLQPNode> deep_copy(
-      std::shared_ptr<PreviousCopiesMap> previous_copies = std::make_shared<PreviousCopiesMap>()) const;
+  std::shared_ptr<AbstractLQPNode> deep_copy() const;
 
   // @{
   /**
@@ -267,6 +265,10 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
    */
 
  protected:
+  // Holds the actual implementation of deep_copy
+  using PreviousCopiesMap = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
+  std::shared_ptr<AbstractLQPNode> _deep_copy(PreviousCopiesMap& previous_copies) const;
+
   /**
    * Override and create a DEEP copy of this LQP node. Used for reusing LQPs, e.g., in views.
    * @param left_child and @param right_child are deep copies of the left and right child respectively, used for deep-copying

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -73,7 +73,9 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   explicit AbstractLQPNode(LQPNodeType node_type);
 
   // Creates a deep copy
-  virtual std::shared_ptr<AbstractLQPNode> deep_copy() const;
+  using PreviousCopiesMap = std::map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
+  std::shared_ptr<AbstractLQPNode> deep_copy(
+      std::shared_ptr<PreviousCopiesMap> previous_copies = std::make_shared<PreviousCopiesMap>()) const;
 
   // @{
   /**

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -266,7 +266,8 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
  protected:
   // Holds the actual implementation of deep_copy
-  using PreviousCopiesMap = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
+  using PreviousCopiesMap =
+      std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
   std::shared_ptr<AbstractLQPNode> _deep_copy(PreviousCopiesMap& previous_copies) const;
 
   /**


### PR DESCRIPTION
fixes #625

This is as untested as the rest of `deep_copy` is. We have an issue for that: #689 