### PR TITLE
Add more detailed timing to SQLPipeline

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -280,9 +280,7 @@ int Console::_eval_sql(const std::string& sql) {
   }
 
   out("===\n");
-  out(std::to_string(row_count) + " rows total (" + "COMPILE: " +
-      std::to_string(_sql_pipeline->compile_time_microseconds().count()) + " µs, " + "EXECUTE: " +
-      std::to_string(_sql_pipeline->execution_time_microseconds().count()) + " µs (wall time))\n");
+  out(std::to_string(row_count) + " rows total " + _sql_pipeline->get_time_string());
 
   return ReturnCode::Ok;
 }

--- a/src/lib/server/query_response_builder.cpp
+++ b/src/lib/server/query_response_builder.cpp
@@ -79,8 +79,7 @@ std::string QueryResponseBuilder::build_command_complete_message(hsql::Statement
 }
 
 std::string QueryResponseBuilder::build_execution_info_message(std::shared_ptr<SQLPipeline> sql_pipeline) {
-  return "Compilation time (µs): " + std::to_string(sql_pipeline->compile_time_microseconds().count()) +
-         "\nExecution time (µs): " + std::to_string(sql_pipeline->execution_time_microseconds().count());
+  return sql_pipeline->get_time_string();
 }
 
 boost::future<uint64_t> QueryResponseBuilder::send_query_response(send_row_t send_row, const Table& table) {

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -71,12 +71,14 @@ class SQLPipeline : public Noncopyable {
   // Returns whether the pipeline requires execution to handle all statements
   bool requires_execution() const;
 
-  // Returns the entire compile time. Only possible to get this after all statements have been executed or if the
+  // Returns the entire time for X. Only possible to get this after all statements have been executed or if the
   // pipeline does not require previous execution to compile all statements.
+  std::chrono::microseconds translate_time_microseconds();
+  std::chrono::microseconds optimize_time_microseconds();
   std::chrono::microseconds compile_time_microseconds();
-
-  // Returns the entire execution time
   std::chrono::microseconds execution_time_microseconds();
+
+  std::string get_time_string();
 
  private:
   std::vector<std::shared_ptr<SQLPipelineStatement>> _sql_pipeline_statements;
@@ -104,6 +106,8 @@ class SQLPipeline : public Noncopyable {
   std::shared_ptr<SQLPipelineStatement> _failed_pipeline_statement;
 
   // Execution times
+  std::chrono::microseconds _translate_time_microseconds{};
+  std::chrono::microseconds _optimize_time_microseconds{};
   std::chrono::microseconds _compile_time_microseconds{};
   std::chrono::microseconds _execution_time_microseconds{};
 };

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -75,6 +75,8 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
 
   auto parsed_sql = get_parsed_sql_statement();
 
+  const auto started = std::chrono::high_resolution_clock::now();
+
   const auto* statement = parsed_sql->getStatement(0);
   if (const auto prepared_statement = dynamic_cast<const hsql::PrepareStatement*>(statement)) {
     // If this is as PreparedStatement, we want to translate the actual query and not the PREPARE FROM ... part.
@@ -88,6 +90,9 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
   DebugAssert(lqp_roots.size() == 1, "LQP translation returned no or more than one LQP root for a single statement.");
   _unoptimized_logical_plan = lqp_roots.front();
 
+  const auto done = std::chrono::high_resolution_clock::now();
+  _translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+
   return _unoptimized_logical_plan;
 }
 
@@ -97,7 +102,13 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   }
 
   const auto& unoptimized_lqp = get_unoptimized_logical_plan();
+
+  const auto started = std::chrono::high_resolution_clock::now();
+
   _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
+
+  const auto done = std::chrono::high_resolution_clock::now();
+  _optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -119,7 +130,9 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
 
   _query_plan = std::make_shared<SQLQueryPlan>();
 
-  const auto started = std::chrono::high_resolution_clock::now();
+  // Stores when the actual compilation started/ended
+  auto started = std::chrono::high_resolution_clock::now();
+  auto done = started;  // dummy value needed for initialization
 
   const auto* statement = get_parsed_sql_statement()->getStatement(0);
 
@@ -140,6 +153,7 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
 
     _query_plan->append_plan(plan.recreate());
     _query_plan_cache_hit = true;
+    done = std::chrono::high_resolution_clock::now();
   } else if (const auto* execute_statement = dynamic_cast<const hsql::ExecuteStatement*>(statement)) {
     // Handle query plan if we are executing a prepared statement
     Assert(_prepared_statements, "Cannot execute statement without prepared statement cache.");
@@ -160,13 +174,18 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
            "Number of arguments provided does not match expected number of arguments.");
 
     _query_plan->append_plan(plan->recreate(arguments));
+    done = std::chrono::high_resolution_clock::now();
   } else {
     // "Normal" mode in which the query plan is created
     const auto& lqp = get_optimized_logical_plan();
+
+    // Reset time to exclude previous pipeline steps
+    started = std::chrono::high_resolution_clock::now();
     _query_plan->add_tree_by_root(_lqp_translator->translate_node(lqp));
 
     // Set number of parameters to match later in case of prepared statement
     _query_plan->set_num_parameters(_num_parameters);
+    done = std::chrono::high_resolution_clock::now();
   }
 
   if (_use_mvcc == UseMvcc::Yes) _query_plan->set_transaction_context(_transaction_context);
@@ -181,7 +200,6 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     SQLQueryCache<SQLQueryPlan>::get().set(_sql_string, *_query_plan);
   }
 
-  const auto done = std::chrono::high_resolution_clock::now();
   _compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   return _query_plan;
@@ -239,6 +257,17 @@ const std::shared_ptr<TransactionContext>& SQLPipelineStatement::transaction_con
   return _transaction_context;
 }
 
+std::chrono::microseconds SQLPipelineStatement::translate_time_microseconds() const {
+  Assert(_unoptimized_logical_plan != nullptr || _optimized_logical_plan,
+         "Cannot return translation duration without having translated.");
+  return _translate_time_micros;
+}
+
+std::chrono::microseconds SQLPipelineStatement::optimize_time_microseconds() const {
+  Assert(_optimized_logical_plan != nullptr, "Cannot return optimization duration without having optimized.");
+  return _optimize_time_micros;
+}
+
 std::chrono::microseconds SQLPipelineStatement::compile_time_microseconds() const {
   Assert(_query_plan != nullptr, "Cannot return compile duration without having created the query plan.");
   return _compile_time_micros;
@@ -247,6 +276,13 @@ std::chrono::microseconds SQLPipelineStatement::compile_time_microseconds() cons
 std::chrono::microseconds SQLPipelineStatement::execution_time_microseconds() const {
   Assert(_result_table != nullptr || !_query_has_output, "Cannot return execution duration without having executed.");
   return _execution_time_micros;
+}
+
+std::string SQLPipelineStatement::get_time_string() const {
+  return "(TRANSLATE: " + std::to_string(translate_time_microseconds().count()) +
+         " µs, OPTIMIZE: " + std::to_string(optimize_time_microseconds().count()) +
+         " µs, COMPILE: " + std::to_string(compile_time_microseconds().count()) +
+         " µs, EXECUTE: " + std::to_string(execution_time_microseconds().count()) + " µs (wall time))\n";
 }
 
 std::string SQLPipelineStatement::create_parse_error_message(const std::string& sql,

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -258,13 +258,14 @@ const std::shared_ptr<TransactionContext>& SQLPipelineStatement::transaction_con
 }
 
 std::chrono::microseconds SQLPipelineStatement::translate_time_microseconds() const {
-  Assert(_unoptimized_logical_plan != nullptr || _optimized_logical_plan,
+  Assert(_unoptimized_logical_plan || _optimized_logical_plan || _query_plan,
          "Cannot return translation duration without having translated.");
   return _translate_time_micros;
 }
 
 std::chrono::microseconds SQLPipelineStatement::optimize_time_microseconds() const {
-  Assert(_optimized_logical_plan != nullptr, "Cannot return optimization duration without having optimized.");
+  Assert(_optimized_logical_plan || _query_plan,
+         "Cannot return optimization duration without having optimized.");
   return _optimize_time_micros;
 }
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -103,10 +103,10 @@ class SQLPipelineStatement : public Noncopyable {
   bool _query_plan_cache_hit = false;
 
   // Execution times
-  std::chrono::microseconds _translate_time_micros;
-  std::chrono::microseconds _optimize_time_micros;
-  std::chrono::microseconds _compile_time_micros;
-  std::chrono::microseconds _execution_time_micros;
+  std::chrono::microseconds _translate_time_micros{};
+  std::chrono::microseconds _optimize_time_micros{};
+  std::chrono::microseconds _compile_time_micros{};
+  std::chrono::microseconds _execution_time_micros{};
 
   PreparedStatementCache _prepared_statements;
   // Number of placeholders in prepared statement; default 0 becasue we assume no prepared statement

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -62,8 +62,14 @@ class SQLPipelineStatement : public Noncopyable {
   // This can be a nullptr if no transaction management is wanted.
   const std::shared_ptr<TransactionContext>& transaction_context() const;
 
+  // Return the duration of each step in the pipeline.
+  std::chrono::microseconds translate_time_microseconds() const;
+  std::chrono::microseconds optimize_time_microseconds() const;
   std::chrono::microseconds compile_time_microseconds() const;
   std::chrono::microseconds execution_time_microseconds() const;
+
+  // Formats all times into a pretty string
+  std::string get_time_string() const;
 
   bool query_plan_cache_hit() const;
 
@@ -97,6 +103,8 @@ class SQLPipelineStatement : public Noncopyable {
   bool _query_plan_cache_hit = false;
 
   // Execution times
+  std::chrono::microseconds _translate_time_micros;
+  std::chrono::microseconds _optimize_time_micros;
   std::chrono::microseconds _compile_time_micros;
   std::chrono::microseconds _execution_time_micros;
 

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -485,12 +485,16 @@ TEST_F(SQLPipelineStatementTest, GetResultTableNoMVCC) {
 TEST_F(SQLPipelineStatementTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
+  EXPECT_THROW(sql_pipeline.translate_time_microseconds(), std::exception);
+  EXPECT_THROW(sql_pipeline.optimize_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
+  EXPECT_GT(sql_pipeline.translate_time_microseconds().count(), 0);
+  EXPECT_GT(sql_pipeline.optimize_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.compile_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
 }

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -399,12 +399,16 @@ TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
 TEST_F(SQLPipelineTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
+  EXPECT_THROW(sql_pipeline.translate_time_microseconds(), std::exception);
+  EXPECT_THROW(sql_pipeline.optimize_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
+  EXPECT_GT(sql_pipeline.translate_time_microseconds().count(), 0);
+  EXPECT_GT(sql_pipeline.optimize_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.compile_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
 }


### PR DESCRIPTION
As per @timzimmermann's request: this PR adds explicit times for translation, optimization and compilation. Before, they were all in the compilation time.

In the console and server, you now get:
```
(TRANSLATE: 209 µs, OPTIMIZE: 19 µs, COMPILE: 89 µs, EXECUTE: 347 µs (wall time))
```

closes #885 