### PR TITLE
Fix stupid race condition

### DIFF
--- a/src/lib/concurrency/commit_context.cpp
+++ b/src/lib/concurrency/commit_context.cpp
@@ -12,11 +12,13 @@ CommitID CommitContext::commit_id() const { return _commit_id; }
 bool CommitContext::is_pending() const { return _pending; }
 
 void CommitContext::make_pending(const TransactionID transaction_id, std::function<void(TransactionID)> callback) {
-  _pending = true;
-
   if (callback) {
     _callback = [callback, transaction_id]() { callback(transaction_id); };
   }
+
+  // This line MUST be AFTER setting the callback. Otherwise we run into a race condition while committing, because this
+  // is 'pending' but the callback is not there yet.
+  _pending = true;
 }
 
 void CommitContext::fire_callback() {

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -125,4 +125,33 @@ TEST_F(ServerTestRunner, TestPreparedStatement) {
   EXPECT_EQ(result2.size(), 2u);
 }
 
+TEST_F(ServerTestRunner, TestParallelConnections) {
+  // This test is by no means perfect, as it can show flaky behaviour. But it is rather hard to get reliable tests with
+  // multiple concurrent connections to detect a randomly (but often) occurring bug.
+  const std::string sql = "SELECT * FROM table_a;";
+  const auto expected_num_rows = _table_a->row_count();
+
+  const auto connection_run = [&]() {
+    pqxx::connection connection{_connection_string};
+    pqxx::nontransaction transaction{connection};
+    const auto result = transaction.exec(sql);
+    EXPECT_EQ(result.size(), expected_num_rows);
+  };
+
+  const auto num_threads = 100u;
+  std::vector<std::future<void>> thread_futures;
+  thread_futures.reserve(num_threads);
+
+  for (auto thread_num = 0u; thread_num < num_threads; ++thread_num) {
+    // We want a future to the thread running, so we can kill it after a future.wait(timeout) or the test would freeze
+    thread_futures.emplace_back(std::async(std::launch::async, connection_run));
+  }
+
+  for (auto& thread_fut : thread_futures) {
+    if (thread_fut.wait_for(std::chrono::seconds(10)) == std::future_status::timeout) {
+      ASSERT_TRUE(false) << "At least one thread got stuck and did not commit.";
+    }
+  }
+}
+
 }  // namespace opossum

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -128,7 +128,9 @@ TEST_F(ServerTestRunner, TestPreparedStatement) {
 
 TEST_F(ServerTestRunner, TestParallelConnections) {
   // This test is by no means perfect, as it can show flaky behaviour. But it is rather hard to get reliable tests with
-  // multiple concurrent connections to detect a randomly (but often) occurring bug.
+  // multiple concurrent connections to detect a randomly (but often) occurring bug. This test will/can only fail if a
+  // bug is present but it should not fail if no bug is present. It just sends 100 parallel connections and if that
+  // fails, there probably is a bug.
   const std::string sql = "SELECT * FROM table_a;";
   const auto expected_num_rows = _table_a->row_count();
 

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -1,6 +1,7 @@
 #include <pqxx/pqxx>
 
 #include <thread>
+#include <future>
 
 #include "base_test.hpp"
 #include "scheduler/node_queue_scheduler.hpp"


### PR DESCRIPTION
This finally fixes a race condition we had while committing. Now, our server should work as intended with many parallel connections :)

The test added should catch this. I'm aware, that this kind of testing is not super great but it is really hard to catch this bug in any other way. So if it fails in CI again, we know the problem is not fully dealt with.

For completeness, to reproduce in playground.cpp 

```cpp
#include <iostream>
#include <thread>
#include <chrono>
#include <future>
#include <memory>

#include "sql/sql_pipeline_builder.hpp"
#include "storage/storage_manager.hpp"
#include "types.hpp"
#include "utils/load_table.hpp"
#include "scheduler/current_scheduler.hpp"
#include "scheduler/node_queue_scheduler.hpp"
#include "scheduler/topology.hpp"

using namespace opossum;  // NOLINT

int main() {
  // CurrentScheduler::set(std::make_shared<NodeQueueScheduler>(Topology::create_numa_topology()));

  const std::string sql = "SELECT * FROM table_a;";

  auto x = load_table("src/test/tables/int.tbl");
  StorageManager::get().add_table("table_a", x);
  const auto expected_num_rows = x->row_count();

  const auto connection_run = [&]() {
    auto pipeline = SQLPipelineBuilder{sql}.create_pipeline();
    const auto result = pipeline.get_result_table();

    if (result == nullptr || result->row_count() != expected_num_rows) {
      std::cout << "BAD RESULT!" << std::endl;
    }
  };

  const auto num_threads = 5000u;
  std::vector<std::future<void>> thread_futures;
  thread_futures.reserve(num_threads);

  for (auto thread_num = 0u; thread_num < num_threads; ++thread_num) {
    // We want a future to the thread running, so we can kill it after a future.wait(timeout) or the test would freeze
    thread_futures.emplace_back(std::async(std::launch::async, connection_run));
  }

  for (auto& thread_fut : thread_futures) {
    if (thread_fut.wait_for(std::chrono::seconds(10)) == std::future_status::timeout) {
      Fail("At least one thread got stuck and did not commit.");
    }
  }
}
```