### PR TITLE
 Push predicates through projections 

### DIFF
--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -18,12 +18,6 @@ bool expressions_equal(const std::vector<std::shared_ptr<AbstractExpression>>& e
                     [&](const auto& expression_a, const auto& expression_b) { return *expression_a == *expression_b; });
 }
 
-bool expressions_contain(const std::shared_ptr<AbstractExpression>& needle,
-                         const std::vector<std::shared_ptr<AbstractExpression>>& haystack) {
-  return std::find_if(haystack.cbegin(), haystack.cend(),
-                      [&](const auto& expression) { return *expression == *needle; }) != haystack.cend();
-}
-
 bool expressions_equal_to_expressions_in_different_lqp(
     const std::vector<std::shared_ptr<AbstractExpression>>& expressions_left,
     const std::vector<std::shared_ptr<AbstractExpression>>& expressions_right, const LQPNodeMapping& node_mapping) {

--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -18,6 +18,12 @@ bool expressions_equal(const std::vector<std::shared_ptr<AbstractExpression>>& e
                     [&](const auto& expression_a, const auto& expression_b) { return *expression_a == *expression_b; });
 }
 
+bool expressions_contain(const std::shared_ptr<AbstractExpression>& needle,
+                         const std::vector<std::shared_ptr<AbstractExpression>>& haystack) {
+  return std::find_if(haystack.cbegin(), haystack.cend(),
+                      [&](const auto& expression) { return *expression == *needle; }) != haystack.cend();
+}
+
 bool expressions_equal_to_expressions_in_different_lqp(
     const std::vector<std::shared_ptr<AbstractExpression>>& expressions_left,
     const std::vector<std::shared_ptr<AbstractExpression>>& expressions_right, const LQPNodeMapping& node_mapping) {

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -106,7 +106,12 @@ void visit_expression(Expression& expression, Visitor visitor) {
 DataType expression_common_type(const DataType lhs, const DataType rhs);
 
 /**
- * @return Whether the expression only references expressions/columns that the specified LQP outputs
+ * @return Checks whether the expression can be evaluated by the ExpressionEvaluator on top of a specified LQP (i.e.,
+ *         all required columns are available).
+ *         This does not necessarily mean that `expression` is fully available at this point - for example, an `IN`
+ *         statement might still need to be converted into a boolean column by a ProjectionNode
+ *         To check if the expression is available in an evaluated form that can be used by a scan / join,
+ *         use `Operator*Predicate::from_expression(...) != nullptr`.
  */
 bool expression_evaluable_on_lqp(const std::shared_ptr<AbstractExpression>& expression, const AbstractLQPNode& lqp);
 

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -107,10 +107,8 @@ DataType expression_common_type(const DataType lhs, const DataType rhs);
 
 /**
  * @return Checks whether the expression can be evaluated by the ExpressionEvaluator on top of a specified LQP (i.e.,
- *         all required columns are available).
- *         This does not necessarily mean that `expression` is fully available at this point - for example, an `IN`
- *         statement might still need to be converted into a boolean column by a ProjectionNode
- *         To check if the expression is available in an evaluated form that can be used by a scan / join,
+ *         all required LQPColumnExpressions are available from this LQP).
+ *         To check if an expression is available in a form ready to be used by a scan/join,
  *         use `Operator*Predicate::from_expression(...) != nullptr`.
  */
 bool expression_evaluable_on_lqp(const std::shared_ptr<AbstractExpression>& expression, const AbstractLQPNode& lqp);

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -23,7 +23,7 @@ bool expressions_equal(const std::vector<std::shared_ptr<AbstractExpression>>& e
                        const std::vector<std::shared_ptr<AbstractExpression>>& expressions_b);
 
 /**
- * Utility to check whether two vectors of Expressions are equal according to AbstractExpression::operator==()
+ * Utility to check whether an expression is contained in a vector according to AbstractExpression::operator==()
  */
 bool expressions_contain(const std::shared_ptr<AbstractExpression>& needle,
                          const std::vector<std::shared_ptr<AbstractExpression>>& haystack);

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -23,12 +23,6 @@ bool expressions_equal(const std::vector<std::shared_ptr<AbstractExpression>>& e
                        const std::vector<std::shared_ptr<AbstractExpression>>& expressions_b);
 
 /**
- * Utility to check whether an expression is contained in a vector according to AbstractExpression::operator==()
- */
-bool expressions_contain(const std::shared_ptr<AbstractExpression>& needle,
-                         const std::vector<std::shared_ptr<AbstractExpression>>& haystack);
-
-/**
  * Utility to compare vectors of Expressions from different LQPs
  */
 bool expressions_equal_to_expressions_in_different_lqp(

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -23,6 +23,12 @@ bool expressions_equal(const std::vector<std::shared_ptr<AbstractExpression>>& e
                        const std::vector<std::shared_ptr<AbstractExpression>>& expressions_b);
 
 /**
+ * Utility to check whether two vectors of Expressions are equal according to AbstractExpression::operator==()
+ */
+bool expressions_contain(const std::shared_ptr<AbstractExpression>& needle,
+                         const std::vector<std::shared_ptr<AbstractExpression>>& haystack);
+
+/**
  * Utility to compare vectors of Expressions from different LQPs
  */
 bool expressions_equal_to_expressions_in_different_lqp(

--- a/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
@@ -80,7 +80,7 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
     return true;
   } else if (input->type == LQPNodeType::Projection) {
     // push below projection if the projection does not generate the column(s) that we are scanning on
-    if (expression_evaluable_on_lqp(predicate_node->predicate, *input->left_input())) {
+    if (OperatorScanPredicate::from_expression(*predicate_node->predicate, *input->left_input()) != std::nullopt) {
       push_down(node, input);
       return true;
     }

--- a/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
@@ -13,6 +13,16 @@ namespace opossum {
 
 std::string PredicatePushdownRule::name() const { return "Predicate Pushdown Rule"; }
 
+void push_down(const std::shared_ptr<AbstractLQPNode>& node, std::shared_ptr<AbstractLQPNode> input) {
+  DebugAssert(node->left_input() && !node->right_input(), "This helper can only push down if there is a single input");
+
+  lqp_remove_node(node);
+  const auto previous_left_input = input->left_input();
+
+  input->set_left_input(node);
+  node->set_left_input(previous_left_input);
+}
+
 bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   if (node->type != LQPNodeType::Predicate) return _apply_to_inputs(node);
 
@@ -20,19 +30,24 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
   const auto outputs = node->outputs();
   if (outputs.empty() || outputs.size() > 1) return _apply_to_inputs(node);
 
-  // Find a join node
   const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
 
   auto input = node->left_input();
   while (input->type == LQPNodeType::Predicate) {
+    // First, try to push down the predicates that come below. That keeps the predicate order intact.
+    if (_apply_to_inputs(node)) return true;
+
+    // We gave that predicate node the chance to be pushed down, but it didn't want to. Now we ignore it.
+    // We only move past it if we can get past a non-predicate node.
     input = input->left_input();
   }
 
   if (input->type == LQPNodeType::Join) {
     const auto join_node = std::dynamic_pointer_cast<JoinNode>(input);
 
-    if (join_node->join_mode != JoinMode::Inner && join_node->join_mode != JoinMode::Cross)
+    if (join_node->join_mode != JoinMode::Inner && join_node->join_mode != JoinMode::Cross) {
       return _apply_to_inputs(node);
+    }
 
     const auto move_to_left = expression_evaluable_on_lqp(predicate_node->predicate, *join_node->left_input());
     const auto move_to_right = expression_evaluable_on_lqp(predicate_node->predicate, *join_node->right_input());
@@ -54,17 +69,23 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
     return true;
 
   } else if (input->type == LQPNodeType::Sort) {
-    // push always down if other node is a sort node
-    const auto sort_node = std::dynamic_pointer_cast<SortNode>(input);
-
-    lqp_remove_node(node);
-    const auto previous_left_input = sort_node->left_input();
-
-    sort_node->set_left_input(node);
-    node->set_left_input(previous_left_input);
-
+    // always push down if other node is a sort node
+    push_down(node, input);
+    return true;
+  } else if (input->type == LQPNodeType::Projection) {
+    // push below projection if the projection does not generate the column(s) that we are scanning on
+    const auto projection_input = input->left_input();
+    for (const auto& predicate_argument : predicate_node->predicate->arguments) {
+      const auto& expressions_before_projection = projection_input->column_expressions();
+      if (!expressions_contain(predicate_argument, expressions_before_projection)) {
+        // This column was created by the projection, so we can't push below it
+        return false;
+      }
+    }
+    push_down(node, input);
     return true;
   }
+
   return false;
 }
 

--- a/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
@@ -13,15 +13,18 @@ namespace opossum {
 
 std::string PredicatePushdownRule::name() const { return "Predicate Pushdown Rule"; }
 
-void push_down(const std::shared_ptr<AbstractLQPNode>& node, std::shared_ptr<AbstractLQPNode> input) {
+namespace {
+// Pushes `node` under `push_below`.
+void push_down(const std::shared_ptr<AbstractLQPNode>& node, std::shared_ptr<AbstractLQPNode> push_below) {
   DebugAssert(node->left_input() && !node->right_input(), "This helper can only push down if there is a single input");
 
   lqp_remove_node(node);
-  const auto previous_left_input = input->left_input();
+  const auto previous_left_input = push_below->left_input();
 
-  input->set_left_input(node);
+  push_below->set_left_input(node);
   node->set_left_input(previous_left_input);
 }
+}  // namespace
 
 bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   if (node->type != LQPNodeType::Predicate) return _apply_to_inputs(node);
@@ -33,11 +36,14 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
   const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
 
   auto input = node->left_input();
-  while (input->type == LQPNodeType::Predicate) {
+
+  if (input->type == LQPNodeType::Predicate) {
     // First, try to push down the predicates that come below. That keeps the predicate order intact.
     if (_apply_to_inputs(node)) return true;
+  }
 
-    // We gave that predicate node the chance to be pushed down, but it didn't want to. Now we ignore it.
+  while (input->type == LQPNodeType::Predicate) {
+    // We gave the predicate nodes below us the chance to be pushed down, but they didn't want to. Now we ignore them.
     // We only move past it if we can get past a non-predicate node.
     input = input->left_input();
   }
@@ -74,17 +80,10 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
     return true;
   } else if (input->type == LQPNodeType::Projection) {
     // push below projection if the projection does not generate the column(s) that we are scanning on
-    const auto projection_input = input->left_input();
-    for (const auto& predicate_argument : predicate_node->predicate->arguments) {
-      if (predicate_argument->type == ExpressionType::Value) continue;
-      const auto& expressions_before_projection = projection_input->column_expressions();
-      if (!expressions_contain(predicate_argument, expressions_before_projection)) {
-        // This column was created by the projection, so we can't push below it
-        return false;
-      }
+    if (expression_evaluable_on_lqp(predicate_node->predicate, *input->left_input())) {
+      push_down(node, input);
+      return true;
     }
-    push_down(node, input);
-    return true;
   }
 
   return false;

--- a/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
@@ -76,6 +76,7 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
     // push below projection if the projection does not generate the column(s) that we are scanning on
     const auto projection_input = input->left_input();
     for (const auto& predicate_argument : predicate_node->predicate->arguments) {
+      if (predicate_argument->type == ExpressionType::Value) continue;
       const auto& expressions_before_projection = projection_input->column_expressions();
       if (!expressions_contain(predicate_argument, expressions_before_projection)) {
         // This column was created by the projection, so we can't push below it

--- a/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
@@ -37,11 +37,27 @@ class PredicatePushdownRuleTest : public StrategyBaseTest {
     _c_b = LQPColumnReference(_table_c, ColumnID{1});
 
     _rule = std::make_shared<PredicatePushdownRule>();
+
+    {
+      // Initialization of projection pushdown LQP
+      auto int_float_node_a = StoredTableNode::make("a");
+      auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
+
+      auto parameter_c = parameter_(ParameterID{0}, a);
+      auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
+                                       ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
+
+      _select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
+
+      _projection_pushdown_node = ProjectionNode::make(expression_vector(_a_a, _a_b, _select_c), _table_a);
+    }
   }
 
   std::shared_ptr<PredicatePushdownRule> _rule;
   std::shared_ptr<StoredTableNode> _table_a, _table_b, _table_c;
   LQPColumnReference _a_a, _a_b, _b_a, _b_b, _c_a, _c_b;
+  std::shared_ptr<ProjectionNode> _projection_pushdown_node;
+  std::shared_ptr<opossum::LQPSelectExpression> _select_c;
 };
 
 TEST_F(PredicatePushdownRuleTest, SimpleLiteralJoinPushdownTest) {
@@ -140,87 +156,49 @@ TEST_F(PredicatePushdownRuleTest, ComplexBlockingPredicatesPushdownTest) {
 }
 
 TEST_F(PredicatePushdownRuleTest, AllowedValuePredicatePushdownThroughProjectionTest) {
-  auto int_float_node_a = StoredTableNode::make("a");
-  auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
+  // We can push `a > 4` under the projection because it does not depend on the subselect.
 
-  auto parameter_c = value_(5);
-  auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
-                                   ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
-
-  auto select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
-
-  auto projection_node = ProjectionNode::make(expression_vector(_a_a, _a_b, select_c), _table_a);
-
-  auto predicate_node = std::make_shared<PredicateNode>(greater_than_(_a_a, _a_b));
-  predicate_node->set_left_input(projection_node);
+  auto predicate_node = std::make_shared<PredicateNode>(greater_than_(_a_a, value_(4)));
+  predicate_node->set_left_input(_projection_pushdown_node);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
-  EXPECT_EQ(reordered, projection_node);
+  EXPECT_EQ(reordered, _projection_pushdown_node);
   EXPECT_EQ(reordered->left_input(), predicate_node);
   EXPECT_EQ(reordered->left_input()->left_input(), _table_a);
 }
 
 TEST_F(PredicatePushdownRuleTest, AllowedColumnPredicatePushdownThroughProjectionTest) {
-  auto int_float_node_a = StoredTableNode::make("a");
-  auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
-
-  auto parameter_c = parameter_(ParameterID{0}, a);
-  auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
-                                   ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
-
-  auto select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
-
-  auto projection_node = ProjectionNode::make(expression_vector(_a_a, _a_b, select_c), _table_a);
+  // We can push `a > b` under the projection because it does not depend on the subselect.
 
   auto predicate_node = std::make_shared<PredicateNode>(greater_than_(_a_a, _a_b));
-  predicate_node->set_left_input(projection_node);
+  predicate_node->set_left_input(_projection_pushdown_node);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
-  EXPECT_EQ(reordered, projection_node);
+  EXPECT_EQ(reordered, _projection_pushdown_node);
   EXPECT_EQ(reordered->left_input(), predicate_node);
   EXPECT_EQ(reordered->left_input()->left_input(), _table_a);
 }
 
 TEST_F(PredicatePushdownRuleTest, ForbiddenPredicatePushdownThroughProjectionTest) {
-  auto int_float_node_a = StoredTableNode::make("a");
-  auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
+  // We can't push `(SELECT ...) > a.b` under the projection because the projection is responsible for the SELECT.
 
-  auto parameter_c = parameter_(ParameterID{0}, a);
-  auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
-                                   ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
-
-  auto select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
-
-  auto projection_node = ProjectionNode::make(expression_vector(_a_a, _a_b, select_c), _table_a);
-
-  auto predicate_node = std::make_shared<PredicateNode>(greater_than_(select_c, _a_b));
-  predicate_node->set_left_input(projection_node);
+  auto predicate_node = std::make_shared<PredicateNode>(greater_than_(_select_c, _a_b));
+  predicate_node->set_left_input(_projection_pushdown_node);
 
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
   EXPECT_EQ(reordered, predicate_node);
-  EXPECT_EQ(reordered->left_input(), projection_node);
+  EXPECT_EQ(reordered->left_input(), _projection_pushdown_node);
   EXPECT_EQ(reordered->left_input()->left_input(), _table_a);
 }
 
 TEST_F(PredicatePushdownRuleTest, PredicatePushdownThroughOtherPredicateTest) {
   // Even if one predicate cannot be pushed down, others might be better off
 
-  auto int_float_node_a = StoredTableNode::make("a");
-  auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
-
-  auto parameter_c = parameter_(ParameterID{0}, a);
-  auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
-                                   ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
-
-  auto select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
-
-  auto projection_node = ProjectionNode::make(expression_vector(_a_a, _a_b, select_c), _table_a);
-
-  auto predicate_node_1 = std::make_shared<PredicateNode>(greater_than_(select_c, _a_b));
-  predicate_node_1->set_left_input(projection_node);
+  auto predicate_node_1 = std::make_shared<PredicateNode>(greater_than_(_select_c, _a_b));
+  predicate_node_1->set_left_input(_projection_pushdown_node);
 
   auto predicate_node_2 = std::make_shared<PredicateNode>(greater_than_(_a_a, _a_b));
   predicate_node_2->set_left_input(predicate_node_1);
@@ -228,7 +206,7 @@ TEST_F(PredicatePushdownRuleTest, PredicatePushdownThroughOtherPredicateTest) {
   auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node_2);
 
   EXPECT_EQ(reordered, predicate_node_1);
-  EXPECT_EQ(reordered->left_input(), projection_node);
+  EXPECT_EQ(reordered->left_input(), _projection_pushdown_node);
   EXPECT_EQ(reordered->left_input()->left_input(), predicate_node_2);
   EXPECT_EQ(reordered->left_input()->left_input()->left_input(), _table_a);
 }

--- a/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
@@ -139,7 +139,29 @@ TEST_F(PredicatePushdownRuleTest, ComplexBlockingPredicatesPushdownTest) {
   EXPECT_EQ(reordered->left_input()->right_input()->left_input(), _table_a);
 }
 
-TEST_F(PredicatePushdownRuleTest, AllowedPredicatePushdownThroughProjectionTest) {
+TEST_F(PredicatePushdownRuleTest, AllowedValuePredicatePushdownThroughProjectionTest) {
+  auto int_float_node_a = StoredTableNode::make("a");
+  auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
+
+  auto parameter_c = value_(5);
+  auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
+                                   ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
+
+  auto select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
+
+  auto projection_node = ProjectionNode::make(expression_vector(_a_a, _a_b, select_c), _table_a);
+
+  auto predicate_node = std::make_shared<PredicateNode>(greater_than_(_a_a, _a_b));
+  predicate_node->set_left_input(projection_node);
+
+  auto reordered = StrategyBaseTest::apply_rule(_rule, predicate_node);
+
+  EXPECT_EQ(reordered, projection_node);
+  EXPECT_EQ(reordered->left_input(), predicate_node);
+  EXPECT_EQ(reordered->left_input()->left_input(), _table_a);
+}
+
+TEST_F(PredicatePushdownRuleTest, AllowedColumnPredicatePushdownThroughProjectionTest) {
   auto int_float_node_a = StoredTableNode::make("a");
   auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
 


### PR DESCRIPTION
Waiting for TPC-H 17 in the CI builds took waaaaay to long. We now push predicates through projections if they can be evaluated earlier. This keeps us from executing subselects that we don't actually need. refs #1012 

```
+-----------+---------+
| Benchmark | change  |
+-----------+---------+
| TPC-H 1   | +0%     |
| TPC-H 2   | +57286% |
| TPC-H 3   | +3%     |
| TPC-H 4   | +2482%  |
| TPC-H 5   | -9%     |
| TPC-H 6   | -8%     |
| TPC-H 7   | +2%     |
| TPC-H 8   | -28%    |
| TPC-H 9   | +1%     |
| TPC-H 10  | +6%     |
| TPC-H 11  | +5%     |
| TPC-H 12  | +0%     |
| TPC-H 13  | -1%     |
| TPC-H 14  | -2%     |
| TPC-H 15  | -2%     |
| TPC-H 16  | -5%     |
| TPC-H 17  | +97398% |
| TPC-H 18  | -1%     |
| TPC-H 19  | +0%     |
| TPC-H 20  | -1%     |
| TPC-H 21  | +4%     |
| TPC-H 22  | -1%     |
| average   | +7142%  |
+-----------+---------+
```

I omitted the p-values because we only had one run for the expensive benchmarks before.