### PR TITLE
Bunch of smaller issues and tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 # third_party stuff
 option(ENABLE_COVERAGE "Set to ON to build Hyrise with enabled coverage checking. Default: OFF" OFF)
 if (${ENABLE_COVERAGE})
-    add_compile_options(-O0)
+    add_compile_options(-O0 -fno-inline -fno-inline-small-functions -fno-default-inline)
 
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
         add_compile_options(-fprofile-arcs -ftest-coverage)

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -63,8 +63,7 @@ std::shared_ptr<const Table> AbstractOperator::get_output() const {
       }(),
       "Empty chunk returned from operator " + description());
 
-  DebugAssert(!_output || _output->row_count() == 0 || _output->column_count() > 0,
-              "Operator " + description() + " did not output any columns");
+  DebugAssert(!_output || _output->column_count() > 0, "Operator " + description() + " did not output any columns");
 
   return _output;
 }

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -16,7 +16,13 @@ void AbstractReadWriteOperator::execute() {
          "AbstractReadWriteOperator::execute() should never be called without having set the transaction context.");
 
   Assert(_state == ReadWriteOperatorState::Pending, "Operator needs to have state Pending in order to be executed.");
-  AbstractOperator::execute();
+
+  try {
+    AbstractOperator::execute();
+  } catch (...) {
+    _mark_as_failed();
+    throw;
+  }
 
   if (_state == ReadWriteOperatorState::Failed) return;
 

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -20,7 +20,11 @@ void AbstractReadWriteOperator::execute() {
   try {
     AbstractOperator::execute();
   } catch (...) {
+    // No matter what goes wrong, we need to mark the operators as failed. Otherwise, when the transaction context
+    // gets destroyed, it will cause another exception that hides the one that caused the actual error. We are NOT
+    // trying to handle the exception here - just making sure that we are not misled when we debug things.
     _mark_as_failed();
+
     throw;
   }
 

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -28,8 +28,6 @@ const std::string GetTable::description(DescriptionMode description_mode) const 
 
 const std::string& GetTable::table_name() const { return _name; }
 
-const std::vector<ChunkID>& GetTable::excluded_chunk_ids() const { return _excluded_chunk_ids; }
-
 void GetTable::set_excluded_chunk_ids(const std::vector<ChunkID>& excluded_chunk_ids) {
   _excluded_chunk_ids = excluded_chunk_ids;
 }

--- a/src/lib/operators/get_table.hpp
+++ b/src/lib/operators/get_table.hpp
@@ -18,7 +18,6 @@ class GetTable : public AbstractReadOnlyOperator {
   const std::string description(DescriptionMode description_mode) const override;
 
   const std::string& table_name() const;
-  const std::vector<ChunkID>& excluded_chunk_ids() const;
 
   void set_excluded_chunk_ids(const std::vector<ChunkID>& excluded_chunk_ids);
 

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<AbstractOperator> CreateView::_on_recreate(
 std::shared_ptr<const Table> CreateView::_on_execute() {
   StorageManager::get().add_view(_view_name, _lqp);
 
-  return std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data);
+  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int}}, TableType::Data);  // Dummy table
 }
 
 }  // namespace opossum

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<AbstractOperator> DropView::_on_recreate(
 std::shared_ptr<const Table> DropView::_on_execute() {
   StorageManager::get().drop_view(_view_name);
 
-  return std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data);  // Dummy table
+  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int}}, TableType::Data);  // Dummy table
 }
 
 }  // namespace opossum

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -196,10 +196,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
   DebugAssert(input_table_left()->column_definitions() == input_table_right()->column_definitions(),
               "Input tables don't have the same layout");
 
-  // Later code relies on input tables containing columns
-  if (input_table_left()->column_count() == 0) {
-    return input_table_left();
-  }
+  // Later code relies on input tables containing columns. This is guaranteed by the AbstractOperator.
 
   /**
    * Later code relies on both tables having > 0 rows. If one doesn't, we can just return the other as the result of

--- a/src/lib/utils/format_duration.cpp
+++ b/src/lib/utils/format_duration.cpp
@@ -10,13 +10,13 @@ std::string format_duration(uint64_t total_nanoseconds) {
   const auto minutes = nanoseconds_remaining / 60'000'000'000;
   nanoseconds_remaining -= minutes * 60'000'000'000;
 
-  const auto seconds = (nanoseconds_remaining / 1'000'000'000) % 1000;
+  const auto seconds = nanoseconds_remaining / 1'000'000'000;
   nanoseconds_remaining -= seconds * 1'000'000'000;
 
-  const auto milliseconds = (nanoseconds_remaining / 1'000'000) % 1000;
+  const auto milliseconds = nanoseconds_remaining / 1'000'000;
   nanoseconds_remaining -= milliseconds * 1'000'000;
 
-  const auto microseconds = (nanoseconds_remaining / 1'000) % 1000;
+  const auto microseconds = nanoseconds_remaining / 1'000;
   nanoseconds_remaining -= microseconds * 1'000;
 
   const auto nanoseconds = nanoseconds_remaining;

--- a/src/lib/utils/format_duration.cpp
+++ b/src/lib/utils/format_duration.cpp
@@ -4,23 +4,35 @@
 
 namespace opossum {
 
-std::string format_duration(uint64_t nanoseconds) {
-  const auto microseconds = (nanoseconds / 1'000) % 1000;
-  const auto milliseconds = (nanoseconds / 1'000'000) % 1000;
-  const auto seconds = (nanoseconds / 1'000'000'000) % 1000;
-  const auto minutes = (nanoseconds / 60'000'000'000) % 1000;
-  nanoseconds %= 1000;
+std::string format_duration(uint64_t total_nanoseconds) {
+  uint64_t nanoseconds_remaining = total_nanoseconds;
+
+  const auto minutes = nanoseconds_remaining / 60'000'000'000;
+  nanoseconds_remaining -= minutes * 60'000'000'000;
+
+  const auto seconds = (nanoseconds_remaining / 1'000'000'000) % 1000;
+  nanoseconds_remaining -= seconds * 1'000'000'000;
+
+  const auto milliseconds = (nanoseconds_remaining / 1'000'000) % 1000;
+  nanoseconds_remaining -= milliseconds * 1'000'000;
+
+  const auto microseconds = (nanoseconds_remaining / 1'000) % 1000;
+  nanoseconds_remaining -= microseconds * 1'000;
+
+  const auto nanoseconds = nanoseconds_remaining;
 
   std::stringstream stream;
 
   if (minutes > 0) {
-    stream << minutes << "m " << seconds << "s";
+    stream << minutes << " min " << seconds << " s";
   } else if (seconds > 0) {
-    stream << seconds << "s " << milliseconds << " ms";
+    stream << seconds << " s " << milliseconds << " ms";
   } else if (milliseconds > 0) {
-    stream << milliseconds << "ms " << microseconds << " µs";
+    stream << milliseconds << " ms " << microseconds << " µs";
+  } else if (microseconds > 0) {
+    stream << microseconds << " µs " << nanoseconds << " ns";
   } else {
-    stream << microseconds << "µs " << nanoseconds << "ns";
+    stream << nanoseconds << " ns";
   }
 
   return stream.str();

--- a/src/lib/utils/format_duration.hpp
+++ b/src/lib/utils/format_duration.hpp
@@ -6,6 +6,6 @@
 namespace opossum {
 
 // "3h 42min" instead of "2,53×10¹²ns"
-std::string format_duration(uint64_t nanoseconds);
+std::string format_duration(uint64_t total_nanoseconds);
 
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -134,6 +134,7 @@ set(
     testing_assert.hpp
     utils/cuckoo_hashtable_test.cpp
     utils/format_bytes_test.cpp
+    utils/format_duration_test.cpp
     utils/numa_memory_resource_test.cpp
     gtest_main.cpp
 )

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -14,7 +14,6 @@ class OperatorsGetTableTest : public BaseTest {
   void SetUp() override {
     _test_table = std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data, 2);
     auto& manager = StorageManager::get();
-    manager.add_table("aNiceTestTable", _test_table);
     manager.add_table("tableWithValues", load_table("src/test/tables/int_float2.tbl", 1u));
   }
 
@@ -22,10 +21,10 @@ class OperatorsGetTableTest : public BaseTest {
 };
 
 TEST_F(OperatorsGetTableTest, GetOutput) {
-  auto gt = std::make_shared<GetTable>("aNiceTestTable");
+  auto gt = std::make_shared<GetTable>("tableWithValues");
   gt->execute();
 
-  EXPECT_EQ(gt->get_output(), _test_table);
+  EXPECT_TABLE_EQ_UNORDERED(gt->get_output(), load_table("src/test/tables/int_float2.tbl", 1u));
 }
 
 TEST_F(OperatorsGetTableTest, ThrowsUnknownTableName) {
@@ -35,7 +34,7 @@ TEST_F(OperatorsGetTableTest, ThrowsUnknownTableName) {
 }
 
 TEST_F(OperatorsGetTableTest, OperatorName) {
-  auto gt = std::make_shared<opossum::GetTable>("aNiceTestTable");
+  auto gt = std::make_shared<opossum::GetTable>("tableWithValues");
 
   EXPECT_EQ(gt->name(), "GetTable");
 }

--- a/src/test/operators/insert_test.cpp
+++ b/src/test/operators/insert_test.cpp
@@ -211,6 +211,28 @@ TEST_F(OperatorsInsertTest, InsertIntFloatNullValues) {
   EXPECT_TRUE(variant_is_null(null_val_float));
 }
 
+TEST_F(OperatorsInsertTest, InsertNullIntoNonNull) {
+  auto t_name = "test1";
+  auto t_name2 = "test2";
+
+  auto t = load_table("src/test/tables/int_float.tbl", 3u);
+  StorageManager::get().add_table(t_name, t);
+
+  auto t2 = load_table("src/test/tables/int_float_with_null.tbl", 4u);
+  StorageManager::get().add_table(t_name2, t2);
+
+  auto gt2 = std::make_shared<GetTable>(t_name2);
+  gt2->execute();
+
+  auto ins = std::make_shared<Insert>(t_name, gt2);
+  auto context = TransactionManager::get().new_transaction_context();
+  ins->set_transaction_context(context);
+  EXPECT_THROW(ins->execute(), std::logic_error);
+  std::cout << "start rollback" << std::endl;
+  context->rollback();
+  std::cout << "end rollback" << std::endl;
+}
+
 TEST_F(OperatorsInsertTest, InsertSingleNullFromDummyProjection) {
   auto t_name = "test1";
 

--- a/src/test/operators/insert_test.cpp
+++ b/src/test/operators/insert_test.cpp
@@ -228,9 +228,7 @@ TEST_F(OperatorsInsertTest, InsertNullIntoNonNull) {
   auto context = TransactionManager::get().new_transaction_context();
   ins->set_transaction_context(context);
   EXPECT_THROW(ins->execute(), std::logic_error);
-  std::cout << "start rollback" << std::endl;
   context->rollback();
-  std::cout << "end rollback" << std::endl;
 }
 
 TEST_F(OperatorsInsertTest, InsertSingleNullFromDummyProjection) {

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -176,6 +176,15 @@ TEST_F(OperatorsProjectionTest, AllColumns) {
   EXPECT_TABLE_EQ_UNORDERED(projection->get_output(), expected_result);
 }
 
+TEST_F(OperatorsProjectionTest, NoColumns) {
+  std::shared_ptr<Table> expected_result = load_table("src/test/tables/float_int.tbl", 2);
+
+  auto projection = std::make_shared<Projection>(_table_wrapper, std::vector<std::shared_ptr<PQPExpression>>{});
+  projection->execute();
+
+  EXPECT_THROW(projection->get_output(), std::logic_error);
+}
+
 TEST_F(OperatorsProjectionTest, ConstantArithmeticProjection) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_int_int_fix_values.tbl", 2);
 

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -177,6 +177,8 @@ TEST_F(OperatorsProjectionTest, AllColumns) {
 }
 
 TEST_F(OperatorsProjectionTest, NoColumns) {
+  if (!IS_DEBUG) return;
+
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/float_int.tbl", 2);
 
   auto projection = std::make_shared<Projection>(_table_wrapper, std::vector<std::shared_ptr<PQPExpression>>{});

--- a/src/test/operators/recreation_test.cpp
+++ b/src/test/operators/recreation_test.cpp
@@ -39,11 +39,11 @@ class RecreationTest : public BaseTest {
     _table_wrapper_c->execute();
     _table_wrapper_d->execute();
 
-    _test_get_table = std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data, 2);
-    StorageManager::get().add_table("aNiceTestTable", _test_get_table);
+    _test_table = load_table("src/test/tables/int_float.tbl", 2);
+    StorageManager::get().add_table("aNiceTestTable", _test_table);
   }
 
-  std::shared_ptr<Table> _test_get_table;
+  std::shared_ptr<Table> _test_table;
   std::shared_ptr<TableWrapper> _table_wrapper_a, _table_wrapper_b, _table_wrapper_c, _table_wrapper_d;
 };
 
@@ -99,14 +99,14 @@ TEST_F(RecreationTest, RecreationGetTable) {
   // build and execute get table
   auto get_table = std::make_shared<GetTable>("aNiceTestTable");
   get_table->execute();
-  EXPECT_TABLE_EQ_UNORDERED(get_table->get_output(), _test_get_table);
+  EXPECT_TABLE_EQ_UNORDERED(get_table->get_output(), _test_table);
 
   // recreate and execute recreated get table
   auto recreated_get_table = get_table->recreate();
   EXPECT_NE(recreated_get_table, nullptr) << "Could not recreate GetTable";
 
   recreated_get_table->execute();
-  EXPECT_TABLE_EQ_UNORDERED(recreated_get_table->get_output(), _test_get_table);
+  EXPECT_TABLE_EQ_UNORDERED(recreated_get_table->get_output(), _test_table);
 }
 
 TEST_F(RecreationTest, RecreationLimit) {

--- a/src/test/operators/table_scan_like_test.cpp
+++ b/src/test/operators/table_scan_like_test.cpp
@@ -41,6 +41,8 @@ class OperatorsTableScanLikeTest : public BaseTest, public ::testing::WithParamI
 
     // load and compress string table
     if (::testing::UnitTest::GetInstance()->current_test_info()->value_param()) {
+      // Not all tests are parameterized - only those using compressed columns are. We have to ask the testing
+      // framework if a parameter is set. Otherwise, GetParam would fail.
       auto test_table_string_compressed = load_table("src/test/tables/int_string_like.tbl", 5);
       ChunkEncoder::encode_chunks(test_table_string_compressed, {ChunkID{0}}, GetParam());
 

--- a/src/test/operators/table_scan_like_test.cpp
+++ b/src/test/operators/table_scan_like_test.cpp
@@ -18,7 +18,7 @@
 
 namespace opossum {
 
-class OperatorsTableScanLikeTest : public BaseTest {
+class OperatorsTableScanLikeTest : public BaseTest, public ::testing::WithParamInterface<EncodingType> {
  protected:
   void SetUp() override {
     std::shared_ptr<Table> test_table = load_table("src/test/tables/int_float.tbl", 2);
@@ -40,17 +40,26 @@ class OperatorsTableScanLikeTest : public BaseTest {
     _gt_special_chars->execute();
 
     // load and compress string table
-    auto test_table_string_dict = load_table("src/test/tables/int_string_like.tbl", 5);
-    ChunkEncoder::encode_chunks(test_table_string_dict, {ChunkID{0}});
+    if (::testing::UnitTest::GetInstance()->current_test_info()->value_param()) {
+      auto test_table_string_compressed = load_table("src/test/tables/int_string_like.tbl", 5);
+      ChunkEncoder::encode_chunks(test_table_string_compressed, {ChunkID{0}}, GetParam());
 
-    StorageManager::get().add_table("table_string_dict", test_table_string_dict);
+      StorageManager::get().add_table("table_string_compressed", test_table_string_compressed);
 
-    _gt_string_dict = std::make_shared<GetTable>("table_string_dict");
-    _gt_string_dict->execute();
+      _gt_string_compressed = std::make_shared<GetTable>("table_string_compressed");
+      _gt_string_compressed->execute();
+    }
   }
 
-  std::shared_ptr<GetTable> _gt, _gt_special_chars, _gt_string, _gt_string_dict;
+  std::shared_ptr<GetTable> _gt, _gt_special_chars, _gt_string, _gt_string_compressed;
 };
+
+auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
+  return std::to_string(static_cast<uint32_t>(info.param));
+};
+
+INSTANTIATE_TEST_CASE_P(EncodingTypes, OperatorsTableScanLikeTest,
+                        ::testing::Values(EncodingType::Dictionary, EncodingType::RunLength), formatter);
 
 /*
     Tests for operator PredicateCondition::Like
@@ -67,6 +76,7 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeNonStringValue) {
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 1u);
 }
+
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyString) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
@@ -74,13 +84,15 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyString) {
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringOnDict) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeEmptyStringOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
+
 TEST_F(OperatorsTableScanLikeTest, ScanLikeCaseInsensitivity) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
@@ -104,27 +116,31 @@ TEST_F(OperatorsTableScanLikeTest, ScanLike_Starting) {
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeEmptyStringDict) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeEmptyStringDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::Like, "%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeStartingOnDictColumn) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeStartingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "Dampf%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::Like, "Dampf%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeStartingOnReferencedDictColumn) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeStartingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_starting.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
   auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "Dampf%");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
+
 // PredicateCondition::Like - Ending
 TEST_F(OperatorsTableScanLikeTest, ScanLikeEnding) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
@@ -132,15 +148,18 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeEnding) {
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeEndingOnDictColumn) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeEndingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%gesellschaft");
+  auto scan =
+      std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::Like, "%gesellschaft");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeEndingOnReferencedDictColumn) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeEndingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_ending.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
   auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "%gesellschaft");
   scan2->execute();
@@ -181,39 +200,45 @@ TEST_F(OperatorsTableScanLikeTest, ScanLikeContaining) {
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnDictColumn) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeContainingOnDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan =
-      std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::Like,
+                                          "%schifffahrtsgesellschaft%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeContainingOnReferencedDictColumn) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeContainingOnReferencedDictColumn) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_containing.tbl", 1);
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
+  auto scan1 = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
   auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "%schifffahrtsgesellschaft%");
   scan2->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan2->get_output(), expected_result);
 }
+
 // PredicateCondition::Like - Not Found
 TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFound) {
   auto scan = std::make_shared<TableScan>(_gt_string, ColumnID{1}, PredicateCondition::Like, "%not_there%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFoundOnDictColumn) {
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::Like, "%not_there%");
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeNotFoundOnDictColumn) {
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::Like, "%not_there%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanLikeNotFoundOnReferencedDictColumn) {
-  auto scan1 = std::make_shared<TableScan>(_gt_string_dict, ColumnID{0}, PredicateCondition::GreaterThan, 0);
+
+TEST_P(OperatorsTableScanLikeTest, ScanLikeNotFoundOnReferencedDictColumn) {
+  auto scan1 = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{0}, PredicateCondition::GreaterThan, 0);
   scan1->execute();
   auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{1}, PredicateCondition::Like, "%not_there%");
   scan2->execute();
   EXPECT_EQ(scan2->get_output()->row_count(), 0u);
 }
+
 // PredicateCondition::NotLike
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyString) {
   // wildcard has to be placed at front and/or back of search string
@@ -221,12 +246,14 @@ TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyString) {
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanNotLikeEmptyStringOnDict) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanNotLikeEmptyStringOnDict) {
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::NotLike, "%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::NotLike, "%");
   scan->execute();
   EXPECT_EQ(scan->get_output()->row_count(), 0u);
 }
+
 TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRows) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
@@ -234,10 +261,11 @@ TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRows) {
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanNotLikeAllRowsOnDict) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanNotLikeAllRowsOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::NotLike, "%foo%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::NotLike, "%foo%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
@@ -249,10 +277,11 @@ TEST_F(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcard) {
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
-TEST_F(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcardOnDict) {
+
+TEST_P(OperatorsTableScanLikeTest, ScanNotLikeUnderscoreWildcardOnDict) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_string_like_not_starting.tbl", 1);
   // wildcard has to be placed at front and/or back of search string
-  auto scan = std::make_shared<TableScan>(_gt_string_dict, ColumnID{1}, PredicateCondition::NotLike, "d_m_f%");
+  auto scan = std::make_shared<TableScan>(_gt_string_compressed, ColumnID{1}, PredicateCondition::NotLike, "d_m_f%");
   scan->execute();
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -320,6 +320,7 @@ TEST_P(OperatorsTableScanTest, ScanOnReferencedCompressedColumn) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanPartiallyCompressed) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered.tbl", 2);
@@ -332,6 +333,7 @@ TEST_P(OperatorsTableScanTest, ScanPartiallyCompressed) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanWeirdPosList) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered_onlyodd.tbl", 2);
@@ -412,6 +414,7 @@ TEST_P(OperatorsTableScanTest, ScanOnReferencedIntValueColumnWithFloatColumnWith
 }
 
 TEST_P(OperatorsTableScanTest, ScanOnIntCompressedColumnWithFloatColumnWithNullValues) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
@@ -429,6 +432,7 @@ TEST_P(OperatorsTableScanTest, ScanOnIntCompressedColumnWithFloatColumnWithNullV
 }
 
 TEST_P(OperatorsTableScanTest, ScanOnReferencedIntCompressedColumnWithFloatColumnWithNullValues) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
@@ -480,6 +484,7 @@ TEST_P(OperatorsTableScanTest, ScanWithEmptyInput) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   // 2**8 + 1 values require a data type of 16bit.
@@ -518,6 +523,7 @@ TEST_P(OperatorsTableScanTest, ScanForNullValuesOnValueColumn) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanForNullValuesOnCompressedColumn) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
@@ -571,6 +577,7 @@ TEST_P(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumn) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanForNullValuesOnReferencedCompressedColumn) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
@@ -599,6 +606,7 @@ TEST_P(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedValueCo
 }
 
 TEST_P(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedCompressedColumn) {
+  // FrameOfReference can only deal with int values, so we skip tables that include non-ints
   if (_encoding_type == EncodingType::FrameOfReference) return;
 
   auto table = create_referencing_table_w_null_row_id(true);

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -31,19 +31,19 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     return table_wrapper;
   }
 
-  std::shared_ptr<TableWrapper> get_table_op_even_dict() {
+  std::shared_ptr<TableWrapper> get_table_op_even_compressed() {
     TableColumnDefinitions table_column_definitions;
     table_column_definitions.emplace_back("a", DataType::Int);
     table_column_definitions.emplace_back("b", DataType::Int);
 
-    std::shared_ptr<Table> test_even_dict = std::make_shared<Table>(table_column_definitions, TableType::Data, 5);
-    for (int i = 0; i <= 24; i += 2) test_even_dict->append({i, 100 + i});
-    ChunkEncoder::encode_chunks(test_even_dict, {ChunkID{0}, ChunkID{1}}, {_encoding_type});
+    std::shared_ptr<Table> test_even_compressed = std::make_shared<Table>(table_column_definitions, TableType::Data, 5);
+    for (int i = 0; i <= 24; i += 2) test_even_compressed->append({i, 100 + i});
+    ChunkEncoder::encode_chunks(test_even_compressed, {ChunkID{0}, ChunkID{1}}, {_encoding_type});
 
-    auto table_wrapper_even_dict = std::make_shared<TableWrapper>(std::move(test_even_dict));
-    table_wrapper_even_dict->execute();
+    auto table_wrapper_even_compressed = std::make_shared<TableWrapper>(std::move(test_even_compressed));
+    table_wrapper_even_compressed->execute();
 
-    return table_wrapper_even_dict;
+    return table_wrapper_even_compressed;
   }
 
   std::shared_ptr<TableWrapper> get_table_op_null() {
@@ -52,7 +52,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     return table_wrapper_null;
   }
 
-  std::shared_ptr<TableWrapper> get_table_op_part_dict() {
+  std::shared_ptr<TableWrapper> get_table_op_part_compressed() {
     TableColumnDefinitions table_column_definitions;
     table_column_definitions.emplace_back("a", DataType::Int);
     table_column_definitions.emplace_back("b", DataType::Float);
@@ -78,7 +78,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
 
     std::shared_ptr<Table> table = std::make_shared<Table>(table_column_definitions, TableType::References, 5);
 
-    const auto test_table_part_dict = get_table_op_part_dict()->get_output();
+    const auto test_table_part_compressed = get_table_op_part_compressed()->get_output();
 
     auto pos_list = std::make_shared<PosList>();
     pos_list->emplace_back(RowID{ChunkID{3}, 1});
@@ -92,8 +92,8 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     pos_list->emplace_back(RowID{ChunkID{0}, 0});
     pos_list->emplace_back(RowID{ChunkID{0}, 4});
 
-    auto col_a = std::make_shared<ReferenceColumn>(test_table_part_dict, ColumnID{0}, pos_list);
-    auto col_b = std::make_shared<ReferenceColumn>(test_table_part_dict, ColumnID{1}, pos_list);
+    auto col_a = std::make_shared<ReferenceColumn>(test_table_part_compressed, ColumnID{0}, pos_list);
+    auto col_b = std::make_shared<ReferenceColumn>(test_table_part_compressed, ColumnID{1}, pos_list);
 
     ChunkColumns columns({col_a, col_b});
 
@@ -225,8 +225,9 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
   return std::to_string(static_cast<uint32_t>(info.param));
 };
 
-// As long as two implementation of dictionary encoding exist, this ensure to run the tests for both.
-INSTANTIATE_TEST_CASE_P(DictionaryEncodingTypes, OperatorsTableScanTest, ::testing::Values(EncodingType::Dictionary),
+INSTANTIATE_TEST_CASE_P(EncodingTypes, OperatorsTableScanTest,
+                        ::testing::Values(EncodingType::Dictionary, EncodingType::RunLength,
+                                          EncodingType::FrameOfReference),
                         formatter);
 
 TEST_P(OperatorsTableScanTest, DoubleScan) {
@@ -258,7 +259,7 @@ TEST_P(OperatorsTableScanTest, SingleScanReturnsCorrectRowCount) {
   EXPECT_TABLE_EQ_UNORDERED(scan->get_output(), expected_result);
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnDictColumn) {
+TEST_P(OperatorsTableScanTest, ScanOnCompressedColumn) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
   std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
@@ -273,7 +274,7 @@ TEST_P(OperatorsTableScanTest, ScanOnDictColumn) {
   tests[PredicateCondition::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
-    auto scan = std::make_shared<TableScan>(get_table_op_even_dict(), ColumnID{0}, test.first, 4);
+    auto scan = std::make_shared<TableScan>(get_table_op_even_compressed(), ColumnID{0}, test.first, 4);
 
     if (test.first == PredicateCondition::Between) {
       EXPECT_THROW(scan->execute(), std::logic_error);
@@ -286,7 +287,7 @@ TEST_P(OperatorsTableScanTest, ScanOnDictColumn) {
   }
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
+TEST_P(OperatorsTableScanTest, ScanOnReferencedCompressedColumn) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk
 
   std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
@@ -301,7 +302,8 @@ TEST_P(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
   tests[PredicateCondition::IsNotNull] = {100, 102, 104, 106};
 
   for (const auto& test : tests) {
-    auto scan1 = std::make_shared<TableScan>(get_table_op_even_dict(), ColumnID{1}, PredicateCondition::LessThan, 108);
+    auto scan1 =
+        std::make_shared<TableScan>(get_table_op_even_compressed(), ColumnID{1}, PredicateCondition::LessThan, 108);
     scan1->execute();
 
     auto scan2 = std::make_shared<TableScan>(scan1, ColumnID{0}, test.first, 4);
@@ -318,9 +320,11 @@ TEST_P(OperatorsTableScanTest, ScanOnReferencedDictColumn) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanPartiallyCompressed) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered.tbl", 2);
 
-  auto table_wrapper = get_table_op_part_dict();
+  auto table_wrapper = get_table_op_part_compressed();
   auto scan_1 = std::make_shared<TableScan>(table_wrapper, ColumnID{0}, PredicateCondition::LessThan, 10);
   scan_1->execute();
 
@@ -328,6 +332,8 @@ TEST_P(OperatorsTableScanTest, ScanPartiallyCompressed) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanWeirdPosList) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/int_float_seq_filtered_onlyodd.tbl", 2);
 
   auto table_wrapper = get_table_op_filtered();
@@ -337,7 +343,7 @@ TEST_P(OperatorsTableScanTest, ScanWeirdPosList) {
   EXPECT_TABLE_EQ_UNORDERED(scan_1->get_output(), expected_result);
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValue) {
+TEST_P(OperatorsTableScanTest, ScanOnCompressedColumnValueGreaterThanMaxDictionaryValue) {
   const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   const auto no_rows = std::vector<AllTypeVariant>{};
 
@@ -350,14 +356,14 @@ TEST_P(OperatorsTableScanTest, ScanOnDictColumnValueGreaterThanMaxDictionaryValu
   tests[PredicateCondition::GreaterThanEquals] = no_rows;
 
   for (const auto& test : tests) {
-    auto scan = std::make_shared<TableScan>(get_table_op_even_dict(), ColumnID{0}, test.first, 30);
+    auto scan = std::make_shared<TableScan>(get_table_op_even_compressed(), ColumnID{0}, test.first, 30);
     scan->execute();
 
     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
   }
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) {
+TEST_P(OperatorsTableScanTest, ScanOnCompressedColumnValueLessThanMinDictionaryValue) {
   const auto all_rows = std::vector<AllTypeVariant>{100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
   const auto no_rows = std::vector<AllTypeVariant>{};
 
@@ -370,7 +376,7 @@ TEST_P(OperatorsTableScanTest, ScanOnDictColumnValueLessThanMinDictionaryValue) 
   tests[PredicateCondition::GreaterThanEquals] = all_rows;
 
   for (const auto& test : tests) {
-    auto scan = std::make_shared<TableScan>(get_table_op_even_dict(), ColumnID{0} /* "a" */, test.first, -10);
+    auto scan = std::make_shared<TableScan>(get_table_op_even_compressed(), ColumnID{0} /* "a" */, test.first, -10);
     scan->execute();
 
     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
@@ -405,7 +411,9 @@ TEST_P(OperatorsTableScanTest, ScanOnReferencedIntValueColumnWithFloatColumnWith
   ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{0u}, expected);
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnIntDictColumnWithFloatColumnWithNullValues) {
+TEST_P(OperatorsTableScanTest, ScanOnIntCompressedColumnWithFloatColumnWithNullValues) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
   ChunkEncoder::encode_all_chunks(table, {_encoding_type});
 
@@ -420,7 +428,9 @@ TEST_P(OperatorsTableScanTest, ScanOnIntDictColumnWithFloatColumnWithNullValues)
   ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{0u}, expected);
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnReferencedIntDictColumnWithFloatColumnWithNullValues) {
+TEST_P(OperatorsTableScanTest, ScanOnReferencedIntCompressedColumnWithFloatColumnWithNullValues) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
   ChunkEncoder::encode_all_chunks(table, {_encoding_type});
 
@@ -435,7 +445,7 @@ TEST_P(OperatorsTableScanTest, ScanOnReferencedIntDictColumnWithFloatColumnWithN
   ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{0u}, expected);
 }
 
-TEST_P(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
+TEST_P(OperatorsTableScanTest, ScanOnCompressedColumnAroundBounds) {
   // scanning for a value that is around the dictionary's bounds
 
   std::map<PredicateCondition, std::vector<AllTypeVariant>> tests;
@@ -449,7 +459,7 @@ TEST_P(OperatorsTableScanTest, ScanOnDictColumnAroundBounds) {
   tests[PredicateCondition::IsNotNull] = {100, 102, 104, 106, 108, 110, 112, 114, 116, 118, 120, 122, 124};
 
   for (const auto& test : tests) {
-    auto scan = std::make_shared<opossum::TableScan>(get_table_op_even_dict(), ColumnID{0}, test.first, 0);
+    auto scan = std::make_shared<opossum::TableScan>(get_table_op_even_compressed(), ColumnID{0}, test.first, 0);
     scan->execute();
 
     ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, test.second);
@@ -470,6 +480,8 @@ TEST_P(OperatorsTableScanTest, ScanWithEmptyInput) {
 }
 
 TEST_P(OperatorsTableScanTest, ScanOnWideDictionaryColumn) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   // 2**8 + 1 values require a data type of 16bit.
   const auto table_wrapper_dict_16 = get_table_op_with_n_dict_entries((1 << 8) + 1);
   auto scan_1 =
@@ -505,7 +517,9 @@ TEST_P(OperatorsTableScanTest, ScanForNullValuesOnValueColumn) {
   scan_for_null_values(table_wrapper, tests);
 }
 
-TEST_P(OperatorsTableScanTest, ScanForNullValuesOnDictColumn) {
+TEST_P(OperatorsTableScanTest, ScanForNullValuesOnCompressedColumn) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
   ChunkEncoder::encode_all_chunks(table, {_encoding_type});
 
@@ -556,7 +570,9 @@ TEST_P(OperatorsTableScanTest, ScanForNullValuesOnReferencedValueColumn) {
   scan_for_null_values(table_wrapper, tests);
 }
 
-TEST_P(OperatorsTableScanTest, ScanForNullValuesOnReferencedDictColumn) {
+TEST_P(OperatorsTableScanTest, ScanForNullValuesOnReferencedCompressedColumn) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   auto table = load_table("src/test/tables/int_float_w_null_8_rows.tbl", 4);
   ChunkEncoder::encode_all_chunks(table, {_encoding_type});
 
@@ -582,7 +598,9 @@ TEST_P(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedValueCo
   scan_for_null_values(table_wrapper, tests);
 }
 
-TEST_P(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedDictColumn) {
+TEST_P(OperatorsTableScanTest, ScanForNullValuesWithNullRowIDOnReferencedCompressedColumn) {
+  if (_encoding_type == EncodingType::FrameOfReference) return;
+
   auto table = create_referencing_table_w_null_row_id(true);
 
   auto table_wrapper = std::make_shared<TableWrapper>(table);
@@ -614,7 +632,7 @@ TEST_P(OperatorsTableScanTest, NullSemantics) {
 TEST_P(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
   const auto expected = std::vector<AllTypeVariant>{110, 112, 114, 116, 118, 120, 122, 124};
 
-  auto scan = std::make_shared<opossum::TableScan>(get_table_op_even_dict(), ColumnID{0},
+  auto scan = std::make_shared<opossum::TableScan>(get_table_op_even_compressed(), ColumnID{0},
                                                    PredicateCondition::GreaterThanEquals, 0);
   scan->set_excluded_chunk_ids({ChunkID{0u}});
   scan->execute();

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -137,7 +137,7 @@ INSERT INTO id_int_int_int_100 (b, id, c, a) SELECT 2, 100, 3, 1 FROM id_int_int
 INSERT INTO mixed_null SELECT a, b, c, d FROM mixed WHERE a = 'c' AND b > 15; INSERT INTO mixed_null SELECT a, b, c, d FROM mixed WHERE d = 'caoe'; INSERT INTO mixed_null (b, c, a, d) SELECT b, c, a, d FROM mixed WHERE id < 13; SELECT * FROM mixed_null;
 
 
--- VIEWS disabled because of #367
+-- VIEWS
 CREATE VIEW count_view1 AS SELECT a, COUNT(DISTINCT b) FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view1;
 CREATE VIEW count_view2 AS SELECT a, COUNT(DISTINCT b) FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view2 WHERE a > 10;
 CREATE VIEW count_view3 (foo, bar) AS SELECT a, COUNT(DISTINCT b) FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view3 WHERE foo > 10;

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -161,7 +161,11 @@ TEST_P(EncodedColumnTest, SequentiallyReadNullableIntColumn) {
       encoded_column_iterable.with_iterators([&](auto encoded_column_it, auto encoded_column_end) {
         auto i = 0;
         for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it, ++i) {
-          EXPECT_EQ((*value_column)[i], encoded_column[i]);
+          if (variant_is_null((*value_column)[i])) {
+            EXPECT_TRUE(variant_is_null(encoded_column[i]));
+          } else {
+            EXPECT_EQ((*value_column)[i], encoded_column[i]);
+          }
 
           EXPECT_EQ(value_column_it->is_null(), encoded_column_it->is_null());
 

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -161,12 +161,14 @@ TEST_P(EncodedColumnTest, SequentiallyReadNullableIntColumn) {
       encoded_column_iterable.with_iterators([&](auto encoded_column_it, auto encoded_column_end) {
         auto i = 0;
         for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it, ++i) {
+          // This covers `EncodedColumn::operator[]`
           if (variant_is_null((*value_column)[i])) {
             EXPECT_TRUE(variant_is_null(encoded_column[i]));
           } else {
             EXPECT_EQ((*value_column)[i], encoded_column[i]);
           }
 
+          // This covers the point access iterator
           EXPECT_EQ(value_column_it->is_null(), encoded_column_it->is_null());
 
           if (!value_column_it->is_null()) {

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -159,13 +159,13 @@ TEST_P(EncodedColumnTest, SequentiallyReadNullableIntColumn) {
 
     value_column_iterable.with_iterators([&](auto value_column_it, auto value_column_end) {
       encoded_column_iterable.with_iterators([&](auto encoded_column_it, auto encoded_column_end) {
-        auto i = 0;
-        for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it, ++i) {
+        auto row_idx = 0;
+        for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it, ++row_idx) {
           // This covers `EncodedColumn::operator[]`
-          if (variant_is_null((*value_column)[i])) {
-            EXPECT_TRUE(variant_is_null(encoded_column[i]));
+          if (variant_is_null((*value_column)[row_idx])) {
+            EXPECT_TRUE(variant_is_null(encoded_column[row_idx]));
           } else {
-            EXPECT_EQ((*value_column)[i], encoded_column[i]);
+            EXPECT_EQ((*value_column)[row_idx], encoded_column[row_idx]);
           }
 
           // This covers the point access iterator

--- a/src/test/storage/encoded_column_test.cpp
+++ b/src/test/storage/encoded_column_test.cpp
@@ -159,7 +159,10 @@ TEST_P(EncodedColumnTest, SequentiallyReadNullableIntColumn) {
 
     value_column_iterable.with_iterators([&](auto value_column_it, auto value_column_end) {
       encoded_column_iterable.with_iterators([&](auto encoded_column_it, auto encoded_column_end) {
-        for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it) {
+        auto i = 0;
+        for (; encoded_column_it != encoded_column_end; ++encoded_column_it, ++value_column_it, ++i) {
+          EXPECT_EQ((*value_column)[i], encoded_column[i]);
+
           EXPECT_EQ(value_column_it->is_null(), encoded_column_it->is_null());
 
           if (!value_column_it->is_null()) {

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -174,12 +174,15 @@ TEST_F(StorageTableTest, MemoryUsageEstimation) {
    * memory usage estimations
    */
 
-  const auto empty_memory_usage = t->estimate_memory_usage();
+  auto mvcc_table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
 
-  t->append({4, "Hello"});
-  t->append({5, "Hello"});
+  const auto empty_memory_usage = mvcc_table->estimate_memory_usage();
 
-  EXPECT_GT(t->estimate_memory_usage(), empty_memory_usage + 2 * (sizeof(int) + sizeof(std::string)));
+  mvcc_table->append({4, "Hello"});
+  mvcc_table->append({5, "Hello"});
+
+  EXPECT_GT(mvcc_table->estimate_memory_usage(), empty_memory_usage + 2 * (sizeof(int) + sizeof(std::string)) +
+                                                     sizeof(TransactionID) + 2 * sizeof(CommitID));
 }
 
 }  // namespace opossum

--- a/src/test/utils/format_bytes_test.cpp
+++ b/src/test/utils/format_bytes_test.cpp
@@ -9,6 +9,7 @@ TEST(Format, Bytes) {
   EXPECT_EQ(format_bytes(11), "11B");
   EXPECT_EQ(format_bytes(1'234), "1.234KB");
   EXPECT_EQ(format_bytes(12'345), "12.345KB");
+  EXPECT_EQ(format_bytes(12'000'000), "12.000MB");
   EXPECT_EQ(format_bytes(12'345'678), "12.345MB");
   EXPECT_EQ(format_bytes(1'234'567'890), "1.234GB");
 }

--- a/src/test/utils/format_duration_test.cpp
+++ b/src/test/utils/format_duration_test.cpp
@@ -1,0 +1,18 @@
+#include "gtest/gtest.h"
+
+#include "utils/format_duration.hpp"
+
+namespace opossum {
+
+TEST(Format, Duration) {
+  EXPECT_EQ(format_duration(0), "0 ns");
+  EXPECT_EQ(format_duration(11), "11 ns");
+  EXPECT_EQ(format_duration(1'000), "1 µs 0 ns");
+  EXPECT_EQ(format_duration(1'234), "1 µs 234 ns");
+  EXPECT_EQ(format_duration(12'345'678), "12 ms 345 µs");
+  EXPECT_EQ(format_duration(1'234'567'890), "1 s 234 ms");
+  EXPECT_EQ(format_duration(60'000'000'000), "1 min 0 s");
+  EXPECT_EQ(format_duration(61'234'567'890), "1 min 1 s");
+}
+
+}  // namespace opossum

--- a/src/test/utils/numa_memory_resource_test.cpp
+++ b/src/test/utils/numa_memory_resource_test.cpp
@@ -39,4 +39,14 @@ TEST_F(NUMAMemoryResourceTest, BasicAllocate) {
   EXPECT_EQ(get_node_id_of(vec.data()), numa_node);
 }
 
+TEST_F(NUMAMemoryResourceTest, AreEqual) {
+#if HYRISE_NUMA_SUPPORT
+  const int numa_node = numa_max_node();
+#else
+  const int numa_node = 1;
+#endif
+
+  EXPECT_EQ(NUMAMemoryResource(numa_node, "foo"), NUMAMemoryResource(numa_node, "bar"));
+}
+
 }  // namespace opossum

--- a/src/test/utils/numa_memory_resource_test.cpp
+++ b/src/test/utils/numa_memory_resource_test.cpp
@@ -51,10 +51,7 @@ TEST_F(NUMAMemoryResourceTest, AreEqual) {
   auto resource_a = NUMAMemoryResource(numa_node, "foo");
   auto resource_b = NUMAMemoryResource(numa_node, "bar");
 
-  EXPECT_TRUE(resource_a.is_equal(resource_b));
-
-  auto ptr = resource_a.allocate(100, 1);
-  resource_b.deallocate(ptr, 100, 1);
+  EXPECT_FALSE(resource_a.is_equal(resource_b));
 }
 
 }  // namespace opossum

--- a/src/test/utils/numa_memory_resource_test.cpp
+++ b/src/test/utils/numa_memory_resource_test.cpp
@@ -46,7 +46,15 @@ TEST_F(NUMAMemoryResourceTest, AreEqual) {
   const int numa_node = 1;
 #endif
 
-  EXPECT_EQ(NUMAMemoryResource(numa_node, "foo"), NUMAMemoryResource(numa_node, "bar"));
+  // Two memory_resources compare equal if and only if memory allocated from one memory_resource can be deallocated from the other and vice versa.
+
+  auto resource_a = NUMAMemoryResource(numa_node, "foo");
+  auto resource_b = NUMAMemoryResource(numa_node, "bar");
+
+  EXPECT_TRUE(resource_a.is_equal(resource_b));
+
+  auto ptr = resource_a.allocate(100, 1);
+  resource_b.deallocate(ptr, 100, 1);
 }
 
 }  // namespace opossum

--- a/src/test/utils/numa_memory_resource_test.cpp
+++ b/src/test/utils/numa_memory_resource_test.cpp
@@ -46,7 +46,8 @@ TEST_F(NUMAMemoryResourceTest, AreEqual) {
   const int numa_node = 1;
 #endif
 
-  // Two memory_resources compare equal if and only if memory allocated from one memory_resource can be deallocated from the other and vice versa.
+  // Two memory_resources compare equal if and only if memory allocated from one memory_resource can be deallocated fro
+  // the other and vice versa.
 
   auto resource_a = NUMAMemoryResource(numa_node, "foo");
   auto resource_b = NUMAMemoryResource(numa_node, "bar");

--- a/src/test/utils/numa_memory_resource_test.cpp
+++ b/src/test/utils/numa_memory_resource_test.cpp
@@ -46,8 +46,8 @@ TEST_F(NUMAMemoryResourceTest, AreEqual) {
   const int numa_node = 1;
 #endif
 
-  // Two memory_resources compare equal if and only if memory allocated from one memory_resource can be deallocated fro
-  // the other and vice versa.
+  // Two memory_resources compare equal if and only if memory allocated from one memory_resource can be deallocated
+  // from the other and vice versa.
 
   auto resource_a = NUMAMemoryResource(numa_node, "foo");
   auto resource_b = NUMAMemoryResource(numa_node, "bar");


### PR DESCRIPTION
I could not focus on something complex, so I worked through the untested parts of the code, wrote tests and fixed some bugs on the way. Changes:

* Operators must return at least one column. Those that don’t “do” anything (e.g. CreateView) return a dummy column “OK”.
* Exceptions within operators are caught, the R/W operators are set as failed and then the exception is rethrown. This is because otherwise the unclean TX context will hide the actual problem (as I have just had with the insert). @mrzzzrm - you might have an opinion on this?
* fixed a bug in how durations were printed
* added a bunch of smaller tests
* changed table scan tests so that they test all encoding schemes