### PR TITLE
Visualise subqueries

### DIFF
--- a/src/lib/planviz/abstract_visualizer.hpp
+++ b/src/lib/planviz/abstract_visualizer.hpp
@@ -39,7 +39,7 @@ struct VizEdgeInfo {
   std::string color = "white";
   std::string font_color = "white";
   double pen_width = 1.0;
-  std::string style;
+  std::string style = "solid";
 };
 
 template <typename GraphBase>

--- a/src/lib/planviz/abstract_visualizer.hpp
+++ b/src/lib/planviz/abstract_visualizer.hpp
@@ -39,6 +39,7 @@ struct VizEdgeInfo {
   std::string color = "white";
   std::string font_color = "white";
   double pen_width = 1.0;
+  std::string style;
 };
 
 template <typename GraphBase>
@@ -78,6 +79,7 @@ class AbstractVisualizer {
     _add_property("fontcolor", &VizEdgeInfo::font_color);
     _add_property("label", &VizEdgeInfo::label);
     _add_property("penwidth", &VizEdgeInfo::pen_width);
+    _add_property("style", &VizEdgeInfo::style);
   }
 
   void visualize(const GraphBase& graph_base, const std::string& graph_filename, const std::string& img_filename) {

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -49,6 +49,7 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
     _build_dataflow(right_input, node);
   }
 
+  // Visualize subselects
   if (const auto projection = std::dynamic_pointer_cast<ProjectionNode>(node)) {
     for (const auto& column_expression : projection->column_expressions()) {
       if (column_expression->is_subselect()) {

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -7,6 +7,8 @@
 #include <utility>
 #include <vector>
 
+#include "logical_query_plan/projection_node.hpp"
+
 namespace opossum {
 
 LQPVisualizer::LQPVisualizer() : AbstractVisualizer() {
@@ -45,6 +47,15 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
     auto right_input = node->right_input();
     _build_subtree(right_input, visualized_nodes);
     _build_dataflow(right_input, node);
+  }
+
+  if (const auto projection = std::dynamic_pointer_cast<ProjectionNode>(node)) {
+    for (const auto& column_expression : projection->column_expressions()) {
+      if (column_expression->is_subselect()) {
+        _build_subtree(column_expression->subselect_node(), visualized_nodes);
+        _build_dataflow(column_expression->subselect_node(), node);
+      }
+    }
   }
 }
 

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -72,7 +72,7 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
   VizEdgeInfo info = edge_info;
 
   // Create label if custom label is not specified
-  if (edge_info.label.empty()) {
+  if (info.label.empty()) {
     try {
       row_count = from->get_statistics()->row_count();
       pen_width = std::fmax(1, std::ceil(std::log10(row_count) / 2));

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -53,14 +53,19 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
     for (const auto& column_expression : projection->column_expressions()) {
       if (column_expression->is_subselect()) {
         _build_subtree(column_expression->subselect_node(), visualized_nodes);
-        _build_dataflow(column_expression->subselect_node(), node);
+
+        auto edge_info = _default_edge;
+        edge_info.label = "Scalar Subquery";
+        edge_info.style = "dashed";
+        _build_dataflow(column_expression->subselect_node(), node, edge_info);
       }
     }
   }
 }
 
 void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from,
-                                    const std::shared_ptr<AbstractLQPNode>& to) {
+                                    const std::shared_ptr<AbstractLQPNode>& to,
+                                    const VizEdgeInfo& edge_info) {
   float row_count, row_percentage = 100.0f;
   double pen_width;
 
@@ -93,11 +98,16 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
     label_stream << "no est.";
   }
 
-  VizEdgeInfo info = _default_edge;
-  info.label = label_stream.str();
+  VizEdgeInfo info = edge_info;
+  info.label = edge_info.label.empty() ? label_stream.str() : edge_info.label;
   info.pen_width = pen_width;
 
   _add_edge(from, to, info);
+}
+
+void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from,
+                                    const std::shared_ptr<AbstractLQPNode>& to) {
+  return _build_dataflow(from, to, _default_edge);
 }
 
 }  // namespace opossum

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -69,38 +69,42 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
   float row_count, row_percentage = 100.0f;
   double pen_width;
 
-  try {
-    row_count = from->get_statistics()->row_count();
-    pen_width = std::fmax(1, std::ceil(std::log10(row_count) / 2));
-  } catch (...) {
-    // statistics don't exist for this edge
-    row_count = NAN;
-    pen_width = 1.0;
-  }
-
-  if (from->left_input()) {
-    try {
-      float input_count = from->left_input()->get_statistics()->row_count();
-      if (from->right_input()) {
-        input_count *= from->right_input()->get_statistics()->row_count();
-      }
-      row_percentage = 100 * row_count / input_count;
-    } catch (...) {
-      // Couldn't create statistics. Using default value of 100%
-    }
-  }
-
-  std::ostringstream label_stream;
-  if (!isnan(row_count)) {
-    label_stream << " " << std::fixed << std::setprecision(1) << row_count << " row(s) | " << row_percentage
-                 << "% estd.";
-  } else {
-    label_stream << "no est.";
-  }
-
   VizEdgeInfo info = edge_info;
-  info.label = edge_info.label.empty() ? label_stream.str() : edge_info.label;
-  info.pen_width = pen_width;
+
+  // Create label if custom label is not specified
+  if (edge_info.label.empty()) {
+    try {
+      row_count = from->get_statistics()->row_count();
+      pen_width = std::fmax(1, std::ceil(std::log10(row_count) / 2));
+    } catch (...) {
+      // statistics don't exist for this edge
+      row_count = NAN;
+      pen_width = 1.0;
+    }
+
+    if (from->left_input()) {
+      try {
+        float input_count = from->left_input()->get_statistics()->row_count();
+        if (from->right_input()) {
+          input_count *= from->right_input()->get_statistics()->row_count();
+        }
+        row_percentage = 100 * row_count / input_count;
+      } catch (...) {
+        // Couldn't create statistics. Using default value of 100%
+      }
+    }
+
+    std::ostringstream label_stream;
+    if (!isnan(row_count)) {
+      label_stream << " " << std::fixed << std::setprecision(1) << row_count << " row(s) | " << row_percentage
+                   << "% estd.";
+    } else {
+      label_stream << "no est.";
+    }
+
+    info.label = label_stream.str();
+    info.pen_width = pen_width;
+  }
 
   _add_edge(from, to, info);
 }

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -57,61 +57,51 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
         auto edge_info = _default_edge;
         edge_info.label = "Scalar Subquery";
         edge_info.style = "dashed";
-        _build_dataflow(column_expression->subselect_node(), node, edge_info);
+        _add_edge(column_expression->subselect_node(), node, edge_info);
       }
     }
   }
-}
-
-void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from,
-                                    const std::shared_ptr<AbstractLQPNode>& to,
-                                    const VizEdgeInfo& edge_info) {
-  float row_count, row_percentage = 100.0f;
-  double pen_width;
-
-  VizEdgeInfo info = edge_info;
-
-  // Create label if custom label is not specified
-  if (info.label.empty()) {
-    try {
-      row_count = from->get_statistics()->row_count();
-      pen_width = std::fmax(1, std::ceil(std::log10(row_count) / 2));
-    } catch (...) {
-      // statistics don't exist for this edge
-      row_count = NAN;
-      pen_width = 1.0;
-    }
-
-    if (from->left_input()) {
-      try {
-        float input_count = from->left_input()->get_statistics()->row_count();
-        if (from->right_input()) {
-          input_count *= from->right_input()->get_statistics()->row_count();
-        }
-        row_percentage = 100 * row_count / input_count;
-      } catch (...) {
-        // Couldn't create statistics. Using default value of 100%
-      }
-    }
-
-    std::ostringstream label_stream;
-    if (!isnan(row_count)) {
-      label_stream << " " << std::fixed << std::setprecision(1) << row_count << " row(s) | " << row_percentage
-                   << "% estd.";
-    } else {
-      label_stream << "no est.";
-    }
-
-    info.label = label_stream.str();
-    info.pen_width = pen_width;
-  }
-
-  _add_edge(from, to, info);
 }
 
 void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from,
                                     const std::shared_ptr<AbstractLQPNode>& to) {
-  return _build_dataflow(from, to, _default_edge);
+  float row_count, row_percentage = 100.0f;
+  double pen_width;
+
+  try {
+    row_count = from->get_statistics()->row_count();
+    pen_width = std::fmax(1, std::ceil(std::log10(row_count) / 2));
+  } catch (...) {
+    // statistics don't exist for this edge
+    row_count = NAN;
+    pen_width = 1.0;
+  }
+
+  if (from->left_input()) {
+    try {
+      float input_count = from->left_input()->get_statistics()->row_count();
+      if (from->right_input()) {
+        input_count *= from->right_input()->get_statistics()->row_count();
+      }
+      row_percentage = 100 * row_count / input_count;
+    } catch (...) {
+      // Couldn't create statistics. Using default value of 100%
+    }
+  }
+
+  std::ostringstream label_stream;
+  if (!isnan(row_count)) {
+    label_stream << " " << std::fixed << std::setprecision(1) << row_count << " row(s) | " << row_percentage
+                 << "% estd.";
+  } else {
+    label_stream << "no est.";
+  }
+
+  VizEdgeInfo info = _default_edge;
+  info.label = label_stream.str();
+  info.pen_width = pen_width;
+
+  _add_edge(from, to, info);
 }
 
 }  // namespace opossum

--- a/src/lib/planviz/lqp_visualizer.hpp
+++ b/src/lib/planviz/lqp_visualizer.hpp
@@ -27,8 +27,6 @@ class LQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
                       std::unordered_set<std::shared_ptr<const AbstractLQPNode>>& visualized_nodes);
 
   void _build_dataflow(const std::shared_ptr<AbstractLQPNode>& from, const std::shared_ptr<AbstractLQPNode>& to);
-  void _build_dataflow(const std::shared_ptr<AbstractLQPNode>& from, const std::shared_ptr<AbstractLQPNode>& to,
-                       const VizEdgeInfo& edge_info);
 };
 
 }  // namespace opossum

--- a/src/lib/planviz/lqp_visualizer.hpp
+++ b/src/lib/planviz/lqp_visualizer.hpp
@@ -27,6 +27,8 @@ class LQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
                       std::unordered_set<std::shared_ptr<const AbstractLQPNode>>& visualized_nodes);
 
   void _build_dataflow(const std::shared_ptr<AbstractLQPNode>& from, const std::shared_ptr<AbstractLQPNode>& to);
+  void _build_dataflow(const std::shared_ptr<AbstractLQPNode>& from, const std::shared_ptr<AbstractLQPNode>& to,
+                       const VizEdgeInfo& edge_info);
 };
 
 }  // namespace opossum


### PR DESCRIPTION
Subqueries are now visualised in the LQP. PQP will come when I'm further down the line with correlated subqueries. But that will be a separate PR then.

Viz now:
![iterm2 pqgloj lqp](https://user-images.githubusercontent.com/7422656/37667791-273c9ee8-2c63-11e8-9c97-dc03a3210df5.png)


The Projection has a "right" child, which is the subquery.