### PR TITLE
Mp18/radix bits

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -26,8 +26,10 @@ namespace opossum {
 
 JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator> left,
                    const std::shared_ptr<const AbstractOperator> right, const JoinMode mode,
-                   const ColumnIDPair& column_ids, const PredicateCondition predicate_condition)
-    : AbstractJoinOperator(OperatorType::JoinHash, left, right, mode, column_ids, predicate_condition) {
+                   const ColumnIDPair& column_ids, const PredicateCondition predicate_condition,
+                   const size_t radix_bits)
+    : AbstractJoinOperator(OperatorType::JoinHash, left, right, mode, column_ids, predicate_condition),
+      _radix_bits(radix_bits) {
   DebugAssert(predicate_condition == PredicateCondition::Equals, "Operator not supported by Hash Join.");
 }
 
@@ -76,7 +78,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
 
   _impl = make_unique_by_data_types<AbstractReadOnlyOperatorImpl, JoinHashImpl>(
       build_input->column_data_type(build_column_id), probe_input->column_data_type(probe_column_id), build_operator,
-      probe_operator, _mode, adjusted_column_ids, _predicate_condition, inputs_swapped);
+      probe_operator, _mode, adjusted_column_ids, _predicate_condition, inputs_swapped, _radix_bits);
   return _impl->_on_execute();
 }
 
@@ -597,13 +599,14 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
  public:
   JoinHashImpl(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right,
                const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition predicate_condition,
-               const bool inputs_swapped)
+               const bool inputs_swapped, const size_t radix_bits)
       : _left(left),
         _right(right),
         _mode(mode),
         _column_ids(column_ids),
         _predicate_condition(predicate_condition),
-        _inputs_swapped(inputs_swapped) {}
+        _inputs_swapped(inputs_swapped),
+        _radix_bits(radix_bits) {}
 
   virtual ~JoinHashImpl() = default;
 
@@ -617,7 +620,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   std::shared_ptr<Table> _output_table;
 
   const unsigned int _partitioning_seed = 13;
-  const size_t _radix_bits = 9;
+  const size_t _radix_bits;
 
   // Determine correct type for hashing
   using HashedType = typename JoinHashTraits<LeftType, RightType>::HashType;

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -405,7 +405,7 @@ void probe(const RadixContainer<RightType>& radix_container,
 
           // This is where the actual comparison happens. `get` only returns values that match and eliminates hash
           // collisions.
-          auto row_ids = hashtable->get(row.value);
+          auto row_ids = hashtable->get(type_cast<HashedType>(row.value));
 
           if (row_ids) {
             for (const auto& row_id : *row_ids) {

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -24,7 +24,8 @@ namespace opossum {
 class JoinHash : public AbstractJoinOperator {
  public:
   JoinHash(const std::shared_ptr<const AbstractOperator> left, const std::shared_ptr<const AbstractOperator> right,
-           const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition predicate_condition);
+           const JoinMode mode, const ColumnIDPair& column_ids, const PredicateCondition predicate_condition,
+           const size_t radix_bits = 9);
 
   const std::string name() const override;
 
@@ -36,6 +37,7 @@ class JoinHash : public AbstractJoinOperator {
   void _on_cleanup() override;
 
   std::unique_ptr<AbstractReadOnlyOperatorImpl> _impl;
+  const size_t _radix_bits;
 
   template <typename LeftType, typename RightType>
   class JoinHashImpl;

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -63,6 +63,19 @@ TYPED_TEST(JoinEquiTest, InnerJoinIntFloat) {
                                              JoinMode::Inner, "src/test/tables/joinoperators/float_int_inner.tbl", 1);
 }
 
+TYPED_TEST(JoinEquiTest, InnerJoinIntFloatRadixBit) {
+  if (std::is_same<TypeParam, JoinHash>::value) {
+    // float with int
+    // radix bits = 1
+    std::shared_ptr<Table> expected_result = load_table("src/test/tables/joinoperators/float_int_inner.tbl", 1);
+    auto join = std::make_shared<JoinHash>(this->_table_wrapper_o, this->_table_wrapper_a, JoinMode::Inner,
+                                           ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, 1);
+    join->execute();
+
+    EXPECT_TABLE_EQ_UNORDERED(join->get_output(), expected_result);
+  }
+}
+
 TYPED_TEST(JoinEquiTest, InnerJoinIntDouble) {
   if (std::is_same<TypeParam, JoinSortMerge>::value) {
     return;


### PR DESCRIPTION
Fixes #897. The problem was that different types were hashed. It worked for larger numbers of radix bits because each partition only had the same values.

Is it ok to add a default constructor argument for the number of radix bits?