### PR TITLE
Exclude function is_valid from sanitizer - bug #892

### DIFF
--- a/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.hpp
+++ b/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.hpp
@@ -68,6 +68,10 @@ class JitKnownRuntimePointer : public JitRuntimePointer {
  public:
   // Checks whether the address pointed to is valid (i.e., can be dereferenced).
   // This solution is based on https://stackoverflow.com/questions/4611776/isbadreadptr-analogue-on-unix
+  // Address sanitizer is disabled to ensure that checking an invalid address is not identified as a false positive.
+#if __has_feature(address_sanitizer)
+  __attribute__((no_sanitize("address")))
+#endif
   bool is_valid() const override {
     const auto ptr = reinterpret_cast<void*>(address());
     auto fd = open("/dev/random", O_WRONLY);


### PR DESCRIPTION
Resolves a false positive finding of the address sanitizer by excluding function `JitKnownRuntimePointer::is_valid()` from the address sanitizer.
The function checks whether a Jit pointer is valid and therefore accesses undefined memory, if this is not the case.

Closes #892 .