### PR TITLE
Exception handlers are killing your call stacks

### DIFF
--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -181,6 +181,10 @@ std::shared_ptr<const Table> SQLPipeline::get_result_table() {
 
   for (auto& pipeline_statement : _sql_pipeline_statements) {
     pipeline_statement->get_result_table();
+    if (_transaction_context && _transaction_context->aborted()) {
+      _failed_pipeline_statement = pipeline_statement;
+      return nullptr;
+    }
   }
 
   _result_table = _sql_pipeline_statements.back()->get_result_table();

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -95,15 +95,7 @@ const std::vector<std::shared_ptr<hsql::SQLParserResult>>& SQLPipeline::get_pars
 
   _parsed_sql_statements.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    try {
-      _parsed_sql_statements.push_back(pipeline_statement->get_parsed_sql_statement());
-    } catch (const std::exception& exception) {
-      _failed_pipeline_statement = pipeline_statement;
-
-      // Don't keep bad values
-      _parsed_sql_statements.clear();
-      throw;
-    }
+    _parsed_sql_statements.push_back(pipeline_statement->get_parsed_sql_statement());
   }
 
   return _parsed_sql_statements;
@@ -120,15 +112,7 @@ const std::vector<std::shared_ptr<AbstractLQPNode>>& SQLPipeline::get_unoptimize
 
   _unoptimized_logical_plans.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    try {
-      _unoptimized_logical_plans.push_back(pipeline_statement->get_unoptimized_logical_plan());
-    } catch (const std::exception& exception) {
-      _failed_pipeline_statement = pipeline_statement;
-
-      // Don't keep bad values
-      _unoptimized_logical_plans.clear();
-      throw;
-    }
+    _unoptimized_logical_plans.push_back(pipeline_statement->get_unoptimized_logical_plan());
   }
 
   return _unoptimized_logical_plans;
@@ -145,15 +129,7 @@ const std::vector<std::shared_ptr<AbstractLQPNode>>& SQLPipeline::get_optimized_
 
   _optimized_logical_plans.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    try {
-      _optimized_logical_plans.push_back(pipeline_statement->get_optimized_logical_plan());
-    } catch (const std::exception& exception) {
-      _failed_pipeline_statement = pipeline_statement;
-
-      // Don't keep bad values
-      _optimized_logical_plans.clear();
-      throw;
-    }
+    _optimized_logical_plans.push_back(pipeline_statement->get_optimized_logical_plan());
   }
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
@@ -175,15 +151,7 @@ const std::vector<std::shared_ptr<SQLQueryPlan>>& SQLPipeline::get_query_plans()
 
   _query_plans.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    try {
-      _query_plans.push_back(pipeline_statement->get_query_plan());
-    } catch (const std::exception& exception) {
-      _failed_pipeline_statement = pipeline_statement;
-
-      // Don't keep bad values
-      _query_plans.clear();
-      throw;
-    }
+    _query_plans.push_back(pipeline_statement->get_query_plan());
   }
 
   return _query_plans;
@@ -200,15 +168,7 @@ const std::vector<std::vector<std::shared_ptr<OperatorTask>>>& SQLPipeline::get_
 
   _tasks.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    try {
-      _tasks.push_back(pipeline_statement->get_tasks());
-    } catch (const std::exception& exception) {
-      _failed_pipeline_statement = pipeline_statement;
-
-      // Don't keep bad values
-      _tasks.clear();
-      throw;
-    }
+    _tasks.push_back(pipeline_statement->get_tasks());
   }
 
   return _tasks;
@@ -220,12 +180,7 @@ std::shared_ptr<const Table> SQLPipeline::get_result_table() {
   }
 
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    try {
-      pipeline_statement->get_result_table();
-    } catch (const std::exception& exception) {
-      _failed_pipeline_statement = pipeline_statement;
-      throw;
-    }
+    pipeline_statement->get_result_table();
   }
 
   _result_table = _sql_pipeline_statements.back()->get_result_table();

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -61,8 +61,7 @@ class SQLPipeline : public Noncopyable {
   // Returns the TransactionContext that was passed to the SQLPipelineStatement, or nullptr if none was passed in.
   std::shared_ptr<TransactionContext> transaction_context() const;
 
-  // This returns the SQLPipelineStatement that caused this pipeline to throw an error.
-  // If there is no failed statement, this fails
+  // This returns the SQLPipelineStatement that aborted the transaction, if any
   std::shared_ptr<SQLPipelineStatement> failed_pipeline_statement() const;
 
   // Returns the number of SQLPipelineStatements present in this pipeline

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -83,13 +83,9 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
     _num_parameters = static_cast<uint16_t>(parsed_sql->parameters().size());
   }
 
-  try {
-    const auto lqp_roots = SQLTranslator{_use_mvcc == UseMvcc::Yes}.translate_parse_result(*parsed_sql);
-    DebugAssert(lqp_roots.size() == 1, "LQP translation returned no or more than one LQP root for a single statement.");
-    _unoptimized_logical_plan = lqp_roots.front();
-  } catch (const std::exception& exception) {
-    throw std::runtime_error("Error while compiling query plan:\n  " + std::string(exception.what()));
-  }
+  const auto lqp_roots = SQLTranslator{_use_mvcc == UseMvcc::Yes}.translate_parse_result(*parsed_sql);
+  DebugAssert(lqp_roots.size() == 1, "LQP translation returned no or more than one LQP root for a single statement.");
+  _unoptimized_logical_plan = lqp_roots.front();
 
   return _unoptimized_logical_plan;
 }
@@ -100,11 +96,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   }
 
   const auto& unoptimized_lqp = get_unoptimized_logical_plan();
-  try {
-    _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
-  } catch (const std::exception& exception) {
-    throw std::runtime_error("Error while optimizing query plan:\n  " + std::string(exception.what()));
-  }
+  _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -138,49 +130,45 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     }
   };
 
-  try {
-    if (const auto cached_plan = SQLQueryCache<SQLQueryPlan>::get().try_get(_sql_string)) {
-      // Handle query plan if statement has been cached
-      auto& plan = *cached_plan;
+  if (const auto cached_plan = SQLQueryCache<SQLQueryPlan>::get().try_get(_sql_string)) {
+    // Handle query plan if statement has been cached
+    auto& plan = *cached_plan;
 
-      DebugAssert(!plan.tree_roots().empty(), "QueryPlan retrieved from cache is empty.");
-      assert_same_mvcc_mode(plan);
+    DebugAssert(!plan.tree_roots().empty(), "QueryPlan retrieved from cache is empty.");
+    assert_same_mvcc_mode(plan);
 
-      _query_plan->append_plan(plan.recreate());
-      _query_plan_cache_hit = true;
-    } else if (const auto* execute_statement = dynamic_cast<const hsql::ExecuteStatement*>(statement)) {
-      // Handle query plan if we are executing a prepared statement
-      Assert(_prepared_statements, "Cannot execute statement without prepared statement cache.");
-      const auto plan = _prepared_statements->try_get(execute_statement->name);
+    _query_plan->append_plan(plan.recreate());
+    _query_plan_cache_hit = true;
+  } else if (const auto* execute_statement = dynamic_cast<const hsql::ExecuteStatement*>(statement)) {
+    // Handle query plan if we are executing a prepared statement
+    Assert(_prepared_statements, "Cannot execute statement without prepared statement cache.");
+    const auto plan = _prepared_statements->try_get(execute_statement->name);
 
-      Assert(plan, "Requested prepared statement does not exist!");
-      assert_same_mvcc_mode(*plan);
+    Assert(plan, "Requested prepared statement does not exist!");
+    assert_same_mvcc_mode(*plan);
 
-      // Get list of arguments from EXECUTE statement.
-      std::vector<AllParameterVariant> arguments;
-      if (execute_statement->parameters != nullptr) {
-        for (const auto* expr : *execute_statement->parameters) {
-          arguments.push_back(HSQLExprTranslator::to_all_parameter_variant(*expr));
-        }
+    // Get list of arguments from EXECUTE statement.
+    std::vector<AllParameterVariant> arguments;
+    if (execute_statement->parameters != nullptr) {
+      for (const auto* expr : *execute_statement->parameters) {
+        arguments.push_back(HSQLExprTranslator::to_all_parameter_variant(*expr));
       }
-
-      Assert(arguments.size() == plan->num_parameters(),
-             "Number of arguments provided does not match expected number of arguments.");
-
-      _query_plan->append_plan(plan->recreate(arguments));
-    } else {
-      // "Normal" mode in which the query plan is created
-      const auto& lqp = get_optimized_logical_plan();
-      _query_plan->add_tree_by_root(LQPTranslator{}.translate_node(lqp));
-
-      // Set number of parameters to match later in case of prepared statement
-      _query_plan->set_num_parameters(_num_parameters);
     }
 
-    if (_use_mvcc == UseMvcc::Yes) _query_plan->set_transaction_context(_transaction_context);
-  } catch (const std::exception& exception) {
-    throw std::runtime_error("Error while translating query plan:\n  " + std::string(exception.what()));
+    Assert(arguments.size() == plan->num_parameters(),
+           "Number of arguments provided does not match expected number of arguments.");
+
+    _query_plan->append_plan(plan->recreate(arguments));
+  } else {
+    // "Normal" mode in which the query plan is created
+    const auto& lqp = get_optimized_logical_plan();
+    _query_plan->add_tree_by_root(LQPTranslator{}.translate_node(lqp));
+
+    // Set number of parameters to match later in case of prepared statement
+    _query_plan->set_num_parameters(_num_parameters);
   }
+
+  if (_use_mvcc == UseMvcc::Yes) _query_plan->set_transaction_context(_transaction_context);
 
   if (const auto* prepared_statement = dynamic_cast<const hsql::PrepareStatement*>(statement)) {
     Assert(_prepared_statements, "Cannot prepare statement without prepared statement cache.");
@@ -207,13 +195,8 @@ const std::vector<std::shared_ptr<OperatorTask>>& SQLPipelineStatement::get_task
   DebugAssert(query_plan->tree_roots().size() == 1,
               "Physical query qlan creation returned no or more than one plan for a single statement.");
 
-  try {
-    const auto& root = query_plan->tree_roots().front();
-    _tasks = OperatorTask::make_tasks_from_operator(root);
-  } catch (const std::exception& exception) {
-    throw std::runtime_error("Error while creating tasks:\n  " + std::string(exception.what()));
-  }
-
+  const auto& root = query_plan->tree_roots().front();
+  _tasks = OperatorTask::make_tasks_from_operator(root);
   return _tasks;
 }
 
@@ -235,12 +218,7 @@ const std::shared_ptr<const Table>& SQLPipelineStatement::get_result_table() {
     return _result_table;
   }
 
-  try {
-    CurrentScheduler::schedule_and_wait_for_tasks(tasks);
-  } catch (const std::exception& exception) {
-    if (_use_mvcc == UseMvcc::Yes) _transaction_context->rollback();
-    throw std::runtime_error("Error while executing tasks:\n  " + std::string(exception.what()));
-  }
+  CurrentScheduler::schedule_and_wait_for_tasks(tasks);
 
   if (_auto_commit) {
     _transaction_context->commit();

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -456,15 +456,7 @@ TEST_F(SQLPipelineStatementTest, GetResultTableBadQueryNoMVCC) {
   auto sql_pipeline = SQLPipelineBuilder{sql}.disable_mvcc().create_pipeline_statement();
 
   // Make sure this is actually the failed execution and not a logic_error from the transaction management.
-  EXPECT_THROW(sql_pipeline.get_result_table(), std::runtime_error);
-}
-
-TEST_F(SQLPipelineStatementTest, GetResultTableBadQuery) {
-  auto sql = "SELECT a + b FROM table_a";
-  auto sql_pipeline = SQLPipelineBuilder{sql}.create_pipeline_statement();
-
-  EXPECT_THROW(sql_pipeline.get_result_table(), std::exception);
-  EXPECT_TRUE(sql_pipeline.transaction_context()->aborted());
+  EXPECT_THROW(sql_pipeline.get_result_table(), std::logic_error);
 }
 
 TEST_F(SQLPipelineStatementTest, GetResultTableNoOutput) {
@@ -620,11 +612,11 @@ TEST_F(SQLPipelineStatementTest, MultiplePreparedStatementsExecute) {
   const std::string execute_statement_multi_invalid = "EXECUTE x_multi (123, 10000, 500, 100)";  // too many arguments
 
   EXPECT_THROW(SQLPipelineBuilder(execute_statement1_invalid).create_pipeline_statement().get_result_table(),
-               std::runtime_error);
+               std::logic_error);
   EXPECT_THROW(SQLPipelineBuilder(execute_statement2_invalid).create_pipeline_statement().get_result_table(),
-               std::runtime_error);
+               std::logic_error);
   EXPECT_THROW(SQLPipelineBuilder(execute_statement_multi_invalid).create_pipeline_statement().get_result_table(),
-               std::runtime_error);
+               std::logic_error);
 
   auto execute_sql_pipeline1 = SQLPipelineBuilder{execute_statement1}
                                    .with_prepared_statement_cache(prepared_statement_cache)

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -409,54 +409,6 @@ TEST_F(SQLPipelineTest, GetTimes) {
   EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
 }
 
-TEST_F(SQLPipelineTest, GetFailedPipelineUnoptimizedLQPs) {
-  auto sql_pipeline = SQLPipelineBuilder{_fail_query}.create_pipeline();
-
-  try {
-    sql_pipeline.get_unoptimized_logical_plans();
-    // Fail if this did not throw an exception
-    FAIL();
-  } catch (const std::exception&) {
-    EXPECT_NE(sql_pipeline.failed_pipeline_statement(), nullptr);
-  }
-}
-
-TEST_F(SQLPipelineTest, GetFailedPipelineOptimizedLQPs) {
-  auto sql_pipeline = SQLPipelineBuilder{_fail_query}.create_pipeline();
-
-  try {
-    sql_pipeline.get_optimized_logical_plans();
-    // Fail if this did not throw an exception
-    FAIL();
-  } catch (const std::exception&) {
-    EXPECT_NE(sql_pipeline.failed_pipeline_statement(), nullptr);
-  }
-}
-
-TEST_F(SQLPipelineTest, GetFailedPipelineGueryPlans) {
-  auto sql_pipeline = SQLPipelineBuilder{_fail_query}.create_pipeline();
-
-  try {
-    sql_pipeline.get_query_plans();
-    // Fail if this did not throw an exception
-    FAIL();
-  } catch (const std::exception&) {
-    EXPECT_NE(sql_pipeline.failed_pipeline_statement(), nullptr);
-  }
-}
-
-TEST_F(SQLPipelineTest, GetFailedPipelineResultTable) {
-  auto sql_pipeline = SQLPipelineBuilder{_fail_query}.create_pipeline();
-
-  try {
-    sql_pipeline.get_result_table();
-    // Fail if this did not throw an exception
-    FAIL();
-  } catch (const std::exception&) {
-    EXPECT_NE(sql_pipeline.failed_pipeline_statement(), nullptr);
-  }
-}
-
 TEST_F(SQLPipelineTest, RequiresExecutionVariations) {
   EXPECT_FALSE(SQLPipelineBuilder{_select_query_a}.create_pipeline().requires_execution());
   EXPECT_FALSE(SQLPipelineBuilder{_join_query}.create_pipeline().requires_execution());

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -184,7 +184,7 @@ TEST_F(SQLTranslatorTest, AggregateWithGroupBy) {
 TEST_F(SQLTranslatorTest, AggregateWithInvalidGroupBy) {
   // Cannot select b without it being in the GROUP BY clause.
   const auto query = "SELECT b, SUM(b) AS s FROM table_a GROUP BY a;";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, AggregateWithExpression) {
@@ -427,10 +427,10 @@ TEST_F(SQLTranslatorTest, InsertSubquery) {
 
 TEST_F(SQLTranslatorTest, InsertInvalidDataType) {
   auto query = "INSERT INTO table_a VALUES (10, 11);";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 
   query = "INSERT INTO table_a (b, a) VALUES (10, 12.5);";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, Update) {
@@ -493,7 +493,7 @@ TEST_F(SQLTranslatorTest, InSubquery) {
 
 TEST_F(SQLTranslatorTest, InSubquerySeveralColumns) {
   const auto query = "SELECT * FROM table_a WHERE a IN (SELECT * FROM table_b);";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, SelectSubquery) {
@@ -621,12 +621,12 @@ TEST_F(SQLTranslatorTest, DropView) {
 
 TEST_F(SQLTranslatorTest, AccessInvalidColumn) {
   const auto query = "SELECT * FROM table_a WHERE invalidname = 0;";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, AccessInvalidTable) {
   const auto query = "SELECT * FROM invalid_table;";
-  EXPECT_THROW(compile_query(query), std::runtime_error);
+  EXPECT_THROW(compile_query(query), std::logic_error);
 }
 
 TEST_F(SQLTranslatorTest, ColumnAlias) {


### PR DESCRIPTION
The catch-rethrow code in `SQLPipeline(Statement)` was achieving very little for me except obscuring the real location of a throw when catching the unhandled Exception in the debugger. 
One `catch` tried to rollback a transaction if it threw an exception during runtime. Imo this goes against our design goal of not doing error recovery since just crashing on any kind of error allows for a much simpler code base. Hyrise is a research DB etc.

I altered `SQLPipeline::_failed_pipeline_statement` to point to an aborted statement, if any. That's the only scenario in which we're doing legitimate error recovery, everything else should be DB shutdown as by our design goals.

PR meant to be basis of a discussion, in person, if you like. @mrks @Bensk1 @lawben 