### PR TITLE
Minor visualization tweaks

### DIFF
--- a/src/lib/planviz/abstract_visualizer.hpp
+++ b/src/lib/planviz/abstract_visualizer.hpp
@@ -23,10 +23,11 @@ struct GraphvizConfig {
 struct VizGraphInfo {
   std::string bg_color = "black";
   std::string rankdir = "BT";
-  double ratio = 0.5;
+  std::string ratio = "compress";
 };
 
 struct VizVertexInfo {
+  uintptr_t id;
   std::string label;
   std::string color = "white";
   std::string font_color = "white";
@@ -67,7 +68,7 @@ class AbstractVisualizer {
     _add_graph_property("ratio", _graph_info.ratio);
 
     // Add vertex properties
-    _add_property("node_id", boost::vertex_index);
+    _add_property("node_id", &VizVertexInfo::id);
     _add_property("color", &VizVertexInfo::color);
     _add_property("label", &VizVertexInfo::label);
     _add_property("shape", &VizVertexInfo::shape);
@@ -105,6 +106,7 @@ class AbstractVisualizer {
   template <typename T>
   void _add_vertex(const T& vertex, const std::string& label = "") {
     VizVertexInfo info = _default_vertex;
+    info.id = reinterpret_cast<uintptr_t>(vertex.get());
     info.label = label;
     _add_vertex(vertex, info);
   }
@@ -118,6 +120,7 @@ class AbstractVisualizer {
       return;
     }
 
+    vertex_info.id = vertex_id;
     vertex_info.label = _wrap_label(vertex_info.label);
     boost::add_vertex(vertex_info, _graph);
   }
@@ -166,7 +169,7 @@ class AbstractVisualizer {
       auto word_length = word.length() + 1;  // include whitespace
 
       if (current_line_length + word_length > MAX_LABEL_WIDTH) {
-        wrapped_label << '\n';
+        wrapped_label << "\\n";
         current_line_length = 0u;
       }
 

--- a/src/lib/planviz/lqp_visualizer.cpp
+++ b/src/lib/planviz/lqp_visualizer.cpp
@@ -15,7 +15,7 @@ namespace opossum {
 
 LQPVisualizer::LQPVisualizer() {
   // Set defaults for this visualizer
-  _default_vertex.shape = "parallelogram";
+  _default_vertex.shape = "rectangle";
 }
 
 LQPVisualizer::LQPVisualizer(GraphvizConfig graphviz_config, VizGraphInfo graph_info, VizVertexInfo vertex_info,


### PR DESCRIPTION
* Print the graph a bit denser
* Use \n instead of newline (makes it easier for other output formats)
* Use rectangles for LQPs, too, because parallelograms take too much space
* Use the LQP pointer address instead of contiguous ids for vertices, so that we can identify them across optimizer runs