### PR TITLE
Add pwd functionality to hyrise console

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -64,6 +64,7 @@ target_link_libraries(
     hyriseBenchmarkLib
     ncurses
     ${READLINE_LIBRARY}
+    ${FILESYSTEM_LIBRARY}
 )
 target_include_directories(
     hyriseConsole

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -119,6 +119,7 @@ class Console {
   int rollback_transaction(const std::string& input);
   int commit_transaction(const std::string& input);
   int print_transaction_info(const std::string& input);
+  int print_current_working_directory(const std::string& args);
 
   // Creates the pipelines and returns whether is was successful (true) or not (false)
   bool _initialize_pipeline(const std::string& sql);


### PR DESCRIPTION
I added the functionality to print the current working directory to make it easier to use relative paths, e.g. to load tables and/or scripts.