### PR TITLE
Fix benchmarks that still used max_chunk_size=0 instead of Chunk::MAX_SIZE

### DIFF
--- a/src/benchmark/operators/product_benchmark.cpp
+++ b/src/benchmark/operators/product_benchmark.cpp
@@ -19,7 +19,7 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_Product)(benchmark::State& state) {
   }
 }
 BENCHMARK_REGISTER_F(BenchmarkBasicFixture, BM_Product)
-    ->Args({0})
+    ->Args({static_cast<int>(Chunk::MAX_SIZE)})
     ->Args({10000});  // for this benchmark only tables with a chunk_size of 0 and 10 000 are used. A product operation
                       // on two tables with chunk_size of 100 000 takes about one hour
 

--- a/src/benchmark/operators/product_benchmark.cpp
+++ b/src/benchmark/operators/product_benchmark.cpp
@@ -20,7 +20,7 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_Product)(benchmark::State& state) {
 }
 BENCHMARK_REGISTER_F(BenchmarkBasicFixture, BM_Product)
     ->Args({static_cast<int>(Chunk::MAX_SIZE)})
-    ->Args({10000});  // for this benchmark only tables with a chunk_size of 0 and 10 000 are used. A product operation
-                      // on two tables with chunk_size of 100 000 takes about one hour
+    ->Args({10000});  // for this benchmark only tables with a the maximum chunk size and one of  10 000 are used.
+                      // A Product on two tables with chunk_size of 100 000 takes about one hour
 
 }  // namespace opossum

--- a/src/benchmark/operators/projection_benchmark.cpp
+++ b/src/benchmark/operators/projection_benchmark.cpp
@@ -73,7 +73,7 @@ BENCHMARK_DEFINE_F(OperatorsProjectionBenchmark, BM_ProjectionConstantTerm)(benc
 }
 
 static void CustomArguments(benchmark::internal::Benchmark* b) {
-  for (ChunkID chunk_size : {ChunkID(0), ChunkID(10000), ChunkID(100000)}) {
+  for (ChunkID chunk_size : {ChunkID(Chunk::MAX_SIZE), ChunkID(10000), ChunkID(100000)}) {
     for (int column_type = 0; column_type <= 2; column_type++) {
       b->Args({static_cast<int>(chunk_size), column_type});
     }

--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -22,8 +22,8 @@ BENCHMARK_DEFINE_F(BenchmarkBasicFixture, BM_Sort_ChunkSizeOut)(benchmark::State
 }
 
 static void ChunkSizeOut(benchmark::internal::Benchmark* b) {
-  for (ChunkID chunk_size_in : {ChunkID(0), ChunkID(10000), ChunkID(100000)}) {
-    for (ChunkID chunk_size_out : {ChunkID(0), ChunkID(10000), ChunkID(100000)}) {
+  for (ChunkID chunk_size_in : {ChunkID(Chunk::MAX_SIZE), ChunkID(10000), ChunkID(100000)}) {
+    for (ChunkID chunk_size_out : {ChunkID(Chunk::MAX_SIZE), ChunkID(10000), ChunkID(100000)}) {
       b->Args({static_cast<int>(chunk_size_in), static_cast<int>(chunk_size_out)});
     }
   }


### PR DESCRIPTION
Apparently we had overlooked these benchmarks when we converted from max_chunk_size=0 to Chunk::MAX_SIZE a while ago.