### PR TITLE
Only evaluate Assert msg on failure

### DIFF
--- a/src/benchmarklib/benchmark_utilities/random_generator.hpp
+++ b/src/benchmarklib/benchmark_utilities/random_generator.hpp
@@ -34,7 +34,7 @@ class RandomGenerator {
    */
   std::set<size_t> select_unique_ids(size_t num_unique, size_t id_length) {
     std::set<size_t> rows;
-    opossum::Assert(num_unique <= id_length, "There are not enough ids to be selected!");
+    Assert(num_unique <= id_length, "There are not enough ids to be selected!");
     for (size_t i = 0; i < num_unique; ++i) {
       size_t index = static_cast<size_t>(-1);
       do {

--- a/src/benchmarklib/tpcc/tpcc_random_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_random_generator.hpp
@@ -27,7 +27,7 @@ class TpccRandomGenerator : public benchmark_utilities::RandomGenerator {
    * Generates a non-uniform random number based on a formula defined by TPCC
    */
   size_t nurand(size_t a, size_t x, size_t y) {
-    opossum::Assert(_nurand_constant_c <= a, "Invalid param: a=" + std::to_string(a));
+    Assert(_nurand_constant_c <= a, "Invalid param: a=" + std::to_string(a));
     return (((random_number(0, a) | random_number(x, y)) + _nurand_constant_c) % (y - x + 1)) + x;
   }
 

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -41,14 +41,6 @@
 
 namespace opossum {
 
-template <typename T>
-inline void Assert(const T& value, const std::string& msg) {
-  if (static_cast<bool>(value)) {
-    return;
-  }
-  throw std::logic_error(msg);
-}
-
 [[noreturn]] inline void Fail(const std::string& msg) { throw std::logic_error(msg); }
 
 }  // namespace opossum

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -36,7 +36,6 @@
 
 // __FILENAME__ is __FILE__ with irrelevant leading chars trimmed
 #ifndef __FILENAME__
-#ifndef __FILENAME__
 #define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
 #endif
 

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -34,6 +34,12 @@
  *     very cheap or the invariant is considered very important
  */
 
+// __FILENAME__ is __FILE__ with irrelevant leading chars trimmed
+#ifndef __FILENAME__
+#ifndef __FILENAME__
+#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+#endif
+
 namespace opossum {
 
 template <typename T>
@@ -48,17 +54,12 @@ inline void Assert(const T& value, const std::string& msg) {
 
 }  // namespace opossum
 
-// clang-format off
-#define Assert(expr, msg) \
-  if (!static_cast<bool>(expr)) { \
-    opossum::Fail(std::string{__FILENAME__} + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
+#define Assert(expr, msg)                                                                  \
+  if (!static_cast<bool>(expr)) {                                                          \
+    opossum::Fail(std::string(__FILENAME__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
   }
-// clang-format on
 
 #if IS_DEBUG
-#ifndef __FILENAME__
-#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
-#endif
 #define DebugAssert(expr, msg) Assert(expr, msg)
 #else
 #define DebugAssert(expr, msg)

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -48,12 +48,18 @@ inline void Assert(const T& value, const std::string& msg) {
 
 }  // namespace opossum
 
+// clang-format off
+#define Assert(expr, msg) \
+  if (!static_cast<bool>(expr)) { \
+    opossum::Fail(std::string{__FILENAME__} + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
+  }
+// clang-format on
+
 #if IS_DEBUG
 #ifndef __FILENAME__
 #define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
 #endif
-#define DebugAssert(expr, msg) \
-  opossum::Assert((expr), std::string{__FILENAME__} + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg)  //  NOLINT
+#define DebugAssert(expr, msg) Assert(expr, msg)
 #else
 #define DebugAssert(expr, msg)
 #endif

--- a/src/test/gtest_main.cpp
+++ b/src/test/gtest_main.cpp
@@ -13,11 +13,11 @@ namespace filesystem = std::experimental::filesystem;
 #include "utils/performance_warning.hpp"
 
 void create_test_data_directory(std::optional<std::string>& prefix) {
-  opossum::Assert(!filesystem::exists(opossum::test_data_path),
+  Assert(!filesystem::exists(opossum::test_data_path),
                   "Cannot create directory for test data: \"" + opossum::test_data_path + "\" already exists.");
 
   if (prefix) {
-    opossum::Assert(filesystem::exists("./" + *prefix),
+    Assert(filesystem::exists("./" + *prefix),
                     "Cannot create directory for test data because \"" + *prefix + "\" does not exist");
   }
 
@@ -31,7 +31,7 @@ void remove_test_data_directory() {
 }
 
 int main(int argc, char** argv) {
-  opossum::Assert(
+  Assert(
       filesystem::exists("src/test/tables"),
       "Cannot find src/test/tables. Are you running the test suite from the main folder of the Hyrise repository?");
 

--- a/src/test/gtest_main.cpp
+++ b/src/test/gtest_main.cpp
@@ -14,11 +14,11 @@ namespace filesystem = std::experimental::filesystem;
 
 void create_test_data_directory(std::optional<std::string>& prefix) {
   Assert(!filesystem::exists(opossum::test_data_path),
-                  "Cannot create directory for test data: \"" + opossum::test_data_path + "\" already exists.");
+         "Cannot create directory for test data: \"" + opossum::test_data_path + "\" already exists.");
 
   if (prefix) {
     Assert(filesystem::exists("./" + *prefix),
-                    "Cannot create directory for test data because \"" + *prefix + "\" does not exist");
+           "Cannot create directory for test data because \"" + *prefix + "\" does not exist");
   }
 
   filesystem::create_directory(opossum::test_data_path);
@@ -31,9 +31,8 @@ void remove_test_data_directory() {
 }
 
 int main(int argc, char** argv) {
-  Assert(
-      filesystem::exists("src/test/tables"),
-      "Cannot find src/test/tables. Are you running the test suite from the main folder of the Hyrise repository?");
+  Assert(filesystem::exists("src/test/tables"),
+         "Cannot find src/test/tables. Are you running the test suite from the main folder of the Hyrise repository?");
 
   opossum::PerformanceWarningDisabler pwd;
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This reduced runtime of TPCH-5 (with somewhat ordered Joins) from 1s to 0.25s in Debug mode.
I should probably dig deeper as to what the hell we're doing in these debug messages, but stopped at `AbstractOperator::get_output()` which was actually taking milliseconds on a `TableScan`

```c++
// returns the result of the operator
std::shared_ptr<const Table> AbstractOperator::get_output() const {
  DebugAssert(
      [&]() {
        if (_output == nullptr) return true;
        if (_output->chunk_count() <= ChunkID{1}) return true;
        for (auto chunk_id = ChunkID{0}; chunk_id < _output->chunk_count(); ++chunk_id) {
          if (_output->get_chunk(chunk_id)->size() < 1) return true;
        }
        return true;
      }(),
      "Empty chunk returned from operator " + description());

  DebugAssert(!_output || _output->row_count() == 0 || _output->column_count() > 0,
              "Operator " + description() + " did not output any columns");

  return _output;
}
```