### PR TITLE
Pipeline metrics

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -280,9 +280,7 @@ int Console::_eval_sql(const std::string& sql) {
   }
 
   out("===\n");
-  out(std::to_string(row_count) + " rows total (" + "COMPILE: " +
-      std::to_string(_sql_pipeline->compile_time_microseconds().count()) + " µs, " + "EXECUTE: " +
-      std::to_string(_sql_pipeline->execution_time_microseconds().count()) + " µs (wall time))\n");
+  out(std::to_string(row_count) + " rows total " + _sql_pipeline->get_time_string());
 
   return ReturnCode::Ok;
 }

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -281,7 +281,7 @@ int Console::_eval_sql(const std::string& sql) {
 
   out("===\n");
   out(std::to_string(row_count) + " rows total\n");
-  out(_sql_pipeline->execution_info().to_string());
+  out(_sql_pipeline->metrics().to_string());
 
   return ReturnCode::Ok;
 }

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -280,7 +280,8 @@ int Console::_eval_sql(const std::string& sql) {
   }
 
   out("===\n");
-  out(std::to_string(row_count) + " rows total " + _sql_pipeline->get_time_string());
+  out(std::to_string(row_count) + " rows total\n");
+  out(_sql_pipeline->execution_info().to_string());
 
   return ReturnCode::Ok;
 }

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -484,7 +484,7 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator_wrapper.hpp
         ${SOURCES}
         ${JIT_EMBEDDED_SOURCES}
-        ${LLVM_BUNDLE_FILE})
+        ${LLVM_BUNDLE_FILE} sql/sql_pipeline_execution_info.cpp sql/sql_pipeline_execution_info.hpp)
     # Prevent clang from complaining about unused defines when compiling the assembly file
     set_property(SOURCE ${LLVM_BUNDLE_FILE} PROPERTY COMPILE_FLAGS -Qunused-arguments)
     set(LIBRARIES ${LIBRARIES} ${LLVM_LIBRARY})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -484,7 +484,7 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator_wrapper.hpp
         ${SOURCES}
         ${JIT_EMBEDDED_SOURCES}
-        ${LLVM_BUNDLE_FILE} sql/sql_pipeline_execution_info.cpp sql/sql_pipeline_execution_info.hpp)
+        ${LLVM_BUNDLE_FILE})
     # Prevent clang from complaining about unused defines when compiling the assembly file
     set_property(SOURCE ${LLVM_BUNDLE_FILE} PROPERTY COMPILE_FLAGS -Qunused-arguments)
     set(LIBRARIES ${LIBRARIES} ${LLVM_LIBRARY})

--- a/src/lib/server/query_response_builder.cpp
+++ b/src/lib/server/query_response_builder.cpp
@@ -79,8 +79,7 @@ std::string QueryResponseBuilder::build_command_complete_message(hsql::Statement
 }
 
 std::string QueryResponseBuilder::build_execution_info_message(std::shared_ptr<SQLPipeline> sql_pipeline) {
-  return "Compilation time (µs): " + std::to_string(sql_pipeline->compile_time_microseconds().count()) +
-         "\nExecution time (µs): " + std::to_string(sql_pipeline->execution_time_microseconds().count());
+  return sql_pipeline->get_time_string();
 }
 
 boost::future<uint64_t> QueryResponseBuilder::send_query_response(send_row_t send_row, const Table& table) {

--- a/src/lib/server/query_response_builder.cpp
+++ b/src/lib/server/query_response_builder.cpp
@@ -79,7 +79,7 @@ std::string QueryResponseBuilder::build_command_complete_message(hsql::Statement
 }
 
 std::string QueryResponseBuilder::build_execution_info_message(std::shared_ptr<SQLPipeline> sql_pipeline) {
-  return sql_pipeline->execution_info().to_string();
+  return sql_pipeline->metrics().to_string();
 }
 
 boost::future<uint64_t> QueryResponseBuilder::send_query_response(send_row_t send_row, const Table& table) {

--- a/src/lib/server/query_response_builder.cpp
+++ b/src/lib/server/query_response_builder.cpp
@@ -79,7 +79,7 @@ std::string QueryResponseBuilder::build_command_complete_message(hsql::Statement
 }
 
 std::string QueryResponseBuilder::build_execution_info_message(std::shared_ptr<SQLPipeline> sql_pipeline) {
-  return sql_pipeline->get_time_string();
+  return sql_pipeline->execution_info().to_string();
 }
 
 boost::future<uint64_t> QueryResponseBuilder::send_query_response(send_row_t send_row, const Table& table) {

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -231,12 +231,12 @@ std::string SQLPipelineExecutionInfo::to_string() const {
   std::vector<bool> query_plan_cache_hits;
 
   for (const auto& statement_info : statement_infos) {
-    total_translate_micros += statement_info.translate_time_micros;
-    total_optimize_micros += statement_info.optimize_time_micros;
-    total_compile_micros += statement_info.compile_time_micros;
-    total_execute_micros += statement_info.execution_time_micros;
+    total_translate_micros += statement_info.get().translate_time_micros;
+    total_optimize_micros += statement_info.get().optimize_time_micros;
+    total_compile_micros += statement_info.get().compile_time_micros;
+    total_execute_micros += statement_info.get().execution_time_micros;
 
-    query_plan_cache_hits.push_back(statement_info.query_plan_cache_hit);
+    query_plan_cache_hits.push_back(statement_info.get().query_plan_cache_hit);
   }
 
   const auto num_cache_hits = std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -1,6 +1,10 @@
 #include "sql_pipeline.hpp"
+
 #include <boost/algorithm/string.hpp>
+
+#include <algorithm>
 #include <utility>
+
 #include "SQLParser.h"
 
 namespace opossum {
@@ -15,11 +19,15 @@ SQLPipeline::SQLPipeline(const std::string& sql, std::shared_ptr<TransactionCont
               "Transaction context without MVCC enabled makes no sense");
 
   hsql::SQLParserResult parse_result;
+  const auto start = std::chrono::high_resolution_clock::now();
   try {
     hsql::SQLParser::parse(sql, &parse_result);
   } catch (const std::exception& exception) {
     throw std::runtime_error("Error while parsing SQL query:\n  " + std::string(exception.what()));
   }
+
+  const auto done = std::chrono::high_resolution_clock::now();
+  _execution_info.parse_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - start);
 
   if (!parse_result.isValid()) {
     throw std::runtime_error(SQLPipelineStatement::create_parse_error_message(sql, parse_result));
@@ -204,74 +212,47 @@ size_t SQLPipeline::statement_count() const { return _sql_pipeline_statements.si
 
 bool SQLPipeline::requires_execution() const { return _requires_execution; }
 
-std::chrono::microseconds SQLPipeline::translate_time_microseconds() {
-  if (_translate_time_microseconds.count() > 0) {
-    return _translate_time_microseconds;
-  }
-
-  if (_requires_execution || _unoptimized_logical_plans.empty()) {
-    Assert(_pipeline_was_executed,
-           "Cannot get translation time without having translated or having executed a multi-statement query");
-  }
-
-  for (const auto& pipeline_statement : _sql_pipeline_statements) {
-    _translate_time_microseconds += pipeline_statement->translate_time_microseconds();
-  }
-
-  return _translate_time_microseconds;
-}
-
-std::chrono::microseconds SQLPipeline::optimize_time_microseconds() {
-  if (_optimize_time_microseconds.count() > 0) {
-    return _optimize_time_microseconds;
-  }
-
-  if (_requires_execution || _optimized_logical_plans.empty()) {
-    Assert(_pipeline_was_executed,
-           "Cannot get optimization time without having optimized or having executed a multi-statement query");
-  }
-
-  for (const auto& pipeline_statement : _sql_pipeline_statements) {
-    _optimize_time_microseconds += pipeline_statement->optimize_time_microseconds();
-  }
-
-  return _optimize_time_microseconds;
-}
-
-std::chrono::microseconds SQLPipeline::compile_time_microseconds() {
-  if (_compile_time_microseconds.count() > 0) {
-    return _compile_time_microseconds;
-  }
-
-  if (_requires_execution || _query_plans.empty()) {
-    Assert(_pipeline_was_executed,
-           "Cannot get compile time without having compiled or having executed a multi-statement query");
-  }
-
-  for (const auto& pipeline_statement : _sql_pipeline_statements) {
-    _compile_time_microseconds += pipeline_statement->compile_time_microseconds();
-  }
-
-  return _compile_time_microseconds;
-}
-
-std::chrono::microseconds SQLPipeline::execution_time_microseconds() {
-  Assert(_pipeline_was_executed, "Cannot return execution duration without having executed.");
-
-  if (_execution_time_microseconds.count() == 0) {
+const SQLPipelineExecutionInfo& SQLPipeline::execution_info() {
+  if (_execution_info.statement_infos.empty()) {
+    _execution_info.statement_infos.reserve(statement_count());
     for (const auto& pipeline_statement : _sql_pipeline_statements) {
-      _execution_time_microseconds += pipeline_statement->execution_time_microseconds();
+      _execution_info.statement_infos.push_back(pipeline_statement->execution_info());
     }
   }
 
-  return _execution_time_microseconds;
+  return _execution_info;
 }
 
-std::string SQLPipeline::get_time_string() {
-  return "(TRANSLATE: " + std::to_string(translate_time_microseconds().count()) +
-         " µs, OPTIMIZE: " + std::to_string(optimize_time_microseconds().count()) +
-         " µs, COMPILE: " + std::to_string(compile_time_microseconds().count()) +
-         " µs, EXECUTE: " + std::to_string(execution_time_microseconds().count()) + " µs (wall time))\n";
+std::string SQLPipelineExecutionInfo::to_string() const {
+  auto total_translate_micros = std::chrono::microseconds::zero();
+  auto total_optimize_micros = std::chrono::microseconds::zero();
+  auto total_compile_micros = std::chrono::microseconds::zero();
+  auto total_execute_micros = std::chrono::microseconds::zero();
+
+  std::vector<bool> query_plan_cache_hits;
+
+  for (const auto& statement_info : statement_infos) {
+    total_translate_micros += statement_info.translate_time_micros;
+    total_optimize_micros += statement_info.optimize_time_micros;
+    total_compile_micros += statement_info.compile_time_micros;
+    total_execute_micros += statement_info.execution_time_micros;
+
+    query_plan_cache_hits.push_back(statement_info.query_plan_cache_hit);
+  }
+
+  const auto num_cache_hits = std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);
+
+  std::ostringstream info_string;
+  info_string << "Execution info: [";
+  info_string << "PARSE: " << parse_time_micros.count() << " µs, ";
+  info_string << "TRANSLATE: " << total_translate_micros.count() << " µs, ";
+  info_string << "OPTIMIZE: " << total_optimize_micros.count() << " µs, ";
+  info_string << "COMPILE: " << total_compile_micros.count() << " µs, ";
+  info_string << "EXECUTE: " << total_execute_micros.count() << " µs (wall time) | ";
+  info_string << "QUERY PLAN CACHE HITS: " << num_cache_hits << "/" << query_plan_cache_hits.size() << " statement(s)";
+  info_string << "]\n";
+
+  return info_string.str();
 }
 
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -218,6 +218,7 @@ const SQLPipelineExecutionInfo& SQLPipeline::execution_info() {
     for (const auto& pipeline_statement : _sql_pipeline_statements) {
       _execution_info.statement_infos.push_back(pipeline_statement->execution_info());
     }
+  }
 
   return _execution_info;
 }

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -231,12 +231,12 @@ std::string SQLPipelineMetrics::to_string() const {
   std::vector<bool> query_plan_cache_hits;
 
   for (const auto& statement_metric : statement_metrics) {
-    total_translate_micros += statement_metric.get().translate_time_micros;
-    total_optimize_micros += statement_metric.get().optimize_time_micros;
-    total_compile_micros += statement_metric.get().compile_time_micros;
-    total_execute_micros += statement_metric.get().execution_time_micros;
+    total_translate_micros += statement_metric->translate_time_micros;
+    total_optimize_micros += statement_metric->optimize_time_micros;
+    total_compile_micros += statement_metric->compile_time_micros;
+    total_execute_micros += statement_metric->execution_time_micros;
 
-    query_plan_cache_hits.push_back(statement_metric.get().query_plan_cache_hit);
+    query_plan_cache_hits.push_back(statement_metric->query_plan_cache_hit);
   }
 
   const auto num_cache_hits = std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -71,12 +71,14 @@ class SQLPipeline : public Noncopyable {
   // Returns whether the pipeline requires execution to handle all statements
   bool requires_execution() const;
 
-  // Returns the entire compile time. Only possible to get this after all statements have been executed or if the
+  // Returns the entire time for X. Only possible to get this after all statements have been executed or if the
   // pipeline does not require previous execution to compile all statements.
+  std::chrono::microseconds translate_time_microseconds();
+  std::chrono::microseconds optimize_time_microseconds();
   std::chrono::microseconds compile_time_microseconds();
-
-  // Returns the entire execution time
   std::chrono::microseconds execution_time_microseconds();
+
+  std::string get_time_string();
 
  private:
   std::vector<std::shared_ptr<SQLPipelineStatement>> _sql_pipeline_statements;
@@ -104,6 +106,8 @@ class SQLPipeline : public Noncopyable {
   std::shared_ptr<SQLPipelineStatement> _failed_pipeline_statement;
 
   // Execution times
+  std::chrono::microseconds _translate_time_microseconds{};
+  std::chrono::microseconds _optimize_time_microseconds{};
   std::chrono::microseconds _compile_time_microseconds{};
   std::chrono::microseconds _execution_time_microseconds{};
 };

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -15,8 +15,8 @@
 namespace opossum {
 
 // Holds relevant information about the execution of an SQLPipeline.
-struct SQLPipelineExecutionInfo {
-  std::vector<std::reference_wrapper<const SQLPipelineStatementExecutionInfo>> statement_infos;
+struct SQLPipelineMetrics {
+  std::vector<std::reference_wrapper<const SQLPipelineStatementMetrics>> statement_metrics;
 
   // This is different from the other measured times as we only get this for all statements at once
   std::chrono::microseconds parse_time_micros{};
@@ -81,7 +81,7 @@ class SQLPipeline : public Noncopyable {
   // Returns whether the pipeline requires execution to handle all statements
   bool requires_execution() const;
 
-  const SQLPipelineExecutionInfo& execution_info();
+  const SQLPipelineMetrics& metrics();
 
  private:
   std::vector<std::shared_ptr<SQLPipelineStatement>> _sql_pipeline_statements;
@@ -106,7 +106,7 @@ class SQLPipeline : public Noncopyable {
   // --> requires execution of first statement before the second one can be translated
   bool _requires_execution{false};
 
-  SQLPipelineExecutionInfo _execution_info{};
+  SQLPipelineMetrics _metrics{};
 
   std::shared_ptr<SQLPipelineStatement> _failed_pipeline_statement;
 };

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -14,6 +14,16 @@
 
 namespace opossum {
 
+// Holds relevant information about the execution of an SQLPipeline.
+struct SQLPipelineExecutionInfo {
+  std::vector<SQLPipelineStatementExecutionInfo> statement_infos;
+
+  // This is different from the other measured times as we only get this for all statements at once
+  std::chrono::microseconds parse_time_micros{};
+
+  std::string to_string() const;
+};
+
 /**
  * This is the unified interface to handle SQL queries and related operations.
  * This should be preferred over using SQLPipelineStatement directly, unless you really know why you need it.
@@ -71,14 +81,7 @@ class SQLPipeline : public Noncopyable {
   // Returns whether the pipeline requires execution to handle all statements
   bool requires_execution() const;
 
-  // Returns the entire time for X. Only possible to get this after all statements have been executed or if the
-  // pipeline does not require previous execution to compile all statements.
-  std::chrono::microseconds translate_time_microseconds();
-  std::chrono::microseconds optimize_time_microseconds();
-  std::chrono::microseconds compile_time_microseconds();
-  std::chrono::microseconds execution_time_microseconds();
-
-  std::string get_time_string();
+  const SQLPipelineExecutionInfo& execution_info();
 
  private:
   std::vector<std::shared_ptr<SQLPipelineStatement>> _sql_pipeline_statements;
@@ -103,13 +106,9 @@ class SQLPipeline : public Noncopyable {
   // --> requires execution of first statement before the second one can be translated
   bool _requires_execution{false};
 
-  std::shared_ptr<SQLPipelineStatement> _failed_pipeline_statement;
+  SQLPipelineExecutionInfo _execution_info{};
 
-  // Execution times
-  std::chrono::microseconds _translate_time_microseconds{};
-  std::chrono::microseconds _optimize_time_microseconds{};
-  std::chrono::microseconds _compile_time_microseconds{};
-  std::chrono::microseconds _execution_time_microseconds{};
+  std::shared_ptr<SQLPipelineStatement> _failed_pipeline_statement;
 };
 
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -16,7 +16,7 @@ namespace opossum {
 
 // Holds relevant information about the execution of an SQLPipeline.
 struct SQLPipelineExecutionInfo {
-  std::vector<SQLPipelineStatementExecutionInfo> statement_infos;
+  std::vector<std::reference_wrapper<const SQLPipelineStatementExecutionInfo>> statement_infos;
 
   // This is different from the other measured times as we only get this for all statements at once
   std::chrono::microseconds parse_time_micros{};

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -16,10 +16,10 @@ namespace opossum {
 
 // Holds relevant information about the execution of an SQLPipeline.
 struct SQLPipelineMetrics {
-  std::vector<std::reference_wrapper<const SQLPipelineStatementMetrics>> statement_metrics;
+  std::vector<std::shared_ptr<const SQLPipelineStatementMetrics>> statement_metrics;
 
   // This is different from the other measured times as we only get this for all statements at once
-  std::chrono::microseconds parse_time_micros{};
+  std::chrono::microseconds parse_time_micros{0};
 
   std::string to_string() const;
 };

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -30,6 +30,7 @@ SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, std::shared_p
       _lqp_translator(lqp_translator),
       _optimizer(optimizer),
       _parsed_sql_statement(std::move(parsed_sql)),
+      _metrics(std::make_shared<SQLPipelineStatementMetrics>()),
       _prepared_statements(prepared_statements) {
   Assert(!_parsed_sql_statement || _parsed_sql_statement->size() == 1,
          "SQLPipelineStatement must hold exactly one SQL statement");

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -91,7 +91,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
   _unoptimized_logical_plan = lqp_roots.front();
 
   const auto done = std::chrono::high_resolution_clock::now();
-  _translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _execution_info.translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   return _unoptimized_logical_plan;
 }
@@ -108,7 +108,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
 
   const auto done = std::chrono::high_resolution_clock::now();
-  _optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _execution_info.optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -152,7 +152,7 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     assert_same_mvcc_mode(plan);
 
     _query_plan->append_plan(plan.recreate());
-    _query_plan_cache_hit = true;
+    _execution_info.query_plan_cache_hit = true;
     done = std::chrono::high_resolution_clock::now();
   } else if (const auto* execute_statement = dynamic_cast<const hsql::ExecuteStatement*>(statement)) {
     // Handle query plan if we are executing a prepared statement
@@ -196,11 +196,11 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
   }
 
   // Cache newly created plan for the according sql statement (only if not already cached)
-  if (!_query_plan_cache_hit) {
+  if (!_execution_info.query_plan_cache_hit) {
     SQLQueryCache<SQLQueryPlan>::get().set(_sql_string, *_query_plan);
   }
 
-  _compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _execution_info.compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   return _query_plan;
 }
@@ -212,7 +212,7 @@ const std::vector<std::shared_ptr<OperatorTask>>& SQLPipelineStatement::get_task
 
   const auto& query_plan = get_query_plan();
   DebugAssert(query_plan->tree_roots().size() == 1,
-              "Physical query qlan creation returned no or more than one plan for a single statement.");
+              "Physical query plan creation returned no or more than one plan for a single statement.");
 
   const auto& root = query_plan->tree_roots().front();
   _tasks = OperatorTask::make_tasks_from_operator(root);
@@ -233,7 +233,7 @@ const std::shared_ptr<const Table>& SQLPipelineStatement::get_result_table() {
   if (statement->isType(hsql::kStmtPrepare)) {
     _query_has_output = false;
     const auto done = std::chrono::high_resolution_clock::now();
-    _execution_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+    _execution_info.execution_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
     return _result_table;
   }
 
@@ -244,7 +244,7 @@ const std::shared_ptr<const Table>& SQLPipelineStatement::get_result_table() {
   }
 
   const auto done = std::chrono::high_resolution_clock::now();
-  _execution_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _execution_info.execution_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   // Get output from the last task
   _result_table = tasks.back()->get_operator()->get_output();
@@ -255,35 +255,6 @@ const std::shared_ptr<const Table>& SQLPipelineStatement::get_result_table() {
 
 const std::shared_ptr<TransactionContext>& SQLPipelineStatement::transaction_context() const {
   return _transaction_context;
-}
-
-std::chrono::microseconds SQLPipelineStatement::translate_time_microseconds() const {
-  Assert(_unoptimized_logical_plan || _optimized_logical_plan || _query_plan,
-         "Cannot return translation duration without having translated.");
-  return _translate_time_micros;
-}
-
-std::chrono::microseconds SQLPipelineStatement::optimize_time_microseconds() const {
-  Assert(_optimized_logical_plan || _query_plan,
-         "Cannot return optimization duration without having optimized.");
-  return _optimize_time_micros;
-}
-
-std::chrono::microseconds SQLPipelineStatement::compile_time_microseconds() const {
-  Assert(_query_plan != nullptr, "Cannot return compile duration without having created the query plan.");
-  return _compile_time_micros;
-}
-
-std::chrono::microseconds SQLPipelineStatement::execution_time_microseconds() const {
-  Assert(_result_table != nullptr || !_query_has_output, "Cannot return execution duration without having executed.");
-  return _execution_time_micros;
-}
-
-std::string SQLPipelineStatement::get_time_string() const {
-  return "(TRANSLATE: " + std::to_string(translate_time_microseconds().count()) +
-         " µs, OPTIMIZE: " + std::to_string(optimize_time_microseconds().count()) +
-         " µs, COMPILE: " + std::to_string(compile_time_microseconds().count()) +
-         " µs, EXECUTE: " + std::to_string(execution_time_microseconds().count()) + " µs (wall time))\n";
 }
 
 std::string SQLPipelineStatement::create_parse_error_message(const std::string& sql,
@@ -324,8 +295,5 @@ std::string SQLPipelineStatement::create_parse_error_message(const std::string& 
   return error_msg.str();
 }
 
-bool SQLPipelineStatement::query_plan_cache_hit() const {
-  DebugAssert(_query_plan != nullptr, "Asking for cache hit before compiling query plan will return undefined result");
-  return _query_plan_cache_hit;
-}
+const SQLPipelineStatementExecutionInfo& SQLPipelineStatement::execution_info() const { return _execution_info; }
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -75,6 +75,8 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
 
   auto parsed_sql = get_parsed_sql_statement();
 
+  const auto started = std::chrono::high_resolution_clock::now();
+
   const auto* statement = parsed_sql->getStatement(0);
   if (const auto prepared_statement = dynamic_cast<const hsql::PrepareStatement*>(statement)) {
     // If this is as PreparedStatement, we want to translate the actual query and not the PREPARE FROM ... part.
@@ -88,6 +90,9 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
   DebugAssert(lqp_roots.size() == 1, "LQP translation returned no or more than one LQP root for a single statement.");
   _unoptimized_logical_plan = lqp_roots.front();
 
+  const auto done = std::chrono::high_resolution_clock::now();
+  _translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+
   return _unoptimized_logical_plan;
 }
 
@@ -97,7 +102,13 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   }
 
   const auto& unoptimized_lqp = get_unoptimized_logical_plan();
+
+  const auto started = std::chrono::high_resolution_clock::now();
+
   _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
+
+  const auto done = std::chrono::high_resolution_clock::now();
+  _optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -119,7 +130,9 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
 
   _query_plan = std::make_shared<SQLQueryPlan>();
 
-  const auto started = std::chrono::high_resolution_clock::now();
+  // Stores when the actual compilation started/ended
+  auto started = std::chrono::high_resolution_clock::now();
+  auto done = started;  // dummy value needed for initialization
 
   const auto* statement = get_parsed_sql_statement()->getStatement(0);
 
@@ -140,6 +153,7 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
 
     _query_plan->append_plan(plan.recreate());
     _query_plan_cache_hit = true;
+    done = std::chrono::high_resolution_clock::now();
   } else if (const auto* execute_statement = dynamic_cast<const hsql::ExecuteStatement*>(statement)) {
     // Handle query plan if we are executing a prepared statement
     Assert(_prepared_statements, "Cannot execute statement without prepared statement cache.");
@@ -160,13 +174,18 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
            "Number of arguments provided does not match expected number of arguments.");
 
     _query_plan->append_plan(plan->recreate(arguments));
+    done = std::chrono::high_resolution_clock::now();
   } else {
     // "Normal" mode in which the query plan is created
     const auto& lqp = get_optimized_logical_plan();
+
+    // Reset time to exclude previous pipeline steps
+    started = std::chrono::high_resolution_clock::now();
     _query_plan->add_tree_by_root(_lqp_translator->translate_node(lqp));
 
     // Set number of parameters to match later in case of prepared statement
     _query_plan->set_num_parameters(_num_parameters);
+    done = std::chrono::high_resolution_clock::now();
   }
 
   if (_use_mvcc == UseMvcc::Yes) _query_plan->set_transaction_context(_transaction_context);
@@ -181,7 +200,6 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     SQLQueryCache<SQLQueryPlan>::get().set(_sql_string, *_query_plan);
   }
 
-  const auto done = std::chrono::high_resolution_clock::now();
   _compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
 
   return _query_plan;
@@ -239,6 +257,17 @@ const std::shared_ptr<TransactionContext>& SQLPipelineStatement::transaction_con
   return _transaction_context;
 }
 
+std::chrono::microseconds SQLPipelineStatement::translate_time_microseconds() const {
+  Assert(_unoptimized_logical_plan != nullptr || _optimized_logical_plan,
+         "Cannot return translation duration without having translated.");
+  return _translate_time_micros;
+}
+
+std::chrono::microseconds SQLPipelineStatement::optimize_time_microseconds() const {
+  Assert(_optimized_logical_plan != nullptr, "Cannot return optimization duration without having optimized.");
+  return _optimize_time_micros;
+}
+
 std::chrono::microseconds SQLPipelineStatement::compile_time_microseconds() const {
   Assert(_query_plan != nullptr, "Cannot return compile duration without having created the query plan.");
   return _compile_time_micros;
@@ -247,6 +276,13 @@ std::chrono::microseconds SQLPipelineStatement::compile_time_microseconds() cons
 std::chrono::microseconds SQLPipelineStatement::execution_time_microseconds() const {
   Assert(_result_table != nullptr || !_query_has_output, "Cannot return execution duration without having executed.");
   return _execution_time_micros;
+}
+
+std::string SQLPipelineStatement::get_time_string() const {
+  return "(TRANSLATE: " + std::to_string(translate_time_microseconds().count()) +
+         " µs, OPTIMIZE: " + std::to_string(optimize_time_microseconds().count()) +
+         " µs, COMPILE: " + std::to_string(compile_time_microseconds().count()) +
+         " µs, EXECUTE: " + std::to_string(execution_time_microseconds().count()) + " µs (wall time))\n";
 }
 
 std::string SQLPipelineStatement::create_parse_error_message(const std::string& sql,

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -91,11 +91,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
   _unoptimized_logical_plan = lqp_roots.front();
 
   const auto done = std::chrono::high_resolution_clock::now();
-<<<<<<< HEAD
   _execution_info.translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
-=======
-  _translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
->>>>>>> origin
 
   return _unoptimized_logical_plan;
 }
@@ -112,11 +108,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
 
   const auto done = std::chrono::high_resolution_clock::now();
-<<<<<<< HEAD
   _execution_info.optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
-=======
-  _optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
->>>>>>> origin
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -160,11 +152,7 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     assert_same_mvcc_mode(plan);
 
     _query_plan->append_plan(plan.recreate());
-<<<<<<< HEAD
     _execution_info.query_plan_cache_hit = true;
-=======
-    _query_plan_cache_hit = true;
->>>>>>> origin
     done = std::chrono::high_resolution_clock::now();
   } else if (const auto* execute_statement = dynamic_cast<const hsql::ExecuteStatement*>(statement)) {
     // Handle query plan if we are executing a prepared statement
@@ -212,11 +200,7 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     SQLQueryCache<SQLQueryPlan>::get().set(_sql_string, *_query_plan);
   }
 
-<<<<<<< HEAD
   _execution_info.compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
-=======
-  _compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
->>>>>>> origin
 
   return _query_plan;
 }
@@ -273,38 +257,6 @@ const std::shared_ptr<TransactionContext>& SQLPipelineStatement::transaction_con
   return _transaction_context;
 }
 
-<<<<<<< HEAD
-=======
-std::chrono::microseconds SQLPipelineStatement::translate_time_microseconds() const {
-  Assert(_unoptimized_logical_plan || _optimized_logical_plan || _query_plan,
-         "Cannot return translation duration without having translated.");
-  return _translate_time_micros;
-}
-
-std::chrono::microseconds SQLPipelineStatement::optimize_time_microseconds() const {
-  Assert(_optimized_logical_plan || _query_plan,
-         "Cannot return optimization duration without having optimized.");
-  return _optimize_time_micros;
-}
-
-std::chrono::microseconds SQLPipelineStatement::compile_time_microseconds() const {
-  Assert(_query_plan != nullptr, "Cannot return compile duration without having created the query plan.");
-  return _compile_time_micros;
-}
-
-std::chrono::microseconds SQLPipelineStatement::execution_time_microseconds() const {
-  Assert(_result_table != nullptr || !_query_has_output, "Cannot return execution duration without having executed.");
-  return _execution_time_micros;
-}
-
-std::string SQLPipelineStatement::get_time_string() const {
-  return "(TRANSLATE: " + std::to_string(translate_time_microseconds().count()) +
-         " µs, OPTIMIZE: " + std::to_string(optimize_time_microseconds().count()) +
-         " µs, COMPILE: " + std::to_string(compile_time_microseconds().count()) +
-         " µs, EXECUTE: " + std::to_string(execution_time_microseconds().count()) + " µs (wall time))\n";
-}
-
->>>>>>> origin
 std::string SQLPipelineStatement::create_parse_error_message(const std::string& sql,
                                                              const hsql::SQLParserResult& result) {
   std::stringstream error_msg;

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -295,5 +295,5 @@ std::string SQLPipelineStatement::create_parse_error_message(const std::string& 
   return error_msg.str();
 }
 
-const SQLPipelineStatementExecutionInfo& SQLPipelineStatement::execution_info() const { return _execution_info; }
+const SQLPipelineStatementMetrics& SQLPipelineStatement::metrics() const { return _execution_info; }
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -258,13 +258,14 @@ const std::shared_ptr<TransactionContext>& SQLPipelineStatement::transaction_con
 }
 
 std::chrono::microseconds SQLPipelineStatement::translate_time_microseconds() const {
-  Assert(_unoptimized_logical_plan != nullptr || _optimized_logical_plan,
+  Assert(_unoptimized_logical_plan || _optimized_logical_plan || _query_plan,
          "Cannot return translation duration without having translated.");
   return _translate_time_micros;
 }
 
 std::chrono::microseconds SQLPipelineStatement::optimize_time_microseconds() const {
-  Assert(_optimized_logical_plan != nullptr, "Cannot return optimization duration without having optimized.");
+  Assert(_optimized_logical_plan || _query_plan,
+         "Cannot return optimization duration without having optimized.");
   return _optimize_time_micros;
 }
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -72,7 +72,7 @@ class SQLPipelineStatement : public Noncopyable {
   // This can be a nullptr if no transaction management is wanted.
   const std::shared_ptr<TransactionContext>& transaction_context() const;
 
-  const SQLPipelineStatementMetrics& metrics() const;
+  const std::shared_ptr<SQLPipelineStatementMetrics>& metrics() const;
 
   // Helper function to create a pretty print error message after an invalid SQL parse
   static std::string create_parse_error_message(const std::string& sql, const hsql::SQLParserResult& result);
@@ -102,7 +102,7 @@ class SQLPipelineStatement : public Noncopyable {
   // Assume there is an output table. Only change if nullptr is returned from execution.
   bool _query_has_output = true;
 
-  SQLPipelineStatementMetrics _execution_info{};
+  std::shared_ptr<SQLPipelineStatementMetrics> _metrics{};
 
   PreparedStatementCache _prepared_statements;
   // Number of placeholders in prepared statement; default 0 because we assume no prepared statement

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -20,8 +20,6 @@ struct SQLPipelineStatementExecutionInfo {
   std::chrono::microseconds execution_time_micros{};
 
   bool query_plan_cache_hit = false;
-
-  std::string to_string() const;
 };
 
 using PreparedStatementCache = std::shared_ptr<SQLQueryCache<SQLQueryPlan>>;

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -13,7 +13,7 @@
 namespace opossum {
 
 // Holds relevant information about the execution of an SQLPipelineStatement.
-struct SQLPipelineStatementExecutionInfo {
+struct SQLPipelineStatementMetrics {
   std::chrono::microseconds translate_time_micros{};
   std::chrono::microseconds optimize_time_micros{};
   std::chrono::microseconds compile_time_micros{};
@@ -72,7 +72,7 @@ class SQLPipelineStatement : public Noncopyable {
   // This can be a nullptr if no transaction management is wanted.
   const std::shared_ptr<TransactionContext>& transaction_context() const;
 
-  const SQLPipelineStatementExecutionInfo& execution_info() const;
+  const SQLPipelineStatementMetrics& metrics() const;
 
   // Helper function to create a pretty print error message after an invalid SQL parse
   static std::string create_parse_error_message(const std::string& sql, const hsql::SQLParserResult& result);
@@ -102,7 +102,7 @@ class SQLPipelineStatement : public Noncopyable {
   // Assume there is an output table. Only change if nullptr is returned from execution.
   bool _query_has_output = true;
 
-  SQLPipelineStatementExecutionInfo _execution_info{};
+  SQLPipelineStatementMetrics _execution_info{};
 
   PreparedStatementCache _prepared_statements;
   // Number of placeholders in prepared statement; default 0 because we assume no prepared statement

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -12,6 +12,18 @@
 
 namespace opossum {
 
+// Holds relevant information about the execution of an SQLPipelineStatement.
+struct SQLPipelineStatementExecutionInfo {
+  std::chrono::microseconds translate_time_micros{};
+  std::chrono::microseconds optimize_time_micros{};
+  std::chrono::microseconds compile_time_micros{};
+  std::chrono::microseconds execution_time_micros{};
+
+  bool query_plan_cache_hit = false;
+
+  std::string to_string() const;
+};
+
 using PreparedStatementCache = std::shared_ptr<SQLQueryCache<SQLQueryPlan>>;
 
 /**
@@ -62,16 +74,7 @@ class SQLPipelineStatement : public Noncopyable {
   // This can be a nullptr if no transaction management is wanted.
   const std::shared_ptr<TransactionContext>& transaction_context() const;
 
-  // Return the duration of each step in the pipeline.
-  std::chrono::microseconds translate_time_microseconds() const;
-  std::chrono::microseconds optimize_time_microseconds() const;
-  std::chrono::microseconds compile_time_microseconds() const;
-  std::chrono::microseconds execution_time_microseconds() const;
-
-  // Formats all times into a pretty string
-  std::string get_time_string() const;
-
-  bool query_plan_cache_hit() const;
+  const SQLPipelineStatementExecutionInfo& execution_info() const;
 
   // Helper function to create a pretty print error message after an invalid SQL parse
   static std::string create_parse_error_message(const std::string& sql, const hsql::SQLParserResult& result);
@@ -100,16 +103,11 @@ class SQLPipelineStatement : public Noncopyable {
   std::shared_ptr<const Table> _result_table;
   // Assume there is an output table. Only change if nullptr is returned from execution.
   bool _query_has_output = true;
-  bool _query_plan_cache_hit = false;
 
-  // Execution times
-  std::chrono::microseconds _translate_time_micros{};
-  std::chrono::microseconds _optimize_time_micros{};
-  std::chrono::microseconds _compile_time_micros{};
-  std::chrono::microseconds _execution_time_micros{};
+  SQLPipelineStatementExecutionInfo _execution_info{};
 
   PreparedStatementCache _prepared_statements;
-  // Number of placeholders in prepared statement; default 0 becasue we assume no prepared statement
+  // Number of placeholders in prepared statement; default 0 because we assume no prepared statement
   uint16_t _num_parameters = 0;
 };
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -102,7 +102,7 @@ class SQLPipelineStatement : public Noncopyable {
   // Assume there is an output table. Only change if nullptr is returned from execution.
   bool _query_has_output = true;
 
-  std::shared_ptr<SQLPipelineStatementMetrics> _metrics{};
+  std::shared_ptr<SQLPipelineStatementMetrics> _metrics;
 
   PreparedStatementCache _prepared_statements;
   // Number of placeholders in prepared statement; default 0 because we assume no prepared statement

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -103,10 +103,10 @@ class SQLPipelineStatement : public Noncopyable {
   bool _query_plan_cache_hit = false;
 
   // Execution times
-  std::chrono::microseconds _translate_time_micros;
-  std::chrono::microseconds _optimize_time_micros;
-  std::chrono::microseconds _compile_time_micros;
-  std::chrono::microseconds _execution_time_micros;
+  std::chrono::microseconds _translate_time_micros{};
+  std::chrono::microseconds _optimize_time_micros{};
+  std::chrono::microseconds _compile_time_micros{};
+  std::chrono::microseconds _execution_time_micros{};
 
   PreparedStatementCache _prepared_statements;
   // Number of placeholders in prepared statement; default 0 becasue we assume no prepared statement

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -62,8 +62,14 @@ class SQLPipelineStatement : public Noncopyable {
   // This can be a nullptr if no transaction management is wanted.
   const std::shared_ptr<TransactionContext>& transaction_context() const;
 
+  // Return the duration of each step in the pipeline.
+  std::chrono::microseconds translate_time_microseconds() const;
+  std::chrono::microseconds optimize_time_microseconds() const;
   std::chrono::microseconds compile_time_microseconds() const;
   std::chrono::microseconds execution_time_microseconds() const;
+
+  // Formats all times into a pretty string
+  std::string get_time_string() const;
 
   bool query_plan_cache_hit() const;
 
@@ -97,6 +103,8 @@ class SQLPipelineStatement : public Noncopyable {
   bool _query_plan_cache_hit = false;
 
   // Execution times
+  std::chrono::microseconds _translate_time_micros;
+  std::chrono::microseconds _optimize_time_micros;
   std::chrono::microseconds _compile_time_micros;
   std::chrono::microseconds _execution_time_micros;
 

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -485,12 +485,16 @@ TEST_F(SQLPipelineStatementTest, GetResultTableNoMVCC) {
 TEST_F(SQLPipelineStatementTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
+  EXPECT_THROW(sql_pipeline.translate_time_microseconds(), std::exception);
+  EXPECT_THROW(sql_pipeline.optimize_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
+  EXPECT_GT(sql_pipeline.translate_time_microseconds().count(), 0);
+  EXPECT_GT(sql_pipeline.optimize_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.compile_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
 }

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -335,10 +335,10 @@ TEST_F(SQLPipelineStatementTest, GetQueryPlanTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_query_plan();
-  auto duration = sql_pipeline.compile_time_microseconds();
+  auto duration = sql_pipeline.execution_info().compile_time_micros;
 
   const auto& plan = sql_pipeline.get_query_plan();
-  auto duration2 = sql_pipeline.compile_time_microseconds();
+  auto duration2 = sql_pipeline.execution_info().compile_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -425,10 +425,10 @@ TEST_F(SQLPipelineStatementTest, GetResultTableTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_result_table();
-  auto duration = sql_pipeline.execution_time_microseconds();
+  auto duration = sql_pipeline.execution_info().execution_time_micros;
 
   const auto& table = sql_pipeline.get_result_table();
-  auto duration2 = sql_pipeline.execution_time_microseconds();
+  auto duration2 = sql_pipeline.execution_info().execution_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -485,18 +485,21 @@ TEST_F(SQLPipelineStatementTest, GetResultTableNoMVCC) {
 TEST_F(SQLPipelineStatementTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
-  EXPECT_THROW(sql_pipeline.translate_time_microseconds(), std::exception);
-  EXPECT_THROW(sql_pipeline.optimize_time_microseconds(), std::exception);
-  EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
-  EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
+  const auto& execution_info = sql_pipeline.execution_info();
+  const auto zero_duration = std::chrono::microseconds::zero();
+
+  EXPECT_EQ(execution_info.translate_time_micros, zero_duration);
+  EXPECT_EQ(execution_info.optimize_time_micros, zero_duration);
+  EXPECT_EQ(execution_info.compile_time_micros, zero_duration);
+  EXPECT_EQ(execution_info.execution_time_micros, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(sql_pipeline.translate_time_microseconds().count(), 0);
-  EXPECT_GT(sql_pipeline.optimize_time_microseconds().count(), 0);
-  EXPECT_GT(sql_pipeline.compile_time_microseconds().count(), 0);
-  EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
+  EXPECT_GT(execution_info.translate_time_micros, zero_duration);
+  EXPECT_GT(execution_info.optimize_time_micros, zero_duration);
+  EXPECT_GT(execution_info.compile_time_micros, zero_duration);
+  EXPECT_GT(execution_info.execution_time_micros, zero_duration);
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -335,10 +335,10 @@ TEST_F(SQLPipelineStatementTest, GetQueryPlanTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_query_plan();
-  auto duration = sql_pipeline.execution_info().compile_time_micros;
+  auto duration = sql_pipeline.metrics().compile_time_micros;
 
   const auto& plan = sql_pipeline.get_query_plan();
-  auto duration2 = sql_pipeline.execution_info().compile_time_micros;
+  auto duration2 = sql_pipeline.metrics().compile_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -425,10 +425,10 @@ TEST_F(SQLPipelineStatementTest, GetResultTableTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_result_table();
-  auto duration = sql_pipeline.execution_info().execution_time_micros;
+  auto duration = sql_pipeline.metrics().execution_time_micros;
 
   const auto& table = sql_pipeline.get_result_table();
-  auto duration2 = sql_pipeline.execution_info().execution_time_micros;
+  auto duration2 = sql_pipeline.metrics().execution_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -485,21 +485,21 @@ TEST_F(SQLPipelineStatementTest, GetResultTableNoMVCC) {
 TEST_F(SQLPipelineStatementTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
-  const auto& execution_info = sql_pipeline.execution_info();
+  const auto& metrics = sql_pipeline.metrics();
   const auto zero_duration = std::chrono::microseconds::zero();
 
-  EXPECT_EQ(execution_info.translate_time_micros, zero_duration);
-  EXPECT_EQ(execution_info.optimize_time_micros, zero_duration);
-  EXPECT_EQ(execution_info.compile_time_micros, zero_duration);
-  EXPECT_EQ(execution_info.execution_time_micros, zero_duration);
+  EXPECT_EQ(metrics.translate_time_micros, zero_duration);
+  EXPECT_EQ(metrics.optimize_time_micros, zero_duration);
+  EXPECT_EQ(metrics.compile_time_micros, zero_duration);
+  EXPECT_EQ(metrics.execution_time_micros, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(execution_info.translate_time_micros, zero_duration);
-  EXPECT_GT(execution_info.optimize_time_micros, zero_duration);
-  EXPECT_GT(execution_info.compile_time_micros, zero_duration);
-  EXPECT_GT(execution_info.execution_time_micros, zero_duration);
+  EXPECT_GT(metrics.translate_time_micros, zero_duration);
+  EXPECT_GT(metrics.optimize_time_micros, zero_duration);
+  EXPECT_GT(metrics.compile_time_micros, zero_duration);
+  EXPECT_GT(metrics.execution_time_micros, zero_duration);
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -335,10 +335,10 @@ TEST_F(SQLPipelineStatementTest, GetQueryPlanTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_query_plan();
-  auto duration = sql_pipeline.metrics().compile_time_micros;
+  auto duration = sql_pipeline.metrics()->compile_time_micros;
 
   const auto& plan = sql_pipeline.get_query_plan();
-  auto duration2 = sql_pipeline.metrics().compile_time_micros;
+  auto duration2 = sql_pipeline.metrics()->compile_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -425,10 +425,10 @@ TEST_F(SQLPipelineStatementTest, GetResultTableTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_result_table();
-  auto duration = sql_pipeline.metrics().execution_time_micros;
+  auto duration = sql_pipeline.metrics()->execution_time_micros;
 
   const auto& table = sql_pipeline.get_result_table();
-  auto duration2 = sql_pipeline.metrics().execution_time_micros;
+  auto duration2 = sql_pipeline.metrics()->execution_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -488,18 +488,18 @@ TEST_F(SQLPipelineStatementTest, GetTimes) {
   const auto& metrics = sql_pipeline.metrics();
   const auto zero_duration = std::chrono::microseconds::zero();
 
-  EXPECT_EQ(metrics.translate_time_micros, zero_duration);
-  EXPECT_EQ(metrics.optimize_time_micros, zero_duration);
-  EXPECT_EQ(metrics.compile_time_micros, zero_duration);
-  EXPECT_EQ(metrics.execution_time_micros, zero_duration);
+  EXPECT_EQ(metrics->translate_time_micros, zero_duration);
+  EXPECT_EQ(metrics->optimize_time_micros, zero_duration);
+  EXPECT_EQ(metrics->compile_time_micros, zero_duration);
+  EXPECT_EQ(metrics->execution_time_micros, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(metrics.translate_time_micros, zero_duration);
-  EXPECT_GT(metrics.optimize_time_micros, zero_duration);
-  EXPECT_GT(metrics.compile_time_micros, zero_duration);
-  EXPECT_GT(metrics.execution_time_micros, zero_duration);
+  EXPECT_GT(metrics->translate_time_micros, zero_duration);
+  EXPECT_GT(metrics->optimize_time_micros, zero_duration);
+  EXPECT_GT(metrics->compile_time_micros, zero_duration);
+  EXPECT_GT(metrics->execution_time_micros, zero_duration);
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -399,12 +399,16 @@ TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
 TEST_F(SQLPipelineTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
+  EXPECT_THROW(sql_pipeline.translate_time_microseconds(), std::exception);
+  EXPECT_THROW(sql_pipeline.optimize_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
   EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
+  EXPECT_GT(sql_pipeline.translate_time_microseconds().count(), 0);
+  EXPECT_GT(sql_pipeline.optimize_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.compile_time_microseconds().count(), 0);
   EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
 }

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -272,11 +272,14 @@ TEST_F(SQLPipelineTest, GetQueryPlansMultiple) {
 TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
+  const auto& execution_info = sql_pipeline.execution_info();
+
   sql_pipeline.get_query_plans();
-  auto duration = sql_pipeline.compile_time_microseconds();
+  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
+  auto duration = execution_info.statement_infos[0].get().compile_time_micros;
 
   const auto& plans = sql_pipeline.get_query_plans();
-  auto duration2 = sql_pipeline.compile_time_microseconds();
+  auto duration2 = execution_info.statement_infos[0].get().compile_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -350,11 +353,15 @@ TEST_F(SQLPipelineTest, GetResultTableMultiple) {
 TEST_F(SQLPipelineTest, GetResultTableTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
+  const auto& execution_info = sql_pipeline.execution_info();
+
   sql_pipeline.get_result_table();
-  auto duration = sql_pipeline.execution_time_microseconds();
+  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
+  auto duration = execution_info.statement_infos[0].get().execution_time_micros;
 
   const auto& table = sql_pipeline.get_result_table();
-  auto duration2 = sql_pipeline.execution_time_microseconds();
+  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
+  auto duration2 = execution_info.statement_infos[0].get().execution_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -399,18 +406,24 @@ TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
 TEST_F(SQLPipelineTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
-  EXPECT_THROW(sql_pipeline.translate_time_microseconds(), std::exception);
-  EXPECT_THROW(sql_pipeline.optimize_time_microseconds(), std::exception);
-  EXPECT_THROW(sql_pipeline.compile_time_microseconds(), std::exception);
-  EXPECT_THROW(sql_pipeline.execution_time_microseconds(), std::exception);
+  const auto& execution_info = sql_pipeline.execution_info();
+  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
+  const auto& statement_info = execution_info.statement_infos[0].get();
+
+  const auto zero_duration = std::chrono::microseconds::zero();
+
+  EXPECT_EQ(statement_info.translate_time_micros, zero_duration);
+  EXPECT_EQ(statement_info.optimize_time_micros, zero_duration);
+  EXPECT_EQ(statement_info.compile_time_micros, zero_duration);
+  EXPECT_EQ(statement_info.execution_time_micros, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(sql_pipeline.translate_time_microseconds().count(), 0);
-  EXPECT_GT(sql_pipeline.optimize_time_microseconds().count(), 0);
-  EXPECT_GT(sql_pipeline.compile_time_microseconds().count(), 0);
-  EXPECT_GT(sql_pipeline.execution_time_microseconds().count(), 0);
+  EXPECT_GT(statement_info.translate_time_micros, zero_duration);
+  EXPECT_GT(statement_info.optimize_time_micros, zero_duration);
+  EXPECT_GT(statement_info.compile_time_micros, zero_duration);
+  EXPECT_GT(statement_info.execution_time_micros, zero_duration);
 }
 
 TEST_F(SQLPipelineTest, RequiresExecutionVariations) {

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -420,6 +420,7 @@ TEST_F(SQLPipelineTest, GetTimes) {
   // Run to get times
   sql_pipeline.get_result_table();
 
+  EXPECT_GT(execution_info.parse_time_micros, zero_duration);
   EXPECT_GT(statement_info.translate_time_micros, zero_duration);
   EXPECT_GT(statement_info.optimize_time_micros, zero_duration);
   EXPECT_GT(statement_info.compile_time_micros, zero_duration);

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -276,10 +276,10 @@ TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
 
   sql_pipeline.get_query_plans();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  auto duration = metrics.statement_metrics[0].get().compile_time_micros;
+  auto duration = metrics.statement_metrics[0]->compile_time_micros;
 
   const auto& plans = sql_pipeline.get_query_plans();
-  auto duration2 = metrics.statement_metrics[0].get().compile_time_micros;
+  auto duration2 = metrics.statement_metrics[0]->compile_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -357,11 +357,11 @@ TEST_F(SQLPipelineTest, GetResultTableTwice) {
 
   sql_pipeline.get_result_table();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  auto duration = metrics.statement_metrics[0].get().execution_time_micros;
+  auto duration = metrics.statement_metrics[0]->execution_time_micros;
 
   const auto& table = sql_pipeline.get_result_table();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  auto duration2 = metrics.statement_metrics[0].get().execution_time_micros;
+  auto duration2 = metrics.statement_metrics[0]->execution_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -408,23 +408,23 @@ TEST_F(SQLPipelineTest, GetTimes) {
 
   const auto& metrics = sql_pipeline.metrics();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  const auto& statement_metrics = metrics.statement_metrics[0].get();
+  const auto& statement_metrics = metrics.statement_metrics[0];
 
   const auto zero_duration = std::chrono::microseconds::zero();
 
-  EXPECT_EQ(statement_metrics.translate_time_micros, zero_duration);
-  EXPECT_EQ(statement_metrics.optimize_time_micros, zero_duration);
-  EXPECT_EQ(statement_metrics.compile_time_micros, zero_duration);
-  EXPECT_EQ(statement_metrics.execution_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics->translate_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics->optimize_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics->compile_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics->execution_time_micros, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
   EXPECT_GT(metrics.parse_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics.translate_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics.optimize_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics.compile_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics.execution_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics->translate_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics->optimize_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics->compile_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics->execution_time_micros, zero_duration);
 }
 
 TEST_F(SQLPipelineTest, RequiresExecutionVariations) {

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -272,14 +272,14 @@ TEST_F(SQLPipelineTest, GetQueryPlansMultiple) {
 TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
-  const auto& execution_info = sql_pipeline.execution_info();
+  const auto& metrics = sql_pipeline.metrics();
 
   sql_pipeline.get_query_plans();
-  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
-  auto duration = execution_info.statement_infos[0].get().compile_time_micros;
+  ASSERT_EQ(metrics.statement_metrics.size(), 1u);
+  auto duration = metrics.statement_metrics[0].get().compile_time_micros;
 
   const auto& plans = sql_pipeline.get_query_plans();
-  auto duration2 = execution_info.statement_infos[0].get().compile_time_micros;
+  auto duration2 = metrics.statement_metrics[0].get().compile_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -353,15 +353,15 @@ TEST_F(SQLPipelineTest, GetResultTableMultiple) {
 TEST_F(SQLPipelineTest, GetResultTableTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
-  const auto& execution_info = sql_pipeline.execution_info();
+  const auto& metrics = sql_pipeline.metrics();
 
   sql_pipeline.get_result_table();
-  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
-  auto duration = execution_info.statement_infos[0].get().execution_time_micros;
+  ASSERT_EQ(metrics.statement_metrics.size(), 1u);
+  auto duration = metrics.statement_metrics[0].get().execution_time_micros;
 
   const auto& table = sql_pipeline.get_result_table();
-  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
-  auto duration2 = execution_info.statement_infos[0].get().execution_time_micros;
+  ASSERT_EQ(metrics.statement_metrics.size(), 1u);
+  auto duration2 = metrics.statement_metrics[0].get().execution_time_micros;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -406,25 +406,25 @@ TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
 TEST_F(SQLPipelineTest, GetTimes) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
-  const auto& execution_info = sql_pipeline.execution_info();
-  ASSERT_EQ(execution_info.statement_infos.size(), 1u);
-  const auto& statement_info = execution_info.statement_infos[0].get();
+  const auto& metrics = sql_pipeline.metrics();
+  ASSERT_EQ(metrics.statement_metrics.size(), 1u);
+  const auto& statement_metrics = metrics.statement_metrics[0].get();
 
   const auto zero_duration = std::chrono::microseconds::zero();
 
-  EXPECT_EQ(statement_info.translate_time_micros, zero_duration);
-  EXPECT_EQ(statement_info.optimize_time_micros, zero_duration);
-  EXPECT_EQ(statement_info.compile_time_micros, zero_duration);
-  EXPECT_EQ(statement_info.execution_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics.translate_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics.optimize_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics.compile_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics.execution_time_micros, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(execution_info.parse_time_micros, zero_duration);
-  EXPECT_GT(statement_info.translate_time_micros, zero_duration);
-  EXPECT_GT(statement_info.optimize_time_micros, zero_duration);
-  EXPECT_GT(statement_info.compile_time_micros, zero_duration);
-  EXPECT_GT(statement_info.execution_time_micros, zero_duration);
+  EXPECT_GT(metrics.parse_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics.translate_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics.optimize_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics.compile_time_micros, zero_duration);
+  EXPECT_GT(statement_metrics.execution_time_micros, zero_duration);
 }
 
 TEST_F(SQLPipelineTest, RequiresExecutionVariations) {

--- a/src/test/sql/sql_query_plan_cache_test.cpp
+++ b/src/test/sql/sql_query_plan_cache_test.cpp
@@ -33,7 +33,7 @@ class SQLQueryPlanCacheTest : public BaseTest {
     auto pipeline_statement = SQLPipelineBuilder{query}.create_pipeline_statement();
     pipeline_statement.get_result_table();
 
-    if (pipeline_statement.metrics().query_plan_cache_hit) {
+    if (pipeline_statement.metrics()->query_plan_cache_hit) {
       _query_plan_cache_hits++;
     }
   }

--- a/src/test/sql/sql_query_plan_cache_test.cpp
+++ b/src/test/sql/sql_query_plan_cache_test.cpp
@@ -33,7 +33,7 @@ class SQLQueryPlanCacheTest : public BaseTest {
     auto pipeline_statement = SQLPipelineBuilder{query}.create_pipeline_statement();
     pipeline_statement.get_result_table();
 
-    if (pipeline_statement.execution_info().query_plan_cache_hit()) {
+    if (pipeline_statement.execution_info().query_plan_cache_hit) {
       _query_plan_cache_hits++;
     }
   }

--- a/src/test/sql/sql_query_plan_cache_test.cpp
+++ b/src/test/sql/sql_query_plan_cache_test.cpp
@@ -33,7 +33,7 @@ class SQLQueryPlanCacheTest : public BaseTest {
     auto pipeline_statement = SQLPipelineBuilder{query}.create_pipeline_statement();
     pipeline_statement.get_result_table();
 
-    if (pipeline_statement.execution_info().query_plan_cache_hit) {
+    if (pipeline_statement.metrics().query_plan_cache_hit) {
       _query_plan_cache_hits++;
     }
   }


### PR DESCRIPTION
This PR adds to #886 by moving all execution info into a struct. The struct has a nice `to_string()` which gives us:

```
Execution info: [PARSE: 8 µs, TRANSLATE: 163 µs, OPTIMIZE: 22 µs, COMPILE: 113 µs, EXECUTE: 172 µs (wall time) | QUERY PLAN CACHE HITS: 1/2 statement(s)]
```