### PR TITLE
Add missing sstream include

### DIFF
--- a/src/lib/utils/format_bytes.cpp
+++ b/src/lib/utils/format_bytes.cpp
@@ -1,6 +1,7 @@
 #include "format_bytes.hpp"
 
 #include <iomanip>
+#include <sstream>
 
 namespace opossum {
 


### PR DESCRIPTION
Current master did not build on MacOS (clang 5.0.1) due to missing include.