### PR TITLE
Make HashJoin build fast again

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -85,7 +85,510 @@ void JoinHash::_on_cleanup() { _impl.reset(); }
 // currently using 32bit Murmur
 using Hash = uint32_t;
 
-// We need to use the impl pattern because the join operator depends on the type of the columns
+/*
+This is how elements of the input relations are saved after materialization.
+The original value is used to detect hash collisions.
+*/
+template <typename T>
+struct PartitionedElement {
+  PartitionedElement() : row_id(NULL_ROW_ID), partition_hash(0), value(T()) {}
+  PartitionedElement(RowID row, Hash hash, T val) : row_id(row), partition_hash(hash), value(val) {}
+
+  RowID row_id;
+  Hash partition_hash;
+  T value;
+};
+
+template <typename T>
+using Partition = std::vector<PartitionedElement<T>>;
+
+/*
+This struct contains radix-partitioned data in a contiguous buffer,
+as well as a list of offsets for each partition.
+*/
+template <typename T>
+struct RadixContainer {
+  std::shared_ptr<Partition<T>> elements;
+  std::vector<size_t> partition_offsets;
+};
+
+/*
+Build all the hash tables for the partitions of Left. We parallelize this process for all partitions of Left
+*/
+template <typename LeftType, typename HashedType>
+std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<LeftType>& radix_container) {
+  /*
+  NUMA notes:
+  The hashtables for each partition P should also reside on the same node as the two vectors leftP and rightP.
+  */
+  std::vector<std::shared_ptr<HashTable<HashedType>>> hashtables;
+  hashtables.resize(radix_container.partition_offsets.size() - 1);
+
+  std::vector<std::shared_ptr<AbstractTask>> jobs;
+  jobs.reserve(radix_container.partition_offsets.size() - 1);
+
+  for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
+       ++current_partition_id) {
+    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
+      auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
+      const auto& partition_left_begin = radix_container.partition_offsets[current_partition_id];
+      const auto& partition_left_end = radix_container.partition_offsets[current_partition_id + 1];
+      const auto partition_size = partition_left_end - partition_left_begin;
+
+      // Prune empty partitions, so that we don't have too many empty hash tables
+      if (partition_size == 0) {
+        return;
+      }
+
+      auto hashtable = std::make_shared<HashTable<HashedType>>(partition_size);
+
+      for (size_t partition_offset = partition_left_begin; partition_offset < partition_left_end; ++partition_offset) {
+        auto& element = partition_left[partition_offset];
+
+        hashtable->put(type_cast<HashedType>(element.value), element.row_id);
+      }
+
+      hashtables[current_partition_id] = hashtable;
+    }));
+    jobs.back()->schedule();
+  }
+
+  CurrentScheduler::wait_for_tasks(jobs);
+
+  return std::move(hashtables);
+}
+
+/*
+Hashes the given value into the HashedType that is defined by the current Hash Traits.
+Performs a lexical cast first, if necessary.
+*/
+template <typename OriginalType, typename HashedType>
+constexpr uint32_t hash_value(OriginalType& value, const unsigned int seed) {
+  // clang-format off
+  // doesn't deal with constexpr nicely
+  if constexpr(!std::is_same_v<OriginalType, HashedType>) {
+    return murmur2<HashedType>(type_cast<HashedType>(value), seed);
+  } else {
+    return murmur2<HashedType>(value, seed);
+  }
+  // clang-format on
+}
+
+template <typename T, typename HashedType>
+std::shared_ptr<Partition<T>> materialize_input(const std::shared_ptr<const Table> in_table, ColumnID column_id,
+                                                std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
+                                                const size_t radix_bits, const unsigned int partitioning_seed,
+                                                bool keep_nulls = false) {
+  // list of all elements that will be partitioned
+  auto elements = std::make_shared<Partition<T>>();
+  elements->resize(in_table->row_count());
+
+  // fan-out
+  const size_t num_partitions = 1 << radix_bits;
+
+  // currently, we just do one pass
+  size_t pass = 0;
+  size_t mask = static_cast<uint32_t>(pow(2, radix_bits * (pass + 1)) - 1);
+
+  auto chunk_offsets = std::vector<size_t>(in_table->chunk_count());
+
+  // fill work queue
+  size_t output_offset = 0;
+  for (ChunkID chunk_id{0}; chunk_id < in_table->chunk_count(); chunk_id++) {
+    auto column = in_table->get_chunk(chunk_id)->get_column(column_id);
+
+    chunk_offsets[chunk_id] = output_offset;
+    output_offset += column->size();
+  }
+
+  // create histograms per chunk
+  histograms = std::vector<std::shared_ptr<std::vector<size_t>>>();
+  histograms.resize(chunk_offsets.size());
+
+  std::vector<std::shared_ptr<AbstractTask>> jobs;
+  jobs.reserve(in_table->chunk_count());
+
+  for (ChunkID chunk_id{0}; chunk_id < in_table->chunk_count(); ++chunk_id) {
+    jobs.emplace_back(std::make_shared<JobTask>([&, chunk_id]() {
+      // Get information from work queue
+      auto output_offset = chunk_offsets[chunk_id];
+      auto column = in_table->get_chunk(chunk_id)->get_column(column_id);
+      auto& output = static_cast<Partition<T>&>(*elements);
+
+      // prepare histogram
+      histograms[chunk_id] = std::make_shared<std::vector<size_t>>(num_partitions);
+
+      auto& histogram = static_cast<std::vector<size_t>&>(*histograms[chunk_id]);
+
+      auto materialized_chunk = std::vector<std::pair<RowID, T>>();
+
+      // Materialize the chunk
+      resolve_column_type<T>(*column, [&, chunk_id, keep_nulls](auto& typed_column) {
+        auto iterable = create_iterable_from_column<T>(typed_column);
+
+        iterable.for_each([&, chunk_id, keep_nulls](const auto& value) {
+          if (!value.is_null() || keep_nulls) {
+            materialized_chunk.emplace_back(RowID{chunk_id, value.chunk_offset()}, value.value());
+          } else {
+            // We need to add this to avoid gaps in the list of offsets when we iterate later on
+            materialized_chunk.emplace_back(NULL_ROW_ID, T{});
+          }
+        });
+      });
+
+      size_t row_id = output_offset;
+
+      /*
+      For ReferenceColumns we do not use the RowIDs from the referenced tables.
+      Instead, we use the index in the ReferenceColumn itself. This way we can later correctly dereference
+      values from different inputs (important for Multi Joins).
+      For performance reasons this if statement is around the for loop.
+      */
+      if (auto ref_column = std::dynamic_pointer_cast<const ReferenceColumn>(column)) {
+        // hash and add to the other elements
+        ChunkOffset offset = 0;
+        for (auto&& elem : materialized_chunk) {
+          if (elem.first.chunk_offset != INVALID_CHUNK_OFFSET) {
+            uint32_t hashed_value = hash_value<T, HashedType>(elem.second, partitioning_seed);
+            output[row_id] = PartitionedElement<T>{RowID{chunk_id, offset}, hashed_value, elem.second};
+
+            const Hash radix = (output[row_id].partition_hash >> (32 - radix_bits * (pass + 1))) & mask;
+            histogram[radix]++;
+
+            row_id++;
+          }
+
+          offset++;
+        }
+      } else {
+        // hash and add to the other elements
+        for (auto&& elem : materialized_chunk) {
+          if (elem.first.chunk_offset == INVALID_CHUNK_OFFSET) continue;
+
+          uint32_t hashed_value = hash_value<T, HashedType>(elem.second, partitioning_seed);
+          output[row_id] = PartitionedElement<T>{elem.first, hashed_value, elem.second};
+
+          const Hash radix = (output[row_id].partition_hash >> (32 - radix_bits * (pass + 1))) & mask;
+          histogram[radix]++;
+
+          row_id++;
+        }
+      }
+    }));
+    jobs.back()->schedule();
+  }
+
+  CurrentScheduler::wait_for_tasks(jobs);
+
+  return elements;
+}
+
+template <typename T>
+RadixContainer<T> partition_radix_parallel(std::shared_ptr<Partition<T>> materialized,
+                                           std::shared_ptr<std::vector<size_t>> chunk_offsets,
+                                           std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
+                                           const size_t radix_bits, bool keep_nulls = false) {
+  // fan-out
+  const size_t num_partitions = 1 << radix_bits;
+
+  // currently, we just do one pass
+  size_t pass = 0;
+  size_t mask = static_cast<uint32_t>(pow(2, radix_bits * (pass + 1)) - 1);
+
+  // allocate new (shared) output
+  auto output = std::make_shared<Partition<T>>();
+  output->resize(materialized->size());
+
+  auto& offsets = static_cast<std::vector<size_t>&>(*chunk_offsets);
+
+  RadixContainer<T> radix_output;
+  radix_output.elements = output;
+  radix_output.partition_offsets.resize(num_partitions + 1);
+
+  // use histograms to calculate partition offsets
+  size_t offset = 0;
+  std::vector<std::vector<size_t>> output_offsets_by_chunk(offsets.size(), std::vector<size_t>(num_partitions));
+  for (size_t partition_id = 0; partition_id < num_partitions; ++partition_id) {
+    radix_output.partition_offsets[partition_id] = offset;
+    for (ChunkID chunk_id{0}; chunk_id < offsets.size(); ++chunk_id) {
+      output_offsets_by_chunk[chunk_id][partition_id] = offset;
+      offset += (*histograms[chunk_id])[partition_id];
+    }
+  }
+  radix_output.partition_offsets[num_partitions] = offset;
+
+  std::vector<std::shared_ptr<AbstractTask>> jobs;
+  jobs.reserve(offsets.size());
+
+  for (ChunkID chunk_id{0}; chunk_id < offsets.size(); ++chunk_id) {
+    jobs.emplace_back(std::make_shared<JobTask>([&, chunk_id]() {
+      size_t input_offset = offsets[chunk_id];
+      auto& output_offsets = output_offsets_by_chunk[chunk_id];
+
+      size_t input_size = 0;
+      if (chunk_id < offsets.size() - 1) {
+        input_size = offsets[chunk_id + 1] - input_offset;
+      } else {
+        input_size = materialized->size() - input_offset;
+      }
+
+      auto& out = static_cast<Partition<T>&>(*output);
+      for (size_t column_offset = input_offset; column_offset < input_offset + input_size; ++column_offset) {
+        auto& element = (*materialized)[column_offset];
+
+        if (!keep_nulls && element.row_id.chunk_offset == INVALID_CHUNK_OFFSET) {
+          continue;
+        }
+
+        const size_t radix = (element.partition_hash >> (32 - radix_bits * (pass + 1))) & mask;
+
+        out[output_offsets[radix]++] = element;
+      }
+    }));
+    jobs.back()->schedule();
+  }
+
+  CurrentScheduler::wait_for_tasks(jobs);
+
+  return radix_output;
+}
+
+/*
+  In the probe phase we take all partitions from the right partition, iterate over them and compare each join candidate
+  with the values in the hash table. Since Left and Right are hashed using the same hash function, we can reduce the
+  number of hash tables that need to be looked into to just 1.
+  */
+template <typename RightType, typename HashedType>
+void probe(const RadixContainer<RightType>& radix_container,
+           const std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables, std::vector<PosList>& pos_list_left,
+           std::vector<PosList>& pos_list_right, const JoinMode mode) {
+  std::vector<std::shared_ptr<AbstractTask>> jobs;
+  jobs.reserve(radix_container.partition_offsets.size() - 1);
+
+  /*
+    NUMA notes:
+    At this point both input relations are partitioned using radix partitioning.
+    Probing will be done per partition for both sides.
+    Therefore, inputs for one partition should be located on the same NUMA node,
+    and the job that probes that partition should also be on that NUMA node.
+    */
+
+  for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
+       ++current_partition_id) {
+    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
+      // Get information from work queue
+      auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
+      const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
+      const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
+
+      // Skip empty partitions to avoid empty output chunks
+      if ((partition_end - partition_begin) == 0) {
+        return;
+      }
+
+      PosList pos_list_left_local;
+      PosList pos_list_right_local;
+
+      if (hashtables[current_partition_id]) {
+        auto& hashtable = hashtables.at(current_partition_id);
+
+        for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
+          auto& row = partition[partition_offset];
+
+          if (mode == JoinMode::Inner && row.row_id.chunk_offset == INVALID_CHUNK_OFFSET) {
+            continue;
+          }
+
+          // This is where the actual comparison happens. `get` only returns values that match and eliminates hash
+          // collisions.
+          auto row_ids = hashtable->get(row.value);
+
+          if (row_ids) {
+            for (const auto& row_id : *row_ids) {
+              if (row_id.chunk_offset != INVALID_CHUNK_OFFSET) {
+                pos_list_left_local.emplace_back(row_id);
+                pos_list_right_local.emplace_back(row.row_id);
+              }
+            }
+            // We assume that the relations have been swapped previously,
+            // so that the outer relation is the probing relation.
+          } else if (mode == JoinMode::Left || mode == JoinMode::Right) {
+            pos_list_left_local.emplace_back(NULL_ROW_ID);
+            pos_list_right_local.emplace_back(row.row_id);
+          }
+        }
+      } else if (mode == JoinMode::Left || mode == JoinMode::Right) {
+        /*
+          We assume that the relations have been swapped previously,
+          so that the outer relation is the probing relation.
+
+          Since we did not find a proper hash table,
+          we know that there is no match in Left for this partition.
+          Hence we are going to write NULL values for each row.
+          */
+
+        for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
+          auto& row = partition[partition_offset];
+          pos_list_left_local.emplace_back(NULL_ROW_ID);
+          pos_list_right_local.emplace_back(row.row_id);
+        }
+      }
+
+      if (!pos_list_left_local.empty()) {
+        pos_list_left[current_partition_id] = std::move(pos_list_left_local);
+        pos_list_right[current_partition_id] = std::move(pos_list_right_local);
+      }
+    }));
+    jobs.back()->schedule();
+  }
+
+  CurrentScheduler::wait_for_tasks(jobs);
+}
+
+template <typename RightType, typename HashedType>
+void probe_semi_anti(const RadixContainer<RightType>& radix_container,
+                     const std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables,
+                     std::vector<PosList>& pos_lists, const JoinMode mode) {
+  std::vector<std::shared_ptr<AbstractTask>> jobs;
+  jobs.reserve(radix_container.partition_offsets.size() - 1);
+
+  for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
+       ++current_partition_id) {
+    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
+      // Get information from work queue
+      auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
+      const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
+      const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
+
+      // Skip empty partitions to avoid empty output chunks
+      if ((partition_end - partition_begin) == 0) {
+        return;
+      }
+
+      PosList pos_list_local;
+
+      if (auto& hashtable = hashtables[current_partition_id]) {
+        // Valid hashtable found, so there is at least one match in this partition
+
+        for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
+          auto& row = partition[partition_offset];
+
+          if (row.row_id.chunk_offset == INVALID_CHUNK_OFFSET) {
+            continue;
+          }
+
+          auto matching_rows = hashtable->get(row.value);
+
+          if ((mode == JoinMode::Semi && matching_rows) || (mode == JoinMode::Anti && !matching_rows)) {
+            // Semi: found at least one match for this row -> match
+            // Anti: no matching rows found -> match
+            pos_list_local.emplace_back(row.row_id);
+          }
+        }
+      } else if (mode == JoinMode::Anti) {
+        // no hashtable on other side, but we are in Anti mode
+        for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
+          auto& row = partition[partition_offset];
+          pos_list_local.emplace_back(row.row_id);
+        }
+      }
+
+      if (!pos_list_local.empty()) {
+        pos_lists[current_partition_id] = std::move(pos_list_local);
+      }
+    }));
+    jobs.back()->schedule();
+  }
+
+  CurrentScheduler::wait_for_tasks(jobs);
+}
+
+using PosLists = std::vector<std::shared_ptr<const PosList>>;
+using PosListsByColumn = std::vector<std::shared_ptr<PosLists>>;
+
+// See usage in _on_execute() for doc.
+PosListsByColumn setup_pos_lists_by_column(const std::shared_ptr<const Table> input_table) {
+  DebugAssert(input_table->type() == TableType::References, "Function only works for reference tables");
+
+  std::map<PosLists, std::shared_ptr<PosLists>> shared_pos_lists_by_pos_lists;
+
+  PosListsByColumn pos_lists_by_column(input_table->column_count());
+  auto pos_lists_by_column_it = pos_lists_by_column.begin();
+
+  const auto& input_chunks = input_table->chunks();
+
+  for (ColumnID column_id{0}; column_id < input_table->column_count(); ++column_id) {
+    // Get all the input pos lists so that we only have to pointer cast the columns once
+    auto pos_list_ptrs = std::make_shared<PosLists>(input_table->chunk_count());
+    auto pos_lists_iter = pos_list_ptrs->begin();
+
+    for (ChunkID chunk_id{0}; chunk_id < input_table->chunk_count(); chunk_id++) {
+      const auto& ref_column_uncasted = input_chunks[chunk_id]->columns()[column_id];
+      const auto ref_column = std::static_pointer_cast<const ReferenceColumn>(ref_column_uncasted);
+      *pos_lists_iter = ref_column->pos_list();
+      ++pos_lists_iter;
+    }
+
+    auto iter = shared_pos_lists_by_pos_lists.emplace(*pos_list_ptrs, pos_list_ptrs).first;
+
+    *pos_lists_by_column_it = iter->second;
+    ++pos_lists_by_column_it;
+  }
+
+  return pos_lists_by_column;
+}
+
+void write_output_columns(ChunkColumns& output_columns, const std::shared_ptr<const Table> input_table,
+                          const PosListsByColumn& input_pos_list_ptrs_sptrs_by_column,
+                          std::shared_ptr<PosList> pos_list) {
+  std::map<std::shared_ptr<PosLists>, std::shared_ptr<PosList>> output_pos_list_cache;
+
+  // We might use this later, but want to have it outside of the for loop
+  std::shared_ptr<Table> dummy_table;
+
+  // Add columns from input table to output chunk
+  for (ColumnID column_id{0}; column_id < input_table->column_count(); ++column_id) {
+    if (input_table->type() == TableType::References) {
+      if (input_table->chunk_count() > 0) {
+        std::shared_ptr<BaseColumn> column;
+        const auto& input_table_pos_lists = input_pos_list_ptrs_sptrs_by_column[column_id];
+
+        auto iter = output_pos_list_cache.find(input_table_pos_lists);
+        if (iter == output_pos_list_cache.end()) {
+          // Get the row ids that are referenced
+          auto new_pos_list = std::make_shared<PosList>(pos_list->size());
+          auto new_pos_list_iter = new_pos_list->begin();
+          for (const auto& row : *pos_list) {
+            if (row.chunk_offset == INVALID_CHUNK_OFFSET) {
+              *new_pos_list_iter = row;
+            } else {
+              const auto& referenced_pos_list = *(*input_table_pos_lists)[row.chunk_id];
+              *new_pos_list_iter = referenced_pos_list[row.chunk_offset];
+            }
+            ++new_pos_list_iter;
+          }
+
+          iter = output_pos_list_cache.emplace(input_table_pos_lists, new_pos_list).first;
+        }
+
+        auto ref_col =
+            std::static_pointer_cast<const ReferenceColumn>(input_table->get_chunk(ChunkID{0})->get_column(column_id));
+        output_columns.push_back(std::make_shared<ReferenceColumn>(ref_col->referenced_table(),
+                                                                   ref_col->referenced_column_id(), iter->second));
+      } else {
+        // If there are no Chunks in the input_table, we can't deduce the Table that input_table is referencING to
+        // pos_list will contain only NULL_ROW_IDs anyway, so it doesn't matter which Table the ReferenceColumn that
+        // we output is referencing. HACK, but works fine: we create a dummy table and let the ReferenceColumn ref
+        // it.
+        if (!dummy_table) dummy_table = Table::create_dummy_table(input_table->column_definitions());
+        output_columns.push_back(std::make_shared<ReferenceColumn>(dummy_table, column_id, pos_list));
+      }
+    } else {
+      output_columns.push_back(std::make_shared<ReferenceColumn>(input_table, column_id, pos_list));
+    }
+  }
+}
+
 template <typename LeftType, typename RightType>
 class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
  public:
@@ -115,416 +618,6 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
   // Determine correct type for hashing
   using HashedType = typename JoinHashTraits<LeftType, RightType>::HashType;
-
-  using PosLists = std::vector<std::shared_ptr<const PosList>>;
-  using PosListsByColumn = std::vector<std::shared_ptr<PosLists>>;
-
-  /*
-  This is how elements of the input relations are saved after materialization.
-  The original value is used to detect hash collisions.
-  */
-  template <typename T>
-  struct PartitionedElement {
-    PartitionedElement() : row_id(NULL_ROW_ID), partition_hash(0), value(T()) {}
-    PartitionedElement(RowID row, Hash hash, T val) : row_id(row), partition_hash(hash), value(val) {}
-
-    RowID row_id;
-    Hash partition_hash;
-    T value;
-  };
-
-  template <typename T>
-  using Partition = std::vector<PartitionedElement<T>>;
-
-  /*
-  This struct contains radix-partitioned data in a contiguous buffer,
-  as well as a list of offsets for each partition.
-  */
-  template <typename T>
-  struct RadixContainer {
-    std::shared_ptr<Partition<T>> elements;
-    std::vector<size_t> partition_offsets;
-  };
-
-  /*
-  Hashes the given value into the HashedType that is defined by the current Hash Traits.
-  Performs a lexical cast first, if necessary.
-  */
-  template <typename T>
-  constexpr uint32_t hash_value(T& value) {
-    // clang-format off
-    // doesn't deal with constexpr nicely
-    if constexpr(!std::is_same_v<T, HashedType>) {
-        return murmur2<HashedType>(type_cast<HashedType>(value), _partitioning_seed);
-    } else {
-      return murmur2<HashedType>(value, _partitioning_seed);
-    }
-    // clang-format on
-  }
-
-  template <typename T>
-  std::shared_ptr<Partition<T>> _materialize_input(const std::shared_ptr<const Table> in_table, ColumnID column_id,
-                                                   std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
-                                                   bool keep_nulls = false) {
-    // list of all elements that will be partitioned
-    auto elements = std::make_shared<Partition<T>>();
-    elements->resize(in_table->row_count());
-
-    // fan-out
-    const size_t num_partitions = 1 << _radix_bits;
-
-    // currently, we just do one pass
-    size_t pass = 0;
-    size_t mask = static_cast<uint32_t>(pow(2, _radix_bits * (pass + 1)) - 1);
-
-    auto chunk_offsets = std::vector<size_t>(in_table->chunk_count());
-
-    // fill work queue
-    size_t output_offset = 0;
-    for (ChunkID chunk_id{0}; chunk_id < in_table->chunk_count(); chunk_id++) {
-      auto column = in_table->get_chunk(chunk_id)->get_column(column_id);
-
-      chunk_offsets[chunk_id] = output_offset;
-      output_offset += column->size();
-    }
-
-    // create histograms per chunk
-    histograms = std::vector<std::shared_ptr<std::vector<size_t>>>();
-    histograms.resize(chunk_offsets.size());
-
-    std::vector<std::shared_ptr<AbstractTask>> jobs;
-    jobs.reserve(in_table->chunk_count());
-
-    for (ChunkID chunk_id{0}; chunk_id < in_table->chunk_count(); ++chunk_id) {
-      jobs.emplace_back(std::make_shared<JobTask>([&, chunk_id]() {
-        // Get information from work queue
-        auto output_offset = chunk_offsets[chunk_id];
-        auto column = in_table->get_chunk(chunk_id)->get_column(column_id);
-        auto& output = static_cast<Partition<T>&>(*elements);
-
-        // prepare histogram
-        histograms[chunk_id] = std::make_shared<std::vector<size_t>>(num_partitions);
-
-        auto& histogram = static_cast<std::vector<size_t>&>(*histograms[chunk_id]);
-
-        auto materialized_chunk = std::vector<std::pair<RowID, T>>();
-
-        // Materialize the chunk
-        resolve_column_type<T>(*column, [&, chunk_id, keep_nulls](auto& typed_column) {
-          auto iterable = create_iterable_from_column<T>(typed_column);
-
-          iterable.for_each([&, chunk_id, keep_nulls](const auto& value) {
-            if (!value.is_null() || keep_nulls) {
-              materialized_chunk.emplace_back(RowID{chunk_id, value.chunk_offset()}, value.value());
-            } else {
-              // We need to add this to avoid gaps in the list of offsets when we iterate later on
-              materialized_chunk.emplace_back(NULL_ROW_ID, T{});
-            }
-          });
-        });
-
-        size_t row_id = output_offset;
-
-        /*
-        For ReferenceColumns we do not use the RowIDs from the referenced tables.
-        Instead, we use the index in the ReferenceColumn itself. This way we can later correctly dereference
-        values from different inputs (important for Multi Joins).
-        For performance reasons this if statement is around the for loop.
-        */
-        if (auto ref_column = std::dynamic_pointer_cast<const ReferenceColumn>(column)) {
-          // hash and add to the other elements
-          ChunkOffset offset = 0;
-          for (auto&& elem : materialized_chunk) {
-            if (elem.first.chunk_offset != INVALID_CHUNK_OFFSET) {
-              uint32_t hashed_value = hash_value<T>(elem.second);
-              output[row_id] = PartitionedElement<T>{RowID{chunk_id, offset}, hashed_value, elem.second};
-
-              const Hash radix = (output[row_id].partition_hash >> (32 - _radix_bits * (pass + 1))) & mask;
-              histogram[radix]++;
-
-              row_id++;
-            }
-
-            offset++;
-          }
-        } else {
-          // hash and add to the other elements
-          for (auto&& elem : materialized_chunk) {
-            if (elem.first.chunk_offset == INVALID_CHUNK_OFFSET) continue;
-
-            uint32_t hashed_value = hash_value<T>(elem.second);
-            output[row_id] = PartitionedElement<T>{elem.first, hashed_value, elem.second};
-
-            const Hash radix = (output[row_id].partition_hash >> (32 - _radix_bits * (pass + 1))) & mask;
-            histogram[radix]++;
-
-            row_id++;
-          }
-        }
-      }));
-      jobs.back()->schedule();
-    }
-
-    CurrentScheduler::wait_for_tasks(jobs);
-
-    return elements;
-  }
-
-  template <typename T>
-  RadixContainer<T> _partition_radix_parallel(std::shared_ptr<Partition<T>> materialized,
-                                              std::shared_ptr<std::vector<size_t>> chunk_offsets,
-                                              std::vector<std::shared_ptr<std::vector<size_t>>>& histograms,
-                                              bool keep_nulls = false) {
-    // fan-out
-    const size_t num_partitions = 1 << _radix_bits;
-
-    // currently, we just do one pass
-    size_t pass = 0;
-    size_t mask = static_cast<uint32_t>(pow(2, _radix_bits * (pass + 1)) - 1);
-
-    // allocate new (shared) output
-    auto output = std::make_shared<Partition<T>>();
-    output->resize(materialized->size());
-
-    auto& offsets = static_cast<std::vector<size_t>&>(*chunk_offsets);
-
-    RadixContainer<T> radix_output;
-    radix_output.elements = output;
-    radix_output.partition_offsets.resize(num_partitions + 1);
-
-    // use histograms to calculate partition offsets
-    size_t offset = 0;
-    std::vector<std::vector<size_t>> output_offsets_by_chunk(offsets.size(), std::vector<size_t>(num_partitions));
-    for (size_t partition_id = 0; partition_id < num_partitions; ++partition_id) {
-      radix_output.partition_offsets[partition_id] = offset;
-      for (ChunkID chunk_id{0}; chunk_id < offsets.size(); ++chunk_id) {
-        output_offsets_by_chunk[chunk_id][partition_id] = offset;
-        offset += (*histograms[chunk_id])[partition_id];
-      }
-    }
-    radix_output.partition_offsets[num_partitions] = offset;
-
-    std::vector<std::shared_ptr<AbstractTask>> jobs;
-    jobs.reserve(offsets.size());
-
-    for (ChunkID chunk_id{0}; chunk_id < offsets.size(); ++chunk_id) {
-      jobs.emplace_back(std::make_shared<JobTask>([&, chunk_id]() {
-        size_t input_offset = offsets[chunk_id];
-        auto& output_offsets = output_offsets_by_chunk[chunk_id];
-
-        size_t input_size = 0;
-        if (chunk_id < offsets.size() - 1) {
-          input_size = offsets[chunk_id + 1] - input_offset;
-        } else {
-          input_size = materialized->size() - input_offset;
-        }
-
-        auto& out = static_cast<Partition<T>&>(*output);
-        for (size_t column_offset = input_offset; column_offset < input_offset + input_size; ++column_offset) {
-          auto& element = (*materialized)[column_offset];
-
-          if (!keep_nulls && element.row_id.chunk_offset == INVALID_CHUNK_OFFSET) {
-            continue;
-          }
-
-          const size_t radix = (element.partition_hash >> (32 - _radix_bits * (pass + 1))) & mask;
-
-          out[output_offsets[radix]++] = element;
-        }
-      }));
-      jobs.back()->schedule();
-    }
-
-    CurrentScheduler::wait_for_tasks(jobs);
-
-    return radix_output;
-  }
-
-  /*
-  Build all the hash tables for the partitions of Left. We parallelize this process for all partitions of Left
-  */
-  void _build(const RadixContainer<LeftType>& radix_container,
-              std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables) {
-    std::vector<std::shared_ptr<AbstractTask>> jobs;
-    jobs.reserve(radix_container.partition_offsets.size() - 1);
-
-    for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
-         ++current_partition_id) {
-      jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
-        auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
-        const auto& partition_left_begin = radix_container.partition_offsets[current_partition_id];
-        const auto& partition_left_end = radix_container.partition_offsets[current_partition_id + 1];
-        const auto partition_size = partition_left_end - partition_left_begin;
-
-        // Prune empty partitions, so that we don't have too many empty hash tables
-        if (partition_size == 0) {
-          return;
-        }
-
-        auto hashtable = std::make_shared<HashTable<HashedType>>(partition_size);
-
-        for (size_t partition_offset = partition_left_begin; partition_offset < partition_left_end;
-             ++partition_offset) {
-          auto& element = partition_left[partition_offset];
-
-          hashtable->put(type_cast<HashedType>(element.value), element.row_id);
-        }
-
-        hashtables[current_partition_id] = hashtable;
-      }));
-      jobs.back()->schedule();
-    }
-
-    CurrentScheduler::wait_for_tasks(jobs);
-  }
-
-  /*
-  In the probe phase we take all partitions from the right partition, iterate over them and compare each join candidate
-  with the values in the hash table. Since Left and Right are hashed using the same hash function, we can reduce the
-  number of hash tables that need to be looked into to just 1.
-  */
-  void _probe(const RadixContainer<RightType>& radix_container,
-              const std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables,
-              std::vector<PosList>& pos_list_left, std::vector<PosList>& pos_list_right) {
-    std::vector<std::shared_ptr<AbstractTask>> jobs;
-    jobs.reserve(radix_container.partition_offsets.size() - 1);
-
-    /*
-    NUMA notes:
-    At this point both input relations are partitioned using radix partitioning.
-    Probing will be done per partition for both sides.
-    Therefore, inputs for one partition should be located on the same NUMA node,
-    and the job that probes that partition should also be on that NUMA node.
-    */
-
-    for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
-         ++current_partition_id) {
-      jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
-        // Get information from work queue
-        auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
-        const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
-        const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
-
-        // Skip empty partitions to avoid empty output chunks
-        if ((partition_end - partition_begin) == 0) {
-          return;
-        }
-
-        PosList pos_list_left_local;
-        PosList pos_list_right_local;
-
-        if (hashtables[current_partition_id]) {
-          auto& hashtable = hashtables.at(current_partition_id);
-
-          for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
-            auto& row = partition[partition_offset];
-
-            if (_mode == JoinMode::Inner && row.row_id.chunk_offset == INVALID_CHUNK_OFFSET) {
-              continue;
-            }
-
-            // This is where the actual comparison happens. `get` only returns values that match and eliminates hash
-            // collisions.
-            auto row_ids = hashtable->get(row.value);
-
-            if (row_ids) {
-              for (const auto& row_id : *row_ids) {
-                if (row_id.chunk_offset != INVALID_CHUNK_OFFSET) {
-                  pos_list_left_local.emplace_back(row_id);
-                  pos_list_right_local.emplace_back(row.row_id);
-                }
-              }
-              // We assume that the relations have been swapped previously,
-              // so that the outer relation is the probing relation.
-            } else if (_mode == JoinMode::Left || _mode == JoinMode::Right) {
-              pos_list_left_local.emplace_back(NULL_ROW_ID);
-              pos_list_right_local.emplace_back(row.row_id);
-            }
-          }
-        } else if (_mode == JoinMode::Left || _mode == JoinMode::Right) {
-          /*
-          We assume that the relations have been swapped previously,
-          so that the outer relation is the probing relation.
-
-          Since we did not find a proper hash table,
-          we know that there is no match in Left for this partition.
-          Hence we are going to write NULL values for each row.
-          */
-
-          for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
-            auto& row = partition[partition_offset];
-            pos_list_left_local.emplace_back(NULL_ROW_ID);
-            pos_list_right_local.emplace_back(row.row_id);
-          }
-        }
-
-        if (!pos_list_left_local.empty()) {
-          pos_list_left[current_partition_id] = std::move(pos_list_left_local);
-          pos_list_right[current_partition_id] = std::move(pos_list_right_local);
-        }
-      }));
-      jobs.back()->schedule();
-    }
-
-    CurrentScheduler::wait_for_tasks(jobs);
-  }
-
-  void _probe_semi_anti(const RadixContainer<RightType>& radix_container,
-                        const std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables,
-                        std::vector<PosList>& pos_lists) {
-    std::vector<std::shared_ptr<AbstractTask>> jobs;
-    jobs.reserve(radix_container.partition_offsets.size() - 1);
-
-    for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
-         ++current_partition_id) {
-      jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
-        // Get information from work queue
-        auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
-        const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
-        const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
-
-        // Skip empty partitions to avoid empty output chunks
-        if ((partition_end - partition_begin) == 0) {
-          return;
-        }
-
-        PosList pos_list_local;
-
-        if (auto& hashtable = hashtables[current_partition_id]) {
-          // Valid hashtable found, so there is at least one match in this partition
-
-          for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
-            auto& row = partition[partition_offset];
-
-            if (row.row_id.chunk_offset == INVALID_CHUNK_OFFSET) {
-              continue;
-            }
-
-            auto matching_rows = hashtable->get(row.value);
-
-            if ((_mode == JoinMode::Semi && matching_rows) || (_mode == JoinMode::Anti && !matching_rows)) {
-              // Semi: found at least one match for this row -> match
-              // Anti: no matching rows found -> match
-              pos_list_local.emplace_back(row.row_id);
-            }
-          }
-        } else if (_mode == JoinMode::Anti) {
-          // no hashtable on other side, but we are in Anti mode
-          for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
-            auto& row = partition[partition_offset];
-            pos_list_local.emplace_back(row.row_id);
-          }
-        }
-
-        if (!pos_list_local.empty()) {
-          pos_lists[current_partition_id] = std::move(pos_list_local);
-        }
-      }));
-      jobs.back()->schedule();
-    }
-
-    CurrentScheduler::wait_for_tasks(jobs);
-  }
 
   std::shared_ptr<const Table> _on_execute() override {
     /*
@@ -592,10 +685,11 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     This helps choosing a scheduler node for the radix phase (see below).
     */
     // Scheduler note: parallelize this at some point. Currently, the amount of jobs would be too high
-    auto materialized_left = _materialize_input<LeftType>(left_in_table, _column_ids.first, histograms_left);
+    auto materialized_left = materialize_input<LeftType, HashedType>(left_in_table, _column_ids.first, histograms_left,
+                                                                     _radix_bits, _partitioning_seed);
     // 'keep_nulls' makes sure that the relation on the right materializes NULL values when executing an OUTER join.
-    auto materialized_right =
-        _materialize_input<RightType>(right_in_table, _column_ids.second, histograms_right, keep_nulls);
+    auto materialized_right = materialize_input<RightType, HashedType>(
+        right_in_table, _column_ids.second, histograms_right, _radix_bits, _partitioning_seed, keep_nulls);
 
     // Radix Partitioning phase
     /*
@@ -608,19 +702,14 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     partitions leftB and leftB should also be on the same node.
     */
     // Scheduler note: parallelize this at some point. Currently, the amount of jobs would be too high
-    auto radix_left = _partition_radix_parallel<LeftType>(materialized_left, left_chunk_offsets, histograms_left);
+    auto radix_left =
+        partition_radix_parallel<LeftType>(materialized_left, left_chunk_offsets, histograms_left, _radix_bits);
     // 'keep_nulls' makes sure that the relation on the right keeps NULL values when executing an OUTER join.
-    auto radix_right =
-        _partition_radix_parallel<RightType>(materialized_right, right_chunk_offsets, histograms_right, keep_nulls);
+    auto radix_right = partition_radix_parallel<RightType>(materialized_right, right_chunk_offsets, histograms_right,
+                                                           _radix_bits, keep_nulls);
 
     // Build phase
-    std::vector<std::shared_ptr<HashTable<HashedType>>> hashtables;
-    hashtables.resize(radix_left.partition_offsets.size() - 1);
-    /*
-    NUMA notes:
-    The hashtables for each partition P should also reside on the same node as the two vectors leftP and rightP.
-    */
-    _build(radix_left, hashtables);
+    auto hashtables = build<LeftType, HashedType>(radix_left);
 
     // Probe phase
     std::vector<PosList> left_pos_lists;
@@ -633,9 +722,9 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     leftP, rightP and hashtableP.
     */
     if (_mode == JoinMode::Semi || _mode == JoinMode::Anti) {
-      _probe_semi_anti(radix_right, hashtables, right_pos_lists);
+      probe_semi_anti<RightType, HashedType>(radix_right, hashtables, right_pos_lists, _mode);
     } else {
-      _probe(radix_right, hashtables, left_pos_lists, right_pos_lists);
+      probe<RightType, HashedType>(radix_right, hashtables, left_pos_lists, right_pos_lists, _mode);
     }
 
     auto only_output_right_input = _inputs_swapped && (_mode == JoinMode::Semi || _mode == JoinMode::Anti);
@@ -694,89 +783,6 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     }
 
     return _output_table;
-  }
-
-  // See usage in _on_execute() for doc.
-  static PosListsByColumn setup_pos_lists_by_column(const std::shared_ptr<const Table> input_table) {
-    DebugAssert(input_table->type() == TableType::References, "Function only works for reference tables");
-
-    std::map<PosLists, std::shared_ptr<PosLists>> shared_pos_lists_by_pos_lists;
-
-    PosListsByColumn pos_lists_by_column(input_table->column_count());
-    auto pos_lists_by_column_it = pos_lists_by_column.begin();
-
-    const auto& input_chunks = input_table->chunks();
-
-    for (ColumnID column_id{0}; column_id < input_table->column_count(); ++column_id) {
-      // Get all the input pos lists so that we only have to pointer cast the columns once
-      auto pos_list_ptrs = std::make_shared<PosLists>(input_table->chunk_count());
-      auto pos_lists_iter = pos_list_ptrs->begin();
-
-      for (ChunkID chunk_id{0}; chunk_id < input_table->chunk_count(); chunk_id++) {
-        const auto ref_column =
-            std::static_pointer_cast<const ReferenceColumn>(input_chunks[chunk_id]->columns()[column_id]);
-        *pos_lists_iter = ref_column->pos_list();
-        ++pos_lists_iter;
-      }
-
-      auto iter = shared_pos_lists_by_pos_lists.emplace(*pos_list_ptrs, pos_list_ptrs).first;
-
-      *pos_lists_by_column_it = iter->second;
-      ++pos_lists_by_column_it;
-    }
-
-    return pos_lists_by_column;
-  }
-
-  static void write_output_columns(ChunkColumns& output_columns, const std::shared_ptr<const Table> input_table,
-                                   const PosListsByColumn& input_pos_list_ptrs_sptrs_by_column,
-                                   std::shared_ptr<PosList> pos_list) {
-    std::map<std::shared_ptr<PosLists>, std::shared_ptr<PosList>> output_pos_list_cache;
-
-    // We might use this later, but want to have it outside of the for loop
-    std::shared_ptr<Table> dummy_table;
-
-    // Add columns from input table to output chunk
-    for (ColumnID column_id{0}; column_id < input_table->column_count(); ++column_id) {
-      if (input_table->type() == TableType::References) {
-        if (input_table->chunk_count() > 0) {
-          std::shared_ptr<BaseColumn> column;
-          const auto& input_table_pos_lists = input_pos_list_ptrs_sptrs_by_column[column_id];
-
-          auto iter = output_pos_list_cache.find(input_table_pos_lists);
-          if (iter == output_pos_list_cache.end()) {
-            // Get the row ids that are referenced
-            auto new_pos_list = std::make_shared<PosList>(pos_list->size());
-            auto new_pos_list_iter = new_pos_list->begin();
-            for (const auto& row : *pos_list) {
-              if (row.chunk_offset == INVALID_CHUNK_OFFSET) {
-                *new_pos_list_iter = row;
-              } else {
-                const auto& referenced_pos_list = *(*input_table_pos_lists)[row.chunk_id];
-                *new_pos_list_iter = referenced_pos_list[row.chunk_offset];
-              }
-              ++new_pos_list_iter;
-            }
-
-            iter = output_pos_list_cache.emplace(input_table_pos_lists, new_pos_list).first;
-          }
-
-          auto ref_col = std::static_pointer_cast<const ReferenceColumn>(
-              input_table->get_chunk(ChunkID{0})->get_column(column_id));
-          output_columns.push_back(std::make_shared<ReferenceColumn>(ref_col->referenced_table(),
-                                                                     ref_col->referenced_column_id(), iter->second));
-        } else {
-          // If there are no Chunks in the input_table, we can't deduce the Table that input_table is referencING to
-          // pos_list will contain only NULL_ROW_IDs anyway, so it doesn't matter which Table the ReferenceColumn that
-          // we output is referencing. HACK, but works fine: we create a dummy table and let the ReferenceColumn ref
-          // it.
-          if (!dummy_table) dummy_table = Table::create_dummy_table(input_table->column_definitions());
-          output_columns.push_back(std::make_shared<ReferenceColumn>(dummy_table, column_id, pos_list));
-        }
-      } else {
-        output_columns.push_back(std::make_shared<ReferenceColumn>(input_table, column_id, pos_list));
-      }
-    }
   }
 };
 


### PR DESCRIPTION
Previously, everything was in `JoinHashImpl<LeftType, RightType>`. The heavy-lifting subroutines such as `_probe` only used `<LeftType, HashedType>` or `<RightType, HashedType>`. Having them as class members means that they get instantiated per `<LeftType, RightType>` combination.

I moved them to their own functions outside of the templated class. I didn't really touch any code, so I wouldn't expect a thorough review.

```
clang -O0 alt: 0m42.911s 
clang -O0 neu: 0m9.610s
~78 % faster

clang -O3 alt: 1m41.671s
clang -O3 neu: 0m40.918s
~60 % faster
```

Also, this is a cool example for #915:

<img width="1920" alt="screen shot 2018-07-03 at 13 57 34" src="https://user-images.githubusercontent.com/575106/42218632-8bdde9a2-7ec9-11e8-9461-adef20072b8b.png">

As you can see, the previous version (on top) and the new version spend roughly the same time instantiating `JoinHashImpl<int, int>`, but once all `RightType` versions are instantiated (first six lines in the lower window), the following instantiations are significantly faster.