### PR TITLE
Fix std::filesystem linking

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -454,6 +454,7 @@ set(
     pthread
     sqlparser
     ${TBB_LIBRARY}
+    stdc++fs
 )
 
 if (${ENABLE_JIT_SUPPORT})


### PR DESCRIPTION
closes #999 