### PR TITLE
Remove run_transaction

### DIFF
--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -31,16 +31,6 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
   return std::make_shared<TransactionContext>(_next_transaction_id++, _last_commit_id);
 }
 
-void TransactionManager::run_transaction(const std::function<void(std::shared_ptr<TransactionContext>)>& fn) {
-  auto transaction_context = new_transaction_context();
-
-  fn(transaction_context);
-
-  if (transaction_context->aborted()) return;
-
-  transaction_context->commit();
-}
-
 /**
  * Logic of the lock-free algorithm
  *

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -57,7 +57,7 @@ class TransactionManager : private Noncopyable {
    */
   std::shared_ptr<TransactionContext> new_transaction_context();
 
-private:
+ private:
   friend class TransactionContext;
 
   TransactionManager();

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -57,19 +57,7 @@ class TransactionManager : private Noncopyable {
    */
   std::shared_ptr<TransactionContext> new_transaction_context();
 
-  /**
-   * Helper: Executes a function object within a context and commits or rolls it back afterwards.
-   *
-   * It calls TransactionContext::rollback_operators() and TransactionContext::commit_operators()
-   * and therefore shouldn’t be used when a scheduler is active. Instead, each operator’s rollback
-   * or committing should be schedule separately, for example by using JobTask.
-   *
-   * Usage: Call TransactionContext::rollback() within the
-   *        function object if transaction should be rolled back.
-   */
-  void run_transaction(const std::function<void(std::shared_ptr<TransactionContext>)>& fn);
-
- private:
+private:
   friend class TransactionContext;
 
   TransactionManager();


### PR DESCRIPTION
The method is a relict from the old TPC-C where we built operators by hand