### PR TITLE
Temporarily disable bitcode pointer test - issue #892

### DIFF
--- a/src/test/operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp
+++ b/src/test/operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp
@@ -84,7 +84,7 @@ TEST_F(GetRuntimePointerForValueTest, RuntimePointersAreInvalidWithoutInitialAdd
   ASSERT_FALSE(GetRuntimePointerForValue(_value_7, _context)->is_valid());
 }
 
-TEST_F(GetRuntimePointerForValueTest, BitcodePointerInstructionsAreProperlySimulated) {
+TEST_F(GetRuntimePointerForValueTest, DISABLED_BitcodePointerInstructionsAreProperlySimulated) {
   // Create a set of valid pointers that the function can work on
   int64_t some_value;
   int64_t* some_pointer_1 = &some_value;


### PR DESCRIPTION
To allow a full execution of all tests on test server the problematic test BitcodePointerInstructionsAreProperlySimulated is disabled until issue with excluding functions from sanitizer is resolved.
PR does not solve issue #892 .