### PR TITLE
Fix santizer false positives for jit pointers #892

### DIFF
--- a/.asan-ignore.txt
+++ b/.asan-ignore.txt
@@ -1,4 +1,2 @@
-# Leaks in libtool-libtldl
-leak:lt__malloc
-leak:libltdl.so
-leak:libsqlite3.so
+# Ignore false positive in check whether a Jit pointer is valid
+interceptor_via_fun:opossum::JitKnownRuntimePointer::is_valid(*)

--- a/.lsan-ignore.txt
+++ b/.lsan-ignore.txt
@@ -1,0 +1,4 @@
+# Leaks in libtool-libtldl
+leak:lt__malloc
+leak:libltdl.so
+leak:libsqlite3.so

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ node {
         stage("clang-debug:sanitizers (master only)") {
           if (env.BRANCH_NAME == 'master') {
             sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
+            sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
           } else {
             echo 'only on master'
           }
@@ -72,7 +72,7 @@ node {
         stage("clang-release:sanitizers (master only)") {
           if (env.BRANCH_NAME == 'master') {
             sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
+            sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
           } else {
             echo 'only on master'
           }
@@ -81,7 +81,7 @@ node {
         stage("clang-release:sanitizers w/o NUMA (master only)") {
           if (env.BRANCH_NAME == 'master') {
             sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-            sh "LSAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
+            sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
           } else {
             echo 'only on master'
           }

--- a/src/lib/operators/jit_operator/specialization/jit_code_specializer.hpp
+++ b/src/lib/operators/jit_operator/specialization/jit_code_specializer.hpp
@@ -53,7 +53,8 @@ class JitCodeSpecializer {
   }
 
  private:
-  //
+  // Undefined Behavior Sanitizer disabled here to prevent false positive through reinterpret_cast.
+  __attribute__((no_sanitize("vptr")))
   void _inline_function_calls(SpecializationContext& context) const;
 
   // Iterates over all load instruction in the function and tries to determine their value from the provided runtime

--- a/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.hpp
+++ b/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.hpp
@@ -68,10 +68,6 @@ class JitKnownRuntimePointer : public JitRuntimePointer {
  public:
   // Checks whether the address pointed to is valid (i.e., can be dereferenced).
   // This solution is based on https://stackoverflow.com/questions/4611776/isbadreadptr-analogue-on-unix
-  // Address sanitizer is disabled to ensure that checking an invalid address is not identified as a false positive.
-#if __has_feature(address_sanitizer)
-  __attribute__((no_sanitize("address")))
-#endif
   bool is_valid() const override {
     const auto ptr = reinterpret_cast<void*>(address());
     auto fd = open("/dev/random", O_WRONLY);

--- a/src/lib/operators/jit_operator/specialization/llvm_extensions.cpp
+++ b/src/lib/operators/jit_operator/specialization/llvm_extensions.cpp
@@ -104,6 +104,8 @@ llvm::Constant* ConstantFoldInstruction(llvm::Instruction* inst, llvm::ArrayRef<
   return llvm::ConstantFoldInstOperands(inst, operands, data_layout, target_library_info);
 }
 
+// Undefined Behavior Sanitizer disabled for alignment to prevent false positive through reinterpret_cast.
+__attribute__((no_sanitize("alignment")))
 llvm::Constant* ResolveConditionRec(llvm::Value* value, SpecializationContext& context,
                                     std::unordered_set<llvm::Value*>& failed) {
   // If resolving the value failed already we fail early here


### PR DESCRIPTION
Added second sanitizer ignore file as the address sanitizer and leak sanitizer require different files.
Renamed .asan-ignore.txt to .lsan-ignore.txt as this file is passed to the leak sanitizer (LSan).
Jenkines now also considers the asan ignore file when executing the address sanitizer (ASan).
Undefined behavior sanitizer (UBSan) false positives could be disabled from within the source code and therefore do not require a separate ignore file.

New PR as PR #895 did not solve bug #892 .
Sanitizer tests are only executed by Jenkins on master branch.
To show that the changes will execute successfully on master branch, a demo branch fabian/bug/892/finally_fix_issue_sanitizer_jit_demo was branched of this fix with a modified Jenkins to enable sanitizer tests on the branch. Sanitizer tests run through successfully: [Jenkins run on demo branch](https://ares.epic.hpi.uni-potsdam.de/jenkins/blue/organizations/jenkins/Hyrise%2Fhyrise/detail/fabian%2Fbug%2F892%2Ffinal_fix_issue_sanitizer_jit_demo/2/pipeline/62).

Closes #892 .