### PR TITLE
Fix LTO, then make it optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ endif()
 
 # Link Time Optimization (LTO)
 cmake_policy(SET CMP0069 NEW)
-option(ENABLE_LTO "Set to ON to build Hyrise with enabled coverage checking. Default: OFF" OFF)
+option(ENABLE_LTO "Set to ON to build Hyrise with enabled Link Time Optimization (LTO). Default: OFF" OFF)
 if (${ENABLE_LTO})
     if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
         cmake_minimum_required(VERSION 3.9 FATAL_ERROR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,22 +64,6 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -march=native")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -march=native")
 
-# Link Time Optimization (LTO)
-if(CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
-    if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
-        cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
-        include(CheckIPOSupported)
-        check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
-        if(ipo_supported)
-            set(INTERPROCEDURAL_OPTIMIZATION TRUE)
-            add_definitions(-DWITH_LTO)
-            message(STATUS "Building with Link-Time Optimization")
-        else()
-            message(WARNING "LTO not supported: ${ipo_output}")
-        endif()
-    endif()
-endif()
-
 # Require NCurses over Curses
 set(CURSES_NEED_NCURSES TRUE)
 
@@ -113,9 +97,33 @@ if(${CI_BUILD})
     endif()
 endif()
 
+# Link Time Optimization (LTO)
+cmake_policy(SET CMP0069 NEW)
+option(ENABLE_LTO "Set to ON to build Hyrise with enabled coverage checking. Default: OFF" OFF)
+if (${ENABLE_LTO})
+    if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
+        cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+        include(CheckIPOSupported)
+        check_ipo_supported(RESULT ipo_supported OUTPUT ipo_output)
+        if(ipo_supported)
+            set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+            add_definitions(-DWITH_LTO)
+            message(STATUS "Building with Link-Time Optimization")
+        else()
+            message(WARNING "LTO not supported: ${ipo_output}")
+        endif()
+    endif()
+endif()
+
 # Include sub-CMakeLists.txt
 add_subdirectory(third_party/ EXCLUDE_FROM_ALL)
+
+# Some third-party libs don't support LTO (if enabled above):
+foreach(no_lto_target gtest gtest_main gmock gmock_main hpinuma_s hpinuma hpinuma_base_s hpinuma_base hpinuma_util_tool hpinuma_msource hpinuma_msource_s)
+    set_property(TARGET ${no_lto_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+endforeach(no_lto_target)
 add_subdirectory(src)
+
 
 # Useful for printing all c++ files in a directory:
 # find . -type f -name "*.cpp" -o -name "*.hpp" | cut -c 3- | sort

--- a/src/benchmarklib/benchmark_utils.cpp
+++ b/src/benchmarklib/benchmark_utils.cpp
@@ -419,11 +419,11 @@ The encoding is always required, the compression is optional.
   },
 
   "type": {
-    <DATA_TPYE>: {
+    <DATA_TYPE>: {
       "encoding": <ENCODING_TYPE_STRING>,
       "compression": <VECTOR_COMPRESSION_TYPE_STRING>
     },
-    <DATA_TPYE>: {
+    <DATA_TYPE>: {
       "encoding": <ENCODING_TYPE_STRING>
     }
   },

--- a/src/lib/utils/performance_warning.hpp
+++ b/src/lib/utils/performance_warning.hpp
@@ -29,7 +29,7 @@ class PerformanceWarningClass {
  public:
   explicit PerformanceWarningClass(const std::string& text) {
     if (_disabled) return;
-    std::cout << "[PERF] " << text << "\n\tPerformance can be affected. This warning is only shown once.\n"
+    std::cerr << "[PERF] " << text << "\n\tPerformance can be affected. This warning is only shown once.\n"
               << std::endl;
   }
 


### PR DESCRIPTION
First of all, LTO does not work right now. This is fixed with this PR. However, various benchmarks on different machines have shown that LTO does not have a significant advantage right now. Let's make it optional for now.

Also, this changes the performance warnings to `cerr`, so that we can get the JSON file of a benchmark by doing `./hyriseBenchmarkTPCH > bla.json` and call the compare script.