### PR TITLE
Some lint/cmake/test fixes

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,4 +29,18 @@ do
 	echo $line | sed 's/\(:[^:]*:\)/\1 /'
 done <<< "$namecheck"
 
+for dir in src/*
+do
+	for file in $(find $dir -name *.cpp -o -name *.hpp)
+	do
+		if grep $(basename $file) $dir/CMakeLists.txt | grep -v '#' > /dev/null
+		then
+			continue
+		else
+			echo $file not found in $dir/CMakeLists.txt
+			exitcode=1
+		fi
+	done
+done
+
 exit $exitcode

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -177,14 +177,13 @@ set(
     operators/index_scan.hpp
     operators/insert.cpp
     operators/insert.hpp
-#    operators/jit_operator/jit_operations.hpp
-#    operators/jit_operator/jit_types.cpp
-#    operators/jit_operator/jit_types.hpp
     operators/join_hash.cpp
     operators/join_hash/hash_traits.hpp
     operators/join_hash.hpp
     operators/join_index.cpp
     operators/join_index.hpp
+    operators/join_mpsm/column_materializer_numa.hpp
+    operators/join_mpsm/radix_cluster_sort_numa.hpp
     operators/join_mpsm.cpp
     operators/join_mpsm.hpp
     operators/join_nested_loop.cpp
@@ -496,6 +495,7 @@ set(
     utils/format_bytes.hpp
     utils/format_duration.cpp
     utils/format_duration.hpp
+    utils/invalid_input_exception.hpp
     utils/load_table.cpp
     utils/load_table.hpp
     utils/murmur_hash.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -76,7 +76,7 @@ set(
     operators/projection_test.cpp
     operators/operator_deep_copy_test.cpp
     operators/sort_test.cpp
-    operators/table_scan_like_test.cpp
+    operators/table_scan_string_test.cpp
     operators/table_scan_test.cpp
     operators/union_all_test.cpp
     operators/union_positions_test.cpp
@@ -114,6 +114,7 @@ set(
     statistics/chunk_statistics/pruning_filters_test.cpp
     statistics/column_statistics_test.cpp
     statistics/generate_table_statistics_test.cpp
+    statistics/statistics_import_export_test.cpp
     statistics/statistics_test_utils.hpp
     statistics/table_statistics_test.cpp
     statistics/table_statistics_join_test.cpp
@@ -149,7 +150,9 @@ set(
     testing_assert.hpp
     utils/cuckoo_hashtable_test.cpp
     utils/format_bytes_test.cpp
+    utils/format_duration_test.cpp
     utils/numa_memory_resource_test.cpp
+    gtest_case_template.cpp
     gtest_main.cpp
 )
 

--- a/src/test/tables/int_string_like_equals.tbl
+++ b/src/test/tables/int_string_like_equals.tbl
@@ -1,0 +1,3 @@
+a|b
+int|string
+12345|Reeperbahn

--- a/src/test/tables/int_string_like_less_than.tbl
+++ b/src/test/tables/int_string_like_less_than.tbl
@@ -1,0 +1,7 @@
+a|b
+int|string
+1234|Dampfschifffahrtsgesellschaft
+12345|Reeperbahn
+123456|Dampfschifffahrtsgesellschaftskapitän
+1234567|Dampfschifffahrtsgesellschaftskapitänsdampf
+1234567|1234

--- a/src/test/tables/int_string_like_not_equals.tbl
+++ b/src/test/tables/int_string_like_not_equals.tbl
@@ -1,0 +1,7 @@
+a|b
+int|string
+123|Schifffahrtsgesellschaft
+1234|Dampfschifffahrtsgesellschaft
+123456|Dampfschifffahrtsgesellschaftskapitän
+1234567|Dampfschifffahrtsgesellschaftskapitänsdampf
+1234567|1234


### PR DESCRIPTION
* Make lint.sh complain about cpp/hpp files that cmake does not know about 
* Add missing cmake entries 
* Add string scan test (reusing the existing LIKE scan and adding equals/ne/lt) fixes #909