### PR TITLE
White spaces in graph viz file names issue #986

### DIFF
--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -63,7 +63,8 @@ void BenchmarkRunner::run() {
   // Visualize query plans
   if (_config.enable_visualization) {
     for (const auto& name_and_plans : _query_plans) {
-      const auto& name = name_and_plans.first;
+      auto name = name_and_plans.first;
+      boost::replace_all(name, " ", "_");
       const auto& lqps = name_and_plans.second.lqps;
       const auto& pqps = name_and_plans.second.pqps;
 

--- a/src/lib/planviz/abstract_visualizer.hpp
+++ b/src/lib/planviz/abstract_visualizer.hpp
@@ -90,7 +90,7 @@ class AbstractVisualizer {
     auto renderer = _graphviz_config.renderer;
     auto format = _graphviz_config.format;
 
-    auto cmd = renderer + " -T" + format + " " + graph_filename + " > " + img_filename;
+    auto cmd = renderer + " -T" + format + " \"" + graph_filename + "\" > \"" + img_filename + "\"";
     auto ret = system(cmd.c_str());
 
     Assert(ret == 0, "Calling graphviz' " + renderer +


### PR DESCRIPTION
This pr removes white spaces from graph viz file names in the benchmark runner.
It also allows white spaces of file names in the plan viz module.

Closes #986 .