### PR TITLE
Remove table names from jit aggregate column names

### DIFF
--- a/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
@@ -420,24 +420,24 @@ TEST_F(JitAwareLQPTranslatorTest, AggregateOperator) {
   const auto aggregate_columns = jit_aggregate->aggregate_columns();
   ASSERT_EQ(aggregate_columns.size(), 5u);
 
-  ASSERT_EQ(aggregate_columns[0].column_name, "COUNT(table_a.a)");
+  ASSERT_EQ(aggregate_columns[0].column_name, "COUNT(a)");
   ASSERT_EQ(aggregate_columns[0].function, AggregateFunction::Count);
   ASSERT_EQ(jit_read_tuples->find_input_column(aggregate_columns[0].tuple_value), ColumnID{0});
 
-  ASSERT_EQ(aggregate_columns[1].column_name, "SUM(table_a.b)");
+  ASSERT_EQ(aggregate_columns[1].column_name, "SUM(b)");
   ASSERT_EQ(aggregate_columns[1].function, AggregateFunction::Sum);
   ASSERT_EQ(jit_read_tuples->find_input_column(aggregate_columns[1].tuple_value), ColumnID{1});
 
-  ASSERT_EQ(aggregate_columns[2].column_name, "AVG(table_a.a + table_a.b)");
+  ASSERT_EQ(aggregate_columns[2].column_name, "AVG(a + b)");
   ASSERT_EQ(aggregate_columns[2].function, AggregateFunction::Avg);
   // This aggregate function should operates on the result of the previously computed expression
   ASSERT_EQ(aggregate_columns[2].tuple_value, expression->result());
 
-  ASSERT_EQ(aggregate_columns[3].column_name, "MIN(table_a.a)");
+  ASSERT_EQ(aggregate_columns[3].column_name, "MIN(a)");
   ASSERT_EQ(aggregate_columns[3].function, AggregateFunction::Min);
   ASSERT_EQ(jit_read_tuples->find_input_column(aggregate_columns[3].tuple_value), ColumnID{0});
 
-  ASSERT_EQ(aggregate_columns[4].column_name, "MAX(table_a.b)");
+  ASSERT_EQ(aggregate_columns[4].column_name, "MAX(b)");
   ASSERT_EQ(aggregate_columns[4].function, AggregateFunction::Max);
   ASSERT_EQ(jit_read_tuples->find_input_column(aggregate_columns[4].tuple_value), ColumnID{1});
 }

--- a/src/test/operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp
+++ b/src/test/operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp
@@ -87,7 +87,6 @@ class GetRuntimePointerForValueTest : public BaseTest {
     assert_address_eq(GetRuntimePointerForValue(_value_7, _context), reinterpret_cast<uint64_t>(some_pointer_1));
   }
 
-
   std::shared_ptr<llvm::LLVMContext> _llvm_context;
   SpecializationContext _context;
   llvm::Value* _value_0;
@@ -100,9 +99,7 @@ class GetRuntimePointerForValueTest : public BaseTest {
   llvm::Value* _value_7;
 };
 
-TEST_F(GetRuntimePointerForValueTest, BitcodePointerInstructionsAreProperlySimulated) {
-  bitcode_pointer_test();
-}
+TEST_F(GetRuntimePointerForValueTest, BitcodePointerInstructionsAreProperlySimulated) { bitcode_pointer_test(); }
 
 TEST_F(GetRuntimePointerForValueTest, RuntimePointersAreInvalidWithoutInitialAddress) {
   //

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -100,7 +100,7 @@ TEST_P(SQLiteTestRunner, CompareToSQLite) {
 
   std::shared_ptr<LQPTranslator> lqp_translator;
   if (use_jit) {
-    if constexpr(HYRISE_JIT_SUPPORT) {
+    if constexpr (HYRISE_JIT_SUPPORT) {
       lqp_translator = std::make_shared<JitAwareLQPTranslator>();
     }
   } else {

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -67,7 +67,7 @@ TEST_P(TPCHTest, TPCHQueryTest) {
 
   std::shared_ptr<LQPTranslator> lqp_translator;
   if (use_jit) {
-    if constexpr(HYRISE_JIT_SUPPORT) {
+    if constexpr (HYRISE_JIT_SUPPORT) {
       lqp_translator = std::make_shared<JitAwareLQPTranslator>();
     }
   } else {


### PR DESCRIPTION
This pr removes the table names from jit aggregate column names.
The issue is solved slightly different to the traditional hyrise aggregate operator as the column names should be known at translation time. The traditional hyrise operator takes the column name from the result of the previous operator which is not available during translation.

Code is also formatted.
