### PR TITLE
Fix SQLiteWrapper returning empty table if last char is a newline

### DIFF
--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
@@ -92,7 +92,8 @@ std::shared_ptr<Table> SQLiteWrapper::execute_query(const std::string& sql_query
   std::vector<std::string> queries;
   boost::algorithm::split(queries, sql_query, boost::is_any_of(";"));
 
-  queries.erase(std::remove_if(queries.begin(), queries.end(), [](std::string const& query) { return query.empty(); }),
+  queries.erase(std::remove_if(queries.begin(), queries.end(),
+                               [](std::string const& query) { return query.empty() || query == "\n"; }),
                 queries.end());
 
   // We need to split the queries such that we only create columns/add rows from the final SELECT query

--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
@@ -10,6 +10,8 @@
 
 #include "constant_mappings.hpp"
 #include "utils/load_table.hpp"
+#include "sql/sql_pipeline.hpp"
+#include "sql/sql_pipeline_builder.hpp"
 
 namespace opossum {
 
@@ -89,12 +91,8 @@ void SQLiteWrapper::create_table_from_tbl(const std::string& file, const std::st
 std::shared_ptr<Table> SQLiteWrapper::execute_query(const std::string& sql_query) {
   sqlite3_stmt* result_row;
 
-  std::vector<std::string> queries;
-  boost::algorithm::split(queries, sql_query, boost::is_any_of(";"));
-
-  queries.erase(std::remove_if(queries.begin(), queries.end(),
-                               [](std::string const& query) { return query.empty() || query == "\n"; }),
-                queries.end());
+  auto sql_pipeline = SQLPipelineBuilder{sql_query}.create_pipeline();
+  const auto& queries = sql_pipeline.get_sql_strings();
 
   // We need to split the queries such that we only create columns/add rows from the final SELECT query
   std::vector<std::string> queries_before_select(queries.begin(), queries.end() - 1);


### PR DESCRIPTION
Fixes #984 

@mrzzzrm, the problem occured because:
The SQLiteWrapper divides the sql string into different queries by the semicolon, so
```
SELECT * FROM t;\n
```
would result in 2 queries, `SELECT * FROM t;`, and `\n`. The result table is determined by the last query executed, which in this case is `\n`. Therefore it just returned an empty table.

Update: Letting the `SQLPipeline` handle the splitting for us now.