### PR TITLE
Fix Coverage for OS X + minor things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ compile_times.txt
 
 # CLion cmake directory
 cmake-build-*
+
+# llvm coverage information
+default.profdata
+default.profraw

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,6 @@ node {
         mkdir clang-release && cd clang-release && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 .. &\
         mkdir clang-release-sanitizers-no-numa && cd clang-release-sanitizers-no-numa && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 -DENABLE_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
-        mkdir gcc-debug-coverage && cd gcc-debug-coverage && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_COVERAGE=ON .. &\
         wait"
       }
 
@@ -89,7 +88,7 @@ node {
         }
       }, gccDebugCoverage: {
         stage("gcc-debug-coverage") {
-          sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --build_directory=gcc-debug-coverage --generate_badge=true --test_data_folder=gcc-debug-coverage"
+          sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --generate_badge=true --launcher=ccache"
           archive 'coverage_badge.svg'
           archive 'coverage_percent.txt'
           archive 'coverage.xml'

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The binary can be executed with `./<YourBuildDirectory>/hyriseTest`.
 Note, that the tests/sanitizers/etc need to be executed from the project root in order for table files to be found.
 
 ### Coverage
-`./scripts/coverage.sh <build dir>` will print a summary to the command line and create detailed html reports at ./coverage/index.html
+`./scripts/coverage.sh` will print a summary to the command line and create detailed html reports at ./coverage/index.html
 
 *Supports only clang on MacOS and only gcc on linux*
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -45,10 +45,10 @@ if [[ "$unamestr" == 'Darwin' ]]; then
   # https://llvm.org/docs/CoverageMappingFormat.html
   
   # merge the profile data using the llvm-profdata tool:
-  llvm-profdata merge -o ./default.profdata ./default.profraw
+  /usr/local/opt/llvm/bin/llvm-profdata merge -o ./default.profdata ./default.profraw
 
   # run LLVM’s code coverage tool
-  llvm-cov show -format=html -instr-profile default.profdata build-coverage/hyriseTest -output-dir=coverage src/lib/
+  /usr/local/opt/llvm/bin/llvm-cov show -format=html -instr-profile default.profdata build-coverage/hyriseTest -output-dir=coverage src/lib/
 
   exit
 fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -3,14 +3,11 @@ set -e
 
 while [ $# -gt 0 ]; do
   case "$1" in
-    --build_directory=*)
-      build_directory="${1#*=}"
-      ;;
     --generate_badge=*)
       generate_badge="${1#*=}"
       ;;
-    --test_data_folder=*)
-      test_data_folder="${1#*=}"
+    --launcher=*)
+      launcher="${1#*=}"
       ;;
     *)
       printf "Error: Invalid argument."
@@ -19,24 +16,56 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-if [ -z "$build_directory" ]
-  then
-    echo "Error: No build directory supplied - use --build_directory=..."
-    exit 1
+if [ ! -d "third_party" ]; then
+  echo "You should call this script from the root of the project"
+  exit
 fi
 
-cd $build_directory
+mkdir -p build-coverage
+cd build-coverage
+platform='unknown'
+unamestr=`uname`
+if [[ "$unamestr" == 'Linux' ]]; then
+   # Use GCC for Linux
+   cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_COVERAGE=ON ..
+elif [[ "$unamestr" == 'Darwin' ]]; then
+   # Use Clang for OS X
+   cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DENABLE_COVERAGE=ON ..
+fi
+
 cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 make hyriseTest -j $((cores / 2))
 cd -
 
-./$build_directory/hyriseTest $test_data_folder
 rm -fr coverage; mkdir coverage
+./build-coverage/hyriseTest build-coverage
+
+if [[ "$unamestr" == 'Darwin' ]]; then
+  # LLVM has its own way of dealing with coverage...
+  # https://llvm.org/docs/CoverageMappingFormat.html
+  
+  # merge the profile data using the llvm-profdata tool:
+  llvm-profdata merge -o ./default.profdata ./default.profraw
+
+  # run LLVM’s code coverage tool
+  llvm-cov show -format=html -instr-profile default.profdata build-coverage/hyriseTest -output-dir=coverage src/lib/
+
+  exit
+fi
+
+# Continuing only with Linux/gcc
+
 # call gcovr twice b/c of https://github.com/gcovr/gcovr/issues/112
 gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude='.*/(?:third_party|src/test|src/benchmark).*' --exclude-unreachable-branches -k
 
+if [ "true" == "$generate_badge" ]
+then
+    # in this step, keep coverage information only if we need it for pycobertura later
+    keep="-k"
+fi
+
 # generate HTML
-gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude='.*/(?:third_party|src/test|src/benchmark).*' --exclude-unreachable-branches -k -g --html --html-details -o coverage/index.html > coverage_output.txt
+gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude='.*/(?:third_party|src/test|src/benchmark).*' --exclude-unreachable-branches $keep -g --html --html-details -o coverage/index.html > coverage_output.txt
 cat coverage_output.txt
 
 if [ "true" == "$generate_badge" ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,17 @@ endif()
 # third_party stuff
 option(ENABLE_COVERAGE "Set to ON to build Hyrise with enabled coverage checking. Default: OFF" OFF)
 if (${ENABLE_COVERAGE})
-    add_compile_options(-O0 -fprofile-arcs -ftest-coverage)
-    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    add_compile_options(-O0)
+
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        add_compile_options(-fprofile-arcs -ftest-coverage)
+        set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+        set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    else()
+        message(FATAL_ERROR "Don't know how to run coverage on your compiler (${CMAKE_CXX_COMPILER_ID}).")
+    endif()
 endif()
 
 # This will be used by the DebugAssert macro to output

--- a/src/lib/abstract_expression.hpp
+++ b/src/lib/abstract_expression.hpp
@@ -50,6 +50,8 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
    */
   explicit AbstractExpression(ExpressionType type);
 
+  virtual ~AbstractExpression() = default;
+
   // creates a DEEP copy of the other expression. Used for reusing LQPs, e.g., in views.
   std::shared_ptr<DerivedExpression> deep_copy() const;
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -81,6 +81,8 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
  public:
   explicit AbstractLQPNode(LQPNodeType node_type);
 
+  virtual ~AbstractLQPNode() = default;
+
   // Creates a deep copy
   std::shared_ptr<AbstractLQPNode> deep_copy() const;
 

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -18,6 +18,7 @@ namespace opossum {
 // We need these classes to perform the dynamic cast into a templated ValueColumn
 class AbstractTypedColumnProcessor {
  public:
+  virtual ~AbstractTypedColumnProcessor() = default;
   virtual void resize_vector(std::shared_ptr<BaseColumn> column, size_t new_size) = 0;
   virtual void copy_data(std::shared_ptr<const BaseColumn> source, size_t source_start_index,
                          std::shared_ptr<BaseColumn> target, size_t target_start_index, size_t length) = 0;

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -230,8 +230,6 @@ void JoinNestedLoop::_write_output_chunks(ChunkColumns& columns, const std::shar
       if (input_table->chunk_count() > 0) {
         auto new_pos_list = std::make_shared<PosList>();
 
-        ChunkID current_chunk_id{0};
-
         // de-reference to the correct RowID so the output can be used in a Multi Join
         for (const auto row : *pos_list) {
           if (row.is_null()) {

--- a/src/lib/optimizer/strategy/abstract_rule.hpp
+++ b/src/lib/optimizer/strategy/abstract_rule.hpp
@@ -14,6 +14,8 @@ class AbstractRule {
  public:
   virtual std::string name() const = 0;
 
+  virtual ~AbstractRule() = default;
+
   /**
    * This function applies the concrete Optimizer Rule to an LQP.
    * apply_to() is intended to be called recursively by the concrete rule.

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -52,6 +52,8 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    */
   explicit TableStatistics(const std::shared_ptr<Table> table);
 
+  virtual ~TableStatistics() = default;
+
   /**
    * Table statistics should not be copied by other actors.
    * Copy constructor not private as copy is used by make_shared.

--- a/src/lib/server/server_session.cpp
+++ b/src/lib/server/server_session.cpp
@@ -184,7 +184,7 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_simple_
 
   return create_sql_pipeline() >> then >> [=](std::unique_ptr<CreatePipelineResult> result) {
     if (result->load_table.has_value()) {
-      return load_table_file(result->load_table.value().first, result->load_table.value().second);
+      return load_table_file(result->load_table->first, result->load_table->second);
     } else {
       return execute_sql_pipeline(result->sql_pipeline) >> then >>
              [=](std::shared_ptr<SQLPipeline> sql_pipeline) { return _send_simple_query_response(sql_pipeline); };


### PR DESCRIPTION
* For OS X, this uses LLVM's preferred way of getting coverage information, not the gcov compatibility one.
* It simplifies the coverage process, so that `./scripts/coverage.sh` is the only thing one has to do, thus fixes #617.
* Two smaller code fixes that I stumbled upon (missing virtual destructor, unnecessary `optional::value()`)