### PR TITLE
CsvParser allow unquoted null strings if specified in parse config

### DIFF
--- a/src/lib/import_export/csv_converter.hpp
+++ b/src/lib/import_export/csv_converter.hpp
@@ -54,8 +54,16 @@ class CsvConverter : public BaseCsvConverter {
       _null_values[position] = true;
       return;
     }
-    Assert(boost::to_lower_copy(value) != ParseConfig::NULL_STRING,
-           "Unquoted null found in CSV file. Either quote it for string literal \"null\" or leave field empty.");
+
+    if (boost::to_lower_copy(value) == ParseConfig::NULL_STRING) {
+      Assert(!_config.reject_null_strings,
+             "Unquoted null found in CSV file. Quote it for string literal \"null\", leave field empty for null value, "
+             "or set 'reject_null_strings' to false in parse config.");
+      if (_is_nullable) {
+        _null_values[position] = true;
+        return;
+      }
+    }
 
     // clang-format off
     if constexpr(std::is_same_v<T, std::string>) {

--- a/src/lib/import_export/csv_meta.hpp
+++ b/src/lib/import_export/csv_meta.hpp
@@ -25,6 +25,9 @@ struct ParseConfig {
   // If this is set to true, "4.3" will not be accepted as a value for a float column
   bool reject_quoted_nonstrings = true;
 
+  // If this is set to true, an unquoted null string causes an exception (only empty field is allowed as null value)
+  bool reject_null_strings = true;
+
   // Indicator whether the Csv follows RFC 4180. (see https://tools.ietf.org/html/rfc4180)
   bool rfc_mode = true;
 

--- a/src/test/operators/import_csv_test.cpp
+++ b/src/test/operators/import_csv_test.cpp
@@ -218,6 +218,23 @@ TEST_F(OperatorsImportCsvTest, ImportStringNullValues) {
 }
 
 TEST_F(OperatorsImportCsvTest, ImportUnquotedNullString) {
+  std::string csv_file = "src/test/csv/string_with_bad_null.csv";
+  auto csv_meta = process_csv_meta_file(csv_file + CsvMeta::META_FILE_EXTENSION);
+  csv_meta.config.reject_null_strings = false;
+  auto importer = std::make_shared<ImportCsv>(csv_file, csv_meta);
+  importer->execute();
+
+  TableColumnDefinitions column_definitions{{"a", DataType::String, true}};
+  auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
+  expected_table->append({"xxx"});
+  expected_table->append({"www"});
+  expected_table->append({NULL_VALUE});
+  expected_table->append({"zzz"});
+
+  EXPECT_TABLE_EQ_ORDERED(importer->get_output(), expected_table);
+}
+
+TEST_F(OperatorsImportCsvTest, ImportUnquotedNullStringThrows) {
   auto importer = std::make_shared<ImportCsv>("src/test/csv/string_with_bad_null.csv");
   EXPECT_THROW(importer->execute(), std::exception);
 }


### PR DESCRIPTION
Fix for #812 