### PR TITLE
Add No-Compression Option to TPC-C Table Generator

### DIFF
--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -22,9 +22,11 @@
 
 namespace opossum {
 
-TpccTableGenerator::TpccTableGenerator(const ChunkOffset chunk_size, const size_t warehouse_size)
+TpccTableGenerator::TpccTableGenerator(const ChunkOffset chunk_size, const size_t warehouse_size,
+   const bool encode_chunks)
     : AbstractBenchmarkTableGenerator(chunk_size),
       _warehouse_size(warehouse_size),
+      _encode_chunks(encode_chunks),
       _random_gen(TpccRandomGenerator()) {}
 
 std::shared_ptr<Table> TpccTableGenerator::generate_items_table() {
@@ -61,7 +63,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_items_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
 
   return table;
 }
@@ -99,7 +103,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_warehouse_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
 
   return table;
 }
@@ -149,7 +155,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_stock_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -191,7 +199,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_district_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -258,7 +268,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_customer_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -291,7 +303,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_history_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -336,7 +350,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_table(
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -439,7 +455,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_line_table(
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -465,7 +483,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_new_order_table() {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& chunk_columns : columns_by_chunk) table->append_chunk(chunk_columns);
 
-  ChunkEncoder::encode_all_chunks(table);
+  if (_encode_chunks) {
+    ChunkEncoder::encode_all_chunks(table);
+  }
   return table;
 }
 
@@ -499,7 +519,7 @@ std::map<std::string, std::shared_ptr<Table>> TpccTableGenerator::generate_all_t
  * a) generate a TPC-C table by table name (e.g. ITEM, WAREHOUSE), and
  * b) have all available table names browsable for the Console auto completion.
  */
-TpccTableGeneratorFunctions TpccTableGenerator::tpcc_table_generator_functions() {
+TpccTableGeneratorFunctions TpccTableGenerator::table_generator_functions() {
   TpccTableGeneratorFunctions generators{
       {"ITEM", []() { return TpccTableGenerator().generate_items_table(); }},
       {"WAREHOUSE", []() { return TpccTableGenerator().generate_warehouse_table(); }},
@@ -520,12 +540,30 @@ TpccTableGeneratorFunctions TpccTableGenerator::tpcc_table_generator_functions()
   return generators;
 }
 
-std::shared_ptr<Table> TpccTableGenerator::generate_tpcc_table(const std::string& tablename) {
-  auto generators = TpccTableGenerator::tpcc_table_generator_functions();
-  if (generators.find(tablename) == generators.end()) {
+std::shared_ptr<Table> TpccTableGenerator::generate_table(const std::string& tablename) {
+  if (tablename == "ITEM") {
+    return generate_items_table();
+  } else if (tablename == "WAREHOUSE") {
+    return generate_warehouse_table();
+  } else if (tablename == "STOCK") {
+    return generate_stock_table();
+  } else if (tablename == "DISTRICT") {
+    return generate_district_table();
+  } else if (tablename == "CUSTOMER") {
+    return generate_customer_table();
+  } else if (tablename == "HISTORY") {
+    return generate_history_table();
+  } else if (tablename == "ORDER") {
+    return generate_new_order_table();
+  } else if (tablename == "NEW_ORDER") {
+    auto order_line_counts = generate_order_line_counts();
+    return generate_order_table(order_line_counts);
+  } else if (tablename == "ORDER_LINE") {
+    auto order_line_counts = generate_order_line_counts();
+    return generate_order_line_table(order_line_counts);
+  } else {
     return nullptr;
   }
-  return generators[tablename]();
 }
 
 }  // namespace opossum

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -22,7 +22,8 @@ using TpccTableGeneratorFunctions = std::unordered_map<std::string, std::functio
 class TpccTableGenerator : public opossum::AbstractBenchmarkTableGenerator {
   // following TPC-C v5.11.0
  public:
-  explicit TpccTableGenerator(const ChunkOffset chunk_size = 1'000'000, const size_t warehouse_size = 1);
+  explicit TpccTableGenerator(const ChunkOffset chunk_size = 1'000'000, const size_t warehouse_size = 1,
+    const bool encode_chunk = true);
 
   virtual ~TpccTableGenerator() = default;
 
@@ -50,12 +51,13 @@ class TpccTableGenerator : public opossum::AbstractBenchmarkTableGenerator {
 
   std::map<std::string, std::shared_ptr<Table>> generate_all_tables();
 
-  static TpccTableGeneratorFunctions tpcc_table_generator_functions();
+  static TpccTableGeneratorFunctions table_generator_functions();
 
-  static std::shared_ptr<Table> generate_tpcc_table(const std::string& tablename);
+  std::shared_ptr<Table> generate_table(const std::string& tablename);
 
   const size_t _warehouse_size;
   const time_t _current_date = std::time(0);
+  const bool _encode_chunks;
 
  protected:
   template <typename T>

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -390,7 +390,7 @@ int Console::generate_tpcc(const std::string& tablename) {
   }
 
   out("Generating TPCC table: \"" + tablename + "\" ...\n");
-  auto table = opossum::TpccTableGenerator::generate_tpcc_table(tablename);
+  auto table = opossum::TpccTableGenerator().generate_table(tablename);
   if (table == nullptr) {
     out("Error: No TPCC table named \"" + tablename + "\" available.\n");
     return Console::ReturnCode::Error;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -123,7 +123,7 @@ Console::Console()
 
   // Register words specifically for command completion purposes, e.g.
   // for TPC-C table generation, 'CUSTOMER', 'DISTRICT', etc
-  auto tpcc_generators = opossum::TpccTableGenerator::tpcc_table_generator_functions();
+  auto tpcc_generators = opossum::TpccTableGenerator::table_generator_functions();
   for (auto it = tpcc_generators.begin(); it != tpcc_generators.end(); ++it) {
     _tpcc_commands.push_back(it->first);
   }


### PR DESCRIPTION
1. Add no compression option.
2. generate_table(table_name) function should be non-static and use settings of instance.