### PR TITLE
coverage with clang

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -17,7 +17,6 @@
 | llvm             | any              |    All   |                 Yes (code sanitizers) |
 | llvm-6.0-tools   | 6                |    Linux |                                    No |
 | parallel         | any              |    All   |                                   Yes |
-| pycobertura      | any              |    All   |                  Yes (coverage on CI) |
 | python           | >= 2.7 && < 3    |    All   |                         Yes (linting) |
 | readline         | >= 7             |    All   |                                    No |
 | sqlite3          | >= 3             |    All   |                                    No |

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,7 @@ RUN apt-get update \
         libpq-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && ln -sf /usr/bin/llvm-symbolizer-3.8 /usr/bin/llvm-symbolizer \
-    && pip install pycobertura
+    && ln -sf /usr/bin/llvm-symbolizer-3.8 /usr/bin/llvm-symbolizer
 
 ENV OPOSSUM_HEADLESS_SETUP=true
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,20 +82,18 @@ node {
             echo 'only on master'
           }
         }
-      }, gccDebugCoverage: {
-        stage("gcc-debug-coverage") {
+      }, clangDebugCoverage: {
+        stage("clang-debug-coverage") {
           sh "export CCACHE_BASEDIR=`pwd`; ./scripts/coverage.sh --generate_badge=true --launcher=ccache"
           archive 'coverage_badge.svg'
           archive 'coverage_percent.txt'
-          archive 'coverage.xml'
-          archive 'coverage_diff.html'
           publishHTML (target: [
             allowMissing: false,
             alwaysLinkToLastBuild: false,
             keepAll: true,
             reportDir: 'coverage',
             reportFiles: 'index.html',
-            reportName: "RCov Report"
+            reportName: "Llvm-cov Report"
           ])
           script {
             coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -55,6 +55,16 @@ echo Coverage Information is in ./coverage/index.html
 
 # Continuing only if diff output is needed with Linux/gcc
 if [[ "$unamestr" == 'Linux' ]] && [ "true" == "$generate_badge" ]; then
+  mkdir -p build-coverage-gcc
+  cd build-coverage-gcc
+  cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_COVERAGE=ON ..
+
+  make hyriseTest -j $((cores / 2))
+  cd -
+
+  rm -fr coverage; mkdir coverage
+  ./build-coverage-gcc/hyriseTest build-coverage --gtest_filter=-SQLiteTestRunnerInstances/*
+
   excludes='(?:.*/)?(?:third_party|src/test|src/benchmark).*'
 
   # call gcovr twice b/c of https://github.com/gcovr/gcovr/issues/112

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -22,15 +22,16 @@ fi
 
 mkdir -p build-coverage
 cd build-coverage
-platform='unknown'
+
+path_to_compiler=''
+
 unamestr=`uname`
-if [[ "$unamestr" == 'Linux' ]]; then
-   # Use GCC for Linux
-   cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DENABLE_COVERAGE=ON ..
-elif [[ "$unamestr" == 'Darwin' ]]; then
-   # Use Clang for OS X
-   cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/opt/llvm/bin/clang++ -DENABLE_COVERAGE=ON ..
+if [[ "$unamestr" == 'Darwin' ]]; then
+   # Use homebrew clang for OS X
+   path_to_compiler='/usr/local/opt/llvm/bin/'
 fi
+
+cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=$path_to_compiler'clang' -DCMAKE_CXX_COMPILER=$path_to_compiler'clang++' -DENABLE_COVERAGE=ON ..
 
 cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 make hyriseTest -j $((cores / 2))
@@ -39,63 +40,52 @@ cd -
 rm -fr coverage; mkdir coverage
 ./build-coverage/hyriseTest build-coverage --gtest_filter=-SQLiteTestRunnerInstances/*
 
-if [[ "$unamestr" == 'Darwin' ]]; then
-  # LLVM has its own way of dealing with coverage...
-  # https://llvm.org/docs/CoverageMappingFormat.html
+# LLVM has its own way of dealing with coverage...
+# https://llvm.org/docs/CoverageMappingFormat.html
   
-  # merge the profile data using the llvm-profdata tool:
-  /usr/local/opt/llvm/bin/llvm-profdata merge -o ./default.profdata ./default.profraw
+# merge the profile data using the llvm-profdata tool:
+$path_to_compiler'llvm-profdata' merge -o ./default.profdata ./default.profraw
 
-  # run LLVM’s code coverage tool
-  /usr/local/opt/llvm/bin/llvm-cov show -format=html -instr-profile ./default.profdata build-coverage/hyriseTest -output-dir=./coverage ./src/lib/
+# run LLVM’s code coverage tool
+$path_to_compiler'llvm-cov' show -format=html -instr-profile ./default.profdata build-coverage/hyriseTest -output-dir=./coverage ./src/lib/
 
-  rm default.profdata default.profraw
+# rm default.profdata default.profraw
 
-  echo Coverage Information is in ./coverage/index.html
+echo Coverage Information is in ./coverage/index.html
 
-  exit
+# Continuing only if diff output is needed with Linux/gcc
+if [[ "$unamestr" == 'Linux' ]] && [ "true" == "$generate_badge" ]; then
+  excludes='(?:.*/)?(?:third_party|src/test|src/benchmark).*'
+
+  # call gcovr twice b/c of https://github.com/gcovr/gcovr/issues/112
+  gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude=$excludes --exclude-unreachable-branches -k
+
+  # generate HTML
+  gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude=$excludes --exclude-unreachable-branches -k -g --html --html-details -o coverage/index.html > coverage_output.txt
+  cat coverage_output.txt
+
+  # generate XML for pycobertura
+  gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -p --exclude=$excludes --exclude-unreachable-branches -g --xml > coverage.xml
+  curl -g -o coverage_master.xml https://ares.epic.hpi.uni-potsdam.de/jenkins/job/Hyrise/job/hyrise/job/master/lastStableBuild/artifact/coverage.xml
+  pycobertura diff coverage_master.xml coverage.xml --format html --output coverage_diff.html || true
+
+  # coverage badge generation
+  coverage_percent=$(cat coverage_output.txt | grep lines: | sed -e 's/lines: //; s/% .*$//')
+  echo $coverage_percent > coverage_percent.txt
+  if (( $(bc <<< "$coverage_percent >= 90") ))
+  then
+      color="brightgreen"
+  elif (( $(bc <<< "$coverage_percent >= 75") ))
+  then
+      color="yellow"
+  elif (( $(bc <<< "$coverage_percent < 75") ))
+  then
+      color="red"
+  fi
+
+  url="https://img.shields.io/badge/Coverage-$coverage_percent%25-$color.svg"
+  curl -g -o coverage_badge.svg $url
+
+  rm coverage_output.txt
 fi
 
-# Continuing only with Linux/gcc
-
-excludes='(?:.*/)?(?:third_party|src/test|src/benchmark).*'
-
-# call gcovr twice b/c of https://github.com/gcovr/gcovr/issues/112
-gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude=$excludes --exclude-unreachable-branches -k
-
-if [ "true" == "$generate_badge" ]
-then
-    # in this step, keep coverage information only if we need it for pycobertura later
-    keep="-k"
-fi
-
-# generate HTML
-gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -s -p --exclude=$excludes --exclude-unreachable-branches $keep -g --html --html-details -o coverage/index.html > coverage_output.txt
-cat coverage_output.txt
-
-if [ "true" == "$generate_badge" ]
-then
-    # generate XML for pycobertura
-    gcovr -r `pwd` --gcov-executable="gcov -s `pwd` -x" -p --exclude=$excludes --exclude-unreachable-branches -g --xml > coverage.xml
-    curl -g -o coverage_master.xml https://ares.epic.hpi.uni-potsdam.de/jenkins/job/Hyrise/job/hyrise/job/master/lastStableBuild/artifact/coverage.xml
-    pycobertura diff coverage_master.xml coverage.xml --format html --output coverage_diff.html || true
-
-    # coverage badge generation
-    coverage_percent=$(cat coverage_output.txt | grep lines: | sed -e 's/lines: //; s/% .*$//')
-    echo $coverage_percent > coverage_percent.txt
-    if (( $(bc <<< "$coverage_percent >= 90") ))
-    then
-        color="brightgreen"
-    elif (( $(bc <<< "$coverage_percent >= 75") ))
-    then
-        color="yellow"
-    elif (( $(bc <<< "$coverage_percent < 75") ))
-    then
-        color="red"
-    fi
-
-    url="https://img.shields.io/badge/Coverage-$coverage_percent%25-$color.svg"
-    curl -g -o coverage_badge.svg $url
-fi
-
-rm coverage_output.txt

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -31,7 +31,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
    path_to_compiler='/usr/local/opt/llvm/bin/'
 fi
 
-cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER="${path_to_compiler}clang" -DCMAKE_CXX_COMPILER="${path_to_compiler}clang++" -DENABLE_COVERAGE=ON ..
+cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=${path_to_compiler}clang -DCMAKE_CXX_COMPILER=${path_to_compiler}clang++ -DENABLE_COVERAGE=ON ..
 
 cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 make hyriseTest -j $((cores / 2))
@@ -39,22 +39,19 @@ cd -
 
 rm -fr coverage; mkdir coverage
 ./build-coverage/hyriseTest build-coverage --gtest_filter=-SQLiteTestRunnerInstances/*
-
-# LLVM has its own way of dealing with coverage...
-# https://llvm.org/docs/CoverageMappingFormat.html
   
 # merge the profile data using the llvm-profdata tool:
-"${path_to_compiler}llvm-profdata" merge -o ./default.profdata ./default.profraw
+${path_to_compiler}llvm-profdata merge -o ./default.profdata ./default.profraw
 
 # run LLVM’s code coverage tool
-"${path_to_compiler}llvm-cov" show -format=html -instr-profile ./default.profdata build-coverage/hyriseTest -output-dir=./coverage ./src/lib/
+${path_to_compiler}llvm-cov show -format=html -instr-profile ./default.profdata build-coverage/hyriseTest -output-dir=./coverage ./src/lib/
 
 echo Coverage Information is in ./coverage/index.html
 
 # Continuing only if diff output is needed with Linux/gcc
 if [ "true" == "$generate_badge" ]; then
 
-  "${path_to_compiler}llvm-cov" export -summary-only -instr-profile ./default.profdata build-coverage/hyriseTest ./src/lib/ > coverage.json
+  ${path_to_compiler}llvm-cov export -summary-only -instr-profile ./default.profdata build-coverage/hyriseTest ./src/lib/ > coverage.json
 
   # coverage badge generation
   total_lines=$(sed 's/.*totals":{"lines":{"count":\([0-9]*\).*/\1/' coverage.json)

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -31,7 +31,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
    path_to_compiler='/usr/local/opt/llvm/bin/'
 fi
 
-cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=$path_to_compiler'clang' -DCMAKE_CXX_COMPILER=$path_to_compiler'clang++' -DENABLE_COVERAGE=ON ..
+cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER="${path_to_compiler}clang" -DCMAKE_CXX_COMPILER="${path_to_compiler}clang++" -DENABLE_COVERAGE=ON ..
 
 cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)
 make hyriseTest -j $((cores / 2))
@@ -44,17 +44,17 @@ rm -fr coverage; mkdir coverage
 # https://llvm.org/docs/CoverageMappingFormat.html
   
 # merge the profile data using the llvm-profdata tool:
-$path_to_compiler'llvm-profdata' merge -o ./default.profdata ./default.profraw
+"${path_to_compiler}llvm-profdata" merge -o ./default.profdata ./default.profraw
 
 # run LLVM’s code coverage tool
-$path_to_compiler'llvm-cov' show -format=html -instr-profile ./default.profdata build-coverage/hyriseTest -output-dir=./coverage ./src/lib/
+"${path_to_compiler}llvm-cov" show -format=html -instr-profile ./default.profdata build-coverage/hyriseTest -output-dir=./coverage ./src/lib/
 
 echo Coverage Information is in ./coverage/index.html
 
 # Continuing only if diff output is needed with Linux/gcc
 if [ "true" == "$generate_badge" ]; then
 
-  $path_to_compiler'llvm-cov' export -summary-only -instr-profile ./default.profdata build-coverage/hyriseTest ./src/lib/ > coverage.json
+  "${path_to_compiler}llvm-cov" export -summary-only -instr-profile ./default.profdata build-coverage/hyriseTest ./src/lib/ > coverage.json
 
   # coverage badge generation
   total_lines=$(sed 's/.*totals":{"lines":{"count":\([0-9]*\).*/\1/' coverage.json)


### PR DESCRIPTION
#905 
Enables clang coverage on Linux (to test JIT files). Coverage diff will still be executed with gcc (and only on linux), since llvm does not have a usable export file type (https://llvm.org/docs/CommandGuide/llvm-cov.html#llvm-cov-report)