### PR TITLE
CI: Only build sanitizer for master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ node {
           sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
         }
       }, clangDebugSanitizers: {
-        stage("clang-debug:sanitizers") {
+        stage("clang-debug:sanitizers (master only)") {
           when { branch "master" }
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
@@ -67,13 +67,13 @@ node {
             sh "./scripts/run_system_test.sh clang-release"
         }
       }, clangReleaseSanitizers: {
-        stage("clang-release:sanitizers") {
+        stage("clang-release:sanitizers (master only)") {
           when { branch "master" }
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
         }
       }, clangReleaseSanitizersNoNuma: {
-        stage("clang-release:sanitizers w/o NUMA") {
+        stage("clang-release:sanitizers w/o NUMA (master only)") {
           when { branch "master" }
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CCACHE_MAXSIZE=10GB\" -e \"CCACHE_LOGFILE=ccache.log\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CCACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
     try {
       stage("Setup") {
         checkout scm
@@ -28,13 +28,11 @@ node {
       parallel clangRelease: {
         stage("clang-release") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-release/ccache.log"
           sh "./clang-release/hyriseTest clang-release"
         }
       }, clangDebugBuildOnly: {
         stage("clang-debug") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-debug/ccache.log"
         }
       }, lint: {
         stage("Linting") {
@@ -56,13 +54,11 @@ node {
       }, clangDebugSanitizers: {
         stage("clang-debug:sanitizers") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-debug-sanitizers/ccache.log"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
         }
       }, gccRelease: {
         stage("gcc-release") {
           sh "export CCACHE_BASEDIR=`pwd`; cd gcc-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./gcc-release/ccache.log"
           sh "./gcc-release/hyriseTest gcc-release"
         }
       }, systemTest: {
@@ -73,14 +69,12 @@ node {
         stage("clang-release:sanitizers") {
           when { branch "master" }
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-release-sanitizers/ccache.log"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
         }
       }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {
           when { branch "master" }
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-release-sanitizers-no-numa/ccache.log"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
         }
       }, gccDebugCoverage: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\" -e \"CCACHE_LOGFILE=/mnt/ccache/log.txt\"") {
     try {
       stage("Setup") {
         checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,15 +71,21 @@ node {
         }
       }, clangReleaseSanitizers: {
         stage("clang-release:sanitizers") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-release-sanitizers/ccache.log"
-          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
+          when { branch "master" }
+          steps {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "cat ./clang-release-sanitizers/ccache.log"
+            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
+          }
         }
       }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "cat ./clang-release-sanitizers-no-numa/ccache.log"
-          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
+          when { branch "master" }
+          steps {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "cat ./clang-release-sanitizers-no-numa/ccache.log"
+            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
+          }
         }
       }, gccDebugCoverage: {
         stage("gcc-debug-coverage") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ node {
         stage("clang-release") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "./clang-release/hyriseTest clang-release"
+          sh "cat /mnt/ccache/log.txt"
         }
       }, clangDebugBuildOnly: {
         stage("clang-debug") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ node {
 
       parallel clangRelease: {
         stage("clang-release") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && CCACHE_LOGFILE=/ccache/log.txt" make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && CCACHE_LOGFILE=/ccache/log.txt make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "./clang-release/hyriseTest clang-release"
           sh "cat /ccache/log.txt"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\"-e \"CACHE_LOGFILE=ccache.log\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
     try {
       stage("Setup") {
         checkout scm
@@ -28,11 +28,13 @@ node {
       parallel clangRelease: {
         stage("clang-release") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-release/ccache.log"
           sh "./clang-release/hyriseTest clang-release"
         }
       }, clangDebugBuildOnly: {
         stage("clang-debug") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-debug/ccache.log"
         }
       }, lint: {
         stage("Linting") {
@@ -53,12 +55,14 @@ node {
         }
       }, clangDebugSanitizers: {
         stage("clang-debug:sanitizers") {
-        sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-debug-sanitizers/ccache.log"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
         }
       }, gccRelease: {
         stage("gcc-release") {
           sh "export CCACHE_BASEDIR=`pwd`; cd gcc-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./gcc-release/ccache.log"
           sh "./gcc-release/hyriseTest gcc-release"
         }
       }, systemTest: {
@@ -67,13 +71,14 @@ node {
         }
       }, clangReleaseSanitizers: {
         stage("clang-release:sanitizers") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && CCACHE_LOGFILE=/ccache/log.txt make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-release-sanitizers/ccache.log"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
-          sh "cat /ccache/log.txt"
         }
       }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-release-sanitizers-no-numa/ccache.log"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
         }
       }, gccDebugCoverage: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
     try {
       stage("Setup") {
         checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\"-e \"CACHE_LOGFILE=ccache.log\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CCACHE_MAXSIZE=10GB\" -e \"CCACHE_LOGFILE=ccache.log\" -e \"CCACHE_SLOPPINESS=file_macro\"") {
     try {
       stage("Setup") {
         checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ node {
   // create ccache volume on host using:
   // mkdir /mnt/ccache; mount -t tmpfs -o size=10G none /mnt/ccache
 
-  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\" -e \"CCACHE_LOGFILE=/mnt/ccache/log.txt\"") {
+  oppossumCI.inside("-u 0:0 -v /mnt/ccache:/ccache -e \"CCACHE_DIR=/ccache\" -e \"CCACHE_CPP2=yes\" -e \"CACHE_MAXSIZE=10GB\" -e \"CCACHE_SLOPPINESS=file_macro\") {
     try {
       stage("Setup") {
         checkout scm
@@ -27,9 +27,9 @@ node {
 
       parallel clangRelease: {
         stage("clang-release") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && CCACHE_LOGFILE=/ccache/log.txt" make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "./clang-release/hyriseTest clang-release"
-          sh "cat /mnt/ccache/log.txt"
+          sh "cat /ccache/log.txt"
         }
       }, clangDebugBuildOnly: {
         stage("clang-debug") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,8 @@ node {
 
       parallel clangRelease: {
         stage("clang-release") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && CCACHE_LOGFILE=/ccache/log.txt make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "./clang-release/hyriseTest clang-release"
-          sh "cat /ccache/log.txt"
         }
       }, clangDebugBuildOnly: {
         stage("clang-debug") {
@@ -68,8 +67,9 @@ node {
         }
       }, clangReleaseSanitizers: {
         stage("clang-release:sanitizers") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && CCACHE_LOGFILE=/ccache/log.txt make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
+          sh "cat /ccache/log.txt"
         }
       }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,20 +72,16 @@ node {
       }, clangReleaseSanitizers: {
         stage("clang-release:sanitizers") {
           when { branch "master" }
-          steps {
-            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-            sh "cat ./clang-release-sanitizers/ccache.log"
-            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
-          }
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-release-sanitizers/ccache.log"
+          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
         }
       }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA") {
           when { branch "master" }
-          steps {
-            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-            sh "cat ./clang-release-sanitizers-no-numa/ccache.log"
-            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
-          }
+          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "cat ./clang-release-sanitizers-no-numa/ccache.log"
+          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
         }
       }, gccDebugCoverage: {
         stage("gcc-debug-coverage") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,9 +53,12 @@ node {
         }
       }, clangDebugSanitizers: {
         stage("clang-debug:sanitizers (master only)") {
-          when { branch "master" }
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
+          if (env.BRANCH_NAME == 'master') {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
+          } else {
+            echo 'only on master'
+          }
         }
       }, gccRelease: {
         stage("gcc-release") {
@@ -68,15 +71,21 @@ node {
         }
       }, clangReleaseSanitizers: {
         stage("clang-release:sanitizers (master only)") {
-          when { branch "master" }
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
+          if (env.BRANCH_NAME == 'master') {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
+          } else {
+            echo 'only on master'
+          }
         }
       }, clangReleaseSanitizersNoNuma: {
         stage("clang-release:sanitizers w/o NUMA (master only)") {
-          when { branch "master" }
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
+          if (env.BRANCH_NAME == 'master') {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
+          } else {
+            echo 'only on master'
+          }
         }
       }, gccDebugCoverage: {
         stage("gcc-debug-coverage") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ node {
         }
       }, clangDebugSanitizers: {
         stage("clang-debug:sanitizers") {
+          when { branch "master" }
           sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
           sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
         }


### PR DESCRIPTION
Having the sanitizer is a good thing and has found a bug or two in the past. However, compiling the sanitizer builds takes way longer than the regular builds. I think it is sufficient to only run the sanitizer for the master.