### PR TITLE
Fix JoinMPSM when NUMA is disabled

### DIFF
--- a/src/lib/operators/join_mpsm.cpp
+++ b/src/lib/operators/join_mpsm.cpp
@@ -181,7 +181,7 @@ class JoinMPSM::JoinMPSMImpl : public AbstractJoinOperatorImpl {
     const size_t numa_nodes = NUMAPlacementManager::get().topology()->nodes().size();
     return static_cast<ClusterID>(std::pow(2, std::floor(std::log2(numa_nodes))));
 #else
-    return ClusterID{2};
+    return ClusterID{1};
 #endif
   }
 

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -244,6 +244,8 @@ class RadixClusterSortNUMA {
 
     std::vector<std::shared_ptr<AbstractTask>> cluster_jobs;
 
+    std::cout << "Input Chunks: " << input_chunks->size() << " " << _cluster_count << std::endl;
+
     for (NodeID node_id{0}; node_id < _cluster_count; node_id++) {
       Assert(node_id < input_chunks->size(), "Node ID outof range: " + std::to_string(node_id) + " " + std::to_string(_cluster_count));
       auto job = std::make_shared<JobTask>([&output, &input_chunks, node_id, radix_bitmask, this]() {

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -244,10 +244,10 @@ class RadixClusterSortNUMA {
 
     std::vector<std::shared_ptr<AbstractTask>> cluster_jobs;
 
-    std::cout << "Input Chunks: " << input_chunks->size() << " " << _cluster_count << std::endl;
-
     for (NodeID node_id{0}; node_id < _cluster_count; node_id++) {
-      Assert(node_id < input_chunks->size(), "Node ID outof range: " + std::to_string(node_id) + " " + std::to_string(_cluster_count));
+      Assert(node_id < input_chunks->size(),
+             "Node ID out of range: " + std::to_string(node_id) + " " + std::to_string(_cluster_count));
+
       auto job = std::make_shared<JobTask>([&output, &input_chunks, node_id, radix_bitmask, this]() {
         (*output)[node_id] = _cluster((*input_chunks)[node_id],
                                       [=](const T& value) { return get_radix<T>(value, radix_bitmask); }, node_id);

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -245,6 +245,7 @@ class RadixClusterSortNUMA {
     std::vector<std::shared_ptr<AbstractTask>> cluster_jobs;
 
     for (NodeID node_id{0}; node_id < _cluster_count; node_id++) {
+      Assert(node_id < input_chunks->size(), "Node ID outof range: " + std::to_string(node_id) + " " + std::to_string(_cluster_count));
       auto job = std::make_shared<JobTask>([&output, &input_chunks, node_id, radix_bitmask, this]() {
         (*output)[node_id] = _cluster((*input_chunks)[node_id],
                                       [=](const T& value) { return get_radix<T>(value, radix_bitmask); }, node_id);

--- a/src/lib/storage/numa_placement_manager.hpp
+++ b/src/lib/storage/numa_placement_manager.hpp
@@ -75,7 +75,7 @@ class NUMAPlacementManager {
   NUMAPlacementManager(NUMAPlacementManager&&) = delete;
 
  protected:
-  explicit NUMAPlacementManager(const std::shared_ptr<Topology> topology = Topology::create_fake_numa_topology(20, 1));
+  explicit NUMAPlacementManager(const std::shared_ptr<Topology> topology = Topology::create_numa_topology());
 
   Options _options;
   std::shared_ptr<Topology> _topology;

--- a/src/lib/storage/numa_placement_manager.hpp
+++ b/src/lib/storage/numa_placement_manager.hpp
@@ -75,7 +75,7 @@ class NUMAPlacementManager {
   NUMAPlacementManager(NUMAPlacementManager&&) = delete;
 
  protected:
-  explicit NUMAPlacementManager(const std::shared_ptr<Topology> topology = Topology::create_numa_topology());
+  explicit NUMAPlacementManager(const std::shared_ptr<Topology> topology = Topology::create_fake_numa_topology(20, 1));
 
   Options _options;
   std::shared_ptr<Topology> _topology;


### PR DESCRIPTION
This should fix the master.
@Beta-Alf  @Bouncner Why was the cluster count set to 2 when there is only one "pseudo node" when NUMA is disabled?

Because in `radix_cluster_sort_numa.hpp` you seem to assume that there are always >= clusters than nodes by iterating node_id from 0 to _cluster_count.