### PR TITLE
Fix included cpps

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 
-# If you call this script without parameters, it performs all checks. The CI does it in two steps so that a failure to provide an issue number for a disabled test does not stop the CI build.
-
 exitcode=0
 
-# find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/operators/jit_operator/specialization/llvm/*.cpp" -print0 | parallel --null --no-notice -j 100% --nice 17 python2.7 ./scripts/cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11,-build/include_what_you_use --linelength=120 {} 2\>\&1 \| grep -v \'\^Done processing\' \| grep -v \'\^Total errors found: 0\' \; test \${PIPESTATUS[0]} -eq 0
-# let "exitcode |= $?"
-# #                             /------------------ runs in parallel -------------------\
-# # Conceptual: find | parallel python cpplint \| grep -v \| test \${PIPESTATUS[0]} -eq 0
-# #             ^      ^        ^                 ^          ^
-# #             |      |        |                 |          |
-# #             |      |        |                 |          Get the return code of the first pipeline item (here: cpplint)
-# #             |      |        |                 Removes the prints for files without errors
-# #             |      |        Regular call of cpplint with options
-# #             |      Runs the following in parallel
-# #             Finds all .cpp and .hpp files, separated by \0
+find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/operators/jit_operator/specialization/llvm/*.cpp" -print0 | parallel --null --no-notice -j 100% --nice 17 python2.7 ./scripts/cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11,-build/include_what_you_use --linelength=120 {} 2\>\&1 \| grep -v \'\^Done processing\' \| grep -v \'\^Total errors found: 0\' \; test \${PIPESTATUS[0]} -eq 0
+let "exitcode |= $?"
+#                             /------------------ runs in parallel -------------------\
+# Conceptual: find | parallel python cpplint \| grep -v \| test \${PIPESTATUS[0]} -eq 0
+#             ^      ^        ^                 ^          ^
+#             |      |        |                 |          |
+#             |      |        |                 |          Get the return code of the first pipeline item (here: cpplint)
+#             |      |        |                 Removes the prints for files without errors
+#             |      |        Regular call of cpplint with options
+#             |      Runs the following in parallel
+#             Finds all .cpp and .hpp files, separated by \0
 
-# # All disabled tests should have an issue number
-# grep -rn 'DISABLED_' src/test | grep -v '#[0-9]\+' | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Disabled tests should be documented with their issue number (e.g. \/* #123 *\/)/'
-# let "exitcode |= $?"
+# All disabled tests should have an issue number
+grep -rn 'DISABLED_' src/test | grep -v '#[0-9]\+' | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Disabled tests should be documented with their issue number (e.g. \/* #123 *\/)/'
+let "exitcode |= $?"
 
 # Check for included cpp files. You would think that this is not necessary, but history proves you wrong.
 regex='#include .*\.cpp'

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,31 +4,31 @@
 
 exitcode=0
 
-find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/operators/jit_operator/specialization/llvm/*.cpp" -print0 | parallel --null --no-notice -j 100% --nice 17 python2.7 ./scripts/cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11,-build/include_what_you_use --linelength=120 {} 2\>\&1 \| grep -v \'\^Done processing\' \| grep -v \'\^Total errors found: 0\' \; test \${PIPESTATUS[0]} -eq 0
-let "exitcode |= $?"
-#                             /------------------ runs in parallel -------------------\
-# Conceptual: find | parallel python cpplint \| grep -v \| test \${PIPESTATUS[0]} -eq 0
-#             ^      ^        ^                 ^          ^
-#             |      |        |                 |          |
-#             |      |        |                 |          Get the return code of the first pipeline item (here: cpplint)
-#             |      |        |                 Removes the prints for files without errors
-#             |      |        Regular call of cpplint with options
-#             |      Runs the following in parallel
-#             Finds all .cpp and .hpp files, separated by \0
+# find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/operators/jit_operator/specialization/llvm/*.cpp" -print0 | parallel --null --no-notice -j 100% --nice 17 python2.7 ./scripts/cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11,-build/include_what_you_use --linelength=120 {} 2\>\&1 \| grep -v \'\^Done processing\' \| grep -v \'\^Total errors found: 0\' \; test \${PIPESTATUS[0]} -eq 0
+# let "exitcode |= $?"
+# #                             /------------------ runs in parallel -------------------\
+# # Conceptual: find | parallel python cpplint \| grep -v \| test \${PIPESTATUS[0]} -eq 0
+# #             ^      ^        ^                 ^          ^
+# #             |      |        |                 |          |
+# #             |      |        |                 |          Get the return code of the first pipeline item (here: cpplint)
+# #             |      |        |                 Removes the prints for files without errors
+# #             |      |        Regular call of cpplint with options
+# #             |      Runs the following in parallel
+# #             Finds all .cpp and .hpp files, separated by \0
 
-# All disabled tests should have an issue number
-grep -rn 'DISABLED_' src/test | grep -v '#[0-9]\+' | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Disabled tests should be documented with their issue number (e.g. \/* #123 *\/)/'
-let "exitcode |= $?"
+# # All disabled tests should have an issue number
+# grep -rn 'DISABLED_' src/test | grep -v '#[0-9]\+' | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Disabled tests should be documented with their issue number (e.g. \/* #123 *\/)/'
+# let "exitcode |= $?"
 
-# Check for variable names in camel case. Exceptions may have to be added here for calls to external libraries.
-regex=' [a-z]\+\([A-Z][a-z]\+\)\+'
-namecheck=$(find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/operators/jit_operator/specialization/llvm/*.cpp" -print0 | xargs -0 grep -rn "$regex" | grep -v '\w*\*' | grep -v '\w*//' | grep -v NOLINT | grep -v sql)
+# Check for included cpp files. You would think that this is not necessary, but history proves you wrong.
+regex='#include .*\.cpp'
+namecheck=$(find src \( -iname "*.cpp" -o -iname "*.hpp" \) -print0 | xargs -0 grep -rn "$regex" | grep -v NOLINT)
 
 let "exitcode |= ! $?"
 while IFS= read -r line
 do
-	echo $line | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Possible violation of naming convention:/' | tr '\n' ' '
-	echo $line | sed 's/^[^ ]*//' | grep -o "$regex" | head -n1
+	echo $line | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/Include of cpp file:/' | tr '\n' ' '
+	echo $line | sed 's/\(:[^:]*:\)/\1 /'
 done <<< "$namecheck"
 
 exit $exitcode

--- a/src/lib/operators/join_mpsm/column_materializer_numa.hpp
+++ b/src/lib/operators/join_mpsm/column_materializer_numa.hpp
@@ -9,7 +9,6 @@
 #include "scheduler/job_task.hpp"
 #include "scheduler/topology.hpp"
 #include "storage/create_iterable_from_column.hpp"
-#include "utils/boost_default_memory_resource.cpp"
 #include "types.hpp"
 #include "utils/numa_memory_resource.hpp"
 

--- a/src/test/logical_query_plan/union_node_test.cpp
+++ b/src/test/logical_query_plan/union_node_test.cpp
@@ -4,7 +4,7 @@
 
 #include "base_test.hpp"
 
-#include "logical_query_plan/mock_node.cpp"
+#include "logical_query_plan/mock_node.hpp"
 #include "logical_query_plan/union_node.hpp"
 
 namespace opossum {

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -1,7 +1,7 @@
 #include <gmock/gmock.h>
 
 #include "../base_test.hpp"
-#include "operators/jit_operator/operators/jit_compute.cpp"
+#include "operators/jit_operator/operators/jit_compute.hpp"
 #include "operators/jit_operator/operators/jit_expression.hpp"
 #include "operators/jit_operator/operators/jit_filter.hpp"
 #include "operators/jit_operator/operators/jit_read_tuples.hpp"

--- a/src/test/server/server_session_test.cpp
+++ b/src/test/server/server_session_test.cpp
@@ -1,8 +1,8 @@
 #include <gmock/gmock.h>
 #include <boost/asio/ip/tcp.hpp>
 #include <server/server_session.hpp>
-// The template is defined and default-instantiated in the .cpp
-#include <server/server_session.cpp>
+// The template is ServerSessionImpl defined and default-instantiated in the .cpp, we include it here to mock it
+#include <server/server_session.cpp>  // NOLINT
 #include "../base_test.hpp"
 #include "mock_connection.hpp"
 #include "mock_task_runner.hpp"


### PR DESCRIPTION
For some reason, people included cpp files. Lint will no longer tolerate that. :rage:

Also, the hacky naming check in lint can go because clang-tidy is way better for that.