### PR TITLE
Benchmark Playground

### DIFF
--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -26,6 +26,22 @@ target_link_libraries(
     benchmark
 )
 
+add_executable(
+    hyriseBenchmarkPlayground
+
+    benchmark_playground.cpp
+    benchmark_basic_fixture.cpp
+    benchmark_basic_fixture.hpp
+    benchmark_main.cpp
+)
+target_link_libraries(
+    hyriseBenchmarkPlayground
+    
+    hyrise
+    hyriseBenchmarkLib
+    benchmark
+)
+
 # General purpose benchmark runner
 add_executable(hyriseBenchmark benchmark_runner_main.cpp)
 target_link_libraries(

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -43,7 +43,7 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
         result.push_back(i);
-        benchmark::ClobberMemory(); // Force that record to be written to memory
+        benchmark::ClobberMemory();  // Force that record to be written to memory
       }
     }
   }
@@ -66,7 +66,7 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::St
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
         result.push_back(i);
-        benchmark::ClobberMemory(); // Force that record to be written to memory
+        benchmark::ClobberMemory();  // Force that record to be written to memory
       }
     }
   }

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -1,0 +1,70 @@
+#include <memory>
+
+#include "benchmark/benchmark.h"
+
+#include "benchmark_basic_fixture.hpp"
+#include "operators/sort.hpp"
+#include "operators/table_wrapper.hpp"
+
+namespace opossum {
+
+using ValueT = int32_t;
+
+class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
+ public:
+  void SetUp(::benchmark::State& state) override {
+    BenchmarkBasicFixture::SetUp(state);
+
+    _vec.resize(1'000'000);
+    std::generate(_vec.begin(), _vec.end(), []() {
+      static ValueT v = 0;
+      v = ++v % 1'000;
+      return v;
+    });
+  }
+  void TearDown(::benchmark::State& state) override { BenchmarkBasicFixture::TearDown(state); }
+
+ protected:
+  std::vector<ValueT> _vec;
+};
+
+BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::State& state) {
+  clear_cache();
+
+  // warm up
+  for (const auto& element : _vec) {
+    benchmark::DoNotOptimize(element);
+  }
+
+  while (state.KeepRunning()) {
+    std::vector<size_t> result;
+    auto size = _vec.size();
+    for (size_t i = 0; i < size; ++i) {
+      if (_vec[i] == 999) {
+        result.push_back(i);
+      }
+    }
+  }
+}
+
+BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_NewApproach)(benchmark::State& state) {
+  clear_cache();
+
+  // warm up
+  for (const auto& element : _vec) {
+    benchmark::DoNotOptimize(element);
+  }
+
+  while (state.KeepRunning()) {
+    std::vector<size_t> result;
+    result.reserve(1000);
+    auto size = _vec.size();
+    for (size_t i = 0; i < size; ++i) {
+      if (_vec[i] == 999) {
+        result.push_back(i);
+      }
+    }
+  }
+}
+
+}  // namespace opossum

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -18,7 +18,7 @@ class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
     _vec.resize(1'000'000);
     std::generate(_vec.begin(), _vec.end(), []() {
       static ValueT v = 0;
-      v = ++v % 1'000;
+      v = ++v % 4;
       return v;
     });
   }
@@ -40,14 +40,14 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
     std::vector<size_t> result;
     auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
-      if (_vec[i] == 999) {
+      if (_vec[i] == 2) {
         result.push_back(i);
       }
     }
   }
 }
 
-BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_NewApproach)(benchmark::State& state) {
+BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::State& state) {
   clear_cache();
 
   // warm up
@@ -57,10 +57,11 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_NewApproach)(benchmark::St
 
   while (state.KeepRunning()) {
     std::vector<size_t> result;
-    result.reserve(1000);
+    // pre-allocate result vector
+    result.reserve(250'000);
     auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
-      if (_vec[i] == 999) {
+      if (_vec[i] == 2) {
         result.push_back(i);
       }
     }

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -39,7 +39,7 @@ class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
     _vec.resize(1'000'000);
     std::generate(_vec.begin(), _vec.end(), []() {
       static ValueT v = 0;
-      v = ++v % 4;
+      v = (v + 1) % 4;
       return v;
     });
   }
@@ -57,7 +57,7 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
 
   while (state.KeepRunning()) {
     std::vector<size_t> result;
-    auto size = _vec.size();
+    const auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
         result.push_back(i);
@@ -78,7 +78,7 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::St
     std::vector<size_t> result;
     // pre-allocate result vector
     result.reserve(250'000);
-    auto size = _vec.size();
+    const auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
         result.push_back(i);

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "benchmark/benchmark.h"
-
 #include "benchmark_basic_fixture.hpp"
 
 namespace opossum {

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -3,8 +3,6 @@
 #include "benchmark/benchmark.h"
 
 #include "benchmark_basic_fixture.hpp"
-#include "operators/sort.hpp"
-#include "operators/table_wrapper.hpp"
 
 namespace opossum {
 

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -5,6 +5,26 @@
 
 namespace opossum {
 
+/**
+ * Welcome to the benchmark playground. Here, you can quickly compare two
+ * approaches in a minimal setup. Of course you can also use it to just benchmark
+ * one single thing.
+ *
+ * In this example, a minimal TableScan-like operation is used to evaluate the
+ * performance impact of pre-allocating the result vector (PosList in hyrise).
+ *
+ * A few tips:
+ * * The optimizer is not your friend. If you do a bunch of calculations and
+ *   don't actually use the result, it will optimize your code out and you will
+ *   benchmark only noise.
+ * * benchmark::ClobberMemory(); can be used to force calculations to be written
+ *   to memory.
+ * * benchmark::DoNotOptimize(<expression>); can be used to prevent <expression>
+ *   from being optimized out. However, this does not stop the optimizer from
+ *   optimizing the expression itself!
+ *
+ */
+
 using ValueT = int32_t;
 
 class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
@@ -12,6 +32,10 @@ class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
   void SetUp(::benchmark::State& state) override {
     BenchmarkBasicFixture::SetUp(state);
 
+    clear_cache();
+
+    // Fill the vector with 1M values in the pattern 0, 1, 2, 3, 0, 1, 2, 3, ...
+    // The "TableScan" will scan for one value (2), so it will select 25%.
     _vec.resize(1'000'000);
     std::generate(_vec.begin(), _vec.end(), []() {
       static ValueT v = 0;
@@ -25,12 +49,14 @@ class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
   std::vector<ValueT> _vec;
 };
 
+/**
+ * Reference implementation, growing the vector on demand
+ */
 BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::State& state) {
-  clear_cache();
+  // Add some benchmark-specific setup here
 
   while (state.KeepRunning()) {
     std::vector<size_t> result;
-    benchmark::DoNotOptimize(result.data());
     auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
@@ -38,17 +64,20 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
         benchmark::ClobberMemory();  // Force that record to be written to memory
       }
     }
+    benchmark::DoNotOptimize(result.data());  // Do not optimize out the vector
   }
 }
 
+/**
+ * Alternative implementation, pre-allocating the vector
+ */
 BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::State& state) {
-  clear_cache();
+  // Add some benchmark-specific setup here
 
   while (state.KeepRunning()) {
     std::vector<size_t> result;
     // pre-allocate result vector
     result.reserve(250'000);
-    benchmark::DoNotOptimize(result.data());
     auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
@@ -56,6 +85,7 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::St
         benchmark::ClobberMemory();  // Force that record to be written to memory
       }
     }
+    benchmark::DoNotOptimize(result.data());  // Do not optimize out the vector
   }
 }
 

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -38,10 +38,12 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
 
   while (state.KeepRunning()) {
     std::vector<size_t> result;
+    benchmark::DoNotOptimize(result.data());
     auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
         result.push_back(i);
+        benchmark::ClobberMemory(); // Force that record to be written to memory
       }
     }
   }
@@ -59,10 +61,12 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::St
     std::vector<size_t> result;
     // pre-allocate result vector
     result.reserve(250'000);
+    benchmark::DoNotOptimize(result.data());
     auto size = _vec.size();
     for (size_t i = 0; i < size; ++i) {
       if (_vec[i] == 2) {
         result.push_back(i);
+        benchmark::ClobberMemory(); // Force that record to be written to memory
       }
     }
   }

--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -31,11 +31,6 @@ class BenchmarkPlaygroundFixture : public BenchmarkBasicFixture {
 BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::State& state) {
   clear_cache();
 
-  // warm up
-  for (const auto& element : _vec) {
-    benchmark::DoNotOptimize(element);
-  }
-
   while (state.KeepRunning()) {
     std::vector<size_t> result;
     benchmark::DoNotOptimize(result.data());
@@ -51,11 +46,6 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
 
 BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::State& state) {
   clear_cache();
-
-  // warm up
-  for (const auto& element : _vec) {
-    benchmark::DoNotOptimize(element);
-  }
 
   while (state.KeepRunning()) {
     std::vector<size_t> result;


### PR DESCRIPTION
We found this pretty useful for our needs. Instead of settings it up temporarily every time, maybe it makes sense to have a benchmark playground - similar to the regular playground. Like http://quick-bench.com/ but you can use hyrise components.

The added benchmark content is just for illustrational purposes, showcasing a scenario in which it is important to prevent the compiler from optimizing out benchmarked code.