### PR TITLE
Fix SIMD-BP128 decompressor

### DIFF
--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -9,6 +9,9 @@
 #include "sql/Expr.h"
 #include "sql/SelectStatement.h"
 
+#include "storage/encoding_type.hpp"
+#include "storage/vector_compression/vector_compression.hpp"
+
 namespace opossum {
 
 /*
@@ -138,5 +141,18 @@ const boost::bimap<DataType, std::string> data_type_to_string =
                  map.insert({hana::first(pair), std::string{hana::second(pair)}});
                  return map;
                });
+
+const boost::bimap<EncodingType, std::string> encoding_type_to_string =
+    make_bimap<EncodingType, std::string>({
+        {EncodingType::DeprecatedDictionary, "Dictionary (Deprecated)"},
+        {EncodingType::Dictionary, "Dictionary"},
+        {EncodingType::RunLength, "RunLength"},
+    });
+
+const boost::bimap<VectorCompressionType, std::string> vector_compression_type_to_string =
+    make_bimap<VectorCompressionType, std::string>({
+        {VectorCompressionType::FixedSizeByteAligned, "Fixed-size byte-aligned"},
+        {VectorCompressionType::SimdBp128, "SIMD-BP128"},
+    });
 
 }  // namespace opossum

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -142,12 +142,11 @@ const boost::bimap<DataType, std::string> data_type_to_string =
                  return map;
                });
 
-const boost::bimap<EncodingType, std::string> encoding_type_to_string =
-    make_bimap<EncodingType, std::string>({
-        {EncodingType::DeprecatedDictionary, "Dictionary (Deprecated)"},
-        {EncodingType::Dictionary, "Dictionary"},
-        {EncodingType::RunLength, "RunLength"},
-    });
+const boost::bimap<EncodingType, std::string> encoding_type_to_string = make_bimap<EncodingType, std::string>({
+    {EncodingType::DeprecatedDictionary, "Dictionary (Deprecated)"},
+    {EncodingType::Dictionary, "Dictionary"},
+    {EncodingType::RunLength, "RunLength"},
+});
 
 const boost::bimap<VectorCompressionType, std::string> vector_compression_type_to_string =
     make_bimap<VectorCompressionType, std::string>({

--- a/src/lib/constant_mappings.hpp
+++ b/src/lib/constant_mappings.hpp
@@ -10,6 +10,9 @@
 
 namespace opossum {
 
+enum class EncodingType : uint8_t;
+enum class VectorCompressionType : uint8_t;
+
 extern const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string;
 extern const std::unordered_map<ExpressionType, std::string> expression_type_to_string;
 extern const std::unordered_map<OrderByMode, std::string> order_by_mode_to_string;
@@ -20,5 +23,7 @@ extern const std::unordered_map<JoinMode, std::string> join_mode_to_string;
 extern const std::unordered_map<UnionMode, std::string> union_mode_to_string;
 extern const boost::bimap<AggregateFunction, std::string> aggregate_function_to_string;
 extern const boost::bimap<DataType, std::string> data_type_to_string;
+extern const boost::bimap<EncodingType, std::string> encoding_type_to_string;
+extern const boost::bimap<VectorCompressionType, std::string> vector_compression_type_to_string;
 
 }  // namespace opossum

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
@@ -43,9 +43,10 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
       return _get_within_cached_meta_block(i);
     }
 
-    if (_is_index_after_cached_meta_block(i)) {
+    if (_is_index_after_or_within_cached_meta_block(i)) {
       const auto relative_index = _index_relative_to_cached_meta_block(i);
       const auto relative_meta_block_index = relative_index / Packing::meta_block_size;
+      DebugAssert(relative_meta_block_index > 0u, "");
 
       _read_meta_info_from_offset(relative_meta_block_index);
       return _get_within_cached_meta_block(i);
@@ -69,7 +70,7 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
   size_t size() const final { return _size; }
 
  private:
-  bool _is_index_within_cached_block(size_t index) {
+  bool _is_index_within_cached_block(size_t index) const {
     const auto begin = _cached_block_first_index;
     const auto end = _cached_block_first_index + Packing::block_size;
     return begin <= index && index < end;
@@ -77,16 +78,16 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
 
   size_t _index_within_cached_block(size_t index) { return index - _cached_block_first_index; }
 
-  bool _is_index_within_cached_meta_block(size_t index) {
+  bool _is_index_within_cached_meta_block(size_t index) const {
     const auto begin = _cached_meta_block_first_index;
     const auto end = _cached_meta_block_first_index + Packing::meta_block_size;
     return begin <= index && index < end;
   }
 
-  size_t _index_relative_to_cached_meta_block(size_t index) { return index - _cached_meta_block_first_index; }
+  size_t _index_relative_to_cached_meta_block(size_t index) const { return index - _cached_meta_block_first_index; }
 
-  bool _is_index_after_cached_meta_block(size_t index) {
-    return (_cached_meta_block_first_index + Packing::meta_block_size) <= index;
+  bool _is_index_after_or_within_cached_meta_block(size_t index) const {
+    return _cached_meta_block_first_index <= index;
   }
 
   uint32_t _get_within_cached_block(size_t index) { return (*_cached_block)[_index_within_cached_block(index)]; }
@@ -103,9 +104,9 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
    * jumps to the meta block with the relative
    * index `meta_block_index`
    */
-  void _read_meta_info_from_offset(size_t meta_block_index) {
+  void _read_meta_info_from_offset(size_t relative_meta_block_index) {
     auto meta_info_offset = _cached_meta_info_offset;
-    for (auto i = 0u; i < meta_block_index; ++i) {
+    for (auto i = 0u; i < relative_meta_block_index; ++i) {
       static const auto meta_info_data_size = 1u;  // One 128 bit block
       const auto meta_block_data_size =
           meta_info_data_size + std::accumulate(_cached_meta_info.begin(), _cached_meta_info.end(), 0u);
@@ -114,7 +115,7 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
     }
 
     _cached_meta_info_offset = meta_info_offset;
-    _cached_meta_block_first_index += meta_block_index * Packing::meta_block_size;
+    _cached_meta_block_first_index += relative_meta_block_index * Packing::meta_block_size;
   }
 
   void _clear_meta_block_cache() {

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
@@ -46,7 +46,6 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
     if (_is_index_after_or_within_cached_meta_block(i)) {
       const auto relative_index = _index_relative_to_cached_meta_block(i);
       const auto relative_meta_block_index = relative_index / Packing::meta_block_size;
-      DebugAssert(relative_meta_block_index > 0u, "");
 
       _read_meta_info_from_offset(relative_meta_block_index);
       return _get_within_cached_meta_block(i);

--- a/src/test/operators/physical_query_plan_test.cpp
+++ b/src/test/operators/physical_query_plan_test.cpp
@@ -1,7 +1,7 @@
 #include <sstream>
 
-#include "gtest/gtest.h"
 #include "base_test.hpp"
+#include "gtest/gtest.h"
 
 #include "operators/get_table.hpp"
 #include "operators/table_scan.hpp"

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -70,16 +70,9 @@ class CompressedVectorTest : public BaseTestWithParam<VectorCompressionType> {
 };
 
 auto formatter = [](const ::testing::TestParamInfo<VectorCompressionType> info) {
-  return std::to_string(static_cast<uint32_t>(info.param));
-};
-
-auto formatter = [](const ::testing::TestParamInfo<CompressedVectorTest> info) {
   const auto type = info.param;
-  auto string = vector_compression_type_to_string.left.at(*spec.vector_compression_type);
-
-  auto string = stream.str();
+  auto string = vector_compression_type_to_string.left.at(type);
   string.erase(std::remove_if(string.begin(), string.end(), [](char c) { return !std::isalnum(c); }), string.end());
-
   return string;
 };
 

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -8,6 +8,7 @@
 #include "storage/vector_compression/resolve_compressed_vector_type.hpp"
 #include "storage/vector_compression/vector_compression.hpp"
 
+#include "constant_mappings.hpp"
 #include "types.hpp"
 
 namespace opossum {
@@ -26,7 +27,7 @@ namespace {
 
 }  // namespace
 
-class CompressedVectorTest : public BaseTest, public ::testing::WithParamInterface<VectorCompressionType> {
+class CompressedVectorTest : public BaseTestWithParam<VectorCompressionType> {
  protected:
   void SetUp() override {}
 
@@ -70,6 +71,16 @@ class CompressedVectorTest : public BaseTest, public ::testing::WithParamInterfa
 
 auto formatter = [](const ::testing::TestParamInfo<VectorCompressionType> info) {
   return std::to_string(static_cast<uint32_t>(info.param));
+};
+
+auto formatter = [](const ::testing::TestParamInfo<CompressedVectorTest> info) {
+  const auto type = info.param;
+  auto string = vector_compression_type_to_string.left.at(*spec.vector_compression_type);
+
+  auto string = stream.str();
+  string.erase(std::remove_if(string.begin(), string.end(), [](char c) { return !std::isalnum(c); }), string.end());
+
+  return string;
 };
 
 INSTANTIATE_TEST_CASE_P(VectorCompressionTypes, CompressedVectorTest,

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -74,7 +74,8 @@ class EncodedColumnTest : public BaseTestWithParam<ColumnEncodingSpec> {
   ChunkOffsetsList create_random_access_chunk_offsets_list() {
     auto list = create_sequential_chunk_offsets_list();
 
-    std::default_random_engine engine{std::random_device{}()};
+    auto random_device = std::random_device{};
+    std::default_random_engine engine{random_device()};
     std::shuffle(list.begin(), list.end(), engine);
 
     return list;

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -74,7 +74,7 @@ class EncodedColumnTest : public BaseTestWithParam<ColumnEncodingSpec> {
   ChunkOffsetsList create_random_access_chunk_offsets_list() {
     auto list = create_sequential_chunk_offsets_list();
 
-    std::default_random_engine engine{};
+    std::default_random_engine engine{std::random_device{}()};
     std::shuffle(list.begin(), list.end(), engine);
 
     return list;

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -1,20 +1,20 @@
 #include <boost/hana/at_key.hpp>
 
+#include <cctype>
 #include <memory>
 #include <random>
 #include <sstream>
-#include <cctype>
 
 #include "base_test.hpp"
 #include "gtest/gtest.h"
 
+#include "constant_mappings.hpp"
+#include "storage/chunk_encoder.hpp"
 #include "storage/column_encoding_utils.hpp"
 #include "storage/create_iterable_from_column.hpp"
 #include "storage/encoding_type.hpp"
 #include "storage/resolve_encoded_column_type.hpp"
-#include "storage/chunk_encoder.hpp"
 #include "storage/value_column.hpp"
-#include "constant_mappings.hpp"
 
 #include "types.hpp"
 #include "utils/enum_constant.hpp"
@@ -82,7 +82,7 @@ class EncodedColumnTest : public BaseTestWithParam<ColumnEncodingSpec> {
 
   template <typename T>
   std::shared_ptr<BaseEncodedColumn> encode_value_column(DataType data_type,
-                                                            const std::shared_ptr<ValueColumn<T>>& value_column) {
+                                                         const std::shared_ptr<ValueColumn<T>>& value_column) {
     const auto column_encoding_spec = GetParam();
     return encode_column(column_encoding_spec.encoding_type, data_type, value_column,
                          column_encoding_spec.vector_compression_type);
@@ -104,12 +104,13 @@ auto formatter = [](const ::testing::TestParamInfo<ColumnEncodingSpec> info) {
   return string;
 };
 
-INSTANTIATE_TEST_CASE_P(ColumnEncodingSpecs, EncodedColumnTest,
-                        ::testing::Values(ColumnEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-                                          ColumnEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
-                                          ColumnEncodingSpec{EncodingType::RunLength},
-                                          ColumnEncodingSpec{EncodingType::DeprecatedDictionary}),
-                        formatter);
+INSTANTIATE_TEST_CASE_P(
+    ColumnEncodingSpecs, EncodedColumnTest,
+    ::testing::Values(ColumnEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+                      ColumnEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
+                      ColumnEncodingSpec{EncodingType::RunLength},
+                      ColumnEncodingSpec{EncodingType::DeprecatedDictionary}),
+    formatter);
 
 TEST_P(EncodedColumnTest, SequenciallyReadNotNullableIntColumn) {
   auto value_column = this->create_int_value_column();


### PR DESCRIPTION
There was a bug causing an integer overflow in the SIMD-BP128 decompressor, which wasn’t tested and slipped through review. I added a test and fixed the bug (and refactored the tests a bit). The real change is in `simd_bp128_decompressor.hpp:89`

Thanks @apopiak for his help.

The changes are described further in the comments.