### PR TITLE
Add method to append existing chunks to table

### DIFF
--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -47,17 +47,14 @@ std::shared_ptr<const Table> GetTable::_on_execute() {
   }
 
   // we create a copy of the original table and don't include the excluded chunks
-  const auto pruned_table =
-      std::make_shared<Table>(original_table->column_definitions(), TableType::Data, original_table->max_chunk_size());
+  const auto pruned_table = std::make_shared<Table>(original_table->column_definitions(), TableType::Data,
+                                                    original_table->max_chunk_size(), original_table->has_mvcc());
   const auto excluded_chunks_set =
       std::unordered_set<ChunkID>(_excluded_chunk_ids.cbegin(), _excluded_chunk_ids.cend());
   for (ChunkID chunk_id{0}; chunk_id < original_table->chunk_count(); ++chunk_id) {
-    if (excluded_chunks_set.count(chunk_id)) {
-      continue;
+    if (excluded_chunks_set.find(chunk_id) == excluded_chunks_set.end()) {
+      pruned_table->append_chunk(original_table->get_chunk(chunk_id));
     }
-
-    const auto& chunk = original_table->get_chunk(chunk_id);
-    pruned_table->append_chunk(chunk->columns(), chunk->get_allocator(), chunk->access_counter());
   }
 
   return pruned_table;

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -89,6 +89,7 @@ class Table : private Noncopyable {
    * Creates a new Chunk and appends it to this table.
    * Makes sure the @param columns match with the TableType (only ReferenceColumns or only data containing columns)
    * En/Disables MVCC for the Chunk depending on whether MVCC is enabled for the table (has_mvcc())
+   * This is a convenience method to enable automatically creating a chunk with correct settings given a set of columns.
    * @param alloc
    */
   void append_chunk(const ChunkColumns& columns, const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt,

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -94,6 +94,12 @@ class Table : private Noncopyable {
   void append_chunk(const ChunkColumns& columns, const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt,
                     const std::shared_ptr<ChunkAccessCounter>& access_counter = nullptr);
 
+  /**
+   * Appends an existing chunk to this table.
+   * Makes sure the columns in the chunk match with the TableType and the MVCC setting is the same as for the table.
+   */
+  void append_chunk(const std::shared_ptr<Chunk> chunk);
+
   // Create and append a Chunk consisting of ValueColumns.
   void append_mutable_chunk();
 


### PR DESCRIPTION
We found a bug in the way `GetTable` currently appends existing chunks to a table.
To fix this we decided to add a new method to `Table` which takes existing chunks and appends them to the table.