### PR TITLE
Fix issue #865 - neg row count for non-overlapping ranges

### DIFF
--- a/src/lib/statistics/column_statistics.cpp
+++ b/src/lib/statistics/column_statistics.cpp
@@ -220,6 +220,11 @@ FilterByColumnComparisonEstimate ColumnStatistics<ColumnDataType>::estimate_pred
   const auto overlapping_range_min = std::max(_min, right_column_statistics.min());
   const auto overlapping_range_max = std::min(_max, right_column_statistics.max());
 
+  // if no overlapping range exists, the result is empty
+  if (overlapping_range_min > overlapping_range_max) {
+    return {0.f, without_null_values(), right_column_statistics.without_null_values()};
+  }
+
   // calculate ratio of values before, in and above the common value range
   const auto left_overlapping_ratio = estimate_range_selectivity(overlapping_range_min, overlapping_range_max);
   const auto right_overlapping_ratio =

--- a/src/test/statistics/column_statistics_test.cpp
+++ b/src/test/statistics/column_statistics_test.cpp
@@ -292,6 +292,15 @@ TEST_F(ColumnStatisticsTest, TwoColumnsEqualsTest) {
 
   EXPECT_FLOAT_EQ(result3.selectivity, expected_selectivity);
   EXPECT_FLOAT_EQ(result4.selectivity, expected_selectivity);
+
+  auto col_stat5 = std::make_shared<ColumnStatistics<float>>(0.0f, 10.f, 20.f, 30.f);
+
+  auto result5 = col_stat3->estimate_predicate_with_column(predicate_condition, *col_stat5);
+  auto result6 = col_stat5->estimate_predicate_with_column(predicate_condition, *col_stat3);
+  expected_selectivity = 0.f;
+
+  EXPECT_FLOAT_EQ(result5.selectivity, expected_selectivity);
+  EXPECT_FLOAT_EQ(result6.selectivity, expected_selectivity);
 }
 
 TEST_F(ColumnStatisticsTest, TwoColumnsLessThanTest) {


### PR DESCRIPTION
Joining columns with non-overlapping range now have row count 0
Added a test for two columns with non-overlapping range.

Closes #865 