### PR TITLE
Selective CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,20 +1,20 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
-// Cancel previous builds
-def jobname = env.JOB_NAME
-def buildnum = env.BUILD_NUMBER.toInteger()
-def job = Jenkins.instance.getItemByFullName(jobname)
- for (build in job.builds) {
-  if (!build.isBuilding()) { continue; }
-  if (buildnum == build.getNumber().toInteger()) { continue; } 
-  echo "Cancelling previous build " + build.getNumber().toString()
-  build.doStop();
-}
-
 node {
   stage ("Start") {
     script {
       githubNotify context: 'CI Pipeline', status: 'PENDING'
+
+      // Cancel previous builds
+      def jobname = env.JOB_NAME
+      def buildnum = env.BUILD_NUMBER.toInteger()
+      def job = Jenkins.instance.getItemByFullName(jobname)
+       for (build in job.builds) {
+        if (!build.isBuilding()) { continue; }
+        if (buildnum == build.getNumber().toInteger()) { continue; } 
+        echo "Cancelling previous build " + build.getNumber().toString()
+        build.doStop();
+      }
     }
   }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,10 +16,7 @@ node {
     try {
       stage("Setup") {
         checkout scm
-        echo "-----"
-        echo ">>> " + sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true)[0] == 't' + "<<<"
-        echo "-----"
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true)[0] == "t"
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def job = Jenkins.instance.getItemByFullName(jobname)
  for (build in job.builds) {
   if (!build.isBuilding()) { continue; }
   echo "_____"
-  echo env.BUILD_NUMBER
+  sys("export")
   // echo build.getNumber().toInteger()
   if (buildnum == build.getNumber().toInteger()) { continue; } 
   build.doStop();

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,11 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 def jobname = env.JOB_NAME
 def buildnum = env.BUILD_NUMBER.toInteger()
 def job = Jenkins.instance.getItemByFullName(jobname)
-for (build in job.builds) {
+ for (build in job.builds) {
   if (!build.isBuilding()) { continue; }
+  echo "_____"
+  echo buildnum
+  echo build.getNumber().toInteger()
   if (buildnum == build.getNumber().toInteger()) { continue; } 
   build.doStop();
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,10 +30,12 @@ node {
         full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) == "true"
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
+        mkdir clang-debug-tidy && cd clang-debug-tidy && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\
         mkdir clang-release-sanitizers && cd clang-release-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\
         mkdir clang-release && cd clang-release && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 .. &\
         mkdir clang-release-sanitizers-no-numa && cd clang-release-sanitizers-no-numa && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
+        mkdir gcc-debug && cd gcc-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         wait"
       }
@@ -70,7 +72,15 @@ node {
             sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
           } else {
             Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+          }
         }
+      }, clangDebugTidy: {
+        stage("clang-debug:tidy") {
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-tidy && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          } else {
+            Utils.markStageSkippedForConditional("clangDebugTidy")
+          }
         }
       }, clangDebugSanitizers: {
         stage("clang-debug:sanitizers") {
@@ -80,6 +90,11 @@ node {
           } else {
             Utils.markStageSkippedForConditional("clangDebugSanitizers")
           }
+        }
+      }, gccDebug: {
+        stage("gcc-debug") {
+          sh "export CCACHE_BASEDIR=`pwd`; cd gcc-debug && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+          sh "./gcc-debug/hyriseTest gcc-debug"
         }
       }, gccRelease: {
         if (env.BRANCH_NAME == 'master' || full_ci) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,9 @@ node {
     try {
       stage("Setup") {
         checkout scm
+        echo "-----"
+        echo sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim()
+        echo "-----"
         full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
     try {
       stage("Setup") {
         checkout scm
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == 'true'
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,6 @@ def buildnum = env.BUILD_NUMBER.toInteger()
 def job = Jenkins.instance.getItemByFullName(jobname)
  for (build in job.builds) {
   if (!build.isBuilding()) { continue; }
-  echo "_____"
-  echo env.BUILD_NUMBER
-  echo build.getNumber()
   if (buildnum == build.getNumber().toInteger()) { continue; } 
   echo "DO STOP"
   build.doStop();

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,6 @@ node {
     try {
       stage("Setup") {
         checkout scm
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) == "true"
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-tidy && cd clang-debug-tidy && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\
@@ -38,6 +37,7 @@ node {
         mkdir gcc-debug && cd gcc-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         wait"
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) == "true"
       }
 
       parallel clangRelease: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ def job = Jenkins.instance.getItemByFullName(jobname)
  for (build in job.builds) {
   if (!build.isBuilding()) { continue; }
   if (buildnum == build.getNumber().toInteger()) { continue; } 
-  echo "DO STOP"
+  echo "Cancelling previous build " + build.getNumber().toString()
   build.doStop();
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,5 @@
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+
 node {
   stage ("Start") {
     script {
@@ -14,8 +16,9 @@ node {
     try {
       stage("Setup") {
         checkout scm
+        full_ci = sh("./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).result.trim() == 'true'
         sh "./install.sh"
-        sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 .. &\
+        sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\
         mkdir clang-release-sanitizers && cd clang-release-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\
         mkdir clang-release && cd clang-release && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 .. &\
@@ -26,8 +29,12 @@ node {
 
       parallel clangRelease: {
         stage("clang-release") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "./clang-release/hyriseTest clang-release"
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "./clang-release/hyriseTest clang-release"
+          } else {
+            Utils.markStageSkippedForConditional("clangRelease")
+          }
         }
       }, clangDebugBuildOnly: {
         stage("clang-debug") {
@@ -47,66 +54,94 @@ node {
         }
       }, clangDebugRunShuffled: {
         stage("clang-debug:test-shuffle") {
-          sh "mkdir ./clang-debug/run-shuffled"
-          sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            sh "mkdir ./clang-debug/run-shuffled"
+            sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+          } else {
+            Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+        }
         }
       }, clangDebugSanitizers: {
         stage("clang-debug:sanitizers") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-debug-sanitizers/hyriseTest clang-debug-sanitizers"
+          } else {
+            Utils.markStageSkippedForConditional("clangDebugSanitizers")
+          }
         }
       }, gccRelease: {
-        stage("gcc-release") {
-          sh "export CCACHE_BASEDIR=`pwd`; cd gcc-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "./gcc-release/hyriseTest gcc-release"
+        if (env.BRANCH_NAME == 'master' || full_ci) {
+          stage("gcc-release") {
+            sh "export CCACHE_BASEDIR=`pwd`; cd gcc-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
+            sh "./gcc-release/hyriseTest gcc-release"
+          }
+        } else {
+            Utils.markStageSkippedForConditional("gccRelease")
+        }
+      }, clangSystemTestDebug: {
+        stage("System Test") {
+            sh "./clang-debug/hyriseSystemTest"
         }
       }, clangSystemTestRelease: {
-        stage("System Test") {
-            sh "./clang-release/hyriseSystemTest"
-        }
+        if (env.BRANCH_NAME == 'master' || full_ci) {
+          stage("System Test") {
+              sh "./clang-release/hyriseSystemTest"
+          }
+        } else {
+            Utils.markStageSkippedForConditional("clangSystemTestRelease")
+          }
       }, clangReleaseSanitizers: {
-        stage("clang-release:sanitizers (master only)") {
-          if (env.BRANCH_NAME == 'master') {
+        stage("clang-release:sanitizers") {
+          if (env.BRANCH_NAME == 'master' || full_ci) {
             sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
             sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers/hyriseTest clang-release-sanitizers"
           } else {
-            echo 'only on master'
+            Utils.markStageSkippedForConditional("clangReleaseSanitizers")
           }
         }
       }, clangReleaseSanitizersNoNuma: {
-        stage("clang-release:sanitizers w/o NUMA (master only)") {
-          if (env.BRANCH_NAME == 'master') {
+        stage("clang-release:sanitizers w/o NUMA") {
+          if (env.BRANCH_NAME == 'master' || full_ci) {
             sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-sanitizers-no-numa && make hyriseTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
             sh "LSAN_OPTIONS=suppressions=.lsan-ignore.txt ASAN_OPTIONS=suppressions=.asan-ignore.txt ./clang-release-sanitizers-no-numa/hyriseTest clang-release-sanitizers-no-numa"
           } else {
-            echo 'only on master'
+            Utils.markStageSkippedForConditional("clangReleaseSanitizersNoNuma")
           }
         }
       }, gccDebugCoverage: {
         stage("gcc-debug-coverage") {
-          sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --generate_badge=true --launcher=ccache"
-          archive 'coverage_badge.svg'
-          archive 'coverage_percent.txt'
-          archive 'coverage.xml'
-          archive 'coverage_diff.html'
-          publishHTML (target: [
-            allowMissing: false,
-            alwaysLinkToLastBuild: false,
-            keepAll: true,
-            reportDir: 'coverage',
-            reportFiles: 'index.html',
-            reportName: "RCov Report"
-          ])
-          script {
-            coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-            githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-            githubNotify context: 'Coverage Diff', description: "Click Details for diff", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/artifact/coverage_diff.html"
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --generate_badge=true --launcher=ccache"
+            archive 'coverage_badge.svg'
+            archive 'coverage_percent.txt'
+            archive 'coverage.xml'
+            archive 'coverage_diff.html'
+            publishHTML (target: [
+              allowMissing: false,
+              alwaysLinkToLastBuild: false,
+              keepAll: true,
+              reportDir: 'coverage',
+              reportFiles: 'index.html',
+              reportName: "RCov Report"
+            ])
+            script {
+              coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+              githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+              githubNotify context: 'Coverage Diff', description: "Click Details for diff", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/artifact/coverage_diff.html"
+            }
+          } else {
+            Utils.markStageSkippedForConditional("gccDebugCoverage")
           }
         }
-      }, memcheck: {
-        stage("valgrind-memcheck") {
-          sh "mkdir ./clang-release-memcheck"
-          sh "valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --gen-suppressions=all --suppressions=.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
+      }, memcheckClangRelease: {
+        stage("valgrind-memcheck-release") {
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            sh "mkdir ./clang-release-memcheck"
+            sh "valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --gen-suppressions=all --suppressions=.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
+          } else {
+            Utils.markStageSkippedForConditional("memcheckClangRelease")
+          }
         }
       }
 
@@ -114,6 +149,9 @@ node {
         // Clean up workspace.
         script {
           githubNotify context: 'CI Pipeline', status: 'SUCCESS'
+          if (env.BRANCH_NAME == 'master' || full_ci) {
+            githubNotify context: 'Full CI', status: 'SUCCESS'
+          }
         }
         step([$class: 'WsCleanup'])
       }
@@ -132,8 +170,5 @@ node {
       sh "ls -A1 | xargs rm -rf"
       deleteDir()
     }
-
   }
-
 }
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node {
         mkdir gcc-debug && cd gcc-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         wait"
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).strip() == "true"
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
       }
 
       parallel clangRelease: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ node {
     try {
       stage("Setup") {
         checkout scm
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true)[0] == "t"
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) == "true"
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
       stage("Setup") {
         checkout scm
         echo "-----"
-        echo sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim()
+        echo sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true)
         echo "-----"
         full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
         sh "./install.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
     try {
       stage("Setup") {
         checkout scm
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).result.trim() == 'true'
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == 'true'
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
       stage("Setup") {
         checkout scm
         echo "-----"
-        echo ">>> " + sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) + "<<<"
+        echo ">>> " + sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true)[0] == 't' + "<<<"
         echo "-----"
         full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
         sh "./install.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ node {
       stage("Setup") {
         checkout scm
         echo "-----"
-        echo sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true)
+        echo ">>> " + sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) + "<<<"
         echo "-----"
         full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).trim() == "true"
         sh "./install.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,8 +7,8 @@ def job = Jenkins.instance.getItemByFullName(jobname)
  for (build in job.builds) {
   if (!build.isBuilding()) { continue; }
   echo "_____"
-  echo buildnum
-  echo build.getNumber().toInteger()
+  echo env.BUILD_NUMBER
+  // echo build.getNumber().toInteger()
   if (buildnum == build.getNumber().toInteger()) { continue; } 
   build.doStop();
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,15 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
+// Cancel previous builds
+def jobname = env.JOB_NAME
+def buildnum = env.BUILD_NUMBER.toInteger()
+def job = Jenkins.instance.getItemByFullName(jobname)
+for (build in job.builds) {
+  if (!build.isBuilding()) { continue; }
+  if (buildnum == build.getNumber().toInteger()) { continue; } 
+  build.doStop();
+}
+
 node {
   stage ("Start") {
     script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ node {
         mkdir gcc-debug && cd gcc-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         mkdir gcc-release && cd gcc-release && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
         wait"
-        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true) == "true"
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).strip() == "true"
       }
 
       parallel clangRelease: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
     try {
       stage("Setup") {
         checkout scm
-        full_ci = sh("./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).result.trim() == 'true'
+        full_ci = sh(script: "./scripts/current_branch_has_pull_request_label.py FullCI", returnStdout: true).result.trim() == 'true'
         sh "./install.sh"
         sh "mkdir clang-debug && cd clang-debug && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_CLANG_TIDY=ON .. &\
         mkdir clang-debug-sanitizers && cd clang-debug-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=clang-6.0 -DCMAKE_CXX_COMPILER=clang++-6.0 -DENABLE_SANITIZATION=ON .. &\

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,9 +7,10 @@ def job = Jenkins.instance.getItemByFullName(jobname)
  for (build in job.builds) {
   if (!build.isBuilding()) { continue; }
   echo "_____"
-  sys("export")
-  // echo build.getNumber().toInteger()
+  echo env.BUILD_NUMBER
+  echo build.getNumber()
   if (buildnum == build.getNumber().toInteger()) { continue; } 
+  echo "DO STOP"
   build.doStop();
 }
 

--- a/scripts/current_branch_has_pull_request_label.py
+++ b/scripts/current_branch_has_pull_request_label.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# This is used by Jenkins - see Jenkinsfile
+
+import json
+import subprocess
+import sys
+try:
+    # For Python 3.0 and later
+    from urllib.request import urlopen
+except ImportError:
+    # Fall back to Python 2's urllib2
+    from urllib2 import urlopen
+
+if (len(sys.argv) != 2):
+	print("Usage: %s label" % (sys.argv[0]))
+	print("Returns whether the current commit belongs to a Github Pull Request that has a certain label")
+	sys.exit(-1)
+
+prs = json.loads(urlopen('https://api.github.com/repos/hyrise/hyrise/pulls').read())
+
+process = subprocess.Popen(['git', 'rev-parse', 'HEAD'], shell=False, stdout=subprocess.PIPE)
+git_head_hash = process.communicate()[0].strip()
+
+for pr in prs:
+	if (pr['head']['sha'] != git_head_hash.decode("utf-8")):
+		continue
+
+	pr_details = json.loads(urlopen('https://api.github.com/repos/hyrise/hyrise/pulls/%i' % (pr['number'])).read())
+
+	for label in pr_details['labels']:
+		if(label['name'] == sys.argv[1]):
+			print("true")
+	else:
+		print("false")
+	
+	break
+else:
+	print("No PR for current commit %s found" % (git_head_hash))

--- a/scripts/current_branch_has_pull_request_label.py
+++ b/scripts/current_branch_has_pull_request_label.py
@@ -31,9 +31,10 @@ for pr in prs:
 	for label in pr_details['labels']:
 		if(label['name'] == sys.argv[1]):
 			print("true")
+			sys.exit(0)
 	else:
 		print("false")
-	
-	break
+		sys.exit(0)
+
 else:
 	print("No PR for current commit %s found" % (git_head_hash))


### PR DESCRIPTION
Already, we do not execute all CI steps for PRs. This is to keep the CI build times and the load on the CI server low. Unfortunately, this means that we sometimes only see problems once we have merged the PR.

This introduces the GitHub Label `FullCI`. For PRs that do not have this tag, only selected CI steps are executed. Once you set `FullCI`, the same test suite as executed for the master is run. The idea is to only set that label once all changes have been done and all review comments have been addressed. This should be in your own interest, because now the build only takes around two minutes (if ccache has a good day).

Not setting `FullCI` does not keep you from getting a green tick, but only with `FullCI`, the PR is ready to be merged. Unfortunately, Jenkins is not (yet?) notified when we set a label, so you might want to rerun the label.

This will be helpful when we do more static code analysis (see #941) because that takes looong.

A push will now cancel running builds in the same PR, again to save time.

Also, I found a way to visualize skipped steps:

<img width="695" alt="screen shot 2018-06-28 at 21 32 58" src="https://user-images.githubusercontent.com/575106/42056725-715bcec0-7b1b-11e8-9599-270688edb4a4.png">
