### PR TITLE
Improve Reference Column Iterable

### DIFF
--- a/src/lib/storage/column_iterables.hpp
+++ b/src/lib/storage/column_iterables.hpp
@@ -119,7 +119,7 @@ class ColumnIterable {
     for_each([&](const auto& value) { container.push_back(value.is_null()); });
   }
 
-  /** @} */
+  /**@}*/
 
  private:
   const Derived& _self() const { return static_cast<const Derived&>(*this); }

--- a/src/lib/storage/column_iterables/chunk_offset_mapping.cpp
+++ b/src/lib/storage/column_iterables/chunk_offset_mapping.cpp
@@ -1,5 +1,8 @@
 #include "chunk_offset_mapping.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 namespace opossum {
 
 ChunkOffsetsByChunkID split_pos_list_by_chunk_id(const PosList& pos_list) {
@@ -16,6 +19,36 @@ ChunkOffsetsByChunkID split_pos_list_by_chunk_id(const PosList& pos_list) {
   }
 
   return chunk_offsets_by_chunk_id;
+}
+
+std::optional<std::pair<ChunkID, ChunkOffsetsList>> to_chunk_id_and_chunk_offsets_list(const PosList& pos_list) {
+  auto chunk_offsets_list = ChunkOffsetsList{};
+  chunk_offsets_list.reserve(pos_list.size());
+
+  // Find first row ID that is not NULL
+  const auto first_not_null_it = std::find_if(pos_list.cbegin(), pos_list.cend(),
+                                              [](const auto& row_id) { return !row_id.is_null(); });
+
+  // If none was found, return empty list
+  if (first_not_null_it == pos_list.cend()) return std::nullopt;
+
+  const auto chunk_id = first_not_null_it->chunk_id;
+
+  // Skip any row ID that is NULL.
+  const auto first_chunk_offset = static_cast<ChunkOffset>(std::distance(pos_list.cbegin(), first_not_null_it));
+  for (auto chunk_offset = first_chunk_offset; chunk_offset < pos_list.size(); ++chunk_offset) {
+    const auto row_id = pos_list[chunk_offset];
+
+    // Skip any row ID that is NULL.
+    if (row_id.is_null()) continue;
+
+    // Fail if PosList references more than one chunk
+    if (row_id.chunk_id != chunk_id) return std::nullopt;
+
+    chunk_offsets_list.push_back({chunk_offset, row_id.chunk_offset});
+  }
+
+  return std::pair{chunk_id, chunk_offsets_list};
 }
 
 }  // namespace opossum

--- a/src/lib/storage/column_iterables/chunk_offset_mapping.hpp
+++ b/src/lib/storage/column_iterables/chunk_offset_mapping.hpp
@@ -27,4 +27,11 @@ using ChunkOffsetsByChunkID = std::unordered_map<ChunkID, ChunkOffsetsList>;
 
 ChunkOffsetsByChunkID split_pos_list_by_chunk_id(const PosList& pos_list);
 
+/**
+ * @brief Converts a PosList into a ChunkOffsetsList
+ *
+ * Returns std::nullopt if the position list references more than one chunk or result would be empty
+ */
+std::optional<std::pair<ChunkID, ChunkOffsetsList>> to_chunk_id_and_chunk_offsets_list(const PosList& pos_list);
+
 }  // namespace opossum

--- a/src/lib/storage/reference_column/reference_column_iterable.hpp
+++ b/src/lib/storage/reference_column/reference_column_iterable.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <map>
-#include <memory>
-#include <utility>
-#include <vector>
-
+#include "resolve_type.hpp"
 #include "storage/column_iterables.hpp"
+#include "storage/column_iterables/chunk_offset_mapping.hpp"
+#include "storage/create_iterable_from_column.hpp"
 #include "storage/reference_column.hpp"
 
 namespace opossum {
@@ -17,14 +15,21 @@ class ReferenceColumnIterable : public ColumnIterable<ReferenceColumnIterable<T>
 
   template <typename Functor>
   void _on_with_iterators(const Functor& functor) const {
-    const auto table = _column.referenced_table();
+    const auto pos_list = _column.pos_list();
+
+    const auto chunk_id_and_chunk_offsets_list = to_chunk_id_and_chunk_offsets_list(*pos_list);
+    if (chunk_id_and_chunk_offsets_list) {
+      const auto& [referenced_chunk_id, chunk_offsets_list] = *chunk_id_and_chunk_offsets_list;
+
+      _referenced_with_iterators(referenced_chunk_id, chunk_offsets_list, functor);
+      return;
+    }
+
     const auto column_id = _column.referenced_column_id();
+    const auto table = _column.referenced_table();
 
-    const auto begin_it = _column.pos_list()->begin();
-    const auto end_it = _column.pos_list()->end();
-
-    auto begin = Iterator{table, column_id, begin_it, begin_it};
-    auto end = Iterator{table, column_id, begin_it, end_it};
+    auto begin = Iterator{column_id, table.get(), pos_list.get(), ChunkOffset{0u}};
+    auto end = Iterator{static_cast<ChunkOffset>(pos_list->size())};
     functor(begin, end);
   }
 
@@ -32,59 +37,74 @@ class ReferenceColumnIterable : public ColumnIterable<ReferenceColumnIterable<T>
   const ReferenceColumn& _column;
 
  private:
+  template <typename Functor>
+  void _referenced_with_iterators(const ChunkID chunk_id, const ChunkOffsetsList& chunk_offsets_list,
+                                  const Functor& functor) const {
+    const auto column_id = _column.referenced_column_id();
+    const auto table = _column.referenced_table();
+
+    const auto base_column = table->get_chunk(chunk_id)->get_column(column_id);
+
+    resolve_column_type<T>(*base_column, [&functor, &chunk_offsets_list](const auto& referenced_column) {
+      using ColumnT = std::decay_t<decltype(referenced_column)>;
+      constexpr auto is_reference_column = std::is_same_v<ColumnT, ReferenceColumn>;
+
+      // clang-format off
+      if constexpr (!is_reference_column) {
+        auto iterable = create_iterable_from_column<T>(referenced_column);
+        iterable.with_iterators(&chunk_offsets_list, [&](auto it, auto end) { functor(it, end); });
+      } else {
+        Fail("Reference column must not reference another reference column.");
+      }
+      // class-format on
+    });
+  }
+
   class Iterator : public BaseColumnIterator<Iterator, ColumnIteratorValue<T>> {
    public:
-    using PosListIterator = PosList::const_iterator;
+    // Begin Iterator
+    Iterator(const ColumnID column_id, const Table* table, const PosList* pos_list, const ChunkOffset chunk_offset)
+        : _column_id{column_id},
+          _table{table},
+          _pos_list{pos_list},
+          _chunk_offset{chunk_offset} {}
 
-   public:
-    explicit Iterator(const std::shared_ptr<const Table> table, const ColumnID column_id,
-                      const PosListIterator& begin_pos_list_it, const PosListIterator& pos_list_it)
-        : _table{table}, _column_id{column_id}, _begin_pos_list_it{begin_pos_list_it}, _pos_list_it{pos_list_it} {}
+    // End Iterator
+    Iterator(const ChunkOffset chunk_offset) : Iterator(ColumnID{0u}, nullptr, nullptr, chunk_offset) {}
 
    private:
     friend class boost::iterator_core_access;  // grants the boost::iterator_facade access to the private interface
 
-    void increment() { ++_pos_list_it; }
+    void increment() { ++_chunk_offset; }
 
-    bool equal(const Iterator& other) const { return _pos_list_it == other._pos_list_it; }
+    bool equal(const Iterator& other) const { return _chunk_offset == other._chunk_offset; }
 
-    // TODO(anyone): benchmark if using two maps instead doing the dynamic cast every time really is faster.
     ColumnIteratorValue<T> dereference() const {
-      if (_pos_list_it->is_null()) return ColumnIteratorValue<T>{T{}, true, 0u};
+      const auto row_id = (*_pos_list)[_chunk_offset];  // NOLINT
 
-      const auto chunk_id = _pos_list_it->chunk_id;
-      const auto& chunk_offset = _pos_list_it->chunk_offset;
-
-      const auto chunk = _table->get_chunk(chunk_id);
-      const auto column = chunk->get_column(_column_id);
-
-      /**
-       * This is just a temporary solution to supporting encoded column type.
-       * It’s very slow and is going to be replaced very soon!
-       */
-      return _value_from_any_column(*column, chunk_offset);
-    }
-
-   private:
-    auto _value_from_any_column(const BaseColumn& column, const ChunkOffset& chunk_offset) const {
-      const auto variant_value = column[chunk_offset];
-
-      const auto chunk_offset_into_ref_column =
-          static_cast<ChunkOffset>(std::distance(_begin_pos_list_it, _pos_list_it));
-
-      if (variant_is_null(variant_value)) {
-        return ColumnIteratorValue<T>{T{}, true, chunk_offset_into_ref_column};
+      if (row_id.is_null()) {
+        return {T{}, true, _chunk_offset};
       }
 
-      return ColumnIteratorValue<T>{type_cast<T>(variant_value), false, chunk_offset_into_ref_column};
+      const auto [chunk_id, chunk_offset] = row_id;
+
+      const auto column = _table->get_chunk(chunk_id)->get_column(_column_id);
+      const auto variant_value = (*column)[chunk_offset];
+
+      if (variant_is_null(variant_value)) {
+        return {T{}, true, _chunk_offset};
+      }
+
+      const auto value = type_cast<T>(variant_value);
+      return {value, false, _chunk_offset};
     }
 
    private:
-    const std::shared_ptr<const Table> _table;
     const ColumnID _column_id;
+    const Table* _table;
+    const PosList* _pos_list;
 
-    const PosListIterator _begin_pos_list_it;
-    PosListIterator _pos_list_it;
+    ChunkOffset _chunk_offset;
   };
 };
 

--- a/src/lib/storage/reference_column/reference_column_iterable.hpp
+++ b/src/lib/storage/reference_column/reference_column_iterable.hpp
@@ -70,7 +70,7 @@ class ReferenceColumnIterable : public ColumnIterable<ReferenceColumnIterable<T>
           _chunk_offset{chunk_offset} {}
 
     // End Iterator
-    Iterator(const ChunkOffset chunk_offset) : Iterator(ColumnID{0u}, nullptr, nullptr, chunk_offset) {}
+    explicit Iterator(const ChunkOffset chunk_offset) : Iterator(ColumnID{0u}, nullptr, nullptr, chunk_offset) {}
 
    private:
     friend class boost::iterator_core_access;  // grants the boost::iterator_facade access to the private interface
@@ -80,13 +80,13 @@ class ReferenceColumnIterable : public ColumnIterable<ReferenceColumnIterable<T>
     bool equal(const Iterator& other) const { return _chunk_offset == other._chunk_offset; }
 
     ColumnIteratorValue<T> dereference() const {
-      const auto row_id = (*_pos_list)[_chunk_offset];  // NOLINT
+      const auto row_id = (*_pos_list)[_chunk_offset];
 
       if (row_id.is_null()) {
         return {T{}, true, _chunk_offset};
       }
 
-      const auto [chunk_id, chunk_offset] = row_id;
+      const auto [chunk_id, chunk_offset] = row_id;  // NOLINT
 
       const auto column = _table->get_chunk(chunk_id)->get_column(_column_id);
       const auto variant_value = (*column)[chunk_offset];


### PR DESCRIPTION
If a reference column references only a single chunk, the iterable will now resolve the type of the referenced column and will use the appropriate iterable to create its iterators.

Addresses #675