### PR TITLE
More aggressive predicate pushdown

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -77,7 +77,7 @@ void collect_select_expressions_by_lqp(SelectExpressionsByLQP& select_expression
 namespace opossum {
 
 std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
-  auto optimizer = std::make_shared<Optimizer>(10);
+  auto optimizer = std::make_shared<Optimizer>(100);
 
   RuleBatch main_batch(RuleBatchExecutionPolicy::Iterative);
   main_batch.add_rule(std::make_shared<PredicatePushdownRule>());
@@ -114,8 +114,14 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<Abstr
          * Apply all optimization over and over until all of them stopped changing the LQP or the max number of
          * iterations is reached
          */
-        for (uint32_t iter_index = 0; iter_index < _max_num_iterations; ++iter_index) {
-          if (!_apply_rule_batch(rule_batch, root_node)) break;
+        auto iter_index = uint32_t{0};
+        for (; iter_index < _max_num_iterations; ++iter_index) {
+          if (!_apply_rule_batch(rule_batch, root_node)) {
+            break;
+          }
+        }
+        if (iter_index == _max_num_iterations) {
+          PerformanceWarning("Maximum number of optimizer iterations reached");
         }
         break;
     }

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -13,6 +13,7 @@
 #include "strategy/join_detection_rule.hpp"
 #include "strategy/predicate_pushdown_rule.hpp"
 #include "strategy/predicate_reordering_rule.hpp"
+#include "utils/performance_warning.hpp"
 
 /**
  * IMPORTANT NOTES ON OPTIMIZING SUB-SELECT LQPS

--- a/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_pushdown_rule.cpp
@@ -35,12 +35,10 @@ bool PredicatePushdownRule::apply_to(const std::shared_ptr<AbstractLQPNode>& nod
 
   const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
 
-  auto input = node->left_input();
+  // First, try to push down the predicates that come below. That keeps the predicate order intact.
+  if (_apply_to_inputs(node)) return true;
 
-  if (input->type == LQPNodeType::Predicate) {
-    // First, try to push down the predicates that come below. That keeps the predicate order intact.
-    if (_apply_to_inputs(node)) return true;
-  }
+  auto input = node->left_input();
 
   while (input->type == LQPNodeType::Predicate) {
     // We gave the predicate nodes below us the chance to be pushed down, but they didn't want to. Now we ignore them.


### PR DESCRIPTION
Missed one opportunity. Originally, wanted to optimize Query 21, but a gifted horse you don't look in the mouth.

```
+-----------+------------------+------+------------------+------+---------+---------------------------------+
| Benchmark | prev. iter/s     | runs | new iter/s       | runs | change  | p-value (significant if <0.001) |
+-----------+------------------+------+------------------+------+---------+---------------------------------+
| TPC-H 1   | 0.886854946613   | 54   | 0.824773132801   | 50   | -7%     |                          0.0000 |
| TPC-H 2   | 16.3936786652    | 984  | 28.3739929199    | 1000 | +73%    |     (run time too short) 0.0000 |
| TPC-H 3   | 12.8011140823    | 769  | 12.8205223083    | 770  | +0%     |                          0.5864 |
| TPC-H 4   | 0.175269573927   | 11   | 0.177131980658   | 11   | +1%     |                          0.2248 |
| TPC-H 5   | 5.90970754623    | 355  | 11.2785053253    | 677  | +91%    |                          0.0000 |
| TPC-H 6   | 32.7629356384    | 1000 | 33.8322296143    | 1000 | +3%     |     (run time too short) 0.0000 |
| TPC-H 7   | 0.916054010391   | 55   | 1.10987770557    | 67   | +21%    |                          0.0000 |
| TPC-H 8   | 0.00476276967674 | 1    | 4.16757774353    | 251  | +87403% |           (not enough runs) nan |
| TPC-H 9   | 2.13188409805    | 128  | 2.12017536163    | 128  | -1%     |                          0.0121 |
| TPC-H 10  | 11.633026123     | 698  | 11.003121376     | 661  | -5%     |                          0.0000 |
| TPC-H 11  | 27.807226181     | 1000 | 30.3959255219    | 1000 | +9%     |     (run time too short) 0.0000 |
| TPC-H 12  | 5.32909965515    | 320  | 9.54899978638    | 573  | +79%    |                          0.0000 |
| TPC-H 13  | 13.0989141464    | 786  | 13.0770711899    | 785  | -0%     |                          0.2354 |
| TPC-H 14  | 19.3210487366    | 1000 | 19.2092571259    | 1000 | -1%     |     (run time too short) 0.0101 |
| TPC-H 15  | 0.0837838947773  | 6    | 0.0854932442307  | 6    | +2%     |        (not enough runs) 0.3672 |
| TPC-H 16  | 2.99305987358    | 180  | 3.35313725471    | 202  | +12%    |                          0.0000 |
| TPC-H 17  | 1.80184793472    | 109  | 1.97248649597    | 119  | +9%     |                          0.0000 |
| TPC-H 18  | 0.0130279855803  | 1    | 0.0122658209875  | 1    | -6%     |           (not enough runs) nan |
| TPC-H 19  | 0.640300571918   | 39   | 0.642749369144   | 39   | +0%     |                          0.6826 |
| TPC-H 20  | 0.00686512654647 | 1    | 0.00701826671138 | 1    | +2%     |           (not enough runs) nan |
| TPC-H 21  | 0.0338893346488  | 3    | 0.107322670519   | 7    | +217%   |        (not enough runs) 0.0000 |
| TPC-H 22  | 0.464944094419   | 28   | 0.472303509712   | 29   | +2%     |                          0.0103 |
| average   |                  |      |                  |      | +3996%  |                                 |
+-----------+------------------+------+------------------+------+---------+---------------------------------+
```