### PR TITLE
TableScan: Don't copy PosLists

### DIFF
--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -93,7 +93,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
     auto job_task = std::make_shared<JobTask>([=, &output_mutex]() {
       const auto chunk_guard = _in_table->get_chunk_with_access_counting(chunk_id);
       // The actual scan happens in the sub classes of BaseTableScanImpl
-      const auto matches_out = std::make_shared<PosList>(_impl->scan_chunk(chunk_id));
+      const auto matches_out = _impl->scan_chunk(chunk_id);
       if (matches_out->empty()) return;
 
       // The ChunkAccessCounter is reused to track accesses of the output chunk. Accesses of derived chunks are counted

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.cpp
@@ -18,12 +18,12 @@ BaseSingleColumnTableScanImpl::BaseSingleColumnTableScanImpl(std::shared_ptr<con
                                                              const PredicateCondition predicate_condition)
     : BaseTableScanImpl{in_table, left_column_id, predicate_condition} {}
 
-PosList BaseSingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
+std::shared_ptr<PosList> BaseSingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
   const auto chunk = _in_table->get_chunk(chunk_id);
   const auto left_column = chunk->get_column(_left_column_id);
 
-  auto matches_out = PosList{};
-  auto context = std::make_shared<Context>(chunk_id, matches_out);
+  auto matches_out = std::make_shared<PosList>();
+  auto context = std::make_shared<Context>(chunk_id, *matches_out);
 
   left_column->visit(*this, context);
 

--- a/src/lib/operators/table_scan/base_single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_single_column_table_scan_impl.hpp
@@ -28,7 +28,7 @@ class BaseSingleColumnTableScanImpl : public BaseTableScanImpl, public ColumnVis
   BaseSingleColumnTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
                                 const PredicateCondition predicate_condition);
 
-  PosList scan_chunk(ChunkID chunk_id) override;
+  std::shared_ptr<PosList> scan_chunk(ChunkID chunk_id) override;
 
   void handle_column(const ReferenceColumn& left_column, std::shared_ptr<ColumnVisitableContext> base_context) override;
 

--- a/src/lib/operators/table_scan/base_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_table_scan_impl.hpp
@@ -21,7 +21,7 @@ class BaseTableScanImpl {
 
   virtual ~BaseTableScanImpl() = default;
 
-  virtual PosList scan_chunk(ChunkID chunk_id) = 0;
+  virtual std::shared_ptr<PosList> scan_chunk(ChunkID chunk_id) = 0;
 
  protected:
   /**

--- a/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
@@ -21,13 +21,13 @@ ColumnComparisonTableScanImpl::ColumnComparisonTableScanImpl(std::shared_ptr<con
                                                              const ColumnID right_column_id)
     : BaseTableScanImpl{in_table, left_column_id, predicate_condition}, _right_column_id{right_column_id} {}
 
-PosList ColumnComparisonTableScanImpl::scan_chunk(ChunkID chunk_id) {
+std::shared_ptr<PosList> ColumnComparisonTableScanImpl::scan_chunk(ChunkID chunk_id) {
   const auto chunk = _in_table->get_chunk(chunk_id);
 
   const auto left_column = chunk->get_column(_left_column_id);
   const auto right_column = chunk->get_column(_right_column_id);
 
-  auto matches_out = PosList{};
+  auto matches_out = std::make_shared<PosList>();
 
   resolve_data_and_column_type(*left_column, [&](auto left_type, auto& typed_left_column) {
     resolve_data_and_column_type(*right_column, [&](auto right_type, auto& typed_right_column) {
@@ -68,7 +68,7 @@ PosList ColumnComparisonTableScanImpl::scan_chunk(ChunkID chunk_id) {
         left_column_iterable.with_iterators([&](auto left_it, auto left_end) {
           right_column_iterable.with_iterators([&](auto right_it, auto right_end) {
             with_comparator(_predicate_condition, [&](auto comparator) {
-              this->_binary_scan(comparator, left_it, left_end, right_it, chunk_id, matches_out);
+              this->_binary_scan(comparator, left_it, left_end, right_it, chunk_id, *matches_out);
             });
           });
         });

--- a/src/lib/operators/table_scan/column_comparison_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_comparison_table_scan_impl.hpp
@@ -27,7 +27,7 @@ class ColumnComparisonTableScanImpl : public BaseTableScanImpl {
   ColumnComparisonTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
                                 const PredicateCondition& predicate_condition, const ColumnID right_column_id);
 
-  PosList scan_chunk(ChunkID chunk_id) override;
+  std::shared_ptr<PosList> scan_chunk(ChunkID chunk_id) override;
 
  private:
   const ColumnID _right_column_id;

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.cpp
@@ -21,7 +21,7 @@ SingleColumnTableScanImpl::SingleColumnTableScanImpl(std::shared_ptr<const Table
                                                      const AllTypeVariant& right_value)
     : BaseSingleColumnTableScanImpl{in_table, left_column_id, predicate_condition}, _right_value{right_value} {}
 
-PosList SingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
+std::shared_ptr<PosList> SingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
   // early outs for specific NULL semantics
   if (variant_is_null(_right_value)) {
     /**
@@ -30,7 +30,7 @@ PosList SingleColumnTableScanImpl::scan_chunk(ChunkID chunk_id) {
      * Because OpIsNull/OpIsNotNull are handled separately in IsNullTableScanImpl,
      * we can assume that comparing with NULLs here will always return nothing.
      */
-    return PosList{};
+    return std::make_shared<PosList>();
   }
 
   return BaseSingleColumnTableScanImpl::scan_chunk(chunk_id);

--- a/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/single_column_table_scan_impl.hpp
@@ -26,7 +26,7 @@ class SingleColumnTableScanImpl : public BaseSingleColumnTableScanImpl {
   SingleColumnTableScanImpl(std::shared_ptr<const Table> in_table, const ColumnID left_column_id,
                             const PredicateCondition& predicate_condition, const AllTypeVariant& right_value);
 
-  PosList scan_chunk(ChunkID) override;
+  std::shared_ptr<PosList> scan_chunk(ChunkID) override;
 
   void handle_column(const BaseValueColumn& base_column, std::shared_ptr<ColumnVisitableContext> base_context) override;
 


### PR DESCRIPTION
Currently, TableScanImpls return a PosList by value. However, the TableScan needs them as `shared_ptr<PosList>` in order to build the output. Now, we avoid copying that PosList after scanning each chunk.

Don't expect any wonders to happen. This just bugged me a lot.
```
 Benchmark | prev. iter/s | new iter/s | change                                                                       
-----------+--------------+------------+--------------
 TPC-H 1   | 0            | 0          | +0% 
 TPC-H 3   | 0            | 0          | +2% 
 TPC-H 5   | 0            | 0          | +1% 
 TPC-H 6   | 3            | 3          | +2% 
 TPC-H 7   | 0            | 0          | -0% 
 TPC-H 9   | 0            | 0          | +2% 
 TPC-H 10  | 0            | 0          | +2% 
 TPC-H 13  | 0            | 0          | +3% 
 average   |              |            | +2% 
```