### PR TITLE
Remove some shared_ptrs where they are not needed

### DIFF
--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -612,9 +612,7 @@ write_aggregate_values(std::shared_ptr<ValueColumn<AggregateType>> column,
   for (auto& kv : *results) {
     null_values[i] = !kv.second.current_aggregate;
 
-    if (!kv.second.current_aggregate) {
-      values[i] = AggregateType();
-    } else {
+    if (kv.second.current_aggregate) {
       values[i] = *kv.second.current_aggregate;
     }
     ++i;

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -676,9 +676,7 @@ write_aggregate_values(std::shared_ptr<ValueColumn<AggregateType>> column,
   for (auto& kv : *results) {
     null_values[i] = !kv.second.current_aggregate;
 
-    if (!kv.second.current_aggregate) {
-      values[i] = AggregateType();
-    } else {
+    if (kv.second.current_aggregate) {
       values[i] = *kv.second.current_aggregate / static_cast<AggregateType>(kv.second.aggregate_count);
     }
     ++i;

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -405,10 +405,10 @@ void probe(const RadixContainer<RightType>& radix_container,
 
           // This is where the actual comparison happens. `get` only returns values that match and eliminates hash
           // collisions.
-          const auto& row_ids = hashtable->get(type_cast<HashedType>(row.value));
+          const auto& matching_rows = hashtable->get(type_cast<HashedType>(row.value));
 
-          if (row_ids) {
-            for (const auto row_id : row_ids->get()) {
+          if (matching_rows) {
+            for (const auto row_id : matching_rows->get()) {
               if (row_id.chunk_offset != INVALID_CHUNK_OFFSET) {
                 pos_list_left_local.emplace_back(row_id);
                 pos_list_right_local.emplace_back(row.row_id);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -118,12 +118,12 @@ struct RadixContainer {
 Build all the hash tables for the partitions of Left. We parallelize this process for all partitions of Left
 */
 template <typename LeftType, typename HashedType>
-std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<LeftType>& radix_container) {
+std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<LeftType>& radix_container) {
   /*
   NUMA notes:
   The hashtables for each partition P should also reside on the same node as the two vectors leftP and rightP.
   */
-  std::vector<std::shared_ptr<HashTable<HashedType>>> hashtables;
+  std::vector<std::optional<HashTable<HashedType>>> hashtables;
   hashtables.resize(radix_container.partition_offsets.size() - 1);
 
   std::vector<std::shared_ptr<AbstractTask>> jobs;
@@ -144,15 +144,15 @@ std::vector<std::shared_ptr<HashTable<HashedType>>> build(const RadixContainer<L
                                                  partition_size]() {
       auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
 
-      auto hashtable = std::make_shared<HashTable<HashedType>>(partition_size);
+      auto hashtable = HashTable<HashedType>{partition_size};
 
       for (size_t partition_offset = partition_left_begin; partition_offset < partition_left_end; ++partition_offset) {
         auto& element = partition_left[partition_offset];
 
-        hashtable->put(type_cast<HashedType>(element.value), element.row_id);
+        hashtable.put(type_cast<HashedType>(element.value), element.row_id);
       }
 
-      hashtables[current_partition_id] = hashtable;
+      hashtables[current_partition_id] = std::move(hashtable);
     }));
     jobs.back()->schedule();
   }
@@ -364,7 +364,7 @@ RadixContainer<T> partition_radix_parallel(std::shared_ptr<Partition<T>> materia
   */
 template <typename RightType, typename HashedType>
 void probe(const RadixContainer<RightType>& radix_container,
-           const std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables, std::vector<PosList>& pos_list_left,
+           const std::vector<std::optional<HashTable<HashedType>>>& hashtables, std::vector<PosList>& pos_list_left,
            std::vector<PosList>& pos_list_right, const JoinMode mode) {
   std::vector<std::shared_ptr<AbstractTask>> jobs;
   jobs.reserve(radix_container.partition_offsets.size() - 1);
@@ -394,7 +394,7 @@ void probe(const RadixContainer<RightType>& radix_container,
       PosList pos_list_right_local;
 
       if (hashtables[current_partition_id]) {
-        auto& hashtable = hashtables.at(current_partition_id);
+        const auto& hashtable = hashtables.at(current_partition_id);
 
         for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
           auto& row = partition[partition_offset];
@@ -405,10 +405,10 @@ void probe(const RadixContainer<RightType>& radix_container,
 
           // This is where the actual comparison happens. `get` only returns values that match and eliminates hash
           // collisions.
-          auto row_ids = hashtable->get(type_cast<HashedType>(row.value));
+          const auto& row_ids = hashtable->get(type_cast<HashedType>(row.value));
 
           if (row_ids) {
-            for (const auto& row_id : *row_ids) {
+            for (const auto row_id : row_ids->get()) {
               if (row_id.chunk_offset != INVALID_CHUNK_OFFSET) {
                 pos_list_left_local.emplace_back(row_id);
                 pos_list_right_local.emplace_back(row.row_id);
@@ -451,7 +451,7 @@ void probe(const RadixContainer<RightType>& radix_container,
 
 template <typename RightType, typename HashedType>
 void probe_semi_anti(const RadixContainer<RightType>& radix_container,
-                     const std::vector<std::shared_ptr<HashTable<HashedType>>>& hashtables,
+                     const std::vector<std::optional<HashTable<HashedType>>>& hashtables,
                      std::vector<PosList>& pos_lists, const JoinMode mode) {
   std::vector<std::shared_ptr<AbstractTask>> jobs;
   jobs.reserve(radix_container.partition_offsets.size() - 1);
@@ -472,7 +472,7 @@ void probe_semi_anti(const RadixContainer<RightType>& radix_container,
 
       PosList pos_list_local;
 
-      if (auto& hashtable = hashtables[current_partition_id]) {
+      if (const auto& hashtable = hashtables[current_partition_id]) {
         // Valid hashtable found, so there is at least one match in this partition
 
         for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
@@ -482,7 +482,7 @@ void probe_semi_anti(const RadixContainer<RightType>& radix_container,
             continue;
           }
 
-          auto matching_rows = hashtable->get(row.value);
+          const auto& matching_rows = hashtable->get(row.value);
 
           if ((mode == JoinMode::Semi && matching_rows) || (mode == JoinMode::Anti && !matching_rows)) {
             // Semi: found at least one match for this row -> match

--- a/src/lib/utils/cuckoo_hashtable.hpp
+++ b/src/lib/utils/cuckoo_hashtable.hpp
@@ -24,7 +24,9 @@ class HashTable : private Noncopyable {
   explicit HashTable(size_t input_table_size) : _input_table_size(input_table_size) {
     // prepare internal hash tables and fill with empty elements
     // can't use resize because elements are not copyable
-    for (size_t i = 0; i < NUMBER_OF_HASH_FUNCTIONS; ++i) _hashtables.emplace_back(input_table_size);
+    for (size_t i = 0; i < NUMBER_OF_HASH_FUNCTIONS; ++i) {
+      _hashtables.emplace_back(input_table_size);
+    }
   }
 
   // we need to explicitly set the move constructor to default when

--- a/src/lib/utils/cuckoo_hashtable.hpp
+++ b/src/lib/utils/cuckoo_hashtable.hpp
@@ -23,7 +23,7 @@ class HashTable : private Noncopyable {
  public:
   explicit HashTable(size_t input_table_size) : _input_table_size(input_table_size) {
     // prepare internal hash tables and fill with empty elements
-    _hashtables.resize(NUMBER_OF_HASH_FUNCTIONS, std::vector<std::shared_ptr<HashElement>>(input_table_size));
+    _hashtables.resize(NUMBER_OF_HASH_FUNCTIONS, std::vector<std::optional<HashElement>>(input_table_size));
   }
 
   // we need to explicitly set the move constructor to default when
@@ -39,13 +39,12 @@ class HashTable : private Noncopyable {
     for (size_t i = 0; i < NUMBER_OF_HASH_FUNCTIONS; i++) {
       auto position = hash<T>(i, value);
       auto element = _hashtables[i][position];
-      if (element != nullptr && value_equal(element->value, value)) {
+      if (element && value_equal(element->value, value)) {
         element->row_ids.push_back(row_id);
         return;
       }
     }
-    auto element =
-        std::make_shared<HashElement>(HashElement{value, pmr_vector<RowID>{row_id}});
+    auto element = HashElement{value, pmr_vector<RowID>{row_id}};
     place(element, 0, 0);
   }
 
@@ -58,7 +57,7 @@ class HashTable : private Noncopyable {
     for (size_t i = 0; i < NUMBER_OF_HASH_FUNCTIONS; i++) {
       auto position = hash<S>(i, value);
       auto element = _hashtables[i][position];
-      if (element != nullptr && value_equal(element->value, value)) {
+      if (element && value_equal(element->value, value)) {
         return element->row_ids;
       }
     }
@@ -83,7 +82,7 @@ class HashTable : private Noncopyable {
   n: maximum number of times function can be recursively
   called before stopping and declaring presence of cycle
   */
-  void place(std::shared_ptr<HashElement> element, int hash_function, size_t iterations) {
+  void place(std::optional<HashElement> element, int hash_function, size_t iterations) {
     /*
     We were not able to reproduce this case with the current setting (3 hash functions). With 3 hash functions the
     hash table will have a maximum load of 33%, which should be less enough to avoid cycles at all. In theory there
@@ -101,7 +100,7 @@ class HashTable : private Noncopyable {
     auto& hashtable = _hashtables[hash_function];
 
     auto old_element = hashtable[position];
-    if (old_element != nullptr) {
+    if (old_element) {
       hashtable[position] = element;
       place(old_element, (hash_function + 1) % NUMBER_OF_HASH_FUNCTIONS, iterations + 1);
     } else {
@@ -119,6 +118,6 @@ class HashTable : private Noncopyable {
   }
 
   size_t _input_table_size;
-  std::vector<std::vector<std::shared_ptr<HashElement>>> _hashtables;
+  std::vector<std::vector<std::optional<HashElement>>> _hashtables;
 };
 }  // namespace opossum

--- a/src/lib/utils/cuckoo_hashtable.hpp
+++ b/src/lib/utils/cuckoo_hashtable.hpp
@@ -40,12 +40,12 @@ class HashTable : private Noncopyable {
       auto position = hash<T>(i, value);
       auto element = _hashtables[i][position];
       if (element != nullptr && value_equal(element->value, value)) {
-        element->row_ids->push_back(row_id);
+        element->row_ids.push_back(row_id);
         return;
       }
     }
     auto element =
-        std::make_shared<HashElement>(HashElement{value, std::make_shared<PosList>(pmr_vector<RowID>{row_id})});
+        std::make_shared<HashElement>(HashElement{value, pmr_vector<RowID>{row_id}});
     place(element, 0, 0);
   }
 
@@ -54,7 +54,7 @@ class HashTable : private Noncopyable {
   All the matching RowIDs are returned in row_ids.
   */
   template <typename S>
-  std::shared_ptr<PosList> get(S value) {
+  std::optional<std::reference_wrapper<const PosList>> get(S value) const {
     for (size_t i = 0; i < NUMBER_OF_HASH_FUNCTIONS; i++) {
       auto position = hash<S>(i, value);
       auto element = _hashtables[i][position];
@@ -62,7 +62,7 @@ class HashTable : private Noncopyable {
         return element->row_ids;
       }
     }
-    return nullptr;
+    return std::nullopt;
   }
 
  protected:
@@ -71,7 +71,7 @@ class HashTable : private Noncopyable {
   */
   struct HashElement {
     T value;
-    std::shared_ptr<PosList> row_ids;
+    PosList row_ids;
   };
 
   /*
@@ -113,7 +113,7 @@ class HashTable : private Noncopyable {
   return hashed value for a value
   */
   template <typename R>
-  int hash(int seed, R value) {
+  int hash(int seed, R value) const {
     // avoid a seed of 0 and increase it by some factor, 10 seems to be working fine
     return murmur2<R>(value, (seed + 1) * 10) % _input_table_size;
   }

--- a/src/test/utils/cuckoo_hashtable_test.cpp
+++ b/src/test/utils/cuckoo_hashtable_test.cpp
@@ -27,7 +27,7 @@ TEST_F(CuckooHashtableTest, StackRowIDs) {
   auto row_ids = hashtable->get(5);
 
   EXPECT_TRUE(row_ids);
-  EXPECT_EQ(row_ids->size(), 2u);
+  EXPECT_EQ(row_ids->get().size(), 2u);
 }
 
 /*


### PR DESCRIPTION
> Nasty shared pointersss are bad. We need to kiiiilll them.
> *But th-they have always been good to us. We never lost an object.*
> Nooo, they just want our performanccce.
> *But what if someone else needs the elements from the hash table?*
> Nobody ever accesses them, preciousss. There is nothing shared about them.
> *And what do we do about the reallocations in the aggregate operator?*
> They are uselesssss as well.

Seriously though. This is not a good idea for a hash table that stores all entries internally:

```
  void put(const T value, const RowID row_id) {
   /// [...]
    auto element =
        std::make_shared<HashElement>(HashElement{value, std::make_shared<PosList>(pmr_vector<RowID>{row_id})});
    place(element, 0, 0);
  }
```

For the execution part of `hyriseBenchmarkTPCH`, this reduces the number of allocations from 16 to 7 million

The net performance gain is not as impressive. I expect a more significant difference in multithreaded execution, where allocations get superlinearly more expensive. @lanice, this might be interesting for you.

```
 Benchmark | prev. iter/s | new iter/s | change
-----------+--------------+------------+----------------
 TPC-H 1   | 0.073        | 0.072      | -1.6%
 TPC-H 3   | 1.056        | 1.11       | +5.1%
 TPC-H 5   | 0.035        | 0.035      | -0.6%
 TPC-H 6   | 5.049        | 4.936      | -2.2%
 TPC-H 7   | 0.124        | 0.136      | +9.5%
 TPC-H 9   | 0.023        | 0.023      | +2.2%
 TPC-H 10  | 0.828        | 0.84       | +1.4%
 TPC-H 13  | 0.645        | 0.632      | -2.0%
 average   |              |            | +1.5%
```