### PR TITLE
Make JoinNestedLoop, JoinIndex, and column/column comparisons faster

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Avoid exception handling. Because Hyrise is not a product, we do not have to rec
 - Use [u]int(8|16|32|64)_t instead of `int, long, uint` etc.
 - Include in this order: header for implementation file, c system, c++ system, other
 - If your templated methods/classes are used outside of your file, they have to be in the header. But if you only use them internally, you should place them in the cpp file.
+- Try to keep the size of your templated methods as small as possible (Thin Template idiom). If only a small part of your method depends on the template parameter, consider moving the rest into a non-templated method. This reduces compile times.
 - Use smart pointers over c-style pointers
 - Use `IS_DEBUG` macro for non-essential checks
 - Be specific: `double a = 3.0;` but `float a = 3.0f;`

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "all_type_variant.hpp"
+#include "join_nested_loop.hpp"
 #include "resolve_type.hpp"
 #include "storage/create_iterable_from_column.hpp"
 #include "storage/index/base_index.hpp"
@@ -78,12 +79,15 @@ void JoinIndex::_perform_join() {
   _right_matches.resize(_right_in_table->chunk_count());
   _left_matches.resize(_left_in_table->chunk_count());
 
-  if (_mode == JoinMode::Left || _mode == JoinMode::Outer) {
+  const auto track_left_matches = (_mode == JoinMode::Left || _mode == JoinMode::Outer);
+  if (track_left_matches) {
     for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
       // initialize the data structures for left matches
       _left_matches[chunk_id_left].resize(_left_in_table->get_chunk(chunk_id_left)->size());
     }
   }
+
+  const auto track_right_matches = (_mode == JoinMode::Right || _mode == JoinMode::Outer);
 
   _pos_list_left = std::make_shared<PosList>();
   _pos_list_right = std::make_shared<PosList>();
@@ -98,7 +102,7 @@ void JoinIndex::_perform_join() {
     const auto chunk_right = _right_in_table->get_chunk(chunk_id_right);
     auto column_right = chunk_right->get_column(_right_column_id);
     const auto indices = chunk_right->get_indices(std::vector<ColumnID>{_right_column_id});
-    _right_matches[chunk_id_right].resize(chunk_right->size());
+    if (track_right_matches) _right_matches[chunk_id_right].resize(chunk_right->size());
 
     std::shared_ptr<BaseIndex> index = nullptr;
 
@@ -109,48 +113,37 @@ void JoinIndex::_perform_join() {
     }
 
     // Scan all chunks from left input
-    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
-      auto chunk_column_left = _left_in_table->get_chunk(chunk_id_left)->get_column(_left_column_id);
+    if (index != nullptr) {
+      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
+        auto chunk_column_left = _left_in_table->get_chunk(chunk_id_left)->get_column(_left_column_id);
 
-      resolve_data_and_column_type(*chunk_column_left, [&](auto left_type, auto& typed_left_column) {
-        using LeftType = typename decltype(left_type)::type;
+        resolve_data_and_column_type(*chunk_column_left, [&](auto left_type, auto& typed_left_column) {
+          using LeftType = typename decltype(left_type)::type;
 
-        auto iterable_left = create_iterable_from_column<LeftType>(typed_left_column);
+          auto iterable_left = create_iterable_from_column<LeftType>(typed_left_column);
 
-        if (index != nullptr) {
           // utilize index for join
           iterable_left.with_iterators([&](auto left_it, auto left_end) {
-            this->_join_two_columns_using_index(left_it, left_end, chunk_id_left, chunk_id_right, index);
+            _join_two_columns_using_index(left_it, left_end, chunk_id_left, chunk_id_right, index);
           });
-        } else {
-          // fallback to nested loop implementation
-          resolve_data_and_column_type(*column_right, [&](auto right_type, auto& typed_right_column) {
-            using RightType = typename decltype(right_type)::type;
-
-            // make sure that we do not compile invalid versions of these lambdas
-            constexpr auto left_is_string_column = (std::is_same<LeftType, std::string>{});
-            constexpr auto right_is_string_column = (std::is_same<RightType, std::string>{});
-
-            constexpr auto neither_is_string_column = !left_is_string_column && !right_is_string_column;
-            constexpr auto both_are_string_columns = left_is_string_column && right_is_string_column;
-
-            // clang-format off
-            if constexpr (neither_is_string_column || both_are_string_columns) {
-              auto iterable_right = create_iterable_from_column<RightType>(typed_right_column);
-
-              iterable_left.with_iterators([&](auto left_it, auto left_end) {
-                  iterable_right.with_iterators([&](auto right_it, auto right_end) {
-                      with_comparator(_predicate_condition, [&](auto comparator) {
-                          this->_join_two_columns_nested_loop(comparator, left_it, left_end, right_it, right_end,
-                                                              chunk_id_left, chunk_id_right);
-                      });
-                  });
-              });
-            }
-          });
-        }
-        // clang-format on
-      });
+        });
+      }
+    } else {
+      // Fall back to NestedLoopJoin
+      auto chunk_column_right = _right_in_table->get_chunk(chunk_id_right)->get_column(_right_column_id);
+      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
+        auto chunk_column_left = _left_in_table->get_chunk(chunk_id_left)->get_column(_left_column_id);
+        JoinNestedLoop::JoinParams params{*_pos_list_left,
+                                          *_pos_list_right,
+                                          _left_matches[chunk_id_left],
+                                          _right_matches[chunk_id_right],
+                                          track_left_matches,
+                                          track_right_matches,
+                                          _mode,
+                                          _predicate_condition};
+        JoinNestedLoop::_join_two_untyped_columns(chunk_column_left, chunk_column_right, chunk_id_left, chunk_id_right,
+                                                  params);
+      }
     }
   }
 

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -77,7 +77,7 @@ void JoinNestedLoop::_create_table_structure() {
   _output_table = std::make_shared<Table>(output_column_definitions, TableType::References);
 }
 
-void _process_match(RowID left_row_id, RowID right_row_id, JoinNestedLoop::JoinParams& params) {
+void JoinNestedLoop::_process_match(RowID left_row_id, RowID right_row_id, JoinNestedLoop::JoinParams& params) {
   params.pos_list_left.emplace_back(left_row_id);
   params.pos_list_right.emplace_back(right_row_id);
 

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -136,8 +136,8 @@ void JoinNestedLoop::_join_two_untyped_columns(std::shared_ptr<const BaseColumn>
         iterable_left.with_iterators([&](auto left_it, auto left_end) {
           iterable_right.with_iterators([&](auto right_it, auto right_end) {
             with_comparator(params.predicate_condition, [&](auto comparator) {
-              // _join_two_typed_columns(comparator, left_it, left_end, right_it, right_end, chunk_id_left,
-              //                         chunk_id_right, params);
+              _join_two_typed_columns(comparator, left_it, left_end, right_it, right_end, chunk_id_left,
+                                      chunk_id_right, params);
             });
           });
         });

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -45,14 +45,16 @@ class JoinNestedLoop : public AbstractJoinOperator {
   // compiler would try to put the entire join for all types into a single, monolithic function. For -O3 on clang, this
   // reduces the compile time from twelve minutes to less than three.
 
-  static void __attribute__((noinline)) _join_two_untyped_columns(std::shared_ptr<const BaseColumn>& column_left,
-                                        std::shared_ptr<const BaseColumn>& column_right, const ChunkID chunk_id_left,
-                                        const ChunkID chunk_id_right, JoinParams& params);
+  static void __attribute__((noinline))
+  _join_two_untyped_columns(std::shared_ptr<const BaseColumn>& column_left,
+                            std::shared_ptr<const BaseColumn>& column_right, const ChunkID chunk_id_left,
+                            const ChunkID chunk_id_right, JoinParams& params);
 
   template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-  static void __attribute__((noinline)) _join_two_typed_columns(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
-                                      RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
-                                      const ChunkID chunk_id_right, JoinParams& params);
+  static void __attribute__((noinline))
+  _join_two_typed_columns(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
+                          RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
+                          const ChunkID chunk_id_right, JoinParams& params);
 
   static void _process_match(RowID left_row_id, RowID right_row_id, JoinParams& params);
 

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -11,6 +11,8 @@
 
 namespace opossum {
 
+class JoinIndex;
+
 class JoinNestedLoop : public AbstractJoinOperator {
  public:
   JoinNestedLoop(const std::shared_ptr<const AbstractOperator> left,
@@ -22,15 +24,37 @@ class JoinNestedLoop : public AbstractJoinOperator {
       const std::vector<AllParameterVariant>& args, const std::shared_ptr<AbstractOperator>& recreated_input_left,
       const std::shared_ptr<AbstractOperator>& recreated_input_right) const override;
 
+  struct JoinParams {
+    PosList& pos_list_left;
+    PosList& pos_list_right;
+    std::vector<bool>& left_matches;
+    std::vector<bool>& right_matches;
+    bool track_left_matches;
+    bool track_right_matches;
+    JoinMode mode;
+    const PredicateCondition predicate_condition;
+  };
+
  protected:
   std::shared_ptr<const Table> _on_execute() override;
 
   void _perform_join();
 
+  // Having all these static methods and passing around the state of the JoinNestedLoop is somewhat ugly, but it allows
+  // us to reuse the code in JoinIndex as a fallback. __attribute__((noinline)) is simply magic - otherwise the
+  // compiler would try to put the entire join for all types into a single, monolithic function. For -O3 on clang, this
+  // reduces the compile time from twelve minutes to less than three.
+
+  static void __attribute__((noinline)) _join_two_untyped_columns(std::shared_ptr<const BaseColumn>& column_left,
+                                        std::shared_ptr<const BaseColumn>& column_right, const ChunkID chunk_id_left,
+                                        const ChunkID chunk_id_right, JoinParams& params);
+
   template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-  void _join_two_columns(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
-                         RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
-                         const ChunkID chunk_id_right, std::vector<bool>& left_matches);
+  static void __attribute__((noinline)) _join_two_typed_columns(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
+                                      RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
+                                      const ChunkID chunk_id_right, JoinParams& params);
+
+  static void _process_match(RowID left_row_id, RowID right_row_id, JoinParams& params);
 
   void _create_table_structure();
 
@@ -50,7 +74,10 @@ class JoinNestedLoop : public AbstractJoinOperator {
   std::shared_ptr<PosList> _pos_list_right;
 
   // for Full Outer, remember the matches on the right side
-  std::set<RowID> _right_matches;
+  std::vector<std::vector<bool>> _right_matches;
+
+  // The JoinIndex uses this join as a fallback if no index exists
+  friend class JoinIndex;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan/base_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_table_scan_impl.hpp
@@ -31,8 +31,8 @@ class BaseTableScanImpl {
 
   template <typename UnaryFunctor, typename LeftIterator>
   // noinline reduces compile time drastically
-  void __attribute__((noinline)) _unary_scan(const UnaryFunctor& func, LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id,
-                   PosList& matches_out) {
+  void __attribute__((noinline)) _unary_scan(const UnaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
+                                             const ChunkID chunk_id, PosList& matches_out) {
     for (; left_it != left_end; ++left_it) {
       const auto left = *left_it;
 
@@ -45,8 +45,8 @@ class BaseTableScanImpl {
   }
 
   template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-  void __attribute__((noinline)) _binary_scan(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end, RightIterator right_it,
-                    const ChunkID chunk_id, PosList& matches_out) {
+  void __attribute__((noinline)) _binary_scan(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
+                                              RightIterator right_it, const ChunkID chunk_id, PosList& matches_out) {
     for (; left_it != left_end; ++left_it, ++right_it) {
       const auto left = *left_it;
       const auto right = *right_it;

--- a/src/lib/operators/table_scan/base_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/base_table_scan_impl.hpp
@@ -30,7 +30,8 @@ class BaseTableScanImpl {
    */
 
   template <typename UnaryFunctor, typename LeftIterator>
-  void _unary_scan(const UnaryFunctor& func, LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id,
+  // noinline reduces compile time drastically
+  void __attribute__((noinline)) _unary_scan(const UnaryFunctor& func, LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id,
                    PosList& matches_out) {
     for (; left_it != left_end; ++left_it) {
       const auto left = *left_it;
@@ -44,7 +45,7 @@ class BaseTableScanImpl {
   }
 
   template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-  void _binary_scan(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end, RightIterator right_it,
+  void __attribute__((noinline)) _binary_scan(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end, RightIterator right_it,
                     const ChunkID chunk_id, PosList& matches_out) {
     for (; left_it != left_end; ++left_it, ++right_it) {
       const auto left = *left_it;


### PR DESCRIPTION
First, this moves the core part from the nested loop join into static methods. These can then be reused by the index join, which currently builds its own nested loop join. (We can't call the actual operator because that would lead to bigger issues with outer joins.)

Second, these methods are marked `__attribute__((noinline))`. Compilers usually try to inline templated functions, but here it takes forever. While this means that we have one more function call, it is only once per chunk, so survivable.

Here are some numbers:

It is interesting to see that gcc seems to compile template-heavy code better than clang.

```
Compile Time in seconds

clang (on my Macbook)

DEBUG                                   old  new  diff
join_nested_loop.cpp                     23   22  - 4%
join_index.cpp                           24    7  -70%
column_comparison_table_scan_impl.cpp    17   17    0%
total                                        -18

RELEASE
join_nested_loop.cpp                    355  128  -64%
join_index.cpp                          710   16  -98%
column_comparison_table_scan_impl.cpp   481  285  -41%
total                                      -1117


gcc (on nemea)

DEBUG                                   old  new  diff
join_nested_loop.cpp                     28   25  -11%
join_index.cpp                           28   10  -64%
column_comparison_table_scan_impl.cpp    23   23    0%
total                                        -21

RELEASE
join_nested_loop.cpp                     88  201 +128% :(
join_index.cpp                          243    8  -97%
column_comparison_table_scan_impl.cpp   118  132  +12% :(
total                                       -108
```

In fact, not inlining the templated part actually seems to make things better:

```
hyriseMicroBenchmarks (on nemea)            old   new
(measured in iterations - more is better)
BM_Join_Small\<JoinNestedLoop\>                     222   273  +23%
BM_Join_Small\<JoinIndex\>                           42    43  + 2%
BenchmarkBasicFixture/BM_TableScanVariable         1736  2249  +30%
BenchmarkBasicFixture/BM_TableScanVariable_OnDict  1275  1699  +33%
```

We should have a look if there are other places where `__attribute__((noinline))` gives us an advantage.

For this PR, there is no need to look at the code too carefully, because the logic didn't change. Have a look at the `JoinParams` struct though, because that is somewhat ugly. My take is that it's forgivable, given the huge improvement that it gives us, but maybe someone comes up with a better idea.