### PR TITLE
Ignore sqlite testrunner for coverage

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -37,7 +37,7 @@ make hyriseTest -j $((cores / 2))
 cd -
 
 rm -fr coverage; mkdir coverage
-./build-coverage/hyriseTest build-coverage
+./build-coverage/hyriseTest build-coverage --gtest_filter=SQLiteTestRunnerInstances/*
 
 if [[ "$unamestr" == 'Darwin' ]]; then
   # LLVM has its own way of dealing with coverage...


### PR DESCRIPTION
The SQL tests are only high level and should not keep us from writing actual unit tests.