### PR TITLE
Remove copy ctor and assignment operator from STRONG_TYPEDEF

### DIFF
--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -24,11 +24,6 @@
     T t;                                                                                                          \
     constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {} \
     D() BOOST_NOEXCEPT_IF(boost::has_nothrow_default_constructor<T>::value) : t() {}                              \
-    D(const D& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_.t) {}                  \
-    D& operator=(const D& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                         \
-      t = other.t;                                                                                                \
-      return *this;                                                                                               \
-    }                                                                                                             \
     D& operator=(const T& other) BOOST_NOEXCEPT_IF(boost::has_nothrow_assign<T>::value) {                         \
       t = other;                                                                                                  \
       return *this;                                                                                               \


### PR DESCRIPTION
This allows me to build master again with gcc 8.1.0 (and clang 6.0.0 as that uses gcc's STL on Arch Linux, apparently).

The copy constructor and copy assignment operator should be generated by default anyway, since the only member has to be trivially copyable.