### PR TITLE
Support encoding types in csv exporter

### DIFF
--- a/src/lib/import_export/csv_parser.hpp
+++ b/src/lib/import_export/csv_parser.hpp
@@ -13,9 +13,10 @@ namespace opossum {
 class Table;
 class Chunk;
 
-/*
- * Creates a Table with values of the parsed csv file <filename> and the corresponding meta file
- * <filename>.meta
+/**
+ * Creates a Table with values of the parsed csv file <filename> and
+ * the corresponding meta file <filename>.meta
+ *
  * The files are parsed according to RFC 4180 if not otherwise specified. [https://tools.ietf.org/html/rfc4180]
  * For non-RFC 4180, all linebreaks within quoted strings are further escaped with an escape character.
  * For the structure of the meta csv file see export_csv.hpp

--- a/src/lib/import_export/csv_writer.cpp
+++ b/src/lib/import_export/csv_writer.cpp
@@ -27,9 +27,45 @@ std::string CsvWriter::escape(const std::string& string) {
   return result;
 }
 
+void CsvWriter::write(const AllTypeVariant& value) {
+  if (_current_col_count > 0) {
+    _stream << _config.separator;
+  }
+
+  _write_value(value);
+  ++_current_col_count;
+}
+
 void CsvWriter::end_line() {
   _stream << _config.delimiter;
   _current_col_count = 0;
+}
+
+void CsvWriter::_write_value(const AllTypeVariant& value) {
+  if (variant_is_null(value))
+    return;
+
+  if (value.type() == typeid(std::string)) {
+    _write_string_value(type_cast<std::string>(value));
+    return;
+  }
+
+  _stream << value;
+}
+
+void CsvWriter::_write_string_value(const std::string& value) {
+  /**
+   * We put an the quotechars around any string value by default
+   * as this is the only time when a comma (,) might be inside a value.
+   * This might consume more space, however it speeds the program as it
+   * does not require additional checks.
+   * If we start allowing more characters as delimiter, we should change
+   * this behaviour to either general quoting or checking for "illegal"
+   * characters.
+   */
+  _stream << _config.quote;
+  _stream << escape(value);
+  _stream << _config.quote;
 }
 
 }  // namespace opossum

--- a/src/lib/import_export/csv_writer.hpp
+++ b/src/lib/import_export/csv_writer.hpp
@@ -19,14 +19,7 @@ class CsvWriter {
    */
   explicit CsvWriter(const std::string& file, const ParseConfig& config = {});
 
-  template <typename T>
-  void write(const T& value) {
-    if (_current_col_count > 0) {
-      _stream << _config.separator;
-    }
-    _write_value(value);
-    ++_current_col_count;
-  }
+  void write(const AllTypeVariant& value);
 
   /*
    * Ends a row of entries in the csv file.
@@ -36,41 +29,12 @@ class CsvWriter {
  protected:
   std::string escape(const std::string& string);
 
-  template <typename T>
-  void _write_value(const T& value);
+  void _write_value(const AllTypeVariant& value);
+  void _write_string_value(const std::string& value);
 
   std::ofstream _stream;
   ColumnID _current_col_count{0};
   ParseConfig _config;
 };
-
-template <typename T>
-void CsvWriter::_write_value(const T& value) {
-  _stream << value;
-}
-
-template <>
-inline void CsvWriter::_write_value<std::string>(const std::string& value) {
-  /* We put an the quotechars around any string value by default
-   * as this is the only time when a comma (,) might be inside a value.
-   * This might consume more space, however it speeds the program as it
-   * does not require additional checks.
-   * If we start allowing more characters as delimiter, we should change
-   * this behaviour to either general quoting or checking for "illegal"
-   * characters.
-   */
-  _stream << _config.quote;
-  _stream << escape(value);
-  _stream << _config.quote;
-}
-
-template <>
-inline void CsvWriter::_write_value<AllTypeVariant>(const AllTypeVariant& value) {
-  if (value.type() == typeid(std::string)) {
-    _write_value(type_cast<std::string>(value));
-  } else {
-    _stream << value;
-  }
-}
 
 }  // namespace opossum

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -11,6 +11,7 @@
 #include "storage/deprecated_dictionary_column.hpp"
 #include "storage/deprecated_dictionary_column/base_attribute_vector.hpp"
 #include "storage/reference_column.hpp"
+#include "storage/materialize.hpp"
 
 #include "constant_mappings.hpp"
 #include "resolve_type.hpp"
@@ -50,7 +51,7 @@ void ExportCsv::_generate_meta_info_file(const std::shared_ptr<const Table>& tab
 }
 
 void ExportCsv::_generate_content_file(const std::shared_ptr<const Table>& table, const std::string& csv_file) {
-  /*
+  /**
    * A naively exported csv file is a materialized file in row format.
    * This offers some advantages, but also disadvantages.
    * The advantages are that it is very straight forward to implement for any column type
@@ -63,71 +64,30 @@ void ExportCsv::_generate_content_file(const std::shared_ptr<const Table>& table
   // Open file for writing
   CsvWriter writer(csv_file);
 
-  // Create visitors for every column, so that we do not have to do that more than once.
-  std::vector<std::shared_ptr<ColumnVisitable>> visitors(table->column_count());
-  for (ColumnID column_id{0}; column_id < table->column_count(); ++column_id) {
-    auto visitor = make_shared_by_data_type<ColumnVisitable, ExportCsvVisitor>(table->column_type(column_id));
-    visitors[column_id] = std::move(visitor);
-  }
-
-  auto context = std::make_shared<ExportCsvContext>(writer);
-
-  /* Multiple rows containing the values of each respective row are written.
-   * Therefore we first iterate through the chunks, then through the rows in the chunks
-   * and afterwards through the columns of the chunks.
-   * This is a lot of iterating, but to convert a column-based table to a row-based representation
-   * takes some effort.
+  /**
+   * Multiple rows containing the values of each respective row are written.
+   * Therefore we first iterate through the chunks, then through the rows
+   * in the chunks and afterwards through the columns of the chunks.
+   *
+   * This is a lot of iterating, but to convert a column-based table to
+   * a row-based representation takes some effort.
    */
   for (ChunkID chunk_id{0}; chunk_id < table->chunk_count(); ++chunk_id) {
-    auto chunk = table->get_chunk(chunk_id);
-    for (ChunkOffset row = 0; row < chunk->size(); ++row) {
-      context->current_row = row;
+    const auto chunk = table->get_chunk(chunk_id);
+
+    for (ChunkOffset chunk_offset = 0; chunk_offset < chunk->size(); ++chunk_offset) {
       for (ColumnID column_id{0}; column_id < table->column_count(); ++column_id) {
-        chunk->get_column(column_id)->visit(*(visitors[column_id]), context);
+        const auto column = chunk->get_column(column_id);
+
+        // The previous implementation did a double dispatch (at least two virtual method calls)
+        // So the subscript operator cannot be much slower.
+        const auto value = (*column)[chunk_offset];
+        writer.write(value);
       }
+
       writer.end_line();
     }
   }
 }
-
-template <typename T>
-class ExportCsv::ExportCsvVisitor : public ColumnVisitable {
-  void handle_column(const BaseValueColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) final {
-    auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
-    const auto& column = static_cast<const ValueColumn<T>&>(base_column);
-
-    auto row = context->current_row;
-
-    if (column.is_nullable() && column.null_values()[row]) {
-      // Write an empty field for a null value
-      context->csv_writer.write("");
-    } else {
-      context->csv_writer.write(column.values()[row]);
-    }
-  }
-
-  void handle_column(const ReferenceColumn& ref_column, std::shared_ptr<ColumnVisitableContext> base_context) final {
-    auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
-
-    context->csv_writer.write(ref_column[context->current_row]);
-  }
-
-  void handle_column(const BaseDeprecatedDictionaryColumn& base_column,
-                     std::shared_ptr<ColumnVisitableContext> base_context) final {
-    auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
-    const auto& column = static_cast<const DeprecatedDictionaryColumn<T>&>(base_column);
-
-    context->csv_writer.write((*column.dictionary())[(column.attribute_vector()->get(context->current_row))]);
-  }
-
-  void handle_column(const BaseDictionaryColumn& base_column,
-                     std::shared_ptr<ColumnVisitableContext> base_context) final {
-    Fail("CSV export not implemented yet for new version of dictionary column.");
-  }
-
-  void handle_column(const BaseEncodedColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) final {
-    Fail("CSV export not implemented yet for encoded columns.");
-  }
-};
 
 }  // namespace opossum

--- a/src/lib/operators/export_csv.hpp
+++ b/src/lib/operators/export_csv.hpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 class ReferenceColumn;
 
-/*
+/**
  * With the ExportCsv operator, selected tables of a database
  * can be exported to csv files. A valid input can either be
  * a table from the storage manager or a result of a different operator.
@@ -26,7 +26,7 @@ class ReferenceColumn;
  */
 class ExportCsv : public AbstractReadOnlyOperator {
  public:
-  /*
+  /**
    * Generates a new ExportCsv operator.
    * @param in          The input for this operator. Must be another operator,
    *                    whose output is used as output for the table. If exporting
@@ -36,9 +36,9 @@ class ExportCsv : public AbstractReadOnlyOperator {
    */
   explicit ExportCsv(const std::shared_ptr<const AbstractOperator> in, const std::string& filename);
 
-  // cannot move-assign because of const members
-  ExportCsv& operator=(ExportCsv&&) = delete;
+  const std::string name() const override;
 
+ protected:
   /*
    * Executes the export process.
    * During this process, two files are created: <table_name>.csv and <table_name>.csv.meta
@@ -85,25 +85,11 @@ class ExportCsv : public AbstractReadOnlyOperator {
    */
   std::shared_ptr<const Table> _on_execute() override;
 
-  /*
-   * Name of the operator is ExportCsv
-   */
-  const std::string name() const override;
-
  private:
   // Name of the output file
   const std::string _filename;
 
   static void _generate_meta_info_file(const std::shared_ptr<const Table>& table, const std::string& meta_file);
   static void _generate_content_file(const std::shared_ptr<const Table>& table, const std::string& csv_file);
-
-  template <typename T>
-  class ExportCsvVisitor;
-
-  struct ExportCsvContext : ColumnVisitableContext {
-    explicit ExportCsvContext(CsvWriter& csv_writer) : csv_writer(csv_writer) {}
-    CsvWriter& csv_writer;
-    ChunkOffset current_row;
-  };
 };
 }  // namespace opossum

--- a/src/lib/operators/import_csv.hpp
+++ b/src/lib/operators/import_csv.hpp
@@ -11,18 +11,20 @@
 
 namespace opossum {
 
-/*
- * Creates a Table with values of to the parsed csv file <filename> and the corresponding meta file
- * <filename>.meta
+/**
+ * Creates a Table with values of the parsed csv file <filename>
+ * and the corresponding meta file <filename>.meta
  * For the structure of the meta csv file see export_csv.hpp
- * If parameter tablename provided, the imported table is stored in the StorageManager. If a table with this name
- * already exists, it is returned and no import is performed.
  *
+ * If the parameter `tablename` is provided, the imported table is stored in the StorageManager.
+ * If a table with this name already exists, it is returned and no import is performed.
+ *
+ * TODO(mjendruk): is this still true?
  * Note: ImportCsv does not support null values at the moment
  */
 class ImportCsv : public AbstractReadOnlyOperator {
  public:
-  /*
+  /**
    * @param filename      Path to the input file.
    * @param tablename     Optional. Name of the table to store/look up in the StorageManager.
    * @param meta          Optional. A specific meta config, to override the given .json file.
@@ -33,16 +35,13 @@ class ImportCsv : public AbstractReadOnlyOperator {
   explicit ImportCsv(const std::string& filename, const std::optional<CsvMeta> csv_meta,
                      const std::optional<std::string> tablename = std::nullopt);
 
-  // cannot move-assign because of const members
-  ImportCsv& operator=(ImportCsv&&) = delete;
-
-  // Name of the operator is "ImportCSV"
   const std::string name() const override;
 
  protected:
   // Returns the table that was created from the csv file.
   std::shared_ptr<const Table> _on_execute() override;
 
+ private:
   // Path to the input file
   const std::string _filename;
   // Name for adding the table to the StorageManager

--- a/src/lib/storage/materialize.hpp
+++ b/src/lib/storage/materialize.hpp
@@ -9,8 +9,9 @@
 namespace opossum {
 
 /**
- * Materialization convenience functions. Can't be put into base_column.hpp because that would lead to circular
- * includes.
+ * @brief Materialization convenience functions.
+ *
+ * Can't be put into base_column.hpp because that would lead to circular includes.
  *
  * Use like:
  *

--- a/src/test/operators/export_csv_test.cpp
+++ b/src/test/operators/export_csv_test.cpp
@@ -127,6 +127,26 @@ TEST_F(OperatorsExportCsvTest, DeprecatedDictionaryColumn) {
                            "1,\"Hallo3\",3.55\n"));
 }
 
+TEST_F(OperatorsExportCsvTest, DictionaryColumnFixedSizeByteAligned) {
+  table->append({1, "Hallo", 3.5f});
+  table->append({1, "Hallo", 3.5f});
+  table->append({1, "Hallo3", 3.55f});
+
+  ChunkEncoder::encode_chunks(table, {ChunkID{0}}, EncodingType::Dictionary);
+
+  auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
+  table_wrapper->execute();
+  auto ex = std::make_shared<opossum::ExportCsv>(table_wrapper, filename);
+  ex->execute();
+
+  EXPECT_TRUE(file_exists(filename));
+  EXPECT_TRUE(file_exists(meta_filename));
+  EXPECT_TRUE(compare_file(filename,
+                           "1,\"Hallo\",3.5\n"
+                           "1,\"Hallo\",3.5\n"
+                           "1,\"Hallo3\",3.55\n"));
+}
+
 TEST_F(OperatorsExportCsvTest, ReferenceColumn) {
   table->append({1, "abc", 1.1f});
   table->append({2, "asdf", 2.2f});


### PR DESCRIPTION
Adds support for all encoded column types to `ExportCsv`. This is one step towards the removal of `DeprecatedDictionaryColumn`.

The previous implementation used the visitor pattern to access values in columns. I replaced it with a call to `operator[]` since that can never be slower and is probably faster in some situations. Consider the code below. First of all. In order to get to the `handle_column` methods, two virtual methods have to be called, `visit` on the column and `handle_column`. Even if the visitor can then directly access the data (such as for `ValueColumn`), It is still going to be slower than just one virtual method call. In case of the `ReferenceColumn`, things get worse. Here, it does really call the subscript operator so the number of virtual method calls per element increases to three. So I think it’s clear to see that calling `operator[]` right away won’t make things worse.

As to the csv importer, I think we need to decide together what to do with regards to encoding types. Currently the implementation only supports encoding each completed chunk using dictionary encoding, but if we wanted to restore the original encoding, we would have to extend the meta file type.

```c++
template <typename T>
class ExportCsv::ExportCsvVisitor : public ColumnVisitable {
  void handle_column(const BaseValueColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) final {
    auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
    const auto& column = static_cast<const ValueColumn<T>&>(base_column);

    auto row = context->current_row;

    if (column.is_nullable() && column.null_values()[row]) {
      // Write an empty field for a null value
      context->csv_writer.write("");
    } else {
      context->csv_writer.write(column.values()[row]);
    }
  }

  void handle_column(const ReferenceColumn& ref_column, std::shared_ptr<ColumnVisitableContext> base_context) final {
    auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);

    context->csv_writer.write(ref_column[context->current_row]);
  }

  void handle_column(const BaseDeprecatedDictionaryColumn& base_column,
                     std::shared_ptr<ColumnVisitableContext> base_context) final {
    auto context = std::static_pointer_cast<ExportCsv::ExportCsvContext>(base_context);
    const auto& column = static_cast<const DeprecatedDictionaryColumn<T>&>(base_column);

    context->csv_writer.write((*column.dictionary())[(column.attribute_vector()->get(context->current_row))]);
  }
};
```

#675