### PR TITLE
Recreate query plan for subselects

### DIFF
--- a/src/lib/operators/pqp_expression.cpp
+++ b/src/lib/operators/pqp_expression.cpp
@@ -100,7 +100,7 @@ bool PQPExpression::operator==(const PQPExpression& other) const {
   return _column_id == other._column_id;
 }
 
-std::shared_ptr<PQPExpression> PQPExpression::set_placeholder_value(const AllTypeVariant& value) {
+std::shared_ptr<PQPExpression> PQPExpression::copy_with_placeholder_value(const AllTypeVariant& value) {
   auto copy = create_literal(value, _alias);
   copy->_column_id = _column_id;
   return copy;

--- a/src/lib/operators/pqp_expression.hpp
+++ b/src/lib/operators/pqp_expression.hpp
@@ -52,7 +52,7 @@ class PQPExpression : public AbstractExpression<PQPExpression> {
 
   bool operator==(const PQPExpression& other) const;
 
-  std::shared_ptr<PQPExpression> set_placeholder_value(const AllTypeVariant& value);
+  std::shared_ptr<PQPExpression> copy_with_placeholder_value(const AllTypeVariant& value);
 
  protected:
   void _deep_copy_impl(const std::shared_ptr<PQPExpression>& copy) const override;

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -148,9 +148,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       auto result_table = tasks.back()->get_operator()->get_output();
       DebugAssert(result_table->column_count() == 1, "Subselect table must have exactly one column.");
 
-      const auto num_result_rows = result_table->row_count();
-      Assert(num_result_rows != 0, "Subselect returned no results.");
-      Assert(num_result_rows == 1, "Subselect returned more than one row.");
+      Assert(result_table->row_count() == 1, "Subselect returned " + std::to_string(result_table->row_count()) + " rows instead of one");
 
       column_expression->set_subselect_table(result_table);
     }

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   for (const auto& column_expression : _column_expressions) {
     TableColumnDefinition column_definition;
 
-    // For subselects, we need to execeute the subquery in order to use the result table later
+    // For subselects, we need to execute the subquery in order to use the result table later
     if (column_expression->is_subselect() && !column_expression->has_subselect_table()) {
       SQLQueryPlan query_plan;
       query_plan.add_tree_by_root(column_expression->subselect_operator());

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -148,7 +148,8 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       auto result_table = tasks.back()->get_operator()->get_output();
       DebugAssert(result_table->column_count() == 1, "Subselect table must have exactly one column.");
 
-      Assert(result_table->row_count() == 1, "Subselect returned " + std::to_string(result_table->row_count()) + " rows instead of one");
+      Assert(result_table->row_count() == 1,
+             "Subselect returned " + std::to_string(result_table->row_count()) + " rows instead of one");
 
       column_expression->set_subselect_table(result_table);
     }

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -21,8 +21,6 @@ class PQPExpression;
 
 /**
  * Operator to select a subset of the set of all columns found in the table
- *
- * Note: Projection does not support null values at the moment
  */
 class Projection : public AbstractReadOnlyOperator {
  public:

--- a/src/test/operators/recreation_test.cpp
+++ b/src/test/operators/recreation_test.cpp
@@ -14,6 +14,7 @@
 #include "operators/table_scan.hpp"
 #include "operators/table_wrapper.hpp"
 #include "operators/union_positions.hpp"
+#include "sql/sql_pipeline_statement.hpp"
 #include "storage/storage_manager.hpp"
 #include "storage/table.hpp"
 #include "types.hpp"
@@ -172,6 +173,38 @@ TEST_F(RecreationTest, DiamondShape) {
   auto recreated_pqp = union_positions->recreate();
 
   EXPECT_EQ(recreated_pqp->input_left()->input_left(), recreated_pqp->input_right()->input_left());
+}
+
+TEST_F(RecreationTest, Subselect) {
+  // Due to the nested structure of the subselect, it makes sense to keep this more high level than the other tests in
+  // this suite. The test is very confusing and error-prone with explicit operators as above.
+  const auto table = load_table("src/test/tables/int_int_int.tbl", 2);
+  StorageManager::get().add_table("table_3int", table);
+
+  const std::string subselect_query = "SELECT * FROM table_3int WHERE a = (SELECT MAX(b) FROM table_3int)";
+  const TableColumnDefinitions column_definitions = {{"a", DataType::Int}, {"b", DataType::Int}, {"c", DataType::Int}};
+
+  SQLPipelineStatement sql_pipeline{subselect_query, UseMvcc::No};
+  const auto first_result = sql_pipeline.get_result_table();
+
+  // Quick sanity check to see that the original query is correct
+  auto expected_first = std::make_shared<Table>(column_definitions, TableType::Data);
+  expected_first->append({10, 10, 10});
+  EXPECT_TABLE_EQ_UNORDERED(first_result, expected_first);
+
+  SQLPipelineStatement{"INSERT INTO table_3int VALUES (11, 11, 11)"}.get_result_table();
+
+  const auto recreated_plan = sql_pipeline.get_query_plan()->recreate();
+  const auto tasks = recreated_plan.create_tasks();
+  CurrentScheduler::schedule_and_wait_for_tasks(tasks);
+
+  const auto recreated_result = tasks.back()->get_operator()->get_output();
+
+  auto expected_recreated = std::make_shared<Table>(column_definitions, TableType::Data);
+  expected_recreated->append({11, 10, 11});
+  expected_recreated->append({11, 11, 11});
+
+  EXPECT_TABLE_EQ_UNORDERED(recreated_result, expected_recreated);
 }
 
 }  // namespace opossum

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -44,6 +44,9 @@ class SQLPipelineStatementTest : public BaseTest {
     _table_b = load_table("src/test/tables/int_float2.tbl", 2);
     StorageManager::get().add_table("table_b", _table_b);
 
+    _table_int = load_table("src/test/tables/int_int_int.tbl", 2);
+    StorageManager::get().add_table("table_int", _table_int);
+
     TableColumnDefinitions column_definitions;
     column_definitions.emplace_back("a", DataType::Int);
     column_definitions.emplace_back("b", DataType::Float);
@@ -56,6 +59,10 @@ class SQLPipelineStatementTest : public BaseTest {
     _int_float_column_definitions.emplace_back("a", DataType::Int);
     _int_float_column_definitions.emplace_back("b", DataType::Float);
 
+    _int_int_int_column_definitions.emplace_back("a", DataType::Int);
+    _int_int_int_column_definitions.emplace_back("b", DataType::Int);
+    _int_int_int_column_definitions.emplace_back("c", DataType::Int);
+
     _select_parse_result = std::make_shared<hsql::SQLParserResult>();
     hsql::SQLParser::parse(_select_query_a, _select_parse_result.get());
 
@@ -67,9 +74,11 @@ class SQLPipelineStatementTest : public BaseTest {
 
   std::shared_ptr<Table> _table_a;
   std::shared_ptr<Table> _table_b;
+  std::shared_ptr<Table> _table_int;
   std::shared_ptr<Table> _join_result;
 
   TableColumnDefinitions _int_float_column_definitions;
+  TableColumnDefinitions _int_int_int_column_definitions;
 
   const std::string _select_query_a = "SELECT * FROM table_a";
   const std::string _invalid_sql = "SELECT FROM table_a";
@@ -681,6 +690,29 @@ TEST_F(SQLPipelineStatementTest, CacheQueryPlan) {
   const auto& cache = SQLQueryCache<SQLQueryPlan>::get();
   EXPECT_EQ(cache.size(), 1u);
   EXPECT_TRUE(cache.has(_select_query_a));
+}
+
+TEST_F(SQLPipelineStatementTest, RecreateSubselectFromCache) {
+  const std::string subselect_query = "SELECT * FROM table_int WHERE a = (SELECT MAX(b) FROM table_int)";
+
+  SQLPipelineStatement first_subselect_sql_pipeline{subselect_query};
+  const auto first_subselect_result = first_subselect_sql_pipeline.get_result_table();
+
+  auto expected_first_result = std::make_shared<Table>(_int_int_int_column_definitions, TableType::Data);
+  expected_first_result->append({10, 10, 10});
+
+  EXPECT_TABLE_EQ_UNORDERED(first_subselect_result, expected_first_result);
+
+  SQLPipelineStatement{"INSERT INTO table_int VALUES (11, 11, 11)"}.get_result_table();
+
+  SQLPipelineStatement second_subselect_sql_pipeline{subselect_query};
+  const auto second_subselect_result = second_subselect_sql_pipeline.get_result_table();
+
+  auto expected_second_result = std::make_shared<Table>(_int_int_int_column_definitions, TableType::Data);
+  expected_second_result->append({11, 10, 11});
+  expected_second_result->append({11, 11, 11});
+
+  EXPECT_TABLE_EQ_UNORDERED(second_subselect_result, expected_second_result);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
This PR fixes #777. The subselect operator is now also recreated.