### PR TITLE
[JIT, for Johannes only] Addition to PR #711 to support LLVM6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ compile_times.txt
 
 # CLion cmake directory
 cmake-build-*
+
+# llvm coverage information
+default.profdata
+default.profraw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ set(CURSES_NEED_NCURSES TRUE)
 # Dependencies
 find_package(FS REQUIRED)
 find_package(Numa)
-find_package(LLVM 5.0.0)
+find_package(LLVM)
 find_package(Tbb REQUIRED)
 find_package(Readline REQUIRED)
 find_package(Curses REQUIRED)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,6 @@ node {
         mkdir clang-release && cd clang-release && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 .. &\
         mkdir clang-release-sanitizers-no-numa && cd clang-release-sanitizers-no-numa && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-5.0 -DCMAKE_CXX_COMPILER=clang++-5.0 -DENABLE_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
-        mkdir gcc-debug-coverage && cd gcc-debug-coverage && cmake -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_COVERAGE=ON .. &\
         wait"
       }
 
@@ -89,7 +88,7 @@ node {
         }
       }, gccDebugCoverage: {
         stage("gcc-debug-coverage") {
-          sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --build_directory=gcc-debug-coverage --generate_badge=true --test_data_folder=gcc-debug-coverage"
+          sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --generate_badge=true --launcher=ccache"
           archive 'coverage_badge.svg'
           archive 'coverage_percent.txt'
           archive 'coverage.xml'

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The binary can be executed with `./<YourBuildDirectory>/hyriseTest`.
 Note, that the tests/sanitizers/etc need to be executed from the project root in order for table files to be found.
 
 ### Coverage
-`./scripts/coverage.sh <build dir>` will print a summary to the command line and create detailed html reports at ./coverage/index.html
+`./scripts/coverage.sh` will print a summary to the command line and create detailed html reports at ./coverage/index.html
 
 *Supports only clang on MacOS and only gcc on linux*
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,8 +36,17 @@ endif()
 # third_party stuff
 option(ENABLE_COVERAGE "Set to ON to build Hyrise with enabled coverage checking. Default: OFF" OFF)
 if (${ENABLE_COVERAGE})
-    add_compile_options(-O0 -fprofile-arcs -ftest-coverage)
-    set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    add_compile_options(-O0)
+
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        add_compile_options(-fprofile-arcs -ftest-coverage)
+        set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+        set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -fprofile-instr-generate -fcoverage-mapping")
+    else()
+        message(FATAL_ERROR "Don't know how to run coverage on your compiler (${CMAKE_CXX_COMPILER_ID}).")
+    endif()
 endif()
 
 # This will be used by the DebugAssert macro to output

--- a/src/lib/abstract_expression.hpp
+++ b/src/lib/abstract_expression.hpp
@@ -50,6 +50,8 @@ class AbstractExpression : public std::enable_shared_from_this<DerivedExpression
    */
   explicit AbstractExpression(ExpressionType type);
 
+  virtual ~AbstractExpression() = default;
+
   // creates a DEEP copy of the other expression. Used for reusing LQPs, e.g., in views.
   std::shared_ptr<DerivedExpression> deep_copy() const;
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -81,6 +81,8 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pr
  public:
   explicit AbstractLQPNode(LQPNodeType node_type);
 
+  virtual ~AbstractLQPNode() = default;
+
   // Creates a deep copy
   std::shared_ptr<AbstractLQPNode> deep_copy() const;
 

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -23,6 +23,8 @@ class LQPTranslator : private Noncopyable {
  public:
   virtual std::shared_ptr<AbstractOperator> translate_node(const std::shared_ptr<AbstractLQPNode>& node) const;
 
+  virtual ~LQPTranslator() = default;
+
  private:
   std::shared_ptr<AbstractOperator> _translate_by_node_type(LQPNodeType type,
                                                             const std::shared_ptr<AbstractLQPNode>& node) const;

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -18,6 +18,7 @@ namespace opossum {
 // We need these classes to perform the dynamic cast into a templated ValueColumn
 class AbstractTypedColumnProcessor {
  public:
+  virtual ~AbstractTypedColumnProcessor() = default;
   virtual void resize_vector(std::shared_ptr<BaseColumn> column, size_t new_size) = 0;
   virtual void copy_data(std::shared_ptr<const BaseColumn> source, size_t source_start_index,
                          std::shared_ptr<BaseColumn> target, size_t target_start_index, size_t length) = 0;

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -12,6 +12,7 @@ namespace opossum {
  */
 class BaseJitColumnReader {
  public:
+  virtual ~BaseJitColumnReader() = default;
   virtual void read_value(JitRuntimeContext& context) = 0;
 };
 

--- a/src/lib/operators/jit_operator/operators/jit_write_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_write_tuples.hpp
@@ -10,6 +10,7 @@ namespace opossum {
  */
 class BaseJitColumnWriter {
  public:
+  virtual ~BaseJitColumnWriter() = default;
   virtual void write_value(JitRuntimeContext& context) const = 0;
 };
 

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -230,8 +230,6 @@ void JoinNestedLoop::_write_output_chunks(ChunkColumns& columns, const std::shar
       if (input_table->chunk_count() > 0) {
         auto new_pos_list = std::make_shared<PosList>();
 
-        ChunkID current_chunk_id{0};
-
         // de-reference to the correct RowID so the output can be used in a Multi Join
         for (const auto row : *pos_list) {
           if (row.is_null()) {

--- a/src/lib/optimizer/strategy/abstract_rule.hpp
+++ b/src/lib/optimizer/strategy/abstract_rule.hpp
@@ -14,6 +14,8 @@ class AbstractRule {
  public:
   virtual std::string name() const = 0;
 
+  virtual ~AbstractRule() = default;
+
   /**
    * This function applies the concrete Optimizer Rule to an LQP.
    * apply_to() is intended to be called recursively by the concrete rule.

--- a/src/lib/optimizer/table_statistics.hpp
+++ b/src/lib/optimizer/table_statistics.hpp
@@ -52,6 +52,8 @@ class TableStatistics : public std::enable_shared_from_this<TableStatistics> {
    */
   explicit TableStatistics(const std::shared_ptr<Table> table);
 
+  virtual ~TableStatistics() = default;
+
   /**
    * Table statistics should not be copied by other actors.
    * Copy constructor not private as copy is used by make_shared.

--- a/src/lib/server/server_session.cpp
+++ b/src/lib/server/server_session.cpp
@@ -184,7 +184,7 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_simple_
 
   return create_sql_pipeline() >> then >> [=](std::unique_ptr<CreatePipelineResult> result) {
     if (result->load_table.has_value()) {
-      return load_table_file(result->load_table.value().first, result->load_table.value().second);
+      return load_table_file(result->load_table->first, result->load_table->second);
     } else {
       return execute_sql_pipeline(result->sql_pipeline) >> then >>
              [=](std::shared_ptr<SQLPipeline> sql_pipeline) { return _send_simple_query_response(sql_pipeline); };


### PR DESCRIPTION
With llvm6 all classes with virtual functions need virtual destructors.
Master was merged to get Markus recent commit (https://github.com/hyrise/hyrise/commit/5fb4d4e5cacb9e2285f53e229e94b5cd10f44898) addressing missing v destructors.
I added the v destructors for new JIT classes and removed specified version info for llvm.