### PR TITLE
Local Predicate Support for Joins

### DIFF
--- a/src/benchmarklib/tpch/tpch_queries.cpp
+++ b/src/benchmarklib/tpch/tpch_queries.cpp
@@ -537,13 +537,11 @@ const char* const tpch_query_10 =
  *
  * Changes:
  *  1. Random values are hardcoded
- *  2. Variable binding in alias not supported by SQLParser
- *    a. removed it
  */
-// const char* const tpch_query_13 =
-//    R"(SELECT c_count, count(*) as custdist FROM (SELECT c_custkey, count(o_orderkey) AS c_count
-//      FROM customer left outer join orders on c_custkey = o_custkey AND o_comment not like '%special%request%'
-//      GROUP BY c_custkey) as c_orders GROUP BY c_count ORDER BY custdist DESC, c_count DESC;)";
+const char* const tpch_query_13 =
+    R"(SELECT c_count, count(*) as custdist FROM (SELECT c_custkey, count(o_orderkey) as c_count
+      FROM customer left outer join orders on c_custkey = o_custkey AND o_comment not like '%special%request%'
+      GROUP BY c_custkey) as c_orders GROUP BY c_count ORDER BY custdist DESC, c_count DESC;)";
 
 /**
  * TPC-H 14
@@ -912,7 +910,7 @@ const std::map<size_t, const char*> tpch_queries = {
     {10, tpch_query_10},
     /* {11, tpch_query_11}, Enable once we support Subselects in Having clause */
     /* {12, tpch_query_12}, Enable once we support IN */
-    /* {13, tpch_query_13}, Enable once we support nested expressions in Join Condition */
+    {13, tpch_query_13},
     /* {14, tpch_query_14}, Enable once we support Case */
     /* {15, tpch_query_15}, Enable once we support Subselects in WHERE condition */
     /* {16, tpch_query_16}, Enable once we support Subselects in WHERE condition */

--- a/src/benchmarklib/tpch/tpch_queries.hpp
+++ b/src/benchmarklib/tpch/tpch_queries.hpp
@@ -6,7 +6,7 @@
 namespace opossum {
 
 /**
- * Contains all supported TPCH queries. Use ordered map to have queries sorted by query id. 
+ * Contains all supported TPCH queries. Use ordered map to have queries sorted by query id.
  * This allows for guaranteed execution order when iterating over the queries.
  */
 extern const std::map<size_t, const char*> tpch_queries;

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -396,14 +396,16 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_join(const hsql::Join
 
   auto left_qualified_column_name = HSQLExprTranslator::to_qualified_column_name(*join_condition->expr);
   auto right_qualified_column_name = HSQLExprTranslator::to_qualified_column_name(*join_condition->expr2);
+  auto predicate_condition = translate_operator_type_to_predicate_condition(join_condition->opType);
+
   const auto left_in_left_node = _get_side(left_node, right_node, join_condition->expr) == LQPInputSide::Left;
   if (!left_in_left_node) {
     std::swap(left_qualified_column_name, right_qualified_column_name);
+    predicate_condition = get_predicate_condition_for_reverse_order(predicate_condition);
   }
 
   const auto column_references = std::make_pair(*left_node->find_column(left_qualified_column_name),
                                                 *right_node->find_column(right_qualified_column_name));
-  auto predicate_condition = translate_operator_type_to_predicate_condition(join_condition->opType);
   auto join_node = JoinNode::make(join_mode, column_references, predicate_condition);
   join_node->set_left_input(left_node);
   join_node->set_right_input(right_node);

--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -85,6 +85,34 @@ class SQLTranslator final : public Noncopyable {
                                                        const std::shared_ptr<AbstractLQPNode>& input_node);
 
   std::shared_ptr<AbstractLQPNode> _translate_join(const hsql::JoinDefinition& select);
+
+  /**
+   * Given a set of input expressions which may contain zero, one, or two column expressions as children,
+   * partition the input expressions into separate lists containing the expressions whose column references
+   * either point to the left, the right, or both sides, respectively.
+   */
+  void _get_sides_from_operator_expressions(const std::vector<const hsql::Expr*>& conditions,
+                                            const std::shared_ptr<AbstractLQPNode>& left_node,
+                                            const std::shared_ptr<AbstractLQPNode>& right_node,
+                                            std::vector<const hsql::Expr*>& both, std::vector<const hsql::Expr*>& left,
+                                            std::vector<const hsql::Expr*>& right);
+
+  /**
+   * Flatten an expression tree solely consisting of conjunctions into a list using a depth-first traversal.
+   */
+  void _flatten_conjunctive_expression_tree(const hsql::Expr* expression, std::vector<const hsql::Expr*>& conditions);
+
+  /**
+  * Convert a set of operator expressions into a chain of predicate nodes and embed these into the given subtree.
+   */
+  void _insert_predicates_before(const std::shared_ptr<AbstractLQPNode>& node,
+                                 const std::vector<const hsql::Expr*>& conditions,
+                                 const LQPInputSide side = LQPInputSide::Left);
+
+  /** Look up the qualified column name of the expression in the two input nodes and return the resulting side.*/
+  LQPInputSide _get_side(const std::shared_ptr<AbstractLQPNode>& left, const std::shared_ptr<AbstractLQPNode>& right,
+                         const hsql::Expr* expression);
+
   std::shared_ptr<AbstractLQPNode> _translate_natural_join(const hsql::JoinDefinition& select);
 
   std::shared_ptr<AbstractLQPNode> _translate_cross_product(const std::vector<hsql::TableRef*>& tables);

--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -14,6 +14,7 @@
 
 namespace opossum {
 
+class JoinNode;
 class AggregateNode;
 class LQPExpression;
 
@@ -85,6 +86,10 @@ class SQLTranslator final : public Noncopyable {
                                                        const std::shared_ptr<AbstractLQPNode>& input_node);
 
   std::shared_ptr<AbstractLQPNode> _translate_join(const hsql::JoinDefinition& select);
+
+  void _insert_nonjoin_predicates(const std::shared_ptr<JoinNode>& join_node,
+                                  const std::vector<const hsql::Expr*>& left_conditions,
+                                  const std::vector<const hsql::Expr*>& right_conditions);
 
   /**
    * Given a set of input expressions which may contain zero, one, or two column expressions as children,

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -700,12 +700,12 @@ TEST_F(SQLTranslatorTest, MultipleJoinConditionsOnBothSides) {
 
 TEST_F(SQLTranslatorTest, JoinConditionAmbiguous) {
   const auto query = "SELECT * FROM table_a JOIN table_b ON a = b";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::invalid_argument);
 }
 
 TEST_F(SQLTranslatorTest, NonJoinConditionAmbiguous) {
   const auto query = "SELECT * FROM table_a JOIN table_b ON table_a.a = table_b.a AND a = 3";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::invalid_argument);
 }
 
 TEST_F(SQLTranslatorTest, ColumnsOfJoinConditionPermuted) {

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -687,7 +687,7 @@ TEST_F(SQLTranslatorTest, MultipleJoinConditionsOnBothSides) {
     JoinNode::make(JoinMode::Inner, LQPColumnReferencePair{_table_a_a, _table_b_a}, PredicateCondition::Equals,
 
       PredicateNode::make(_table_a_a, PredicateCondition::Equals, _table_a_b,
-        PredicateNode::make(_table_a_b, PredicateCondition::NotEquals, static_cast<int64_t>(3),
+        PredicateNode::make(_table_a_b, PredicateCondition::NotEquals, static_cast<int32_t>(3),
           _stored_table_node_a)),
 
       PredicateNode::make(_table_b_b, PredicateCondition::Equals, _table_b_a,
@@ -700,12 +700,12 @@ TEST_F(SQLTranslatorTest, MultipleJoinConditionsOnBothSides) {
 
 TEST_F(SQLTranslatorTest, JoinConditionAmbiguous) {
   const auto query = "SELECT * FROM table_a JOIN table_b ON a = b";
-  EXPECT_THROW(compile_query(query), std::invalid_argument);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, NonJoinConditionAmbiguous) {
   const auto query = "SELECT * FROM table_a JOIN table_b ON table_a.a = table_b.a AND a = 3";
-  EXPECT_THROW(compile_query(query), std::invalid_argument);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, ColumnsOfJoinConditionPermuted) {

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -709,12 +709,12 @@ TEST_F(SQLTranslatorTest, NonJoinConditionAmbiguous) {
 }
 
 TEST_F(SQLTranslatorTest, ColumnsOfJoinConditionPermuted) {
-  const auto query = "SELECT * FROM table_a JOIN table_b ON table_b.a = table_a.b";
+  const auto query = "SELECT * FROM table_a JOIN table_b ON table_b.a < table_a.b";
   auto result_node = compile_query(query);
 
   // clang-format off
   const auto expected = ProjectionNode::make_pass_through(
-    JoinNode::make(JoinMode::Inner, LQPColumnReferencePair {_table_a_b, _table_b_a}, PredicateCondition::Equals,
+    JoinNode::make(JoinMode::Inner, LQPColumnReferencePair {_table_a_b, _table_b_a}, PredicateCondition::GreaterThan,
       _stored_table_node_a,
       _stored_table_node_b));
   // clang-format on

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -21,7 +21,7 @@
 
 namespace opossum {
 
-class TPCHTest : public BaseTestWithParam<size_t> {
+class TPCHTest : public BaseTestWithParam<std::pair<const size_t, const char*>> {
  protected:
   std::shared_ptr<SQLiteWrapper> _sqlite_wrapper;
 
@@ -43,11 +43,12 @@ class TPCHTest : public BaseTestWithParam<size_t> {
 };
 
 TEST_P(TPCHTest, TPCHQueryTest) {
-  const auto query_idx = GetParam();
+  size_t query_idx;
+  const char* query;
+  std::tie(query_idx, query) = GetParam();
 
   SCOPED_TRACE("TPC-H " + std::to_string(query_idx));
 
-  const auto query = tpch_queries.at(query_idx);
   const auto sqlite_result_table = _sqlite_wrapper->execute_query(query);
 
   auto sql_pipeline = SQLPipelineBuilder{query}.disable_mvcc().create_pipeline();
@@ -58,30 +59,7 @@ TEST_P(TPCHTest, TPCHQueryTest) {
 }
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(TPCHTestInstances, TPCHTest, ::testing::Values(
-  1,
-  // 2,  /* Enable once we support Subselects in WHERE condition */
-  3,
-  // 4,  /* Enable once we support Exists and Subselects in WHERE condition */
-  5,
-  6,
-  7,
-  // 8,  /* Enable once CASE and arithmetic operations of Aggregations are supported */
-  9,
-  10
-  // 11, /* Enable once we support Subselects in Having clause */
-  // 12, /* Enable once we support IN */
-  // 13, /* Enable once we support nested expressions in Join Condition */
-  // 14, /* Enable once we support Case */
-  // 15, /* Enable once we support Subselects in WHERE condition */
-  // 16, /* Enable once we support Subselects in WHERE condition */
-  // 17, /* Enable once we support Subselects in WHERE condition */
-  // 18, /* Enable once we support Subselects in WHERE condition */
-  // 19, /* Enable once we support OR in WHERE condition */
-  // 20, /* Enable once we support Subselects in WHERE condition */
-  // 21, /* Enable once we support Exists and Subselect in WHERE condition */
-  // 22  /* Enable once we support SUBSTRING, IN, EXISTS, and un-/correlated Subselects in WHERE condition */
-), );  // NOLINT
+INSTANTIATE_TEST_CASE_P(TPCHTestInstances, TPCHTest, ::testing::ValuesIn(tpch_queries), );  // NOLINT
 // clang-format on
 
 }  // namespace opossum


### PR DESCRIPTION
A join condition may contain multiple conditions which may or may not contribute to matchmaking. By example:

    SELECT * FROM A JOIN B ON A.a = B.a AND A.comment NOT LIKE 'special request';

As a result, given the expression tree, perform the following steps:

1. Flatten expression tree in order to get a list of conditions.
2. Inspect expression list in order to determine if it is a real join condition involving two column IDs from different tables or if it is a simple predicate (= which has at least one literal) which can be demoted in the left or right subtree.
3. For all simple predicates, append predicate nodes in the correct subtree.
