### PR TITLE
Resolve null ptr issue in specialised operator code with LLVM6 (#911)

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -487,6 +487,7 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator/specialization/jit_code_specializer.hpp
         operators/jit_operator/specialization/jit_repository.cpp
         operators/jit_operator/specialization/jit_repository.hpp
+        operators/jit_operator/specialization/jit_runtime_pointer.cpp
         operators/jit_operator/specialization/jit_runtime_pointer.hpp
         operators/jit_operator/specialization/llvm/CloneFunction.cpp
         operators/jit_operator/specialization/llvm/InlineFunction.cpp

--- a/src/lib/operators/jit_operator/jit_types.cpp
+++ b/src/lib/operators/jit_operator/jit_types.cpp
@@ -53,7 +53,7 @@ void JitVariantVector::set_is_null(const size_t index, const bool is_null) { _is
 
 std::vector<bool>& JitVariantVector::get_is_null_vector() { return _is_null; }
 
-// Generate get, get, grow_by_one, and get_vector methods for all data types defined in JIT_DATA_TYPE_INFO
+// Generate get, set, grow_by_one, and get_vector methods for all data types defined in JIT_DATA_TYPE_INFO
 BOOST_PP_SEQ_FOR_EACH(JIT_VARIANT_VECTOR_GET, _, JIT_DATA_TYPE_INFO)
 BOOST_PP_SEQ_FOR_EACH(JIT_VARIANT_VECTOR_SET, _, JIT_DATA_TYPE_INFO)
 BOOST_PP_SEQ_FOR_EACH(JIT_VARIANT_VECTOR_GROW_BY_ONE, _, JIT_DATA_TYPE_INFO)

--- a/src/lib/operators/jit_operator/specialization/jit_code_specializer.cpp
+++ b/src/lib/operators/jit_operator/specialization/jit_code_specializer.cpp
@@ -209,12 +209,16 @@ void JitCodeSpecializer::_inline_function_calls(SpecializationContext& context) 
 
     // Instruct LLVM to perform the function inlining and push all new call sites to the working queue
     llvm::InlineFunctionInfo info;
-    // TODO(Fabian) check 2nd last argument value nullptr for llvm::Function *ForwardVarArgsTo
     if (InlineFunction(call_site, info, nullptr, false, nullptr, context)) {
       for (const auto& new_call_site : info.InlinedCallSites) {
         call_sites.push(new_call_site);
       }
     }
+
+    // clear runtime_value_map to allow multiple inlining of same function
+    auto runtime_this = context.runtime_value_map[context.root_function->arg_begin()];
+    context.runtime_value_map.clear();
+    context.runtime_value_map[context.root_function->arg_begin()] = runtime_this;
 
     call_sites.pop();
   }

--- a/src/lib/operators/jit_operator/specialization/jit_code_specializer.cpp
+++ b/src/lib/operators/jit_operator/specialization/jit_code_specializer.cpp
@@ -13,6 +13,7 @@
 #include <queue>
 
 #include "llvm_extensions.hpp"
+#include "jit_runtime_pointer.hpp"
 
 namespace opossum {
 
@@ -240,9 +241,7 @@ void JitCodeSpecializer::_perform_load_substitution(SpecializationContext& conte
     // constant.
     const auto address = runtime_pointer->address();
     if (inst.getType()->isIntegerTy()) {
-      const auto bit_width = inst.getType()->getIntegerBitWidth();
-      const auto mask = bit_width == 64 ? 0xffffffffffffffff : (static_cast<uint64_t>(1) << bit_width) - 1;
-      const auto value = *reinterpret_cast<uint64_t*>(address) & mask;
+      const auto value = dereference_flexible_width_int_pointer(address, inst.getType()->getIntegerBitWidth());
       inst.replaceAllUsesWith(llvm::ConstantInt::get(inst.getType(), value));
     } else if (inst.getType()->isFloatTy()) {
       const auto value = *reinterpret_cast<float*>(address);

--- a/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.cpp
+++ b/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.cpp
@@ -13,7 +13,7 @@ uint64_t dereference_flexible_width_int_pointer(const uint64_t address, const un
     case 64:
       return *reinterpret_cast<uint64_t*>(address);
     default:
-      throw std::runtime_error("Int pointer with bit width " + std::to_string(integer_bit_width) + " not supported.");
+      Fail("Integer pointer with bit width " + std::to_string(integer_bit_width) + " not supported.");
   }
 }
 

--- a/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.cpp
+++ b/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.cpp
@@ -1,0 +1,20 @@
+#include "jit_runtime_pointer.hpp"
+
+namespace opossum {
+
+uint64_t dereference_flexible_width_int_pointer(const uint64_t address, const unsigned integer_bit_width) {
+  switch (integer_bit_width) {
+    case 8:
+      return *reinterpret_cast<uint8_t*>(address);
+    case 16:
+      return *reinterpret_cast<uint16_t*>(address);
+    case 32:
+      return *reinterpret_cast<uint32_t*>(address);
+    case 64:
+      return *reinterpret_cast<uint64_t*>(address);
+    default:
+      throw std::runtime_error("Int pointer with bit width " + std::to_string(integer_bit_width) + " not supported.");
+  }
+}
+
+}  // namespace opossum

--- a/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.hpp
+++ b/src/lib/operators/jit_operator/specialization/jit_runtime_pointer.hpp
@@ -161,4 +161,6 @@ class JitDereferencedRuntimePointer : public JitKnownRuntimePointer {
   const std::shared_ptr<const JitKnownRuntimePointer> _base;
 };
 
+uint64_t dereference_flexible_width_int_pointer(const uint64_t address, const unsigned integer_bit_width);
+
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/specialization/llvm/InlineFunction.cpp
+++ b/src/lib/operators/jit_operator/specialization/llvm/InlineFunction.cpp
@@ -60,6 +60,7 @@
 #include "llvm/IR/Type.h"
 #include "llvm/IR/User.h"
 #include "llvm/IR/Value.h"
+#include "llvm/IR/ValueMap.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -1629,9 +1630,11 @@ bool opossum::InlineFunction(CallSite CS, InlineFunctionInfo &IFI,
   Function::iterator FirstNewBlock;
 
   { // Scope to destroy VMap after cloning.
-    // TODO(Fabian) Check, if map is correctly copied
     ValueToValueMapTy VMap;
-    VMap.insert(Context.llvm_value_map.begin(), Context.llvm_value_map.end());
+    // key_value is const to ensure that values are copied and not moved during insert
+    for (const ValueToValueMapTy::value_type &key_value : Context.llvm_value_map) {
+      VMap.insert(key_value);
+    }
     // Keep a list of pair (dst, src) to emit byval initializations.
     SmallVector<std::pair<Value*, Value*>, 4> ByValInit;
 

--- a/src/lib/operators/jit_operator/specialization/llvm/InlineFunction.diff
+++ b/src/lib/operators/jit_operator/specialization/llvm/InlineFunction.diff
@@ -3,36 +3,39 @@
 > 
 > #include "../llvm_extensions.hpp"
 > 
-77c81
+58a63
+> #include "llvm/IR/ValueMap.h"
+77c82
 < EnableNoAliasConversion("enable-noalias-to-md-conversion", cl::init(true),
 ---
 > EnableNoAliasConversion("opossum-enable-noalias-to-md-conversion", cl::init(true),
-82c86
+82c87
 < PreserveAlignmentAssumptions("preserve-alignment-assumptions-during-inlining",
 ---
 > PreserveAlignmentAssumptions("opossum-preserve-alignment-assumptions-during-inlining",
-1492c1496
+1492c1497
 < bool llvm::InlineFunction(CallSite CS, InlineFunctionInfo &IFI,
 ---
 > bool opossum::InlineFunction(CallSite CS, InlineFunctionInfo &IFI,
-1494c1498,1499
+1494c1499,1500
 <                           Function *ForwardVarArgsTo) {
 ---
 >                           Function *ForwardVarArgsTo,
 >                           opossum::SpecializationContext& Context) {
-1626a1632
->     // TODO(Fabian) Check, if map is correctly copied
-1627a1634
->     VMap.insert(Context.llvm_value_map.begin(), Context.llvm_value_map.end());
-1667c1674
+1627a1634,1637
+>     // key_value is const to ensure that values are copied and not moved during insert
+>     for (const ValueToValueMapTy::value_type &key_value : Context.llvm_value_map) {
+>       VMap.insert(key_value);
+>     }
+1667c1677
 <     CloneAndPruneFunctionInto(Caller, CalledFunc, VMap,
 ---
 >     opossum::CloneAndPruneFunctionInto(Caller, CalledFunc, VMap,
-1669c1676
+1669c1679
 <                               &InlinedFunctionInfo, TheCall);
 ---
 >                               &InlinedFunctionInfo, TheCall, Context);
-2339a2347,2350
+2339a2350,2353
 > 
 > template constexpr bool llvm::DominatorTreeBase<llvm::BasicBlock, false>::IsPostDominator;
 > 

--- a/src/lib/operators/jit_operator/specialization/llvm_extensions.cpp
+++ b/src/lib/operators/jit_operator/specialization/llvm_extensions.cpp
@@ -5,6 +5,8 @@
 
 #include <unordered_set>
 
+#include "jit_runtime_pointer.hpp"
+
 namespace opossum {
 
 const std::shared_ptr<const JitRuntimePointer>& GetRuntimePointerForValue(const llvm::Value* value,
@@ -104,8 +106,6 @@ llvm::Constant* ConstantFoldInstruction(llvm::Instruction* inst, llvm::ArrayRef<
   return llvm::ConstantFoldInstOperands(inst, operands, data_layout, target_library_info);
 }
 
-// Undefined Behavior Sanitizer disabled for alignment to prevent false positive through reinterpret_cast.
-__attribute__((no_sanitize("alignment")))
 llvm::Constant* ResolveConditionRec(llvm::Value* value, SpecializationContext& context,
                                     std::unordered_set<llvm::Value*>& failed) {
   // If resolving the value failed already we fail early here
@@ -125,8 +125,7 @@ llvm::Constant* ResolveConditionRec(llvm::Value* value, SpecializationContext& c
       const auto address = runtime_pointer->address();
       const auto int_type = llvm::dyn_cast<llvm::IntegerType>(load->getType());
       const auto bit_width = int_type->getIntegerBitWidth();
-      const auto mask = bit_width == 64 ? 0xffffffffffffffff : (static_cast<uint64_t>(1) << bit_width) - 1;
-      const auto value = *reinterpret_cast<uint64_t*>(address) & mask;
+      const auto value = dereference_flexible_width_int_pointer(address, bit_width);
       return llvm::ConstantInt::get(int_type, value, int_type->getSignBit() > 0);
     }
   } else if (auto inst = llvm::dyn_cast<llvm::Instruction>(value)) {

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -127,7 +127,7 @@ TEST_F(JitOperatorWrapperTest, JitOperatorsSpecializedWithMultipleInliningOfSame
   // First the compute function call with the object "expression" is inlined,
   // then the two function calls with the two time referenced object "column_expression" are inlined.
 
-  // Specialize SQL query: SELECT a+a FROM src/test/tables/10_ints.tbl
+  // Specialize SQL query: SELECT a+a FROM src/test/tables/10_ints.tbl;
 
   // read column a into jit tuple at index 0
   auto read_operator = std::make_shared<JitReadTuples>();
@@ -140,7 +140,7 @@ TEST_F(JitOperatorWrapperTest, JitOperatorsSpecializedWithMultipleInliningOfSame
   auto expression = std::make_shared<JitExpression>(column_expression, add_type, column_expression, result_tuple_index);
   auto compute_operator = std::make_shared<JitCompute>(expression);
 
-  // copy value from index 1 from to output table for non-jit operators
+  // copy computed value from jit tuple at index 1 to output table for non-jit operators
   auto write_operator = std::make_shared<JitWriteTuples>();
   write_operator->add_output_column("a+a", expression->result());
 

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -132,7 +132,7 @@ TEST_F(JitOperatorWrapperTest, JitOperatorsSpecializedWithMultipleInliningOfSame
   // compute a+a
   auto column_expression = std::make_shared<JitExpression>(tuple_value);
   auto add_type = ExpressionType::Addition;
-  size_t result_tuple_index = 1;  // of jit runtime context
+  auto result_tuple_index = read_operator->add_temporary_value();  // of jit runtime context
   auto expression = std::make_shared<JitExpression>(column_expression, add_type, column_expression, result_tuple_index);
   auto compute_operator = std::make_shared<JitCompute>(expression);
 

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -1,6 +1,8 @@
 #include <gmock/gmock.h>
 
 #include "../base_test.hpp"
+#include "operators/jit_operator/operators/jit_compute.cpp"
+#include "operators/jit_operator/operators/jit_expression.hpp"
 #include "operators/jit_operator/operators/jit_filter.hpp"
 #include "operators/jit_operator/operators/jit_read_tuples.hpp"
 #include "operators/jit_operator/operators/jit_write_tuples.hpp"
@@ -118,6 +120,35 @@ TEST_F(JitOperatorWrapperTest, CallsJitOperatorHooks) {
   jit_operator_wrapper.add_jit_operator(source);
   jit_operator_wrapper.add_jit_operator(sink);
   jit_operator_wrapper.execute();
+}
+
+TEST_F(JitOperatorWrapperTest, JitOperatorsSpecializedWithMultipleInliningOfSameFunction) {
+  // Specialize SQL query: SELECT a+a FROM src/test/tables/10_ints.tbl
+
+  // read column a into jit tuple
+  auto read_operator = std::make_shared<JitReadTuples>();
+  auto tuple_value = read_operator->add_input_column(DataType::Int, false, ColumnID(0));
+
+  // compute a+a
+  auto column_expression = std::make_shared<JitExpression>(tuple_value);
+  auto add_type = ExpressionType::Addition;
+  size_t result_tuple_index = 1;  // of jit runtime context
+  auto expression = std::make_shared<JitExpression>(column_expression, add_type, column_expression, result_tuple_index);
+  auto compute_operator = std::make_shared<JitCompute>(expression);
+
+  // make result accessible to non-jit operators
+  auto write_operator = std::make_shared<JitWriteTuples>();
+  write_operator->add_output_column("a+a", expression->result());
+
+  JitOperatorWrapper jit_operator_wrapper(_int_table_wrapper, JitExecutionMode::Compile);
+  jit_operator_wrapper.add_jit_operator(read_operator);
+  jit_operator_wrapper.add_jit_operator(compute_operator);
+  jit_operator_wrapper.add_jit_operator(write_operator);
+
+  ASSERT_NO_THROW(jit_operator_wrapper.execute());
+
+  auto result = jit_operator_wrapper.get_output();
+  ASSERT_EQ(result->get_value<int>(ColumnID(0), 1), 48);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
Removed null ptr issue in LLVM6 during execution of specialised jit code by clearing a `runtime_value_map` after inlining of each function.
The map caches the retrieved runtime values during function inlining. This lead to a problem when a function was inlined multiple times with different objects. The programme execution path depends on the context objects as they determine which path is taken at a condition or switch statement. Inlining and specialising a function with the wrong information can, therefore, cause as in our case the dereferenciation of null pointers.

The specialisation test case takes on my MacBook 276ms. I hope that is still acceptable as it is the only time that a query is actually specialised in the test cases.

Closes #911 .