### PR TITLE
Untie LQP output from input on when the output is deleted

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -31,7 +31,9 @@ std::string QualifiedColumnName::as_string() const {
 AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type) : _type(node_type) {}
 
 AbstractLQPNode::~AbstractLQPNode() {
-  Assert(_outputs.empty(), "Bug detected. There are outputs that should still reference to this node. Thus this node shouldn't get deleted");
+  Assert(
+      _outputs.empty(),
+      "Bug detected. There are outputs that should still reference to this node. Thus this node shouldn't get deleted");
   if (_inputs[0]) _inputs[0]->_remove_output_pointer(*this);
   if (_inputs[1]) _inputs[1]->_remove_output_pointer(*this);
 }
@@ -474,9 +476,8 @@ void AbstractLQPNode::_input_changed() {
 }
 
 void AbstractLQPNode::_remove_output_pointer(const AbstractLQPNode& output) {
-  const auto iter =
-      std::find_if(_outputs.begin(), _outputs.end(), [&](const auto& other) {
-        /**
+  const auto iter = std::find_if(_outputs.begin(), _outputs.end(), [&](const auto& other) {
+    /**
          * HACK! We're checking for other.expired() here as well when looking for `output`
          * If nothing else breaks the only way we might get `other.expired()` to be true is if `other` is the expired
          * weak_ptr<> to output - and thus the element we're looking for - in the following scenario:
@@ -487,8 +488,8 @@ void AbstractLQPNode::_remove_output_pointer(const AbstractLQPNode& output) {
          * node_b.reset(); // ~AbstractLQPNode() will call `node_a_remove_output_pointer(node_b)`
          *                 // But we can't lock node_b anymore, since its ref count is already 0
          */
-        return &output == other.lock().get() || other.expired();
-      });
+    return &output == other.lock().get() || other.expired();
+  });
   DebugAssert(iter != _outputs.end(), "Specified output node is not actually a output node of this node.");
 
   /**

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -34,6 +34,9 @@ AbstractLQPNode::~AbstractLQPNode() {
   Assert(
       _outputs.empty(),
       "Bug detected. There are outputs that should still reference to this node. Thus this node shouldn't get deleted");
+
+  // We're in the destructor, thus we must make sure we're not calling any virtual methods - so we're doing the removal
+  // directly instead of calling set_input_left/right(nullptr)
   if (_inputs[0]) _inputs[0]->_remove_output_pointer(*this);
   if (_inputs[1]) _inputs[1]->_remove_output_pointer(*this);
 }

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -30,6 +30,12 @@ std::string QualifiedColumnName::as_string() const {
 
 AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type) : _type(node_type) {}
 
+AbstractLQPNode::~AbstractLQPNode() {
+  Assert(_outputs.empty(), "Bug detected. There are outputs that should still reference to this node. Thus this node shouldn't get deleted");
+  if (_inputs[0]) _inputs[0]->_remove_output_pointer(*this);
+  if (_inputs[1]) _inputs[1]->_remove_output_pointer(*this);
+}
+
 LQPColumnReference AbstractLQPNode::adapt_column_reference_to_different_lqp(
     const LQPColumnReference& column_reference, const std::shared_ptr<AbstractLQPNode>& original_lqp,
     const std::shared_ptr<AbstractLQPNode>& copied_lqp) {
@@ -134,7 +140,7 @@ void AbstractLQPNode::set_input(LQPInputSide side, const std::shared_ptr<Abstrac
 
   // Untie from previous input
   if (current_input) {
-    current_input->_remove_output_pointer(shared_from_this());
+    current_input->_remove_output_pointer(*this);
   }
 
   /**
@@ -467,9 +473,22 @@ void AbstractLQPNode::_input_changed() {
   }
 }
 
-void AbstractLQPNode::_remove_output_pointer(const std::shared_ptr<AbstractLQPNode>& output) {
+void AbstractLQPNode::_remove_output_pointer(const AbstractLQPNode& output) {
   const auto iter =
-      std::find_if(_outputs.begin(), _outputs.end(), [&](const auto& other) { return output == other.lock(); });
+      std::find_if(_outputs.begin(), _outputs.end(), [&](const auto& other) {
+        /**
+         * HACK! We're checking for other.expired() here as well when looking for `output`
+         * If nothing else breaks the only way we might get `other.expired()` to be true is if `other` is the expired
+         * weak_ptr<> to output - and thus the element we're looking for - in the following scenario:
+         *
+         * auto node_a = Node::make()
+         * auto node_b = Node::make(..., node_a)
+         *
+         * node_b.reset(); // ~AbstractLQPNode() will call `node_a_remove_output_pointer(node_b)`
+         *                 // But we can't lock node_b anymore, since its ref count is already 0
+         */
+        return &output == other.lock().get() || other.expired();
+      });
   DebugAssert(iter != _outputs.end(), "Specified output node is not actually a output node of this node.");
 
   /**

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -80,6 +80,7 @@ struct QualifiedColumnName {
 class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, private Noncopyable {
  public:
   explicit AbstractLQPNode(LQPNodeType node_type);
+  virtual ~AbstractLQPNode();
 
   // Creates a deep copy
   std::shared_ptr<AbstractLQPNode> deep_copy() const;
@@ -385,7 +386,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
    * Add or remove a output without manipulating this outputs input ptr. For internal usage in set_left_input(),
    * set_right_input(), remove_output
    */
-  void _remove_output_pointer(const std::shared_ptr<AbstractLQPNode>& output);
+  void _remove_output_pointer(const AbstractLQPNode& output);
   void _add_output_pointer(const std::shared_ptr<AbstractLQPNode>& output);
   // @}
 };

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -396,4 +396,18 @@ TEST_F(LogicalQueryPlanTest, ColumnIDByColumnReference) {
   EXPECT_EQ(mock_node_a->find_output_column_id(LQPColumnReference{mock_node_b, ColumnID{0}}), std::nullopt);
 }
 
+TEST_F(LogicalQueryPlanTest, OutputResetOnNodeDelete) {
+  auto mock_node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}});
+  auto mock_node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "y"}});
+  auto join_node = JoinNode::make(JoinMode::Cross, mock_node_a, mock_node_b);
+
+  EXPECT_EQ(mock_node_a->output_count(), 1u);
+  EXPECT_EQ(mock_node_b->output_count(), 1u);
+
+  join_node.reset();
+
+  EXPECT_EQ(mock_node_a->output_count(), 0u);
+  EXPECT_EQ(mock_node_b->output_count(), 0u);
+}
+
 }  // namespace opossum


### PR DESCRIPTION
Hacky way to untie the LQP when a node gets deleted. Let's discuss this in person @mrks