### PR TITLE
Increase number of cuckoo hash functions

### DIFF
--- a/src/lib/utils/cuckoo_hashtable.hpp
+++ b/src/lib/utils/cuckoo_hashtable.hpp
@@ -18,7 +18,7 @@ where it is a temporary object for probing. There is no need to delete elements 
 */
 template <typename T>
 class HashTable : private Noncopyable {
-  static const size_t NUMBER_OF_HASH_FUNCTIONS = 3;
+  static const size_t NUMBER_OF_HASH_FUNCTIONS = 4;
 
  public:
   explicit HashTable(size_t input_table_size) : _input_table_size(input_table_size) {


### PR DESCRIPTION
Had this 
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Error while executing tasks:
  src/lib/utils/cuckoo_hashtable.hpp:93 There is a cycle in Cuckoo. Need to rehash with different hash functions
```
thrown at me a few times now in the TPCH benchmark. Increasing the number of hash functions (i.e. cycles?) seems to fix it.