### PR TITLE
JIT: tests for data structures, operations, operators

### DIFF
--- a/src/lib/operators/jit_operator/operators/jit_read_tuple.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuple.cpp
@@ -34,6 +34,8 @@ void JitReadTuple::before_query(const Table& in_table, JitRuntimeContext& contex
 
 void JitReadTuple::before_chunk(const Table& in_table, const Chunk& in_chunk, JitRuntimeContext& context) const {
   context.inputs.clear();
+  context.chunk_offset = 0;
+  context.chunk_size = in_chunk.size();
 
   // Create the column iterator for each input column and store them to the runtime context
   for (const auto& input_column : _input_columns) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -145,8 +145,9 @@ set(
 if (${ENABLE_JIT_SUPPORT})
     set(HYRISE_UNIT_TEST_SOURCES
         ${HYRISE_UNIT_TEST_SOURCES}
-        operators/jit_operator/jit_variant_vector_test.cpp
         operators/jit_operator/jit_operations_test.cpp
+        operators/jit_operator/jit_tuple_value_test.cpp
+        operators/jit_operator/jit_variant_vector_test.cpp
     )
 endif()
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -142,6 +142,14 @@ set(
     gtest_main.cpp
 )
 
+if (${ENABLE_JIT_SUPPORT})
+    set(HYRISE_UNIT_TEST_SOURCES
+        ${HYRISE_UNIT_TEST_SOURCES}
+        operators/jit_operator/jit_variant_vector_test.cpp
+        operators/jit_operator/jit_operations_test.cpp
+    )
+endif()
+
 set (
     SYSTEM_TEST_SOURCES
     ${SHARED_SOURCES}

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -148,6 +148,10 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator/jit_operations_test.cpp
         operators/jit_operator/jit_tuple_value_test.cpp
         operators/jit_operator/jit_variant_vector_test.cpp
+        operators/jit_operator/operators/jit_compute_test.cpp
+        operators/jit_operator/operators/jit_expression_test.cpp
+        operators/jit_operator/operators/jit_filter_test.cpp
+        operators/jit_operator/operators/jit_read_write_tuple_test.cpp
     )
 endif()
 

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -215,7 +215,7 @@ TEST_F(JitOperationsTest, JitNot) {
 
 TEST_F(JitOperationsTest, JitIs_Not_Null) {
   JitRuntimeContext context;
-  context.tuple.resize(2);
+  context.tuple.resize(3);
 
   const JitTupleValue null_value{DataType::Bool, true, 0};
   const JitTupleValue non_null_value{DataType::Int, true, 1};

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -1,10 +1,9 @@
-#include "../../base_test.hpp"
 #include "operators/jit_operator/jit_operations.hpp"
+#include "../../base_test.hpp"
 
 namespace opossum {
 
-class JitOperationsTest : public BaseTest {
-};
+class JitOperationsTest : public BaseTest {};
 
 TEST_F(JitOperationsTest, ComputeResultType) {
   // We only test a selection of data type combinations and operations.
@@ -48,10 +47,7 @@ TEST_F(JitOperationsTest, ComputeResultType) {
   EXPECT_THROW(jit_compute_type(jit_modulo, DataType::Int, DataType::Float), std::logic_error);
 }
 
-
-TEST_F(JitOperationsTest, Computations) {
-
-}
+TEST_F(JitOperationsTest, Computations) {}
 
 TEST_F(JitOperationsTest, JitAnd) {
   JitRuntimeContext context;
@@ -111,8 +107,10 @@ TEST_F(JitOperationsTest, JitAnd) {
   }
 
   // Check that invalid data type combinations are rejected
-  const JitTupleValue int_value{DataType::Int, false, 0};
-  EXPECT_THROW(jit_and(true_value, int_value, result_value, context), std::logic_error);
+  if (!IS_DEBUG) {
+    const JitTupleValue int_value{DataType::Int, false, 0};
+    EXPECT_THROW(jit_and(true_value, int_value, result_value, context), std::logic_error);
+  }
 }
 
 TEST_F(JitOperationsTest, JitOr) {
@@ -173,8 +171,10 @@ TEST_F(JitOperationsTest, JitOr) {
   }
 
   // Check that invalid data type combinations are rejected
-  const JitTupleValue int_value{DataType::Int, false, 0};
-  EXPECT_THROW(jit_or(true_value, int_value, result_value, context), std::logic_error);
+  if (IS_DEBUG) {
+    const JitTupleValue int_value{DataType::Int, false, 0};
+    EXPECT_THROW(jit_or(true_value, int_value, result_value, context), std::logic_error);
+  }
 }
 
 TEST_F(JitOperationsTest, JitNot) {
@@ -207,8 +207,10 @@ TEST_F(JitOperationsTest, JitNot) {
   }
 
   // Check that invalid data type combinations are rejected
-  const JitTupleValue int_value{DataType::Int, false, 0};
-  EXPECT_THROW(jit_not(int_value, result_value, context), std::logic_error);
+  if (IS_DEBUG) {
+    const JitTupleValue int_value{DataType::Int, false, 0};
+    EXPECT_THROW(jit_not(int_value, result_value, context), std::logic_error);
+  }
 }
 
 TEST_F(JitOperationsTest, JitIs_Not_Null) {
@@ -244,4 +246,4 @@ TEST_F(JitOperationsTest, JitIs_Not_Null) {
   }
 }
 
-} // namespace opossum
+}  // namespace opossum

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -107,7 +107,7 @@ TEST_F(JitOperationsTest, JitAnd) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (!IS_DEBUG) {
+  if (IS_DEBUG) {
     const JitTupleValue int_value{DataType::Int, false, 0};
     EXPECT_THROW(jit_and(true_value, int_value, result_value, context), std::logic_error);
   }

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -47,7 +47,115 @@ TEST_F(JitOperationsTest, ComputeResultType) {
   EXPECT_THROW(jit_compute_type(jit_modulo, DataType::Int, DataType::Float), std::logic_error);
 }
 
-TEST_F(JitOperationsTest, Computations) {}
+TEST_F(JitOperationsTest, ArithmeticComputations) {
+  // We only test a selection of data type combinations and operations.
+  JitRuntimeContext context;
+  context.tuple.resize(5);
+
+  const JitTupleValue int_value{DataType::Int, false, 0};
+  const JitTupleValue long_value{DataType::Long, false, 1};
+  const JitTupleValue float_value{DataType::Float, false, 2};
+  const JitTupleValue double_value{DataType::Double, false, 3};
+
+  int_value.set<int32_t>(2, context);
+  long_value.set<int64_t>(5l, context);
+  float_value.set<float>(3.14f, context);
+  double_value.set<double>(1.23, context);
+
+  const JitTupleValue int_result_value{DataType::Int, false, 4};
+  const JitTupleValue long_result_value{DataType::Long, false, 4};
+  const JitTupleValue float_result_value{DataType::Float, false, 4};
+  const JitTupleValue double_result_value{DataType::Double, false, 4};
+  const JitTupleValue bool_result_value{DataType::Bool, false, 4};
+
+  jit_compute(jit_addition, int_value, long_value, long_result_value, context);
+  ASSERT_EQ(2 + 5l, long_result_value.get<int64_t>(context));
+
+  jit_compute(jit_subtraction, float_value, long_value, float_result_value, context);
+  ASSERT_EQ(3.14f - 5l, float_result_value.get<float>(context));
+
+  jit_compute(jit_multiplication, double_value, int_value, double_result_value, context);
+  ASSERT_EQ(1.23 * 2, double_result_value.get<double>(context));
+
+  jit_compute(jit_division, int_value, float_value, float_result_value, context);
+  ASSERT_EQ(2 / 3.14f, float_result_value.get<float>(context));
+
+  jit_compute(jit_modulo, long_value, int_value, long_result_value, context);
+  ASSERT_EQ(5l % 2, long_result_value.get<int64_t>(context));
+
+  jit_compute(jit_power, double_value, float_value, double_result_value, context);
+  ASSERT_EQ(std::pow(1.23, 3.14f), double_result_value.get<double>(context));
+}
+
+TEST_F(JitOperationsTest, Predicates) {
+  JitRuntimeContext context;
+  context.tuple.resize(5);
+
+  const JitTupleValue int_1{DataType::Int, false, 0};
+  const JitTupleValue int_2{DataType::Int, false, 1};
+  const JitTupleValue float_1{DataType::Float, false, 2};
+  const JitTupleValue float_2{DataType::Float, false, 3};
+  const JitTupleValue result_value{DataType::Bool, false, 4};
+
+  int_1.set<int32_t>(1, context);
+  int_2.set<int32_t>(2, context);
+  float_1.set<float>(1.0f, context);
+  float_2.set<float>(2.0f, context);
+
+  // GreaterThan
+  jit_compute(jit_greater_than, int_1, int_2, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  jit_compute(jit_greater_than, int_1, float_1, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  jit_compute(jit_greater_than, float_2, int_1, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  // GreaterThanEquals
+  jit_compute(jit_greater_than_equals, float_1, float_2, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  jit_compute(jit_greater_than_equals, float_1, int_1, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  jit_compute(jit_greater_than_equals, int_2, float_1, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  // LessThan
+  jit_compute(jit_less_than, int_1, int_2, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  jit_compute(jit_less_than, int_1, float_1, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  jit_compute(jit_less_than, float_2, int_1, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  // LessThanEquals
+  jit_compute(jit_less_than_equals, float_1, float_2, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  jit_compute(jit_less_than_equals, float_1, int_1, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  jit_compute(jit_less_than_equals, int_2, float_1, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  // Equals
+  jit_compute(jit_equals, float_1, float_2, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+
+  jit_compute(jit_equals, float_1, int_1, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  // NotEquals
+  jit_compute(jit_not_equals, int_1, int_2, result_value, context);
+  ASSERT_TRUE(result_value.get<bool>(context));
+
+  jit_compute(jit_not_equals, int_1, float_1, result_value, context);
+  ASSERT_FALSE(result_value.get<bool>(context));
+}
 
 TEST_F(JitOperationsTest, JitAnd) {
   JitRuntimeContext context;

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -1,0 +1,247 @@
+#include "../../base_test.hpp"
+#include "operators/jit_operator/jit_operations.hpp"
+
+namespace opossum {
+
+class JitOperationsTest : public BaseTest {
+};
+
+TEST_F(JitOperationsTest, ComputeResultType) {
+  // We only test a selection of data type combinations and operations.
+  const auto int_plus_int = jit_compute_type(jit_addition, DataType::Int, DataType::Int);
+  EXPECT_EQ(int_plus_int, DataType::Int);
+
+  const auto int_plus_long = jit_compute_type(jit_addition, DataType::Int, DataType::Long);
+  EXPECT_EQ(int_plus_long, DataType::Long);
+
+  const auto long_plus_int = jit_compute_type(jit_addition, DataType::Long, DataType::Int);
+  EXPECT_EQ(long_plus_int, DataType::Long);
+
+  const auto int_plus_float = jit_compute_type(jit_addition, DataType::Int, DataType::Float);
+  EXPECT_EQ(int_plus_float, DataType::Float);
+
+  const auto int_plus_double = jit_compute_type(jit_addition, DataType::Int, DataType::Double);
+  EXPECT_EQ(int_plus_double, DataType::Double);
+
+  const auto float_plus_double = jit_compute_type(jit_addition, DataType::Float, DataType::Double);
+  EXPECT_EQ(float_plus_double, DataType::Double);
+
+  const auto int_minus_int = jit_compute_type(jit_subtraction, DataType::Int, DataType::Int);
+  EXPECT_EQ(int_minus_int, DataType::Int);
+
+  const auto int_times_long = jit_compute_type(jit_multiplication, DataType::Int, DataType::Long);
+  EXPECT_EQ(int_times_long, DataType::Long);
+
+  const auto long_modulo_int = jit_compute_type(jit_modulo, DataType::Long, DataType::Int);
+  EXPECT_EQ(long_modulo_int, DataType::Long);
+
+  const auto int_raised_to_float = jit_compute_type(jit_power, DataType::Int, DataType::Float);
+  EXPECT_EQ(int_raised_to_float, DataType::Double);
+
+  const auto int_divided_by_double = jit_compute_type(jit_division, DataType::Int, DataType::Double);
+  EXPECT_EQ(int_divided_by_double, DataType::Double);
+
+  const auto float_times_double = jit_compute_type(jit_multiplication, DataType::Float, DataType::Double);
+  EXPECT_EQ(float_times_double, DataType::Double);
+
+  EXPECT_THROW(jit_compute_type(jit_addition, DataType::String, DataType::Int), std::logic_error);
+  EXPECT_THROW(jit_compute_type(jit_modulo, DataType::Int, DataType::Float), std::logic_error);
+}
+
+
+TEST_F(JitOperationsTest, Computations) {
+
+}
+
+TEST_F(JitOperationsTest, JitAnd) {
+  JitRuntimeContext context;
+  context.tuple.resize(4);
+
+  const JitTupleValue null_value{DataType::Bool, true, 0};
+  const JitTupleValue true_value{DataType::Bool, false, 1};
+  const JitTupleValue false_value{DataType::Bool, false, 2};
+  const JitTupleValue result_value{DataType::Bool, true, 3};
+
+  null_value.set_is_null(true, context);
+  true_value.set(true, context);
+  false_value.set(false, context);
+
+  // Test of three-valued logic AND operation
+  {
+    jit_and(null_value, null_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_and(null_value, true_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_and(null_value, false_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+  {
+    jit_and(true_value, null_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_and(true_value, true_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_and(true_value, false_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+  {
+    jit_and(false_value, null_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+  {
+    jit_and(false_value, true_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+  {
+    jit_and(false_value, false_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+
+  // Check that invalid data type combinations are rejected
+  const JitTupleValue int_value{DataType::Int, false, 0};
+  EXPECT_THROW(jit_and(true_value, int_value, result_value, context), std::logic_error);
+}
+
+TEST_F(JitOperationsTest, JitOr) {
+  JitRuntimeContext context;
+  context.tuple.resize(4);
+
+  const JitTupleValue null_value{DataType::Bool, true, 0};
+  const JitTupleValue true_value{DataType::Bool, false, 1};
+  const JitTupleValue false_value{DataType::Bool, false, 2};
+  const JitTupleValue result_value{DataType::Bool, true, 3};
+
+  null_value.set_is_null(true, context);
+  true_value.set(true, context);
+  false_value.set(false, context);
+
+  // Test of three-valued logic OR operation
+  {
+    jit_or(null_value, null_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_or(null_value, true_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_or(null_value, false_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_or(true_value, null_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_or(true_value, true_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_or(true_value, false_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_or(false_value, null_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_or(false_value, true_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_or(false_value, false_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+
+  // Check that invalid data type combinations are rejected
+  const JitTupleValue int_value{DataType::Int, false, 0};
+  EXPECT_THROW(jit_or(true_value, int_value, result_value, context), std::logic_error);
+}
+
+TEST_F(JitOperationsTest, JitNot) {
+  JitRuntimeContext context;
+  context.tuple.resize(4);
+
+  const JitTupleValue null_value{DataType::Bool, true, 0};
+  const JitTupleValue true_value{DataType::Bool, false, 1};
+  const JitTupleValue false_value{DataType::Bool, false, 2};
+  const JitTupleValue result_value{DataType::Bool, true, 3};
+
+  null_value.set_is_null(true, context);
+  true_value.set(true, context);
+  false_value.set(false, context);
+
+  // Test of three-valued logic NOT operation
+  {
+    jit_not(null_value, result_value, context);
+    EXPECT_TRUE(result_value.is_null(context));
+  }
+  {
+    jit_not(true_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+  {
+    jit_not(false_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+
+  // Check that invalid data type combinations are rejected
+  const JitTupleValue int_value{DataType::Int, false, 0};
+  EXPECT_THROW(jit_not(int_value, result_value, context), std::logic_error);
+}
+
+TEST_F(JitOperationsTest, JitIs_Not_Null) {
+  JitRuntimeContext context;
+  context.tuple.resize(2);
+
+  const JitTupleValue null_value{DataType::Bool, true, 0};
+  const JitTupleValue non_null_value{DataType::Int, true, 1};
+  const JitTupleValue result_value{DataType::Bool, false, 2};
+
+  null_value.set_is_null(true, context);
+  non_null_value.set_is_null(true, context);
+
+  {
+    jit_is_null(null_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_is_not_null(null_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+  {
+    jit_is_null(non_null_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_TRUE(result_value.get<bool>(context));
+  }
+  {
+    jit_is_not_null(non_null_value, result_value, context);
+    EXPECT_FALSE(result_value.is_null(context));
+    EXPECT_FALSE(result_value.get<bool>(context));
+  }
+}
+
+} // namespace opossum

--- a/src/test/operators/jit_operator/jit_tuple_value_test.cpp
+++ b/src/test/operators/jit_operator/jit_tuple_value_test.cpp
@@ -11,7 +11,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
   context.tuple.resize(10);
 
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Int, false, index};
     const auto value_in = static_cast<int32_t>(std::rand());
     tuple_value.set(value_in, context);
@@ -19,7 +19,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
     EXPECT_EQ(value_in, value_out);
   }
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Long, false, index};
     const auto value_in = static_cast<int64_t>(std::rand());
     tuple_value.set(value_in, context);
@@ -27,7 +27,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
     EXPECT_EQ(value_in, value_out);
   }
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Float, false, index};
     const auto value_in = static_cast<float>(std::rand());
     tuple_value.set(value_in, context);
@@ -35,7 +35,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
     EXPECT_EQ(value_in, value_out);
   }
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Double, false, index};
     const auto value_in = static_cast<double >(std::rand());
     tuple_value.set(value_in, context);
@@ -43,7 +43,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
     EXPECT_EQ(value_in, value_out);
   }
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::String, false, index};
     const auto value_in = std::string("some string");
     tuple_value.set(value_in, context);
@@ -51,7 +51,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
     EXPECT_EQ(value_in, value_out);
   }
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Bool, false, index};
     const auto value_in = false;
     tuple_value.set(value_in, context);
@@ -60,13 +60,12 @@ TEST_F(JitTupleValueTest, GetAndSet) {
   }
 }
 
-
-TEST_F(JitVariantVectorTest, IsNullAndSetIsNull) {
+TEST_F(JitTupleValueTest, IsNullAndSetIsNull) {
   JitRuntimeContext context;
   context.tuple.resize(10);
 
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Int, true, index};
     const auto is_null_in = false;
     tuple_value.set_is_null(is_null_in, context);
@@ -74,7 +73,7 @@ TEST_F(JitVariantVectorTest, IsNullAndSetIsNull) {
     EXPECT_EQ(is_null_in, is_null_out);
   }
   {
-    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Int, true, index};
     const auto is_null_in = true;
     tuple_value.set_is_null(is_null_in, context);

--- a/src/test/operators/jit_operator/jit_tuple_value_test.cpp
+++ b/src/test/operators/jit_operator/jit_tuple_value_test.cpp
@@ -3,8 +3,7 @@
 
 namespace opossum {
 
-class JitTupleValueTest : public BaseTest {
-};
+class JitTupleValueTest : public BaseTest {};
 
 TEST_F(JitTupleValueTest, GetAndSet) {
   JitRuntimeContext context;
@@ -37,7 +36,7 @@ TEST_F(JitTupleValueTest, GetAndSet) {
   {
     const auto index = static_cast<size_t>(std::rand()) % 10;
     JitTupleValue tuple_value{DataType::Double, false, index};
-    const auto value_in = static_cast<double >(std::rand());
+    const auto value_in = static_cast<double>(std::rand());
     tuple_value.set(value_in, context);
     const auto value_out = tuple_value.get<double>(context);
     EXPECT_EQ(value_in, value_out);
@@ -82,4 +81,4 @@ TEST_F(JitTupleValueTest, IsNullAndSetIsNull) {
   }
 }
 
-} // namespace opossum
+}  // namespace opossum

--- a/src/test/operators/jit_operator/jit_tuple_value_test.cpp
+++ b/src/test/operators/jit_operator/jit_tuple_value_test.cpp
@@ -1,0 +1,86 @@
+#include "../../base_test.hpp"
+#include "operators/jit_operator/jit_types.hpp"
+
+namespace opossum {
+
+class JitTupleValueTest : public BaseTest {
+};
+
+TEST_F(JitTupleValueTest, GetAndSet) {
+  JitRuntimeContext context;
+  context.tuple.resize(10);
+
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Int, false, index};
+    const auto value_in = static_cast<int32_t>(std::rand());
+    tuple_value.set(value_in, context);
+    const auto value_out = tuple_value.get<int32_t>(context);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Long, false, index};
+    const auto value_in = static_cast<int64_t>(std::rand());
+    tuple_value.set(value_in, context);
+    const auto value_out = tuple_value.get<int64_t>(context);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Float, false, index};
+    const auto value_in = static_cast<float>(std::rand());
+    tuple_value.set(value_in, context);
+    const auto value_out = tuple_value.get<float>(context);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Double, false, index};
+    const auto value_in = static_cast<double >(std::rand());
+    tuple_value.set(value_in, context);
+    const auto value_out = tuple_value.get<double>(context);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::String, false, index};
+    const auto value_in = std::string("some string");
+    tuple_value.set(value_in, context);
+    const auto value_out = tuple_value.get<std::string>(context);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Bool, false, index};
+    const auto value_in = false;
+    tuple_value.set(value_in, context);
+    const auto value_out = tuple_value.get<bool>(context);
+    EXPECT_EQ(value_in, value_out);
+  }
+}
+
+
+TEST_F(JitVariantVectorTest, IsNullAndSetIsNull) {
+  JitRuntimeContext context;
+  context.tuple.resize(10);
+
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Int, true, index};
+    const auto is_null_in = false;
+    tuple_value.set_is_null(is_null_in, context);
+    const auto is_null_out = tuple_value.is_null(context);
+    EXPECT_EQ(is_null_in, is_null_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    JitTupleValue tuple_value{DataType::Int, true, index};
+    const auto is_null_in = true;
+    tuple_value.set_is_null(is_null_in, context);
+    const auto is_null_out = tuple_value.is_null(context);
+    EXPECT_EQ(is_null_in, is_null_out);
+  }
+}
+
+} // namespace opossum

--- a/src/test/operators/jit_operator/jit_variant_vector_test.cpp
+++ b/src/test/operators/jit_operator/jit_variant_vector_test.cpp
@@ -1,0 +1,79 @@
+#include "../../base_test.hpp"
+#include "operators/jit_operator/jit_types.hpp"
+
+namespace opossum {
+
+class JitVariantVectorTest : public BaseTest {};
+
+TEST_F(JitVariantVectorTest, GetAndSet) {
+  JitVariantVector vector;
+  vector.resize(10);
+
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto value_in = static_cast<int32_t>(std::rand());
+    vector.set(index, value_in);
+    const auto value_out = vector.get<int32_t>(index);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto value_in = static_cast<int64_t>(std::rand());
+    vector.set(index, value_in);
+    const auto value_out = vector.get<int64_t>(index);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto value_in = static_cast<float>(std::rand()) / RAND_MAX;
+    vector.set(index, value_in);
+    const auto value_out = vector.get<float>(index);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto value_in = static_cast<double>(std::rand()) / RAND_MAX;
+    vector.set(index, value_in);
+    const auto value_out = vector.get<double>(index);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto value_in = std::string("some string");
+    vector.set(index, value_in);
+    const auto value_out = vector.get<std::string>(index);
+    EXPECT_EQ(value_in, value_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto value_in = false;
+    vector.set(index, value_in);
+    const auto value_out = vector.get<bool>(index);
+    EXPECT_EQ(value_in, value_out);
+  }
+
+  EXPECT_ANY_THROW(vector.set(-1, 123));
+  EXPECT_ANY_THROW(vector.set(10, 123));
+}
+
+TEST_F(JitVariantVectorTest, IsNullAndSetIsNull) {
+  JitVariantVector vector;
+  vector.resize(10);
+
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto is_null_in = false;
+    vector.set_is_null(index, is_null_in);
+    const auto is_null_out = vector.is_null(index);
+    EXPECT_EQ(is_null_in, is_null_out);
+  }
+  {
+    const auto index = static_cast<int32_t>(std::rand()) % 10;
+    const auto is_null_in = true;
+    vector.set_is_null(index, is_null_in);
+    const auto is_null_out = vector.is_null(index);
+    EXPECT_EQ(is_null_in, is_null_out);
+  }
+}
+
+}  // namespace opossum

--- a/src/test/operators/jit_operator/jit_variant_vector_test.cpp
+++ b/src/test/operators/jit_operator/jit_variant_vector_test.cpp
@@ -51,9 +51,6 @@ TEST_F(JitVariantVectorTest, GetAndSet) {
     const auto value_out = vector.get<bool>(index);
     EXPECT_EQ(value_in, value_out);
   }
-
-  EXPECT_ANY_THROW(vector.set(-1, 123));
-  EXPECT_ANY_THROW(vector.set(10, 123));
 }
 
 TEST_F(JitVariantVectorTest, IsNullAndSetIsNull) {

--- a/src/test/operators/jit_operator/operators/jit_compute_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_compute_test.cpp
@@ -1,0 +1,4 @@
+//
+// Created by Johannes Frohnhofen on 4/28/18.
+//
+

--- a/src/test/operators/jit_operator/operators/jit_compute_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_compute_test.cpp
@@ -1,4 +1,61 @@
-//
-// Created by Johannes Frohnhofen on 4/28/18.
-//
+#include "operators/jit_operator/operators/jit_compute.hpp"
+#include "../../../base_test.hpp"
 
+namespace opossum {
+
+// Mock JitOperator that passes individual tuples into the chain and ignores consumed tuples
+// This operator is used as both the tuple source and sink in this test
+class MockOperator : public AbstractJittable {
+ public:
+  std::string description() const final { return "MockOperator"; }
+
+  void emit(JitRuntimeContext& context) { _emit(context); }
+
+ private:
+  void _consume(JitRuntimeContext& context) const final {}
+};
+
+class JitComputeTest : public BaseTest {};
+
+TEST_F(JitComputeTest, TriggersComputationOfNestedExpression) {
+  JitRuntimeContext context;
+  context.tuple.resize(5);
+
+  // This test computes the expression "D = A + B > C"
+
+  // Create tuple values for inputs
+  JitTupleValue a_value{DataType::Int, false, 0};
+  JitTupleValue b_value{DataType::Int, false, 1};
+  JitTupleValue c_value{DataType::Int, false, 2};
+
+  // Construct expression tree
+  auto a_expression = std::make_shared<JitExpression>(a_value);
+  auto b_expression = std::make_shared<JitExpression>(b_value);
+  auto c_expression = std::make_shared<JitExpression>(c_value);
+  auto a_plus_b = std::make_shared<JitExpression>(a_expression, ExpressionType::Addition, b_expression, 3);
+  auto expression = std::make_shared<JitExpression>(a_plus_b, ExpressionType::GreaterThan, c_expression, 4);
+
+  // Construct operator chain
+  auto mock_op = std::make_shared<MockOperator>();
+  auto compute = std::make_shared<JitCompute>(expression);
+  mock_op->set_next_operator(compute);
+  compute->set_next_operator(mock_op);
+
+  // We test the correct computation of the expression ten times with random values
+  for (auto i = 0; i < 10; ++i) {
+    // Create input tuple values
+    auto a = static_cast<int32_t>(std::rand());
+    auto b = static_cast<int32_t>(std::rand());
+    auto c = static_cast<int32_t>(std::rand());
+
+    // Set input values in tuple
+    a_value.set<int32_t>(a, context);
+    b_value.set<int32_t>(b, context);
+    c_value.set<int32_t>(c, context);
+
+    mock_op->emit(context);
+    ASSERT_EQ(a + b > c, context.tuple.get<bool>(4));
+  }
+}
+
+}  // namespace opossum

--- a/src/test/operators/jit_operator/operators/jit_compute_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_compute_test.cpp
@@ -21,14 +21,13 @@ TEST_F(JitComputeTest, TriggersComputationOfNestedExpression) {
   JitRuntimeContext context;
   context.tuple.resize(5);
 
-  // This test computes the expression "D = A + B > C"
 
   // Create tuple values for inputs
   JitTupleValue a_value{DataType::Int, false, 0};
   JitTupleValue b_value{DataType::Int, false, 1};
   JitTupleValue c_value{DataType::Int, false, 2};
 
-  // Construct expression tree
+  // Construct expression tree for "A + B > C"
   auto a_expression = std::make_shared<JitExpression>(a_value);
   auto b_expression = std::make_shared<JitExpression>(b_value);
   auto c_expression = std::make_shared<JitExpression>(c_value);
@@ -36,10 +35,11 @@ TEST_F(JitComputeTest, TriggersComputationOfNestedExpression) {
   auto expression = std::make_shared<JitExpression>(a_plus_b, ExpressionType::GreaterThan, c_expression, 4);
 
   // Construct operator chain
-  auto mock_op = std::make_shared<MockOperator>();
+  auto source = std::make_shared<MockOperator>();
   auto compute = std::make_shared<JitCompute>(expression);
-  mock_op->set_next_operator(compute);
-  compute->set_next_operator(mock_op);
+  auto sink = std::make_shared<MockOperator>();
+  source->set_next_operator(compute);
+  compute->set_next_operator(sink);
 
   // We test the correct computation of the expression ten times with random values
   for (auto i = 0; i < 10; ++i) {
@@ -53,7 +53,7 @@ TEST_F(JitComputeTest, TriggersComputationOfNestedExpression) {
     b_value.set<int32_t>(b, context);
     c_value.set<int32_t>(c, context);
 
-    mock_op->emit(context);
+    //mock_op->emit(context);
     ASSERT_EQ(a + b > c, context.tuple.get<bool>(4));
   }
 }

--- a/src/test/operators/jit_operator/operators/jit_compute_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_compute_test.cpp
@@ -21,7 +21,6 @@ TEST_F(JitComputeTest, TriggersComputationOfNestedExpression) {
   JitRuntimeContext context;
   context.tuple.resize(5);
 
-
   // Create tuple values for inputs
   JitTupleValue a_value{DataType::Int, false, 0};
   JitTupleValue b_value{DataType::Int, false, 1};
@@ -53,7 +52,7 @@ TEST_F(JitComputeTest, TriggersComputationOfNestedExpression) {
     b_value.set<int32_t>(b, context);
     c_value.set<int32_t>(c, context);
 
-    //mock_op->emit(context);
+    source->emit(context);
     ASSERT_EQ(a + b > c, context.tuple.get<bool>(4));
   }
 }

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -79,7 +79,7 @@ TEST_F(JitExpressionTest, Not) {
     expression.compute(context);
     ASSERT_TRUE(context.tuple.get<bool>(result_index));
   }
-  {
+  if (IS_DEBUG) {
     // Not can only be computed on boolean values
     auto input_value = JitTupleValue{DataType::Int, false, 0};
     JitExpression expression(std::make_shared<JitExpression>(input_value), ExpressionType::Not, result_index);

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -1,0 +1,3 @@
+//
+// Created by Johannes Frohnhofen on 5/1/18.
+//

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -1,3 +1,264 @@
-//
-// Created by Johannes Frohnhofen on 5/1/18.
-//
+#include "../../../base_test.hpp"
+#include "operators/jit_operator/operators/jit_compute.hpp"
+
+namespace opossum {
+
+class JitExpressionTest : public BaseTest {};
+
+TEST_F(JitExpressionTest, Is_Not_Null) {
+  JitRuntimeContext context;
+  context.tuple.resize(2);
+
+  auto input_value = JitTupleValue{DataType::Int, true, 0};
+  auto result_index = 1;
+
+  {
+    JitExpression expression(std::make_shared<JitExpression>(input_value), ExpressionType::IsNull, result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Bool);
+    ASSERT_FALSE(expression.result().is_nullable());
+
+    input_value.set_is_null(true, context);
+    expression.compute(context);
+    ASSERT_TRUE(expression.result().get<bool>(context));
+
+    input_value.set_is_null(false, context);
+    expression.compute(context);
+    ASSERT_FALSE(context.tuple.get<bool>(result_index));
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(input_value), ExpressionType::IsNotNull, result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Bool);
+    ASSERT_FALSE(expression.result().is_nullable());
+
+    input_value.set_is_null(true, context);
+    expression.compute(context);
+    ASSERT_FALSE(context.tuple.get<bool>(result_index));
+
+    input_value.set_is_null(false, context);
+    expression.compute(context);
+    ASSERT_TRUE(context.tuple.get<bool>(result_index));
+  }
+}
+
+TEST_F(JitExpressionTest, Not) {
+  JitRuntimeContext context;
+  context.tuple.resize(2);
+  auto result_index = 1;
+
+  {
+    auto input_value = JitTupleValue{DataType::Bool, false, 0};
+    JitExpression expression(std::make_shared<JitExpression>(input_value), ExpressionType::Not, result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Bool);
+    ASSERT_FALSE(expression.result().is_nullable());
+
+    input_value.set<bool>(true, context);
+    expression.compute(context);
+    ASSERT_FALSE(expression.result().get<bool>(context));
+
+    input_value.set<bool>(false, context);
+    expression.compute(context);
+    ASSERT_TRUE(context.tuple.get<bool>(result_index));
+  }
+  {
+    auto input_value = JitTupleValue{DataType::Bool, true, 0};
+    JitExpression expression(std::make_shared<JitExpression>(input_value), ExpressionType::Not, result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Bool);
+    ASSERT_TRUE(expression.result().is_nullable());
+
+    input_value.set_is_null(true, context);
+    expression.compute(context);
+    ASSERT_TRUE(context.tuple.is_null(result_index));
+
+    input_value.set_is_null(false, context);
+    input_value.set<bool>(true, context);
+    expression.compute(context);
+    ASSERT_FALSE(context.tuple.get<bool>(result_index));
+
+    input_value.set_is_null(false, context);
+    input_value.set<bool>(false, context);
+    expression.compute(context);
+    ASSERT_TRUE(context.tuple.get<bool>(result_index));
+  }
+  {
+    // Not can only be computed on boolean values
+    auto input_value = JitTupleValue{DataType::Int, false, 0};
+    JitExpression expression(std::make_shared<JitExpression>(input_value), ExpressionType::Not, result_index);
+    ASSERT_THROW(expression.compute(context), std::logic_error);
+  }
+}
+
+TEST_F(JitExpressionTest, ArithmeticOperations) {
+  JitRuntimeContext context;
+  context.tuple.resize(6);
+  auto result_index = 5;
+
+  auto int_value = static_cast<int32_t>(std::rand());
+  auto long_value = static_cast<int64_t>(std::rand());
+  auto float_value = static_cast<float>(std::rand()) / RAND_MAX;
+  auto double_value = static_cast<double>(std::rand()) / RAND_MAX;
+
+  auto int_tuple_value = JitTupleValue{DataType::Int, false, 0};
+  auto long_tuple_value = JitTupleValue{DataType::Long, false, 1};
+  auto float_tuple_value = JitTupleValue{DataType::Float, false, 2};
+  auto double_tuple_value = JitTupleValue{DataType::Double, false, 3};
+  auto null_tuple_value = JitTupleValue{DataType::Int, true, 4};
+
+  int_tuple_value.set<int32_t>(int_value, context);
+  long_tuple_value.set<int64_t>(long_value, context);
+  float_tuple_value.set<float>(float_value, context);
+  double_tuple_value.set<double>(double_value, context);
+  null_tuple_value.set_is_null(true, context);
+
+  {
+    JitExpression expression(std::make_shared<JitExpression>(int_tuple_value), ExpressionType::Addition,
+                             std::make_shared<JitExpression>(float_tuple_value), result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Float);
+    ASSERT_FALSE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_EQ(expression.result().get<float>(context), int_value + float_value);
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(int_tuple_value), ExpressionType::Subtraction,
+                             std::make_shared<JitExpression>(double_tuple_value), result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Double);
+    ASSERT_FALSE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_EQ(expression.result().get<double>(context), int_value - double_value);
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(long_tuple_value), ExpressionType::Multiplication,
+                             std::make_shared<JitExpression>(int_tuple_value), result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Long);
+    ASSERT_FALSE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_EQ(expression.result().get<int64_t>(context), long_value * int_value);
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(float_tuple_value), ExpressionType::Division,
+                             std::make_shared<JitExpression>(double_tuple_value), result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Double);
+    ASSERT_FALSE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_EQ(expression.result().get<double>(context), float_value / double_value);
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(long_tuple_value), ExpressionType::Power,
+                             std::make_shared<JitExpression>(double_tuple_value), result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Double);
+    ASSERT_FALSE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_EQ(expression.result().get<double>(context), std::pow(long_value, double_value));
+  }
+
+  // Check NULL semantics
+  {
+    JitExpression expression(std::make_shared<JitExpression>(null_tuple_value), ExpressionType::Addition,
+                             std::make_shared<JitExpression>(null_tuple_value), result_index);
+    ASSERT_TRUE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_TRUE(expression.result().is_null(context));
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(int_tuple_value), ExpressionType::Multiplication,
+                             std::make_shared<JitExpression>(null_tuple_value), result_index);
+    ASSERT_TRUE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_TRUE(expression.result().is_null(context));
+  }
+  {
+    JitExpression expression(std::make_shared<JitExpression>(null_tuple_value), ExpressionType::Power,
+                             std::make_shared<JitExpression>(int_tuple_value), result_index);
+    ASSERT_TRUE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_TRUE(expression.result().is_null(context));
+  }
+}
+
+TEST_F(JitExpressionTest, PredicateOperations) {
+  /*{
+    JitExpression expression(std::make_shared<JitExpression>(int_tuple_value), ExpressionType::G,
+                             std::make_shared<JitExpression>(float_tuple_value), result_index);
+    ASSERT_EQ(expression.result().data_type(), DataType::Float);
+    ASSERT_FALSE(expression.result().is_nullable());
+    expression.compute(context);
+    ASSERT_EQ(expression.result().get<float>(context), int_value + float_value);
+  }*/
+}
+
+TEST_F(JitExpressionTest, NestedExpressions) {
+  JitRuntimeContext context;
+  context.tuple.resize(10);
+
+  auto a_tuple_value = JitTupleValue{DataType::Int, false, 0};
+  auto b_tuple_value = JitTupleValue{DataType::Long, false, 1};
+  auto c_tuple_value = JitTupleValue{DataType::Float, false, 2};
+  auto d_tuple_value = JitTupleValue{DataType::Double, false, 3};
+
+  // Compute "(A - (B * C)) / (D + B)"
+  {
+    auto b_times_c =
+        std::make_shared<JitExpression>(std::make_shared<JitExpression>(b_tuple_value), ExpressionType::Multiplication,
+                                        std::make_shared<JitExpression>(c_tuple_value), 4);
+    auto a_minus_b_times_c = std::make_shared<JitExpression>(std::make_shared<JitExpression>(a_tuple_value),
+                                                             ExpressionType::Subtraction, b_times_c, 5);
+    auto d_plus_b =
+        std::make_shared<JitExpression>(std::make_shared<JitExpression>(d_tuple_value), ExpressionType::Addition,
+                                        std::make_shared<JitExpression>(b_tuple_value), 6);
+    JitExpression expression(a_minus_b_times_c, ExpressionType::Division, d_plus_b, 7);
+
+    for (auto i = 0; i < 10; ++i) {
+      auto a_value = static_cast<int32_t>(std::rand());
+      auto b_value = static_cast<int64_t>(std::rand());
+      auto c_value = static_cast<float>(std::rand()) / RAND_MAX;
+      auto d_value = static_cast<double>(std::rand()) / RAND_MAX;
+
+      a_tuple_value.set<int32_t>(a_value, context);
+      b_tuple_value.set<int64_t>(b_value, context);
+      c_tuple_value.set<float>(c_value, context);
+      d_tuple_value.set<double>(d_value, context);
+
+      ASSERT_EQ(expression.result().data_type(), DataType::Double);
+      ASSERT_FALSE(expression.result().is_nullable());
+      expression.compute(context);
+      ASSERT_EQ(expression.result().get<double>(context), (a_value - (b_value * c_value)) / (d_value + b_value));
+    }
+  }
+
+  // Compute "(A > B AND C >= D) OR (A + B) < C"
+  {
+    auto a_gt_b =
+        std::make_shared<JitExpression>(std::make_shared<JitExpression>(a_tuple_value), ExpressionType::GreaterThan,
+                                        std::make_shared<JitExpression>(b_tuple_value), 4);
+    auto c_gte_d = std::make_shared<JitExpression>(std::make_shared<JitExpression>(c_tuple_value),
+                                                   ExpressionType::GreaterThanEquals,
+                                                   std::make_shared<JitExpression>(d_tuple_value), 5);
+    auto a_gt_b_and_c_gte_d = std::make_shared<JitExpression>(a_gt_b, ExpressionType::And, c_gte_d, 6);
+
+    auto a_plus_b =
+        std::make_shared<JitExpression>(std::make_shared<JitExpression>(a_tuple_value), ExpressionType::Addition,
+                                        std::make_shared<JitExpression>(b_tuple_value), 7);
+    auto a_plus_b_lt_c = std::make_shared<JitExpression>(a_plus_b, ExpressionType::LessThan,
+                                                         std::make_shared<JitExpression>(c_tuple_value), 8);
+    JitExpression expression(a_gt_b_and_c_gte_d, ExpressionType::Or, a_plus_b_lt_c, 9);
+
+    for (auto i = 0; i < 10; ++i) {
+      auto a_value = static_cast<int32_t>(std::rand());
+      auto b_value = static_cast<int64_t>(std::rand());
+      auto c_value = static_cast<float>(std::rand()) / RAND_MAX;
+      auto d_value = static_cast<double>(std::rand()) / RAND_MAX;
+
+      a_tuple_value.set<int32_t>(a_value, context);
+      b_tuple_value.set<int64_t>(b_value, context);
+      c_tuple_value.set<float>(c_value, context);
+      d_tuple_value.set<double>(d_value, context);
+
+      ASSERT_EQ(expression.result().data_type(), DataType::Bool);
+      ASSERT_FALSE(expression.result().is_nullable());
+      expression.compute(context);
+      ASSERT_EQ(expression.result().get<bool>(context),
+                (a_value > b_value && c_value >= d_value) || a_value + b_value < c_value);
+    }
+  }
+}
+
+}  // namespace opossum

--- a/src/test/operators/jit_operator/operators/jit_filter_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_filter_test.cpp
@@ -1,4 +1,71 @@
-//
-// Created by Johannes Frohnhofen on 4/28/18.
-//
+#include "operators/jit_operator/operators/jit_filter.hpp"
+#include "../../../base_test.hpp"
 
+namespace opossum {
+
+// Mock JitOperator that records whether tuples are passed to it
+class MockSink : public AbstractJittable {
+ public:
+  std::string description() const final { return "MockSink"; }
+
+  void reset() const { _consume_was_called = false; }
+
+  bool consume_was_called() const { return _consume_was_called; }
+
+ private:
+  void _consume(JitRuntimeContext& context) const final { _consume_was_called = true; }
+
+  // Must be static, since _consume is const
+  static bool _consume_was_called;
+};
+
+bool MockSink::_consume_was_called = false;
+
+// Mock JitOperator that passes on individual tuples
+class MockSource : public AbstractJittable {
+ public:
+  std::string description() const final { return "MockSource"; }
+
+  void emit(JitRuntimeContext& context) { _emit(context); }
+
+ private:
+  void _consume(JitRuntimeContext& context) const final {}
+};
+
+class JitFilterTest : public BaseTest {};
+
+TEST_F(JitFilterTest, FiltersTuplesAccordingToCondition) {
+  JitRuntimeContext context;
+  context.tuple.resize(1);
+
+  JitTupleValue condition_value{DataType::Bool, true, 0};
+  auto source = std::make_shared<MockSource>();
+  auto filter = std::make_shared<JitFilter>(condition_value);
+  auto sink = std::make_shared<MockSink>();
+
+  // Link operators to pipeline
+  source->set_next_operator(filter);
+  filter->set_next_operator(sink);
+
+  // Condition variables with a NULL value should be filtered out
+  condition_value.set_is_null(false, context);
+  condition_value.set<bool>(false, context);
+  sink->reset();
+  source->emit(context);
+  ASSERT_FALSE(sink->consume_was_called());
+
+  // FALSE condition variables should be filtered out
+  condition_value.set_is_null(false, context);
+  condition_value.set<bool>(true, context);
+  sink->reset();
+  source->emit(context);
+  ASSERT_TRUE(sink->consume_was_called());
+
+  // Only condition variables with TRUE should pass
+  condition_value.set_is_null(true, context);
+  sink->reset();
+  source->emit(context);
+  ASSERT_FALSE(sink->consume_was_called());
+}
+
+}  // namespace opossum

--- a/src/test/operators/jit_operator/operators/jit_filter_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_filter_test.cpp
@@ -1,0 +1,4 @@
+//
+// Created by Johannes Frohnhofen on 4/28/18.
+//
+

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -1,0 +1,62 @@
+#include "../../../base_test.hpp"
+#include "operators/jit_operator/operators/jit_read_tuple.hpp"
+#include "operators/jit_operator/operators/jit_write_tuple.hpp"
+#include "utils/load_table.hpp"
+
+namespace opossum {
+
+class JitReadWriteTupleTest : public BaseTest {};
+
+TEST_F(JitReadWriteTupleTest, CreateOutputTable) {
+  auto write_tuple = std::make_shared<JitWriteTuple>();
+
+  TableColumnDefinitions column_definitions = {{"a", DataType::Int, false},
+                                               {"b", DataType::Long, true},
+                                               {"c", DataType::Float, false},
+                                               {"d", DataType::Double, false},
+                                               {"e", DataType::String, true}};
+
+  for (const auto& column_definition : column_definitions) {
+    write_tuple->add_output_column(column_definition.name,
+                                   JitTupleValue(column_definition.data_type, column_definition.nullable, 0));
+  }
+
+  auto output_table = write_tuple->create_output_table(1);
+  ASSERT_EQ(output_table->column_definitions(), column_definitions);
+}
+
+TEST_F(JitReadWriteTupleTest, CopyTable) {
+  JitRuntimeContext context;
+  context.tuple.resize(2);
+
+  // Create operator chain that passes from the input tuple to an output table unmodified
+  auto read_tuple = std::make_shared<JitReadTuple>();
+  auto write_tuple = std::make_shared<JitWriteTuple>();
+  read_tuple->set_next_operator(write_tuple);
+
+  // Add all input table columns to pipeline
+  auto a_value = read_tuple->add_input_column(DataType::Int, true, ColumnID{0});
+  auto b_value = read_tuple->add_input_column(DataType::Float, true, ColumnID{1});
+  write_tuple->add_output_column("a", a_value);
+  write_tuple->add_output_column("b", b_value);
+
+  // Initialize operators with actual input table
+  auto input_table = load_table("src/test/tables/int_float_null_sorted_asc.tbl", 2);
+  auto output_table = write_tuple->create_output_table(2);
+  read_tuple->before_query(*input_table, context);
+  write_tuple->before_query(*output_table, context);
+
+  // Pass each chunk through the pipeline
+  for (const auto& chunk : input_table->chunks()) {
+    read_tuple->before_chunk(*input_table, *chunk, context);
+    read_tuple->execute(context);
+    write_tuple->after_chunk(*output_table, context);
+  }
+  write_tuple->after_query(*output_table, context);
+
+  // Both tables should be equal now
+  ASSERT_TRUE(check_table_equal(input_table, output_table, OrderSensitivity::Yes, TypeCmpMode::Strict,
+                                FloatComparisonMode::AbsoluteDifference));
+}
+
+}  // namespace opossum

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -25,9 +25,50 @@ TEST_F(JitReadWriteTupleTest, CreateOutputTable) {
   ASSERT_EQ(output_table->column_definitions(), column_definitions);
 }
 
+TEST_F(JitReadWriteTupleTest, TupleIndicesAreIncremented) {
+  auto read_tuple = std::make_shared<JitReadTuple>();
+
+  // Add different kinds of values (input columns, literals, temporary values) to the runtime tuple
+  auto tuple_index_1 = read_tuple->add_input_column(DataType::Int, false, ColumnID{0}).tuple_index();
+  auto tuple_index_2 = read_tuple->add_literal_value(1).tuple_index();
+  auto tuple_index_3 = read_tuple->add_temporary_value();
+  auto tuple_index_4 = read_tuple->add_input_column(DataType::Int, false, ColumnID{1}).tuple_index();
+  auto tuple_index_5 = read_tuple->add_literal_value("some string").tuple_index();
+  auto tuple_index_6 = read_tuple->add_temporary_value();
+
+  // All values should have their own position in the tuple with tuple indices increasing
+  ASSERT_LT(tuple_index_1, tuple_index_2);
+  ASSERT_LT(tuple_index_2, tuple_index_3);
+  ASSERT_LT(tuple_index_3, tuple_index_4);
+  ASSERT_LT(tuple_index_4, tuple_index_5);
+  ASSERT_LT(tuple_index_5, tuple_index_6);
+
+  // Adding the same input column twice should not create a new value in the tuple
+  auto tuple_index_1_b = read_tuple->add_input_column(DataType::Int, false, ColumnID{0}).tuple_index();
+  ASSERT_EQ(tuple_index_1, tuple_index_1_b);
+}
+
+TEST_F(JitReadWriteTupleTest, LiteralValuesAreInitialized) {
+  auto read_tuple = std::make_shared<JitReadTuple>();
+
+  auto int_value = read_tuple->add_literal_value(1);
+  auto float_value = read_tuple->add_literal_value(1.23f);
+  auto double_value = read_tuple->add_literal_value(12.3);
+  auto string_value = read_tuple->add_literal_value("some string");
+
+  // Since we only test literal values here an empty input table is sufficient
+  JitRuntimeContext context;
+  Table input_table(TableColumnDefinitions{}, TableType::Data);
+  read_tuple->before_query(input_table, context);
+
+  ASSERT_EQ(int_value.get<int32_t>(context), 1);
+  ASSERT_EQ(float_value.get<float>(context), 1.23f);
+  ASSERT_EQ(double_value.get<double>(context), 12.3);
+  ASSERT_EQ(string_value.get<std::string>(context), "some string");
+}
+
 TEST_F(JitReadWriteTupleTest, CopyTable) {
   JitRuntimeContext context;
-  context.tuple.resize(2);
 
   // Create operator chain that passes from the input tuple to an output table unmodified
   auto read_tuple = std::make_shared<JitReadTuple>();


### PR DESCRIPTION
This PR adds tests for JIT code that is already in the Hyrise master branch, but not tested so far.
This includes tests for:
- the `JitVariantVector` and `JitTupleVector` data structures
- `jit_compute_type` and `jit_compute` functions
- `JitExpression`
- `JitFilter`, `JitCompute`, `JitReadTuple` and `JitWriteTuple` operators