### PR TITLE
Avoid jobs without work load in join hash

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -129,8 +129,8 @@ std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<L
 
   for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
        ++current_partition_id) {
-    const auto& partition_left_begin = radix_container.partition_offsets[current_partition_id];
-    const auto& partition_left_end = radix_container.partition_offsets[current_partition_id + 1];
+    const auto partition_left_begin = radix_container.partition_offsets[current_partition_id];
+    const auto partition_left_end = radix_container.partition_offsets[current_partition_id + 1];
     const auto partition_size = partition_left_end - partition_left_begin;
 
     // Prune empty partitions, so that we don't have too many empty hash tables
@@ -138,7 +138,7 @@ std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<L
       continue;
     }
 
-    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id, partition_size]() {
+    jobs.emplace_back(std::make_shared<JobTask>([&, partition_left_begin, partition_left_end, current_partition_id, partition_size]() {
       auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
 
       auto hashtable = std::make_shared<HashTable<HashedType>>(partition_size);
@@ -376,15 +376,15 @@ void probe(const RadixContainer<RightType>& radix_container,
 
   for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
        ++current_partition_id) {
-    const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
-    const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
+    const auto partition_begin = radix_container.partition_offsets[current_partition_id];
+    const auto partition_end = radix_container.partition_offsets[current_partition_id + 1];
 
     // Skip empty partitions to avoid empty output chunks
-    if ((partition_end - partition_begin) == 0) {
+    if (partition_begin == partition_end) {
       continue;
     }
 
-    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
+    jobs.emplace_back(std::make_shared<JobTask>([&, partition_begin, partition_end, current_partition_id]() {
       // Get information from work queue
       auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
       PosList pos_list_left_local;
@@ -455,15 +455,15 @@ void probe_semi_anti(const RadixContainer<RightType>& radix_container,
 
   for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
        ++current_partition_id) {
-    const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
-    const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
+    const auto partition_begin = radix_container.partition_offsets[current_partition_id];
+    const auto partition_end = radix_container.partition_offsets[current_partition_id + 1];
 
     // Skip empty partitions to avoid empty output chunks
-    if ((partition_end - partition_begin) == 0) {
+    if (partition_begin == partition_end) {
       continue;
     }
 
-    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
+    jobs.emplace_back(std::make_shared<JobTask>([&, partition_begin, partition_end, current_partition_id]() {
       // Get information from work queue
       auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -129,16 +129,17 @@ std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<L
 
   for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
        ++current_partition_id) {
-    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
-      auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
-      const auto& partition_left_begin = radix_container.partition_offsets[current_partition_id];
-      const auto& partition_left_end = radix_container.partition_offsets[current_partition_id + 1];
-      const auto partition_size = partition_left_end - partition_left_begin;
+    const auto& partition_left_begin = radix_container.partition_offsets[current_partition_id];
+    const auto& partition_left_end = radix_container.partition_offsets[current_partition_id + 1];
+    const auto partition_size = partition_left_end - partition_left_begin;
 
-      // Prune empty partitions, so that we don't have too many empty hash tables
-      if (partition_size == 0) {
-        return;
-      }
+    // Prune empty partitions, so that we don't have too many empty hash tables
+    if (partition_size == 0) {
+      continue;
+    }
+
+    jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id, partition_size]() {
+      auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
 
       auto hashtable = std::make_shared<HashTable<HashedType>>(partition_size);
 
@@ -375,17 +376,17 @@ void probe(const RadixContainer<RightType>& radix_container,
 
   for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
        ++current_partition_id) {
+    const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
+    const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
+
+    // Skip empty partitions to avoid empty output chunks
+    if ((partition_end - partition_begin) == 0) {
+      continue;
+    }
+
     jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
       // Get information from work queue
       auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
-      const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
-      const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
-
-      // Skip empty partitions to avoid empty output chunks
-      if ((partition_end - partition_begin) == 0) {
-        return;
-      }
-
       PosList pos_list_left_local;
       PosList pos_list_right_local;
 
@@ -454,16 +455,17 @@ void probe_semi_anti(const RadixContainer<RightType>& radix_container,
 
   for (size_t current_partition_id = 0; current_partition_id < (radix_container.partition_offsets.size() - 1);
        ++current_partition_id) {
+    const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
+    const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
+
+    // Skip empty partitions to avoid empty output chunks
+    if ((partition_end - partition_begin) == 0) {
+      continue;
+    }
+
     jobs.emplace_back(std::make_shared<JobTask>([&, current_partition_id]() {
       // Get information from work queue
       auto& partition = static_cast<Partition<RightType>&>(*radix_container.elements);
-      const auto& partition_begin = radix_container.partition_offsets[current_partition_id];
-      const auto& partition_end = radix_container.partition_offsets[current_partition_id + 1];
-
-      // Skip empty partitions to avoid empty output chunks
-      if ((partition_end - partition_begin) == 0) {
-        return;
-      }
 
       PosList pos_list_local;
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -138,7 +138,8 @@ std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<L
       continue;
     }
 
-    jobs.emplace_back(std::make_shared<JobTask>([&, partition_left_begin, partition_left_end, current_partition_id, partition_size]() {
+    jobs.emplace_back(std::make_shared<JobTask>([&, partition_left_begin, partition_left_end, current_partition_id,
+                                                 partition_size]() {
       auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
 
       auto hashtable = std::make_shared<HashTable<HashedType>>(partition_size);


### PR DESCRIPTION
Currently, there are many jobs created during the Hash Join without any work load. In my setup (benchmark with scale factor 0.01, 100 runs) almost 55 % of the jobs scheduled during the build phase had nothing to do. The graphic below shows the distribution of partition sizes within this phase. A partition size ("value") of 0 means, the job has no workload.


![screenshot from 2018-07-03 17-25-09](https://user-images.githubusercontent.com/11941962/42270088-44b259ac-7f80-11e8-92d5-0483c339b592.png)
