### PR TITLE
Builder pattern for convenient construction of SQLPipeline[Statements]

### DIFF
--- a/src/benchmark/operators/sql_benchmark.cpp
+++ b/src/benchmark/operators/sql_benchmark.cpp
@@ -7,6 +7,7 @@
 #include "logical_query_plan/lqp_translator.hpp"
 #include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql_translator.hpp"
+#include "sql/sql.hpp"
 #include "storage/storage_manager.hpp"
 #include "utils/load_table.hpp"
 
@@ -64,7 +65,7 @@ class SQLBenchmark : public BenchmarkBasicFixture {
     SQLQueryCache<SQLQueryPlan>::get().resize(16);
 
     while (st.KeepRunning()) {
-      SQLPipelineStatement pipeline_statement{query};
+      auto pipeline_statement = SQL{query}.pipeline_statement();
       pipeline_statement.get_query_plan();
     }
   }

--- a/src/benchmark/operators/sql_benchmark.cpp
+++ b/src/benchmark/operators/sql_benchmark.cpp
@@ -5,9 +5,9 @@
 #include "SQLParser.h"
 #include "benchmark/benchmark.h"
 #include "logical_query_plan/lqp_translator.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql_translator.hpp"
-#include "sql/sql.hpp"
 #include "storage/storage_manager.hpp"
 #include "utils/load_table.hpp"
 

--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -11,6 +11,7 @@
 #include "scheduler/current_scheduler.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline.hpp"
 #include "tpch/tpch_db_generator.hpp"
 #include "tpch/tpch_queries.hpp"
@@ -200,7 +201,7 @@ class TpchBenchmark final {
         const auto query_benchmark_begin = std::chrono::steady_clock::now();
 
         // Execute the query, we don't care about the results
-        SQLPipeline{opossum::tpch_queries[query_id], _use_mvcc}.get_result_table();
+        SQL{opossum::tpch_queries[query_id]}.set_use_mvcc(_use_mvcc).pipeline().get_result_table();
 
         const auto query_benchmark_end = std::chrono::steady_clock::now();
 
@@ -221,7 +222,7 @@ class TpchBenchmark final {
       BenchmarkState state{_max_num_query_runs, _max_duration};
       while (state.keep_running()) {
         // Execute the query, we don't care about the results
-        SQLPipeline{sql, _use_mvcc}.get_result_table();
+        SQL{sql}.set_use_mvcc(_use_mvcc).pipeline().get_result_table();
       }
 
       QueryBenchmarkResult result;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -31,6 +31,7 @@
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
 #include "sql/sql_pipeline_statement.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_translator.hpp"
 #include "storage/storage_manager.hpp"
 #include "tpcc/tpcc_table_generator.hpp"
@@ -220,9 +221,9 @@ int Console::_eval_command(const CommandFunction& func, const std::string& comma
 bool Console::_initialize_pipeline(const std::string& sql) {
   try {
     if (_explicitly_created_transaction_context != nullptr) {
-      _sql_pipeline = std::make_unique<SQLPipeline>(sql, _prepared_statements, _explicitly_created_transaction_context);
+      _sql_pipeline = std::make_unique<SQLPipeline>(SQL{sql}.set_prepared_statement_cache(_prepared_statements).set_transaction_context(_explicitly_created_transaction_context).pipeline());
     } else {
-      _sql_pipeline = std::make_unique<SQLPipeline>(sql, _prepared_statements);
+      _sql_pipeline = std::make_unique<SQLPipeline>(SQL{sql}.set_prepared_statement_cache(_prepared_statements).pipeline());
     }
   } catch (const std::exception& exception) {
     out(std::string(exception.what()) + '\n');

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -30,8 +30,8 @@
 #include "scheduler/current_scheduler.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
-#include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql.hpp"
+#include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql_translator.hpp"
 #include "storage/storage_manager.hpp"
 #include "tpcc/tpcc_table_generator.hpp"
@@ -221,9 +221,14 @@ int Console::_eval_command(const CommandFunction& func, const std::string& comma
 bool Console::_initialize_pipeline(const std::string& sql) {
   try {
     if (_explicitly_created_transaction_context != nullptr) {
-      _sql_pipeline = std::make_unique<SQLPipeline>(SQL{sql}.set_prepared_statement_cache(_prepared_statements).set_transaction_context(_explicitly_created_transaction_context).pipeline());
+      _sql_pipeline =
+          std::make_unique<SQLPipeline>(SQL{sql}
+                                            .set_prepared_statement_cache(_prepared_statements)
+                                            .set_transaction_context(_explicitly_created_transaction_context)
+                                            .pipeline());
     } else {
-      _sql_pipeline = std::make_unique<SQLPipeline>(SQL{sql}.set_prepared_statement_cache(_prepared_statements).pipeline());
+      _sql_pipeline =
+          std::make_unique<SQLPipeline>(SQL{sql}.set_prepared_statement_cache(_prepared_statements).pipeline());
     }
   } catch (const std::exception& exception) {
     out(std::string(exception.what()) + '\n');

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -227,6 +227,8 @@ set(
     sql/lru_cache.hpp
     sql/lru_k_cache.hpp
     sql/random_cache.hpp
+    sql/sql.cpp
+    sql/sql.hpp
     sql/sql_pipeline.cpp
     sql/sql_pipeline.hpp
     sql/sql_pipeline_statement.cpp

--- a/src/lib/sql/sql.cpp
+++ b/src/lib/sql/sql.cpp
@@ -1,0 +1,37 @@
+#include "sql.hpp"
+
+namespace opossum {
+
+SQL::SQL(const std::string& sql): _sql(sql) {}
+
+SQL& SQL::set_use_mvcc(const UseMvcc use_mvcc) {
+  _use_mvcc = use_mvcc;
+  return *this;
+}
+
+SQL& SQL::set_optimizer(const std::shared_ptr<Optimizer>& optimizer) {
+  _optimizer = optimizer;
+  return *this;
+}
+
+SQL& SQL::set_prepared_statement_cache(const PreparedStatementCache& prepared_statements) {
+  _prepared_statements = prepared_statements;
+  return *this;
+}
+
+SQL& SQL::set_transaction_context(const std::shared_ptr<TransactionContext>& transaction_context) {
+  _transaction_context = transaction_context;
+  _use_mvcc = UseMvcc::Yes;
+
+  return *this;
+}
+
+SQLPipeline SQL::pipeline() const {
+  return {_sql, _transaction_context, _use_mvcc, _optimizer, _prepared_statements};
+}
+
+SQLPipelineStatement SQL::pipeline_statement() const {
+  return {_sql, nullptr, _use_mvcc, _transaction_context, _optimizer, _prepared_statements};
+}
+
+}  // namespace opossum

--- a/src/lib/sql/sql.cpp
+++ b/src/lib/sql/sql.cpp
@@ -2,7 +2,7 @@
 
 namespace opossum {
 
-SQL::SQL(const std::string& sql): _sql(sql) {}
+SQL::SQL(const std::string& sql) : _sql(sql) {}
 
 SQL& SQL::set_use_mvcc(const UseMvcc use_mvcc) {
   _use_mvcc = use_mvcc;
@@ -26,12 +26,18 @@ SQL& SQL::set_transaction_context(const std::shared_ptr<TransactionContext>& tra
   return *this;
 }
 
+SQL& SQL::disable_mvcc() { return set_use_mvcc(UseMvcc::No); }
+
 SQLPipeline SQL::pipeline() const {
-  return {_sql, _transaction_context, _use_mvcc, _optimizer, _prepared_statements};
+  auto optimizer = _optimizer ? _optimizer : Optimizer::create_default_optimizer();
+
+  return {_sql, _transaction_context, _use_mvcc, optimizer, _prepared_statements};
 }
 
 SQLPipelineStatement SQL::pipeline_statement() const {
-  return {_sql, nullptr, _use_mvcc, _transaction_context, _optimizer, _prepared_statements};
+  auto optimizer = _optimizer ? _optimizer : Optimizer::create_default_optimizer();
+
+  return {_sql, nullptr, _use_mvcc, _transaction_context, optimizer, _prepared_statements};
 }
 
 }  // namespace opossum

--- a/src/lib/sql/sql.hpp
+++ b/src/lib/sql/sql.hpp
@@ -13,9 +13,7 @@ namespace opossum {
 class Optimizer;
 
 /**
- * Builder for SQLPipeline[Statement]s with configuration options. Favour this interface over calling the
- * SQLPipeline[Statement] constructors with their long parameter list. See SQLPipeline[Statement] doc for these classes,
- * in short SQLPipeline ist for queries with multiple statement, SQLPipelineStatement for single statement queries.
+ * Interface for the configured execution of SQL.
  *
  * Minimal usage:
  *      SQL{"SELECT * FROM t;"}.pipeline().get_result_table()
@@ -29,6 +27,10 @@ class Optimizer;
  * Defaults:
  *  - MVCC is enabled
  *  - The default Optimizer (Optimizer::create_default_optimizer() is used.
+ *
+ * Favour this interface over calling the SQLPipeline[Statement] constructors with their long parameter list.
+ * See SQLPipeline[Statement] doc for these classes, in short SQLPipeline ist for queries with multiple statement,
+ * SQLPipelineStatement for single statement queries.
  */
 class SQL final {
  public:

--- a/src/lib/sql/sql.hpp
+++ b/src/lib/sql/sql.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "types.hpp"
+
+#include "sql_pipeline.hpp"
+#include "sql_pipeline_statement.hpp"
+
+namespace opossum {
+
+class Optimizer;
+
+/**
+ * Builder for SQLPipeline[Statement]s with configuration options.
+ *
+ *
+ */
+class SQL final {
+ public:
+  explicit SQL(const std::string& sql);
+
+  SQL& set_use_mvcc(const UseMvcc use_mvcc);
+  SQL& set_optimizer(const std::shared_ptr<Optimizer>& optimizer);
+  SQL& set_prepared_statement_cache(const PreparedStatementCache& prepared_statements);
+  SQL& set_transaction_context(const std::shared_ptr<TransactionContext>& transaction_context);
+
+  SQLPipeline pipeline() const;
+  SQLPipelineStatement pipeline_statement() const;
+
+ private:
+  const std::string _sql;
+
+  UseMvcc _use_mvcc{UseMvcc::No};
+  std::shared_ptr<TransactionContext> _transaction_context;
+  std::shared_ptr<Optimizer> _optimizer;
+  PreparedStatementCache _prepared_statements;
+};
+
+}  // namespace opossum

--- a/src/lib/sql/sql.hpp
+++ b/src/lib/sql/sql.hpp
@@ -13,9 +13,22 @@ namespace opossum {
 class Optimizer;
 
 /**
- * Builder for SQLPipeline[Statement]s with configuration options.
+ * Builder for SQLPipeline[Statement]s with configuration options. Favour this interface over calling the
+ * SQLPipeline[Statement] constructors with their long parameter list. See SQLPipeline[Statement] doc for these classes,
+ * in short SQLPipeline ist for queries with multiple statement, SQLPipelineStatement for single statement queries.
  *
+ * Minimal usage:
+ *      SQL{"SELECT * FROM t;"}.pipeline().get_result_table()
  *
+ * With custom Optimizer and TransactionContext:
+ *      SQL{query}.
+ *          set_optimizer(optimizer).
+ *          set_transaction_context(tc).
+ *          pipeline();
+ *
+ * Defaults:
+ *  - MVCC is enabled
+ *  - The default Optimizer (Optimizer::create_default_optimizer() is used.
  */
 class SQL final {
  public:
@@ -26,13 +39,18 @@ class SQL final {
   SQL& set_prepared_statement_cache(const PreparedStatementCache& prepared_statements);
   SQL& set_transaction_context(const std::shared_ptr<TransactionContext>& transaction_context);
 
+  /**
+   * Short for set_use_mvcc(UseMvcc::No)
+   */
+  SQL& disable_mvcc();
+
   SQLPipeline pipeline() const;
   SQLPipelineStatement pipeline_statement() const;
 
  private:
   const std::string _sql;
 
-  UseMvcc _use_mvcc{UseMvcc::No};
+  UseMvcc _use_mvcc{UseMvcc::Yes};
   std::shared_ptr<TransactionContext> _transaction_context;
   std::shared_ptr<Optimizer> _optimizer;
   PreparedStatementCache _prepared_statements;

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -8,8 +8,8 @@ namespace opossum {
 SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context,
                          const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
                          const PreparedStatementCache& prepared_statements)
-: _transaction_context(transaction_context), _optimizer(optimizer) {
-  DebugAssert(transaction_context->phase() == TransactionPhase::Active,
+    : _transaction_context(transaction_context), _optimizer(optimizer) {
+  DebugAssert(!_transaction_context || _transaction_context->phase() == TransactionPhase::Active,
               "The transaction context cannot have been committed already.");
   DebugAssert(!_transaction_context || use_mvcc == UseMvcc::Yes,
               "Transaction context without MVCC enabled makes no sense");
@@ -66,7 +66,7 @@ SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<TransactionCont
     sql_string_offset += statement_string_length;
 
     auto pipeline_statement = std::make_shared<SQLPipelineStatement>(
-    statement_string, std::move(parsed_statement), use_mvcc, transaction_context, optimizer, prepared_statements);
+        statement_string, std::move(parsed_statement), use_mvcc, transaction_context, optimizer, prepared_statements);
     _sql_pipeline_statements.push_back(std::move(pipeline_statement));
   }
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -5,55 +5,15 @@
 
 namespace opossum {
 
-// No explicit transaction context constructors
-SQLPipeline::SQLPipeline(const std::string& sql, const UseMvcc use_mvcc)
-    : SQLPipeline(sql, Optimizer::create_default_optimizer(), nullptr, use_mvcc) {}
-
-SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer, const UseMvcc use_mvcc)
-    : SQLPipeline(sql, optimizer, nullptr, use_mvcc) {
-  DebugAssert(optimizer != nullptr, "Cannot pass nullptr as explicit optimizer.");
-}
-
-SQLPipeline::SQLPipeline(const std::string& sql, const PreparedStatementCache& prepared_statements,
-                         const UseMvcc use_mvcc)
-    : SQLPipeline(sql, Optimizer::create_default_optimizer(), prepared_statements, use_mvcc) {
-  DebugAssert(prepared_statements != nullptr, "Cannot pass nullptr as explicit prepared statement cache.");
-}
-
-SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                         const PreparedStatementCache& prepared_statements, const UseMvcc use_mvcc)
-    : SQLPipeline(sql, nullptr, use_mvcc, optimizer, prepared_statements) {}
-
-// Explicit transaction context constructors
-SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<opossum::TransactionContext> transaction_context)
-    : SQLPipeline(sql, Optimizer::create_default_optimizer(), nullptr, std::move(transaction_context)) {}
-
-SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                         std::shared_ptr<opossum::TransactionContext> transaction_context)
-    : SQLPipeline(sql, optimizer, nullptr, std::move(transaction_context)) {
-  DebugAssert(optimizer != nullptr, "Cannot pass nullptr as explicit optimizer.");
-}
-
-SQLPipeline::SQLPipeline(const std::string& sql, const PreparedStatementCache& prepared_statements,
-                         std::shared_ptr<opossum::TransactionContext> transaction_context)
-    : SQLPipeline(sql, Optimizer::create_default_optimizer(), prepared_statements, std::move(transaction_context)) {
-  DebugAssert(prepared_statements != nullptr, "Cannot pass nullptr as explicit prepared statement cache.");
-}
-
-SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                         const PreparedStatementCache& prepared_statements,
-                         std::shared_ptr<opossum::TransactionContext> transaction_context)
-    : SQLPipeline(sql, transaction_context, UseMvcc::Yes, optimizer, prepared_statements) {
-  DebugAssert(transaction_context != nullptr, "Cannot pass nullptr as explicit transaction context.");
-  DebugAssert(transaction_context->phase() == TransactionPhase::Active,
-              "The transaction context cannot have been committed already.");
-}
-
-// Private constructor
 SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context,
                          const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
                          const PreparedStatementCache& prepared_statements)
-    : _transaction_context(transaction_context), _optimizer(optimizer) {
+: _transaction_context(transaction_context), _optimizer(optimizer) {
+  DebugAssert(transaction_context->phase() == TransactionPhase::Active,
+              "The transaction context cannot have been committed already.");
+  DebugAssert(!_transaction_context || use_mvcc == UseMvcc::Yes,
+              "Transaction context without MVCC enabled makes no sense");
+
   hsql::SQLParserResult parse_result;
   try {
     hsql::SQLParser::parse(sql, &parse_result);
@@ -106,7 +66,7 @@ SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<TransactionCont
     sql_string_offset += statement_string_length;
 
     auto pipeline_statement = std::make_shared<SQLPipelineStatement>(
-        statement_string, std::move(parsed_statement), use_mvcc, transaction_context, optimizer, prepared_statements);
+    statement_string, std::move(parsed_statement), use_mvcc, transaction_context, optimizer, prepared_statements);
     _sql_pipeline_statements.push_back(std::move(pipeline_statement));
   }
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -32,6 +32,7 @@ namespace opossum {
  */
 class SQLPipeline : public Noncopyable {
  public:
+  // Prefer using the SQL builder interface for constructing SQLPipelines conveniently
   SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context, const UseMvcc use_mvcc,
               const std::shared_ptr<Optimizer>& optimizer, const PreparedStatementCache& prepared_statements);
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -32,30 +32,8 @@ namespace opossum {
  */
 class SQLPipeline : public Noncopyable {
  public:
-  // No explicit transaction context constructors
-  explicit SQLPipeline(const std::string& sql, const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-              const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  SQLPipeline(const std::string& sql, const PreparedStatementCache& prepared_statements,
-              const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-              const PreparedStatementCache& prepared_statements, const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  // Explicit transaction context constructors
-  SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context);
-
-  SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-              std::shared_ptr<TransactionContext> transaction_context);
-
-  SQLPipeline(const std::string& sql, const PreparedStatementCache& prepared_statements,
-              std::shared_ptr<TransactionContext> transaction_context);
-
-  SQLPipeline(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-              const PreparedStatementCache& prepared_statements,
-              std::shared_ptr<TransactionContext> transaction_context);
+  SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context, const UseMvcc use_mvcc,
+              const std::shared_ptr<Optimizer>& optimizer, const PreparedStatementCache& prepared_statements);
 
   // Returns the SQL string for each statement.
   const std::vector<std::string>& get_sql_strings();
@@ -100,9 +78,6 @@ class SQLPipeline : public Noncopyable {
   std::chrono::microseconds execution_time_microseconds();
 
  private:
-  SQLPipeline(const std::string& sql, std::shared_ptr<TransactionContext> transaction_context, const UseMvcc use_mvcc,
-              const std::shared_ptr<Optimizer>& optimizer, const PreparedStatementCache& prepared_statements);
-
   std::vector<std::shared_ptr<SQLPipelineStatement>> _sql_pipeline_statements;
 
   std::shared_ptr<TransactionContext> _transaction_context;
@@ -116,13 +91,14 @@ class SQLPipeline : public Noncopyable {
   std::vector<std::shared_ptr<SQLQueryPlan>> _query_plans;
   std::vector<std::vector<std::shared_ptr<OperatorTask>>> _tasks;
   std::shared_ptr<const Table> _result_table;
+
   // Indicates whether get_result_table has been run successfully
-  bool _pipeline_was_executed = false;
+  bool _pipeline_was_executed{false};
 
   // Indicates whether translating a statement in the pipeline requires the execution of a previous statement
   // e.g. CREATE VIEW foo AS SELECT * FROM bar; SELECT * FROM foo;
   // --> requires execution of first statement before the second one can be translated
-  bool _requires_execution;
+  bool _requires_execution{false};
 
   std::shared_ptr<SQLPipelineStatement> _failed_pipeline_statement;
 

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -12,61 +12,11 @@
 #include "scheduler/current_scheduler.hpp"
 #include "sql/hsql_expr_translator.hpp"
 #include "sql/sql_query_plan.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_translator.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const UseMvcc use_mvcc)
-    : SQLPipelineStatement(sql, Optimizer::create_default_optimizer(), nullptr, use_mvcc) {}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                                           const UseMvcc use_mvcc)
-    : SQLPipelineStatement(sql, optimizer, nullptr, use_mvcc) {
-  DebugAssert(optimizer != nullptr, "Cannot pass nullptr as explicit optimizer.");
-}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const PreparedStatementCache& prepared_statements,
-                                           const UseMvcc use_mvcc)
-    : SQLPipelineStatement(sql, Optimizer::create_default_optimizer(), prepared_statements, use_mvcc) {
-  DebugAssert(prepared_statements != nullptr, "Cannot pass nullptr as explicit prepared statement cache.");
-}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                                           const PreparedStatementCache& prepared_statements, const UseMvcc use_mvcc)
-    : _sql_string(sql),
-      _use_mvcc(use_mvcc),
-      _auto_commit(_use_mvcc == UseMvcc::Yes),
-      _optimizer(optimizer),
-      _prepared_statements(prepared_statements) {}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql,
-                                           const std::shared_ptr<TransactionContext>& transaction_context)
-    : SQLPipelineStatement(sql, Optimizer::create_default_optimizer(), nullptr, transaction_context) {}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                                           const std::shared_ptr<TransactionContext>& transaction_context)
-    : SQLPipelineStatement(sql, optimizer, nullptr, transaction_context) {
-  DebugAssert(optimizer != nullptr, "Cannot pass nullptr as explicit optimizer.");
-}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const PreparedStatementCache& prepared_statements,
-                                           const std::shared_ptr<TransactionContext>& transaction_context)
-    : SQLPipelineStatement(sql, Optimizer::create_default_optimizer(), prepared_statements, transaction_context) {
-  DebugAssert(prepared_statements != nullptr, "Cannot pass nullptr as explicit prepared statement cache.");
-}
-
-SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                                           const PreparedStatementCache& prepared_statements,
-                                           const std::shared_ptr<TransactionContext>& transaction_context)
-    : _sql_string(sql),
-      _use_mvcc(UseMvcc::Yes),
-      _auto_commit(false),
-      _transaction_context(transaction_context),
-      _optimizer(optimizer),
-      _prepared_statements(prepared_statements) {
-  DebugAssert(transaction_context != nullptr, "Cannot pass nullptr as explicit transaction context.");
-}
 
 SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, std::shared_ptr<hsql::SQLParserResult> parsed_sql,
                                            const UseMvcc use_mvcc,
@@ -81,8 +31,9 @@ SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, std::shared_p
       _parsed_sql_statement(std::move(parsed_sql)),
       _prepared_statements(prepared_statements) {
   DebugAssert(!_sql_string.empty(), "An SQLPipelineStatement should always contain a SQL statement string for caching");
-  Assert(_parsed_sql_statement->size() == 1, "SQLPipelineStatement must hold exactly one SQL statement");
-  DebugAssert(!_transaction_context || _use_mvcc == UseMvcc::Yes,
+  DebugAssert(transaction_context->phase() == TransactionPhase::Active,
+              "The transaction context cannot have been committed already.");
+  DebugAssert(!_transaction_context || use_mvcc == UseMvcc::Yes,
               "Transaction context without MVCC enabled makes no sense");
 }
 
@@ -126,7 +77,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
     // If this is as PreparedStatement, we want to translate the actual query and not the PREPARE FROM ... part.
     // However, that part is not yet parsed, so we need to parse the raw string from the PreparedStatement.
     Assert(_prepared_statements, "Cannot prepare statement without prepared statement cache.");
-    parsed_sql = SQLPipelineStatement(prepared_statement->query).get_parsed_sql_statement();
+    parsed_sql = SQL{prepared_statement->query}.pipeline_statement().get_parsed_sql_statement();
     _num_parameters = static_cast<uint16_t>(parsed_sql->parameters().size());
   }
 

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -11,8 +11,8 @@
 #include "optimizer/optimizer.hpp"
 #include "scheduler/current_scheduler.hpp"
 #include "sql/hsql_expr_translator.hpp"
-#include "sql/sql_query_plan.hpp"
 #include "sql/sql.hpp"
+#include "sql/sql_query_plan.hpp"
 #include "sql/sql_translator.hpp"
 #include "utils/assert.hpp"
 
@@ -30,8 +30,10 @@ SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, std::shared_p
       _optimizer(optimizer),
       _parsed_sql_statement(std::move(parsed_sql)),
       _prepared_statements(prepared_statements) {
+  Assert(!_parsed_sql_statement || _parsed_sql_statement->size() == 1,
+         "SQLPipelineStatement must hold exactly one SQL statement");
   DebugAssert(!_sql_string.empty(), "An SQLPipelineStatement should always contain a SQL statement string for caching");
-  DebugAssert(transaction_context->phase() == TransactionPhase::Active,
+  DebugAssert(!_transaction_context || transaction_context->phase() == TransactionPhase::Active,
               "The transaction context cannot have been committed already.");
   DebugAssert(!_transaction_context || use_mvcc == UseMvcc::Yes,
               "Transaction context without MVCC enabled makes no sense");

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -31,6 +31,7 @@ using PreparedStatementCache = std::shared_ptr<SQLQueryCache<SQLQueryPlan>>;
  */
 class SQLPipelineStatement : public Noncopyable {
  public:
+  // Prefer using the SQL builder interface for constructing SQLPipelineStatements conveniently
   SQLPipelineStatement(const std::string& sql, std::shared_ptr<hsql::SQLParserResult> parsed_sql,
                        const UseMvcc use_mvcc, const std::shared_ptr<TransactionContext>& transaction_context,
                        const std::shared_ptr<Optimizer>& optimizer, const PreparedStatementCache& prepared_statements);

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -31,34 +31,6 @@ using PreparedStatementCache = std::shared_ptr<SQLQueryCache<SQLQueryPlan>>;
  */
 class SQLPipelineStatement : public Noncopyable {
  public:
-  // Constructors for creation from SQL string
-  explicit SQLPipelineStatement(const std::string& sql, const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  // No explicit transaction context constructors
-  SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                       const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  SQLPipelineStatement(const std::string& sql, const PreparedStatementCache& prepared_statements,
-                       const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                       const PreparedStatementCache& prepared_statements, const UseMvcc use_mvcc = UseMvcc::Yes);
-
-  // Explicit transaction context constructors
-  SQLPipelineStatement(const std::string& sql, const std::shared_ptr<TransactionContext>& transaction_context);
-
-  SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                       const std::shared_ptr<TransactionContext>& transaction_context);
-
-  SQLPipelineStatement(const std::string& sql, const PreparedStatementCache& prepared_statements,
-                       const std::shared_ptr<TransactionContext>& transaction_context);
-
-  SQLPipelineStatement(const std::string& sql, const std::shared_ptr<Optimizer>& optimizer,
-                       const PreparedStatementCache& prepared_statements,
-                       const std::shared_ptr<TransactionContext>& transaction_context);
-
-  // Constructor for creation from SQLParseResult statement.
-  // This should be called from SQLPipeline and not by the user directly.
   SQLPipelineStatement(const std::string& sql, std::shared_ptr<hsql::SQLParserResult> parsed_sql,
                        const UseMvcc use_mvcc, const std::shared_ptr<TransactionContext>& transaction_context,
                        const std::shared_ptr<Optimizer>& optimizer, const PreparedStatementCache& prepared_statements);

--- a/src/test/optimizer/strategy/constant_calculation_rule_test.cpp
+++ b/src/test/optimizer/strategy/constant_calculation_rule_test.cpp
@@ -14,11 +14,12 @@
 #include "optimizer/strategy/constant_calculation_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
 #include "sql/sql_pipeline.hpp"
+#include "sql/sql.hpp"
 #include "storage/storage_manager.hpp"
 
 namespace {
 std::shared_ptr<opossum::AbstractLQPNode> compile_query(const std::string& query) {
-  return opossum::SQLPipeline{query, opossum::UseMvcc::No}.get_unoptimized_logical_plans().at(0);
+  return opossum::SQL{query}.pipeline().get_unoptimized_logical_plans().at(0);
 }
 }  // namespace
 

--- a/src/test/optimizer/strategy/constant_calculation_rule_test.cpp
+++ b/src/test/optimizer/strategy/constant_calculation_rule_test.cpp
@@ -13,13 +13,13 @@
 #include "logical_query_plan/stored_table_node.hpp"
 #include "optimizer/strategy/constant_calculation_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
-#include "sql/sql_pipeline.hpp"
 #include "sql/sql.hpp"
+#include "sql/sql_pipeline.hpp"
 #include "storage/storage_manager.hpp"
 
 namespace {
 std::shared_ptr<opossum::AbstractLQPNode> compile_query(const std::string& query) {
-  return opossum::SQL{query}.pipeline().get_unoptimized_logical_plans().at(0);
+  return opossum::SQL{query}.disable_mvcc().pipeline().get_unoptimized_logical_plans().at(0);
 }
 }  // namespace
 

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -15,6 +15,7 @@
 #include "scheduler/job_task.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline.hpp"
 #include "storage/storage_manager.hpp"
 
@@ -77,14 +78,14 @@ class SQLPipelineTest : public BaseTest {
 };
 
 TEST_F(SQLPipelineTest, SimpleCreation) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
   EXPECT_EQ(sql_pipeline.statement_count(), 1u);
 }
 
 TEST_F(SQLPipelineTest, SimpleCreationWithoutMVCC) {
-  SQLPipeline sql_pipeline{_select_query_a, UseMvcc::No};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline(),
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
   EXPECT_EQ(sql_pipeline.statement_count(), 1u);
@@ -92,21 +93,21 @@ TEST_F(SQLPipelineTest, SimpleCreationWithoutMVCC) {
 
 TEST_F(SQLPipelineTest, SimpleCreationWithCustomTransactionContext) {
   auto context = TransactionManager::get().new_transaction_context();
-  SQLPipeline sql_pipeline{_select_query_a, context};
+  auto sql_pipeline = SQL{_select_query_a}.set_transaction_context(context).pipeline();
 
   EXPECT_EQ(sql_pipeline.transaction_context().get(), context.get());
   EXPECT_EQ(sql_pipeline.statement_count(), 1u);
 }
 
 TEST_F(SQLPipelineTest, SimpleCreationMulti) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
   EXPECT_EQ(sql_pipeline.statement_count(), 2u);
 }
 
 TEST_F(SQLPipelineTest, SimpleCreationWithoutMVCCMulti) {
-  SQLPipeline sql_pipeline{_multi_statement_query, UseMvcc::No};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
 
   EXPECT_EQ(sql_pipeline.transaction_context(), nullptr);
   EXPECT_EQ(sql_pipeline.statement_count(), 2u);
@@ -114,14 +115,14 @@ TEST_F(SQLPipelineTest, SimpleCreationWithoutMVCCMulti) {
 
 TEST_F(SQLPipelineTest, SimpleCreationWithCustomTransactionContextMulti) {
   auto context = TransactionManager::get().new_transaction_context();
-  SQLPipeline sql_pipeline{_multi_statement_query, context};
+  auto sql_pipeline = SQL{}.pipeline(); _multi_statement_query, context;
 
   EXPECT_EQ(sql_pipeline.transaction_context().get(), context.get());
   EXPECT_EQ(sql_pipeline.statement_count(), 2u);
 }
 
 TEST_F(SQLPipelineTest, SimpleCreationInvalid) {
-  EXPECT_THROW(SQLPipeline sql_pipeline{_multi_statement_invalid}, std::exception);
+  EXPECT_THROW(auto sql_pipeline = SQL{_multi_statement_invalid}.pipeline(), std::exception);
 }
 
 TEST_F(SQLPipelineTest, ConstructorCombinations) {
@@ -131,18 +132,18 @@ TEST_F(SQLPipelineTest, ConstructorCombinations) {
   auto transaction_context = TransactionManager::get().new_transaction_context();
 
   // No transaction context
-  EXPECT_NO_THROW(SQLPipeline(_select_query_a, optimizer, UseMvcc::Yes));
-  EXPECT_NO_THROW(SQLPipeline(_select_query_a, prepared_cache, UseMvcc::No));
-  EXPECT_NO_THROW(SQLPipeline(_select_query_a, optimizer, prepared_cache, UseMvcc::Yes));
+  EXPECT_NO_THROW(SQL(_select_query_a).set_optimizer(optimizer).set_use_mvcc(UseMvcc::Yes).pipeline());
+  EXPECT_NO_THROW(SQL(_select_query_a).set_prepared_statement_cache(prepared_cache).set_use_mvcc(UseMvcc::No).pipeline());
+  EXPECT_NO_THROW(SQL(_select_query_a).set_optimizer(optimizer).set_prepared_statement_cache(prepared_cache).set_use_mvcc(UseMvcc::Yes).pipeline());
 
   // With transaction context
-  EXPECT_NO_THROW(SQLPipeline(_select_query_a, optimizer, transaction_context));
-  EXPECT_NO_THROW(SQLPipeline(_select_query_a, prepared_cache, transaction_context));
-  EXPECT_NO_THROW(SQLPipeline(_select_query_a, optimizer, prepared_cache, transaction_context));
+  EXPECT_NO_THROW(SQL(_select_query_a).set_transaction_context(transaction_context).set_optimizer(optimizer).set_use_mvcc(UseMvcc::Yes).pipeline());
+  EXPECT_NO_THROW(SQL(_select_query_a).set_transaction_context(transaction_context).set_prepared_statement_cache(prepared_cache).set_use_mvcc(UseMvcc::No).pipeline());
+  EXPECT_NO_THROW(SQL(_select_query_a).set_transaction_context(transaction_context).set_optimizer(optimizer).set_prepared_statement_cache(prepared_cache).set_use_mvcc(UseMvcc::Yes).pipeline());
 }
 
 TEST_F(SQLPipelineTest, GetParsedSQLStatements) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
   const auto& parsed_sql_statements = sql_pipeline.get_parsed_sql_statements();
 
   EXPECT_EQ(parsed_sql_statements.size(), 1u);
@@ -150,12 +151,12 @@ TEST_F(SQLPipelineTest, GetParsedSQLStatements) {
 }
 
 TEST_F(SQLPipelineTest, GetParsedSQLStatementsExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependent};
+  auto sql_pipeline = SQL{_multi_statement_dependent}.pipeline();
   EXPECT_NO_THROW(sql_pipeline.get_parsed_sql_statements());
 }
 
 TEST_F(SQLPipelineTest, GetParsedSQLStatementsMultiple) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
   const auto& parsed_sql_statements = sql_pipeline.get_parsed_sql_statements();
 
   EXPECT_EQ(parsed_sql_statements.size(), 2u);
@@ -164,21 +165,21 @@ TEST_F(SQLPipelineTest, GetParsedSQLStatementsMultiple) {
 }
 
 TEST_F(SQLPipelineTest, GetUnoptimizedLQPs) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
   const auto& lqps = sql_pipeline.get_unoptimized_logical_plans();
 
   EXPECT_EQ(lqps.size(), 1u);
 }
 
 TEST_F(SQLPipelineTest, GetUnoptimizedLQPsMultiple) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
   const auto& lqps = sql_pipeline.get_unoptimized_logical_plans();
 
   EXPECT_EQ(lqps.size(), 2u);
 }
 
 TEST_F(SQLPipelineTest, GetUnoptimizedLQPTwice) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   sql_pipeline.get_unoptimized_logical_plans();
   const auto& lqps = sql_pipeline.get_unoptimized_logical_plans();
@@ -187,7 +188,7 @@ TEST_F(SQLPipelineTest, GetUnoptimizedLQPTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetUnoptimizedLQPExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependent};
+  auto sql_pipeline = SQL{_multi_statement_dependent}.pipeline();
 
   try {
     sql_pipeline.get_unoptimized_logical_plans();
@@ -201,7 +202,7 @@ TEST_F(SQLPipelineTest, GetUnoptimizedLQPExecutionRequired) {
 }
 
 TEST_F(SQLPipelineTest, GetOptimizedLQP) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   const auto& lqps = sql_pipeline.get_optimized_logical_plans();
 
@@ -209,14 +210,14 @@ TEST_F(SQLPipelineTest, GetOptimizedLQP) {
 }
 
 TEST_F(SQLPipelineTest, GetOptimizedLQPsMultiple) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
   const auto& lqps = sql_pipeline.get_optimized_logical_plans();
 
   EXPECT_EQ(lqps.size(), 2u);
 }
 
 TEST_F(SQLPipelineTest, GetOptimizedLQPTwice) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   sql_pipeline.get_unoptimized_logical_plans();
   const auto& lqps = sql_pipeline.get_optimized_logical_plans();
@@ -225,7 +226,7 @@ TEST_F(SQLPipelineTest, GetOptimizedLQPTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetOptimizedLQPExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependent};
+  auto sql_pipeline = SQL{_multi_statement_dependent}.pipeline();
 
   try {
     sql_pipeline.get_optimized_logical_plans();
@@ -239,21 +240,21 @@ TEST_F(SQLPipelineTest, GetOptimizedLQPExecutionRequired) {
 }
 
 TEST_F(SQLPipelineTest, GetQueryPlans) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
   const auto& plans = sql_pipeline.get_query_plans();
 
   EXPECT_EQ(plans.size(), 1u);
 }
 
 TEST_F(SQLPipelineTest, GetQueryPlansMultiple) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
   const auto& plans = sql_pipeline.get_query_plans();
 
   EXPECT_EQ(plans.size(), 2u);
 }
 
 TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   sql_pipeline.get_query_plans();
   auto duration = sql_pipeline.compile_time_microseconds();
@@ -267,7 +268,7 @@ TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetQueryPlansExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependent};
+  auto sql_pipeline = SQL{_multi_statement_dependent}.pipeline();
   try {
     sql_pipeline.get_query_plans();
     // Fail if this did not throw an exception
@@ -280,21 +281,21 @@ TEST_F(SQLPipelineTest, GetQueryPlansExecutionRequired) {
 }
 
 TEST_F(SQLPipelineTest, GetTasks) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
   const auto& tasks = sql_pipeline.get_tasks();
 
   EXPECT_EQ(tasks.size(), 1u);
 }
 
 TEST_F(SQLPipelineTest, GetTasksMultiple) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{_multi_statement_query}.pipeline();
   const auto& tasks = sql_pipeline.get_tasks();
 
   EXPECT_EQ(tasks.size(), 2u);
 }
 
 TEST_F(SQLPipelineTest, GetTasksTwice) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   sql_pipeline.get_tasks();
   const auto& tasks = sql_pipeline.get_tasks();
@@ -303,7 +304,7 @@ TEST_F(SQLPipelineTest, GetTasksTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetTasksExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependent};
+  auto sql_pipeline = SQL{_multi_statement_dependent}.pipeline();
 
   try {
     sql_pipeline.get_tasks();
@@ -317,21 +318,21 @@ TEST_F(SQLPipelineTest, GetTasksExecutionRequired) {
 }
 
 TEST_F(SQLPipelineTest, GetResultTable) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
   const auto& table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ_UNORDERED(table, _table_a)
 }
 
 TEST_F(SQLPipelineTest, GetResultTableMultiple) {
-  SQLPipeline sql_pipeline{_multi_statement_query};
+  auto sql_pipeline = SQL{}.pipeline(); _multi_statement_query;
   const auto& table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ_UNORDERED(table, _table_a_multi)
 }
 
 TEST_F(SQLPipelineTest, GetResultTableTwice) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   sql_pipeline.get_result_table();
   auto duration = sql_pipeline.execution_time_microseconds();
@@ -345,14 +346,14 @@ TEST_F(SQLPipelineTest, GetResultTableTwice) {
 }
 
 TEST_F(SQLPipelineTest, GetResultTableExecutionRequired) {
-  SQLPipeline sql_pipeline{_multi_statement_dependent};
+  auto sql_pipeline = SQL{_multi_statement_dependent}.pipeline();
   const auto& table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ_UNORDERED(table, _table_a)
 }
 
 TEST_F(SQLPipelineTest, GetResultTableWithScheduler) {
-  SQLPipeline sql_pipeline{_join_query};
+  auto sql_pipeline = SQL{_join_query}.pipeline();
 
   CurrentScheduler::set(std::make_shared<NodeQueueScheduler>(Topology::create_fake_numa_topology(8, 4)));
   const auto& table = sql_pipeline.get_result_table();
@@ -362,14 +363,14 @@ TEST_F(SQLPipelineTest, GetResultTableWithScheduler) {
 
 TEST_F(SQLPipelineTest, GetResultTableBadQuery) {
   auto sql = "SELECT a + b FROM table_a";
-  SQLPipeline sql_pipeline{sql};
+  auto sql_pipeline = SQL{sql}.pipeline();
 
   EXPECT_THROW(sql_pipeline.get_result_table(), std::exception);
 }
 
 TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
   const auto sql = "UPDATE table_a SET a = 1 WHERE a < 150";
-  SQLPipeline sql_pipeline{sql};
+  auto sql_pipeline = SQL{sql}.pipeline();
 
   const auto& table = sql_pipeline.get_result_table();
   EXPECT_EQ(table, nullptr);
@@ -380,7 +381,7 @@ TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
 }
 
 TEST_F(SQLPipelineTest, GetTimes) {
-  SQLPipeline sql_pipeline{_select_query_a};
+  auto sql_pipeline = SQL{_select_query_a}.pipeline();
 
   EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
@@ -393,7 +394,7 @@ TEST_F(SQLPipelineTest, GetTimes) {
 }
 
 TEST_F(SQLPipelineTest, GetFailedPipelineUnoptimizedLQPs) {
-  SQLPipeline sql_pipeline{_fail_query};
+  auto sql_pipeline = SQL{_fail_query}.pipeline();
 
   try {
     sql_pipeline.get_unoptimized_logical_plans();
@@ -405,7 +406,7 @@ TEST_F(SQLPipelineTest, GetFailedPipelineUnoptimizedLQPs) {
 }
 
 TEST_F(SQLPipelineTest, GetFailedPipelineOptimizedLQPs) {
-  SQLPipeline sql_pipeline{_fail_query};
+  auto sql_pipeline = SQL{_fail_query}.pipeline();
 
   try {
     sql_pipeline.get_optimized_logical_plans();
@@ -417,7 +418,7 @@ TEST_F(SQLPipelineTest, GetFailedPipelineOptimizedLQPs) {
 }
 
 TEST_F(SQLPipelineTest, GetFailedPipelineGueryPlans) {
-  SQLPipeline sql_pipeline{_fail_query};
+  auto sql_pipeline = SQL{_fail_query}.pipeline();
 
   try {
     sql_pipeline.get_query_plans();
@@ -429,7 +430,7 @@ TEST_F(SQLPipelineTest, GetFailedPipelineGueryPlans) {
 }
 
 TEST_F(SQLPipelineTest, GetFailedPipelineResultTable) {
-  SQLPipeline sql_pipeline{_fail_query};
+  auto sql_pipeline = SQL{_fail_query}.pipeline();
 
   try {
     sql_pipeline.get_result_table();
@@ -441,45 +442,45 @@ TEST_F(SQLPipelineTest, GetFailedPipelineResultTable) {
 }
 
 TEST_F(SQLPipelineTest, RequiresExecutionVariations) {
-  EXPECT_FALSE(SQLPipeline{_select_query_a}.requires_execution());
-  EXPECT_FALSE(SQLPipeline{_join_query}.requires_execution());
-  EXPECT_FALSE(SQLPipeline{_multi_statement_query}.requires_execution());
-  EXPECT_TRUE(SQLPipeline{_multi_statement_dependent}.requires_execution());
+  EXPECT_FALSE(SQL{_select_query_a}.pipeline().requires_execution());
+  EXPECT_FALSE(SQL{_join_query}.pipeline().requires_execution());
+  EXPECT_FALSE(SQL{_multi_statement_query}.pipeline().requires_execution());
+  EXPECT_TRUE(SQL{_multi_statement_dependent}.pipeline().requires_execution());
 
   const std::string create_view_single = "CREATE VIEW blub AS SELECT * FROM foo;";
-  EXPECT_FALSE(SQLPipeline{create_view_single}.requires_execution());
+  EXPECT_FALSE(SQL{create_view_single}.pipeline().requires_execution());
 
   const std::string create_view_multi_reverse = "SELECT * FROM blub; " + create_view_single;
-  EXPECT_TRUE(SQLPipeline{create_view_multi_reverse}.requires_execution());
+  EXPECT_TRUE(SQL{create_view_multi_reverse}.pipeline().requires_execution());
 
   const std::string create_view_multi_middle = create_view_multi_reverse + " SELECT * FROM foo;";
-  EXPECT_TRUE(SQLPipeline{create_view_multi_reverse}.requires_execution());
+  EXPECT_TRUE(SQL{create_view_multi_reverse}.pipeline().requires_execution());
 
   const std::string create_table_single = "CREATE TABLE foo2 (c int);";
-  EXPECT_FALSE(SQLPipeline{create_table_single}.requires_execution());
+  EXPECT_FALSE(SQL{create_table_single}.pipeline().requires_execution());
 
   const std::string create_table_multi = create_table_single + "SELECT * FROM foo2;";
-  EXPECT_TRUE(SQLPipeline{create_table_multi}.requires_execution());
+  EXPECT_TRUE(SQL{create_table_multi}.pipeline().requires_execution());
 
   const std::string drop_table_single = "DROP TABLE foo;";
-  EXPECT_FALSE(SQLPipeline{drop_table_single}.requires_execution());
+  EXPECT_FALSE(SQL{drop_table_single}.pipeline().requires_execution());
 
   const std::string drop_table_multi = "SELECT * FROM foo; " + drop_table_single;
-  EXPECT_TRUE(SQLPipeline{drop_table_multi}.requires_execution());
+  EXPECT_TRUE(SQL{drop_table_multi}.pipeline().requires_execution());
 
   const std::string multi_no_exec =
       "SELECT * FROM foo; INSERT INTO foo VALUES (2); SELECT * FROM blub; DELETE FROM foo WHERE a = 2;";
-  EXPECT_FALSE(SQLPipeline{multi_no_exec}.requires_execution());
+  EXPECT_FALSE(SQL{multi_no_exec}.pipeline().requires_execution());
 }
 
 TEST_F(SQLPipelineTest, CorrectStatementStringSplitting) {
   // Tests that the string passed into the pipeline is correctly split into the statement substrings
-  SQLPipeline select_pipeline{_select_query_a};
+  auto select_pipeline = SQL{_select_query_a}.pipeline();
   const auto& select_strings = select_pipeline.get_sql_strings();
   EXPECT_EQ(select_strings.size(), 1u);
   EXPECT_EQ(select_strings.at(0), _select_query_a);
 
-  SQLPipeline dependent_pipeline{_multi_statement_query};
+  auto dependent_pipeline = SQL{_multi_statement_query}.pipeline();
   const auto& dependent_strings = dependent_pipeline.get_sql_strings();
   EXPECT_EQ(dependent_strings.size(), 2u);
   // "INSERT INTO table_a VALUES (11, 11.11); SELECT * FROM table_a";
@@ -488,7 +489,7 @@ TEST_F(SQLPipelineTest, CorrectStatementStringSplitting) {
 
   // Add newlines, tabd and weird spacing
   auto spacing_sql = "\n\t\n SELECT\na, b, c,d,e FROM\t(SELECT * FROM foo);    \t  ";
-  SQLPipeline spacing_pipeline{spacing_sql};
+  auto spacing_pipeline = SQL{spacing_sql}.pipeline();
   const auto& spacing_strings = spacing_pipeline.get_sql_strings();
   EXPECT_EQ(spacing_strings.size(), 1u);
   EXPECT_EQ(spacing_strings.at(0),
@@ -501,7 +502,7 @@ TEST_F(SQLPipelineTest, CorrectStatementStringSplitting) {
     AND bar.y = 25
   ORDER BY foo.x ASC
   )";
-  SQLPipeline multi_line_pipeline{multi_line_sql};
+  auto multi_line_pipeline = SQL{multi_line_sql}.pipeline();
   const auto& multi_line_strings = multi_line_pipeline.get_sql_strings();
   EXPECT_EQ(multi_line_strings.size(), 1u);
   EXPECT_EQ(multi_line_strings.at(0),
@@ -509,11 +510,11 @@ TEST_F(SQLPipelineTest, CorrectStatementStringSplitting) {
 }
 
 TEST_F(SQLPipelineTest, CacheQueryPlanTwice) {
-  SQLPipeline sql_pipeline1{_select_query_a};
+  auto sql_pipeline1 = SQL{_select_query_a}.pipeline();
   sql_pipeline1.get_result_table();
 
   // INSERT INTO table_a VALUES (11, 11.11); SELECT * FROM table_a
-  SQLPipeline sql_pipeline2{_multi_statement_query};
+  auto sql_pipeline2 = SQL{_multi_statement_query}.pipeline();
   sql_pipeline2.get_result_table();
 
   // The second part of _multi_statement_query is _select_query_a, which is already cached
@@ -522,7 +523,7 @@ TEST_F(SQLPipelineTest, CacheQueryPlanTwice) {
   EXPECT_TRUE(cache.has(_select_query_a));
   EXPECT_TRUE(cache.has("INSERT INTO table_a VALUES (11, 11.11);"));
 
-  SQLPipeline sql_pipeline3{_select_query_a};
+  auto sql_pipeline3 = SQL{_select_query_a}.pipeline();
   sql_pipeline3.get_result_table();
 
   // Make sure the cache hasn't changed

--- a/src/test/sql/sql_query_plan_cache_test.cpp
+++ b/src/test/sql/sql_query_plan_cache_test.cpp
@@ -4,10 +4,10 @@
 
 #include "base_test.hpp"
 
-#include "sql/sql.hpp"
 #include "sql/gdfs_cache.hpp"
 #include "sql/lru_cache.hpp"
 #include "sql/lru_k_cache.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql_query_cache.hpp"
 #include "sql/sql_query_plan.hpp"
@@ -52,7 +52,7 @@ TEST_F(SQLQueryPlanCacheTest, SQLQueryPlanCacheTest) {
   EXPECT_FALSE(cache.has(Q2));
 
   // Execute a query and cache its plan.
-  SQL{Q1, UseMvcc::No};
+  auto pipeline_statement = SQL{Q1}.disable_mvcc().pipeline_statement();
   pipeline_statement.get_result_table();
   cache.set(Q1, *(pipeline_statement.get_query_plan()));
 

--- a/src/test/sql/sql_query_plan_cache_test.cpp
+++ b/src/test/sql/sql_query_plan_cache_test.cpp
@@ -4,6 +4,7 @@
 
 #include "base_test.hpp"
 
+#include "sql/sql.hpp"
 #include "sql/gdfs_cache.hpp"
 #include "sql/lru_cache.hpp"
 #include "sql/lru_k_cache.hpp"
@@ -29,7 +30,7 @@ class SQLQueryPlanCacheTest : public BaseTest {
   }
 
   void execute_query(const std::string& query) {
-    SQLPipelineStatement pipeline_statement{query};
+    auto pipeline_statement = SQL{query}.pipeline_statement();
     pipeline_statement.get_result_table();
 
     if (pipeline_statement.query_plan_cache_hit()) {
@@ -51,7 +52,7 @@ TEST_F(SQLQueryPlanCacheTest, SQLQueryPlanCacheTest) {
   EXPECT_FALSE(cache.has(Q2));
 
   // Execute a query and cache its plan.
-  SQLPipelineStatement pipeline_statement{Q1, UseMvcc::No};
+  SQL{Q1, UseMvcc::No};
   pipeline_statement.get_result_table();
   cache.set(Q1, *(pipeline_statement.get_query_plan()));
 

--- a/src/test/sql/sql_query_plan_test.cpp
+++ b/src/test/sql/sql_query_plan_test.cpp
@@ -11,6 +11,7 @@
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
 #include "sql/sql_pipeline_statement.hpp"
+#include "sql/sql.hpp"
 #include "storage/storage_manager.hpp"
 
 namespace opossum {
@@ -30,7 +31,7 @@ class SQLQueryPlanTest : public BaseTest {
 TEST_F(SQLQueryPlanTest, SQLQueryPlanCloneTest) {
   std::string query1 = "SELECT a FROM table_a;";
 
-  SQLPipelineStatement pipeline_statement{query1, UseMvcc::No};
+  auto pipeline_statement = SQL{query1}.pipeline_statement();
 
   // Get the query plan.
   const auto& plan1 = pipeline_statement.get_query_plan();

--- a/src/test/sql/sql_query_plan_test.cpp
+++ b/src/test/sql/sql_query_plan_test.cpp
@@ -10,8 +10,8 @@
 #include "scheduler/job_task.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
-#include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql.hpp"
+#include "sql/sql_pipeline_statement.hpp"
 #include "storage/storage_manager.hpp"
 
 namespace opossum {
@@ -31,7 +31,7 @@ class SQLQueryPlanTest : public BaseTest {
 TEST_F(SQLQueryPlanTest, SQLQueryPlanCloneTest) {
   std::string query1 = "SELECT a FROM table_a;";
 
-  auto pipeline_statement = SQL{query1}.pipeline_statement();
+  auto pipeline_statement = SQL{query1}.disable_mvcc().pipeline_statement();
 
   // Get the query plan.
   const auto& plan1 = pipeline_statement.get_query_plan();
@@ -66,7 +66,7 @@ TEST_F(SQLQueryPlanTest, SQLQueryPlanCloneWithSchedulerTest) {
   std::string query1 = "SELECT * FROM table_a WHERE a >= 1234 AND b < 457.9;";
 
   // Generate query plan.
-  SQLPipelineStatement pipeline_statement{query1, UseMvcc::No};
+  auto pipeline_statement = SQL{query1}.disable_mvcc().pipeline_statement();
 
   // Get the query plan template.
   const auto& tmpl = pipeline_statement.get_query_plan();

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -23,6 +23,7 @@
 #include "logical_query_plan/stored_table_node.hpp"
 #include "logical_query_plan/update_node.hpp"
 #include "null_value.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline.hpp"
 #include "sql/sql_translator.hpp"
 #include "storage/storage_manager.hpp"
@@ -31,7 +32,7 @@ using namespace std::string_literals;  // NOLINT
 
 namespace {
 std::shared_ptr<opossum::AbstractLQPNode> compile_query(const std::string& query) {
-  return opossum::SQLPipeline{query, opossum::UseMvcc::No}.get_unoptimized_logical_plans().at(0);
+  return opossum::SQL{query}.disable_mvcc().pipeline().get_unoptimized_logical_plans().at(0);
 }
 
 void load_test_tables() {

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -19,6 +19,7 @@
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/operator_task.hpp"
 #include "scheduler/topology.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline.hpp"
 #include "sql/sql_pipeline_statement.hpp"
 #include "sqlite_wrapper.hpp"
@@ -85,7 +86,7 @@ TEST_P(SQLiteTestRunner, CompareToSQLite) {
   std::ifstream file("src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql");
   const std::string query = GetParam();
 
-  SQLPipeline sql_pipeline{query};
+  auto sql_pipeline = SQL{query}.pipeline();
   const auto& result_table = sql_pipeline.get_result_table();
 
   auto sqlite_result_table = _sqlite->execute_query(query);

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -11,6 +11,7 @@
 #include "operators/abstract_operator.hpp"
 #include "optimizer/optimizer.hpp"
 #include "scheduler/operator_task.hpp"
+#include "sql/sql.hpp"
 #include "sql/sql_pipeline.hpp"
 #include "sql/sql_translator.hpp"
 #include "sql/sqlite_testrunner/sqlite_wrapper.hpp"
@@ -49,7 +50,7 @@ TEST_P(TPCHTest, TPCHQueryTest) {
   const auto query = tpch_queries[query_idx];
   const auto sqlite_result_table = _sqlite_wrapper->execute_query(query);
 
-  SQLPipeline sql_pipeline{query, UseMvcc::No};
+  auto sql_pipeline SQL{query}.pipeline();
   const auto& result_table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ(result_table, sqlite_result_table, OrderSensitivity::No, TypeCmpMode::Lenient,

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -50,7 +50,7 @@ TEST_P(TPCHTest, TPCHQueryTest) {
   const auto query = tpch_queries[query_idx];
   const auto sqlite_result_table = _sqlite_wrapper->execute_query(query);
 
-  auto sql_pipeline SQL{query}.disable_mvcc().pipeline();
+  auto sql_pipeline = SQL{query}.disable_mvcc().pipeline();
   const auto& result_table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ(result_table, sqlite_result_table, OrderSensitivity::No, TypeCmpMode::Lenient,

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -50,7 +50,7 @@ TEST_P(TPCHTest, TPCHQueryTest) {
   const auto query = tpch_queries[query_idx];
   const auto sqlite_result_table = _sqlite_wrapper->execute_query(query);
 
-  auto sql_pipeline SQL{query}.pipeline();
+  auto sql_pipeline SQL{query}.disable_mvcc().pipeline();
   const auto& result_table = sql_pipeline.get_result_table();
 
   EXPECT_TABLE_EQ(result_table, sqlite_result_table, OrderSensitivity::No, TypeCmpMode::Lenient,


### PR DESCRIPTION
```c++
/**
 * Interface for the configured execution of SQL.
 *
 * Minimal usage:
 *      SQL{"SELECT * FROM t;"}.pipeline().get_result_table()
 *
 * With custom Optimizer and TransactionContext:
 *      SQL{query}.
 *          set_optimizer(optimizer).
 *          set_transaction_context(tc).
 *          pipeline();
 *
 * Defaults:
 *  - MVCC is enabled
 *  - The default Optimizer (Optimizer::create_default_optimizer() is used.
 *
 * Favour this interface over calling the SQLPipeline[Statement] constructors with their long parameter list.
 * See SQLPipeline[Statement] doc for these classes, in short SQLPipeline ist for queries with multiple statement,
 * SQLPipelineStatement for single statement queries.
 */
```

This stems from my MA where I need to introduce more options to the SQLPipeline and the current way of adding constructors just doesn't scale. The name `SQL` may seem somewhat provocatively, but I think it works nicely as an interface. If you have better ideas for names, let me know.