### PR TITLE
POC: Split up NLJ into multiple c++ files

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -101,6 +101,12 @@ set(
     operators/join_hash.hpp
     operators/join_nested_loop.cpp
     operators/join_nested_loop.hpp
+    operators/join_nested_loop_outer_resolve.hpp
+    operators/join_nested_loop_outer_resolve_int32.cpp
+    operators/join_nested_loop_outer_resolve_int64.cpp
+    operators/join_nested_loop_outer_resolve_float.cpp
+    operators/join_nested_loop_outer_resolve_double.cpp
+    operators/join_nested_loop_outer_resolve_string.cpp
     operators/join_sort_merge.cpp
     operators/join_sort_merge.hpp
     operators/limit.cpp

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -72,35 +72,6 @@ void JoinNestedLoop::_create_table_structure() {
   }
 }
 
-// inner join loop that joins two columns via their iterators
-template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-void JoinNestedLoop::_join_two_columns(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
-                                       RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
-                                       const ChunkID chunk_id_right, std::vector<bool>& left_matches) {
-  for (; left_it != left_end; ++left_it) {
-    const auto left_value = *left_it;
-    if (left_value.is_null()) continue;
-
-    for (auto right_it = right_begin; right_it != right_end; ++right_it) {
-      const auto right_value = *right_it;
-      if (right_value.is_null()) continue;
-
-      if (func(left_value.value(), right_value.value())) {
-        _pos_list_left->emplace_back(RowID{chunk_id_left, left_value.chunk_offset()});
-        _pos_list_right->emplace_back(RowID{chunk_id_right, right_value.chunk_offset()});
-
-        if (_is_outer_join) {
-          left_matches[left_value.chunk_offset()] = true;
-        }
-
-        if (_mode == JoinMode::Outer) {
-          _right_matches.insert(RowID{chunk_id_right, right_value.chunk_offset()});
-        }
-      }
-    }
-  }
-}
-
 void JoinNestedLoop::_perform_join() {
   auto left_table = _left_in_table;
   auto right_table = _right_in_table;
@@ -140,35 +111,7 @@ void JoinNestedLoop::_perform_join() {
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < right_table->chunk_count(); ++chunk_id_right) {
       auto column_right = right_table->get_chunk(chunk_id_right)->get_column(right_column_id);
 
-      resolve_data_and_column_type(left_data_type, *column_left, [&](auto left_type, auto& typed_left_column) {
-        resolve_data_and_column_type(right_data_type, *column_right, [&](auto right_type, auto& typed_right_column) {
-          using LeftType = typename decltype(left_type)::type;
-          using RightType = typename decltype(right_type)::type;
-
-          // make sure that we do not compile invalid versions of these lambdas
-          constexpr auto left_is_string_column = (std::is_same<LeftType, std::string>{});
-          constexpr auto right_is_string_column = (std::is_same<RightType, std::string>{});
-
-          constexpr auto neither_is_string_column = !left_is_string_column && !right_is_string_column;
-          constexpr auto both_are_string_columns = left_is_string_column && right_is_string_column;
-
-          // clang-format off
-          if constexpr (neither_is_string_column || both_are_string_columns) {
-            auto iterable_left = create_iterable_from_column<LeftType>(typed_left_column);
-            auto iterable_right = create_iterable_from_column<RightType>(typed_right_column);
-
-            iterable_left.with_iterators([&](auto left_it, auto left_end) {
-              iterable_right.with_iterators([&](auto right_it, auto right_end) {
-                with_comparator(_predicate_condition, [&](auto comparator) {
-                  this->_join_two_columns(comparator, left_it, left_end, right_it, right_end, chunk_id_left,
-                                          chunk_id_right, left_matches);
-                });
-              });
-            });
-          }
-          // clang-format on
-        });
-      });
+      resolve_data_and_column_type(left_data_type, *column_left, OuterResolve(*this, left_matches, chunk_id_left, chunk_id_right, right_data_type, *column_right, _predicate_condition));
     }
 
     if (_is_outer_join) {

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -23,6 +23,7 @@ class JoinNestedLoop : public AbstractJoinOperator {
  protected:
   std::shared_ptr<const Table> _on_execute() override;
 
+ private:
   void _perform_join();
 
   template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
@@ -34,6 +35,22 @@ class JoinNestedLoop : public AbstractJoinOperator {
 
   void _write_output_chunks(const std::shared_ptr<Chunk>& output_chunk, const std::shared_ptr<const Table> input_table,
                             std::shared_ptr<PosList> pos_list);
+
+  struct OuterResolve {
+    OuterResolve(JoinNestedLoop& join_nested_loop, std::vector<bool>& left_matches, ChunkID chunk_id_left, ChunkID chunk_id_right, DataType right_data_type, const BaseColumn& column_right, PredicateCondition predicate_condition):
+    join_nested_loop(join_nested_loop), left_matches(left_matches), chunk_id_left(chunk_id_left), chunk_id_right(chunk_id_right), right_data_type(right_data_type), column_right(column_right), predicate_condition(predicate_condition) {}
+
+    JoinNestedLoop& join_nested_loop;
+    std::vector<bool>& left_matches;
+    ChunkID chunk_id_left;
+    ChunkID chunk_id_right;
+    DataType right_data_type;
+    const BaseColumn& column_right;
+    PredicateCondition predicate_condition;
+
+    template<typename ColumnDataType, typename ColumnType>
+    void operator()(ColumnDataType left_type, ColumnType& typed_left_column) const;
+  };
 
   std::shared_ptr<Table> _output_table;
   std::shared_ptr<const Table> _left_in_table;

--- a/src/lib/operators/join_nested_loop_outer_resolve.hpp
+++ b/src/lib/operators/join_nested_loop_outer_resolve.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "join_nested_loop.hpp"
+#include "resolve_type.hpp"
+#include "storage/create_iterable_from_column.hpp"
+#include "type_comparison.hpp"
+
+namespace opossum {
+
+// inner join loop that joins two columns via their iterators
+template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
+void JoinNestedLoop::_join_two_columns(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
+                                       RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
+                                       const ChunkID chunk_id_right, std::vector<bool>& left_matches) {
+  for (; left_it != left_end; ++left_it) {
+    const auto left_value = *left_it;
+    if (left_value.is_null()) continue;
+
+    for (auto right_it = right_begin; right_it != right_end; ++right_it) {
+      const auto right_value = *right_it;
+      if (right_value.is_null()) continue;
+
+      if (func(left_value.value(), right_value.value())) {
+        _pos_list_left->emplace_back(RowID{chunk_id_left, left_value.chunk_offset()});
+        _pos_list_right->emplace_back(RowID{chunk_id_right, right_value.chunk_offset()});
+
+        if (_is_outer_join) {
+          left_matches[left_value.chunk_offset()] = true;
+        }
+
+        if (_mode == JoinMode::Outer) {
+          _right_matches.insert(RowID{chunk_id_right, right_value.chunk_offset()});
+        }
+      }
+    }
+  }
+}
+
+template<typename ColumnDataType, typename ColumnType>
+void JoinNestedLoop::OuterResolve::operator()(ColumnDataType left_type, ColumnType& typed_left_column) const {
+  resolve_data_and_column_type(right_data_type, column_right, [&](auto right_type, auto& typed_right_column) {
+    using LeftType = typename decltype(left_type)::type;
+    using RightType = typename decltype(right_type)::type;
+
+    // make sure that we do not compile invalid versions of these lambdas
+    constexpr auto left_is_string_column = (std::is_same<LeftType, std::string>{});
+    constexpr auto right_is_string_column = (std::is_same<RightType, std::string>{});
+
+    constexpr auto neither_is_string_column = !left_is_string_column && !right_is_string_column;
+    constexpr auto both_are_string_columns = left_is_string_column && right_is_string_column;
+
+    // clang-format off
+    if constexpr (neither_is_string_column || both_are_string_columns) {
+      auto iterable_left = create_iterable_from_column<LeftType>(typed_left_column);
+      auto iterable_right = create_iterable_from_column<RightType>(typed_right_column);
+
+      iterable_left.with_iterators([&](auto left_it, auto left_end) {
+        iterable_right.with_iterators([&](auto right_it, auto right_end) {
+          with_comparator(predicate_condition, [&](auto comparator) {
+            join_nested_loop._join_two_columns(comparator, left_it, left_end, right_it, right_end, chunk_id_left,
+                                               chunk_id_right, left_matches);
+          });
+        });
+      });
+    }
+    // clang-format on
+  });
+}
+
+}  // namespace opossum

--- a/src/lib/operators/join_nested_loop_outer_resolve_double.cpp
+++ b/src/lib/operators/join_nested_loop_outer_resolve_double.cpp
@@ -1,0 +1,15 @@
+#include "join_nested_loop_outer_resolve.hpp"
+
+#include "types.hpp"
+
+#include "storage/reference_column.hpp"
+
+namespace opossum {
+
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<double>, const ReferenceColumn&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<double>, const ValueColumn<double>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<double>, const DictionaryColumn<double>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<double>, const DeprecatedDictionaryColumn<double>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<double>, const RunLengthColumn<double>&) const;
+
+}  // namespace opossum

--- a/src/lib/operators/join_nested_loop_outer_resolve_float.cpp
+++ b/src/lib/operators/join_nested_loop_outer_resolve_float.cpp
@@ -1,0 +1,15 @@
+#include "join_nested_loop_outer_resolve.hpp"
+
+#include "types.hpp"
+
+#include "storage/reference_column.hpp"
+
+namespace opossum {
+
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<float>, const ReferenceColumn&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<float>, const ValueColumn<float>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<float>, const DictionaryColumn<float>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<float>, const DeprecatedDictionaryColumn<float>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<float>, const RunLengthColumn<float>&) const;
+
+}  // namespace opossum

--- a/src/lib/operators/join_nested_loop_outer_resolve_int32.cpp
+++ b/src/lib/operators/join_nested_loop_outer_resolve_int32.cpp
@@ -1,0 +1,15 @@
+#include "join_nested_loop_outer_resolve.hpp"
+
+#include "types.hpp"
+
+#include "storage/reference_column.hpp"
+
+namespace opossum {
+
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int32_t>, const ReferenceColumn&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int32_t>, const ValueColumn<int32_t>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int32_t>, const DictionaryColumn<int32_t>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int32_t>, const DeprecatedDictionaryColumn<int32_t>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int32_t>, const RunLengthColumn<int32_t>&) const;
+
+}  // namespace opossum

--- a/src/lib/operators/join_nested_loop_outer_resolve_int64.cpp
+++ b/src/lib/operators/join_nested_loop_outer_resolve_int64.cpp
@@ -1,0 +1,15 @@
+#include "join_nested_loop_outer_resolve.hpp"
+
+#include "types.hpp"
+
+#include "storage/reference_column.hpp"
+
+namespace opossum {
+
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int64_t>, const ReferenceColumn&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int64_t>, const ValueColumn<int64_t>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int64_t>, const DictionaryColumn<int64_t>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int64_t>, const DeprecatedDictionaryColumn<int64_t>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<int64_t>, const RunLengthColumn<int64_t>&) const;
+
+}  // namespace opossum

--- a/src/lib/operators/join_nested_loop_outer_resolve_string.cpp
+++ b/src/lib/operators/join_nested_loop_outer_resolve_string.cpp
@@ -1,0 +1,15 @@
+#include "join_nested_loop_outer_resolve.hpp"
+
+#include "types.hpp"
+
+#include "storage/reference_column.hpp"
+
+namespace opossum {
+
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<std::string>, const ReferenceColumn&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<std::string>, const ValueColumn<std::string>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<std::string>, const DictionaryColumn<std::string>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<std::string>, const DeprecatedDictionaryColumn<std::string>&) const;
+template void JoinNestedLoop::OuterResolve::operator()<>(boost::hana::basic_type<std::string>, const RunLengthColumn<std::string>&) const;
+
+}  // namespace opossum


### PR DESCRIPTION
For me, this reduced memory peak from 20% to 7% per clang++ process. When just compiling the NLJ, with 8 threads, it reduces compile time from 1:00s to 0:35s.

What do you think, do we continue down this path? @mrks  @mjendruk  @adi64 