### PR TITLE
Change TPCH query array to map

### DIFF
--- a/src/benchmarklib/tpch/tpch_queries.cpp
+++ b/src/benchmarklib/tpch/tpch_queries.cpp
@@ -74,14 +74,14 @@ const char* const tpch_query_1 =
  * Changes:
  *  1. Random values are hardcoded
  */
-const char* const tpch_query_2 =
-    R"(SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
-       FROM "part", supplier, partsupp, nation, region
-       WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND p_size = 15 AND p_type like '%BRASS' AND
-       s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'EUROPE' AND
-       ps_supplycost = (SELECT min(ps_supplycost) FROM partsupp, supplier, nation, region
-       WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey
-       AND n_regionkey = r_regionkey AND r_name = 'EUROPE') ORDER BY s_acctbal DESC, n_name, s_name, p_partkey;)";
+// const char* const tpch_query_2 =
+//    R"(SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
+//       FROM "part", supplier, partsupp, nation, region
+//       WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND p_size = 15 AND p_type like '%BRASS' AND
+//       s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'EUROPE' AND
+//       ps_supplycost = (SELECT min(ps_supplycost) FROM partsupp, supplier, nation, region
+//       WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey
+//       AND n_regionkey = r_regionkey AND r_name = 'EUROPE') ORDER BY s_acctbal DESC, n_name, s_name, p_partkey;)";
 
 /**
  * TPC-H 3
@@ -137,11 +137,11 @@ const char* const tpch_query_3 =
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
-const char* const tpch_query_4 =
-    R"(SELECT o_orderpriority, count(*) as order_count FROM orders WHERE o_orderdate >= '1996-07-01' AND
-      o_orderdate < '1996-10-01' AND exists (
-      SELECT *FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitdate < l_receiptdate)
-      GROUP BY o_orderpriority ORDER BY o_orderpriority;)";
+// const char* const tpch_query_4 =
+//    R"(SELECT o_orderpriority, count(*) as order_count FROM orders WHERE o_orderdate >= '1996-07-01' AND
+//      o_orderdate < '1996-10-01' AND exists (
+//      SELECT *FROM lineitem WHERE l_orderkey = o_orderkey AND l_commitdate < l_receiptdate)
+//      GROUP BY o_orderpriority ORDER BY o_orderpriority;)";
 
 /**
  * TPC-H 5
@@ -332,14 +332,14 @@ const char* const tpch_query_7 =
  *  3. Extract is not supported
  *    a. Use full date instead
  */
-const char* const tpch_query_8 =
-    R"(SELECT o_year, SUM(case when nation = 'BRAZIL' then volume else 0 end) / SUM(volume) as mkt_share
-      FROM (SELECT o_orderdate as o_year, l_extendedprice * (1-l_discount) as volume,
-      n2.n_name as nation FROM "part", supplier, lineitem, orders, customer, nation n1, nation n2, region
-      WHERE p_partkey = l_partkey AND s_suppkey = l_suppkey AND l_orderkey = o_orderkey AND
-      o_custkey = c_custkey AND c_nationkey = n1.n_nationkey AND n1.n_regionkey = r_regionkey AND
-      r_name = 'AMERICA' AND s_nationkey = n2.n_nationkey AND o_orderdate between '1995-01-01'
-      AND '1996-12-31' AND p_type = 'ECONOMY ANODIZED STEEL') as all_nations GROUP BY o_year ORDER BY o_year;)";
+// const char* const tpch_query_8 =
+//    R"(SELECT o_year, SUM(case when nation = 'BRAZIL' then volume else 0 end) / SUM(volume) as mkt_share
+//      FROM (SELECT o_orderdate as o_year, l_extendedprice * (1-l_discount) as volume,
+//      n2.n_name as nation FROM "part", supplier, lineitem, orders, customer, nation n1, nation n2, region
+//      WHERE p_partkey = l_partkey AND s_suppkey = l_suppkey AND l_orderkey = o_orderkey AND
+//      o_custkey = c_custkey AND c_nationkey = n1.n_nationkey AND n1.n_regionkey = r_regionkey AND
+//      r_name = 'AMERICA' AND s_nationkey = n2.n_nationkey AND o_orderdate between '1995-01-01'
+//      AND '1996-12-31' AND p_type = 'ECONOMY ANODIZED STEEL') as all_nations GROUP BY o_year ORDER BY o_year;)";
 
 /**
  * TPC-H 9
@@ -469,12 +469,12 @@ const char* const tpch_query_10 =
  *  1. Random values are hardcoded
 
  */
-const char* const tpch_query_11 =
-    R"(SELECT ps_partkey, SUM(ps_supplycost * ps_availqty) as value FROM partsupp, supplier, nation
-      WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY'
-      GROUP BY ps_partkey having SUM(ps_supplycost * ps_availqty) > (
-      SELECT SUM(ps_supplycost * ps_availqty) * 0.0001 FROM partsupp, supplier, nation
-      WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY') ORDER BY value DESC;)";
+// const char* const tpch_query_11 =
+//    R"(SELECT ps_partkey, SUM(ps_supplycost * ps_availqty) as value FROM partsupp, supplier, nation
+//      WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY'
+//      GROUP BY ps_partkey having SUM(ps_supplycost * ps_availqty) > (
+//      SELECT SUM(ps_supplycost * ps_availqty) * 0.0001 FROM partsupp, supplier, nation
+//      WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY') ORDER BY value DESC;)";
 
 /**
  * TPC-H 12
@@ -510,13 +510,13 @@ const char* const tpch_query_11 =
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
-const char* const tpch_query_12 =
-    R"(SELECT l_shipmode, SUM(case when o_orderpriority ='1-URGENT' or o_orderpriority ='2-HIGH' then 1 else 0 end)
-      as high_line_count, SUM(case when o_orderpriority <> '1-URGENT' AND
-      o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count FROM orders, lineitem
-      WHERE o_orderkey = l_orderkey AND l_shipmode IN ('MAIL','SHIP') AND l_commitdate < l_receiptdate
-      AND l_shipdate < l_commitdate AND l_receiptdate >= '1994-01-01' AND
-      l_receiptdate < '1995-01-01' GROUP BY l_shipmode ORDER BY l_shipmode;)";
+// const char* const tpch_query_12 =
+//    R"(SELECT l_shipmode, SUM(case when o_orderpriority ='1-URGENT' or o_orderpriority ='2-HIGH' then 1 else 0 end)
+//      as high_line_count, SUM(case when o_orderpriority <> '1-URGENT' AND
+//      o_orderpriority <> '2-HIGH' then 1 else 0 end) as low_line_count FROM orders, lineitem
+//      WHERE o_orderkey = l_orderkey AND l_shipmode IN ('MAIL','SHIP') AND l_commitdate < l_receiptdate
+//      AND l_shipdate < l_commitdate AND l_receiptdate >= '1994-01-01' AND
+//      l_receiptdate < '1995-01-01' GROUP BY l_shipmode ORDER BY l_shipmode;)";
 
 /**
  * TPC-H 13
@@ -540,10 +540,10 @@ const char* const tpch_query_12 =
  *  2. Variable binding in alias not supported by SQLParser
  *    a. removed it
  */
-const char* const tpch_query_13 =
-    R"(SELECT c_count, count(*) as custdist FROM (SELECT c_custkey, count(o_orderkey) AS c_count
-      FROM customer left outer join orders on c_custkey = o_custkey AND o_comment not like '%special%request%'
-      GROUP BY c_custkey) as c_orders GROUP BY c_count ORDER BY custdist DESC, c_count DESC;)";
+// const char* const tpch_query_13 =
+//    R"(SELECT c_count, count(*) as custdist FROM (SELECT c_custkey, count(o_orderkey) AS c_count
+//      FROM customer left outer join orders on c_custkey = o_custkey AND o_comment not like '%special%request%'
+//      GROUP BY c_custkey) as c_orders GROUP BY c_count ORDER BY custdist DESC, c_count DESC;)";
 
 /**
  * TPC-H 14
@@ -569,10 +569,10 @@ const char* const tpch_query_13 =
  *  3. implicit type conversions for arithmetic operations are not supported
  *    a. changed 1 to 1.0 explicitly
  */
-const char* const tpch_query_14 =
-    R"(SELECT 100.00 * SUM(case when p_type like 'PROMO%' then l_extendedprice*(1.0-l_discount) else 0 end)
-      / SUM(l_extendedprice * (1.0 - l_discount)) as promo_revenue FROM lineitem, "part" WHERE l_partkey = p_partkey
-      AND l_shipdate >= '1995-09-01' AND l_shipdate < '1995-10-01';)";
+// const char* const tpch_query_14 =
+//    R"(SELECT 100.00 * SUM(case when p_type like 'PROMO%' then l_extendedprice*(1.0-l_discount) else 0 end)
+//      / SUM(l_extendedprice * (1.0 - l_discount)) as promo_revenue FROM lineitem, "part" WHERE l_partkey = p_partkey
+//      AND l_shipdate >= '1995-09-01' AND l_shipdate < '1995-10-01';)";
 
 /**
  * TPC-H 15
@@ -605,16 +605,16 @@ const char* const tpch_query_14 =
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
-const char* const tpch_query_15 =
-    R"(create view revenue[STREAM_ID] (supplier_no, total_revenue) as SELECT l_suppkey,
-      SUM(l_extendedprice * (1.0 - l_discount)) FROM lineitem WHERE l_shipdate >= date '[DATE]'
-      AND l_shipdate < date '[DATE]' + interval '3' month GROUP BY l_suppkey;
-
-      SELECT s_suppkey, s_name, s_address, s_phone, total_revenue FROM supplier, revenue[STREAM_ID]
-      WHERE s_suppkey = supplier_no AND total_revenue = (SELECT max(total_revenue)
-      FROM revenue[STREAM_ID]) ORDER BY s_suppkey;
-
-      drop view revenue[STREAM_ID];)";
+// const char* const tpch_query_15 =
+//    R"(create view revenue[STREAM_ID] (supplier_no, total_revenue) as SELECT l_suppkey,
+//      SUM(l_extendedprice * (1.0 - l_discount)) FROM lineitem WHERE l_shipdate >= date '[DATE]'
+//      AND l_shipdate < date '[DATE]' + interval '3' month GROUP BY l_suppkey;
+//
+//      SELECT s_suppkey, s_name, s_address, s_phone, total_revenue FROM supplier, revenue[STREAM_ID]
+//      WHERE s_suppkey = supplier_no AND total_revenue = (SELECT max(total_revenue)
+//      FROM revenue[STREAM_ID]) ORDER BY s_suppkey;
+//
+//      drop view revenue[STREAM_ID];)";
 
 /**
  * TPC-H 16
@@ -640,12 +640,12 @@ const char* const tpch_query_15 =
  *  1. Random values are hardcoded
 
  */
-const char* const tpch_query_16 =
-    R"(SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
-      FROM partsupp, "part" WHERE p_partkey = ps_partkey AND p_brand <> 'Brand#45' AND p_type not like 'MEDIUM POLISHED%'
-      AND p_size in (49, 14, 23, 45, 19, 3, 36, 9)
-      AND ps_suppkey not in (SELECT s_suppkey FROM supplier WHERE s_comment like '%Customer%Complaints%')
-      GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;)";
+// const char* const tpch_query_16 =
+//    R"(SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
+//      FROM partsupp, "part" WHERE p_partkey = ps_partkey AND p_brand <> 'Brand#45'
+//      AND p_type not like 'MEDIUM POLISHED%' AND p_size in (49, 14, 23, 45, 19, 3, 36, 9)
+//      AND ps_suppkey not in (SELECT s_suppkey FROM supplier WHERE s_comment like '%Customer%Complaints%')
+//      GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;)";
 
 /**
  * TPC-H 17
@@ -668,10 +668,10 @@ const char* const tpch_query_16 =
  *  1. Random values are hardcoded
 
  */
-const char* const tpch_query_17 =
-    R"(SELECT SUM(l_extendedprice) / 7.0 as avg_yearly FROM lineitem, \"part\" WHERE p_partkey = l_partkey
-      AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < (SELECT 0.2 * avg(l_quantity)
-      FROM lineitem WHERE l_partkey = p_partkey);)";
+// const char* const tpch_query_17 =
+//    R"(SELECT SUM(l_extendedprice) / 7.0 as avg_yearly FROM lineitem, \"part\" WHERE p_partkey = l_partkey
+//      AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < (SELECT 0.2 * avg(l_quantity)
+//      FROM lineitem WHERE l_partkey = p_partkey);)";
 
 /**
  * TPC-H 18
@@ -696,11 +696,11 @@ const char* const tpch_query_17 =
  *  1. Random values are hardcoded
 
  */
-const char* const tpch_query_18 =
-    R"(SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity)
-      FROM customer, orders, lineitem WHERE o_orderkey in (SELECT l_orderkey FROM lineitem
-      GROUP BY l_orderkey having SUM(l_quantity) > 300) AND c_custkey = o_custkey AND o_orderkey = l_orderkey
-      GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice ORDER BY o_totalprice DESC, o_orderdate;)";
+// const char* const tpch_query_18 =
+//    R"(SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity)
+//      FROM customer, orders, lineitem WHERE o_orderkey in (SELECT l_orderkey FROM lineitem
+//      GROUP BY l_orderkey having SUM(l_quantity) > 300) AND c_custkey = o_custkey AND o_orderkey = l_orderkey
+//      GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice ORDER BY o_totalprice DESC, o_orderdate;)";
 
 /**
  * TPC-H 19
@@ -743,17 +743,17 @@ const char* const tpch_query_18 =
  *  2. implicit type conversions for arithmetic operations are not supported
  *    a. changed 1 to 1.0 explicitly
  */
-const char* const tpch_query_19 =
-    R"(SELECT SUM(l_extendedprice * (1.0 - l_discount) ) as revenue FROM lineitem, "part" WHERE (p_partkey = l_partkey
-      AND p_brand = 'Brand#12' AND p_container in ( 'SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') AND
-      l_quantity >= 1 AND l_quantity <= 1 + 10 AND p_size between 1 AND 5 AND l_shipmode
-      in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') or (p_partkey = l_partkey
-      AND p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
-      AND l_quantity >= 10 AND l_quantity <= 10 + 10 AND p_size between 1 AND 10
-      AND l_shipmode in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') or
-      (p_partkey = l_partkey AND p_brand = 'Brand#34' AND p_container in ( 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
-      AND l_quantity >= 20 AND l_quantity <= 20 + 10 AND p_size between 1 AND 15 AND l_shipmode in
-      ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON');)";
+// const char* const tpch_query_19 =
+//    R"(SELECT SUM(l_extendedprice * (1.0 - l_discount) ) as revenue FROM lineitem, "part" WHERE (p_partkey = l_partkey
+//      AND p_brand = 'Brand#12' AND p_container in ( 'SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') AND
+//      l_quantity >= 1 AND l_quantity <= 1 + 10 AND p_size between 1 AND 5 AND l_shipmode
+//      in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') or (p_partkey = l_partkey
+//      AND p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+//      AND l_quantity >= 10 AND l_quantity <= 10 + 10 AND p_size between 1 AND 10
+//      AND l_shipmode in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') or
+//      (p_partkey = l_partkey AND p_brand = 'Brand#34' AND p_container in ( 'LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+//      AND l_quantity >= 20 AND l_quantity <= 20 + 10 AND p_size between 1 AND 15 AND l_shipmode in
+//      ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON');)";
 
 /**
  * TPC-H 20
@@ -792,12 +792,12 @@ const char* const tpch_query_19 =
  *    b. pre-calculate date operation
 
  */
-const char* const tpch_query_20 =
-    R"(SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey in (SELECT ps_suppkey FROM partsupp
-      WHERE ps_partkey in (SELECT p_partkey FROM "part" WHERE p_name like 'forest%') AND ps_availqty >
-      (SELECT 0.5 * SUM(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND
-      l_shipdate >= '1994-01-01' AND l_shipdate < '1995-01-01')) AND s_nationkey = n_nationkey
-      AND n_name = 'CANADA' ORDER BY s_name;)";
+// const char* const tpch_query_20 =
+//    R"(SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey in (SELECT ps_suppkey FROM partsupp
+//      WHERE ps_partkey in (SELECT p_partkey FROM "part" WHERE p_name like 'forest%') AND ps_availqty >
+//      (SELECT 0.5 * SUM(l_quantity) FROM lineitem WHERE l_partkey = ps_partkey AND l_suppkey = ps_suppkey AND
+//      l_shipdate >= '1994-01-01' AND l_shipdate < '1995-01-01')) AND s_nationkey = n_nationkey
+//      AND n_name = 'CANADA' ORDER BY s_name;)";
 
 /**
  * TPC-H 21
@@ -837,13 +837,13 @@ const char* const tpch_query_20 =
  *    b. pre-calculate date operation
 
  */
-const char* const tpch_query_21 =
-    R"(SELECT s_name, count(*) as numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey
-      AND o_orderkey = l1.l_orderkey AND o_orderstatus = 'F' AND l1.l_receiptdate > l1.l_commitdate AND exists
-      (SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND not exists
-      (SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND
-      l3.l_receiptdate > l3.l_commitdate ) AND s_nationkey = n_nationkey AND n_name = 'SAUDI ARABIA' GROUP BY s_name
-      ORDER BY numwait DESC, s_name;)";
+// const char* const tpch_query_21 =
+//    R"(SELECT s_name, count(*) as numwait FROM supplier, lineitem l1, orders, nation WHERE s_suppkey = l1.l_suppkey
+//      AND o_orderkey = l1.l_orderkey AND o_orderstatus = 'F' AND l1.l_receiptdate > l1.l_commitdate AND exists
+//      (SELECT * FROM lineitem l2 WHERE l2.l_orderkey = l1.l_orderkey AND l2.l_suppkey <> l1.l_suppkey) AND not exists
+//      (SELECT * FROM lineitem l3 WHERE l3.l_orderkey = l1.l_orderkey AND l3.l_suppkey <> l1.l_suppkey AND
+//      l3.l_receiptdate > l3.l_commitdate ) AND s_nationkey = n_nationkey AND n_name = 'SAUDI ARABIA' GROUP BY s_name
+//      ORDER BY numwait DESC, s_name;)";
 
 /**
  * TPC-H 22
@@ -885,50 +885,44 @@ const char* const tpch_query_21 =
  * ORDER BY
  *     CNTRYCODE
  */
-const char* const tpch_query_22 =
-    R"(SELECT CNTRYCODE, COUNT(*) AS NUMCUST, SUM(C_ACCTBAL) AS TOTACCTBAL
-       FROM (SELECT SUBSTRING(C_PHONE,1,2) AS CNTRYCODE, C_ACCTBAL
-       FROM CUSTOMER WHERE SUBSTRING(C_PHONE,1,2) IN ('13', '31', '23', '29', '30', '18', '17') AND
-       C_ACCTBAL > (SELECT AVG(C_ACCTBAL) FROM CUSTOMER WHERE C_ACCTBAL > 0.00 AND
-       SUBSTRING(C_PHONE,1,2) IN ('13', '31', '23', '29', '30', '18', '17')) AND
-       NOT EXISTS ( SELECT * FROM ORDERS WHERE O_CUSTKEY = C_CUSTKEY)) AS CUSTSALE
-       GROUP BY CNTRYCODE
-       ORDER BY CNTRYCODE;)";
+// const char* const tpch_query_22 =
+//    R"(SELECT CNTRYCODE, COUNT(*) AS NUMCUST, SUM(C_ACCTBAL) AS TOTACCTBAL
+//       FROM (SELECT SUBSTRING(C_PHONE,1,2) AS CNTRYCODE, C_ACCTBAL
+//       FROM CUSTOMER WHERE SUBSTRING(C_PHONE,1,2) IN ('13', '31', '23', '29', '30', '18', '17') AND
+//       C_ACCTBAL > (SELECT AVG(C_ACCTBAL) FROM CUSTOMER WHERE C_ACCTBAL > 0.00 AND
+//       SUBSTRING(C_PHONE,1,2) IN ('13', '31', '23', '29', '30', '18', '17')) AND
+//       NOT EXISTS ( SELECT * FROM ORDERS WHERE O_CUSTKEY = C_CUSTKEY)) AS CUSTSALE
+//       GROUP BY CNTRYCODE
+//       ORDER BY CNTRYCODE;)";
 
 }  // namespace
 
 namespace opossum {
 
-const char* tpch_queries[NUM_TPCH_QUERIES] = {tpch_query_1,  tpch_query_2,  tpch_query_3,  tpch_query_4,  tpch_query_5,
-                                              tpch_query_6,  tpch_query_7,  tpch_query_8,  tpch_query_9,  tpch_query_10,
-                                              tpch_query_11, tpch_query_12, tpch_query_13, tpch_query_14, tpch_query_15,
-                                              tpch_query_16, tpch_query_17, tpch_query_18, tpch_query_19, tpch_query_20,
-                                              tpch_query_21, tpch_query_22};
-
-size_t tpch_supported_queries[NUM_SUPPORTED_TPCH_QUERIES] = {
-    0,
-    // 1, /* // Enable once we support Subselects in WHERE condition */
-    2,
-    // 3, /* Enable once we support Exists and Subselects in WHERE condition */
-    4, 5, 6,
-    // 7, /* Enable once CASE and arithmetic operations of Aggregations are supported */
-    8, 9
-    // 10, /* Enable once we support Subselects in Having clause */
-    // 11, /* Enable once we support IN */
-    // 12, /* Enable once we support nested expressions in Join Condition */
-    // 13, /* Enable once we support Case */
-    // 14, /* Enable once we support Subselects in WHERE condition */
-    // 15, /* Enable once we support Subselects in WHERE condition */
-    // 16, /* Enable once we support Subselects in WHERE condition */
-    // 17, /* Enable once we support Subselects in WHERE condition */
-    // 18, /* Enable once we support OR in WHERE condition */
-    // 19, /* Enable once we support Subselects in WHERE condition */
-    // 20, /* Enable once we support Exists and Subselect in WHERE condition */
-    // 21 /* Enable once we support SUBSTRING, IN and EXISTS */
-    /* Enable once we support SUBSTRING, IN, EXISTS,
-     * and both uncorrelated and correlated Subselects in WHERE condition
-     */
-    // 22
+const std::map<size_t, const char*> tpch_queries = {
+    {1, tpch_query_1},
+    /* {2, tpch_query_2},   Enable once we support Subselects in WHERE condition */
+    {3, tpch_query_3},
+    /* {4, tpch_query_4},   Enable once we support Exists and Subselects in WHERE condition */
+    {5, tpch_query_5},
+    {6, tpch_query_6},
+    {7, tpch_query_7},
+    /* {8, tpch_query_8},   Enable once CASE and arithmetic operations of Aggregations are supported */
+    {9, tpch_query_9},
+    {10, tpch_query_10},
+    /* {11, tpch_query_11}, Enable once we support Subselects in Having clause */
+    /* {12, tpch_query_12}, Enable once we support IN */
+    /* {13, tpch_query_13}, Enable once we support nested expressions in Join Condition */
+    /* {14, tpch_query_14}, Enable once we support Case */
+    /* {15, tpch_query_15}, Enable once we support Subselects in WHERE condition */
+    /* {16, tpch_query_16}, Enable once we support Subselects in WHERE condition */
+    /* {17, tpch_query_17}, Enable once we support Subselects in WHERE condition */
+    /* {18, tpch_query_18}, Enable once we support Subselects in WHERE condition */
+    /* {19, tpch_query_19}, Enable once we support OR in WHERE condition */
+    /* {20, tpch_query_20}, Enable once we support Subselects in WHERE condition */
+    /* {21, tpch_query_21}, Enable once we support Exists and correlated Subselect in WHERE condition */
+    /* {22, tpch_query_22}  Enable once we support SUBSTRING, IN, EXISTS,
+                            and both uncorrelated and correlated Subselects in WHERE condition */
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/tpch/tpch_queries.hpp
+++ b/src/benchmarklib/tpch/tpch_queries.hpp
@@ -6,7 +6,8 @@
 namespace opossum {
 
 /**
- * Contains all supported TPCH queries. Use ordered map to have  by query id.
+ * Contains all supported TPCH queries. Use ordered map to have queries sorted by query id. 
+ * This allows for guaranteed execution order when iterating over the queries.
  */
 extern const std::map<size_t, const char*> tpch_queries;
 

--- a/src/benchmarklib/tpch/tpch_queries.hpp
+++ b/src/benchmarklib/tpch/tpch_queries.hpp
@@ -1,16 +1,13 @@
 #pragma once
 
 #include <cstdlib>
+#include <map>
 
 namespace opossum {
 
-constexpr size_t NUM_TPCH_QUERIES = 22;
-constexpr size_t NUM_SUPPORTED_TPCH_QUERIES = 7;
-
-extern const char* tpch_queries[NUM_TPCH_QUERIES];
-
 /**
- * Indicates whether the query with a specific index is considered to be supported by Hyrise
+ * Contains all supported TPCH queries. Use ordered map to have  by query id.
  */
-extern size_t tpch_supported_queries[NUM_SUPPORTED_TPCH_QUERIES];
+extern const std::map<size_t, const char*> tpch_queries;
+
 }  // namespace opossum

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -45,9 +45,9 @@ class TPCHTest : public BaseTestWithParam<size_t> {
 TEST_P(TPCHTest, TPCHQueryTest) {
   const auto query_idx = GetParam();
 
-  SCOPED_TRACE("TPC-H " + std::to_string(query_idx + 1));
+  SCOPED_TRACE("TPC-H " + std::to_string(query_idx));
 
-  const auto query = tpch_queries[query_idx];
+  const auto query = tpch_queries.at(query_idx);
   const auto sqlite_result_table = _sqlite_wrapper->execute_query(query);
 
   auto sql_pipeline = SQLPipelineBuilder{query}.disable_mvcc().create_pipeline();
@@ -59,27 +59,28 @@ TEST_P(TPCHTest, TPCHQueryTest) {
 
 // clang-format off
 INSTANTIATE_TEST_CASE_P(TPCHTestInstances, TPCHTest, ::testing::Values(
-  0,
-  // 1, /* // Enable once we support Subselects in WHERE condition */
-  2,
-  // 3, /* Enable once we support Exists and Subselects in WHERE condition */
-  4,
+  1,
+  // 2,  /* Enable once we support Subselects in WHERE condition */
+  3,
+  // 4,  /* Enable once we support Exists and Subselects in WHERE condition */
   5,
   6,
-  // 7, /* Enable once CASE and arithmetic operations of Aggregations are supported */
-  8,
-  9
-  // 10, /* Enable once we support Subselects in Having clause */
-  // 11, /* Enable once we support IN */
-  // 12, /* Enable once we support nested expressions in Join Condition */
-  // 13, /* Enable once we support Case */
-  // 14, /* Enable once we support Subselects in WHERE condition */
+  7,
+  // 8,  /* Enable once CASE and arithmetic operations of Aggregations are supported */
+  9,
+  10
+  // 11, /* Enable once we support Subselects in Having clause */
+  // 12, /* Enable once we support IN */
+  // 13, /* Enable once we support nested expressions in Join Condition */
+  // 14, /* Enable once we support Case */
   // 15, /* Enable once we support Subselects in WHERE condition */
   // 16, /* Enable once we support Subselects in WHERE condition */
   // 17, /* Enable once we support Subselects in WHERE condition */
-  // 18, /* Enable once we support OR in WHERE condition */
-  // 19, /* Enable once we support Subselects in WHERE condition */
-  // 20 /* Enable once we support Exists and Subselect in WHERE condition */
+  // 18, /* Enable once we support Subselects in WHERE condition */
+  // 19, /* Enable once we support OR in WHERE condition */
+  // 20, /* Enable once we support Subselects in WHERE condition */
+  // 21, /* Enable once we support Exists and Subselect in WHERE condition */
+  // 22  /* Enable once we support SUBSTRING, IN, EXISTS, and un-/correlated Subselects in WHERE condition */
 ), );  // NOLINT
 // clang-format on
 


### PR DESCRIPTION
Closes #791.

We can now access the queries by the correct index to query mapping without silly off by one confusion. All unused queries had to be commented because the compiler is not happy otherwise.