### PR TITLE
AbstractOperator::type() to query concrete type 

### DIFF
--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -8,10 +8,10 @@
 
 namespace opossum {
 
-AbstractJoinOperator::AbstractJoinOperator(const std::shared_ptr<const AbstractOperator> left,
+AbstractJoinOperator::AbstractJoinOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator> left,
                                            const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                                            const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
-    : AbstractReadOnlyOperator(left, right),
+    : AbstractReadOnlyOperator(type, left, right),
       _mode(mode),
       _column_ids(column_ids),
       _predicate_condition(predicate_condition) {

--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -24,7 +24,7 @@ namespace opossum {
 
 class AbstractJoinOperator : public AbstractReadOnlyOperator {
  public:
-  AbstractJoinOperator(const std::shared_ptr<const AbstractOperator> left,
+  AbstractJoinOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator> left,
                        const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                        const ColumnIDPair& column_ids, const PredicateCondition predicate_condition);
 

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -14,9 +14,11 @@
 
 namespace opossum {
 
-AbstractOperator::AbstractOperator(const std::shared_ptr<const AbstractOperator> left,
+AbstractOperator::AbstractOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator> left,
                                    const std::shared_ptr<const AbstractOperator> right)
-    : _input_left(left), _input_right(right) {}
+    : _type(type), _input_left(left), _input_right(right) {}
+
+OperatorType AbstractOperator::type() const { return _type; }
 
 void AbstractOperator::execute() {
   DebugAssert(!_output, "Operator has already been executed");

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -14,6 +14,40 @@ class OperatorTask;
 class Table;
 class TransactionContext;
 
+enum class OperatorType {
+  Aggregate,
+  Delete,
+  Difference,
+  ExportBinary,
+  ExportCsv,
+  GetTable,
+  ImportBinary,
+  ImportCsv,
+  IndexScan,
+  Insert,
+  JoinHash,
+  JoinIndex,
+  JoinNestedLoop,
+  JoinSortMerge,
+  Limit,
+  Print,
+  Product,
+  Projection,
+  Sort,
+  TableScan,
+  TableWrapper,
+  UnionAll,
+  UnionPositions,
+  Update,
+  Validate,
+  CreateView,
+  DropView,
+  ShowColumns,
+  ShowTables,
+
+  Mock  // for Tests that need to Mock operators
+};
+
 // AbstractOperator is the abstract super class for all operators.
 // All operators have up to two input tables and one output table.
 // Their lifecycle has three phases:
@@ -30,10 +64,12 @@ class TransactionContext;
 
 class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, private Noncopyable {
  public:
-  AbstractOperator(const std::shared_ptr<const AbstractOperator> left = nullptr,
+  AbstractOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator> left = nullptr,
                    const std::shared_ptr<const AbstractOperator> right = nullptr);
 
   virtual ~AbstractOperator() = default;
+
+  OperatorType type() const;
 
   // Overriding implementations need to call on_operator_started/finished() on the _transaction_context as well
   virtual void execute();
@@ -101,6 +137,8 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
   virtual std::shared_ptr<AbstractOperator> _on_recreate(
       const std::vector<AllParameterVariant>& args, const std::shared_ptr<AbstractOperator>& recreated_input_left,
       const std::shared_ptr<AbstractOperator>& recreated_input_right) const = 0;
+
+  const OperatorType _type;
 
   // Shared pointers to input operators, can be nullptr.
   std::shared_ptr<const AbstractOperator> _input_left;

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -5,9 +5,10 @@
 
 namespace opossum {
 
-AbstractReadWriteOperator::AbstractReadWriteOperator(const std::shared_ptr<const AbstractOperator> left,
+AbstractReadWriteOperator::AbstractReadWriteOperator(const OperatorType type,
+                                                     const std::shared_ptr<const AbstractOperator> left,
                                                      const std::shared_ptr<const AbstractOperator> right)
-    : AbstractOperator(left, right), _state{ReadWriteOperatorState::Pending} {}
+    : AbstractOperator(type, left, right), _state{ReadWriteOperatorState::Pending} {}
 
 void AbstractReadWriteOperator::execute() {
   DebugAssert(!_output, "Operator has already been executed");

--- a/src/lib/operators/abstract_read_write_operator.hpp
+++ b/src/lib/operators/abstract_read_write_operator.hpp
@@ -28,7 +28,8 @@ enum class ReadWriteOperatorState {
  */
 class AbstractReadWriteOperator : public AbstractOperator {
  public:
-  explicit AbstractReadWriteOperator(const std::shared_ptr<const AbstractOperator> left = nullptr,
+  explicit AbstractReadWriteOperator(const OperatorType type,
+                                     const std::shared_ptr<const AbstractOperator> left = nullptr,
                                      const std::shared_ptr<const AbstractOperator> right = nullptr);
 
   void execute() override;

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -22,7 +22,9 @@ namespace opossum {
 Aggregate::Aggregate(const std::shared_ptr<AbstractOperator> in,
                      const std::vector<AggregateColumnDefinition>& aggregates,
                      const std::vector<ColumnID> groupby_column_ids)
-    : AbstractReadOnlyOperator(in), _aggregates(aggregates), _groupby_column_ids(groupby_column_ids) {
+    : AbstractReadOnlyOperator(OperatorType::Aggregate, in),
+      _aggregates(aggregates),
+      _groupby_column_ids(groupby_column_ids) {
   Assert(!(aggregates.empty() && groupby_column_ids.empty()),
          "Neither aggregate nor groupby columns have been specified");
 }

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -12,7 +12,7 @@
 namespace opossum {
 
 Delete::Delete(const std::string& table_name, const std::shared_ptr<const AbstractOperator>& values_to_delete)
-    : AbstractReadWriteOperator{values_to_delete}, _table_name{table_name} {}
+    : AbstractReadWriteOperator{OperatorType::Delete, values_to_delete}, _table_name{table_name} {}
 
 const std::string Delete::name() const { return "Delete"; }
 

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -17,7 +17,7 @@
 namespace opossum {
 Difference::Difference(const std::shared_ptr<const AbstractOperator> left_in,
                        const std::shared_ptr<const AbstractOperator> right_in)
-    : AbstractReadOnlyOperator(left_in, right_in) {}
+    : AbstractReadOnlyOperator(OperatorType::Difference, left_in, right_in) {}
 
 const std::string Difference::name() const { return "Difference"; }
 

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -113,7 +113,7 @@ void _export_value(std::ofstream& ofstream, const T& value) {
 namespace opossum {
 
 ExportBinary::ExportBinary(const std::shared_ptr<const AbstractOperator> in, const std::string& filename)
-    : AbstractReadOnlyOperator(in), _filename(filename) {}
+    : AbstractReadOnlyOperator(OperatorType::ExportBinary, in), _filename(filename) {}
 
 const std::string ExportBinary::name() const { return "ExportBinary"; }
 

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -18,7 +18,7 @@
 namespace opossum {
 
 ExportCsv::ExportCsv(const std::shared_ptr<const AbstractOperator> in, const std::string& filename)
-    : AbstractReadOnlyOperator(in), _filename(filename) {}
+    : AbstractReadOnlyOperator(OperatorType::ExportCsv, in), _filename(filename) {}
 
 const std::string ExportCsv::name() const { return "ExportCSV"; }
 

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -12,7 +12,7 @@
 
 namespace opossum {
 
-GetTable::GetTable(const std::string& name) : _name(name) {}
+GetTable::GetTable(const std::string& name) : AbstractReadOnlyOperator(OperatorType::GetTable), _name(name) {}
 
 const std::string GetTable::name() const { return "GetTable"; }
 

--- a/src/lib/operators/import_binary.cpp
+++ b/src/lib/operators/import_binary.cpp
@@ -22,7 +22,7 @@
 namespace opossum {
 
 ImportBinary::ImportBinary(const std::string& filename, const std::optional<std::string> tablename)
-    : _filename(filename), _tablename(tablename) {}
+    : AbstractReadOnlyOperator(OperatorType::ImportBinary), _filename(filename), _tablename(tablename) {}
 
 const std::string ImportBinary::name() const { return "ImportBinary"; }
 

--- a/src/lib/operators/import_csv.cpp
+++ b/src/lib/operators/import_csv.cpp
@@ -13,7 +13,10 @@ namespace opossum {
 
 ImportCsv::ImportCsv(const std::string& filename, const std::optional<std::string> tablename,
                      const std::optional<CsvMeta> csv_meta)
-    : _filename(filename), _tablename(tablename), _csv_meta(csv_meta) {}
+    : AbstractReadOnlyOperator(OperatorType::ImportCsv),
+      _filename(filename),
+      _tablename(tablename),
+      _csv_meta(csv_meta) {}
 
 ImportCsv::ImportCsv(const std::string& filename, const std::optional<CsvMeta> csv_meta,
                      const std::optional<std::string> tablename)

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -16,7 +16,7 @@ namespace opossum {
 IndexScan::IndexScan(const std::shared_ptr<const AbstractOperator> in, const ColumnIndexType index_type,
                      const std::vector<ColumnID> left_column_ids, const PredicateCondition predicate_condition,
                      const std::vector<AllTypeVariant> right_values, const std::vector<AllTypeVariant> right_values2)
-    : AbstractReadOnlyOperator{in},
+    : AbstractReadOnlyOperator{OperatorType::IndexScan, in},
       _index_type{index_type},
       _left_column_ids{left_column_ids},
       _predicate_condition{predicate_condition},

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -91,7 +91,7 @@ class TypedColumnProcessor : public AbstractTypedColumnProcessor {
 };
 
 Insert::Insert(const std::string& target_table_name, const std::shared_ptr<AbstractOperator>& values_to_insert)
-    : AbstractReadWriteOperator(values_to_insert), _target_table_name(target_table_name) {}
+    : AbstractReadWriteOperator(OperatorType::Insert, values_to_insert), _target_table_name(target_table_name) {}
 
 const std::string Insert::name() const { return "Insert"; }
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -26,7 +26,7 @@ namespace opossum {
 JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator> left,
                    const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                    const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
-    : AbstractJoinOperator(left, right, mode, column_ids, predicate_condition) {
+    : AbstractJoinOperator(OperatorType::JoinHash, left, right, mode, column_ids, predicate_condition) {
   DebugAssert(predicate_condition == PredicateCondition::Equals, "Operator not supported by Hash Join.");
 }
 

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -27,7 +27,7 @@ namespace opossum {
 JoinIndex::JoinIndex(const std::shared_ptr<const AbstractOperator> left,
                      const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                      const std::pair<ColumnID, ColumnID>& column_ids, const PredicateCondition predicate_condition)
-    : AbstractJoinOperator(left, right, mode, column_ids, predicate_condition) {
+    : AbstractJoinOperator(OperatorType::JoinIndex, left, right, mode, column_ids, predicate_condition) {
   DebugAssert(mode != JoinMode::Cross, "Cross Join is not supported by index join.");
 }
 

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -27,7 +27,7 @@ namespace opossum {
 JoinNestedLoop::JoinNestedLoop(const std::shared_ptr<const AbstractOperator> left,
                                const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                                const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
-    : AbstractJoinOperator(left, right, mode, column_ids, predicate_condition) {}
+    : AbstractJoinOperator(OperatorType::JoinNestedLoop, left, right, mode, column_ids, predicate_condition) {}
 
 const std::string JoinNestedLoop::name() const { return "JoinNestedLoop"; }
 

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -35,7 +35,7 @@ namespace opossum {
 JoinSortMerge::JoinSortMerge(const std::shared_ptr<const AbstractOperator> left,
                              const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
                              const ColumnIDPair& column_ids, const PredicateCondition op)
-    : AbstractJoinOperator(left, right, mode, column_ids, op) {
+    : AbstractJoinOperator(OperatorType::JoinSortMerge, left, right, mode, column_ids, op) {
   // Validate the parameters
   DebugAssert(mode != JoinMode::Cross, "This operator does not support cross joins.");
   DebugAssert(left != nullptr, "The left input operator is null.");

--- a/src/lib/operators/limit.cpp
+++ b/src/lib/operators/limit.cpp
@@ -12,7 +12,7 @@
 namespace opossum {
 
 Limit::Limit(const std::shared_ptr<const AbstractOperator> in, const size_t num_rows)
-    : AbstractReadOnlyOperator(in), _num_rows(num_rows) {}
+    : AbstractReadOnlyOperator(OperatorType::Limit, in), _num_rows(num_rows) {}
 
 const std::string Limit::name() const { return "Limit"; }
 

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -10,7 +10,7 @@
 namespace opossum {
 
 CreateView::CreateView(const std::string& view_name, std::shared_ptr<const AbstractLQPNode> lqp)
-    : _view_name(view_name), _lqp(lqp) {}
+    : AbstractReadOnlyOperator(OperatorType::CreateView), _view_name(view_name), _lqp(lqp) {}
 
 const std::string CreateView::name() const { return "CreateView"; }
 

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -9,7 +9,8 @@
 
 namespace opossum {
 
-DropView::DropView(const std::string& view_name) : _view_name(view_name) {}
+DropView::DropView(const std::string& view_name)
+    : AbstractReadOnlyOperator(OperatorType::DropView), _view_name(view_name) {}
 
 const std::string DropView::name() const { return "DropView"; }
 

--- a/src/lib/operators/maintenance/show_columns.cpp
+++ b/src/lib/operators/maintenance/show_columns.cpp
@@ -17,7 +17,7 @@
 namespace opossum {
 
 ShowColumns::ShowColumns(const std::string& table_name)
-    : AbstractReadOnlyOperator(OperatorType::DropView), _table_name(table_name) {}
+    : AbstractReadOnlyOperator(OperatorType::ShowColumns), _table_name(table_name) {}
 
 const std::string ShowColumns::name() const { return "ShowColumns"; }
 

--- a/src/lib/operators/maintenance/show_columns.cpp
+++ b/src/lib/operators/maintenance/show_columns.cpp
@@ -16,7 +16,8 @@
 
 namespace opossum {
 
-ShowColumns::ShowColumns(const std::string& table_name) : _table_name(table_name) {}
+ShowColumns::ShowColumns(const std::string& table_name)
+    : AbstractReadOnlyOperator(OperatorType::DropView), _table_name(table_name) {}
 
 const std::string ShowColumns::name() const { return "ShowColumns"; }
 

--- a/src/lib/operators/maintenance/show_tables.cpp
+++ b/src/lib/operators/maintenance/show_tables.cpp
@@ -14,7 +14,7 @@
 
 namespace opossum {
 
-ShowTables::ShowTables() : AbstractReadOnlyOperator(OperatorType::DropView) {}
+ShowTables::ShowTables() : AbstractReadOnlyOperator(OperatorType::ShowTables) {}
 
 const std::string ShowTables::name() const { return "ShowTables"; }
 

--- a/src/lib/operators/maintenance/show_tables.cpp
+++ b/src/lib/operators/maintenance/show_tables.cpp
@@ -14,6 +14,8 @@
 
 namespace opossum {
 
+ShowTables::ShowTables() : AbstractReadOnlyOperator(OperatorType::DropView) {}
+
 const std::string ShowTables::name() const { return "ShowTables"; }
 
 std::shared_ptr<AbstractOperator> ShowTables::_on_recreate(

--- a/src/lib/operators/maintenance/show_tables.hpp
+++ b/src/lib/operators/maintenance/show_tables.hpp
@@ -11,6 +11,8 @@ namespace opossum {
 // maintenance operator to get all table names stored by the StorageManager
 class ShowTables : public AbstractReadOnlyOperator {
  public:
+  ShowTables();
+
   const std::string name() const override;
 
  protected:

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -16,7 +16,7 @@
 namespace opossum {
 
 Print::Print(const std::shared_ptr<const AbstractOperator> in, std::ostream& out, uint32_t flags)
-    : AbstractReadOnlyOperator(in), _out(out), _flags(flags) {}
+    : AbstractReadOnlyOperator(OperatorType::Print, in), _out(out), _flags(flags) {}
 
 const std::string Print::name() const { return "Print"; }
 

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -11,7 +11,7 @@
 namespace opossum {
 Product::Product(const std::shared_ptr<const AbstractOperator> left,
                  const std::shared_ptr<const AbstractOperator> right)
-    : AbstractReadOnlyOperator(left, right) {}
+    : AbstractReadOnlyOperator(OperatorType::Product, left, right) {}
 
 const std::string Product::name() const { return "Product"; }
 

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -23,7 +23,7 @@
 namespace opossum {
 
 Projection::Projection(const std::shared_ptr<const AbstractOperator> in, const ColumnExpressions& column_expressions)
-    : AbstractReadOnlyOperator(in), _column_expressions(column_expressions) {}
+    : AbstractReadOnlyOperator(OperatorType::Projection, in), _column_expressions(column_expressions) {}
 
 const std::string Projection::name() const { return "Projection"; }
 

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -14,7 +14,7 @@ namespace opossum {
 
 Sort::Sort(const std::shared_ptr<const AbstractOperator> in, const ColumnID column_id, const OrderByMode order_by_mode,
            const size_t output_chunk_size)
-    : AbstractReadOnlyOperator(in),
+    : AbstractReadOnlyOperator(OperatorType::Sort, in),
       _column_id(column_id),
       _order_by_mode(order_by_mode),
       _output_chunk_size(output_chunk_size) {}

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -31,7 +31,7 @@ namespace opossum {
 
 TableScan::TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id,
                      const PredicateCondition predicate_condition, const AllParameterVariant right_parameter)
-    : AbstractReadOnlyOperator{OperatorType::Sort, in},
+    : AbstractReadOnlyOperator{OperatorType::TableScan, in},
       _left_column_id{left_column_id},
       _predicate_condition{predicate_condition},
       _right_parameter{right_parameter} {}

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -31,7 +31,7 @@ namespace opossum {
 
 TableScan::TableScan(const std::shared_ptr<const AbstractOperator> in, ColumnID left_column_id,
                      const PredicateCondition predicate_condition, const AllParameterVariant right_parameter)
-    : AbstractReadOnlyOperator{in},
+    : AbstractReadOnlyOperator{OperatorType::Sort, in},
       _left_column_id{left_column_id},
       _predicate_condition{predicate_condition},
       _right_parameter{right_parameter} {}

--- a/src/lib/operators/table_wrapper.cpp
+++ b/src/lib/operators/table_wrapper.cpp
@@ -6,7 +6,8 @@
 
 namespace opossum {
 
-TableWrapper::TableWrapper(const std::shared_ptr<const Table> table) : _table(table) {}
+TableWrapper::TableWrapper(const std::shared_ptr<const Table> table)
+    : AbstractReadOnlyOperator(OperatorType::TableWrapper), _table(table) {}
 
 const std::string TableWrapper::name() const { return "TableWrapper"; }
 

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -10,7 +10,7 @@
 namespace opossum {
 UnionAll::UnionAll(const std::shared_ptr<const AbstractOperator> left_in,
                    const std::shared_ptr<const AbstractOperator> right_in)
-    : AbstractReadOnlyOperator(left_in, right_in) {
+    : AbstractReadOnlyOperator(OperatorType::UnionAll, left_in, right_in) {
   // nothing to do here
 }
 

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -57,7 +57,7 @@ namespace opossum {
 
 UnionPositions::UnionPositions(const std::shared_ptr<const AbstractOperator>& left,
                                const std::shared_ptr<const AbstractOperator>& right)
-    : AbstractReadOnlyOperator(left, right) {}
+    : AbstractReadOnlyOperator(OperatorType::UnionPositions, left, right) {}
 
 std::shared_ptr<AbstractOperator> UnionPositions::_on_recreate(
     const std::vector<AllParameterVariant>& args, const std::shared_ptr<AbstractOperator>& recreated_input_left,

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -17,7 +17,8 @@ namespace opossum {
 
 Update::Update(const std::string& table_to_update_name, std::shared_ptr<AbstractOperator> fields_to_update_op,
                std::shared_ptr<AbstractOperator> update_values_op)
-    : AbstractReadWriteOperator(fields_to_update_op, update_values_op), _table_to_update_name{table_to_update_name} {}
+    : AbstractReadWriteOperator(OperatorType::Update, fields_to_update_op, update_values_op),
+      _table_to_update_name{table_to_update_name} {}
 
 Update::~Update() = default;
 

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -30,7 +30,7 @@ bool is_row_visible(CommitID our_tid, CommitID snapshot_commit_id, ChunkOffset c
 
 }  // namespace
 
-Validate::Validate(const std::shared_ptr<AbstractOperator> in) : AbstractReadOnlyOperator(in) {}
+Validate::Validate(const std::shared_ptr<AbstractOperator> in) : AbstractReadOnlyOperator(OperatorType::Validate, in) {}
 
 const std::string Validate::name() const { return "Validate"; }
 

--- a/src/test/concurrency/transaction_context_test.cpp
+++ b/src/test/concurrency/transaction_context_test.cpp
@@ -30,7 +30,7 @@ class TransactionContextTest : public BaseTest {
  */
 class CommitFuncOp : public AbstractReadWriteOperator {
  public:
-  explicit CommitFuncOp(std::function<void()> func) : _func{func} {}
+  explicit CommitFuncOp(std::function<void()> func) : AbstractReadWriteOperator(OperatorType::Mock), _func{func} {}
 
   const std::string name() const override { return "CommitOp"; }
 


### PR DESCRIPTION
we have the same in `AbstractLQPNode`. #NeedThisForMyMA