### PR TITLE
Rename child/parent in LQP to input/output

### DIFF
--- a/src/lib/abstract_expression.cpp
+++ b/src/lib/abstract_expression.cpp
@@ -63,7 +63,7 @@ const std::shared_ptr<DerivedExpression> AbstractExpression<DerivedExpression>::
 }
 
 template <typename DerivedExpression>
-void AbstractExpression<DerivedExpression>::set_right_child(const std::shared_ptr<DerivedExpression>& right) {
+void AbstractExpression<DerivedExpression>::set_right_child(const std::shared_ptr<DerivedExpression> &right) {
   _right_child = right;
 }
 
@@ -263,7 +263,7 @@ std::string AbstractExpression<DerivedExpression>::to_string(
          "To generate expression string, Expressions need to be operators or operands (which are already covered "
          "further up).");
 
-  Assert(left_child(), "Operator needs left child.");
+  Assert(left_child(), "Operator needs left input.");
 
   std::string result;
   const auto left_column_name = left_child()->to_string(input_column_names, false);
@@ -275,7 +275,7 @@ std::string AbstractExpression<DerivedExpression>::to_string(
     const auto right_column_name = right_child()->to_string(input_column_names, false);
     result = left_column_name + " " + op + " " + right_column_name;
   } else {
-    Assert(!right_child(), "Unary Operator can only have left child.");
+    Assert(!right_child(), "Unary Operator can only have left input.");
 
     result = op + " " + left_column_name;
   }

--- a/src/lib/abstract_expression.cpp
+++ b/src/lib/abstract_expression.cpp
@@ -63,7 +63,7 @@ const std::shared_ptr<DerivedExpression> AbstractExpression<DerivedExpression>::
 }
 
 template <typename DerivedExpression>
-void AbstractExpression<DerivedExpression>::set_right_child(const std::shared_ptr<DerivedExpression> &right) {
+void AbstractExpression<DerivedExpression>::set_right_child(const std::shared_ptr<DerivedExpression>& right) {
   _right_child = right;
 }
 

--- a/src/lib/abstract_expression.cpp
+++ b/src/lib/abstract_expression.cpp
@@ -270,7 +270,7 @@ std::string AbstractExpression<DerivedExpression>::to_string(
   const auto& op = expression_type_to_operator_string.at(_type);
 
   if (is_binary_operator()) {
-    Assert(right_child(), "Binary Operator needs both children.");
+    Assert(right_child(), "Binary Operator needs both inputs.");
 
     const auto right_column_name = right_child()->to_string(input_column_names, false);
     result = left_column_name + " " + op + " " + right_column_name;

--- a/src/lib/abstract_expression.hpp
+++ b/src/lib/abstract_expression.hpp
@@ -87,7 +87,7 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
   void set_left_child(const std::shared_ptr<DerivedExpression>& left);
 
   const std::shared_ptr<DerivedExpression> right_child() const;
-  void set_right_child(const std::shared_ptr<DerivedExpression> &right);
+  void set_right_child(const std::shared_ptr<DerivedExpression>& right);
   // @}
 
   ExpressionType type() const;

--- a/src/lib/abstract_expression.hpp
+++ b/src/lib/abstract_expression.hpp
@@ -87,7 +87,7 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
   void set_left_child(const std::shared_ptr<DerivedExpression>& left);
 
   const std::shared_ptr<DerivedExpression> right_child() const;
-  void set_right_child(const std::shared_ptr<DerivedExpression>& right);
+  void set_right_child(const std::shared_ptr<DerivedExpression> &right);
   // @}
 
   ExpressionType type() const;

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -42,107 +42,107 @@ LQPColumnReference AbstractLQPNode::adapt_column_reference_to_different_lqp(
   return copied_lqp->output_column_references()[output_column_id];
 }
 
-std::vector<std::shared_ptr<AbstractLQPNode>> AbstractLQPNode::parents() const {
-  std::vector<std::shared_ptr<AbstractLQPNode>> parents;
-  parents.reserve(_parents.size());
+std::vector<std::shared_ptr<AbstractLQPNode>> AbstractLQPNode::outputs() const {
+  std::vector<std::shared_ptr<AbstractLQPNode>> outputs;
+  outputs.reserve(_outputs.size());
 
-  for (const auto& parent_weak_ptr : _parents) {
-    const auto parent = parent_weak_ptr.lock();
-    DebugAssert(parent, "Failed to lock parent");
-    parents.emplace_back(parent);
+  for (const auto& output_weak_ptr : _outputs) {
+    const auto output = output_weak_ptr.lock();
+    DebugAssert(output, "Failed to lock output");
+    outputs.emplace_back(output);
   }
 
-  return parents;
+  return outputs;
 }
 
-std::vector<LQPParentRelation> AbstractLQPNode::parent_relations() const {
-  std::vector<LQPParentRelation> parent_relations(parent_count());
+std::vector<LQPOutputRelation> AbstractLQPNode::output_relations() const {
+  std::vector<LQPOutputRelation> output_relations(output_count());
 
-  const auto parents = this->parents();
-  const auto child_sides = get_child_sides();
+  const auto outputs = this->outputs();
+  const auto child_sides = get_input_sides();
 
-  for (size_t parent_idx = 0; parent_idx < parent_relations.size(); ++parent_idx) {
-    parent_relations[parent_idx] = LQPParentRelation{parents[parent_idx], child_sides[parent_idx]};
+  for (size_t output_idx = 0; output_idx < output_relations.size(); ++output_idx) {
+    output_relations[output_idx] = LQPOutputRelation{outputs[output_idx], child_sides[output_idx]};
   }
 
-  return parent_relations;
+  return output_relations;
 }
 
-size_t AbstractLQPNode::parent_count() const { return _parents.size(); }
+size_t AbstractLQPNode::output_count() const { return _outputs.size(); }
 
-void AbstractLQPNode::remove_parent(const std::shared_ptr<AbstractLQPNode>& parent) {
-  const auto child_side = get_child_side(parent);
-  parent->set_child(child_side, nullptr);
+void AbstractLQPNode::remove_output(const std::shared_ptr<AbstractLQPNode> &output) {
+  const auto child_side = get_input_side(output);
+  output->set_input(child_side, nullptr);
 }
 
-void AbstractLQPNode::clear_parents() {
-  // Don't use for-each loop here, as remove_parent manipulates the _parents vector
-  while (!_parents.empty()) {
-    auto parent = _parents.front().lock();
-    DebugAssert(parent, "Failed to lock parent");
-    remove_parent(parent);
+void AbstractLQPNode::clear_outputs() {
+  // Don't use for-each loop here, as remove_output manipulates the _outputs vector
+  while (!_outputs.empty()) {
+    auto output = _outputs.front().lock();
+    DebugAssert(output, "Failed to lock output");
+    remove_output(output);
   }
 }
 
-LQPChildSide AbstractLQPNode::get_child_side(const std::shared_ptr<AbstractLQPNode>& parent) const {
-  if (parent->_children[0].get() == this) {
-    return LQPChildSide::Left;
-  } else if (parent->_children[1].get() == this) {
-    return LQPChildSide::Right;
+LQPInputSide AbstractLQPNode::get_input_side(const std::shared_ptr<AbstractLQPNode> &output) const {
+  if (output->_inputs[0].get() == this) {
+    return LQPInputSide::Left;
+  } else if (output->_inputs[1].get() == this) {
+    return LQPInputSide::Right;
   } else {
-    Fail("Specified parent node is not actually a parent node of this node.");
+    Fail("Specified output node is not actually a output node of this node.");
   }
 }
 
-std::vector<LQPChildSide> AbstractLQPNode::get_child_sides() const {
-  std::vector<LQPChildSide> child_sides;
-  child_sides.reserve(_parents.size());
+std::vector<LQPInputSide> AbstractLQPNode::get_input_sides() const {
+  std::vector<LQPInputSide> child_sides;
+  child_sides.reserve(_outputs.size());
 
-  for (const auto& parent_weak_ptr : _parents) {
-    const auto parent = parent_weak_ptr.lock();
-    DebugAssert(parent, "Failed to lock parent");
-    child_sides.emplace_back(get_child_side(parent));
+  for (const auto& output_weak_ptr : _outputs) {
+    const auto output = output_weak_ptr.lock();
+    DebugAssert(output, "Failed to lock output");
+    child_sides.emplace_back(get_input_side(output));
   }
 
   return child_sides;
 }
 
-std::shared_ptr<AbstractLQPNode> AbstractLQPNode::left_child() const { return _children[0]; }
+std::shared_ptr<AbstractLQPNode> AbstractLQPNode::left_input() const { return _inputs[0]; }
 
-void AbstractLQPNode::set_left_child(const std::shared_ptr<AbstractLQPNode>& left) {
-  set_child(LQPChildSide::Left, left);
+void AbstractLQPNode::set_left_input(const std::shared_ptr<AbstractLQPNode> &left) {
+  set_input(LQPInputSide::Left, left);
 }
 
-std::shared_ptr<AbstractLQPNode> AbstractLQPNode::right_child() const { return _children[1]; }
+std::shared_ptr<AbstractLQPNode> AbstractLQPNode::right_input() const { return _inputs[1]; }
 
-void AbstractLQPNode::set_right_child(const std::shared_ptr<AbstractLQPNode>& right) {
-  set_child(LQPChildSide::Right, right);
+void AbstractLQPNode::set_right_input(const std::shared_ptr<AbstractLQPNode>& right) {
+  set_input(LQPInputSide::Right, right);
 }
 
-std::shared_ptr<AbstractLQPNode> AbstractLQPNode::child(LQPChildSide side) const {
+std::shared_ptr<AbstractLQPNode> AbstractLQPNode::input(LQPInputSide side) const {
   const auto child_index = static_cast<int>(side);
-  return _children[child_index];
+  return _inputs[child_index];
 }
 
-void AbstractLQPNode::set_child(LQPChildSide side, const std::shared_ptr<AbstractLQPNode>& child) {
-  // We need a reference to _children[child_index], so not calling this->child(side)
-  auto& current_child = _children[static_cast<int>(side)];
+void AbstractLQPNode::set_input(LQPInputSide side, const std::shared_ptr<AbstractLQPNode> &input) {
+  // We need a reference to _inputs[child_index], so not calling this->input(side)
+  auto& current_child = _inputs[static_cast<int>(side)];
 
-  if (current_child == child) {
+  if (current_child == input) {
     return;
   }
 
-  // Untie from previous child
+  // Untie from previous input
   if (current_child) {
-    current_child->_remove_parent_pointer(shared_from_this());
+    current_child->_remove_output_pointer(shared_from_this());
   }
 
   /**
    * Tie in the new child
    */
-  current_child = child;
+  current_child = input;
   if (current_child) {
-    current_child->_add_parent_pointer(shared_from_this());
+    current_child->_add_output_pointer(shared_from_this());
   }
 
   _child_changed();
@@ -150,21 +150,21 @@ void AbstractLQPNode::set_child(LQPChildSide side, const std::shared_ptr<Abstrac
 
 LQPNodeType AbstractLQPNode::type() const { return _type; }
 
-bool AbstractLQPNode::subtree_is_read_only() const {
+bool AbstractLQPNode::subplan_is_read_only() const {
   auto read_only = true;
-  if (left_child()) read_only &= left_child()->subtree_is_read_only();
-  if (right_child()) read_only &= right_child()->subtree_is_read_only();
+  if (left_input()) read_only &= left_input()->subplan_is_read_only();
+  if (right_input()) read_only &= right_input()->subplan_is_read_only();
   return read_only;
 }
 
-bool AbstractLQPNode::subtree_is_validated() const {
+bool AbstractLQPNode::subplan_is_validated() const {
   if (type() == LQPNodeType::Validate) return true;
 
-  if (!left_child() && !right_child()) return false;
+  if (!left_input() && !right_input()) return false;
 
   auto children_validated = true;
-  if (left_child()) children_validated &= left_child()->subtree_is_validated();
-  if (right_child()) children_validated &= right_child()->subtree_is_validated();
+  if (left_input()) children_validated &= left_input()->subplan_is_validated();
+  if (right_input()) children_validated &= right_input()->subplan_is_validated();
   return children_validated;
 }
 
@@ -172,20 +172,20 @@ void AbstractLQPNode::set_statistics(const std::shared_ptr<TableStatistics>& sta
 
 const std::shared_ptr<TableStatistics> AbstractLQPNode::get_statistics() {
   if (!_statistics) {
-    _statistics = derive_statistics_from(left_child(), right_child());
+    _statistics = derive_statistics_from(left_input(), right_input());
   }
 
   return _statistics;
 }
 
 std::shared_ptr<TableStatistics> AbstractLQPNode::derive_statistics_from(
-    const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {
-  DebugAssert(left_child,
-              "Default implementation of derive_statistics_from() requires a left child, override in concrete node "
+    const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
+  DebugAssert(left_input,
+              "Default implementation of derive_statistics_from() requires a left input, override in concrete node "
               "implementation for different behavior");
-  DebugAssert(!right_child, "Default implementation of derive_statistics_from() cannot have a right_child");
+  DebugAssert(!right_input, "Default implementation of derive_statistics_from() cannot have a right_input");
 
-  return left_child->get_statistics();
+  return left_input->get_statistics();
 }
 
 const std::vector<std::string>& AbstractLQPNode::output_column_names() const {
@@ -193,22 +193,22 @@ const std::vector<std::string>& AbstractLQPNode::output_column_names() const {
    * This function has to be overwritten if columns or their order are in any way redefined by this Node.
    * Examples include Projections, Aggregates, and Joins.
    */
-  DebugAssert(left_child() && !right_child(),
+  DebugAssert(left_input() && !right_input(),
               "Node has no or two inputs and therefore needs to override this function.");
-  return left_child()->output_column_names();
+  return left_input()->output_column_names();
 }
 
 const std::vector<LQPColumnReference>& AbstractLQPNode::output_column_references() const {
   /**
-   * Default implementation of output_column_references() will return the ColumnReferences of the left_child if it exists,
+   * Default implementation of output_column_references() will return the ColumnReferences of the left_input if it exists,
    * otherwise will pretend that all Columns originate in this node.
    * Nodes with both children need to override this as the default implementation can't cover their behaviour.
    */
 
   if (!_output_column_references) {
-    Assert(!right_child(), "Nodes that have two children must override this method");
-    if (left_child()) {
-      _output_column_references = left_child()->output_column_references();
+    Assert(!right_input(), "Nodes that have two children must override this method");
+    if (left_input()) {
+      _output_column_references = left_input()->output_column_references();
     } else {
       _output_column_references.emplace();
       for (auto column_id = ColumnID{0}; column_id < output_column_count(); ++column_id) {
@@ -260,9 +260,9 @@ std::optional<LQPColumnReference> AbstractLQPNode::find_column(const QualifiedCo
   };
 
   const auto column_reference_from_left =
-      resolve_qualified_column_name(left_child(), *qualified_column_name_without_local_table_name);
+      resolve_qualified_column_name(left_input(), *qualified_column_name_without_local_table_name);
   const auto column_reference_from_right =
-      resolve_qualified_column_name(right_child(), *qualified_column_name_without_local_table_name);
+      resolve_qualified_column_name(right_input(), *qualified_column_name_without_local_table_name);
 
   Assert(!column_reference_from_left || !column_reference_from_right ||
              column_reference_from_left == column_reference_from_right,
@@ -288,27 +288,27 @@ std::shared_ptr<const AbstractLQPNode> AbstractLQPNode::find_table_name_origin(c
 
   // If this node has an alias, it hides the names of tables in its children and search does not continue.
   // Also, it does not need to continue if there are no children
-  if (!left_child() || _table_alias) {
+  if (!left_input() || _table_alias) {
     return nullptr;
   }
 
-  const auto table_name_origin_in_left_child = left_child()->find_table_name_origin(table_name);
+  const auto table_name_origin_in_left_input = left_input()->find_table_name_origin(table_name);
 
-  if (right_child()) {
-    const auto table_name_origin_in_right_child = right_child()->find_table_name_origin(table_name);
+  if (right_input()) {
+    const auto table_name_origin_in_right_input = right_input()->find_table_name_origin(table_name);
 
-    if (table_name_origin_in_left_child && table_name_origin_in_right_child) {
+    if (table_name_origin_in_left_input && table_name_origin_in_right_input) {
       // Both children could contain the table in the case of a diamond-shaped LQP as produced by an OR.
       // This is legal as long as they ultimately resolve to the same table origin.
-      Assert(table_name_origin_in_left_child == table_name_origin_in_right_child,
+      Assert(table_name_origin_in_left_input == table_name_origin_in_right_input,
              "If a node has two children, both have to resolve a table name to the same node");
-      return table_name_origin_in_left_child;
-    } else if (table_name_origin_in_right_child) {
-      return table_name_origin_in_right_child;
+      return table_name_origin_in_left_input;
+    } else if (table_name_origin_in_right_input) {
+      return table_name_origin_in_right_input;
     }
   }
 
-  return table_name_origin_in_left_child;
+  return table_name_origin_in_left_input;
 }
 
 std::optional<ColumnID> AbstractLQPNode::find_output_column_id(const LQPColumnReference& column_reference) const {
@@ -331,55 +331,55 @@ ColumnID AbstractLQPNode::get_output_column_id(const LQPColumnReference& column_
 size_t AbstractLQPNode::output_column_count() const { return output_column_names().size(); }
 
 void AbstractLQPNode::remove_from_tree() {
-  Assert(!right_child(), "Can only remove nodes that only have a left child or no children");
+  Assert(!right_input(), "Can only remove nodes that only have a left input or no children");
 
   /**
-   * Back up parents and in which child side they hold this node
+   * Back up outputs and in which child side they hold this node
    */
-  auto parents = this->parents();
-  auto child_sides = this->get_child_sides();
+  auto outputs = this->outputs();
+  auto child_sides = this->get_input_sides();
 
   /**
-   * Hold left_child ptr in extra variable to keep the ref count up and untie it from this node.
-   * left_child might be nullptr
+   * Hold left_input ptr in extra variable to keep the ref count up and untie it from this node.
+   * left_input might be nullptr
    */
-  auto left_child = this->left_child();
-  set_left_child(nullptr);
+  auto left_input = this->left_input();
+  set_left_input(nullptr);
 
   /**
-   * Tie this nodes previous parents with this nodes previous left child
-   * If left_child is nullptr, still call set_child so this node will get untied from the LQP.
+   * Tie this nodes previous outputs with this nodes previous left child
+   * If left_input is nullptr, still call set_child so this node will get untied from the LQP.
    */
-  for (size_t parent_idx = 0; parent_idx < parents.size(); ++parent_idx) {
-    parents[parent_idx]->set_child(child_sides[parent_idx], left_child);
+  for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx) {
+    outputs[output_idx]->set_input(child_sides[output_idx], left_input);
   }
 }
 
 void AbstractLQPNode::replace_with(const std::shared_ptr<AbstractLQPNode>& replacement_node) {
-  DebugAssert(replacement_node->_parents.empty(), "Node can't have parents");
-  DebugAssert(!replacement_node->left_child() && !replacement_node->right_child(), "Node can't have children");
+  DebugAssert(replacement_node->_outputs.empty(), "Node can't have outputs");
+  DebugAssert(!replacement_node->left_input() && !replacement_node->right_input(), "Node can't have children");
 
-  const auto parents = this->parents();
-  const auto child_sides = this->get_child_sides();
+  const auto outputs = this->outputs();
+  const auto child_sides = this->get_input_sides();
 
   /**
    * Tie the replacement_node with this nodes children
    */
-  replacement_node->set_left_child(left_child());
-  replacement_node->set_right_child(right_child());
+  replacement_node->set_left_input(left_input());
+  replacement_node->set_right_input(right_input());
 
   /**
-   * Tie the replacement_node with this nodes parents. This will effectively perform clear_parents() on this node.
+   * Tie the replacement_node with this nodes outputs. This will effectively perform clear_outputs() on this node.
    */
-  for (size_t parent_idx = 0; parent_idx < parents.size(); ++parent_idx) {
-    parents[parent_idx]->set_child(child_sides[parent_idx], replacement_node);
+  for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx) {
+    outputs[output_idx]->set_input(child_sides[output_idx], replacement_node);
   }
 
   /**
    * Untie this node from the LQP
    */
-  set_left_child(nullptr);
-  set_right_child(nullptr);
+  set_left_input(nullptr);
+  set_right_input(nullptr);
 }
 
 void AbstractLQPNode::set_alias(const std::optional<std::string>& table_alias) { _table_alias = table_alias; }
@@ -387,8 +387,8 @@ void AbstractLQPNode::set_alias(const std::optional<std::string>& table_alias) {
 void AbstractLQPNode::print(std::ostream& out) const {
   const auto get_children_fn = [](const auto& node) {
     std::vector<std::shared_ptr<const AbstractLQPNode>> children;
-    if (node->left_child()) children.emplace_back(node->left_child());
-    if (node->right_child()) children.emplace_back(node->right_child());
+    if (node->left_input()) children.emplace_back(node->left_input());
+    if (node->right_input()) children.emplace_back(node->right_input());
     return children;
   };
   const auto node_print_fn = [](const auto& node, auto& stream) {
@@ -403,14 +403,14 @@ void AbstractLQPNode::print(std::ostream& out) const {
 }
 
 std::string AbstractLQPNode::get_verbose_column_name(ColumnID column_id) const {
-  DebugAssert(!right_child(), "Node with right child needs to override this function.");
+  DebugAssert(!right_input(), "Node with right input needs to override this function.");
 
   /**
    *  A AbstractLQPNode without a left child should generally be a StoredTableNode, which overrides this function. But
    *  since get_verbose_column_name() is just a convenience function we don't want to force anyone to override this
    *  function when experimenting with nodes. Thus we handle the case of no left child here as well.
    */
-  if (!left_child()) {
+  if (!left_input()) {
     if (_table_alias) {
       return *_table_alias + "." + output_column_names()[column_id];
     }
@@ -418,7 +418,7 @@ std::string AbstractLQPNode::get_verbose_column_name(ColumnID column_id) const {
     return output_column_names()[column_id];
   }
 
-  const auto verbose_name = left_child()->get_verbose_column_name(column_id);
+  const auto verbose_name = left_input()->get_verbose_column_name(column_id);
 
   if (_table_alias) {
     return *_table_alias + "." + verbose_name;
@@ -455,26 +455,26 @@ void AbstractLQPNode::_child_changed() {
   _output_column_references.reset();
 
   _on_child_changed();
-  for (auto& parent : parents()) {
-    parent->_child_changed();
+  for (auto& output : outputs()) {
+    output->_child_changed();
   }
 }
 
-void AbstractLQPNode::_remove_parent_pointer(const std::shared_ptr<AbstractLQPNode>& parent) {
+void AbstractLQPNode::_remove_output_pointer(const std::shared_ptr<AbstractLQPNode>& output) {
   const auto iter =
-      std::find_if(_parents.begin(), _parents.end(), [&](const auto& other) { return parent == other.lock(); });
-  DebugAssert(iter != _parents.end(), "Specified parent node is not actually a parent node of this node.");
+      std::find_if(_outputs.begin(), _outputs.end(), [&](const auto& other) { return output == other.lock(); });
+  DebugAssert(iter != _outputs.end(), "Specified output node is not actually a output node of this node.");
 
   /**
    * TODO(anybody) This is actually a O(n) operation, could be O(1) by just swapping the last element into the deleted
    * element.
    */
-  _parents.erase(iter);
+  _outputs.erase(iter);
 }
 
-void AbstractLQPNode::_add_parent_pointer(const std::shared_ptr<AbstractLQPNode>& parent) {
-  // Having the same parent multiple times is allowed, e.g. for self joins
-  _parents.emplace_back(parent);
+void AbstractLQPNode::_add_output_pointer(const std::shared_ptr<AbstractLQPNode>& output) {
+  // Having the same output multiple times is allowed, e.g. for self joins
+  _outputs.emplace_back(output);
 }
 
 std::shared_ptr<LQPExpression> AbstractLQPNode::adapt_expression_to_different_lqp(
@@ -511,11 +511,11 @@ AbstractLQPNode::_find_first_subplan_mismatch_impl(const std::shared_ptr<const A
 
   if (!lhs->shallow_equals(*rhs)) return std::make_pair(lhs, rhs);
 
-  const auto left_child_mismatch = _find_first_subplan_mismatch_impl(lhs->left_child(), rhs->left_child());
-  if (left_child_mismatch) return left_child_mismatch;
+  const auto left_input_mismatch = _find_first_subplan_mismatch_impl(lhs->left_input(), rhs->left_input());
+  if (left_input_mismatch) return left_input_mismatch;
 
-  const auto right_child_mismatch = _find_first_subplan_mismatch_impl(lhs->right_child(), rhs->right_child());
-  if (right_child_mismatch) return right_child_mismatch;
+  const auto right_input_mismatch = _find_first_subplan_mismatch_impl(lhs->right_input(), rhs->right_input());
+  if (right_input_mismatch) return right_input_mismatch;
 
   return std::nullopt;
 }
@@ -603,13 +603,13 @@ std::shared_ptr<AbstractLQPNode> AbstractLQPNode::_deep_copy(PreviousCopiesMap& 
     return it->second;
   }
 
-  auto copied_left_child = left_child() ? left_child()->_deep_copy(previous_copies) : nullptr;
-  auto copied_right_child = right_child() ? right_child()->_deep_copy(previous_copies) : nullptr;
+  auto copied_left_input = left_input() ? left_input()->_deep_copy(previous_copies) : nullptr;
+  auto copied_right_input = right_input() ? right_input()->_deep_copy(previous_copies) : nullptr;
 
   // We cannot use the copy constructor here, because it does not work with shared_from_this()
-  auto deep_copy = _deep_copy_impl(copied_left_child, copied_right_child);
-  if (copied_left_child) deep_copy->set_left_child(copied_left_child);
-  if (copied_right_child) deep_copy->set_right_child(copied_right_child);
+  auto deep_copy = _deep_copy_impl(copied_left_input, copied_right_input);
+  if (copied_left_input) deep_copy->set_left_input(copied_left_input);
+  if (copied_right_input) deep_copy->set_right_input(copied_right_input);
 
   previous_copies.emplace(shared_from_this(), deep_copy);
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -39,12 +39,12 @@ enum class LQPNodeType {
   Mock
 };
 
-enum class LQPChildSide { Left, Right };
+enum class LQPInputSide { Left, Right };
 
-// Describes the parent of a Node and which of the parent's children a node is
-struct LQPParentRelation {
-  std::shared_ptr<AbstractLQPNode> parent;
-  LQPChildSide child_side{LQPChildSide::Left};
+// Describes the output of a Node and which of the output's inputs a node is
+struct LQPOutputRelation {
+  std::shared_ptr<AbstractLQPNode> output;
+  LQPInputSide input_side{LQPInputSide::Left};
 };
 
 struct QualifiedColumnName {
@@ -61,9 +61,9 @@ struct QualifiedColumnName {
  * Base class for a Node in the Logical Query Plan.
  *
  * The Logical Query Plan (abbreviated LQP) is a Directional Acyclic Graph (DAG) with each node having 0..2 incoming
- * edges and 0..n outgoing edges. The adjacent nodes on incoming edges are called "children" and those on the outgoing
- * edges "parents". The direction of the edges models data flow (with "data" being Tables) where children produce the
- * input data their parents operate on. A Node represents an "Operation" such as the application of a Predicate or a
+ * edges and 0..n outgoing edges. The adjacent nodes on incoming edges are called "inputs" and those on the outgoing
+ * edges "outputs". The direction of the edges models data flow (with "data" being Tables) where inputs produce the
+ * input data their outputs operate on. A Node represents an "Operation" such as the application of a Predicate or a
  * Join.
  *
  * The LQP is created by the SQLTranslator and can optionally be further processed by the Optimizer.
@@ -74,7 +74,7 @@ struct QualifiedColumnName {
  * We decided to have mutable Nodes for now. By that we can apply rules without creating new nodes for every
  * optimization rule.
  *
- * We do not want people to copy an LQP node as a copy would still have the same children. Instead, they should use
+ * We do not want people to copy an LQP node as a copy would still have the same inputs. Instead, they should use
  * deep_copy().
  */
 class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, private Noncopyable {
@@ -86,69 +86,69 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   // @{
   /**
-   * Set and get the parents/children of this node.
+   * Set and get the outputs/inputs of this node.
    *
-   * The _parents are implicitly set in set_left_child/set_right_child.
-   * For removing parents use remove_parent() or clear_parents().
+   * The _outputs are implicitly set in set_left_input/set_right_input.
+   * For removing outputs use remove_output() or clear_outputs().
    *
-   * set_child() is a shorthand for set_left_child() or set_right_child(), useful if the side is a runtime value
+   * set_child() is a shorthand for set_left_input() or set_right_input(), useful if the side is a runtime value
    */
 
   /**
-   * Locks all parents and returns them as shared_ptrs
+   * Locks all outputs and returns them as shared_ptrs
    */
-  std::vector<std::shared_ptr<AbstractLQPNode>> parents() const;
+  std::vector<std::shared_ptr<AbstractLQPNode>> outputs() const;
 
   /**
-   * @return {{parents()[0], get_child_sides()[0]}, ..., {parents()[n-1], get_child_sides()[n-1]}}
+   * @return {{outputs()[0], get_child_sides()[0]}, ..., {outputs()[n-1], get_child_sides()[n-1]}}
    */
-  std::vector<LQPParentRelation> parent_relations() const;
+  std::vector<LQPOutputRelation> output_relations() const;
 
   /**
-   * Same as parents().size(), but avoids locking all parent pointers
+   * Same as outputs().size(), but avoids locking all output pointers
    */
-  size_t parent_count() const;
+  size_t output_count() const;
 
-  void remove_parent(const std::shared_ptr<AbstractLQPNode>& parent);
-  void clear_parents();
+  void remove_output(const std::shared_ptr<AbstractLQPNode> &output);
+  void clear_outputs();
 
   /**
-   * @pre this has a parent
-   * @return whether this is its parents left or right child.
+   * @pre this has has @param output as an output
+   * @return whether this is the left or right input in the specified output.
    */
-  LQPChildSide get_child_side(const std::shared_ptr<AbstractLQPNode>& parent) const;
+  LQPInputSide get_input_side(const std::shared_ptr<AbstractLQPNode> &output) const;
 
   /**
-   * @returns {get_child_side(parents()[0], ..., get_child_side(parents()[n-1])}
+   * @returns {get_output_side(outputs()[0], ..., get_output_side(outputs()[n-1])}
    */
-  std::vector<LQPChildSide> get_child_sides() const;
+  std::vector<LQPInputSide> get_input_sides() const;
 
-  std::shared_ptr<AbstractLQPNode> left_child() const;
-  void set_left_child(const std::shared_ptr<AbstractLQPNode>& left);
+  std::shared_ptr<AbstractLQPNode> left_input() const;
+  void set_left_input(const std::shared_ptr<AbstractLQPNode> &left);
 
-  std::shared_ptr<AbstractLQPNode> right_child() const;
-  void set_right_child(const std::shared_ptr<AbstractLQPNode>& right);
+  std::shared_ptr<AbstractLQPNode> right_input() const;
+  void set_right_input(const std::shared_ptr<AbstractLQPNode>& right);
 
-  std::shared_ptr<AbstractLQPNode> child(LQPChildSide side) const;
+  std::shared_ptr<AbstractLQPNode> input(LQPInputSide side) const;
 
-  void set_child(LQPChildSide side, const std::shared_ptr<AbstractLQPNode>& child);
+  void set_input(LQPInputSide side, const std::shared_ptr<AbstractLQPNode> &input);
   // @}
 
   LQPNodeType type() const;
 
   // Returns whether this subtree is read only. Defaults to true - if a node makes modifications, it has to override
   // this
-  virtual bool subtree_is_read_only() const;
+  virtual bool subplan_is_read_only() const;
 
   // Returns whether all tables in this subtree were validated
-  bool subtree_is_validated() const;
+  bool subplan_is_validated() const;
 
   // @{
   /**
    * These functions provide access to statistics for this particular node.
    *
    * AbstractLQPNode::derive_statistics_from() calculates new statistics for this node as they would appear if
-   * left_child and right_child WERE its children. This works for the actual children of this node during the lazy
+   * left_input and right_input WERE its inputs. This works for the actual inputs of this node during the lazy
    * initialization in get_statistics() as well as e.g. in an optimizer rule
    * that tries to reorder nodes based on some statistics. In that case it will call this function for all the nodes
    * that shall be reordered with the same reference node.
@@ -158,8 +158,8 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   void set_statistics(const std::shared_ptr<TableStatistics>& statistics);
   const std::shared_ptr<TableStatistics> get_statistics();
   virtual std::shared_ptr<TableStatistics> derive_statistics_from(
-      const std::shared_ptr<AbstractLQPNode>& left_child,
-      const std::shared_ptr<AbstractLQPNode>& right_child = nullptr) const;
+      const std::shared_ptr<AbstractLQPNode>& left_input,
+      const std::shared_ptr<AbstractLQPNode>& right_input = nullptr) const;
   // @}
 
   /**
@@ -213,7 +213,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   ColumnID get_output_column_id(const LQPColumnReference& column_reference) const;
 
   /**
-   * Makes this nodes parents point to this node's left child
+   * Makes this nodes outputs point to this node's left child
    * Unties this node's child from this node
    *
    * @pre this has no right child
@@ -222,7 +222,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   /**
    * Replaces 'this' node with @param replacement_node node.
-   * @pre replacement_node has neither parent nor children
+   * @pre replacement_node has neither output nor inputs
    */
   void replace_with(const std::shared_ptr<AbstractLQPNode>& replacement_node);
 
@@ -243,7 +243,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   void print(std::ostream& out = std::cout) const;
 
   /**
-   * Returns a string describing this node, but nothing about its children.
+   * Returns a string describing this node, but nothing about its inputs.
    */
   virtual std::string description() const = 0;
 
@@ -285,7 +285,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   /**
    * @defgroup Comparing two LQPs
-   * shallow_equals() compares only the nodes without considering the children, find_first_subplan_mismatch() will compare the entire
+   * shallow_equals() compares only the nodes without considering the inputs, find_first_subplan_mismatch() will compare the entire
    * sub plan
    * @{
    */
@@ -309,15 +309,15 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   /**
    * Override and create a DEEP copy of this LQP node. Used for reusing LQPs, e.g., in views.
-   * @param left_child and @param right_child are deep copies of the left and right child respectively, used for deep-copying
+   * @param left_input and @param right_input are deep copies of the left and right child respectively, used for deep-copying
    * ColumnReferences
    */
   virtual std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const = 0;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const = 0;
 
   /**
-   * In derived nodes, clear all data that depends on children and only set it lazily on request (see, e.g.
+   * In derived nodes, clear all data that depends on inputs and only set it lazily on request (see, e.g.
    * output_column_names())
    */
   virtual void _on_child_changed() {}
@@ -362,12 +362,12 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
                       const AbstractLQPNode& lqp_right, const LQPColumnReference& column_reference_right);
 
  private:
-  std::vector<std::weak_ptr<AbstractLQPNode>> _parents;
-  std::array<std::shared_ptr<AbstractLQPNode>, 2> _children;
+  std::vector<std::weak_ptr<AbstractLQPNode>> _outputs;
+  std::array<std::shared_ptr<AbstractLQPNode>, 2> _inputs;
   std::shared_ptr<TableStatistics> _statistics;
 
   /**
-   * Reset statistics, call _on_child_changed() for node specific behaviour and call _child_changed() on parents
+   * Reset statistics, call _on_child_changed() for node specific behaviour and call _child_changed() on outputs
    */
   void _child_changed();
 
@@ -377,11 +377,11 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   // @{
   /**
-   * Add or remove a parent without manipulating this parents child ptr. For internal usage in set_left_child(),
-   * set_right_child(), remove_parent
+   * Add or remove a output without manipulating this outputs child ptr. For internal usage in set_left_input(),
+   * set_right_input(), remove_output
    */
-  void _remove_parent_pointer(const std::shared_ptr<AbstractLQPNode>& parent);
-  void _add_parent_pointer(const std::shared_ptr<AbstractLQPNode>& parent);
+  void _remove_output_pointer(const std::shared_ptr<AbstractLQPNode>& output);
+  void _add_output_pointer(const std::shared_ptr<AbstractLQPNode>& output);
   // @}
 };
 
@@ -417,19 +417,19 @@ class EnableMakeForLQPNode {
           if constexpr (std::is_convertible_v<NthTypeOf<sizeof...(Args)-2, Args...>, std::shared_ptr<AbstractLQPNode>>) {  // NOLINT - too long, but better than breaking
             // last two arguments are shared_ptr<AbstractLQPNode>
             auto node = make_impl(args_tuple, std::make_index_sequence<sizeof...(Args) - 2>());
-            node->set_left_child(std::get<sizeof...(Args) - 2>(args_tuple));
-            node->set_right_child(std::get<sizeof...(Args) - 1>(args_tuple));
+            node->set_left_input(std::get<sizeof...(Args) - 2>(args_tuple));
+            node->set_right_input(std::get<sizeof...(Args) - 1>(args_tuple));
             return node;
           } else {
             // last argument is shared_ptr<AbstractLQPNode>
             auto node = make_impl(args_tuple, std::make_index_sequence<sizeof...(Args)-1>());
-            node->set_left_child(std::get<sizeof...(Args)-1>(args_tuple));
+            node->set_left_input(std::get<sizeof...(Args)-1>(args_tuple));
             return node;
           }
         } else {
           // last argument is shared_ptr<AbstractLQPNode>
           auto node = make_impl(args_tuple, std::make_index_sequence<sizeof...(Args)-1>());
-          node->set_left_child(std::get<sizeof...(Args)-1>(args_tuple));
+          node->set_left_input(std::get<sizeof...(Args)-1>(args_tuple));
           return node;
         }
       } else {

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -91,7 +91,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
    * The _outputs are implicitly set in set_left_input/set_right_input.
    * For removing outputs use remove_output() or clear_outputs().
    *
-   * set_child() is a shorthand for set_left_input() or set_right_input(), useful if the side is a runtime value
+   * set_input() is a shorthand for set_left_input() or set_right_input(), useful if the side is a runtime value
    */
 
   /**
@@ -213,10 +213,10 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   ColumnID get_output_column_id(const LQPColumnReference& column_reference) const;
 
   /**
-   * Makes this nodes outputs point to this node's left child
-   * Unties this node's child from this node
+   * Makes this nodes outputs point to this node's left input
+   * Unties this node's input from this node
    *
-   * @pre this has no right child
+   * @pre this has no right input
    */
   void remove_from_tree();
 
@@ -309,7 +309,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   /**
    * Override and create a DEEP copy of this LQP node. Used for reusing LQPs, e.g., in views.
-   * @param left_input and @param right_input are deep copies of the left and right child respectively, used for deep-copying
+   * @param left_input and @param right_input are deep copies of the left and right input respectively, used for deep-copying
    * ColumnReferences
    */
   virtual std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
@@ -377,7 +377,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
   // @{
   /**
-   * Add or remove a output without manipulating this outputs child ptr. For internal usage in set_left_input(),
+   * Add or remove a output without manipulating this outputs input ptr. For internal usage in set_left_input(),
    * set_right_input(), remove_output
    */
   void _remove_output_pointer(const std::shared_ptr<AbstractLQPNode>& output);
@@ -387,7 +387,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
 
 /**
  * LQP node types should derive from this in order to enable the <NodeType>::make() function that allows for a clean
- * notation when building LQPs via code by allowing to pass in a nodes child(ren) as the last argument(s).
+ * notation when building LQPs via code by allowing to pass in a nodes input(ren) as the last argument(s).
  *
  * const auto input_lqp =
  * PredicateNode::make(_mock_node_a, PredicateCondition::Equals, 42,

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -109,14 +109,14 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
    */
   size_t output_count() const;
 
-  void remove_output(const std::shared_ptr<AbstractLQPNode> &output);
+  void remove_output(const std::shared_ptr<AbstractLQPNode>& output);
   void clear_outputs();
 
   /**
    * @pre this has has @param output as an output
    * @return whether this is the left or right input in the specified output.
    */
-  LQPInputSide get_input_side(const std::shared_ptr<AbstractLQPNode> &output) const;
+  LQPInputSide get_input_side(const std::shared_ptr<AbstractLQPNode>& output) const;
 
   /**
    * @returns {get_output_side(outputs()[0], ..., get_output_side(outputs()[n-1])}
@@ -124,14 +124,14 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   std::vector<LQPInputSide> get_input_sides() const;
 
   std::shared_ptr<AbstractLQPNode> left_input() const;
-  void set_left_input(const std::shared_ptr<AbstractLQPNode> &left);
+  void set_left_input(const std::shared_ptr<AbstractLQPNode>& left);
 
   std::shared_ptr<AbstractLQPNode> right_input() const;
   void set_right_input(const std::shared_ptr<AbstractLQPNode>& right);
 
   std::shared_ptr<AbstractLQPNode> input(LQPInputSide side) const;
 
-  void set_input(LQPInputSide side, const std::shared_ptr<AbstractLQPNode> &input);
+  void set_input(LQPInputSide side, const std::shared_ptr<AbstractLQPNode>& input);
   // @}
 
   LQPNodeType type() const;
@@ -320,7 +320,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
    * In derived nodes, clear all data that depends on inputs and only set it lazily on request (see, e.g.
    * output_column_names())
    */
-  virtual void _on_child_changed() {}
+  virtual void _on_input_changed() {}
 
   // Used to easily differentiate between node types without pointer casts.
   LQPNodeType _type;
@@ -367,9 +367,9 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   std::shared_ptr<TableStatistics> _statistics;
 
   /**
-   * Reset statistics, call _on_child_changed() for node specific behaviour and call _child_changed() on outputs
+   * Reset statistics, call _on_input_changed() for node specific behaviour and call _input_changed() on outputs
    */
-  void _child_changed();
+  void _input_changed();
 
   static std::optional<std::pair<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>>>
   _find_first_subplan_mismatch_impl(const std::shared_ptr<const AbstractLQPNode>& lhs,

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -100,7 +100,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
   std::vector<std::shared_ptr<AbstractLQPNode>> outputs() const;
 
   /**
-   * @return {{outputs()[0], get_child_sides()[0]}, ..., {outputs()[n-1], get_child_sides()[n-1]}}
+   * @return {{outputs()[0], get_input_sides()[0]}, ..., {outputs()[n-1], get_input_sides()[n-1]}}
    */
   std::vector<LQPOutputRelation> output_relations() const;
 

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -119,7 +119,7 @@ std::string AggregateNode::get_verbose_column_name(ColumnID column_id) const {
   }
 }
 
-void AggregateNode::_on_child_changed() {
+void AggregateNode::_on_input_changed() {
   DebugAssert(!right_input(), "AggregateNode can't have a right input.");
 
   _output_column_names.reset();

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -126,7 +126,7 @@ void AggregateNode::_on_input_changed() {
 }
 
 const std::vector<std::string>& AggregateNode::output_column_names() const {
-  Assert(left_input(), "Child not set, can't know output column names without it");
+  Assert(left_input(), "Input not set, can't know output column names without it");
   if (!_output_column_names) {
     _update_output();
   }
@@ -186,7 +186,7 @@ bool AggregateNode::shallow_equals(const AbstractLQPNode& rhs) const {
   Assert(rhs.type() == type(), "Can only compare nodes of the same type()");
   const auto& aggregate_node = static_cast<const AggregateNode&>(rhs);
 
-  Assert(left_input() && rhs.left_input(), "Can't compare column references without children");
+  Assert(left_input() && rhs.left_input(), "Can't compare column references without inputs");
   return _equals(*left_input(), _aggregate_expressions, *rhs.left_input(), aggregate_node.aggregate_expressions()) &&
          _equals(*left_input(), _groupby_column_references, *rhs.left_input(),
                  aggregate_node.groupby_column_references());
@@ -194,8 +194,8 @@ bool AggregateNode::shallow_equals(const AbstractLQPNode& rhs) const {
 
 void AggregateNode::_update_output() const {
   /**
-   * The output (column names and output-to-input mapping) of this node gets cleared whenever a child changed and is
-   * re-computed on request. This allows LQPs to be in temporary invalid states (e.g. no left child in Join) and thus
+   * The output (column names and output-to-input mapping) of this node gets cleared whenever an input changed and is
+   * re-computed on request. This allows LQPs to be in temporary invalid states (e.g. no left input in Join) and thus
    * allows easier manipulation in the optimizer.
    */
 

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -24,22 +24,22 @@ AggregateNode::AggregateNode(const std::vector<std::shared_ptr<LQPExpression>>& 
 }
 
 std::shared_ptr<AbstractLQPNode> AggregateNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
-  Assert(left_child(), "Can't clone without child, need it to adapt column references");
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
+  Assert(left_input(), "Can't clone without input, need it to adapt column references");
 
   std::vector<std::shared_ptr<LQPExpression>> aggregate_expressions;
   aggregate_expressions.reserve(_aggregate_expressions.size());
   for (const auto& expression : _aggregate_expressions) {
     aggregate_expressions.emplace_back(
-        adapt_expression_to_different_lqp(expression->deep_copy(), left_child(), copied_left_child));
+        adapt_expression_to_different_lqp(expression->deep_copy(), left_input(), copied_left_input));
   }
 
   std::vector<LQPColumnReference> groupby_column_references;
   groupby_column_references.reserve(_groupby_column_references.size());
   for (const auto& groupby_column_reference : _groupby_column_references) {
     groupby_column_references.emplace_back(
-        adapt_column_reference_to_different_lqp(groupby_column_reference, left_child(), copied_left_child));
+        adapt_column_reference_to_different_lqp(groupby_column_reference, left_input(), copied_left_input));
   }
 
   return AggregateNode::make(aggregate_expressions, groupby_column_references);
@@ -59,8 +59,8 @@ std::string AggregateNode::description() const {
   s << "[Aggregate] ";
 
   std::vector<std::string> verbose_column_names;
-  if (left_child()) {
-    verbose_column_names = left_child()->get_verbose_column_names();
+  if (left_input()) {
+    verbose_column_names = left_input()->get_verbose_column_names();
   }
 
   auto stream_aggregate = [&](const std::shared_ptr<LQPExpression>& aggregate_expr) {
@@ -97,7 +97,7 @@ std::string AggregateNode::description() const {
 }
 
 std::string AggregateNode::get_verbose_column_name(ColumnID column_id) const {
-  DebugAssert(left_child(), "Need input to generate name");
+  DebugAssert(left_input(), "Need input to generate name");
 
   if (column_id < _groupby_column_references.size()) {
     return _groupby_column_references[column_id].description();
@@ -112,21 +112,21 @@ std::string AggregateNode::get_verbose_column_name(ColumnID column_id) const {
     return *aggregate_expression->alias();
   }
 
-  if (left_child()) {
-    return aggregate_expression->to_string(left_child()->get_verbose_column_names());
+  if (left_input()) {
+    return aggregate_expression->to_string(left_input()->get_verbose_column_names());
   } else {
     return aggregate_expression->to_string();
   }
 }
 
 void AggregateNode::_on_child_changed() {
-  DebugAssert(!right_child(), "AggregateNode can't have a right child.");
+  DebugAssert(!right_input(), "AggregateNode can't have a right input.");
 
   _output_column_names.reset();
 }
 
 const std::vector<std::string>& AggregateNode::output_column_names() const {
-  Assert(left_child(), "Child not set, can't know output column names without it");
+  Assert(left_input(), "Child not set, can't know output column names without it");
   if (!_output_column_names) {
     _update_output();
   }
@@ -186,9 +186,9 @@ bool AggregateNode::shallow_equals(const AbstractLQPNode& rhs) const {
   Assert(rhs.type() == type(), "Can only compare nodes of the same type()");
   const auto& aggregate_node = static_cast<const AggregateNode&>(rhs);
 
-  Assert(left_child() && rhs.left_child(), "Can't compare column references without children");
-  return _equals(*left_child(), _aggregate_expressions, *rhs.left_child(), aggregate_node.aggregate_expressions()) &&
-         _equals(*left_child(), _groupby_column_references, *rhs.left_child(),
+  Assert(left_input() && rhs.left_input(), "Can't compare column references without children");
+  return _equals(*left_input(), _aggregate_expressions, *rhs.left_input(), aggregate_node.aggregate_expressions()) &&
+         _equals(*left_input(), _groupby_column_references, *rhs.left_input(),
                  aggregate_node.groupby_column_references());
 }
 
@@ -201,7 +201,7 @@ void AggregateNode::_update_output() const {
 
   DebugAssert(!_output_column_references, "No need to update, _update_output() shouldn't get called.");
   DebugAssert(!_output_column_names, "No need to update, _update_output() shouldn't get called.");
-  DebugAssert(left_child(), "Can't set output without input");
+  DebugAssert(left_input(), "Can't set output without input");
 
   _output_column_names.emplace();
   _output_column_names->reserve(_groupby_column_references.size() + _aggregate_expressions.size());
@@ -218,8 +218,8 @@ void AggregateNode::_update_output() const {
   for (const auto& groupby_column_reference : _groupby_column_references) {
     _output_column_references->emplace_back(groupby_column_reference);
 
-    const auto input_column_id = left_child()->get_output_column_id(groupby_column_reference);
-    _output_column_names->emplace_back(left_child()->output_column_names()[input_column_id]);
+    const auto input_column_id = left_input()->get_output_column_id(groupby_column_reference);
+    _output_column_names->emplace_back(left_input()->output_column_names()[input_column_id]);
   }
 
   auto column_id = static_cast<ColumnID>(_groupby_column_references.size());
@@ -237,7 +237,7 @@ void AggregateNode::_update_output() const {
        * This might result in multiple output columns with the same name, but we accept that.
        * Other DBs behave similarly (e.g. MySQL).
        */
-      column_name = aggregate_expression->to_string(left_child()->output_column_names());
+      column_name = aggregate_expression->to_string(left_input()->output_column_names());
     }
 
     _output_column_names->emplace_back(column_name);

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -62,7 +62,7 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
       const std::shared_ptr<AbstractLQPNode>& copied_left_input,
       const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
-  void _on_child_changed() override;
+  void _on_input_changed() override;
 
  private:
   std::vector<std::shared_ptr<LQPExpression>> _aggregate_expressions;

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -60,8 +60,8 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -13,8 +13,8 @@ std::string CreateViewNode::view_name() const { return _view_name; }
 std::shared_ptr<const AbstractLQPNode> CreateViewNode::lqp() const { return _lqp; }
 
 std::shared_ptr<AbstractLQPNode> CreateViewNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   // no need to deep_copy the _lqp because it is const anyway
   return std::make_shared<CreateViewNode>(_view_name, _lqp);
 }

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -23,8 +23,8 @@ class CreateViewNode : public AbstractLQPNode {
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   const std::string _view_name;
   const std::shared_ptr<const AbstractLQPNode> _lqp;
 };

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -12,8 +12,8 @@ namespace opossum {
 DeleteNode::DeleteNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Delete), _table_name(table_name) {}
 
 std::shared_ptr<AbstractLQPNode> DeleteNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return DeleteNode::make(_table_name);
 }
 
@@ -25,7 +25,7 @@ std::string DeleteNode::description() const {
   return desc.str();
 }
 
-bool DeleteNode::subtree_is_read_only() const { return false; }
+bool DeleteNode::subplan_is_read_only() const { return false; }
 
 const std::string& DeleteNode::table_name() const { return _table_name; }
 

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -15,7 +15,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
   explicit DeleteNode(const std::string& table_name);
 
   std::string description() const override;
-  bool subtree_is_read_only() const override;
+  bool subplan_is_read_only() const override;
 
   bool shallow_equals(const AbstractLQPNode& rhs) const override;
 
@@ -23,8 +23,8 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   const std::string _table_name;
 };
 

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -13,8 +13,8 @@ DropViewNode::DropViewNode(const std::string& view_name)
     : AbstractLQPNode(LQPNodeType::DropView), _view_name(view_name) {}
 
 std::shared_ptr<AbstractLQPNode> DropViewNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return DropViewNode::make(_view_name);
 }
 
@@ -26,7 +26,7 @@ std::string DropViewNode::description() const {
   return desc.str();
 }
 
-bool DropViewNode::subtree_is_read_only() const { return false; }
+bool DropViewNode::subplan_is_read_only() const { return false; }
 
 const std::vector<std::string>& DropViewNode::output_column_names() const {
   static std::vector<std::string> output_column_names_dummy;

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -15,7 +15,7 @@ class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public AbstractL
   explicit DropViewNode(const std::string& view_name);
 
   std::string description() const override;
-  bool subtree_is_read_only() const override;
+  bool subplan_is_read_only() const override;
   const std::vector<std::string>& output_column_names() const override;
 
   bool shallow_equals(const AbstractLQPNode& rhs) const override;
@@ -24,8 +24,8 @@ class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public AbstractL
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   const std::string _view_name;

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -12,8 +12,8 @@ namespace opossum {
 DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) { _output_column_references.emplace(); }
 
 std::shared_ptr<AbstractLQPNode> DummyTableNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return DummyTableNode::make();
 }
 

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -24,8 +24,8 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   std::vector<std::string> _output_column_names;
 };
 

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -13,8 +13,8 @@ namespace opossum {
 InsertNode::InsertNode(const std::string table_name) : AbstractLQPNode(LQPNodeType::Insert), _table_name(table_name) {}
 
 std::shared_ptr<AbstractLQPNode> InsertNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return InsertNode::make(_table_name);
 }
 
@@ -26,7 +26,7 @@ std::string InsertNode::description() const {
   return desc.str();
 }
 
-bool InsertNode::subtree_is_read_only() const { return false; }
+bool InsertNode::subplan_is_read_only() const { return false; }
 
 const std::string& InsertNode::table_name() const { return _table_name; }
 

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -16,7 +16,7 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
   explicit InsertNode(const std::string table_name);
 
   std::string description() const override;
-  bool subtree_is_read_only() const override;
+  bool subplan_is_read_only() const override;
 
   bool shallow_equals(const AbstractLQPNode& rhs) const override;
 
@@ -24,8 +24,8 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   const std::string _table_name;
 };
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<AbstractLQPNode> JoinNode::_deep_copy_impl(
 }
 
 std::string JoinNode::description() const {
-  Assert(left_input() && right_input(), "Can't generate description if children aren't set");
+  Assert(left_input() && right_input(), "Can't generate description if inputren aren't set");
 
   std::ostringstream desc;
 
@@ -106,7 +106,7 @@ const std::optional<PredicateCondition>& JoinNode::predicate_condition() const {
 JoinMode JoinNode::join_mode() const { return _join_mode; }
 
 std::string JoinNode::get_verbose_column_name(ColumnID column_id) const {
-  Assert(left_input() && right_input(), "Can't generate column names without children being set");
+  Assert(left_input() && right_input(), "Can't generate column names without inputren being set");
 
   if (column_id < left_input()->output_column_count()) {
     return left_input()->get_verbose_column_name(column_id);
@@ -131,15 +131,15 @@ void JoinNode::_on_input_changed() { _output_column_names.reset(); }
 
 void JoinNode::_update_output() const {
   /**
-   * The output (column names and output-to-input mapping) of this node gets cleared whenever a child changed and is
-   * re-computed on request. This allows LQPs to be in temporary invalid states (e.g. no left child in Join) and thus
+   * The output (column names and output-to-input mapping) of this node gets cleared whenever a input changed and is
+   * re-computed on request. This allows LQPs to be in temporary invalid states (e.g. no left input in Join) and thus
    * allows easier manipulation in the optimizer.
    */
 
   DebugAssert(left_input() && right_input(), "Need both inputs to compute output");
 
   /**
-   * Collect the output column names of the children on the fly, because the children might change.
+   * Collect the output column names of the inputren on the fly, because the inputren might change.
    */
   const auto& left_names = left_input()->output_column_names();
   const auto& right_names = right_input()->output_column_names();
@@ -154,7 +154,7 @@ void JoinNode::_update_output() const {
   _output_column_names->insert(_output_column_names->end(), left_names.begin(), left_names.end());
 
   /**
-   * Collect the output ColumnIDs of the children on the fly, because the children might change.
+   * Collect the output ColumnIDs of the inputren on the fly, because the inputren might change.
    */
   _output_column_references.emplace();
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -32,23 +32,23 @@ JoinNode::JoinNode(const JoinMode join_mode, const LQPColumnReferencePair& join_
 }
 
 std::shared_ptr<AbstractLQPNode> JoinNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   if (_join_mode == JoinMode::Cross || _join_mode == JoinMode::Natural) {
     return JoinNode::make(_join_mode);
   } else {
-    Assert(left_child(), "Can't clone without child");
+    Assert(left_input(), "Can't clone without input");
 
     const auto join_column_references = LQPColumnReferencePair{
-        adapt_column_reference_to_different_lqp(_join_column_references->first, left_child(), copied_left_child),
-        adapt_column_reference_to_different_lqp(_join_column_references->first, right_child(), copied_right_child),
+        adapt_column_reference_to_different_lqp(_join_column_references->first, left_input(), copied_left_input),
+        adapt_column_reference_to_different_lqp(_join_column_references->first, right_input(), copied_right_input),
     };
     return JoinNode::make(_join_mode, join_column_references, *_predicate_condition);
   }
 }
 
 std::string JoinNode::description() const {
-  Assert(left_child() && right_child(), "Can't generate description if children aren't set");
+  Assert(left_input() && right_input(), "Can't generate description if children aren't set");
 
   std::ostringstream desc;
 
@@ -80,19 +80,19 @@ const std::vector<LQPColumnReference>& JoinNode::output_column_references() cons
 }
 
 std::shared_ptr<TableStatistics> JoinNode::derive_statistics_from(
-    const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
   if (_join_mode == JoinMode::Cross) {
-    return left_child->get_statistics()->generate_cross_join_statistics(right_child->get_statistics());
+    return left_input->get_statistics()->generate_cross_join_statistics(right_input->get_statistics());
   } else {
     Assert(_join_column_references,
            "Only cross joins and joins with join column ids supported for generating join statistics");
     Assert(_predicate_condition,
            "Only cross joins and joins with predicate condition supported for generating join statistics");
 
-    ColumnIDPair join_colum_ids{left_child->get_output_column_id(_join_column_references->first),
-                                right_child->get_output_column_id(_join_column_references->second)};
+    ColumnIDPair join_colum_ids{left_input->get_output_column_id(_join_column_references->first),
+                                right_input->get_output_column_id(_join_column_references->second)};
 
-    return left_child->get_statistics()->generate_predicated_join_statistics(right_child->get_statistics(), _join_mode,
+    return left_input->get_statistics()->generate_predicated_join_statistics(right_input->get_statistics(), _join_mode,
                                                                              join_colum_ids, *_predicate_condition);
   }
 }
@@ -106,12 +106,12 @@ const std::optional<PredicateCondition>& JoinNode::predicate_condition() const {
 JoinMode JoinNode::join_mode() const { return _join_mode; }
 
 std::string JoinNode::get_verbose_column_name(ColumnID column_id) const {
-  Assert(left_child() && right_child(), "Can't generate column names without children being set");
+  Assert(left_input() && right_input(), "Can't generate column names without children being set");
 
-  if (column_id < left_child()->output_column_count()) {
-    return left_child()->get_verbose_column_name(column_id);
+  if (column_id < left_input()->output_column_count()) {
+    return left_input()->get_verbose_column_name(column_id);
   }
-  return right_child()->get_verbose_column_name(static_cast<ColumnID>(column_id - left_child()->output_column_count()));
+  return right_input()->get_verbose_column_name(static_cast<ColumnID>(column_id - left_input()->output_column_count()));
 }
 
 bool JoinNode::shallow_equals(const AbstractLQPNode& rhs) const {
@@ -136,13 +136,13 @@ void JoinNode::_update_output() const {
    * allows easier manipulation in the optimizer.
    */
 
-  DebugAssert(left_child() && right_child(), "Need both inputs to compute output");
+  DebugAssert(left_input() && right_input(), "Need both inputs to compute output");
 
   /**
    * Collect the output column names of the children on the fly, because the children might change.
    */
-  const auto& left_names = left_child()->output_column_names();
-  const auto& right_names = right_child()->output_column_names();
+  const auto& left_names = left_input()->output_column_names();
+  const auto& right_names = right_input()->output_column_names();
 
   _output_column_names.emplace();
   const auto only_output_left_columns = _join_mode == JoinMode::Semi || _join_mode == JoinMode::Anti;
@@ -158,14 +158,14 @@ void JoinNode::_update_output() const {
    */
   _output_column_references.emplace();
 
-  _output_column_references->insert(_output_column_references->end(), left_child()->output_column_references().begin(),
-                                    left_child()->output_column_references().end());
+  _output_column_references->insert(_output_column_references->end(), left_input()->output_column_references().begin(),
+                                    left_input()->output_column_references().end());
 
   if (!only_output_left_columns) {
     _output_column_names->insert(_output_column_names->end(), right_names.begin(), right_names.end());
     _output_column_references->insert(_output_column_references->end(),
-                                      right_child()->output_column_references().begin(),
-                                      right_child()->output_column_references().end());
+                                      right_input()->output_column_references().begin(),
+                                      right_input()->output_column_references().end());
   }
 }
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -127,7 +127,7 @@ bool JoinNode::shallow_equals(const AbstractLQPNode& rhs) const {
          _equals(*this, _join_column_references->second, join_node, join_node._join_column_references->second);
 }
 
-void JoinNode::_on_child_changed() { _output_column_names.reset(); }
+void JoinNode::_on_input_changed() { _output_column_names.reset(); }
 
 void JoinNode::_update_output() const {
   /**

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -37,8 +37,8 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   const std::vector<LQPColumnReference>& output_column_references() const override;
 
   std::shared_ptr<TableStatistics> derive_statistics_from(
-      const std::shared_ptr<AbstractLQPNode>& left_child,
-      const std::shared_ptr<AbstractLQPNode>& right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& left_input,
+      const std::shared_ptr<AbstractLQPNode>& right_input) const override;
 
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
@@ -47,8 +47,8 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
  protected:
   void _on_child_changed() override;
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   JoinMode _join_mode;

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -45,7 +45,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   bool shallow_equals(const AbstractLQPNode& rhs) const override;
 
  protected:
-  void _on_child_changed() override;
+  void _on_input_changed() override;
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
       const std::shared_ptr<AbstractLQPNode>& copied_left_input,
       const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;

--- a/src/lib/logical_query_plan/limit_node.cpp
+++ b/src/lib/logical_query_plan/limit_node.cpp
@@ -9,8 +9,8 @@ namespace opossum {
 LimitNode::LimitNode(const size_t num_rows) : AbstractLQPNode(LQPNodeType::Limit), _num_rows(num_rows) {}
 
 std::shared_ptr<AbstractLQPNode> LimitNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return LimitNode::make(_num_rows);
 }
 

--- a/src/lib/logical_query_plan/limit_node.hpp
+++ b/src/lib/logical_query_plan/limit_node.hpp
@@ -21,8 +21,8 @@ class LimitNode : public EnableMakeForLQPNode<LimitNode>, public AbstractLQPNode
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   const size_t _num_rows;

--- a/src/lib/logical_query_plan/logical_plan_root_node.cpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.cpp
@@ -9,8 +9,8 @@ namespace opossum {
 LogicalPlanRootNode::LogicalPlanRootNode() : AbstractLQPNode(LQPNodeType::Root) {}
 
 std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return LogicalPlanRootNode::make();
 }
 

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -24,8 +24,8 @@ class LogicalPlanRootNode : public EnableMakeForLQPNode<LogicalPlanRootNode>, pu
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -31,8 +31,8 @@ MockNode::MockNode(const std::shared_ptr<TableStatistics>& statistics, const std
 }
 
 std::shared_ptr<AbstractLQPNode> MockNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   if (_constructor_arguments.type() == typeid(std::shared_ptr<TableStatistics>)) {
     return MockNode::make(boost::get<std::shared_ptr<TableStatistics>>(_constructor_arguments), _table_alias);
   }

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -37,8 +37,8 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   std::vector<std::string> _output_column_names;

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -39,15 +39,15 @@ class PredicateNode : public EnableMakeForLQPNode<PredicateNode>, public Abstrac
   void set_scan_type(ScanType scan_type);
 
   std::shared_ptr<TableStatistics> derive_statistics_from(
-      const std::shared_ptr<AbstractLQPNode>& left_child,
-      const std::shared_ptr<AbstractLQPNode>& right_child = nullptr) const override;
+      const std::shared_ptr<AbstractLQPNode>& left_input,
+      const std::shared_ptr<AbstractLQPNode>& right_input = nullptr) const override;
 
   bool shallow_equals(const AbstractLQPNode& rhs) const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   const LQPColumnReference _column_reference;

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<ProjectionNode> ProjectionNode::make_pass_through(const std::sha
   std::vector<std::shared_ptr<LQPExpression>> expressions =
       LQPExpression::create_columns(child->output_column_references());
   const auto projection_node = ProjectionNode::make(expressions);
-  projection_node->set_left_child(child);
+  projection_node->set_left_input(child);
   return projection_node;
 }
 
@@ -30,8 +30,8 @@ std::string ProjectionNode::description() const {
   desc << "[Projection] ";
 
   std::vector<std::string> verbose_column_names;
-  if (left_child()) {
-    verbose_column_names = left_child()->get_verbose_column_names();
+  if (left_input()) {
+    verbose_column_names = left_input()->get_verbose_column_names();
   }
 
   for (size_t column_idx = 0; column_idx < _column_expressions.size(); ++column_idx) {
@@ -45,15 +45,15 @@ std::string ProjectionNode::description() const {
 }
 
 std::shared_ptr<AbstractLQPNode> ProjectionNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
-  Assert(left_child() && copied_left_child, "Can't deep copy without child to adjust ColumnReferences");
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
+  Assert(left_input() && copied_left_input, "Can't deep copy without input to adjust ColumnReferences");
 
   std::vector<std::shared_ptr<LQPExpression>> column_expressions;
   column_expressions.reserve(_column_expressions.size());
   for (const auto& expression : _column_expressions) {
     column_expressions.emplace_back(
-        adapt_expression_to_different_lqp(expression->deep_copy(), left_child(), copied_left_child));
+        adapt_expression_to_different_lqp(expression->deep_copy(), left_input(), copied_left_input));
   }
 
   return ProjectionNode::make(column_expressions);
@@ -64,7 +64,7 @@ const std::vector<std::shared_ptr<LQPExpression>>& ProjectionNode::column_expres
 }
 
 void ProjectionNode::_on_child_changed() {
-  DebugAssert(!right_child(), "Projection can't have a right child");
+  DebugAssert(!right_input(), "Projection can't have a right input");
 
   _output_column_names.reset();
 }
@@ -85,7 +85,7 @@ const std::vector<std::string>& ProjectionNode::output_column_names() const {
 }
 
 std::string ProjectionNode::get_verbose_column_name(ColumnID column_id) const {
-  DebugAssert(left_child(), "Need input to generate name");
+  DebugAssert(left_input(), "Need input to generate name");
   DebugAssert(column_id < _column_expressions.size(), "ColumnID out of range");
 
   const auto& column_expression = _column_expressions[column_id];
@@ -94,8 +94,8 @@ std::string ProjectionNode::get_verbose_column_name(ColumnID column_id) const {
     return *column_expression->alias();
   }
 
-  if (left_child()) {
-    return column_expression->to_string(left_child()->output_column_names());
+  if (left_input()) {
+    return column_expression->to_string(left_input()->output_column_names());
   } else {
     return column_expression->to_string();
   }
@@ -105,8 +105,8 @@ bool ProjectionNode::shallow_equals(const AbstractLQPNode& rhs) const {
   Assert(rhs.type() == type(), "Can only compare nodes of the same type()");
   const auto& projection_node = dynamic_cast<const ProjectionNode&>(rhs);
 
-  Assert(left_child() && rhs.left_child(), "Can't compare column references without children");
-  return _equals(*left_child(), _column_expressions, *projection_node.left_child(),
+  Assert(left_input() && rhs.left_input(), "Can't compare column references without children");
+  return _equals(*left_input(), _column_expressions, *projection_node.left_input(),
                  projection_node._column_expressions);
 }
 
@@ -119,7 +119,7 @@ void ProjectionNode::_update_output() const {
 
   DebugAssert(!_output_column_names, "No need to update, _update_output() shouldn't get called.");
   DebugAssert(!_output_column_names, "No need to update, _update_output() shouldn't get called.");
-  DebugAssert(left_child(), "Can't set output without input");
+  DebugAssert(left_input(), "Can't set output without input");
 
   _output_column_names.emplace();
   _output_column_names->reserve(_column_expressions.size());
@@ -136,13 +136,13 @@ void ProjectionNode::_update_output() const {
     }
 
     if (expression->type() == ExpressionType::Column) {
-      DebugAssert(left_child(), "ProjectionNode needs a child.");
+      DebugAssert(left_input(), "ProjectionNode needs a input.");
 
       _output_column_references->emplace_back(expression->column_reference());
 
       if (!expression->alias()) {
-        const auto input_column_id = left_child()->get_output_column_id(expression->column_reference());
-        const auto& column_name = left_child()->output_column_names()[input_column_id];
+        const auto input_column_id = left_input()->get_output_column_id(expression->column_reference());
+        const auto& column_name = left_input()->output_column_names()[input_column_id];
         _output_column_names->emplace_back(column_name);
       }
 
@@ -151,7 +151,7 @@ void ProjectionNode::_update_output() const {
       _output_column_references->emplace_back(shared_from_this(), column_id);
 
       if (!expression->alias()) {
-        _output_column_names->emplace_back(expression->to_string(left_child()->output_column_names()));
+        _output_column_names->emplace_back(expression->to_string(left_input()->output_column_names()));
       }
 
     } else {

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -63,7 +63,7 @@ const std::vector<std::shared_ptr<LQPExpression>>& ProjectionNode::column_expres
   return _column_expressions;
 }
 
-void ProjectionNode::_on_child_changed() {
+void ProjectionNode::_on_input_changed() {
   DebugAssert(!right_input(), "Projection can't have a right input");
 
   _output_column_names.reset();

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -13,11 +13,11 @@
 
 namespace opossum {
 
-std::shared_ptr<ProjectionNode> ProjectionNode::make_pass_through(const std::shared_ptr<AbstractLQPNode>& child) {
+std::shared_ptr<ProjectionNode> ProjectionNode::make_pass_through(const std::shared_ptr<AbstractLQPNode>& input) {
   std::vector<std::shared_ptr<LQPExpression>> expressions =
-      LQPExpression::create_columns(child->output_column_references());
+      LQPExpression::create_columns(input->output_column_references());
   const auto projection_node = ProjectionNode::make(expressions);
-  projection_node->set_left_input(child);
+  projection_node->set_left_input(input);
   return projection_node;
 }
 
@@ -105,15 +105,15 @@ bool ProjectionNode::shallow_equals(const AbstractLQPNode& rhs) const {
   Assert(rhs.type() == type(), "Can only compare nodes of the same type()");
   const auto& projection_node = dynamic_cast<const ProjectionNode&>(rhs);
 
-  Assert(left_input() && rhs.left_input(), "Can't compare column references without children");
+  Assert(left_input() && rhs.left_input(), "Can't compare column references without inputs");
   return _equals(*left_input(), _column_expressions, *projection_node.left_input(),
                  projection_node._column_expressions);
 }
 
 void ProjectionNode::_update_output() const {
   /**
-   * The output (column names and output-to-input mapping) of this node gets cleared whenever a child changed and is
-   * re-computed on request. This allows LQPs to be in temporary invalid states (e.g. no left child in Join) and thus
+   * The output (column names and output-to-input mapping) of this node gets cleared whenever an input changed and is
+   * re-computed on request. This allows LQPs to be in temporary invalid states (e.g. no left input in Join) and thus
    * allows easier manipulation in the optimizer.
    */
 

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -37,7 +37,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
       const std::shared_ptr<AbstractLQPNode>& copied_left_input,
       const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
-  void _on_child_changed() override;
+  void _on_input_changed() override;
 
  private:
   std::vector<std::shared_ptr<LQPExpression>> _column_expressions;

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -35,8 +35,8 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   void _on_child_changed() override;
 
  private:

--- a/src/lib/logical_query_plan/show_columns_node.cpp
+++ b/src/lib/logical_query_plan/show_columns_node.cpp
@@ -8,8 +8,8 @@ ShowColumnsNode::ShowColumnsNode(const std::string& table_name)
     : AbstractLQPNode(LQPNodeType::ShowColumns), _table_name(table_name) {}
 
 std::shared_ptr<AbstractLQPNode> ShowColumnsNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return ShowColumnsNode::make(_table_name);
 }
 

--- a/src/lib/logical_query_plan/show_columns_node.hpp
+++ b/src/lib/logical_query_plan/show_columns_node.hpp
@@ -22,8 +22,8 @@ class ShowColumnsNode : public EnableMakeForLQPNode<ShowColumnsNode>, public Abs
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   const std::string _table_name;

--- a/src/lib/logical_query_plan/show_tables_node.cpp
+++ b/src/lib/logical_query_plan/show_tables_node.cpp
@@ -7,8 +7,8 @@ namespace opossum {
 ShowTablesNode::ShowTablesNode() : AbstractLQPNode(LQPNodeType::ShowTables) {}
 
 std::shared_ptr<AbstractLQPNode> ShowTablesNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return ShowTablesNode::make();
 }
 

--- a/src/lib/logical_query_plan/show_tables_node.hpp
+++ b/src/lib/logical_query_plan/show_tables_node.hpp
@@ -21,8 +21,8 @@ class ShowTablesNode : public EnableMakeForLQPNode<ShowTablesNode>, public Abstr
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -16,14 +16,14 @@ SortNode::SortNode(const OrderByDefinitions& order_by_definitions)
     : AbstractLQPNode(LQPNodeType::Sort), _order_by_definitions(order_by_definitions) {}
 
 std::shared_ptr<AbstractLQPNode> SortNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   OrderByDefinitions order_by_definitions;
   order_by_definitions.reserve(_order_by_definitions.size());
 
   for (const auto& order_by_definition : _order_by_definitions) {
     const auto column_reference =
-        adapt_column_reference_to_different_lqp(order_by_definition.column_reference, left_child(), copied_left_child);
+        adapt_column_reference_to_different_lqp(order_by_definition.column_reference, left_input(), copied_left_input);
     order_by_definitions.emplace_back(column_reference, order_by_definition.order_by_mode);
   }
 

--- a/src/lib/logical_query_plan/sort_node.hpp
+++ b/src/lib/logical_query_plan/sort_node.hpp
@@ -37,8 +37,8 @@ class SortNode : public EnableMakeForLQPNode<SortNode>, public AbstractLQPNode {
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   const OrderByDefinitions _order_by_definitions;

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -63,7 +63,7 @@ bool StoredTableNode::shallow_equals(const AbstractLQPNode& rhs) const {
   return _table_name == stored_table_node._table_name;
 }
 
-void StoredTableNode::_on_input_changed() { Fail("StoredTableNode cannot have children."); }
+void StoredTableNode::_on_input_changed() { Fail("StoredTableNode cannot have inputs."); }
 
 std::optional<QualifiedColumnName> StoredTableNode::_resolve_local_table_name(
     const QualifiedColumnName& qualified_column_name) const {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -63,7 +63,7 @@ bool StoredTableNode::shallow_equals(const AbstractLQPNode& rhs) const {
   return _table_name == stored_table_node._table_name;
 }
 
-void StoredTableNode::_on_child_changed() { Fail("StoredTableNode cannot have children."); }
+void StoredTableNode::_on_input_changed() { Fail("StoredTableNode cannot have children."); }
 
 std::optional<QualifiedColumnName> StoredTableNode::_resolve_local_table_name(
     const QualifiedColumnName& qualified_column_name) const {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -24,8 +24,8 @@ StoredTableNode::StoredTableNode(const std::string& table_name, const std::optio
 }
 
 std::shared_ptr<AbstractLQPNode> StoredTableNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return StoredTableNode::make(_table_name);
 }
 
@@ -42,8 +42,8 @@ std::shared_ptr<const AbstractLQPNode> StoredTableNode::find_table_name_origin(c
 const std::vector<std::string>& StoredTableNode::output_column_names() const { return _output_column_names; }
 
 std::shared_ptr<TableStatistics> StoredTableNode::derive_statistics_from(
-    const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {
-  DebugAssert(!left_child && !right_child, "StoredTableNode must be leaf");
+    const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
+  DebugAssert(!left_input && !right_input, "StoredTableNode must be leaf");
   return StorageManager::get().get_table(_table_name)->table_statistics();
 }
 

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -38,7 +38,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
       const std::shared_ptr<AbstractLQPNode>& copied_left_input,
       const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
-  void _on_child_changed() override;
+  void _on_input_changed() override;
   std::optional<QualifiedColumnName> _resolve_local_table_name(
       const QualifiedColumnName& qualified_column_name) const override;
 

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -27,8 +27,8 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   const std::vector<std::string>& output_column_names() const override;
 
   std::shared_ptr<TableStatistics> derive_statistics_from(
-      const std::shared_ptr<AbstractLQPNode>& left_child = nullptr,
-      const std::shared_ptr<AbstractLQPNode>& right_child = nullptr) const override;
+      const std::shared_ptr<AbstractLQPNode>& left_input = nullptr,
+      const std::shared_ptr<AbstractLQPNode>& right_input = nullptr) const override;
 
   std::string get_verbose_column_name(ColumnID column_id) const override;
 
@@ -36,8 +36,8 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   void _on_child_changed() override;
   std::optional<QualifiedColumnName> _resolve_local_table_name(
       const QualifiedColumnName& qualified_column_name) const override;

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -13,8 +13,8 @@ namespace opossum {
 UnionNode::UnionNode(UnionMode union_mode) : AbstractLQPNode(LQPNodeType::Union), _union_mode(union_mode) {}
 
 std::shared_ptr<AbstractLQPNode> UnionNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return UnionNode::make(_union_mode);
 }
 
@@ -23,14 +23,14 @@ UnionMode UnionNode::union_mode() const { return _union_mode; }
 std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.at(_union_mode); }
 
 std::string UnionNode::get_verbose_column_name(ColumnID column_id) const {
-  Assert(left_child() && right_child(), "Need children to determine Column name");
-  Assert(column_id < left_child()->output_column_names().size(), "ColumnID out of range");
-  Assert(right_child()->output_column_names().size() == left_child()->output_column_names().size(),
+  Assert(left_input() && right_input(), "Need children to determine Column name");
+  Assert(column_id < left_input()->output_column_names().size(), "ColumnID out of range");
+  Assert(right_input()->output_column_names().size() == left_input()->output_column_names().size(),
          "Input node mismatch");
 
-  const auto left_column_name = left_child()->output_column_names()[column_id];
+  const auto left_column_name = left_input()->output_column_names()[column_id];
 
-  const auto right_column_name = right_child()->output_column_names()[column_id];
+  const auto right_column_name = right_input()->output_column_names()[column_id];
   Assert(left_column_name == right_column_name, "Input column names don't match");
 
   if (_table_alias) {
@@ -41,21 +41,21 @@ std::string UnionNode::get_verbose_column_name(ColumnID column_id) const {
 }
 
 const std::vector<std::string>& UnionNode::output_column_names() const {
-  DebugAssert(left_child()->output_column_names() == right_child()->output_column_names(), "Input layouts differ.");
-  return left_child()->output_column_names();
+  DebugAssert(left_input()->output_column_names() == right_input()->output_column_names(), "Input layouts differ.");
+  return left_input()->output_column_names();
 }
 
 const std::vector<LQPColumnReference>& UnionNode::output_column_references() const {
   if (!_output_column_references) {
-    DebugAssert(left_child()->output_column_references() == right_child()->output_column_references(),
+    DebugAssert(left_input()->output_column_references() == right_input()->output_column_references(),
                 "Input layouts differ.");
-    _output_column_references = left_child()->output_column_references();
+    _output_column_references = left_input()->output_column_references();
   }
   return *_output_column_references;
 }
 
 std::shared_ptr<TableStatistics> UnionNode::derive_statistics_from(
-    const std::shared_ptr<AbstractLQPNode>& left_child, const std::shared_ptr<AbstractLQPNode>& right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
   Fail("Statistics for UNION not yet implemented");
 }
 

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -23,7 +23,7 @@ UnionMode UnionNode::union_mode() const { return _union_mode; }
 std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.at(_union_mode); }
 
 std::string UnionNode::get_verbose_column_name(ColumnID column_id) const {
-  Assert(left_input() && right_input(), "Need children to determine Column name");
+  Assert(left_input() && right_input(), "Need inputs to determine Column name");
   Assert(column_id < left_input()->output_column_names().size(), "ColumnID out of range");
   Assert(right_input()->output_column_names().size() == left_input()->output_column_names().size(),
          "Input node mismatch");

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -23,15 +23,15 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
   const std::vector<LQPColumnReference>& output_column_references() const override;
 
   std::shared_ptr<TableStatistics> derive_statistics_from(
-      const std::shared_ptr<AbstractLQPNode>& left_child,
-      const std::shared_ptr<AbstractLQPNode>& right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& left_input,
+      const std::shared_ptr<AbstractLQPNode>& right_input) const override;
 
   bool shallow_equals(const AbstractLQPNode& rhs) const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 
  private:
   UnionMode _union_mode;

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -63,7 +63,7 @@ bool UpdateNode::shallow_equals(const AbstractLQPNode& rhs) const {
   Assert(rhs.type() == type(), "Can only compare nodes of the same type()");
   const auto& update_node = static_cast<const UpdateNode&>(rhs);
 
-  Assert(left_input() && rhs.left_input(), "Can't compare column references without children");
+  Assert(left_input() && rhs.left_input(), "Can't compare column references without inputs");
   return _table_name == update_node._table_name &&
          _equals(*left_input(), _column_expressions, *update_node.left_input(), update_node._column_expressions);
 }

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -15,14 +15,14 @@ UpdateNode::UpdateNode(const std::string& table_name,
     : AbstractLQPNode(LQPNodeType::Update), _table_name(table_name), _column_expressions(column_expressions) {}
 
 std::shared_ptr<AbstractLQPNode> UpdateNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   std::vector<std::shared_ptr<LQPExpression>> column_expressions(_column_expressions.size());
   column_expressions.reserve(_column_expressions.size());
 
   for (const auto& expression : column_expressions) {
     column_expressions.emplace_back(
-        adapt_expression_to_different_lqp(expression->deep_copy(), left_child(), copied_left_child));
+        adapt_expression_to_different_lqp(expression->deep_copy(), left_input(), copied_left_input));
   }
 
   return UpdateNode::make(_table_name, column_expressions);
@@ -36,8 +36,8 @@ std::string UpdateNode::description() const {
   if (!_column_expressions.empty()) {
     desc << ", Columns: ";
     std::vector<std::string> verbose_column_names;
-    if (left_child()) {
-      verbose_column_names = left_child()->get_verbose_column_names();
+    if (left_input()) {
+      verbose_column_names = left_input()->get_verbose_column_names();
     }
 
     for (size_t column_idx = 0; column_idx < _column_expressions.size(); ++column_idx) {
@@ -51,7 +51,7 @@ std::string UpdateNode::description() const {
   return desc.str();
 }
 
-bool UpdateNode::subtree_is_read_only() const { return false; }
+bool UpdateNode::subplan_is_read_only() const { return false; }
 
 const std::vector<std::shared_ptr<LQPExpression>>& UpdateNode::column_expressions() const {
   return _column_expressions;
@@ -63,8 +63,8 @@ bool UpdateNode::shallow_equals(const AbstractLQPNode& rhs) const {
   Assert(rhs.type() == type(), "Can only compare nodes of the same type()");
   const auto& update_node = static_cast<const UpdateNode&>(rhs);
 
-  Assert(left_child() && rhs.left_child(), "Can't compare column references without children");
+  Assert(left_input() && rhs.left_input(), "Can't compare column references without children");
   return _table_name == update_node._table_name &&
-         _equals(*left_child(), _column_expressions, *update_node.left_child(), update_node._column_expressions);
+         _equals(*left_input(), _column_expressions, *update_node.left_input(), update_node._column_expressions);
 }
 }  // namespace opossum

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,7 +19,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public AbstractLQPNo
                       const std::vector<std::shared_ptr<LQPExpression>>& column_expressions);
 
   std::string description() const override;
-  bool subtree_is_read_only() const override;
+  bool subplan_is_read_only() const override;
 
   const std::string& table_name() const;
 
@@ -29,8 +29,8 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public AbstractLQPNo
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
   const std::string _table_name;
   std::vector<std::shared_ptr<LQPExpression>> _column_expressions;
 };

--- a/src/lib/logical_query_plan/validate_node.cpp
+++ b/src/lib/logical_query_plan/validate_node.cpp
@@ -7,8 +7,8 @@ namespace opossum {
 ValidateNode::ValidateNode() : AbstractLQPNode(LQPNodeType::Validate) {}
 
 std::shared_ptr<AbstractLQPNode> ValidateNode::_deep_copy_impl(
-    const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-    const std::shared_ptr<AbstractLQPNode>& copied_right_child) const {
+    const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+    const std::shared_ptr<AbstractLQPNode>& copied_right_input) const {
   return ValidateNode::make();
 }
 

--- a/src/lib/logical_query_plan/validate_node.hpp
+++ b/src/lib/logical_query_plan/validate_node.hpp
@@ -19,8 +19,8 @@ class ValidateNode : public EnableMakeForLQPNode<ValidateNode>, public AbstractL
 
  protected:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(
-      const std::shared_ptr<AbstractLQPNode>& copied_left_child,
-      const std::shared_ptr<AbstractLQPNode>& copied_right_child) const override;
+      const std::shared_ptr<AbstractLQPNode>& copied_left_input,
+      const std::shared_ptr<AbstractLQPNode>& copied_right_input) const override;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/join_ordering/join_graph.cpp
+++ b/src/lib/optimizer/join_ordering/join_graph.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<JoinGraph> JoinGraph::from_lqp(const std::shared_ptr<AbstractLQP
 }
 
 std::shared_ptr<JoinGraph> JoinGraph::from_predicates(
-    std::vector<std::shared_ptr<AbstractLQPNode>> vertices, std::vector<LQPParentRelation> parent_relations,
+    std::vector<std::shared_ptr<AbstractLQPNode>> vertices, std::vector<LQPOutputRelation> output_relations,
     const std::vector<std::shared_ptr<const AbstractJoinPlanPredicate>>& predicates) {
   std::unordered_map<std::shared_ptr<AbstractLQPNode>, size_t> vertex_to_index;
   std::map<JoinVertexSet, std::shared_ptr<JoinEdge>> vertices_to_edge;
@@ -40,12 +40,12 @@ std::shared_ptr<JoinGraph> JoinGraph::from_predicates(
     iter->second->predicates.emplace_back(predicate);
   }
 
-  return std::make_shared<JoinGraph>(std::move(vertices), std::move(parent_relations), std::move(edges));
+  return std::make_shared<JoinGraph>(std::move(vertices), std::move(output_relations), std::move(edges));
 }
 
 JoinGraph::JoinGraph(std::vector<std::shared_ptr<AbstractLQPNode>> vertices,
-                     std::vector<LQPParentRelation> parent_relations, std::vector<std::shared_ptr<JoinEdge>> edges)
-    : vertices(std::move(vertices)), parent_relations(std::move(parent_relations)), edges(std::move(edges)) {}
+                     std::vector<LQPOutputRelation> output_relations, std::vector<std::shared_ptr<JoinEdge>> edges)
+    : vertices(std::move(vertices)), output_relations(std::move(output_relations)), edges(std::move(edges)) {}
 
 std::vector<std::shared_ptr<const AbstractJoinPlanPredicate>> JoinGraph::find_predicates(
     const JoinVertexSet& vertex_set) const {

--- a/src/lib/optimizer/join_ordering/join_graph.hpp
+++ b/src/lib/optimizer/join_ordering/join_graph.hpp
@@ -19,7 +19,7 @@ namespace opossum {
 class JoinEdge;
 
 /**
- * Represents a connected subgraph of an LQP, with the LQPNodes "above" contained in the parent_relations and the
+ * Represents a connected subgraph of an LQP, with the LQPNodes "above" contained in the output_relations and the
  * subplans "below" it being the vertices.
  * The JoinGraph clusters Predicates operating on the same set of vertices into JoinEdges.
  *
@@ -41,11 +41,11 @@ class JoinGraph final {
    * Converts the predicates into edges and creates a JoinGraph from them.
    */
   static std::shared_ptr<JoinGraph> from_predicates(
-      std::vector<std::shared_ptr<AbstractLQPNode>> vertices, std::vector<LQPParentRelation> parent_relations,
+      std::vector<std::shared_ptr<AbstractLQPNode>> vertices, std::vector<LQPOutputRelation> output_relations,
       const std::vector<std::shared_ptr<const AbstractJoinPlanPredicate>>& predicates);
 
   JoinGraph() = default;
-  JoinGraph(std::vector<std::shared_ptr<AbstractLQPNode>> vertices, std::vector<LQPParentRelation> parent_relations,
+  JoinGraph(std::vector<std::shared_ptr<AbstractLQPNode>> vertices, std::vector<LQPOutputRelation> output_relations,
             std::vector<std::shared_ptr<JoinEdge>> edges);
 
   /**
@@ -67,7 +67,7 @@ class JoinGraph final {
   void print(std::ostream& stream = std::cout) const;
 
   std::vector<std::shared_ptr<AbstractLQPNode>> vertices;
-  std::vector<LQPParentRelation> parent_relations;
+  std::vector<LQPOutputRelation> output_relations;
   std::vector<std::shared_ptr<JoinEdge>> edges;
 };
 }  // namespace opossum

--- a/src/lib/optimizer/join_ordering/join_graph_builder.cpp
+++ b/src/lib/optimizer/join_ordering/join_graph_builder.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 std::shared_ptr<JoinGraph> JoinGraphBuilder::operator()(const std::shared_ptr<AbstractLQPNode>& lqp) {
   /**
    * Traverse the LQP until the first non-vertex type (e.g. a UnionNode) is found or a node doesn't have precisely
-   * one child. This way, we traverse past Sort/Aggregate etc. nodes that later form the "parents" of the JoinGraph
+   * one child. This way, we traverse past Sort/Aggregate etc. nodes that later form the "outputs" of the JoinGraph
    */
   auto current_node = lqp;
   while (_lqp_node_type_is_vertex(current_node->type())) {

--- a/src/lib/optimizer/join_ordering/join_graph_builder.cpp
+++ b/src/lib/optimizer/join_ordering/join_graph_builder.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 std::shared_ptr<JoinGraph> JoinGraphBuilder::operator()(const std::shared_ptr<AbstractLQPNode>& lqp) {
   /**
    * Traverse the LQP until the first non-vertex type (e.g. a UnionNode) is found or a node doesn't have precisely
-   * one child. This way, we traverse past Sort/Aggregate etc. nodes that later form the "outputs" of the JoinGraph
+   * one input. This way, we traverse past Sort/Aggregate etc. nodes that later form the "outputs" of the JoinGraph
    */
   auto current_node = lqp;
   while (_lqp_node_type_is_vertex(current_node->type())) {
@@ -29,7 +29,7 @@ std::shared_ptr<JoinGraph> JoinGraphBuilder::operator()(const std::shared_ptr<Ab
 }
 
 void JoinGraphBuilder::_traverse(const std::shared_ptr<AbstractLQPNode>& node) {
-  // Makes it possible to call _traverse() on children without checking whether they exist first.
+  // Makes it possible to call _traverse() on inputren without checking whether they exist first.
   if (!node) {
     return;
   }
@@ -153,7 +153,7 @@ JoinGraphBuilder::PredicateParseResult JoinGraphBuilder::_parse_predicate(
 JoinGraphBuilder::PredicateParseResult JoinGraphBuilder::_parse_union(
     const std::shared_ptr<UnionNode>& union_node) const {
   DebugAssert(union_node->left_input() && union_node->right_input(),
-              "UnionNode needs both children set in order to be parsed");
+              "UnionNode needs both inputren set in order to be parsed");
 
   const auto parse_result_left = _parse_predicate(union_node->left_input());
   const auto parse_result_right = _parse_predicate(union_node->right_input());

--- a/src/lib/optimizer/join_ordering/join_graph_builder.hpp
+++ b/src/lib/optimizer/join_ordering/join_graph_builder.hpp
@@ -24,7 +24,7 @@ class AbstractLQPNode;
  *        \_[4] [MockTable] y
  *
  * The JoinGraph created from it would contain two vertices (x and y), one edge (between x and y, with the predicate
- * x2 <= y1) and one parent_relation (Projection, left child side)
+ * x2 <= y1) and one output_relation (Projection, left input side)
  */
 class JoinGraphBuilder final {
  public:

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<Abstr
   // Add explicit root node, so the rules can freely change the tree below it without having to maintain a root node
   // to return to the Optimizer
   const auto root_node = LogicalPlanRootNode::make();
-  root_node->set_left_child(input);
+  root_node->set_left_input(input);
 
   for (const auto& rule_batch : _rule_batches) {
     switch (rule_batch.execution_policy()) {
@@ -56,8 +56,8 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<Abstr
   }
 
   // Remove LogicalPlanRootNode
-  const auto optimized_node = root_node->left_child();
-  optimized_node->clear_parents();
+  const auto optimized_node = root_node->left_input();
+  optimized_node->clear_outputs();
 
   return optimized_node;
 }

--- a/src/lib/optimizer/strategy/abstract_rule.cpp
+++ b/src/lib/optimizer/strategy/abstract_rule.cpp
@@ -10,11 +10,11 @@ bool AbstractRule::_apply_to_children(std::shared_ptr<AbstractLQPNode> node) {
   auto children_changed = false;
 
   // Apply this rule recursively
-  if (node->left_child()) {
-    children_changed |= apply_to(node->left_child());
+  if (node->left_input()) {
+    children_changed |= apply_to(node->left_input());
   }
-  if (node->right_child()) {
-    children_changed |= apply_to(node->right_child());
+  if (node->right_input()) {
+    children_changed |= apply_to(node->right_input());
   }
 
   return children_changed;

--- a/src/lib/optimizer/strategy/abstract_rule.cpp
+++ b/src/lib/optimizer/strategy/abstract_rule.cpp
@@ -6,18 +6,18 @@
 
 namespace opossum {
 
-bool AbstractRule::_apply_to_children(std::shared_ptr<AbstractLQPNode> node) {
-  auto children_changed = false;
+bool AbstractRule::_apply_to_inputs(std::shared_ptr<AbstractLQPNode> node) {
+  auto inputs_changed = false;
 
   // Apply this rule recursively
   if (node->left_input()) {
-    children_changed |= apply_to(node->left_input());
+    inputs_changed |= apply_to(node->left_input());
   }
   if (node->right_input()) {
-    children_changed |= apply_to(node->right_input());
+    inputs_changed |= apply_to(node->right_input());
   }
 
-  return children_changed;
+  return inputs_changed;
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/abstract_rule.hpp
+++ b/src/lib/optimizer/strategy/abstract_rule.hpp
@@ -24,10 +24,10 @@ class AbstractRule {
 
  protected:
   /**
-   * IMPORTANT: Takes a copy of the node ptr because applying this rule to children of this node might remove this node
+   * IMPORTANT: Takes a copy of the node ptr because applying this rule to inputs of this node might remove this node
    * from the tree, which might result in this node being deleted if we don't take a copy of the shared_ptr here.
    */
-  bool _apply_to_children(std::shared_ptr<AbstractLQPNode> node);
+  bool _apply_to_inputs(std::shared_ptr<AbstractLQPNode> node);
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/constant_calculation_rule.cpp
+++ b/src/lib/optimizer/strategy/constant_calculation_rule.cpp
@@ -64,7 +64,7 @@ bool ConstantCalculationRule::_replace_expression_in_parents(const std::shared_p
                                                              const LQPColumnReference& expression_column,
                                                              const AllTypeVariant& value) {
   auto parent_tree_changed = false;
-  for (auto parent : node->parents()) {
+  for (auto parent : node->outputs()) {
     if (parent->type() != LQPNodeType::Predicate) {
       parent_tree_changed |= _replace_expression_in_parents(parent, expression_column, value);
       continue;

--- a/src/lib/optimizer/strategy/constant_calculation_rule.cpp
+++ b/src/lib/optimizer/strategy/constant_calculation_rule.cpp
@@ -50,8 +50,8 @@ bool ConstantCalculationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& n
     // If the value is std::nullopt, then the expression could not be resolved at this point,
     // e.g. because it is not an arithmetic operator.
     if (value != std::nullopt &&
-        _replace_expression_in_parents(node, node->output_column_references()[column_id], *value)) {
-      // If we successfully replaced the occurrences of the expression in the parent tree,
+        _replace_expression_in_outputs(node, node->output_column_references()[column_id], *value)) {
+      // If we successfully replaced the occurrences of the expression in the output tree,
       // we can remove the column here.
       _remove_column_from_projection(projection_node, column_id);
     }
@@ -60,17 +60,17 @@ bool ConstantCalculationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& n
   return _apply_to_children(node);
 }
 
-bool ConstantCalculationRule::_replace_expression_in_parents(const std::shared_ptr<AbstractLQPNode>& node,
+bool ConstantCalculationRule::_replace_expression_in_outputs(const std::shared_ptr<AbstractLQPNode>& node,
                                                              const LQPColumnReference& expression_column,
                                                              const AllTypeVariant& value) {
-  auto parent_tree_changed = false;
-  for (auto parent : node->outputs()) {
-    if (parent->type() != LQPNodeType::Predicate) {
-      parent_tree_changed |= _replace_expression_in_parents(parent, expression_column, value);
+  auto output_plan_changed = false;
+  for (auto output : node->outputs()) {
+    if (output->type() != LQPNodeType::Predicate) {
+      output_plan_changed |= _replace_expression_in_outputs(output, expression_column, value);
       continue;
     }
 
-    auto predicate_node = std::static_pointer_cast<PredicateNode>(parent);
+    auto predicate_node = std::static_pointer_cast<PredicateNode>(output);
 
     // We look for a PredicateNode which has an LQPColumnReference as value,
     // referring to the column which contains the Expression we resolved before.
@@ -80,12 +80,12 @@ bool ConstantCalculationRule::_replace_expression_in_parents(const std::shared_p
       auto new_predicate_node = std::make_shared<PredicateNode>(predicate_node->column_reference(),
                                                                 predicate_node->predicate_condition(), value);
       predicate_node->replace_with(new_predicate_node);
-      parent_tree_changed = true;
+      output_plan_changed = true;
     }
 
-    parent_tree_changed |= _replace_expression_in_parents(parent, expression_column, value);
+    output_plan_changed |= _replace_expression_in_outputs(output, expression_column, value);
   }
-  return parent_tree_changed;
+  return output_plan_changed;
 }
 
 void ConstantCalculationRule::_remove_column_from_projection(const std::shared_ptr<ProjectionNode>& node,

--- a/src/lib/optimizer/strategy/constant_calculation_rule.cpp
+++ b/src/lib/optimizer/strategy/constant_calculation_rule.cpp
@@ -20,7 +20,7 @@ std::string ConstantCalculationRule::name() const { return "Constant Calculation
 
 bool ConstantCalculationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
   if (node->type() != LQPNodeType::Projection) {
-    return _apply_to_children(node);
+    return _apply_to_inputs(node);
   }
 
   auto projection_node = std::static_pointer_cast<ProjectionNode>(node);
@@ -57,7 +57,7 @@ bool ConstantCalculationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& n
     }
   }
 
-  return _apply_to_children(node);
+  return _apply_to_inputs(node);
 }
 
 bool ConstantCalculationRule::_replace_expression_in_outputs(const std::shared_ptr<AbstractLQPNode>& node,

--- a/src/lib/optimizer/strategy/constant_calculation_rule.hpp
+++ b/src/lib/optimizer/strategy/constant_calculation_rule.hpp
@@ -25,7 +25,7 @@ class ConstantCalculationRule : public AbstractRule {
   bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) override;
 
  private:
-  bool _replace_expression_in_parents(const std::shared_ptr<AbstractLQPNode>& node,
+  bool _replace_expression_in_outputs(const std::shared_ptr<AbstractLQPNode>& node,
                                       const LQPColumnReference& expression_column, const AllTypeVariant& value);
   void _remove_column_from_projection(const std::shared_ptr<ProjectionNode>& node, ColumnID column_id);
 

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -31,7 +31,7 @@ std::string IndexScanRule::name() const { return "Index Scan Rule"; }
 
 bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
   if (node->type() == LQPNodeType::Predicate) {
-    const auto& child = node->left_child();
+    const auto& child = node->left_input();
 
     if (child->type() == LQPNodeType::StoredTable) {
       const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
@@ -62,10 +62,10 @@ bool IndexScanRule::_is_index_scan_applicable(const IndexInfo& index_info,
   const auto column_id = predicate_node->get_output_column_id(predicate_node->column_reference());
   if (index_info.column_ids[0] != column_id) return false;
 
-  const auto row_count_table = predicate_node->left_child()->derive_statistics_from(nullptr, nullptr)->row_count();
+  const auto row_count_table = predicate_node->left_input()->derive_statistics_from(nullptr, nullptr)->row_count();
   if (row_count_table < INDEX_SCAN_ROW_COUNT_THRESHOLD) return false;
 
-  const auto row_count_predicate = predicate_node->derive_statistics_from(predicate_node->left_child())->row_count();
+  const auto row_count_predicate = predicate_node->derive_statistics_from(predicate_node->left_input())->row_count();
   const float selectivity = row_count_predicate / row_count_table;
 
   if (selectivity > INDEX_SCAN_SELECTIVITY_THRESHOLD) return false;

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -47,7 +47,7 @@ bool IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
     }
   }
 
-  return _apply_to_children(node);
+  return _apply_to_inputs(node);
 }
 
 bool IndexScanRule::_is_index_scan_applicable(const IndexInfo& index_info,

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -14,7 +14,7 @@ class AbstractLQPNode;
 class PredicateNode;
 
 /**
- * This optimizer rule finds PredicateNodes whose children are StoredTableNodes. These PredicateNodes are candidates
+ * This optimizer rule finds PredicateNodes whose inputs are StoredTableNodes. These PredicateNodes are candidates
  * for being executed by IndexScans. If the expected selectivity of the predicate falls below a certain threshold, the
  * ScanType of the PredicateNode is set to IndexScan.
  *

--- a/src/lib/optimizer/strategy/join_detection_rule.cpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.cpp
@@ -52,16 +52,16 @@ bool JoinDetectionRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
 
 std::optional<JoinDetectionRule::JoinCondition> JoinDetectionRule::_find_predicate_for_cross_join(
     const std::shared_ptr<JoinNode>& cross_join) {
-  Assert(cross_join->left_child() && cross_join->right_child(), "Cross Join must have two children");
+  Assert(cross_join->left_input() && cross_join->right_input(), "Cross Join must have two children");
 
-  // Everytime we traverse a node which we're the right child of, the ColumnIDs a predicate needs to reference become
+  // Everytime we traverse a node which we're the right input of, the ColumnIDs a predicate needs to reference become
   // offset
   auto column_id_offset = 0;
 
   // Go up in LQP to find corresponding PredicateNode
   std::shared_ptr<AbstractLQPNode> node = cross_join;
   while (true) {
-    const auto parents = node->parents();
+    const auto parents = node->outputs();
 
     /**
      * Can't deal with the parents.size() > 0 case - would need to check that a potential predicate exists in all
@@ -71,8 +71,8 @@ std::optional<JoinDetectionRule::JoinCondition> JoinDetectionRule::_find_predica
       break;
     }
 
-    if (node->get_child_side(parents[0]) == LQPChildSide::Right) {
-      column_id_offset += parents[0]->left_child()->output_column_count();
+    if (node->get_input_side(parents[0]) == LQPInputSide::Right) {
+      column_id_offset += parents[0]->left_input()->output_column_count();
     }
 
     node = parents[0];
@@ -104,15 +104,15 @@ std::optional<JoinDetectionRule::JoinCondition> JoinDetectionRule::_find_predica
       auto predicate_left_column_reference = predicate_node->column_reference();
       auto predicate_right_column_reference = boost::get<LQPColumnReference>(predicate_node->value());
 
-      const auto left_in_left = cross_join->left_child()->find_output_column_id(predicate_left_column_reference);
-      const auto right_in_right = cross_join->right_child()->find_output_column_id(predicate_right_column_reference);
+      const auto left_in_left = cross_join->left_input()->find_output_column_id(predicate_left_column_reference);
+      const auto right_in_right = cross_join->right_input()->find_output_column_id(predicate_right_column_reference);
 
       if (left_in_left && right_in_right) {
         return JoinCondition{predicate_node, predicate_left_column_reference, predicate_right_column_reference};
       }
 
-      const auto left_in_right = cross_join->right_child()->find_output_column_id(predicate_left_column_reference);
-      const auto right_in_left = cross_join->left_child()->find_output_column_id(predicate_right_column_reference);
+      const auto left_in_right = cross_join->right_input()->find_output_column_id(predicate_left_column_reference);
+      const auto right_in_left = cross_join->left_input()->find_output_column_id(predicate_right_column_reference);
 
       if (right_in_left && left_in_right) {
         return JoinCondition{predicate_node, predicate_right_column_reference, predicate_left_column_reference};

--- a/src/lib/optimizer/strategy/join_detection_rule.cpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.cpp
@@ -61,21 +61,21 @@ std::optional<JoinDetectionRule::JoinCondition> JoinDetectionRule::_find_predica
   // Go up in LQP to find corresponding PredicateNode
   std::shared_ptr<AbstractLQPNode> node = cross_join;
   while (true) {
-    const auto parents = node->outputs();
+    const auto outputs = node->outputs();
 
     /**
-     * Can't deal with the parents.size() > 0 case - would need to check that a potential predicate exists in all
-     * parents and this is too much work considering the JoinDetectionRule will be removed soon-ish (TM)
+     * Can't deal with the outputs.size() > 0 case - would need to check that a potential predicate exists in all
+     * outputs and this is too much work considering the JoinDetectionRule will be removed soon-ish (TM)
      */
-    if (parents.empty() || parents.size() > 1) {
+    if (outputs.empty() || outputs.size() > 1) {
       break;
     }
 
-    if (node->get_input_side(parents[0]) == LQPInputSide::Right) {
-      column_id_offset += parents[0]->left_input()->output_column_count();
+    if (node->get_input_side(outputs[0]) == LQPInputSide::Right) {
+      column_id_offset += outputs[0]->left_input()->output_column_count();
     }
 
-    node = parents[0];
+    node = outputs[0];
 
     /**
      * TODO(anyone)

--- a/src/lib/optimizer/strategy/join_detection_rule.cpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.cpp
@@ -47,12 +47,12 @@ bool JoinDetectionRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) {
     }
   }
 
-  return _apply_to_children(node);
+  return _apply_to_inputs(node);
 }
 
 std::optional<JoinDetectionRule::JoinCondition> JoinDetectionRule::_find_predicate_for_cross_join(
     const std::shared_ptr<JoinNode>& cross_join) {
-  Assert(cross_join->left_input() && cross_join->right_input(), "Cross Join must have two children");
+  Assert(cross_join->left_input() && cross_join->right_input(), "Cross Join must have two inputs");
 
   // Everytime we traverse a node which we're the right input of, the ColumnIDs a predicate needs to reference become
   // offset

--- a/src/lib/optimizer/strategy/join_detection_rule.hpp
+++ b/src/lib/optimizer/strategy/join_detection_rule.hpp
@@ -31,7 +31,7 @@ struct ColumnID;
  *
  * The rule traverses the LQP recursively searching for JoinNodes with JoinMode::Cross.
  * For each Cross Join Node it will look for an appropriate join condition
- * by searching the parent nodes for PredicateNodes. Each PredicateNode is a potential candidate
+ * by searching the output nodes for PredicateNodes. Each PredicateNode is a potential candidate
  * but only those that compare two columns are interesting enough to check.
  * When such a PredicateNode is found, the rule will check whether each ColumnID comes from the left/right input.
  *

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -54,9 +54,9 @@ bool PredicateReorderingRule::apply_to(const std::shared_ptr<AbstractLQPNode>& n
 }
 
 bool PredicateReorderingRule::_reorder_predicates(std::vector<std::shared_ptr<PredicateNode>>& predicates) const {
-  // Store original input and parent
+  // Store original input and output
   auto child = predicates.back()->left_input();
-  const auto parents = predicates.front()->outputs();
+  const auto outputs = predicates.front()->outputs();
   const auto child_sides = predicates.front()->get_input_sides();
 
   const auto sort_predicate = [&](auto& left, auto& right) {
@@ -78,8 +78,8 @@ bool PredicateReorderingRule::_reorder_predicates(std::vector<std::shared_ptr<Pr
   // Ensure that nodes are chained correctly
   predicates.back()->set_left_input(child);
 
-  for (size_t parent_idx = 0; parent_idx < parents.size(); ++parent_idx) {
-    parents[parent_idx]->set_input(child_sides[parent_idx], predicates.front());
+  for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx) {
+    outputs[output_idx]->set_input(child_sides[output_idx], predicates.front());
   }
 
   for (size_t predicate_index = 0; predicate_index < predicates.size() - 1; predicate_index++) {

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -27,15 +27,15 @@ void LQPVisualizer::_build_graph(const std::vector<std::shared_ptr<AbstractLQPNo
 }
 
 void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node) {
-  if (node->left_child()) {
-    auto left_child = node->left_child();
+  if (node->left_input()) {
+    auto left_child = node->left_input();
     _add_vertex(left_child, left_child->description());
     _build_dataflow(left_child, node);
     _build_subtree(left_child);
   }
 
-  if (node->right_child()) {
-    auto right_child = node->right_child();
+  if (node->right_input()) {
+    auto right_child = node->right_input();
     _add_vertex(right_child, right_child->description());
     _build_dataflow(right_child, node);
     _build_subtree(right_child);
@@ -56,11 +56,11 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
     pen_width = 1.0;
   }
 
-  if (from->left_child()) {
+  if (from->left_input()) {
     try {
-      float input_count = from->left_child()->get_statistics()->row_count();
-      if (from->right_child()) {
-        input_count *= from->right_child()->get_statistics()->row_count();
+      float input_count = from->left_input()->get_statistics()->row_count();
+      if (from->right_input()) {
+        input_count *= from->right_input()->get_statistics()->row_count();
       }
       row_percentage = 100 * row_count / input_count;
     } catch (...) {

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -28,17 +28,17 @@ void LQPVisualizer::_build_graph(const std::vector<std::shared_ptr<AbstractLQPNo
 
 void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node) {
   if (node->left_input()) {
-    auto left_child = node->left_input();
-    _add_vertex(left_child, left_child->description());
-    _build_dataflow(left_child, node);
-    _build_subtree(left_child);
+    auto left_input = node->left_input();
+    _add_vertex(left_input, left_input->description());
+    _build_dataflow(left_input, node);
+    _build_subtree(left_input);
   }
 
   if (node->right_input()) {
-    auto right_child = node->right_input();
-    _add_vertex(right_child, right_child->description());
-    _build_dataflow(right_child, node);
-    _build_subtree(right_child);
+    auto right_input = node->right_input();
+    _add_vertex(right_input, right_input->description());
+    _build_dataflow(right_input, node);
+    _build_subtree(right_input);
   }
 }
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -229,13 +229,13 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_insert(const hsql::In
 
     // create projection and add to the node chain
     auto projection_node = ProjectionNode::make(projections);
-    projection_node->set_left_child(current_result_node);
+    projection_node->set_left_input(current_result_node);
 
     current_result_node = projection_node;
   }
 
   auto insert_node = InsertNode::make(table_name);
-  insert_node->set_left_child(current_result_node);
+  insert_node->set_left_input(current_result_node);
 
   return insert_node;
 }
@@ -248,7 +248,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_delete(const hsql::De
   }
 
   auto delete_node = DeleteNode::make(del.tableName);
-  delete_node->set_left_child(current_result_node);
+  delete_node->set_left_input(current_result_node);
 
   return delete_node;
 }
@@ -284,7 +284,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_update(const hsql::Up
   }
 
   std::shared_ptr<AbstractLQPNode> update_node = UpdateNode::make((update.table)->name, update_expressions);
-  update_node->set_left_child(current_values_node);
+  update_node->set_left_input(current_values_node);
 
   return update_node;
 }
@@ -406,8 +406,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_join(const hsql::Join
   auto predicate_condition = translate_operator_type_to_predicate_condition(condition.opType);
 
   auto join_node = JoinNode::make(join_mode, column_references, predicate_condition);
-  join_node->set_left_child(left_node);
-  join_node->set_right_child(right_node);
+  join_node->set_left_input(left_node);
+  join_node->set_right_input(right_node);
 
   return join_node;
 }
@@ -432,14 +432,14 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_natural_join(const hs
   Assert(!join_column_names.empty(), "No matching columns for natural join found");
 
   std::shared_ptr<AbstractLQPNode> return_node = JoinNode::make(JoinMode::Cross);
-  return_node->set_left_child(left_node);
-  return_node->set_right_child(right_node);
+  return_node->set_left_input(left_node);
+  return_node->set_right_input(right_node);
 
   for (const auto& join_column_name : join_column_names) {
     auto left_column_reference = left_node->get_column({join_column_name});
     auto right_column_reference = right_node->get_column({join_column_name});
     auto predicate = PredicateNode::make(left_column_reference, PredicateCondition::Equals, right_column_reference);
-    predicate->set_left_child(return_node);
+    predicate->set_left_input(return_node);
     return_node = predicate;
   }
 
@@ -460,7 +460,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_natural_join(const hs
   const auto column_expressions = LQPExpression::create_columns(column_references);
 
   auto projection = ProjectionNode::make(column_expressions);
-  projection->set_left_child(return_node);
+  projection->set_left_input(return_node);
 
   return projection;
 }
@@ -473,8 +473,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_cross_product(const s
     auto next_node = _translate_table_ref(*tables[i]);
 
     auto new_product = JoinNode::make(JoinMode::Cross);
-    new_product->set_left_child(product);
-    new_product->set_right_child(next_node);
+    new_product->set_left_input(product);
+    new_product->set_right_input(next_node);
 
     product = new_product;
   }
@@ -507,7 +507,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_table_ref_alias(const
     ++column_id;
   }
   auto projection_node = ProjectionNode::make(projections);
-  projection_node->set_left_child(node);
+  projection_node->set_left_input(node);
   return projection_node;
 }
 
@@ -525,7 +525,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_table_ref(const hsql:
         return _translate_table_ref_alias(_validate_if_active(stored_table_node), table);
       } else if (StorageManager::get().has_view(table.name)) {
         node = StorageManager::get().get_view(table.name);
-        Assert(!_validate || node->subtree_is_validated(), "Trying to add non-validated view to validated query");
+        Assert(!_validate || node->subplan_is_validated(), "Trying to add non-validated view to validated query");
       } else {
         Fail(std::string("Did not find a table or view with name ") + table.name);
       }
@@ -558,8 +558,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_where(const hsql::Exp
    */
   if (expr.opType == hsql::kOpOr) {
     auto union_unique_node = UnionNode::make(UnionMode::Positions);
-    union_unique_node->set_left_child(_translate_where(*expr.expr, input_node));
-    union_unique_node->set_right_child(_translate_where(*expr.expr2, input_node));
+    union_unique_node->set_left_input(_translate_where(*expr.expr, input_node));
+    union_unique_node->set_right_input(_translate_where(*expr.expr2, input_node));
     return union_unique_node;
   }
 
@@ -581,8 +581,8 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_having(const hsql::Ex
 
   if (expr.opType == hsql::kOpOr) {
     auto union_unique_node = UnionNode::make(UnionMode::Positions);
-    union_unique_node->set_left_child(_translate_having(*expr.expr, aggregate_node, input_node));
-    union_unique_node->set_right_child(_translate_having(*expr.expr2, aggregate_node, input_node));
+    union_unique_node->set_left_input(_translate_having(*expr.expr, aggregate_node, input_node));
+    union_unique_node->set_right_input(_translate_having(*expr.expr2, aggregate_node, input_node));
     return union_unique_node;
   }
 
@@ -594,7 +594,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_having(const hsql::Ex
   return _translate_predicate(expr, true,
                               [&](const hsql::Expr& hsql_expr) {
                                 const auto column_operand_expression =
-                                    HSQLExprTranslator::to_lqp_expression(hsql_expr, aggregate_node->left_child());
+                                    HSQLExprTranslator::to_lqp_expression(hsql_expr, aggregate_node->left_input());
                                 return aggregate_node->get_column_by_expression(column_operand_expression);
                               },
                               input_node);
@@ -683,7 +683,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_aggregate(
     groupby_aliasing_expressions[column_id]->set_alias(select_column_hsql_expr->alias);
   }
   auto groupby_aliasing_node = ProjectionNode::make(groupby_aliasing_expressions);
-  groupby_aliasing_node->set_left_child(input_node);
+  groupby_aliasing_node->set_left_input(input_node);
 
   /**
    * Collect the ColumnReferences of the GroupByColumns
@@ -780,7 +780,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_aggregate(
    * Create the AggregateNode, optionally add the PredicateNodes for the HAVING clause and finally add a ProjectionNode
    */
   auto aggregate_node = AggregateNode::make(aggregate_expressions, groupby_column_references);
-  aggregate_node->set_left_child(input_node);
+  aggregate_node->set_left_input(input_node);
 
   /**
    * Create the ProjectionNode
@@ -799,9 +799,9 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_aggregate(
    */
   if (has_having) {
     auto having_node = _translate_having(*group_by->having, aggregate_node, aggregate_node);
-    projection_node->set_left_child(having_node);
+    projection_node->set_left_input(having_node);
   } else {
-    projection_node->set_left_child(aggregate_node);
+    projection_node->set_left_input(aggregate_node);
   }
 
   return projection_node;
@@ -861,7 +861,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_projection(
   }
 
   auto projection_node = ProjectionNode::make(select_column_expressions);
-  projection_node->set_left_child(input_node);
+  projection_node->set_left_input(input_node);
 
   return projection_node;
 }
@@ -888,7 +888,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_order_by(
   }
 
   auto sort_node = SortNode::make(order_by_definitions);
-  sort_node->set_left_child(input_node);
+  sort_node->set_left_input(input_node);
 
   return sort_node;
 }
@@ -896,7 +896,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_order_by(
 std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_limit(const hsql::LimitDescription& limit,
                                                                  const std::shared_ptr<AbstractLQPNode>& input_node) {
   auto limit_node = LimitNode::make(limit.limit);
-  limit_node->set_left_child(input_node);
+  limit_node->set_left_input(input_node);
   return limit_node;
 }
 
@@ -1042,7 +1042,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
     column_expressions.push_back(HSQLExprTranslator::to_lqp_expression(*value_ref_hsql_expr, current_node));
 
     auto projection_node = std::make_shared<ProjectionNode>(column_expressions);
-    projection_node->set_left_child(current_node);
+    projection_node->set_left_input(current_node);
     current_node = projection_node;
     has_nested_expression = true;
 
@@ -1061,7 +1061,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
   const auto column_id = resolve_column(*column_ref_hsql_expr);
 
   auto predicate_node = PredicateNode::make(column_id, predicate_condition, value, value2);
-  predicate_node->set_left_child(current_node);
+  predicate_node->set_left_input(current_node);
 
   current_node = predicate_node;
 
@@ -1074,7 +1074,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_predicate(
     column_expressions.pop_back();
 
     auto projection_node = std::make_shared<ProjectionNode>(column_expressions);
-    projection_node->set_left_child(current_node);
+    projection_node->set_left_input(current_node);
     current_node = projection_node;
   }
 
@@ -1114,7 +1114,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create(const hsql::Cr
 
         // Create a projection node for this renaming
         auto projection_node = ProjectionNode::make(projections);
-        projection_node->set_left_child(view);
+        projection_node->set_left_input(view);
         view = projection_node;
       }
 
@@ -1140,7 +1140,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_validate_if_active(
   if (!_validate) return input_node;
 
   auto validate_node = ValidateNode::make();
-  validate_node->set_left_child(input_node);
+  validate_node->set_left_input(input_node);
   return validate_node;
 }
 

--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -41,7 +41,7 @@ class AggregateNodeTest : public BaseTest {
     _groupby_columns = std::vector<LQPColumnReference>{_a, _c};
 
     _aggregate_node = AggregateNode::make(_aggregates, _groupby_columns);
-    _aggregate_node->set_left_child(_mock_node);
+    _aggregate_node->set_left_input(_mock_node);
   }
 
   std::shared_ptr<MockNode> _mock_node;
@@ -140,13 +140,13 @@ TEST_F(AggregateNodeTest, ShallowEquals) {
   const auto groupby_columns_a = std::vector<LQPColumnReference>{_a, _c};
 
   const auto other_aggregate_node_a = AggregateNode::make(aggregates_a, _groupby_columns);
-  other_aggregate_node_a->set_left_child(_mock_node);
+  other_aggregate_node_a->set_left_input(_mock_node);
   EXPECT_FALSE(_aggregate_node->shallow_equals(*other_aggregate_node_a));
   EXPECT_FALSE(other_aggregate_node_a->shallow_equals(*_aggregate_node));
 
   const auto groupby_columns_b = std::vector<LQPColumnReference>{_a, _c, _b};
   const auto other_aggregate_node_b = AggregateNode::make(_aggregates, groupby_columns_b);
-  other_aggregate_node_b->set_left_child(_mock_node);
+  other_aggregate_node_b->set_left_input(_mock_node);
   EXPECT_FALSE(_aggregate_node->shallow_equals(*other_aggregate_node_b));
   EXPECT_FALSE(other_aggregate_node_b->shallow_equals(*_aggregate_node));
 }

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -26,22 +26,22 @@ class JoinNodeTest : public BaseTest {
     _t_b_y = {_mock_node_b, ColumnID{1}};
 
     _join_node = JoinNode::make(JoinMode::Cross);
-    _join_node->set_left_child(_mock_node_a);
-    _join_node->set_right_child(_mock_node_b);
+    _join_node->set_left_input(_mock_node_a);
+    _join_node->set_right_input(_mock_node_b);
 
     _inner_join_node = JoinNode::make(JoinMode::Inner, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
-    _inner_join_node->set_left_child(_mock_node_a);
-    _inner_join_node->set_right_child(_mock_node_b);
+    _inner_join_node->set_left_input(_mock_node_a);
+    _inner_join_node->set_right_input(_mock_node_b);
 
     _semi_join_node =
         std::make_shared<JoinNode>(JoinMode::Semi, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
-    _semi_join_node->set_left_child(_mock_node_a);
-    _semi_join_node->set_right_child(_mock_node_b);
+    _semi_join_node->set_left_input(_mock_node_a);
+    _semi_join_node->set_right_input(_mock_node_b);
 
     _anti_join_node =
         std::make_shared<JoinNode>(JoinMode::Anti, std::make_pair(_t_a_a, _t_b_y), PredicateCondition::Equals);
-    _anti_join_node->set_left_child(_mock_node_a);
-    _anti_join_node->set_right_child(_mock_node_b);
+    _anti_join_node->set_left_input(_mock_node_a);
+    _anti_join_node->set_right_input(_mock_node_b);
   }
 
   std::shared_ptr<MockNode> _mock_node_a;

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -63,17 +63,17 @@ class LogicalQueryPlanTest : public BaseTest {
     _nodes[4] = JoinNode::make(JoinMode::Cross);
     _nodes[5] = JoinNode::make(JoinMode::Cross);
 
-    _nodes[5]->set_right_child(_nodes[7]);
-    _nodes[0]->set_right_child(_nodes[4]);
-    _nodes[4]->set_left_child(_nodes[5]);
-    _nodes[4]->set_right_child(_nodes[7]);
-    _nodes[5]->set_left_child(_nodes[6]);
-    _nodes[2]->set_left_child(_nodes[5]);
-    _nodes[1]->set_right_child(_nodes[3]);
-    _nodes[3]->set_left_child(_nodes[5]);
-    _nodes[3]->set_right_child(_nodes[7]);
-    _nodes[1]->set_left_child(_nodes[2]);
-    _nodes[0]->set_left_child(_nodes[1]);
+    _nodes[5]->set_right_input(_nodes[7]);
+    _nodes[0]->set_right_input(_nodes[4]);
+    _nodes[4]->set_left_input(_nodes[5]);
+    _nodes[4]->set_right_input(_nodes[7]);
+    _nodes[5]->set_left_input(_nodes[6]);
+    _nodes[2]->set_left_input(_nodes[5]);
+    _nodes[1]->set_right_input(_nodes[3]);
+    _nodes[3]->set_left_input(_nodes[5]);
+    _nodes[3]->set_right_input(_nodes[7]);
+    _nodes[1]->set_left_input(_nodes[2]);
+    _nodes[0]->set_left_input(_nodes[1]);
   }
 
   std::array<std::shared_ptr<AbstractLQPNode>, 8> _nodes;
@@ -92,88 +92,88 @@ class LogicalQueryPlanTest : public BaseTest {
 };
 
 TEST_F(LogicalQueryPlanTest, SimpleParentTest) {
-  ASSERT_EQ(_mock_node_a->left_child(), nullptr);
-  ASSERT_EQ(_mock_node_a->right_child(), nullptr);
-  ASSERT_TRUE(_mock_node_a->parents().empty());
+  ASSERT_EQ(_mock_node_a->left_input(), nullptr);
+  ASSERT_EQ(_mock_node_a->right_input(), nullptr);
+  ASSERT_TRUE(_mock_node_a->outputs().empty());
 
-  _predicate_node_a->set_left_child(_mock_node_a);
+  _predicate_node_a->set_left_input(_mock_node_a);
 
-  ASSERT_EQ(_mock_node_a->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
-  ASSERT_EQ(_predicate_node_a->left_child(), _mock_node_a);
-  ASSERT_EQ(_predicate_node_a->right_child(), nullptr);
-  ASSERT_TRUE(_predicate_node_a->parents().empty());
+  ASSERT_EQ(_mock_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
+  ASSERT_EQ(_predicate_node_a->left_input(), _mock_node_a);
+  ASSERT_EQ(_predicate_node_a->right_input(), nullptr);
+  ASSERT_TRUE(_predicate_node_a->outputs().empty());
 
-  _projection_node->set_left_child(_predicate_node_a);
+  _projection_node->set_left_input(_predicate_node_a);
 
-  ASSERT_EQ(_predicate_node_a->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_projection_node});
-  ASSERT_EQ(_projection_node->left_child(), _predicate_node_a);
-  ASSERT_EQ(_projection_node->right_child(), nullptr);
-  ASSERT_TRUE(_projection_node->parents().empty());
+  ASSERT_EQ(_predicate_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_projection_node});
+  ASSERT_EQ(_projection_node->left_input(), _predicate_node_a);
+  ASSERT_EQ(_projection_node->right_input(), nullptr);
+  ASSERT_TRUE(_projection_node->outputs().empty());
 
-  ASSERT_ANY_THROW(_projection_node->get_child_side(_mock_node_a));
+  ASSERT_ANY_THROW(_projection_node->get_input_side(_mock_node_a));
 }
 
 TEST_F(LogicalQueryPlanTest, SimpleClearParentsTest) {
-  _predicate_node_a->set_left_child(_mock_node_a);
+  _predicate_node_a->set_left_input(_mock_node_a);
 
-  ASSERT_EQ(_mock_node_a->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
-  ASSERT_EQ(_predicate_node_a->left_child(), _mock_node_a);
-  ASSERT_EQ(_predicate_node_a->right_child(), nullptr);
-  ASSERT_TRUE(_predicate_node_a->parents().empty());
+  ASSERT_EQ(_mock_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
+  ASSERT_EQ(_predicate_node_a->left_input(), _mock_node_a);
+  ASSERT_EQ(_predicate_node_a->right_input(), nullptr);
+  ASSERT_TRUE(_predicate_node_a->outputs().empty());
 
-  _mock_node_a->clear_parents();
+  _mock_node_a->clear_outputs();
 
-  ASSERT_TRUE(_mock_node_a->parents().empty());
-  ASSERT_EQ(_predicate_node_a->left_child(), nullptr);
-  ASSERT_EQ(_predicate_node_a->right_child(), nullptr);
-  ASSERT_TRUE(_predicate_node_a->parents().empty());
+  ASSERT_TRUE(_mock_node_a->outputs().empty());
+  ASSERT_EQ(_predicate_node_a->left_input(), nullptr);
+  ASSERT_EQ(_predicate_node_a->right_input(), nullptr);
+  ASSERT_TRUE(_predicate_node_a->outputs().empty());
 }
 
 TEST_F(LogicalQueryPlanTest, ChainSameNodesTest) {
-  ASSERT_EQ(_mock_node_a->left_child(), nullptr);
-  ASSERT_EQ(_mock_node_a->right_child(), nullptr);
-  ASSERT_TRUE(_mock_node_a->parents().empty());
+  ASSERT_EQ(_mock_node_a->left_input(), nullptr);
+  ASSERT_EQ(_mock_node_a->right_input(), nullptr);
+  ASSERT_TRUE(_mock_node_a->outputs().empty());
 
-  _predicate_node_a->set_left_child(_mock_node_a);
+  _predicate_node_a->set_left_input(_mock_node_a);
 
-  ASSERT_EQ(_mock_node_a->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
-  ASSERT_EQ(_predicate_node_a->left_child(), _mock_node_a);
-  ASSERT_EQ(_predicate_node_a->right_child(), nullptr);
-  ASSERT_TRUE(_predicate_node_a->parents().empty());
+  ASSERT_EQ(_mock_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
+  ASSERT_EQ(_predicate_node_a->left_input(), _mock_node_a);
+  ASSERT_EQ(_predicate_node_a->right_input(), nullptr);
+  ASSERT_TRUE(_predicate_node_a->outputs().empty());
 
-  _predicate_node_b->set_left_child(_predicate_node_a);
+  _predicate_node_b->set_left_input(_predicate_node_a);
 
-  ASSERT_EQ(_predicate_node_a->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_b});
-  ASSERT_EQ(_predicate_node_b->left_child(), _predicate_node_a);
-  ASSERT_EQ(_predicate_node_b->right_child(), nullptr);
-  ASSERT_TRUE(_predicate_node_b->parents().empty());
+  ASSERT_EQ(_predicate_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_b});
+  ASSERT_EQ(_predicate_node_b->left_input(), _predicate_node_a);
+  ASSERT_EQ(_predicate_node_b->right_input(), nullptr);
+  ASSERT_TRUE(_predicate_node_b->outputs().empty());
 
-  _projection_node->set_left_child(_predicate_node_b);
+  _projection_node->set_left_input(_predicate_node_b);
 
-  ASSERT_EQ(_predicate_node_b->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_projection_node});
-  ASSERT_EQ(_projection_node->left_child(), _predicate_node_b);
-  ASSERT_EQ(_projection_node->right_child(), nullptr);
-  ASSERT_TRUE(_projection_node->parents().empty());
+  ASSERT_EQ(_predicate_node_b->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_projection_node});
+  ASSERT_EQ(_projection_node->left_input(), _predicate_node_b);
+  ASSERT_EQ(_projection_node->right_input(), nullptr);
+  ASSERT_TRUE(_projection_node->outputs().empty());
 }
 
 TEST_F(LogicalQueryPlanTest, TwoInputsTest) {
-  ASSERT_EQ(_join_node->left_child(), nullptr);
-  ASSERT_EQ(_join_node->right_child(), nullptr);
-  ASSERT_TRUE(_join_node->parents().empty());
+  ASSERT_EQ(_join_node->left_input(), nullptr);
+  ASSERT_EQ(_join_node->right_input(), nullptr);
+  ASSERT_TRUE(_join_node->outputs().empty());
 
-  _join_node->set_left_child(_mock_node_a);
-  _join_node->set_right_child(_mock_node_b);
+  _join_node->set_left_input(_mock_node_a);
+  _join_node->set_right_input(_mock_node_b);
 
-  ASSERT_EQ(_join_node->left_child(), _mock_node_a);
-  ASSERT_EQ(_join_node->right_child(), _mock_node_b);
-  ASSERT_TRUE(_join_node->parents().empty());
+  ASSERT_EQ(_join_node->left_input(), _mock_node_a);
+  ASSERT_EQ(_join_node->right_input(), _mock_node_b);
+  ASSERT_TRUE(_join_node->outputs().empty());
 
-  ASSERT_EQ(_mock_node_a->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_join_node});
-  ASSERT_EQ(_mock_node_b->parents(), std::vector<std::shared_ptr<AbstractLQPNode>>{_join_node});
+  ASSERT_EQ(_mock_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_join_node});
+  ASSERT_EQ(_mock_node_b->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_join_node});
 }
 
 TEST_F(LogicalQueryPlanTest, AliasedSubqueryTest) {
-  _predicate_node_a->set_left_child(_mock_node_a);
+  _predicate_node_a->set_left_input(_mock_node_a);
 
   ASSERT_EQ(_predicate_node_a->find_table_name_origin("t_a"), _mock_node_a);
 
@@ -188,17 +188,17 @@ TEST_F(LogicalQueryPlanTest, AliasedSubqueryTest) {
 }
 
 TEST_F(LogicalQueryPlanTest, ComplexGraphStructure) {
-  ASSERT_LQP_TIE(_nodes[0], LQPChildSide::Left, _nodes[1]);
-  ASSERT_LQP_TIE(_nodes[0], LQPChildSide::Right, _nodes[4]);
-  ASSERT_LQP_TIE(_nodes[1], LQPChildSide::Left, _nodes[2]);
-  ASSERT_LQP_TIE(_nodes[1], LQPChildSide::Right, _nodes[3]);
-  ASSERT_LQP_TIE(_nodes[2], LQPChildSide::Left, _nodes[5]);
-  ASSERT_LQP_TIE(_nodes[3], LQPChildSide::Left, _nodes[5]);
-  ASSERT_LQP_TIE(_nodes[4], LQPChildSide::Left, _nodes[5]);
-  ASSERT_LQP_TIE(_nodes[3], LQPChildSide::Right, _nodes[7]);
-  ASSERT_LQP_TIE(_nodes[5], LQPChildSide::Left, _nodes[6]);
-  ASSERT_LQP_TIE(_nodes[5], LQPChildSide::Right, _nodes[7]);
-  ASSERT_LQP_TIE(_nodes[4], LQPChildSide::Right, _nodes[7]);
+  ASSERT_LQP_TIE(_nodes[0], LQPInputSide::Left, _nodes[1]);
+  ASSERT_LQP_TIE(_nodes[0], LQPInputSide::Right, _nodes[4]);
+  ASSERT_LQP_TIE(_nodes[1], LQPInputSide::Left, _nodes[2]);
+  ASSERT_LQP_TIE(_nodes[1], LQPInputSide::Right, _nodes[3]);
+  ASSERT_LQP_TIE(_nodes[2], LQPInputSide::Left, _nodes[5]);
+  ASSERT_LQP_TIE(_nodes[3], LQPInputSide::Left, _nodes[5]);
+  ASSERT_LQP_TIE(_nodes[4], LQPInputSide::Left, _nodes[5]);
+  ASSERT_LQP_TIE(_nodes[3], LQPInputSide::Right, _nodes[7]);
+  ASSERT_LQP_TIE(_nodes[5], LQPInputSide::Left, _nodes[6]);
+  ASSERT_LQP_TIE(_nodes[5], LQPInputSide::Right, _nodes[7]);
+  ASSERT_LQP_TIE(_nodes[4], LQPInputSide::Right, _nodes[7]);
 }
 
 TEST_F(LogicalQueryPlanTest, ComplexGraphPrinted) {
@@ -223,32 +223,32 @@ TEST_F(LogicalQueryPlanTest, ComplexGraphPrinted) {
 TEST_F(LogicalQueryPlanTest, ComplexGraphRemoveFromTree) {
   _nodes[2]->remove_from_tree();
 
-  EXPECT_TRUE(_nodes[2]->parents().empty());
-  EXPECT_EQ(_nodes[2]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[2]->right_child(), nullptr);
+  EXPECT_TRUE(_nodes[2]->outputs().empty());
+  EXPECT_EQ(_nodes[2]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[2]->right_input(), nullptr);
 
-  // Make sure _node[1], _node[3] and _node[4] are the only parents _nodes[5] has
-  EXPECT_EQ(_nodes[5]->parents().size(), 3u);
-  ASSERT_LQP_TIE(_nodes[1], LQPChildSide::Left, _nodes[5]);
-  ASSERT_LQP_TIE(_nodes[3], LQPChildSide::Left, _nodes[5]);
-  ASSERT_LQP_TIE(_nodes[4], LQPChildSide::Left, _nodes[5]);
+  // Make sure _node[1], _node[3] and _node[4] are the only outputs _nodes[5] has
+  EXPECT_EQ(_nodes[5]->outputs().size(), 3u);
+  ASSERT_LQP_TIE(_nodes[1], LQPInputSide::Left, _nodes[5]);
+  ASSERT_LQP_TIE(_nodes[3], LQPInputSide::Left, _nodes[5]);
+  ASSERT_LQP_TIE(_nodes[4], LQPInputSide::Left, _nodes[5]);
 
-  ASSERT_LQP_TIE(_nodes[1], LQPChildSide::Right, _nodes[3]);
+  ASSERT_LQP_TIE(_nodes[1], LQPInputSide::Right, _nodes[3]);
 }
 
 TEST_F(LogicalQueryPlanTest, ComplexGraphRemoveFromTreeLeaf) {
   _nodes[6]->remove_from_tree();
   _nodes[7]->remove_from_tree();
 
-  EXPECT_TRUE(_nodes[6]->parents().empty());
-  EXPECT_TRUE(_nodes[7]->parents().empty());
-  EXPECT_EQ(_nodes[6]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[6]->right_child(), nullptr);
-  EXPECT_EQ(_nodes[7]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[7]->right_child(), nullptr);
-  EXPECT_EQ(_nodes[5]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[3]->right_child(), nullptr);
-  EXPECT_EQ(_nodes[4]->right_child(), nullptr);
+  EXPECT_TRUE(_nodes[6]->outputs().empty());
+  EXPECT_TRUE(_nodes[7]->outputs().empty());
+  EXPECT_EQ(_nodes[6]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[6]->right_input(), nullptr);
+  EXPECT_EQ(_nodes[7]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[7]->right_input(), nullptr);
+  EXPECT_EQ(_nodes[5]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[3]->right_input(), nullptr);
+  EXPECT_EQ(_nodes[4]->right_input(), nullptr);
 }
 
 TEST_F(LogicalQueryPlanTest, ComplexGraphReplaceWith) {
@@ -257,24 +257,24 @@ TEST_F(LogicalQueryPlanTest, ComplexGraphReplaceWith) {
   _nodes[5]->replace_with(new_node);
 
   // Make sure _nodes[5] is untied from the LQP
-  EXPECT_TRUE(_nodes[5]->parents().empty());
-  EXPECT_EQ(_nodes[5]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[5]->right_child(), nullptr);
+  EXPECT_TRUE(_nodes[5]->outputs().empty());
+  EXPECT_EQ(_nodes[5]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[5]->right_input(), nullptr);
 
   // Make sure new_node is the only parent of _nodes[6]
-  EXPECT_EQ(_nodes[6]->parents().size(), 1u);
-  ASSERT_LQP_TIE(new_node, LQPChildSide::Left, _nodes[6]);
+  EXPECT_EQ(_nodes[6]->outputs().size(), 1u);
+  ASSERT_LQP_TIE(new_node, LQPInputSide::Left, _nodes[6]);
 
-  // Make sure new_node, _nodes[3] and _nodes[4] are the only parents of _nodes[7]
-  EXPECT_EQ(_nodes[7]->parents().size(), 3u);
-  ASSERT_LQP_TIE(_nodes[3], LQPChildSide::Right, _nodes[7]);
-  ASSERT_LQP_TIE(_nodes[4], LQPChildSide::Right, _nodes[7]);
-  ASSERT_LQP_TIE(new_node, LQPChildSide::Right, _nodes[7]);
+  // Make sure new_node, _nodes[3] and _nodes[4] are the only outputs of _nodes[7]
+  EXPECT_EQ(_nodes[7]->outputs().size(), 3u);
+  ASSERT_LQP_TIE(_nodes[3], LQPInputSide::Right, _nodes[7]);
+  ASSERT_LQP_TIE(_nodes[4], LQPInputSide::Right, _nodes[7]);
+  ASSERT_LQP_TIE(new_node, LQPInputSide::Right, _nodes[7]);
 
-  // Make sure _nodes[5] former parents point to new_node.
-  ASSERT_LQP_TIE(_nodes[2], LQPChildSide::Left, new_node);
-  ASSERT_LQP_TIE(_nodes[3], LQPChildSide::Left, new_node);
-  ASSERT_LQP_TIE(_nodes[4], LQPChildSide::Left, new_node);
+  // Make sure _nodes[5] former outputs point to new_node.
+  ASSERT_LQP_TIE(_nodes[2], LQPInputSide::Left, new_node);
+  ASSERT_LQP_TIE(_nodes[3], LQPInputSide::Left, new_node);
+  ASSERT_LQP_TIE(_nodes[4], LQPInputSide::Left, new_node);
 }
 
 TEST_F(LogicalQueryPlanTest, ComplexGraphReplaceWithLeaf) {
@@ -285,18 +285,18 @@ TEST_F(LogicalQueryPlanTest, ComplexGraphReplaceWithLeaf) {
   _nodes[7]->replace_with(new_node_b);
 
   // Make sure _nodes[6] is untied from the LQP
-  EXPECT_TRUE(_nodes[6]->parents().empty());
-  EXPECT_EQ(_nodes[6]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[6]->right_child(), nullptr);
+  EXPECT_TRUE(_nodes[6]->outputs().empty());
+  EXPECT_EQ(_nodes[6]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[6]->right_input(), nullptr);
 
   // Make sure _nodes[7] is untied from the LQP
-  EXPECT_TRUE(_nodes[7]->parents().empty());
-  EXPECT_EQ(_nodes[7]->left_child(), nullptr);
-  EXPECT_EQ(_nodes[7]->right_child(), nullptr);
+  EXPECT_TRUE(_nodes[7]->outputs().empty());
+  EXPECT_EQ(_nodes[7]->left_input(), nullptr);
+  EXPECT_EQ(_nodes[7]->right_input(), nullptr);
 
-  ASSERT_LQP_TIE(_nodes[5], LQPChildSide::Left, new_node_a);
-  ASSERT_LQP_TIE(_nodes[3], LQPChildSide::Right, new_node_b);
-  ASSERT_LQP_TIE(_nodes[4], LQPChildSide::Right, new_node_b);
+  ASSERT_LQP_TIE(_nodes[5], LQPInputSide::Left, new_node_a);
+  ASSERT_LQP_TIE(_nodes[3], LQPInputSide::Right, new_node_b);
+  ASSERT_LQP_TIE(_nodes[4], LQPInputSide::Right, new_node_b);
 }
 
 TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
@@ -319,10 +319,10 @@ TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
                               AggregateFunction::Sum, {LQPExpression::create_column(column_reference_a)})}),
                           std::vector<LQPColumnReference>{{column_reference_b}});
 
-  aggregate_node->set_left_child(predicate_node);
-  predicate_node->set_left_child(join_node);
-  join_node->set_left_child(mock_node_a);
-  join_node->set_right_child(mock_node_b);
+  aggregate_node->set_left_input(predicate_node);
+  predicate_node->set_left_input(join_node);
+  join_node->set_left_input(mock_node_a);
+  join_node->set_right_input(mock_node_b);
 
   const auto lqp = aggregate_node;
   const auto lqp_copy = lqp->deep_copy();
@@ -332,23 +332,23 @@ TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
   /**
    * Test that column_reference_a and column_reference_b can be resolved from the JoinNode
    */
-  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_a, lqp->left_child(),
-                                                                     lqp_copy->left_child())
+  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_a, lqp->left_input(),
+                                                                     lqp_copy->left_input())
                 .original_column_id(),
             column_reference_a.original_column_id());
-  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_a, lqp->left_child(),
-                                                                     lqp_copy->left_child())
+  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_a, lqp->left_input(),
+                                                                     lqp_copy->left_input())
                 .original_node(),
-            lqp_copy->left_child()->left_child()->left_child());
+            lqp_copy->left_input()->left_input()->left_input());
 
-  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp->left_child(),
-                                                                     lqp_copy->left_child())
+  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp->left_input(),
+                                                                     lqp_copy->left_input())
                 .original_column_id(),
             column_reference_b.original_column_id());
-  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp->left_child(),
-                                                                     lqp_copy->left_child())
+  EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp->left_input(),
+                                                                     lqp_copy->left_input())
                 .original_node(),
-            lqp_copy->left_child()->left_child()->right_child());
+            lqp_copy->left_input()->left_input()->left_input());
 
   /**
    * column_reference_b can be resolved from the Aggregate since it is a GroupByColumn
@@ -357,7 +357,7 @@ TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
       AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp, lqp_copy).original_column_id(),
       column_reference_b.original_column_id());
   EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp, lqp_copy).original_node(),
-            lqp_copy->left_child()->left_child()->right_child());
+            lqp_copy->left_input()->left_input()->left_input());
 
   /**
    * SUM(a) can be resolved from the Aggregate
@@ -384,7 +384,7 @@ TEST_F(LogicalQueryPlanTest, ColumnIDByColumnReference) {
                               AggregateFunction::Sum, {LQPExpression::create_column(column_reference_a)})}),
                           std::vector<LQPColumnReference>{{column_reference_b}});
 
-  aggregate_node->set_left_child(mock_node_a);
+  aggregate_node->set_left_input(mock_node_a);
 
   const auto column_reference_c = LQPColumnReference{aggregate_node, ColumnID{1}};
 

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -91,7 +91,7 @@ class LogicalQueryPlanTest : public BaseTest {
   LQPColumnReference _t_b_b;
 };
 
-TEST_F(LogicalQueryPlanTest, SimpleParentTest) {
+TEST_F(LogicalQueryPlanTest, SimpleOutputTest) {
   ASSERT_EQ(_mock_node_a->left_input(), nullptr);
   ASSERT_EQ(_mock_node_a->right_input(), nullptr);
   ASSERT_TRUE(_mock_node_a->outputs().empty());
@@ -113,7 +113,7 @@ TEST_F(LogicalQueryPlanTest, SimpleParentTest) {
   ASSERT_ANY_THROW(_projection_node->get_input_side(_mock_node_a));
 }
 
-TEST_F(LogicalQueryPlanTest, SimpleClearParentsTest) {
+TEST_F(LogicalQueryPlanTest, SimpleClearOutputs) {
   _predicate_node_a->set_left_input(_mock_node_a);
 
   ASSERT_EQ(_mock_node_a->outputs(), std::vector<std::shared_ptr<AbstractLQPNode>>{_predicate_node_a});
@@ -261,7 +261,7 @@ TEST_F(LogicalQueryPlanTest, ComplexGraphReplaceWith) {
   EXPECT_EQ(_nodes[5]->left_input(), nullptr);
   EXPECT_EQ(_nodes[5]->right_input(), nullptr);
 
-  // Make sure new_node is the only parent of _nodes[6]
+  // Make sure new_node is the only output of _nodes[6]
   EXPECT_EQ(_nodes[6]->outputs().size(), 1u);
   ASSERT_LQP_TIE(new_node, LQPInputSide::Left, _nodes[6]);
 
@@ -348,7 +348,7 @@ TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
   EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp->left_input(),
                                                                      lqp_copy->left_input())
                 .original_node(),
-            lqp_copy->left_input()->left_input()->left_input());
+            lqp_copy->left_input()->left_input()->right_input());
 
   /**
    * column_reference_b can be resolved from the Aggregate since it is a GroupByColumn
@@ -357,7 +357,7 @@ TEST_F(LogicalQueryPlanTest, ColumnReferenceCloning) {
       AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp, lqp_copy).original_column_id(),
       column_reference_b.original_column_id());
   EXPECT_EQ(AbstractLQPNode::adapt_column_reference_to_different_lqp(column_reference_b, lqp, lqp_copy).original_node(),
-            lqp_copy->left_input()->left_input()->left_input());
+            lqp_copy->left_input()->left_input()->right_input());
 
   /**
    * SUM(a) can be resolved from the Aggregate

--- a/src/test/logical_query_plan/lqp_find_first_subplan_mismatch_test.cpp
+++ b/src/test/logical_query_plan/lqp_find_first_subplan_mismatch_test.cpp
@@ -90,17 +90,17 @@ class LQPFindSubplanMismatchTest : public ::testing::Test {
   }
 
   std::shared_ptr<AbstractLQPNode> _build_query_lqp(QueryNodes& query_nodes) {
-    query_nodes.validate_node->set_left_child(query_nodes.stored_table_node_a);
-    query_nodes.predicate_node_a->set_left_child(query_nodes.validate_node);
-    query_nodes.predicate_node_b->set_left_child(query_nodes.stored_table_node_a);
-    query_nodes.union_node->set_left_child(query_nodes.predicate_node_a);
-    query_nodes.union_node->set_right_child(query_nodes.predicate_node_b);
-    query_nodes.limit_node->set_left_child(query_nodes.union_node);
-    query_nodes.join_node->set_left_child(query_nodes.limit_node);
-    query_nodes.join_node->set_right_child(query_nodes.sort_node);
-    query_nodes.sort_node->set_left_child(query_nodes.aggregate_node);
-    query_nodes.aggregate_node->set_left_child(query_nodes.mock_node_b);
-    query_nodes.projection_node->set_left_child(query_nodes.join_node);
+    query_nodes.validate_node->set_left_input(query_nodes.stored_table_node_a);
+    query_nodes.predicate_node_a->set_left_input(query_nodes.validate_node);
+    query_nodes.predicate_node_b->set_left_input(query_nodes.stored_table_node_a);
+    query_nodes.union_node->set_left_input(query_nodes.predicate_node_a);
+    query_nodes.union_node->set_right_input(query_nodes.predicate_node_b);
+    query_nodes.limit_node->set_left_input(query_nodes.union_node);
+    query_nodes.join_node->set_left_input(query_nodes.limit_node);
+    query_nodes.join_node->set_right_input(query_nodes.sort_node);
+    query_nodes.sort_node->set_left_input(query_nodes.aggregate_node);
+    query_nodes.aggregate_node->set_left_input(query_nodes.mock_node_b);
+    query_nodes.projection_node->set_left_input(query_nodes.join_node);
 
     return query_nodes.projection_node;
   }
@@ -141,8 +141,8 @@ TEST_F(LQPFindSubplanMismatchTest, AdditionalNode) {
 
   _build_query_lqps();
 
-  _query_nodes_rhs.predicate_node_b->set_left_child(additional_predicate_node);
-  additional_predicate_node->set_left_child(_query_nodes_rhs.stored_table_node_a);
+  _query_nodes_rhs.predicate_node_b->set_left_input(additional_predicate_node);
+  additional_predicate_node->set_left_input(_query_nodes_rhs.stored_table_node_a);
 
   auto mismatch = _query_lqp_lhs->find_first_subplan_mismatch(_query_lqp_rhs);
   ASSERT_TRUE(mismatch);

--- a/src/test/logical_query_plan/predicate_node_test.cpp
+++ b/src/test/logical_query_plan/predicate_node_test.cpp
@@ -16,7 +16,7 @@ class PredicateNodeTest : public BaseTest {
 
     _table_node = StoredTableNode::make("table_a");
     _predicate_node = PredicateNode::make(LQPColumnReference{_table_node, ColumnID{0}}, PredicateCondition::Equals, 5);
-    _predicate_node->set_left_child(_table_node);
+    _predicate_node->set_left_input(_table_node);
   }
 
   std::shared_ptr<StoredTableNode> _table_node;
@@ -28,17 +28,17 @@ TEST_F(PredicateNodeTest, Descriptions) {
 
   auto predicate_b =
       PredicateNode::make(LQPColumnReference{_table_node, ColumnID{1}}, PredicateCondition::NotEquals, 2.5);
-  predicate_b->set_left_child(_table_node);
+  predicate_b->set_left_input(_table_node);
   EXPECT_EQ(predicate_b->description(), "[Predicate] table_a.f != 2.5");
 
   auto predicate_c =
       PredicateNode::make(LQPColumnReference{_table_node, ColumnID{2}}, PredicateCondition::Between, 2.5, 10.0);
-  predicate_c->set_left_child(_table_node);
+  predicate_c->set_left_input(_table_node);
   EXPECT_EQ(predicate_c->description(), "[Predicate] table_a.d BETWEEN 2.5 AND 10");
 
   auto predicate_d =
       PredicateNode::make(LQPColumnReference{_table_node, ColumnID{3}}, PredicateCondition::Equals, "test");
-  predicate_d->set_left_child(_table_node);
+  predicate_d->set_left_input(_table_node);
   EXPECT_EQ(predicate_d->description(), "[Predicate] table_a.s = test");
 }
 

--- a/src/test/logical_query_plan/projection_node_test.cpp
+++ b/src/test/logical_query_plan/projection_node_test.cpp
@@ -33,7 +33,7 @@ class ProjectionNodeTest : public BaseTest {
         _c_expr, _a_expr, LQPExpression::create_column(_b, {"alias_for_b"}),
         LQPExpression::create_binary_operator(ExpressionType::Addition, _b_expr, _c_expr, {"some_addition"}),
         LQPExpression::create_binary_operator(ExpressionType::Addition, _a_expr, _c_expr)});
-    _projection_node->set_left_child(_mock_node);
+    _projection_node->set_left_input(_mock_node);
 
     _some_addition = {_projection_node, ColumnID{3}};
     _a_plus_c = {_projection_node, ColumnID{4}};

--- a/src/test/logical_query_plan/sort_node_test.cpp
+++ b/src/test/logical_query_plan/sort_node_test.cpp
@@ -34,13 +34,13 @@ TEST_F(SortNodeTest, Descriptions) {
   EXPECT_EQ(_sort_node->description(), "[Sort] table_a.i (Ascending)");
 
   auto sort_b = SortNode::make(std::vector<OrderByDefinition>{OrderByDefinition{_a_a, OrderByMode::Descending}});
-  sort_b->set_left_child(_table_node);
+  sort_b->set_left_input(_table_node);
   EXPECT_EQ(sort_b->description(), "[Sort] table_a.i (Descending)");
 
   auto sort_c = SortNode::make(std::vector<OrderByDefinition>{OrderByDefinition{_a_c, OrderByMode::Descending},
                                                               OrderByDefinition{_a_b, OrderByMode::Ascending},
                                                               OrderByDefinition{_a_a, OrderByMode::Descending}});
-  sort_c->set_left_child(_table_node);
+  sort_c->set_left_input(_table_node);
   EXPECT_EQ(sort_c->description(), "[Sort] table_a.d (Descending), table_a.f (Ascending), table_a.i (Descending)");
 }
 

--- a/src/test/logical_query_plan/union_node_test.cpp
+++ b/src/test/logical_query_plan/union_node_test.cpp
@@ -20,8 +20,8 @@ class UnionNodeTest : public BaseTest {
     _c = {_mock_node, ColumnID{2}};
 
     _union_node = UnionNode::make(UnionMode::Positions);
-    _union_node->set_left_child(_mock_node);
-    _union_node->set_right_child(_mock_node);
+    _union_node->set_left_input(_mock_node);
+    _union_node->set_right_input(_mock_node);
   }
 
   std::shared_ptr<MockNode> _mock_node;
@@ -60,8 +60,8 @@ TEST_F(UnionNodeTest, MismatchingColumnNames) {
       MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "d"}, {DataType::Int, "c"}}, "t_a");
 
   auto invalid_union = UnionNode::make(UnionMode::Positions);
-  invalid_union->set_left_child(_mock_node);
-  invalid_union->set_right_child(mock_node_b);
+  invalid_union->set_left_input(_mock_node);
+  invalid_union->set_right_input(mock_node_b);
 
   EXPECT_THROW(invalid_union->get_verbose_column_name(ColumnID{1}), std::exception);
 }
@@ -71,8 +71,8 @@ TEST_F(UnionNodeTest, VerboseColumnNames) {
    * UnionNode will only prefix columns with its own ALIAS and forget any table names / aliases of its input tables
    */
   auto verbose_union = UnionNode::make(UnionMode::Positions);
-  verbose_union->set_left_child(_mock_node);
-  verbose_union->set_right_child(_mock_node);
+  verbose_union->set_left_input(_mock_node);
+  verbose_union->set_right_input(_mock_node);
   verbose_union->set_alias("union_alias");
 
   EXPECT_EQ(_union_node->get_verbose_column_name(ColumnID{0}), "a");

--- a/src/test/optimizer/join_ordering/join_graph_builder_test.cpp
+++ b/src/test/optimizer/join_ordering/join_graph_builder_test.cpp
@@ -53,7 +53,7 @@ class JoinGraphBuilderTest : public ::testing::Test {
     _aggregate_node_a = std::make_shared<AggregateNode>(std::vector<std::shared_ptr<LQPExpression>>{sum_expression},
                                                         std::vector<LQPColumnReference>{_mock_node_a_x2});
 
-    _aggregate_node_a->set_left_child(_mock_node_a);
+    _aggregate_node_a->set_left_input(_mock_node_a);
 
     _sum_mock_node_a_x1 = _aggregate_node_a->get_column("sum_a"s);
 
@@ -85,25 +85,25 @@ class JoinGraphBuilderTest : public ::testing::Test {
     /**
      * Wire up LQP
      */
-    _projection_node_a->set_left_child(_predicate_node_j);
-    _predicate_node_j->set_left_child(_predicate_node_h);
-    _predicate_node_h->set_left_child(_cross_join_node_a);
-    _cross_join_node_a->set_left_child(_predicate_node_g);
-    _cross_join_node_a->set_right_child(_mock_node_c);
-    _predicate_node_g->set_left_child(_predicate_node_f);
-    _predicate_node_f->set_left_child(_inner_join_node_a);
-    _inner_join_node_a->set_left_child(_predicate_node_a);
-    _inner_join_node_a->set_right_child(_predicate_node_e);
-    _predicate_node_e->set_left_child(_union_node_a);
-    _union_node_a->set_left_child(_predicate_node_c);
-    _union_node_a->set_right_child(_union_node_b);
-    _predicate_node_c->set_left_child(_predicate_node_b);
-    _predicate_node_b->set_left_child(_mock_node_b);
-    _union_node_b->set_left_child(_predicate_node_d);
-    _union_node_b->set_right_child(_predicate_node_i);
-    _predicate_node_d->set_left_child(_mock_node_b);
-    _predicate_node_i->set_left_child(_mock_node_b);
-    _predicate_node_a->set_left_child(_aggregate_node_a);
+    _projection_node_a->set_left_input(_predicate_node_j);
+    _predicate_node_j->set_left_input(_predicate_node_h);
+    _predicate_node_h->set_left_input(_cross_join_node_a);
+    _cross_join_node_a->set_left_input(_predicate_node_g);
+    _cross_join_node_a->set_right_input(_mock_node_c);
+    _predicate_node_g->set_left_input(_predicate_node_f);
+    _predicate_node_f->set_left_input(_inner_join_node_a);
+    _inner_join_node_a->set_left_input(_predicate_node_a);
+    _inner_join_node_a->set_right_input(_predicate_node_e);
+    _predicate_node_e->set_left_input(_union_node_a);
+    _union_node_a->set_left_input(_predicate_node_c);
+    _union_node_a->set_right_input(_union_node_b);
+    _predicate_node_c->set_left_input(_predicate_node_b);
+    _predicate_node_b->set_left_input(_mock_node_b);
+    _union_node_b->set_left_input(_predicate_node_d);
+    _union_node_b->set_right_input(_predicate_node_i);
+    _predicate_node_d->set_left_input(_mock_node_b);
+    _predicate_node_i->set_left_input(_mock_node_b);
+    _predicate_node_a->set_left_input(_aggregate_node_a);
 
     _join_graph = JoinGraphBuilder{}(_lqp);  // NOLINT
   }
@@ -177,9 +177,9 @@ TEST_F(JoinGraphBuilderTest, ComplexLQP) {
   /**
    * Test parent relations
    */
-  ASSERT_EQ(_join_graph->parent_relations.size(), 1u);
-  EXPECT_EQ(_join_graph->parent_relations.at(0).parent, _projection_node_a);
-  EXPECT_EQ(_join_graph->parent_relations.at(0).child_side, LQPChildSide::Left);
+  ASSERT_EQ(_join_graph->output_relations.size(), 1u);
+  EXPECT_EQ(_join_graph->output_relations.at(0).output, _projection_node_a);
+  EXPECT_EQ(_join_graph->output_relations.at(0).input_side, LQPInputSide::Left);
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/join_ordering/join_graph_builder_test.cpp
+++ b/src/test/optimizer/join_ordering/join_graph_builder_test.cpp
@@ -175,7 +175,7 @@ TEST_F(JoinGraphBuilderTest, ComplexLQP) {
   EXPECT_EQ(to_string(edge_ac->predicates.at(0)), "x2 <= z1");
 
   /**
-   * Test parent relations
+   * Test output relations
    */
   ASSERT_EQ(_join_graph->output_relations.size(), 1u);
   EXPECT_EQ(_join_graph->output_relations.at(0).output, _projection_node_a);

--- a/src/test/optimizer/strategy/constant_calculation_rule_test.cpp
+++ b/src/test/optimizer/strategy/constant_calculation_rule_test.cpp
@@ -41,19 +41,19 @@ TEST_F(ConstantCalculationRuleTest, ResolveExpressionTest) {
   const auto resolved = StrategyBaseTest::apply_rule(_rule, result_node);
 
   EXPECT_EQ(resolved->type(), LQPNodeType::Projection);
-  EXPECT_EQ(resolved->left_child()->type(), LQPNodeType::Projection);
-  EXPECT_FALSE(resolved->right_child());
+  EXPECT_EQ(resolved->left_input()->type(), LQPNodeType::Projection);
+  EXPECT_FALSE(resolved->right_input());
 
-  ASSERT_EQ(resolved->left_child()->left_child()->type(), LQPNodeType::Predicate);
-  const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(resolved->left_child()->left_child());
-  EXPECT_FALSE(predicate_node->right_child());
+  ASSERT_EQ(resolved->left_input()->left_input()->type(), LQPNodeType::Predicate);
+  const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(resolved->left_input()->left_input());
+  EXPECT_FALSE(predicate_node->right_input());
   EXPECT_EQ(predicate_node->predicate_condition(), PredicateCondition::Equals);
 
-  ASSERT_EQ(predicate_node->left_child()->type(), LQPNodeType::Projection);
-  const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(predicate_node->left_child());
+  ASSERT_EQ(predicate_node->left_input()->type(), LQPNodeType::Projection);
+  const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(predicate_node->left_input());
   EXPECT_EQ(projection_node->column_expressions().size(), 2u);
 
-  const auto original_node = projection_node->left_child();
+  const auto original_node = projection_node->left_input();
 
   ASSERT_TRUE(is_variant(predicate_node->value()));
   EXPECT_EQ(predicate_node->column_reference(), LQPColumnReference(original_node, ColumnID{0}));

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -184,7 +184,7 @@ TEST_F(IndexScanRuleTest, IndexScanWithIndex) {
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::IndexScan);
 }
 
-TEST_F(IndexScanRuleTest, IndexScanOnlyOnParentOfStoredTableNode) {
+TEST_F(IndexScanRuleTest, IndexScanOnlyOnOutputOfStoredTableNode) {
   auto stored_table_node = StoredTableNode::make("a");
 
   auto table = StorageManager::get().get_table("a");

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -72,7 +72,7 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithoutIndex) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -90,7 +90,7 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithIndexOnOtherColumn) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -108,7 +108,7 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithMultiColumnIndex) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -123,7 +123,7 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithTwoColumnPredicate) {
 
   auto predicate_node_0 = PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}},
                                               PredicateCondition::GreaterThan, ColumnID{1});
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -141,7 +141,7 @@ TEST_F(IndexScanRuleTest, NoIndexScanWithHighSelectivity) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -159,7 +159,7 @@ TEST_F(IndexScanRuleTest, NoIndexScanIfNotGroupKey) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -177,7 +177,7 @@ TEST_F(IndexScanRuleTest, IndexScanWithIndex) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::TableScan);
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_0);
@@ -195,11 +195,11 @@ TEST_F(IndexScanRuleTest, IndexScanOnlyOnParentOfStoredTableNode) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   auto predicate_node_1 =
       PredicateNode::make(LQPColumnReference{predicate_node_0, ColumnID{1}}, PredicateCondition::LessThan, 15);
-  predicate_node_1->set_left_child(predicate_node_0);
+  predicate_node_1->set_left_input(predicate_node_0);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);
   EXPECT_EQ(predicate_node_0->scan_type(), ScanType::IndexScan);

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -57,11 +57,11 @@ class JoinDetectionRuleTest : public StrategyBaseTest, public ::testing::WithPar
       }
     }
 
-    if (node->left_child()) {
-      count += _count_cross_joins(node->left_child());
+    if (node->left_input()) {
+      count += _count_cross_joins(node->left_input());
     }
-    if (node->right_child()) {
-      count += _count_cross_joins(node->right_child());
+    if (node->right_input()) {
+      count += _count_cross_joins(node->right_input());
     }
 
     return count;
@@ -94,21 +94,21 @@ TEST_F(JoinDetectionRuleTest, SimpleDetectionTest) {
 
   // Generate LQP
   const auto cross_join_node = JoinNode::make(JoinMode::Cross);
-  cross_join_node->set_left_child(_table_node_a);
-  cross_join_node->set_right_child(_table_node_b);
+  cross_join_node->set_left_input(_table_node_a);
+  cross_join_node->set_right_input(_table_node_b);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _b_a);
-  predicate_node->set_left_child(cross_join_node);
+  predicate_node->set_left_input(cross_join_node);
 
   // Apply rule
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
   // Verification of the new JOIN
   ASSERT_INNER_JOIN_NODE(output, PredicateCondition::Equals, _a_a, _b_a);
 
-  ASSERT_NE(output->left_child(), nullptr);
-  ASSERT_NE(output->right_child(), nullptr);
-  EXPECT_EQ(output->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->right_child()->type(), LQPNodeType::StoredTable);
+  ASSERT_NE(output->left_input(), nullptr);
+  ASSERT_NE(output->right_input(), nullptr);
+  EXPECT_EQ(output->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->right_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
@@ -138,25 +138,25 @@ TEST_F(JoinDetectionRuleTest, SecondDetectionTest) {
 
   // Generate LQP
   const auto cross_join_node = JoinNode::make(JoinMode::Cross);
-  cross_join_node->set_left_child(_table_node_a);
-  cross_join_node->set_right_child(_table_node_b);
+  cross_join_node->set_left_input(_table_node_a);
+  cross_join_node->set_right_input(_table_node_b);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _b_a);
-  predicate_node->set_left_child(cross_join_node);
+  predicate_node->set_left_input(cross_join_node);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(predicate_node);
+  projection_node->set_left_input(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child(), PredicateCondition::Equals, _a_a, _b_a);
+  ASSERT_INNER_JOIN_NODE(output->left_input(), PredicateCondition::Equals, _a_a, _b_a);
 
-  EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, NoPredicate) {
@@ -175,21 +175,21 @@ TEST_F(JoinDetectionRuleTest, NoPredicate) {
 
   // Generate LQP
   const auto cross_join_node = JoinNode::make(JoinMode::Cross);
-  cross_join_node->set_left_child(_table_node_a);
-  cross_join_node->set_right_child(_table_node_b);
+  cross_join_node->set_left_input(_table_node_a);
+  cross_join_node->set_right_input(_table_node_b);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(cross_join_node);
+  projection_node->set_left_input(cross_join_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
-  ASSERT_CROSS_JOIN_NODE(output->left_child());
+  ASSERT_CROSS_JOIN_NODE(output->left_input());
 
-  EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, NoMatchingPredicate) {
@@ -211,23 +211,23 @@ TEST_F(JoinDetectionRuleTest, NoMatchingPredicate) {
 
   // Generate LQP
   const auto cross_join_node = JoinNode::make(JoinMode::Cross);
-  cross_join_node->set_left_child(_table_node_a);
-  cross_join_node->set_right_child(_table_node_b);
+  cross_join_node->set_left_input(_table_node_a);
+  cross_join_node->set_right_input(_table_node_b);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _a_b);
-  predicate_node->set_left_child(cross_join_node);
+  predicate_node->set_left_input(cross_join_node);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(predicate_node);
+  projection_node->set_left_input(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
-  EXPECT_EQ(output->left_child()->type(), LQPNodeType::Predicate);
-  ASSERT_CROSS_JOIN_NODE(output->left_child()->left_child());
-  EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->type(), LQPNodeType::Predicate);
+  ASSERT_CROSS_JOIN_NODE(output->left_input()->left_input());
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
@@ -249,23 +249,23 @@ TEST_F(JoinDetectionRuleTest, NonCrossJoin) {
    */
 
   const auto join_node = JoinNode::make(JoinMode::Inner, std::make_pair(_a_b, _b_b), PredicateCondition::Equals);
-  join_node->set_left_child(_table_node_a);
-  join_node->set_right_child(_table_node_b);
+  join_node->set_left_input(_table_node_a);
+  join_node->set_right_input(_table_node_b);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _b_a);
-  predicate_node->set_left_child(join_node);
+  predicate_node->set_left_input(join_node);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(predicate_node);
+  projection_node->set_left_input(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
-  EXPECT_EQ(output->left_child()->type(), LQPNodeType::Predicate);
-  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), PredicateCondition::Equals, _a_b, _b_b);
-  EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->type(), LQPNodeType::Predicate);
+  ASSERT_INNER_JOIN_NODE(output->left_input()->left_input(), PredicateCondition::Equals, _a_b, _b_b);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, MultipleJoins) {
@@ -298,33 +298,33 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins) {
    *
    */
   const auto join_node1 = JoinNode::make(JoinMode::Cross);
-  join_node1->set_left_child(_table_node_a);
-  join_node1->set_right_child(_table_node_b);
+  join_node1->set_left_input(_table_node_a);
+  join_node1->set_right_input(_table_node_b);
 
   const auto join_node2 = JoinNode::make(JoinMode::Cross);
-  join_node2->set_left_child(join_node1);
-  join_node2->set_right_child(_table_node_c);
+  join_node2->set_left_input(join_node1);
+  join_node2->set_right_input(_table_node_c);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _b_a);
-  predicate_node->set_left_child(join_node2);
+  predicate_node->set_left_input(join_node2);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(predicate_node);
+  projection_node->set_left_input(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
-  ASSERT_EQ(output->left_child()->type(), LQPNodeType::Join);
+  ASSERT_EQ(output->left_input()->type(), LQPNodeType::Join);
 
-  const auto first_join_node = std::dynamic_pointer_cast<JoinNode>(output->left_child());
+  const auto first_join_node = std::dynamic_pointer_cast<JoinNode>(output->left_input());
   EXPECT_EQ(first_join_node->join_mode(), JoinMode::Cross);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child()->left_child(), PredicateCondition::Equals, _a_a, _b_a);
+  ASSERT_INNER_JOIN_NODE(output->left_input()->left_input(), PredicateCondition::Equals, _a_a, _b_a);
 
-  EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
@@ -353,19 +353,19 @@ TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
   const auto join_node2 = JoinNode::make(JoinMode::Cross);
   const auto predicate_node = PredicateNode::make(_b_a, PredicateCondition::Equals, _c_b);
 
-  predicate_node->set_left_child(join_node1);
-  join_node1->set_left_child(_table_node_a);
-  join_node1->set_right_child(join_node2);
-  join_node2->set_left_child(_table_node_b);
-  join_node2->set_right_child(_table_node_c);
+  predicate_node->set_left_input(join_node1);
+  join_node1->set_left_input(_table_node_a);
+  join_node1->set_right_input(join_node2);
+  join_node2->set_left_input(_table_node_b);
+  join_node2->set_right_input(_table_node_c);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
   EXPECT_EQ(output, join_node1);
-  EXPECT_EQ(output->left_child(), _table_node_a);
-  ASSERT_INNER_JOIN_NODE(output->right_child(), PredicateCondition::Equals, _b_a, _c_b);
-  EXPECT_EQ(output->right_child()->left_child(), _table_node_b);
-  EXPECT_EQ(output->right_child()->right_child(), _table_node_c);
+  EXPECT_EQ(output->left_input(), _table_node_a);
+  ASSERT_INNER_JOIN_NODE(output->right_input(), PredicateCondition::Equals, _b_a, _c_b);
+  EXPECT_EQ(output->right_input()->right_input(), _table_node_b);
+  EXPECT_EQ(output->right_input()->right_input(), _table_node_c);
 }
 
 TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
@@ -398,33 +398,33 @@ TEST_F(JoinDetectionRuleTest, MultipleJoins2) {
    *
    */
   const auto join_node1 = JoinNode::make(JoinMode::Cross);
-  join_node1->set_left_child(_table_node_a);
-  join_node1->set_right_child(_table_node_b);
+  join_node1->set_left_input(_table_node_a);
+  join_node1->set_right_input(_table_node_b);
 
   const auto join_node2 = JoinNode::make(JoinMode::Cross);
-  join_node2->set_left_child(join_node1);
-  join_node2->set_right_child(_table_node_c);
+  join_node2->set_left_input(join_node1);
+  join_node2->set_right_input(_table_node_c);
 
   const auto predicate_node = PredicateNode::make(_c_a, PredicateCondition::Equals, _a_a);
-  predicate_node->set_left_child(join_node2);
+  predicate_node->set_left_input(join_node2);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(predicate_node);
+  projection_node->set_left_input(predicate_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Projection);
 
   // Verification of the new JOIN
-  ASSERT_INNER_JOIN_NODE(output->left_child(), PredicateCondition::Equals, _a_a, _c_a);
+  ASSERT_INNER_JOIN_NODE(output->left_input(), PredicateCondition::Equals, _a_a, _c_a);
 
-  EXPECT_EQ(output->left_child()->left_child()->type(), LQPNodeType::Join);
-  const auto second_join_node = std::dynamic_pointer_cast<JoinNode>(output->left_child()->left_child());
+  EXPECT_EQ(output->left_input()->left_input()->type(), LQPNodeType::Join);
+  const auto second_join_node = std::dynamic_pointer_cast<JoinNode>(output->left_input()->left_input());
   EXPECT_EQ(second_join_node->join_mode(), JoinMode::Cross);
 
-  EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, NoOptimizationAcrossProjection) {
@@ -447,24 +447,24 @@ TEST_F(JoinDetectionRuleTest, NoOptimizationAcrossProjection) {
    *
    */
   const auto join_node = JoinNode::make(JoinMode::Cross);
-  join_node->set_left_child(_table_node_a);
-  join_node->set_right_child(_table_node_b);
+  join_node->set_left_input(_table_node_a);
+  join_node->set_right_input(_table_node_b);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a),
                                                                LQPExpression::create_column(_b_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(join_node);
+  projection_node->set_left_input(join_node);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _b_a);
-  predicate_node->set_left_child(projection_node);
+  predicate_node->set_left_input(projection_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Predicate);
-  EXPECT_EQ(output->left_child()->type(), LQPNodeType::Projection);
-  ASSERT_CROSS_JOIN_NODE(output->left_child()->left_child());
-  EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->type(), LQPNodeType::Projection);
+  ASSERT_CROSS_JOIN_NODE(output->left_input()->left_input());
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_F(JoinDetectionRuleTest, NoJoinDetectionAcrossProjections) {
@@ -487,26 +487,26 @@ TEST_F(JoinDetectionRuleTest, NoJoinDetectionAcrossProjections) {
    *
    */
   const auto join_node = JoinNode::make(JoinMode::Cross);
-  join_node->set_left_child(_table_node_a);
-  join_node->set_right_child(_table_node_b);
+  join_node->set_left_input(_table_node_a);
+  join_node->set_right_input(_table_node_b);
 
   const std::vector<std::shared_ptr<LQPExpression>> columns = {LQPExpression::create_column(_a_a),
                                                                LQPExpression::create_column(_b_a)};
   const auto projection_node = ProjectionNode::make(columns);
-  projection_node->set_left_child(join_node);
+  projection_node->set_left_input(join_node);
 
   const auto predicate_node = PredicateNode::make(_a_a, PredicateCondition::Equals, _b_a);
-  predicate_node->set_left_child(projection_node);
+  predicate_node->set_left_input(projection_node);
 
   auto output = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
   EXPECT_EQ(output->type(), LQPNodeType::Predicate);
-  EXPECT_EQ(output->left_child()->type(), LQPNodeType::Projection);
+  EXPECT_EQ(output->left_input()->type(), LQPNodeType::Projection);
 
-  ASSERT_EQ(output->left_child()->left_child()->type(), LQPNodeType::Join);
+  ASSERT_EQ(output->left_input()->left_input()->type(), LQPNodeType::Join);
 
-  EXPECT_EQ(output->left_child()->left_child()->left_child()->type(), LQPNodeType::StoredTable);
-  EXPECT_EQ(output->left_child()->left_child()->right_child()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
+  EXPECT_EQ(output->left_input()->left_input()->left_input()->type(), LQPNodeType::StoredTable);
 }
 
 TEST_P(JoinDetectionRuleTest, JoinDetectionSQL) {

--- a/src/test/optimizer/strategy/join_detection_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_detection_rule_test.cpp
@@ -364,7 +364,7 @@ TEST_F(JoinDetectionRuleTest, JoinInRightChild) {
   EXPECT_EQ(output, join_node1);
   EXPECT_EQ(output->left_input(), _table_node_a);
   ASSERT_INNER_JOIN_NODE(output->right_input(), PredicateCondition::Equals, _b_a, _c_b);
-  EXPECT_EQ(output->right_input()->right_input(), _table_node_b);
+  EXPECT_EQ(output->right_input()->left_input(), _table_node_b);
   EXPECT_EQ(output->right_input()->right_input(), _table_node_c);
 }
 

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -237,11 +237,11 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
   EXPECT_EQ(reordered_1->left_input(), predicate_node_3);
 }
 
-TEST_F(PredicateReorderingTest, PredicatesAsRightChild) {
+TEST_F(PredicateReorderingTest, PredicatesAsRightInput) {
   /**
    * Check that Reordering predicates works if a predicate chain is both on the left and right side of a node.
    * This is particularly interesting because the PredicateReorderingRule needs to re-attach the ordered chain of
-   * predicates to the parent (the cross node in this case). This test checks whether the attachment happens as the
+   * predicates to the output (the cross node in this case). This test checks whether the attachment happens as the
    * correct child.
    *
    *             _______Cross________
@@ -286,13 +286,13 @@ TEST_F(PredicateReorderingTest, PredicatesAsRightChild) {
   EXPECT_EQ(reordered->left_input()->left_input(), predicate_0);
   EXPECT_EQ(reordered->left_input()->left_input()->left_input(), table_0);
   EXPECT_EQ(reordered->right_input(), predicate_4);
-  EXPECT_EQ(reordered->right_input()->right_input(), predicate_3);
-  EXPECT_EQ(reordered->right_input()->right_input()->right_input(), predicate_2);
+  EXPECT_EQ(reordered->right_input()->left_input(), predicate_3);
+  EXPECT_EQ(reordered->right_input()->left_input()->left_input(), predicate_2);
 }
 
-TEST_F(PredicateReorderingTest, PredicatesWithMultipleParents) {
+TEST_F(PredicateReorderingTest, PredicatesWithMultipleOutputs) {
   /**
-   * If a PredicateNode has multiple parents, it should not be considered for reordering
+   * If a PredicateNode has multiple outputs, it should not be considered for reordering
    */
   /**
    *      _____Union___
@@ -303,7 +303,7 @@ TEST_F(PredicateReorderingTest, PredicatesWithMultipleParents) {
    *         |
    *       Table
    *
-   * predicate_a should come before predicate_b - but since Predicate_b has two parents, it can't be reordered
+   * predicate_a should come before predicate_b - but since Predicate_b has two outputs, it can't be reordered
    */
 
   /**

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -92,17 +92,17 @@ TEST_F(PredicateReorderingTest, SimpleReorderingTest) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   auto predicate_node_1 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
-  predicate_node_1->set_left_child(predicate_node_0);
+  predicate_node_1->set_left_input(predicate_node_0);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_1);
 
   EXPECT_EQ(reordered, predicate_node_0);
-  EXPECT_EQ(reordered->left_child(), predicate_node_1);
-  EXPECT_EQ(reordered->left_child()->left_child(), stored_table_node);
+  EXPECT_EQ(reordered->left_input(), predicate_node_1);
+  EXPECT_EQ(reordered->left_input()->left_input(), stored_table_node);
 }
 
 TEST_F(PredicateReorderingTest, MoreComplexReorderingTest) {
@@ -113,21 +113,21 @@ TEST_F(PredicateReorderingTest, MoreComplexReorderingTest) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 5);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   auto predicate_node_1 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 1);
-  predicate_node_1->set_left_child(predicate_node_0);
+  predicate_node_1->set_left_input(predicate_node_0);
 
   auto predicate_node_2 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 9);
-  predicate_node_2->set_left_child(predicate_node_1);
+  predicate_node_2->set_left_input(predicate_node_1);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_2);
   EXPECT_EQ(reordered, predicate_node_2);
-  EXPECT_EQ(reordered->left_child(), predicate_node_0);
-  EXPECT_EQ(reordered->left_child()->left_child(), predicate_node_1);
-  EXPECT_EQ(reordered->left_child()->left_child()->left_child(), stored_table_node);
+  EXPECT_EQ(reordered->left_input(), predicate_node_0);
+  EXPECT_EQ(reordered->left_input()->left_input(), predicate_node_1);
+  EXPECT_EQ(reordered->left_input()->left_input()->left_input(), stored_table_node);
 }
 
 TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
@@ -164,38 +164,38 @@ TEST_F(PredicateReorderingTest, TwoReorderings) {
 
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   auto predicate_node_1 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
-  predicate_node_1->set_left_child(predicate_node_0);
+  predicate_node_1->set_left_input(predicate_node_0);
 
   auto sort_node = SortNode::make(
       std::vector<OrderByDefinition>{{LQPColumnReference{stored_table_node, ColumnID{0}}, OrderByMode::Ascending}});
-  sort_node->set_left_child(predicate_node_1);
+  sort_node->set_left_input(predicate_node_1);
 
   auto predicate_node_2 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{2}}, PredicateCondition::GreaterThan, 90);
-  predicate_node_2->set_left_child(sort_node);
+  predicate_node_2->set_left_input(sort_node);
 
   auto predicate_node_3 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{1}}, PredicateCondition::GreaterThan, 50);
-  predicate_node_3->set_left_child(predicate_node_2);
+  predicate_node_3->set_left_input(predicate_node_2);
 
   const auto& expressions = LQPExpression::create_columns(
       {LQPColumnReference{stored_table_node, ColumnID{0}}, LQPColumnReference{stored_table_node, ColumnID{1}}});
   const auto projection_node = ProjectionNode::make(expressions);
-  projection_node->set_left_child(predicate_node_3);
+  projection_node->set_left_input(predicate_node_3);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, projection_node);
 
   EXPECT_EQ(reordered, projection_node);
-  EXPECT_EQ(reordered->left_child(), predicate_node_2);
-  EXPECT_EQ(reordered->left_child()->left_child(), predicate_node_3);
-  EXPECT_EQ(reordered->left_child()->left_child()->left_child(), sort_node);
-  EXPECT_EQ(reordered->left_child()->left_child()->left_child()->left_child(), predicate_node_0);
-  EXPECT_EQ(reordered->left_child()->left_child()->left_child()->left_child()->left_child(), predicate_node_1);
-  EXPECT_EQ(reordered->left_child()->left_child()->left_child()->left_child()->left_child()->left_child(),
+  EXPECT_EQ(reordered->left_input(), predicate_node_2);
+  EXPECT_EQ(reordered->left_input()->left_input(), predicate_node_3);
+  EXPECT_EQ(reordered->left_input()->left_input()->left_input(), sort_node);
+  EXPECT_EQ(reordered->left_input()->left_input()->left_input()->left_input(), predicate_node_0);
+  EXPECT_EQ(reordered->left_input()->left_input()->left_input()->left_input()->left_input(), predicate_node_1);
+  EXPECT_EQ(reordered->left_input()->left_input()->left_input()->left_input()->left_input()->left_input(),
             stored_table_node);
 }
 
@@ -209,11 +209,11 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
   // predicate_node_1 -> predicate_node_0 -> stored_table_node
   auto predicate_node_0 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 20);
-  predicate_node_0->set_left_child(stored_table_node);
+  predicate_node_0->set_left_input(stored_table_node);
 
   auto predicate_node_1 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 40);
-  predicate_node_1->set_left_child(predicate_node_0);
+  predicate_node_1->set_left_input(predicate_node_0);
 
   predicate_node_1->get_statistics();
 
@@ -223,18 +223,18 @@ TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
   // predicate_node_3 -> predicate_node_2 -> stored_table_node
   auto predicate_node_2 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 40);
-  predicate_node_2->set_left_child(stored_table_node);
+  predicate_node_2->set_left_input(stored_table_node);
 
   auto predicate_node_3 =
       PredicateNode::make(LQPColumnReference{stored_table_node, ColumnID{0}}, PredicateCondition::LessThan, 20);
-  predicate_node_3->set_left_child(predicate_node_2);
+  predicate_node_3->set_left_input(predicate_node_2);
 
   auto reordered_1 = StrategyBaseTest::apply_rule(_rule, predicate_node_3);
 
   EXPECT_EQ(reordered, predicate_node_1);
-  EXPECT_EQ(reordered->left_child(), predicate_node_0);
+  EXPECT_EQ(reordered->left_input(), predicate_node_0);
   EXPECT_EQ(reordered_1, predicate_node_2);
-  EXPECT_EQ(reordered_1->left_child(), predicate_node_3);
+  EXPECT_EQ(reordered_1->left_input(), predicate_node_3);
 }
 
 TEST_F(PredicateReorderingTest, PredicatesAsRightChild) {
@@ -271,23 +271,23 @@ TEST_F(PredicateReorderingTest, PredicatesAsRightChild) {
   auto predicate_3 = PredicateNode::make(LQPColumnReference{table_1, ColumnID{0}}, PredicateCondition::GreaterThan, 50);
   auto predicate_4 = PredicateNode::make(LQPColumnReference{table_1, ColumnID{0}}, PredicateCondition::GreaterThan, 30);
 
-  predicate_1->set_left_child(table_0);
-  predicate_0->set_left_child(predicate_1);
-  predicate_4->set_left_child(table_1);
-  predicate_3->set_left_child(predicate_4);
-  predicate_2->set_left_child(predicate_3);
-  cross_node->set_left_child(predicate_0);
-  cross_node->set_right_child(predicate_2);
+  predicate_1->set_left_input(table_0);
+  predicate_0->set_left_input(predicate_1);
+  predicate_4->set_left_input(table_1);
+  predicate_3->set_left_input(predicate_4);
+  predicate_2->set_left_input(predicate_3);
+  cross_node->set_left_input(predicate_0);
+  cross_node->set_right_input(predicate_2);
 
   const auto reordered = StrategyBaseTest::apply_rule(_rule, cross_node);
 
   EXPECT_EQ(reordered, cross_node);
-  EXPECT_EQ(reordered->left_child(), predicate_1);
-  EXPECT_EQ(reordered->left_child()->left_child(), predicate_0);
-  EXPECT_EQ(reordered->left_child()->left_child()->left_child(), table_0);
-  EXPECT_EQ(reordered->right_child(), predicate_4);
-  EXPECT_EQ(reordered->right_child()->left_child(), predicate_3);
-  EXPECT_EQ(reordered->right_child()->left_child()->left_child(), predicate_2);
+  EXPECT_EQ(reordered->left_input(), predicate_1);
+  EXPECT_EQ(reordered->left_input()->left_input(), predicate_0);
+  EXPECT_EQ(reordered->left_input()->left_input()->left_input(), table_0);
+  EXPECT_EQ(reordered->right_input(), predicate_4);
+  EXPECT_EQ(reordered->right_input()->right_input(), predicate_3);
+  EXPECT_EQ(reordered->right_input()->right_input()->right_input(), predicate_2);
 }
 
 TEST_F(PredicateReorderingTest, PredicatesWithMultipleParents) {
@@ -320,18 +320,18 @@ TEST_F(PredicateReorderingTest, PredicatesWithMultipleParents) {
   auto predicate_b_node =
       PredicateNode::make(LQPColumnReference{table_node, ColumnID{0}}, PredicateCondition::GreaterThan, 10);
 
-  union_node->set_left_child(predicate_a_node);
-  union_node->set_right_child(predicate_b_node);
-  predicate_a_node->set_left_child(predicate_b_node);
-  predicate_b_node->set_left_child(table_node);
+  union_node->set_left_input(predicate_a_node);
+  union_node->set_right_input(predicate_b_node);
+  predicate_a_node->set_left_input(predicate_b_node);
+  predicate_b_node->set_left_input(table_node);
 
   const auto reordered = StrategyBaseTest::apply_rule(_rule, union_node);
 
   EXPECT_EQ(reordered, union_node);
-  EXPECT_EQ(reordered->left_child(), predicate_a_node);
-  EXPECT_EQ(reordered->right_child(), predicate_b_node);
-  EXPECT_EQ(predicate_a_node->left_child(), predicate_b_node);
-  EXPECT_EQ(predicate_b_node->left_child(), table_node);
+  EXPECT_EQ(reordered->left_input(), predicate_a_node);
+  EXPECT_EQ(reordered->right_input(), predicate_b_node);
+  EXPECT_EQ(predicate_a_node->left_input(), predicate_b_node);
+  EXPECT_EQ(predicate_b_node->left_input(), table_node);
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/strategy/predicate_reordering_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_test.cpp
@@ -242,7 +242,7 @@ TEST_F(PredicateReorderingTest, PredicatesAsRightInput) {
    * Check that Reordering predicates works if a predicate chain is both on the left and right side of a node.
    * This is particularly interesting because the PredicateReorderingRule needs to re-attach the ordered chain of
    * predicates to the output (the cross node in this case). This test checks whether the attachment happens as the
-   * correct child.
+   * correct input.
    *
    *             _______Cross________
    *            /                    \

--- a/src/test/optimizer/strategy/strategy_base_test.cpp
+++ b/src/test/optimizer/strategy/strategy_base_test.cpp
@@ -14,13 +14,13 @@ std::shared_ptr<AbstractLQPNode> StrategyBaseTest::apply_rule(const std::shared_
                                                               const std::shared_ptr<AbstractLQPNode>& input) {
   // Add explicit root node
   const auto root_node = LogicalPlanRootNode::make();
-  root_node->set_left_child(input);
+  root_node->set_left_input(input);
 
   rule->apply_to(root_node);
 
   // Remove LogicalPlanRootNode
-  const auto optimized_node = root_node->left_child();
-  optimized_node->clear_parents();
+  const auto optimized_node = root_node->left_input();
+  optimized_node->clear_outputs();
 
   return optimized_node;
 }

--- a/src/test/optimizer/strategy/strategy_base_test.hpp
+++ b/src/test/optimizer/strategy/strategy_base_test.hpp
@@ -13,7 +13,7 @@ class AbstractRule;
 class StrategyBaseTest : public BaseTest {
  protected:
   /**
-   * Helper method for applying a single rule to an LQP. Creates the temporary LogicalPlanRootNode and returns its child
+   * Helper method for applying a single rule to an LQP. Creates the temporary LogicalPlanRootNode and returns its input
    * after applying the rule
    */
   std::shared_ptr<AbstractLQPNode> apply_rule(const std::shared_ptr<AbstractRule>& rule,

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -215,7 +215,7 @@ TEST_F(SQLPipelineStatementTest, GetUnoptimizedLQPValidated) {
 
   // We did not need the context yet
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
-  EXPECT_TRUE(lqp->subtree_is_validated());
+  EXPECT_TRUE(lqp->subplan_is_validated());
 }
 
 TEST_F(SQLPipelineStatementTest, GetUnoptimizedLQPNotValidated) {
@@ -225,7 +225,7 @@ TEST_F(SQLPipelineStatementTest, GetUnoptimizedLQPNotValidated) {
 
   // We did not need the context yet
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
-  EXPECT_FALSE(lqp->subtree_is_validated());
+  EXPECT_FALSE(lqp->subplan_is_validated());
 }
 
 TEST_F(SQLPipelineStatementTest, GetOptimizedLQP) {
@@ -254,7 +254,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPValidated) {
 
   // We did not need the context yet
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
-  EXPECT_TRUE(lqp->subtree_is_validated());
+  EXPECT_TRUE(lqp->subplan_is_validated());
 }
 
 TEST_F(SQLPipelineStatementTest, GetOptimizedLQPNotValidated) {
@@ -264,7 +264,7 @@ TEST_F(SQLPipelineStatementTest, GetOptimizedLQPNotValidated) {
 
   // We did not need the context yet
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
-  EXPECT_FALSE(lqp->subtree_is_validated());
+  EXPECT_FALSE(lqp->subplan_is_validated());
 }
 
 TEST_F(SQLPipelineStatementTest, GetOptimizedLQPDoesNotInfluenceUnoptimizedLQP) {

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -466,10 +466,10 @@ TEST_F(SQLTranslatorTest, MixedAggregateAndGroupBySelectList) {
    * [Projection] table_b.a, SUM(table_c.a), table_a.b, table_a.b
    *  |_[Aggregate] SUM(table_c.a) GROUP BY [table_a.b, table_a.a, table_b.a, table_b.b]
    *     |_[Cross Join]
-   *      | |_[Cross Join]                     (left_child)
+   *      | |_[Cross Join]                     (left_input)
    *      |   |_[StoredTable] Name: 'table_a'
    *      |   |_[StoredTable] Name: 'table_b'
-   *      |_[StoredTable] Name: 'table_c'      (right_child)
+   *      |_[StoredTable] Name: 'table_c'      (right_input)
    */
 
   const auto result = compile_query(query);
@@ -478,14 +478,14 @@ TEST_F(SQLTranslatorTest, MixedAggregateAndGroupBySelectList) {
   ASSERT_NE(result->left_input()->left_input(), nullptr);                               // CrossJoin
   ASSERT_NE(result->left_input()->left_input()->left_input(), nullptr);                 // CrossJoin
   ASSERT_NE(result->left_input()->left_input()->left_input()->left_input(), nullptr);   // table_a
-  ASSERT_NE(result->left_input()->left_input()->left_input()->left_input(), nullptr);  // table_b
-  ASSERT_NE(result->left_input()->left_input()->left_input(), nullptr);                // table_c
+  ASSERT_NE(result->left_input()->left_input()->left_input()->right_input(), nullptr);  // table_b
+  ASSERT_NE(result->left_input()->left_input()->right_input(), nullptr);                // table_c
 
   ASSERT_EQ(result->left_input()->type(), LQPNodeType::Aggregate);
   const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result->left_input());
   const auto table_a_node = result->left_input()->left_input()->left_input()->left_input();
-  const auto table_b_node = result->left_input()->left_input()->left_input()->left_input();
-  const auto table_c_node = result->left_input()->left_input()->left_input();
+  const auto table_b_node = result->left_input()->left_input()->left_input()->right_input();
+  const auto table_c_node = result->left_input()->left_input()->right_input();
 
   /**
    * Assert the Projection

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -84,19 +84,19 @@ TEST_F(SQLTranslatorTest, ExpressionTest) {
   const auto result_node = compile_query(query);
 
   EXPECT_EQ(result_node->type(), LQPNodeType::Projection);
-  EXPECT_EQ(result_node->left_child()->type(), LQPNodeType::Projection);
-  EXPECT_FALSE(result_node->right_child());
+  EXPECT_EQ(result_node->left_input()->type(), LQPNodeType::Projection);
+  EXPECT_FALSE(result_node->right_input());
 
-  ASSERT_EQ(result_node->left_child()->left_child()->type(), LQPNodeType::Predicate);
-  const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(result_node->left_child()->left_child());
-  EXPECT_FALSE(predicate_node->right_child());
+  ASSERT_EQ(result_node->left_input()->left_input()->type(), LQPNodeType::Predicate);
+  const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(result_node->left_input()->left_input());
+  EXPECT_FALSE(predicate_node->right_input());
   EXPECT_EQ(predicate_node->predicate_condition(), PredicateCondition::Equals);
 
-  ASSERT_EQ(predicate_node->left_child()->type(), LQPNodeType::Projection);
-  const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(predicate_node->left_child());
+  ASSERT_EQ(predicate_node->left_input()->type(), LQPNodeType::Projection);
+  const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(predicate_node->left_input());
   EXPECT_TRUE(projection_node->column_expressions().back()->is_arithmetic_operator());
 
-  const auto original_node = projection_node->left_child();
+  const auto original_node = projection_node->left_input();
 
   // The value() of the PredicateNode is the LQPColumnReference to the (added) projection node column
   // containing the nested expression
@@ -109,9 +109,9 @@ TEST_F(SQLTranslatorTest, ExpressionWithColumnTest) {
   const auto query = "SELECT * FROM table_a WHERE a = 1231 + b";
   const auto result_node = compile_query(query);
 
-  ASSERT_EQ(result_node->left_child()->left_child()->left_child()->type(), LQPNodeType::Projection);
+  ASSERT_EQ(result_node->left_input()->left_input()->left_input()->type(), LQPNodeType::Projection);
   const auto projection_node =
-      std::dynamic_pointer_cast<ProjectionNode>(result_node->left_child()->left_child()->left_child());
+      std::dynamic_pointer_cast<ProjectionNode>(result_node->left_input()->left_input()->left_input());
 
   const auto expression = projection_node->column_expressions().back();
   EXPECT_TRUE(expression->is_arithmetic_operator());
@@ -156,7 +156,7 @@ TEST_F(SQLTranslatorTest, AggregateWithGroupBy) {
   const auto result_node = compile_query(query);
 
   EXPECT_EQ(result_node->type(), LQPNodeType::Projection);
-  EXPECT_FALSE(result_node->right_child());
+  EXPECT_FALSE(result_node->right_input());
 
   const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(result_node);
   EXPECT_NE(projection_node, nullptr);
@@ -165,14 +165,14 @@ TEST_F(SQLTranslatorTest, AggregateWithGroupBy) {
   EXPECT_EQ(projection_node->output_column_names()[0], std::string("a"));
   EXPECT_EQ(projection_node->output_column_names()[1], std::string("s"));
 
-  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result_node->left_child());
+  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result_node->left_input());
   ASSERT_NE(aggregate_node, nullptr);
-  ASSERT_NE(aggregate_node->left_child(), nullptr);
+  ASSERT_NE(aggregate_node->left_input(), nullptr);
 
-  const auto stored_table_node = aggregate_node->left_child();
+  const auto stored_table_node = aggregate_node->left_input();
   EXPECT_EQ(stored_table_node->type(), LQPNodeType::StoredTable);
-  EXPECT_FALSE(stored_table_node->left_child());
-  EXPECT_FALSE(stored_table_node->right_child());
+  EXPECT_FALSE(stored_table_node->left_input());
+  EXPECT_FALSE(stored_table_node->right_input());
 
   EXPECT_EQ(aggregate_node->aggregate_expressions().size(), 1u);
   const std::vector<LQPColumnReference> groupby_columns = {LQPColumnReference{stored_table_node, ColumnID{0}}};
@@ -191,7 +191,7 @@ TEST_F(SQLTranslatorTest, AggregateWithExpression) {
   const auto result_node = compile_query(query);
 
   EXPECT_EQ(result_node->type(), LQPNodeType::Projection);
-  EXPECT_FALSE(result_node->right_child());
+  EXPECT_FALSE(result_node->right_input());
 
   const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(result_node);
   EXPECT_NE(projection_node, nullptr);
@@ -200,16 +200,16 @@ TEST_F(SQLTranslatorTest, AggregateWithExpression) {
   EXPECT_EQ(projection_node->output_column_names()[0], std::string("s"));
   EXPECT_EQ(projection_node->output_column_names()[1], std::string("f"));
 
-  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result_node->left_child());
+  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result_node->left_input());
   EXPECT_EQ(aggregate_node->aggregate_expressions().size(), 2u);
   EXPECT_EQ(aggregate_node->groupby_column_references().size(), 0u);
   EXPECT_EQ(aggregate_node->aggregate_expressions().at(0)->alias(), std::string("s"));
   EXPECT_EQ(aggregate_node->aggregate_expressions().at(1)->alias(), std::string("f"));
 
-  const auto stored_table_node = aggregate_node->left_child();
+  const auto stored_table_node = aggregate_node->left_input();
   EXPECT_EQ(stored_table_node->type(), LQPNodeType::StoredTable);
-  EXPECT_FALSE(stored_table_node->left_child());
-  EXPECT_FALSE(stored_table_node->right_child());
+  EXPECT_FALSE(stored_table_node->left_input());
+  EXPECT_FALSE(stored_table_node->right_input());
 }
 
 TEST_F(SQLTranslatorTest, AggregateWithCountDistinct) {
@@ -217,7 +217,7 @@ TEST_F(SQLTranslatorTest, AggregateWithCountDistinct) {
   const auto result_node = compile_query(query);
 
   EXPECT_EQ(result_node->type(), LQPNodeType::Projection);
-  EXPECT_FALSE(result_node->right_child());
+  EXPECT_FALSE(result_node->right_input());
 
   const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(result_node);
   EXPECT_NE(projection_node, nullptr);
@@ -226,20 +226,20 @@ TEST_F(SQLTranslatorTest, AggregateWithCountDistinct) {
   EXPECT_EQ(projection_node->output_column_names()[0], std::string("a"));
   EXPECT_EQ(projection_node->output_column_names()[1], std::string("s"));
 
-  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result_node->left_child());
+  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result_node->left_input());
   EXPECT_NE(aggregate_node, nullptr);
-  EXPECT_NE(aggregate_node->left_child(), nullptr);
+  EXPECT_NE(aggregate_node->left_input(), nullptr);
   EXPECT_EQ(aggregate_node->aggregate_expressions().size(), 1u);
   const std::vector<LQPColumnReference> groupby_columns(
-      {LQPColumnReference{aggregate_node->left_child(), ColumnID{0}}});
+      {LQPColumnReference{aggregate_node->left_input(), ColumnID{0}}});
   EXPECT_EQ(aggregate_node->groupby_column_references(), groupby_columns);
   EXPECT_EQ(aggregate_node->aggregate_expressions().at(0)->alias(), std::string("s"));
   EXPECT_EQ(aggregate_node->aggregate_expressions().at(0)->aggregate_function(), AggregateFunction::CountDistinct);
 
-  const auto stored_table_node = aggregate_node->left_child();
+  const auto stored_table_node = aggregate_node->left_input();
   EXPECT_EQ(stored_table_node->type(), LQPNodeType::StoredTable);
-  EXPECT_FALSE(stored_table_node->left_child());
-  EXPECT_FALSE(stored_table_node->right_child());
+  EXPECT_FALSE(stored_table_node->left_input());
+  EXPECT_FALSE(stored_table_node->right_input());
 }
 
 TEST_F(SQLTranslatorTest, SelectMultipleOrderBy) {
@@ -474,18 +474,18 @@ TEST_F(SQLTranslatorTest, MixedAggregateAndGroupBySelectList) {
 
   const auto result = compile_query(query);
 
-  ASSERT_NE(result->left_child(), nullptr);                                             // Aggregate
-  ASSERT_NE(result->left_child()->left_child(), nullptr);                               // CrossJoin
-  ASSERT_NE(result->left_child()->left_child()->left_child(), nullptr);                 // CrossJoin
-  ASSERT_NE(result->left_child()->left_child()->left_child()->left_child(), nullptr);   // table_a
-  ASSERT_NE(result->left_child()->left_child()->left_child()->right_child(), nullptr);  // table_b
-  ASSERT_NE(result->left_child()->left_child()->right_child(), nullptr);                // table_c
+  ASSERT_NE(result->left_input(), nullptr);                                             // Aggregate
+  ASSERT_NE(result->left_input()->left_input(), nullptr);                               // CrossJoin
+  ASSERT_NE(result->left_input()->left_input()->left_input(), nullptr);                 // CrossJoin
+  ASSERT_NE(result->left_input()->left_input()->left_input()->left_input(), nullptr);   // table_a
+  ASSERT_NE(result->left_input()->left_input()->left_input()->left_input(), nullptr);  // table_b
+  ASSERT_NE(result->left_input()->left_input()->left_input(), nullptr);                // table_c
 
-  ASSERT_EQ(result->left_child()->type(), LQPNodeType::Aggregate);
-  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result->left_child());
-  const auto table_a_node = result->left_child()->left_child()->left_child()->left_child();
-  const auto table_b_node = result->left_child()->left_child()->left_child()->right_child();
-  const auto table_c_node = result->left_child()->left_child()->right_child();
+  ASSERT_EQ(result->left_input()->type(), LQPNodeType::Aggregate);
+  const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(result->left_input());
+  const auto table_a_node = result->left_input()->left_input()->left_input()->left_input();
+  const auto table_b_node = result->left_input()->left_input()->left_input()->left_input();
+  const auto table_c_node = result->left_input()->left_input()->left_input();
 
   /**
    * Assert the Projection
@@ -574,7 +574,7 @@ TEST_F(SQLTranslatorTest, ColumnAlias) {
 
   EXPECT_EQ(result_node->type(), LQPNodeType::Projection);
 
-  const auto& expressions = std::dynamic_pointer_cast<ProjectionNode>(result_node->left_child())->column_expressions();
+  const auto& expressions = std::dynamic_pointer_cast<ProjectionNode>(result_node->left_input())->column_expressions();
   EXPECT_EQ(expressions.size(), 2u);
   EXPECT_EQ(*expressions[0]->alias(), std::string("y"));
   EXPECT_EQ(*expressions[1]->alias(), std::string("z"));

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -268,14 +268,14 @@ void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, Predic
 
 void ASSERT_CROSS_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node) {}
 
-bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPInputSide child_side,
-                   const std::shared_ptr<const AbstractLQPNode>& child) {
-  auto parents = child->outputs();
-  for (const auto& parent2 : parents) {
-    if (!parent2) {
+bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& output, LQPInputSide input_side,
+                   const std::shared_ptr<const AbstractLQPNode>& input) {
+  auto outputs = input->outputs();
+  for (const auto& output2 : outputs) {
+    if (!output2) {
       return false;
     }
-    if (parent == parent2 && parent2->input(child_side) == child) {
+    if (output == output2 && output2->input(input_side) == input) {
       return true;
     }
   }

--- a/src/test/testing_assert.cpp
+++ b/src/test/testing_assert.cpp
@@ -268,14 +268,14 @@ void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, Predic
 
 void ASSERT_CROSS_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node) {}
 
-bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPChildSide child_side,
+bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPInputSide child_side,
                    const std::shared_ptr<const AbstractLQPNode>& child) {
-  auto parents = child->parents();
+  auto parents = child->outputs();
   for (const auto& parent2 : parents) {
     if (!parent2) {
       return false;
     }
-    if (parent == parent2 && parent2->child(child_side) == child) {
+    if (parent == parent2 && parent2->input(child_side) == child) {
       return true;
     }
   }

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -53,14 +53,14 @@ void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, Predic
 
 void ASSERT_CROSS_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node);
 
-bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPChildSide child_side,
+bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPInputSide child_side,
                    const std::shared_ptr<const AbstractLQPNode>& child);
 
 template <typename Functor>
 bool contained_in_lqp(const std::shared_ptr<AbstractLQPNode>& node, Functor contains_fn) {
   if (node == nullptr) return false;
   if (contains_fn(node)) return true;
-  return contained_in_lqp(node->left_child(), contains_fn) || contained_in_lqp(node->right_child(), contains_fn);
+  return contained_in_lqp(node->left_input(), contains_fn) || contained_in_lqp(node->right_input(), contains_fn);
 }
 
 template <typename Functor>

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -53,8 +53,8 @@ void ASSERT_INNER_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node, Predic
 
 void ASSERT_CROSS_JOIN_NODE(const std::shared_ptr<AbstractLQPNode>& node);
 
-bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& parent, LQPInputSide child_side,
-                   const std::shared_ptr<const AbstractLQPNode>& child);
+bool check_lqp_tie(const std::shared_ptr<const AbstractLQPNode>& output, LQPInputSide input_side,
+                   const std::shared_ptr<const AbstractLQPNode>& input);
 
 template <typename Functor>
 bool contained_in_lqp(const std::shared_ptr<AbstractLQPNode>& node, Functor contains_fn) {
@@ -124,8 +124,8 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
   ASSERT_EQ(expression->aggregate_function_arguments()[0]->type(), ExpressionType::Column);                  \
   ASSERT_EQ(expression->aggregate_function_arguments()[0]->column_reference(), actual_column_reference);
 
-#define ASSERT_LQP_TIE(parent, child_side, child) \
-  if (!opossum::check_lqp_tie(parent, child_side, child)) FAIL();
+#define ASSERT_LQP_TIE(output, input_side, input) \
+  if (!opossum::check_lqp_tie(output, input_side, input)) FAIL();
 
 #define EXPECT_LQP_EQ(lhs, rhs)                                  \
   {                                                              \


### PR DESCRIPTION
Renamings only - so unless you wanna crawl the code base for places where I missed words (I searched with some care), there is nothing to review.