### PR TITLE
semi and anti join node output column references fix

### DIFF
--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -134,7 +134,7 @@ void JoinNode::_update_output() const {
   _output_column_names.emplace();
   bool only_left = _join_mode == JoinMode::Semi || _join_mode == JoinMode::Anti;
 
-    auto output_size = only_left ? left_names.size() : left_names.size() + right_names.size();
+  auto output_size = only_left ? left_names.size() : left_names.size() + right_names.size();
   _output_column_names->reserve(output_size);
 
   _output_column_names->insert(_output_column_names->end(), left_names.begin(), left_names.end());

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -132,10 +132,11 @@ void JoinNode::_update_output() const {
   const auto& right_names = right_child()->output_column_names();
 
   _output_column_names.emplace();
-  _output_column_names->reserve(left_names.size() + right_names.size());
+
+  auto output_size = _join_mode == JoinMode::Semi ? left_names.size() : left_names.size() + right_names.size();
+  _output_column_names->reserve(output_size);
 
   _output_column_names->insert(_output_column_names->end(), left_names.begin(), left_names.end());
-  _output_column_names->insert(_output_column_names->end(), right_names.begin(), right_names.end());
 
   /**
    * Collect the output ColumnIDs of the children on the fly, because the children might change.
@@ -144,8 +145,13 @@ void JoinNode::_update_output() const {
 
   _output_column_references->insert(_output_column_references->end(), left_child()->output_column_references().begin(),
                                     left_child()->output_column_references().end());
-  _output_column_references->insert(_output_column_references->end(), right_child()->output_column_references().begin(),
-                                    right_child()->output_column_references().end());
+
+  if (_join_mode != JoinMode::Semi) {
+    _output_column_names->insert(_output_column_names->end(), right_names.begin(), right_names.end());
+    _output_column_references->insert(_output_column_references->end(),
+                                      right_child()->output_column_references().begin(),
+                                      right_child()->output_column_references().end());
+  }
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -132,10 +132,11 @@ void JoinNode::_update_output() const {
   const auto& right_names = right_child()->output_column_names();
 
   _output_column_names.emplace();
-  bool only_left = _join_mode == JoinMode::Semi || _join_mode == JoinMode::Anti;
+  const auto only_output_left_columns = _join_mode == JoinMode::Semi || _join_mode == JoinMode::Anti;
 
-  auto output_size = only_left ? left_names.size() : left_names.size() + right_names.size();
-  _output_column_names->reserve(output_size);
+  const auto output_column_count =
+      only_output_left_columns ? left_names.size() : left_names.size() + right_names.size();
+  _output_column_names->reserve(output_column_count);
 
   _output_column_names->insert(_output_column_names->end(), left_names.begin(), left_names.end());
 
@@ -147,7 +148,7 @@ void JoinNode::_update_output() const {
   _output_column_references->insert(_output_column_references->end(), left_child()->output_column_references().begin(),
                                     left_child()->output_column_references().end());
 
-  if (!only_left) {
+  if (!only_output_left_columns) {
     _output_column_names->insert(_output_column_names->end(), right_names.begin(), right_names.end());
     _output_column_references->insert(_output_column_references->end(),
                                       right_child()->output_column_references().begin(),

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -132,8 +132,9 @@ void JoinNode::_update_output() const {
   const auto& right_names = right_child()->output_column_names();
 
   _output_column_names.emplace();
+  bool only_left = _join_mode == JoinMode::Semi || _join_mode == JoinMode::Anti;
 
-  auto output_size = _join_mode == JoinMode::Semi ? left_names.size() : left_names.size() + right_names.size();
+    auto output_size = only_left ? left_names.size() : left_names.size() + right_names.size();
   _output_column_names->reserve(output_size);
 
   _output_column_names->insert(_output_column_names->end(), left_names.begin(), left_names.end());
@@ -146,7 +147,7 @@ void JoinNode::_update_output() const {
   _output_column_references->insert(_output_column_references->end(), left_child()->output_column_references().begin(),
                                     left_child()->output_column_references().end());
 
-  if (_join_mode != JoinMode::Semi) {
+  if (!only_left) {
     _output_column_names->insert(_output_column_names->end(), right_names.begin(), right_names.end());
     _output_column_references->insert(_output_column_references->end(),
                                       right_child()->output_column_references().begin(),

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -98,18 +98,17 @@ TEST_F(JoinNodeTest, OutputColumnReferences) {
 }
 
 TEST_F(JoinNodeTest, OutputColumnReferencesSemiJoin) {
-    ASSERT_EQ(_semi_join_node->output_column_references().size(), 3u);
-    EXPECT_EQ(_semi_join_node->output_column_references().at(0), _t_a_a);
-    EXPECT_EQ(_semi_join_node->output_column_references().at(1), _t_a_b);
-    EXPECT_EQ(_semi_join_node->output_column_references().at(2), _t_a_c);
+  ASSERT_EQ(_semi_join_node->output_column_references().size(), 3u);
+  EXPECT_EQ(_semi_join_node->output_column_references().at(0), _t_a_a);
+  EXPECT_EQ(_semi_join_node->output_column_references().at(1), _t_a_b);
+  EXPECT_EQ(_semi_join_node->output_column_references().at(2), _t_a_c);
 }
 
 TEST_F(JoinNodeTest, OutputColumnReferencesAntiJoin) {
-   ASSERT_EQ(_anti_join_node->output_column_references().size(), 3u);
-   EXPECT_EQ(_anti_join_node->output_column_references().at(0), _t_a_a);
-   EXPECT_EQ(_anti_join_node->output_column_references().at(1), _t_a_b);
-   EXPECT_EQ(_anti_join_node->output_column_references().at(2), _t_a_c);
-
+  ASSERT_EQ(_anti_join_node->output_column_references().size(), 3u);
+  EXPECT_EQ(_anti_join_node->output_column_references().at(0), _t_a_a);
+  EXPECT_EQ(_anti_join_node->output_column_references().at(1), _t_a_b);
+  EXPECT_EQ(_anti_join_node->output_column_references().at(2), _t_a_c);
 }
 
 }  // namespace opossum

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -34,11 +34,23 @@ class JoinNodeTest : public BaseTest {
         std::make_shared<JoinNode>(JoinMode::Inner, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
     _inner_join_node->set_left_child(_mock_node_a);
     _inner_join_node->set_right_child(_mock_node_b);
+
+    _semi_join_node =
+        std::make_shared<JoinNode>(JoinMode::Semi, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
+    _semi_join_node->set_left_child(_mock_node_a);
+    _semi_join_node->set_right_child(_mock_node_b);
+
+    _anti_join_node =
+        std::make_shared<JoinNode>(JoinMode::Anti, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
+    _anti_join_node->set_left_child(_mock_node_a);
+    _anti_join_node->set_right_child(_mock_node_b);
   }
 
   std::shared_ptr<MockNode> _mock_node_a;
   std::shared_ptr<MockNode> _mock_node_b;
   std::shared_ptr<JoinNode> _inner_join_node;
+  std::shared_ptr<JoinNode> _semi_join_node;
+  std::shared_ptr<JoinNode> _anti_join_node;
   std::shared_ptr<JoinNode> _join_node;
   LQPColumnReference _t_a_a;
   LQPColumnReference _t_a_b;
@@ -50,6 +62,10 @@ class JoinNodeTest : public BaseTest {
 TEST_F(JoinNodeTest, Description) { EXPECT_EQ(_join_node->description(), "[Cross Join]"); }
 
 TEST_F(JoinNodeTest, DescriptionInnerJoin) { EXPECT_EQ(_inner_join_node->description(), "[Inner Join] t_a.a = t_b.y"); }
+
+TEST_F(JoinNodeTest, DescriptionSemiJoin) { EXPECT_EQ(_semi_join_node->description(), "[Semi Join] t_a.a = t_b.y"); }
+
+TEST_F(JoinNodeTest, DescriptionAntiJoin) { EXPECT_EQ(_anti_join_node->description(), "[Anti Join] t_a.a = t_b.y"); }
 
 TEST_F(JoinNodeTest, VerboseColumnNames) {
   EXPECT_EQ(_join_node->get_verbose_column_name(ColumnID{0}), "t_a.a");
@@ -79,6 +95,21 @@ TEST_F(JoinNodeTest, OutputColumnReferences) {
   EXPECT_EQ(_join_node->output_column_references().at(2), _t_a_c);
   EXPECT_EQ(_join_node->output_column_references().at(3), _t_b_x);
   EXPECT_EQ(_join_node->output_column_references().at(4), _t_b_y);
+}
+
+TEST_F(JoinNodeTest, OutputColumnReferencesSemiJoin) {
+    ASSERT_EQ(_semi_join_node->output_column_references().size(), 3u);
+    EXPECT_EQ(_semi_join_node->output_column_references().at(0), _t_a_a);
+    EXPECT_EQ(_semi_join_node->output_column_references().at(1), _t_a_b);
+    EXPECT_EQ(_semi_join_node->output_column_references().at(2), _t_a_c);
+}
+
+TEST_F(JoinNodeTest, OutputColumnReferencesAntiJoin) {
+   ASSERT_EQ(_anti_join_node->output_column_references().size(), 3u);
+   EXPECT_EQ(_anti_join_node->output_column_references().at(0), _t_a_a);
+   EXPECT_EQ(_anti_join_node->output_column_references().at(1), _t_a_b);
+   EXPECT_EQ(_anti_join_node->output_column_references().at(2), _t_a_c);
+
 }
 
 }  // namespace opossum


### PR DESCRIPTION
Semi and anti join only return the columns of the left input table. 
The output_column_references() returned the columns of both tables, though.
This pull request fixes the output_column_references of semi and anti joins and tests the new implementation.