### PR TITLE
ColumnPruningRule

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -101,6 +101,8 @@ set(
     logical_query_plan/alias_node.hpp
     logical_query_plan/aggregate_node.cpp
     logical_query_plan/aggregate_node.hpp
+    logical_query_plan/base_non_query_node.hpp
+    logical_query_plan/base_non_query_node.cpp
     logical_query_plan/create_view_node.cpp
     logical_query_plan/create_view_node.hpp
     logical_query_plan/delete_node.cpp
@@ -251,6 +253,8 @@ set(
     optimizer/optimizer.hpp
     optimizer/strategy/abstract_rule.cpp
     optimizer/strategy/abstract_rule.hpp
+    optimizer/strategy/column_pruning_rule.cpp
+    optimizer/strategy/column_pruning_rule.hpp
     optimizer/strategy/chunk_pruning_rule.cpp
     optimizer/strategy/chunk_pruning_rule.hpp
     optimizer/strategy/constant_calculation_rule.cpp

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -9,11 +9,11 @@
 
 #include "expression/expression_utils.hpp"
 #include "expression/lqp_column_expression.hpp"
-#include "statistics/table_statistics.hpp"
+#include "resolve_type.hpp"
 #include "statistics/column_statistics.hpp"
+#include "statistics/table_statistics.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
-#include "resolve_type.hpp"
 
 namespace opossum {
 
@@ -44,7 +44,7 @@ std::string AggregateNode::description() const {
 }
 
 std::shared_ptr<TableStatistics> AggregateNode::derive_statistics_from(
-const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
+    const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
   DebugAssert(left_input && !right_input, "AggregateNode need left_input and no right_input");
 
   const auto input_statistics = left_input->get_statistics();
@@ -62,7 +62,7 @@ const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<Abstra
       resolve_data_type(expression->data_type(), [&](const auto data_type_t) {
         using ExpressionDataType = typename decltype(data_type_t)::type;
         column_statistics.emplace_back(
-        std::make_shared<ColumnStatistics<ExpressionDataType>>(ColumnStatistics<ExpressionDataType>::dummy()));
+            std::make_shared<ColumnStatistics<ExpressionDataType>>(ColumnStatistics<ExpressionDataType>::dummy()));
       });
     }
   }

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -9,8 +9,11 @@
 
 #include "expression/expression_utils.hpp"
 #include "expression/lqp_column_expression.hpp"
+#include "statistics/table_statistics.hpp"
+#include "statistics/column_statistics.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
+#include "resolve_type.hpp"
 
 namespace opossum {
 
@@ -38,6 +41,33 @@ std::string AggregateNode::description() const {
   stream << "] Aggregates: [" << expression_column_names(aggregate_expressions) << "]";
 
   return stream.str();
+}
+
+std::shared_ptr<TableStatistics> AggregateNode::derive_statistics_from(
+const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {
+  DebugAssert(left_input && !right_input, "AggregateNode need left_input and no right_input");
+
+  const auto input_statistics = left_input->get_statistics();
+  const auto row_count = input_statistics->row_count();
+
+  std::vector<std::shared_ptr<const BaseColumnStatistics>> column_statistics;
+  column_statistics.reserve(_column_expressions.size());
+
+  for (const auto& expression : _column_expressions) {
+    const auto column_id = left_input->find_column_id(*expression);
+    if (column_id) {
+      column_statistics.emplace_back(input_statistics->column_statistics()[*column_id]);
+    } else {
+      // TODO(anybody) Statistics for expressions not yet supported
+      resolve_data_type(expression->data_type(), [&](const auto data_type_t) {
+        using ExpressionDataType = typename decltype(data_type_t)::type;
+        column_statistics.emplace_back(
+        std::make_shared<ColumnStatistics<ExpressionDataType>>(ColumnStatistics<ExpressionDataType>::dummy()));
+      });
+    }
+  }
+
+  return std::make_shared<TableStatistics>(TableType::Data, row_count, column_statistics);
 }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& AggregateNode::column_expressions() const {

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -27,6 +27,9 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   std::vector<std::shared_ptr<AbstractExpression>> node_expressions() const override;
 
+  std::shared_ptr<TableStatistics> derive_statistics_from(
+  const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const override;
+
   const std::vector<std::shared_ptr<AbstractExpression>> group_by_expressions;
   const std::vector<std::shared_ptr<AbstractExpression>> aggregate_expressions;
 

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -28,7 +28,8 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
   std::vector<std::shared_ptr<AbstractExpression>> node_expressions() const override;
 
   std::shared_ptr<TableStatistics> derive_statistics_from(
-  const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const override;
+      const std::shared_ptr<AbstractLQPNode>& left_input,
+      const std::shared_ptr<AbstractLQPNode>& right_input) const override;
 
   const std::vector<std::shared_ptr<AbstractExpression>> group_by_expressions;
   const std::vector<std::shared_ptr<AbstractExpression>> aggregate_expressions;

--- a/src/lib/logical_query_plan/base_non_query_node.cpp
+++ b/src/lib/logical_query_plan/base_non_query_node.cpp
@@ -1,0 +1,9 @@
+#include "base_non_query_node.hpp"
+
+namespace opossum {
+
+const std::vector<std::shared_ptr<AbstractExpression>>& BaseNonQueryNode::column_expressions() const {
+  return _column_expressions_dummy;
+}
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "abstract_lqp_node.hpp"
+
+namespace opossum {
+
+/**
+ * Base class for LQP nodes that do not query data and therefore do not output columns
+ */
+class BaseNonQueryNode : public AbstractLQPNode {
+ public:
+  using AbstractLQPNode::AbstractLQPNode;
+
+  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+
+ private:
+  const std::vector<std::shared_ptr<AbstractExpression>> _column_expressions_dummy; // always empty
+};
+
+}  // namespace opossum

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -5,7 +5,9 @@
 namespace opossum {
 
 /**
- * Base class for LQP nodes that do not query data and therefore do not output columns
+ * Base class for LQP nodes that do not query data (e.g, DML and DDL nodes) and therefore do not output columns.
+ *
+ * Helper class that provides a column_expressions() override and contains an empty dummy expression vector
  */
 class BaseNonQueryNode : public AbstractLQPNode {
  public:

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -14,7 +14,7 @@ class BaseNonQueryNode : public AbstractLQPNode {
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 
  private:
-  const std::vector<std::shared_ptr<AbstractExpression>> _column_expressions_dummy; // always empty
+  const std::vector<std::shared_ptr<AbstractExpression>> _column_expressions_dummy;  // always empty
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -8,7 +8,7 @@
 namespace opossum {
 
 CreateViewNode::CreateViewNode(const std::string& view_name, const std::shared_ptr<LQPView>& view)
-    : AbstractLQPNode(LQPNodeType::CreateView), _view_name(view_name), _view(view) {}
+    : BaseNonQueryNode(LQPNodeType::CreateView), _view_name(view_name), _view(view) {}
 
 std::string CreateViewNode::view_name() const { return _view_name; }
 

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 
-#include "abstract_lqp_node.hpp"
+#include "base_non_query_node.hpp"
 #include "enable_make_for_lqp_node.hpp"
 #include "storage/lqp_view.hpp"
 
@@ -11,7 +11,7 @@ namespace opossum {
 /**
  * This node type represents the CREATE VIEW management command.
  */
-class CreateViewNode : public EnableMakeForLQPNode<CreateViewNode>, public AbstractLQPNode {
+class CreateViewNode : public EnableMakeForLQPNode<CreateViewNode>, public BaseNonQueryNode {
  public:
   CreateViewNode(const std::string& view_name, const std::shared_ptr<LQPView>& view);
 

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -12,7 +12,7 @@ using namespace std::string_literals;  // NOLINT
 namespace opossum {
 
 DropViewNode::DropViewNode(const std::string& view_name)
-    : AbstractLQPNode(LQPNodeType::DropView), _view_name(view_name) {}
+    : BaseNonQueryNode(LQPNodeType::DropView), _view_name(view_name) {}
 
 std::string DropViewNode::description() const { return "[Drop] View: '"s + _view_name + "'"; }
 

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -3,14 +3,14 @@
 #include <memory>
 #include <string>
 
-#include "abstract_lqp_node.hpp"
+#include "base_non_query_node.hpp"
 
 namespace opossum {
 
 /**
  * Node type to represent deleting a view from the StorageManager
  */
-class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public AbstractLQPNode {
+class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public BaseNonQueryNode {
  public:
   explicit DropViewNode(const std::string& view_name);
 

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -517,7 +517,7 @@ std::vector<std::shared_ptr<AbstractExpression>> LQPTranslator::_translate_expre
         return ExpressionVisitation::DoNotVisitArguments;
       }
 
-      Assert(expression->type != ExpressionType::LQPColumn, "Failed to resolve Column, LQP is invalid");
+      Assert(expression->type != ExpressionType::LQPColumn, "Failed to resolve Column '"s + expression->as_column_name() + "', LQP is invalid");
 
       return ExpressionVisitation::VisitArguments;
     });

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -517,7 +517,8 @@ std::vector<std::shared_ptr<AbstractExpression>> LQPTranslator::_translate_expre
         return ExpressionVisitation::DoNotVisitArguments;
       }
 
-      Assert(expression->type != ExpressionType::LQPColumn, "Failed to resolve Column '"s + expression->as_column_name() + "', LQP is invalid");
+      Assert(expression->type != ExpressionType::LQPColumn,
+             "Failed to resolve Column '"s + expression->as_column_name() + "', LQP is invalid");
 
       return ExpressionVisitation::VisitArguments;
     });

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -133,6 +133,14 @@ void lqp_remove_node(const std::shared_ptr<AbstractLQPNode>& node) {
   }
 }
 
+void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side, const std::shared_ptr<AbstractLQPNode>& node) {
+  DebugAssert(node->input_count() == 0 && node->output_count() == 0, "Expected node without inputs and outputs");
+
+  const auto old_input = parent_node->input(input_side);
+  parent_node->set_input(input_side, node);
+  node->set_left_input(old_input);
+}
+
 bool lqp_is_validated(const std::shared_ptr<AbstractLQPNode>& lqp) {
   if (!lqp) return true;
   if (lqp->type == LQPNodeType::Validate) return true;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -133,7 +133,8 @@ void lqp_remove_node(const std::shared_ptr<AbstractLQPNode>& node) {
   }
 }
 
-void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side, const std::shared_ptr<AbstractLQPNode>& node) {
+void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side,
+                     const std::shared_ptr<AbstractLQPNode>& node) {
   DebugAssert(node->input_count() == 0 && node->output_count() == 0, "Expected node without inputs and outputs");
 
   const auto old_input = parent_node->input(input_side);

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -3,11 +3,14 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
+#include <queue>
 
 namespace opossum {
 
 class AbstractLQPNode;
 class AbstractExpression;
+enum class LQPInputSide;
 
 using LQPNodeMapping = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
 using LQPMismatch = std::pair<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>>;
@@ -31,6 +34,8 @@ void lqp_replace_node(const std::shared_ptr<AbstractLQPNode>& original_node,
 
 void lqp_remove_node(const std::shared_ptr<AbstractLQPNode>& node);
 
+void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side, const std::shared_ptr<AbstractLQPNode>& node);
+
 /**
  * @return whether all paths to all leafs contain a Validate node - i.e. the LQP can be used in an MVCC aware context
  */
@@ -41,5 +46,38 @@ bool lqp_is_validated(const std::shared_ptr<AbstractLQPNode>& lqp);
  * @return      the expression, or nullptr if no expression could be created
  */
 std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(const std::shared_ptr<AbstractLQPNode>& lqp);
+
+enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
+
+/**
+ * Calls the passed @param visitor on each node of the @param lqp.
+ * The visitor returns `ExpressionVisitation`, indicating whether the current nodes's input should be visited
+ * as well.
+ * Each node is visited exactly once.
+ *
+ * @tparam LQP          Either `std::shared_ptr<AbstractLQPNode>` or `const std::shared_ptr<AbstractLQPNode>`
+ * @tparam Visitor      Functor called with every node as a param.
+ *                      Returns `LQPVisitation`
+ */
+template <typename LQP, typename Visitor>
+void visit_lqp(LQP& lqp, Visitor visitor) {
+  // The reference wrapper bit is important so we can manipulate the LQP even by replacing node
+  std::queue<std::decay_t<LQP>> node_queue;
+  node_queue.push(lqp);
+
+  std::unordered_set<std::decay_t<LQP>> visited_nodes;
+
+  while (!node_queue.empty()) {
+    auto node = node_queue.front();
+    node_queue.pop();
+
+    if (!visited_nodes.emplace(node).second) continue;
+
+    if (visitor(node) == LQPVisitation::VisitInputs) {
+      if (node->left_input()) node_queue.push(node->left_input());
+      if (node->right_input()) node_queue.push(node->right_input());
+    }
+  }
+}
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -2,9 +2,9 @@
 
 #include <memory>
 #include <optional>
+#include <queue>
 #include <unordered_map>
 #include <unordered_set>
-#include <queue>
 
 namespace opossum {
 
@@ -34,7 +34,8 @@ void lqp_replace_node(const std::shared_ptr<AbstractLQPNode>& original_node,
 
 void lqp_remove_node(const std::shared_ptr<AbstractLQPNode>& node);
 
-void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side, const std::shared_ptr<AbstractLQPNode>& node);
+void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side,
+                     const std::shared_ptr<AbstractLQPNode>& node);
 
 /**
  * @return whether all paths to all leafs contain a Validate node - i.e. the LQP can be used in an MVCC aware context

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -62,7 +62,6 @@ enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
  */
 template <typename LQP, typename Visitor>
 void visit_lqp(LQP& lqp, Visitor visitor) {
-  // The reference wrapper bit is important so we can manipulate the LQP even by replacing node
   std::queue<std::decay_t<LQP>> node_queue;
   node_queue.push(lqp);
 

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -18,7 +18,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
       const std::shared_ptr<AbstractLQPNode>& left_input,
       const std::shared_ptr<AbstractLQPNode>& right_input) const override;
 
-  const std::vector<std::shared_ptr<AbstractExpression>> expressions;
+  std::vector<std::shared_ptr<AbstractExpression>> expressions;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<const Table> AliasOperator::_on_execute() {
     output_columns.reserve(input_table_left()->column_count());
 
     for (const auto& column_id : _column_ids) {
-      output_columns.emplace_back(input_chunk->get_mutable_column(column_id));
+      output_columns.emplace_back(input_chunk->get_column(column_id));
     }
 
     output_table->append_chunk(output_columns, input_chunk->get_allocator(), input_chunk->access_counter());

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -43,8 +43,9 @@ std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionCont
 
       auto expected = 0u;
       // Actual row lock for delete happens here
-      const auto success = referenced_chunk->lock_mvcc_columns()->tids[row_id.chunk_offset].compare_exchange_strong(
-          expected, _transaction_id);
+      const auto success =
+          referenced_chunk->get_scoped_mvcc_columns_lock()->tids[row_id.chunk_offset].compare_exchange_strong(
+              expected, _transaction_id);
 
       // the row is already locked and the transaction needs to be rolled back
       if (!success) {
@@ -64,7 +65,7 @@ void Delete::_on_commit_records(const CommitID cid) {
     for (const auto& row_id : *pos_list) {
       auto chunk = _table->get_chunk(row_id.chunk_id);
 
-      chunk->lock_mvcc_columns()->end_cids[row_id.chunk_offset] = cid;
+      chunk->get_scoped_mvcc_columns_lock()->end_cids[row_id.chunk_offset] = cid;
       // We do not unlock the rows so subsequent transactions properly fail when attempting to update these rows.
     }
   }
@@ -87,7 +88,8 @@ void Delete::_on_rollback_records() {
       auto expected = _transaction_id;
 
       // unlock all rows locked in _on_execute
-      const auto result = chunk->lock_mvcc_columns()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
+      const auto result =
+          chunk->get_scoped_mvcc_columns_lock()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
 
       // If the above operation fails, it means the row is locked by another transaction. This must have been
       // the reason why the rollback was initiated. Since _on_execute stopped at this row, we can stop

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionCont
 
       auto expected = 0u;
       // Actual row lock for delete happens here
-      const auto success = referenced_chunk->mvcc_columns()->tids[row_id.chunk_offset].compare_exchange_strong(
+      const auto success = referenced_chunk->lock_mvcc_columns()->tids[row_id.chunk_offset].compare_exchange_strong(
           expected, _transaction_id);
 
       // the row is already locked and the transaction needs to be rolled back
@@ -64,7 +64,7 @@ void Delete::_on_commit_records(const CommitID cid) {
     for (const auto& row_id : *pos_list) {
       auto chunk = _table->get_chunk(row_id.chunk_id);
 
-      chunk->mvcc_columns()->end_cids[row_id.chunk_offset] = cid;
+      chunk->lock_mvcc_columns()->end_cids[row_id.chunk_offset] = cid;
       // We do not unlock the rows so subsequent transactions properly fail when attempting to update these rows.
     }
   }
@@ -87,7 +87,7 @@ void Delete::_on_rollback_records() {
       auto expected = _transaction_id;
 
       // unlock all rows locked in _on_execute
-      const auto result = chunk->mvcc_columns()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
+      const auto result = chunk->lock_mvcc_columns()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
 
       // If the above operation fails, it means the row is locked by another transaction. This must have been
       // the reason why the rollback was initiated. Since _on_execute stopped at this row, we can stop

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -137,12 +137,12 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       auto rows_to_insert_this_loop = std::min(_target_table->max_chunk_size() - current_chunk->size(), remaining_rows);
 
       // Resize MVCC vectors.
-      current_chunk->mvcc_columns()->grow_by(rows_to_insert_this_loop, MvccColumns::MAX_COMMIT_ID);
+      current_chunk->lock_mvcc_columns()->grow_by(rows_to_insert_this_loop, MvccColumns::MAX_COMMIT_ID);
 
       // Resize current chunk to full size.
       auto old_size = current_chunk->size();
       for (ColumnID column_id{0}; column_id < current_chunk->column_count(); ++column_id) {
-        typed_column_processors[column_id]->resize_vector(current_chunk->get_mutable_column(column_id),
+        typed_column_processors[column_id]->resize_vector(current_chunk->get_column(column_id),
                                                           old_size + rows_to_insert_this_loop);
       }
 
@@ -179,7 +179,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
         const auto& source_column = source_chunk->get_column(column_id);
         typed_column_processors[column_id]->copy_data(source_column, source_chunk_start_index,
-                                                      target_chunk->get_mutable_column(column_id), target_start_index,
+                                                      target_chunk->get_column(column_id), target_start_index,
                                                       num_to_insert);
       }
       still_to_insert -= num_to_insert;
@@ -199,7 +199,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       // the transaction IDs are set here and not during the resize, because
       // tbb::concurrent_vector::grow_to_at_least(n, t)" does not work with atomics, since their copy constructor is
       // deleted.
-      target_chunk->mvcc_columns()->tids[i] = context->transaction_id();
+      target_chunk->lock_mvcc_columns()->tids[i] = context->transaction_id();
       _inserted_rows.emplace_back(RowID{target_chunk_id, i});
     }
 
@@ -214,7 +214,7 @@ void Insert::_on_commit_records(const CommitID cid) {
   for (auto row_id : _inserted_rows) {
     auto chunk = _target_table->get_chunk(row_id.chunk_id);
 
-    auto mvcc_columns = chunk->mvcc_columns();
+    auto mvcc_columns = chunk->lock_mvcc_columns();
     mvcc_columns->begin_cids[row_id.chunk_offset] = cid;
     mvcc_columns->tids[row_id.chunk_offset] = 0u;
   }
@@ -225,11 +225,11 @@ void Insert::_on_rollback_records() {
     auto chunk = _target_table->get_chunk(row_id.chunk_id);
     // We set the begin and end cids to 0 (effectively making it invisible for everyone) so that the ChunkCompression
     // does not think that this row is still incomplete. We need to make sure that the end is written before the begin.
-    chunk->mvcc_columns()->end_cids[row_id.chunk_offset] = 0u;
+    chunk->lock_mvcc_columns()->end_cids[row_id.chunk_offset] = 0u;
     std::atomic_thread_fence(std::memory_order_release);
-    chunk->mvcc_columns()->begin_cids[row_id.chunk_offset] = 0u;
+    chunk->lock_mvcc_columns()->begin_cids[row_id.chunk_offset] = 0u;
 
-    chunk->mvcc_columns()->tids[row_id.chunk_offset] = 0u;
+    chunk->lock_mvcc_columns()->tids[row_id.chunk_offset] = 0u;
   }
 }
 

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<const Table> Print::_on_execute() {
       }
 
       if (_flags & PrintMvcc && chunk->has_mvcc_columns()) {
-        auto mvcc_columns = chunk->mvcc_columns();
+        auto mvcc_columns = chunk->lock_mvcc_columns();
 
         auto begin = mvcc_columns->begin_cids[row];
         auto end = mvcc_columns->end_cids[row];

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<const Table> Print::_on_execute() {
       }
 
       if (_flags & PrintMvcc && chunk->has_mvcc_columns()) {
-        auto mvcc_columns = chunk->lock_mvcc_columns();
+        auto mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
 
         auto begin = mvcc_columns->begin_cids[row];
         auto end = mvcc_columns->end_cids[row];

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   }
 
   /**
-   * If an column expression is a PQPColumnExpression then it might be possible to forward the input column, if the
+   * If an expression is a PQPColumnExpression then it might be possible to forward the input column, if the
    * input TableType (References or Data) matches the output column type.
    */
   const auto only_projects_columns = std::all_of(expressions.begin(), expressions.end(), [&](const auto& expression) {

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -70,15 +70,14 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       if (forward_columns) {
         const auto pqp_column_expression = std::dynamic_pointer_cast<PQPColumnExpression>(expression);
         Assert(pqp_column_expression, "Expected PQPColumnExpression");
-        output_columns.emplace_back(std::const_pointer_cast<BaseColumn>(
-        input_chunk->get_column(pqp_column_expression->column_id)));
+        output_columns.emplace_back(input_chunk->get_column(pqp_column_expression->column_id));
       } else {
         output_columns.emplace_back(evaluator.evaluate_expression_to_column(*expression));
       }
     }
 
     output_table->append_chunk(output_columns);
-    output_table->get_chunk(chunk_id)->set_mvcc_columns(input_chunk->mvcc_columns_ptr());
+    output_table->get_chunk(chunk_id)->set_mvcc_columns(input_chunk->mvcc_columns());
   }
 
   return output_table;

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<const Table> UnionAll::_on_execute() {
       // iterating over all columns of the current chunk
       for (ColumnID column_id{0}; column_id < input->column_count(); ++column_id) {
         // While we don't modify the column, we need to get a non-const pointer so that we can put it into the chunk
-        output_columns.push_back(input->get_chunk(in_chunk_id)->get_mutable_column(column_id));
+        output_columns.push_back(input->get_chunk(in_chunk_id)->get_column(column_id));
       }
 
       // adding newly filled chunk to the output table

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
     auto right_chunk = input_table_right()->get_chunk(chunk_id);
 
     for (ColumnID column_id{0}; column_id < input_table_left()->column_count(); ++column_id) {
-      auto right_col = right_chunk->get_mutable_column(column_id);
+      auto right_col = right_chunk->get_column(column_id);
 
       auto left_col = std::dynamic_pointer_cast<const ReferenceColumn>(left_chunk->get_column(column_id));
 

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
       for (auto row_id : *ref_col_in->pos_list()) {
         const auto referenced_chunk = referenced_table->get_chunk(row_id.chunk_id);
 
-        auto mvcc_columns = referenced_chunk->lock_mvcc_columns();
+        auto mvcc_columns = referenced_chunk->get_scoped_mvcc_columns_lock();
 
         if (is_row_visible(our_tid, snapshot_commit_id, row_id.chunk_offset, *mvcc_columns)) {
           pos_list_out->emplace_back(row_id);
@@ -95,7 +95,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
     } else {
       referenced_table = in_table;
       DebugAssert(chunk_in->has_mvcc_columns(), "Trying to use Validate on a table that has no MVCC columns");
-      const auto mvcc_columns = chunk_in->lock_mvcc_columns();
+      const auto mvcc_columns = chunk_in->get_scoped_mvcc_columns_lock();
 
       // Generate pos_list_out.
       auto chunk_size = chunk_in->size();  // The compiler fails to optimize this in the for clause :(

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
       for (auto row_id : *ref_col_in->pos_list()) {
         const auto referenced_chunk = referenced_table->get_chunk(row_id.chunk_id);
 
-        auto mvcc_columns = referenced_chunk->mvcc_columns();
+        auto mvcc_columns = referenced_chunk->lock_mvcc_columns();
 
         if (is_row_visible(our_tid, snapshot_commit_id, row_id.chunk_offset, *mvcc_columns)) {
           pos_list_out->emplace_back(row_id);
@@ -95,7 +95,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
     } else {
       referenced_table = in_table;
       DebugAssert(chunk_in->has_mvcc_columns(), "Trying to use Validate on a table that has no MVCC columns");
-      const auto mvcc_columns = chunk_in->mvcc_columns();
+      const auto mvcc_columns = chunk_in->lock_mvcc_columns();
 
       // Generate pos_list_out.
       auto chunk_size = chunk_in->size();  // The compiler fails to optimize this in the for clause :(

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -8,12 +8,12 @@
 #include "logical_query_plan/logical_plan_root_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "strategy/chunk_pruning_rule.hpp"
+#include "strategy/column_pruning_rule.hpp"
 #include "strategy/constant_calculation_rule.hpp"
 #include "strategy/index_scan_rule.hpp"
 #include "strategy/join_detection_rule.hpp"
 #include "strategy/predicate_pushdown_rule.hpp"
 #include "strategy/predicate_reordering_rule.hpp"
-#include "strategy/column_pruning_rule.hpp"
 
 /**
  * IMPORTANT NOTES ON OPTIMIZING SUB-SELECT LQPS

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -80,6 +80,11 @@ namespace opossum {
 std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   auto optimizer = std::make_shared<Optimizer>(10);
 
+  // Run pruning just once since the rule would otherwise insert the pruning ProjectionNodes multiple times.
+  RuleBatch pruning_batch(RuleBatchExecutionPolicy::Once);
+  pruning_batch.add_rule(std::make_shared<ColumnPruningRule>());
+  optimizer->add_rule_batch(pruning_batch);
+
   RuleBatch main_batch(RuleBatchExecutionPolicy::Iterative);
   main_batch.add_rule(std::make_shared<PredicatePushdownRule>());
   main_batch.add_rule(std::make_shared<PredicateReorderingRule>());
@@ -90,7 +95,6 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   final_batch.add_rule(std::make_shared<ChunkPruningRule>());
   final_batch.add_rule(std::make_shared<ConstantCalculationRule>());
   final_batch.add_rule(std::make_shared<IndexScanRule>());
-  final_batch.add_rule(std::make_shared<ColumnPruningRule>());
   optimizer->add_rule_batch(final_batch);
 
   return optimizer;

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -13,6 +13,7 @@
 #include "strategy/join_detection_rule.hpp"
 #include "strategy/predicate_pushdown_rule.hpp"
 #include "strategy/predicate_reordering_rule.hpp"
+#include "strategy/column_pruning_rule.hpp"
 
 /**
  * IMPORTANT NOTES ON OPTIMIZING SUB-SELECT LQPS
@@ -89,6 +90,7 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   final_batch.add_rule(std::make_shared<ChunkPruningRule>());
   final_batch.add_rule(std::make_shared<ConstantCalculationRule>());
   final_batch.add_rule(std::make_shared<IndexScanRule>());
+  final_batch.add_rule(std::make_shared<ColumnPruningRule>());
   optimizer->add_rule_batch(final_batch);
 
   return optimizer;

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -31,7 +31,7 @@ bool ColumnPruningRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) c
   actually_used_columns.insert(output_columns.begin(), output_columns.end());
 
   // Search for ProjectionNodes that forward the unused columns and prune them accordingly
-  _prune_unused_columns_in_projections(root, actually_used_columns);
+  _prune_columns_in_projections(root, actually_used_columns);
 
   // Search the plan for leaf nodes and prune all columns from them that are not referenced
   return _prune_columns_from_leafs(root, actually_used_columns);
@@ -115,8 +115,8 @@ bool ColumnPruningRule::_prune_columns_from_leafs(const std::shared_ptr<Abstract
   return lqp_changed;
 }
 
-void ColumnPruningRule::_prune_unused_columns_in_projections(const std::shared_ptr<AbstractLQPNode>& lqp,
-                                                             const ExpressionUnorderedSet& referenced_columns) {
+void ColumnPruningRule::_prune_columns_in_projections(const std::shared_ptr<AbstractLQPNode> &lqp,
+                                                      const ExpressionUnorderedSet &referenced_columns) {
   /**
    * Prune otherwise unused columns that are forwarded by ProjectionNodes
    */

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -2,26 +2,24 @@
 
 #include <unordered_map>
 
-#include "expression/abstract_expression.hpp"
-#include "expression/expression_utils.hpp"
-#include "expression/expression_functional.hpp"
-#include "logical_query_plan/abstract_lqp_node.hpp"
-#include "logical_query_plan/dummy_table_node.hpp"
-#include "logical_query_plan/lqp_utils.hpp"
-#include "logical_query_plan/aggregate_node.hpp"
-#include "logical_query_plan/projection_node.hpp"
-#include "logical_query_plan/join_node.hpp"
-#include "logical_query_plan/predicate_node.hpp"
-#include "logical_query_plan/sort_node.hpp"
 #include "../../logical_query_plan/lqp_utils.hpp"
+#include "expression/abstract_expression.hpp"
+#include "expression/expression_functional.hpp"
+#include "expression/expression_utils.hpp"
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/dummy_table_node.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-std::string ColumnPruningRule::name() const {
-  return "Column Pruning Rule";
-}
+std::string ColumnPruningRule::name() const { return "Column Pruning Rule"; }
 
 bool ColumnPruningRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
   // Collect the columns that are used in expressions somewhere in the LQP.
@@ -72,10 +70,8 @@ ExpressionUnorderedSet ColumnPruningRule::_collect_consumed_columns(const std::s
   return consumed_columns;
 }
 
-bool ColumnPruningRule::_search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
-                                                            const ExpressionUnorderedSet &referenced_columns) {
-
-
+bool ColumnPruningRule::_search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode>& lqp,
+                                                            const ExpressionUnorderedSet& referenced_columns) {
   auto lqp_changed = false;
 
   auto leaf_parents = std::vector<std::pair<std::shared_ptr<AbstractLQPNode>, LQPInputSide>>{};
@@ -107,8 +103,8 @@ bool ColumnPruningRule::_search_for_leafs_and_prune_columns(const std::shared_pt
     // We cannot have a ProjectionNode that outputs no columns, so let's avoid that
     if (referenced_leaf_columns.empty()) continue;
 
-    // If a leaf outputs columns that are never used, prune those columns by inserting a ProjectionNode that only contains
-    // the used columns
+    // If a leaf outputs columns that are never used, prune those columns by inserting a ProjectionNode that only
+    // contains the used columns
     lqp_insert_node(parent, leaf_input_side, ProjectionNode::make(referenced_leaf_columns));
     lqp_changed = true;
   }
@@ -116,8 +112,8 @@ bool ColumnPruningRule::_search_for_leafs_and_prune_columns(const std::shared_pt
   return lqp_changed;
 }
 
-void ColumnPruningRule::_search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
-                                                                  const ExpressionUnorderedSet &referenced_columns) {
+void ColumnPruningRule::_search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode>& lqp,
+                                                                  const ExpressionUnorderedSet& referenced_columns) {
   /**
    * Prune otherwise unused columns that are forwarded by ProjectionNodes
    */
@@ -134,7 +130,7 @@ void ColumnPruningRule::_search_for_projections_and_prune_columns(const std::sha
   // Replace ProjectionNodes with pruned ProjectionNodes if necessary
   for (const auto& projection_node : projection_nodes) {
     auto referenced_projection_expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
-    for (const auto &expression : projection_node->node_expressions()) {
+    for (const auto& expression : projection_node->node_expressions()) {
       // We keep all non-column expressions
       if (expression->type != ExpressionType::LQPColumn) {
         referenced_projection_expressions.emplace_back(expression);
@@ -155,8 +151,6 @@ void ColumnPruningRule::_search_for_projections_and_prune_columns(const std::sha
       lqp_replace_node(projection_node, ProjectionNode::make(referenced_projection_expressions));
     }
   }
-
-
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -1,0 +1,162 @@
+#include "column_pruning_rule.hpp"
+
+#include <unordered_map>
+
+#include "expression/abstract_expression.hpp"
+#include "expression/expression_utils.hpp"
+#include "expression/expression_functional.hpp"
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/dummy_table_node.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
+#include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
+#include "../../logical_query_plan/lqp_utils.hpp"
+
+using namespace opossum::expression_functional;  // NOLINT
+
+namespace opossum {
+
+std::string ColumnPruningRule::name() const {
+  return "Column Pruning Rule";
+}
+
+bool ColumnPruningRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
+  // Collect the columns that are used in expressions somewhere in the LQP.
+  // This EXCLUDES columns that merely forwarded by Projections
+  auto referenced_columns = _collect_consumed_columns(root);
+
+  // The output columns of the plan are always considered to be referenced (i.e., we cannot prune them
+  const auto output_columns = root->column_expressions();
+  referenced_columns.insert(output_columns.begin(), output_columns.end());
+
+  // Search for ProjectionNodes that forward the unused columns and prune them accordingly
+  _search_for_projections_and_prune_columns(root, referenced_columns);
+
+  // Search the plan for leaf nodes and prune all columns from them that are not referenced
+  return _search_for_leafs_and_prune_columns(root, referenced_columns);
+}
+
+ExpressionUnorderedSet ColumnPruningRule::_collect_consumed_columns(const std::shared_ptr<AbstractLQPNode>& lqp) {
+  auto consumed_columns = ExpressionUnorderedSet{};
+
+  // Search an expression for referenced columns
+  const auto collect_consumed_columns_from_expression = [&](const auto& expression) {
+    visit_expression(expression, [&](const auto& sub_expression) {
+      if (sub_expression->type == ExpressionType::LQPColumn) {
+        consumed_columns.emplace(sub_expression);
+      }
+      return ExpressionVisitation::VisitArguments;
+    });
+  };
+
+  // Search the entire LQP for columns used in AbstractLQPNode::node_expressions(), i.e. columns that are necessary for
+  // the "functioning" of the LQP.
+  // For ProjectionNodes, ignore forwarded columns (since they would include all columns and we wouldn't be able to
+  // prune) by only searching the arguments of expression.
+  visit_lqp(lqp, [&](const auto& node) {
+    for (const auto& expression : node->node_expressions()) {
+      if (node->type == LQPNodeType::Projection) {
+        for (const auto& argument : expression->arguments) {
+          collect_consumed_columns_from_expression(argument);
+        }
+      } else {
+        collect_consumed_columns_from_expression(expression);
+      }
+    }
+    return LQPVisitation::VisitInputs;
+  });
+
+  return consumed_columns;
+}
+
+bool ColumnPruningRule::_search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
+                                                            const ExpressionUnorderedSet &referenced_columns) {
+
+
+  auto lqp_changed = false;
+
+  auto leaf_parents = std::vector<std::pair<std::shared_ptr<AbstractLQPNode>, LQPInputSide>>{};
+  visit_lqp(lqp, [&](auto& node) {
+    for (const auto input_side : {LQPInputSide::Left, LQPInputSide::Right}) {
+      const auto input = node->input(input_side);
+      if (input && input->input_count() == 0) leaf_parents.emplace_back(node, input_side);
+    }
+
+    // Do not visit the ProjectionNode we may have just inserted, that would lead to infinite recursion
+    return LQPVisitation::VisitInputs;
+  });
+
+  for (const auto& parent_and_leaf_input_side : leaf_parents) {
+    const auto& parent = parent_and_leaf_input_side.first;
+    const auto& leaf_input_side = parent_and_leaf_input_side.second;
+    const auto leaf = parent->input(leaf_input_side);
+
+    // Collect all columns from the leaf that are actually referenced
+    auto referenced_leaf_columns = std::vector<std::shared_ptr<AbstractExpression>>{};
+    for (const auto& expression : leaf->column_expressions()) {
+      if (referenced_columns.find(expression) != referenced_columns.end()) {
+        referenced_leaf_columns.emplace_back(expression);
+      }
+    }
+
+    if (leaf->column_expressions().size() == referenced_leaf_columns.size()) continue;
+
+    // We cannot have a ProjectionNode that outputs no columns, so let's avoid that
+    if (referenced_leaf_columns.empty()) continue;
+
+    // If a leaf outputs columns that are never used, prune those columns by inserting a ProjectionNode that only contains
+    // the used columns
+    lqp_insert_node(parent, leaf_input_side, ProjectionNode::make(referenced_leaf_columns));
+    lqp_changed = true;
+  }
+
+  return lqp_changed;
+}
+
+void ColumnPruningRule::_search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
+                                                                  const ExpressionUnorderedSet &referenced_columns) {
+  /**
+   * Prune otherwise unused columns that are forwarded by ProjectionNodes
+   */
+
+  // First collect all the ProjectionNodes. Don't prune while visiting because visit_lqp() can't deal with nodes being
+  // replaced
+  auto projection_nodes = std::vector<std::shared_ptr<ProjectionNode>>{};
+  visit_lqp(lqp, [&](auto& node) {
+    if (node->type != LQPNodeType::Projection) return LQPVisitation::VisitInputs;
+    projection_nodes.emplace_back(std::static_pointer_cast<ProjectionNode>(node));
+    return LQPVisitation::VisitInputs;
+  });
+
+  // Replace ProjectionNodes with pruned ProjectionNodes if necessary
+  for (const auto& projection_node : projection_nodes) {
+    auto referenced_projection_expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
+    for (const auto &expression : projection_node->node_expressions()) {
+      // We keep all non-column expressions
+      if (expression->type != ExpressionType::LQPColumn) {
+        referenced_projection_expressions.emplace_back(expression);
+      } else if (referenced_columns.find(expression) != referenced_columns.end()) {
+        referenced_projection_expressions.emplace_back(expression);
+      }
+    }
+
+    if (projection_node->node_expressions().size() == referenced_projection_expressions.size()) {
+      // No columns to prune
+      continue;
+    }
+
+    // We cannot have a ProjectionNode that outputs no columns
+    if (referenced_projection_expressions.empty()) {
+      lqp_remove_node(projection_node);
+    } else {
+      lqp_replace_node(projection_node, ProjectionNode::make(referenced_projection_expressions));
+    }
+  }
+
+
+}
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -12,7 +12,12 @@ class AbstractLQPNode;
 /**
  * Removes never-referenced base relation columns from the LQP by inserting ProjectionNodes that select only those
  * expressions needed "further up" in the plan.
- * Does NOT eliminate columns added as temporary columns later in the plan.
+ *
+ * Does NOT eliminate columns added as temporary columns later in the plan or columns that become useless after a
+ * certain point in the LQP. *
+ * E.g. `SELECT * FROM t WHERE a + 5 > b AND a + 6 > c`: Here `a + 5` and `a + 6` introduce temporary columns that will
+ * NOT be removed by this Rule. But it `t` contains a column "d", which is obviously never used in this query, this
+ * column "d" will be pruned.
  */
 class ColumnPruningRule : public AbstractRule {
  public:
@@ -20,11 +25,11 @@ class ColumnPruningRule : public AbstractRule {
   bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
  private:
-  static ExpressionUnorderedSet _collect_consumed_columns(const std::shared_ptr<AbstractLQPNode>& lqp);
-  static bool _search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode>& lqp,
-                                                  const ExpressionUnorderedSet& referenced_columns);
-  static void _search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode>& lqp,
-                                                        const ExpressionUnorderedSet& referenced_columns);
+  static ExpressionUnorderedSet _collect_actually_used_columns(const std::shared_ptr<AbstractLQPNode>& lqp);
+  static bool _prune_columns_from_leafs(const std::shared_ptr<AbstractLQPNode>& lqp,
+                                        const ExpressionUnorderedSet& referenced_columns);
+  static void _prune_unused_columns_in_projections(const std::shared_ptr<AbstractLQPNode>& lqp,
+                                                   const ExpressionUnorderedSet& referenced_columns);
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -20,10 +20,10 @@ class ColumnPruningRule : public AbstractRule {
 
  private:
   static ExpressionUnorderedSet _collect_consumed_columns(const std::shared_ptr<AbstractLQPNode>& lqp);
-  static bool _search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
-                                                  const ExpressionUnorderedSet &referenced_columns);
-  static void _search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
-                                                  const ExpressionUnorderedSet &referenced_columns);
+  static bool _search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode>& lqp,
+                                                  const ExpressionUnorderedSet& referenced_columns);
+  static void _search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode>& lqp,
+                                                        const ExpressionUnorderedSet& referenced_columns);
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "abstract_rule.hpp"
+#include "expression/abstract_expression.hpp"
+
+namespace opossum {
+
+class AbstractLQPNode;
+
+/**
+ * Removes never-referenced columns from the LQP by inserting ProjectionNodes that select only those expressions needed
+ * "further up" in the plan.
+ */
+class ColumnPruningRule : public AbstractRule {
+ public:
+  std::string name() const override;
+  bool apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
+
+ private:
+  static ExpressionUnorderedSet _collect_consumed_columns(const std::shared_ptr<AbstractLQPNode>& lqp);
+  static bool _search_for_leafs_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
+                                                  const ExpressionUnorderedSet &referenced_columns);
+  static void _search_for_projections_and_prune_columns(const std::shared_ptr<AbstractLQPNode> &lqp,
+                                                  const ExpressionUnorderedSet &referenced_columns);
+};
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -28,8 +28,8 @@ class ColumnPruningRule : public AbstractRule {
   static ExpressionUnorderedSet _collect_actually_used_columns(const std::shared_ptr<AbstractLQPNode>& lqp);
   static bool _prune_columns_from_leafs(const std::shared_ptr<AbstractLQPNode>& lqp,
                                         const ExpressionUnorderedSet& referenced_columns);
-  static void _prune_unused_columns_in_projections(const std::shared_ptr<AbstractLQPNode>& lqp,
-                                                   const ExpressionUnorderedSet& referenced_columns);
+  static void _prune_columns_in_projections(const std::shared_ptr<AbstractLQPNode> &lqp,
+                                            const ExpressionUnorderedSet &referenced_columns);
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -10,8 +10,9 @@ namespace opossum {
 class AbstractLQPNode;
 
 /**
- * Removes never-referenced columns from the LQP by inserting ProjectionNodes that select only those expressions needed
- * "further up" in the plan.
+ * Removes never-referenced base relation columns from the LQP by inserting ProjectionNodes that select only those
+ * expressions needed "further up" in the plan.
+ * Does NOT eliminate columns added as temporary columns later in the plan.
  */
 class ColumnPruningRule : public AbstractRule {
  public:

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -17,9 +17,9 @@
 
 namespace opossum {
 
-Chunk::Chunk(const ChunkColumns& columns, std::shared_ptr<MvccColumns> mvcc_columns,
+Chunk::Chunk(const ChunkColumns& columns, const std::shared_ptr<MvccColumns>& mvcc_columns,
              const std::optional<PolymorphicAllocator<Chunk>>& alloc,
-             const std::shared_ptr<ChunkAccessCounter> access_counter)
+             const std::shared_ptr<ChunkAccessCounter>& access_counter)
     : _columns(columns), _mvcc_columns(mvcc_columns), _access_counter(access_counter) {
 #if IS_DEBUG
   const auto chunk_size = columns.empty() ? 0u : columns[0]->size();
@@ -36,7 +36,7 @@ bool Chunk::is_mutable() const { return _is_mutable; }
 
 void Chunk::mark_immutable() { _is_mutable = false; }
 
-void Chunk::replace_column(size_t column_id, std::shared_ptr<BaseColumn> column) {
+void Chunk::replace_column(size_t column_id, const std::shared_ptr<BaseColumn>& column) {
   std::atomic_store(&_columns.at(column_id), column);
 }
 
@@ -103,7 +103,7 @@ std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(
   return result;
 }
 
-std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(const std::vector<ColumnID> column_ids) const {
+std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(const std::vector<ColumnID>& column_ids) const {
   auto columns = _get_columns_for_ids(column_ids);
   return get_indices(columns);
 }
@@ -118,12 +118,12 @@ std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
 }
 
 std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
-                                            const std::vector<ColumnID> column_ids) const {
+                                            const std::vector<ColumnID>& column_ids) const {
   auto columns = _get_columns_for_ids(column_ids);
   return get_index(index_type, columns);
 }
 
-void Chunk::remove_index(std::shared_ptr<BaseIndex> index) {
+void Chunk::remove_index(const std::shared_ptr<BaseIndex>& index) {
   auto it = std::find(_indices.cbegin(), _indices.cend(), index);
   DebugAssert(it != _indices.cend(), "Trying to remove a non-existing index");
   _indices.erase(it);
@@ -151,14 +151,14 @@ bool Chunk::references_exactly_one_table() const {
 
 void Chunk::migrate(boost::container::pmr::memory_resource* memory_source) {
   // Migrating chunks with indices is not implemented yet.
-  if (_indices.size() > 0) {
+  if (!_indices.empty()) {
     Fail("Cannot migrate Chunk with Indices.");
   }
 
   _alloc = PolymorphicAllocator<size_t>(memory_source);
   ChunkColumns new_columns(_alloc);
-  for (size_t i = 0; i < _columns.size(); i++) {
-    new_columns.push_back(_columns.at(i)->copy_using_allocator(_alloc));
+  for (const auto& column : _columns) {
+    new_columns.push_back(column->copy_using_allocator(_alloc));
   }
   _columns = std::move(new_columns);
 }
@@ -203,7 +203,7 @@ std::vector<std::shared_ptr<const BaseColumn>> Chunk::_get_columns_for_ids(
 
 std::shared_ptr<ChunkStatistics> Chunk::statistics() const { return _statistics; }
 
-void Chunk::set_statistics(std::shared_ptr<ChunkStatistics> chunk_statistics) {
+void Chunk::set_statistics(const std::shared_ptr<ChunkStatistics>& chunk_statistics) {
   Assert(!is_mutable(), "Cannot set statistics on mutable chunks.");
   DebugAssert(chunk_statistics->statistics().size() == column_count(),
               "ChunkStatistics must have same column amount as Chunk");

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -44,7 +44,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row are the MVCC columns.
-  if (has_mvcc_columns()) lock_mvcc_columns()->grow_by(1u, MvccColumns::MAX_COMMIT_ID);
+  if (has_mvcc_columns()) get_scoped_mvcc_columns_lock()->grow_by(1u, MvccColumns::MAX_COMMIT_ID);
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_columns.size() == values.size()),
@@ -75,13 +75,13 @@ uint32_t Chunk::size() const {
 bool Chunk::has_mvcc_columns() const { return _mvcc_columns != nullptr; }
 bool Chunk::has_access_counter() const { return _access_counter != nullptr; }
 
-SharedScopedLockingPtr<MvccColumns> Chunk::lock_mvcc_columns() {
+SharedScopedLockingPtr<MvccColumns> Chunk::get_scoped_mvcc_columns_lock() {
   DebugAssert((has_mvcc_columns()), "Chunk does not have mvcc columns");
 
   return {*_mvcc_columns, _mvcc_columns->_mutex};
 }
 
-SharedScopedLockingPtr<const MvccColumns> Chunk::lock_mvcc_columns() const {
+SharedScopedLockingPtr<const MvccColumns> Chunk::get_scoped_mvcc_columns_lock() const {
   DebugAssert((has_mvcc_columns()), "Chunk does not have mvcc columns");
 
   return {*_mvcc_columns, _mvcc_columns->_mutex};

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -87,13 +87,9 @@ SharedScopedLockingPtr<const MvccColumns> Chunk::lock_mvcc_columns() const {
   return {*_mvcc_columns, _mvcc_columns->_mutex};
 }
 
-std::shared_ptr<MvccColumns> Chunk::mvcc_columns() const {
-  return _mvcc_columns;
-}
+std::shared_ptr<MvccColumns> Chunk::mvcc_columns() const { return _mvcc_columns; }
 
-void Chunk::set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns) {
-  _mvcc_columns = mvcc_columns;
-}
+void Chunk::set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns) { _mvcc_columns = mvcc_columns; }
 
 std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(
     const std::vector<std::shared_ptr<const BaseColumn>>& columns) const {

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -17,9 +17,9 @@
 
 namespace opossum {
 
-Chunk::Chunk(const ChunkColumns& columns, const std::shared_ptr<MvccColumns>& mvcc_columns,
+Chunk::Chunk(const ChunkColumns& columns, std::shared_ptr<MvccColumns> mvcc_columns,
              const std::optional<PolymorphicAllocator<Chunk>>& alloc,
-             const std::shared_ptr<ChunkAccessCounter>& access_counter)
+             const std::shared_ptr<ChunkAccessCounter> access_counter)
     : _columns(columns), _mvcc_columns(mvcc_columns), _access_counter(access_counter) {
 #if IS_DEBUG
   const auto chunk_size = columns.empty() ? 0u : columns[0]->size();
@@ -36,7 +36,7 @@ bool Chunk::is_mutable() const { return _is_mutable; }
 
 void Chunk::mark_immutable() { _is_mutable = false; }
 
-void Chunk::replace_column(size_t column_id, const std::shared_ptr<BaseColumn>& column) {
+void Chunk::replace_column(size_t column_id, std::shared_ptr<BaseColumn> column) {
   std::atomic_store(&_columns.at(column_id), column);
 }
 
@@ -92,6 +92,10 @@ SharedScopedLockingPtr<const MvccColumns> Chunk::mvcc_columns() const {
   return {*_mvcc_columns, _mvcc_columns->_mutex};
 }
 
+void Chunk::set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns) {
+  _mvcc_columns = mvcc_columns;
+}
+
 std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(
     const std::vector<std::shared_ptr<const BaseColumn>>& columns) const {
   auto result = std::vector<std::shared_ptr<BaseIndex>>();
@@ -100,7 +104,7 @@ std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(
   return result;
 }
 
-std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(const std::vector<ColumnID>& column_ids) const {
+std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(const std::vector<ColumnID> column_ids) const {
   auto columns = _get_columns_for_ids(column_ids);
   return get_indices(columns);
 }
@@ -115,12 +119,12 @@ std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
 }
 
 std::shared_ptr<BaseIndex> Chunk::get_index(const ColumnIndexType index_type,
-                                            const std::vector<ColumnID>& column_ids) const {
+                                            const std::vector<ColumnID> column_ids) const {
   auto columns = _get_columns_for_ids(column_ids);
   return get_index(index_type, columns);
 }
 
-void Chunk::remove_index(const std::shared_ptr<BaseIndex>& index) {
+void Chunk::remove_index(std::shared_ptr<BaseIndex> index) {
   auto it = std::find(_indices.cbegin(), _indices.cend(), index);
   DebugAssert(it != _indices.cend(), "Trying to remove a non-existing index");
   _indices.erase(it);
@@ -148,14 +152,14 @@ bool Chunk::references_exactly_one_table() const {
 
 void Chunk::migrate(boost::container::pmr::memory_resource* memory_source) {
   // Migrating chunks with indices is not implemented yet.
-  if (!_indices.empty()) {
+  if (_indices.size() > 0) {
     Fail("Cannot migrate Chunk with Indices.");
   }
 
   _alloc = PolymorphicAllocator<size_t>(memory_source);
   ChunkColumns new_columns(_alloc);
-  for (const auto& column : _columns) {
-    new_columns.push_back(column->copy_using_allocator(_alloc));
+  for (size_t i = 0; i < _columns.size(); i++) {
+    new_columns.push_back(_columns.at(i)->copy_using_allocator(_alloc));
   }
   _columns = std::move(new_columns);
 }
@@ -200,7 +204,7 @@ std::vector<std::shared_ptr<const BaseColumn>> Chunk::_get_columns_for_ids(
 
 std::shared_ptr<ChunkStatistics> Chunk::statistics() const { return _statistics; }
 
-void Chunk::set_statistics(const std::shared_ptr<ChunkStatistics>& chunk_statistics) {
+void Chunk::set_statistics(std::shared_ptr<ChunkStatistics> chunk_statistics) {
   Assert(!is_mutable(), "Cannot set statistics on mutable chunks.");
   DebugAssert(chunk_statistics->statistics().size() == column_count(),
               "ChunkStatistics must have same column amount as Chunk");

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -44,7 +44,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row are the MVCC columns.
-  if (has_mvcc_columns()) mvcc_columns()->grow_by(1u, MvccColumns::MAX_COMMIT_ID);
+  if (has_mvcc_columns()) lock_mvcc_columns()->grow_by(1u, MvccColumns::MAX_COMMIT_ID);
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_columns.size() == values.size()),
@@ -58,12 +58,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   }
 }
 
-std::shared_ptr<BaseColumn> Chunk::get_mutable_column(ColumnID column_id) const {
-  Assert(is_mutable(), "Cannot get mutable column from immutable chunk.");
-  return std::atomic_load(&_columns.at(column_id));
-}
-
-std::shared_ptr<const BaseColumn> Chunk::get_column(ColumnID column_id) const {
+std::shared_ptr<BaseColumn> Chunk::get_column(ColumnID column_id) const {
   return std::atomic_load(&_columns.at(column_id));
 }
 
@@ -80,16 +75,20 @@ uint32_t Chunk::size() const {
 bool Chunk::has_mvcc_columns() const { return _mvcc_columns != nullptr; }
 bool Chunk::has_access_counter() const { return _access_counter != nullptr; }
 
-SharedScopedLockingPtr<MvccColumns> Chunk::mvcc_columns() {
+SharedScopedLockingPtr<MvccColumns> Chunk::lock_mvcc_columns() {
   DebugAssert((has_mvcc_columns()), "Chunk does not have mvcc columns");
 
   return {*_mvcc_columns, _mvcc_columns->_mutex};
 }
 
-SharedScopedLockingPtr<const MvccColumns> Chunk::mvcc_columns() const {
+SharedScopedLockingPtr<const MvccColumns> Chunk::lock_mvcc_columns() const {
   DebugAssert((has_mvcc_columns()), "Chunk does not have mvcc columns");
 
   return {*_mvcc_columns, _mvcc_columns->_mutex};
+}
+
+std::shared_ptr<MvccColumns> Chunk::mvcc_columns() const {
+  return _mvcc_columns;
 }
 
 void Chunk::set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns) {

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -43,9 +43,9 @@ class Chunk : private Noncopyable {
   // The last chunk offset is reserved for NULL as used in ReferenceColumns.
   static constexpr ChunkOffset MAX_SIZE = std::numeric_limits<ChunkOffset>::max() - 1;
 
-  Chunk(const ChunkColumns& columns, std::shared_ptr<MvccColumns> mvcc_columns = nullptr,
+  Chunk(const ChunkColumns& columns, const std::shared_ptr<MvccColumns>& mvcc_columns = nullptr,
         const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt,
-        const std::shared_ptr<ChunkAccessCounter> access_counter = nullptr);
+        const std::shared_ptr<ChunkAccessCounter>& access_counter = nullptr);
 
   // returns whether new rows can be appended to this Chunk
   bool is_mutable() const;
@@ -53,7 +53,7 @@ class Chunk : private Noncopyable {
   void mark_immutable();
 
   // Atomically replaces the current column at column_id with the passed column
-  void replace_column(size_t column_id, std::shared_ptr<BaseColumn> column);
+  void replace_column(size_t column_id, const std::shared_ptr<BaseColumn>& column);
 
   // returns the number of columns (cannot exceed ColumnID (uint16_t))
   uint16_t column_count() const;
@@ -99,11 +99,11 @@ class Chunk : private Noncopyable {
 
   std::vector<std::shared_ptr<BaseIndex>> get_indices(
       const std::vector<std::shared_ptr<const BaseColumn>>& columns) const;
-  std::vector<std::shared_ptr<BaseIndex>> get_indices(const std::vector<ColumnID> column_ids) const;
+  std::vector<std::shared_ptr<BaseIndex>> get_indices(const std::vector<ColumnID>& column_ids) const;
 
   std::shared_ptr<BaseIndex> get_index(const ColumnIndexType index_type,
                                        const std::vector<std::shared_ptr<const BaseColumn>>& columns) const;
-  std::shared_ptr<BaseIndex> get_index(const ColumnIndexType index_type, const std::vector<ColumnID> column_ids) const;
+  std::shared_ptr<BaseIndex> get_index(const ColumnIndexType index_type, const std::vector<ColumnID>& column_ids) const;
 
   template <typename Index>
   std::shared_ptr<BaseIndex> create_index(const std::vector<std::shared_ptr<const BaseColumn>>& index_columns) {
@@ -127,7 +127,7 @@ class Chunk : private Noncopyable {
     return create_index<Index>(columns);
   }
 
-  void remove_index(std::shared_ptr<BaseIndex> index);
+  void remove_index(const std::shared_ptr<BaseIndex>& index);
 
   void migrate(boost::container::pmr::memory_resource* memory_source);
 
@@ -139,22 +139,12 @@ class Chunk : private Noncopyable {
 
   std::shared_ptr<ChunkStatistics> statistics() const;
 
-  void set_statistics(std::shared_ptr<ChunkStatistics> statistics);
+  void set_statistics(const std::shared_ptr<ChunkStatistics>& statistics);
 
   /**
    * For debugging purposes, makes an estimation about the memory used by this Chunk and its Columns
    */
   size_t estimate_memory_usage() const;
-
-  /**
-   * @return A clone of this Chunk, with the same columns, allocator etc.
-   */
-  std::shared_ptr<Chunk> forward_clone() const;
-
-  /**
-   * @return A clone of this Chunk, with the same allocator etc. but all Columns become materialized ValueColumns
-   */
-  std::shared_ptr<Chunk> materialized_clone() const;
 
  private:
   std::vector<std::shared_ptr<const BaseColumn>> _get_columns_for_ids(const std::vector<ColumnID>& column_ids) const;

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -43,9 +43,9 @@ class Chunk : private Noncopyable {
   // The last chunk offset is reserved for NULL as used in ReferenceColumns.
   static constexpr ChunkOffset MAX_SIZE = std::numeric_limits<ChunkOffset>::max() - 1;
 
-  Chunk(const ChunkColumns& columns, const std::shared_ptr<MvccColumns>& mvcc_columns = nullptr,
+  Chunk(const ChunkColumns& columns, std::shared_ptr<MvccColumns> mvcc_columns = nullptr,
         const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt,
-        const std::shared_ptr<ChunkAccessCounter>& access_counter = nullptr);
+        const std::shared_ptr<ChunkAccessCounter> access_counter = nullptr);
 
   // returns whether new rows can be appended to this Chunk
   bool is_mutable() const;
@@ -53,7 +53,7 @@ class Chunk : private Noncopyable {
   void mark_immutable();
 
   // Atomically replaces the current column at column_id with the passed column
-  void replace_column(size_t column_id, const std::shared_ptr<BaseColumn>& column);
+  void replace_column(size_t column_id, std::shared_ptr<BaseColumn> column);
 
   // returns the number of columns (cannot exceed ColumnID (uint16_t))
   uint16_t column_count() const;
@@ -94,14 +94,17 @@ class Chunk : private Noncopyable {
    */
   SharedScopedLockingPtr<MvccColumns> mvcc_columns();
   SharedScopedLockingPtr<const MvccColumns> mvcc_columns() const;
+  std::shared_ptr<MvccColumns> mvcc_columns_ptr() const {return _mvcc_columns;}
+
+  void set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns);
 
   std::vector<std::shared_ptr<BaseIndex>> get_indices(
       const std::vector<std::shared_ptr<const BaseColumn>>& columns) const;
-  std::vector<std::shared_ptr<BaseIndex>> get_indices(const std::vector<ColumnID>& column_ids) const;
+  std::vector<std::shared_ptr<BaseIndex>> get_indices(const std::vector<ColumnID> column_ids) const;
 
   std::shared_ptr<BaseIndex> get_index(const ColumnIndexType index_type,
                                        const std::vector<std::shared_ptr<const BaseColumn>>& columns) const;
-  std::shared_ptr<BaseIndex> get_index(const ColumnIndexType index_type, const std::vector<ColumnID>& column_ids) const;
+  std::shared_ptr<BaseIndex> get_index(const ColumnIndexType index_type, const std::vector<ColumnID> column_ids) const;
 
   template <typename Index>
   std::shared_ptr<BaseIndex> create_index(const std::vector<std::shared_ptr<const BaseColumn>>& index_columns) {
@@ -125,7 +128,7 @@ class Chunk : private Noncopyable {
     return create_index<Index>(columns);
   }
 
-  void remove_index(const std::shared_ptr<BaseIndex>& index);
+  void remove_index(std::shared_ptr<BaseIndex> index);
 
   void migrate(boost::container::pmr::memory_resource* memory_source);
 
@@ -137,7 +140,7 @@ class Chunk : private Noncopyable {
 
   std::shared_ptr<ChunkStatistics> statistics() const;
 
-  void set_statistics(const std::shared_ptr<ChunkStatistics>& chunk_statistics);
+  void set_statistics(std::shared_ptr<ChunkStatistics> statistics);
 
   /**
    * For debugging purposes, makes an estimation about the memory used by this Chunk and its Columns

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -91,8 +91,8 @@ class Chunk : private Noncopyable {
    *
    * @return a locking ptr to the mvcc columns
    */
-  SharedScopedLockingPtr<MvccColumns> lock_mvcc_columns();
-  SharedScopedLockingPtr<const MvccColumns> lock_mvcc_columns() const;
+  SharedScopedLockingPtr<MvccColumns> get_scoped_mvcc_columns_lock();
+  SharedScopedLockingPtr<const MvccColumns> get_scoped_mvcc_columns_lock() const;
 
   std::shared_ptr<MvccColumns> mvcc_columns() const;
   void set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns);

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -75,8 +75,7 @@ class Chunk : private Noncopyable {
    *       However, if you call get_column again, be aware that
    *       the return type might have changed.
    */
-  std::shared_ptr<BaseColumn> get_mutable_column(ColumnID column_id) const;
-  std::shared_ptr<const BaseColumn> get_column(ColumnID column_id) const;
+  std::shared_ptr<BaseColumn> get_column(ColumnID column_id) const;
 
   const ChunkColumns& columns() const;
 
@@ -92,10 +91,10 @@ class Chunk : private Noncopyable {
    *
    * @return a locking ptr to the mvcc columns
    */
-  SharedScopedLockingPtr<MvccColumns> mvcc_columns();
-  SharedScopedLockingPtr<const MvccColumns> mvcc_columns() const;
-  std::shared_ptr<MvccColumns> mvcc_columns_ptr() const {return _mvcc_columns;}
+  SharedScopedLockingPtr<MvccColumns> lock_mvcc_columns();
+  SharedScopedLockingPtr<const MvccColumns> lock_mvcc_columns() const;
 
+  std::shared_ptr<MvccColumns> mvcc_columns() const;
   void set_mvcc_columns(const std::shared_ptr<MvccColumns>& mvcc_columns);
 
   std::vector<std::shared_ptr<BaseIndex>> get_indices(

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -139,7 +139,7 @@ class Chunk : private Noncopyable {
 
   std::shared_ptr<ChunkStatistics> statistics() const;
 
-  void set_statistics(const std::shared_ptr<ChunkStatistics>& statistics);
+  void set_statistics(const std::shared_ptr<ChunkStatistics>& chunk_statistics);
 
   /**
    * For debugging purposes, makes an estimation about the memory used by this Chunk and its Columns

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -46,7 +46,7 @@ void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::
   chunk->set_statistics(std::make_shared<ChunkStatistics>(column_statistics));
 
   if (chunk->has_mvcc_columns()) {
-    chunk->lock_mvcc_columns()->shrink();
+    chunk->get_scoped_mvcc_columns_lock()->shrink();
   }
 }
 

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -46,7 +46,7 @@ void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::
   chunk->set_statistics(std::make_shared<ChunkStatistics>(column_statistics));
 
   if (chunk->has_mvcc_columns()) {
-    chunk->mvcc_columns()->shrink();
+    chunk->lock_mvcc_columns()->shrink();
   }
 }
 

--- a/src/lib/storage/mvcc_columns.hpp
+++ b/src/lib/storage/mvcc_columns.hpp
@@ -49,7 +49,7 @@ struct MvccColumns {
    *
    * Exclusively locked in shrink()
    * Locked for shared ownership when MVCC columns of a Chunk are accessed
-   * via the lock_mvcc_columns() getters
+   * via the get_scoped_mvcc_columns_lock() getters
    */
   std::shared_mutex _mutex;
 

--- a/src/lib/storage/mvcc_columns.hpp
+++ b/src/lib/storage/mvcc_columns.hpp
@@ -49,7 +49,7 @@ struct MvccColumns {
    *
    * Exclusively locked in shrink()
    * Locked for shared ownership when MVCC columns of a Chunk are accessed
-   * via the mvcc_columns() getters
+   * via the lock_mvcc_columns() getters
    */
   std::shared_mutex _mutex;
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -85,7 +85,7 @@ ColumnID Table::column_id_by_name(const std::string& column_name) const {
   return static_cast<ColumnID>(std::distance(_column_definitions.begin(), iter));
 }
 
-void Table::append(std::vector<AllTypeVariant> values) {
+void Table::append(const std::vector<AllTypeVariant>& values) {
   if (_chunks.empty() || _chunks.back()->size() >= _max_chunk_size) {
     append_mutable_chunk();
   }
@@ -168,7 +168,7 @@ void Table::append_chunk(const ChunkColumns& columns, const std::optional<Polymo
   _chunks.emplace_back(std::make_shared<Chunk>(columns, mvcc_columns, alloc, access_counter));
 }
 
-void Table::append_chunk(const std::shared_ptr<Chunk> chunk) {
+void Table::append_chunk(const std::shared_ptr<Chunk>& chunk) {
 #if IS_DEBUG
   for (const auto& column : chunk->columns()) {
     const auto is_reference_column = std::dynamic_pointer_cast<ReferenceColumn>(column) != nullptr;

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -85,7 +85,7 @@ ColumnID Table::column_id_by_name(const std::string& column_name) const {
   return static_cast<ColumnID>(std::distance(_column_definitions.begin(), iter));
 }
 
-void Table::append(const std::vector<AllTypeVariant>& values) {
+void Table::append(std::vector<AllTypeVariant> values) {
   if (_chunks.empty() || _chunks.back()->size() >= _max_chunk_size) {
     append_mutable_chunk();
   }
@@ -168,7 +168,7 @@ void Table::append_chunk(const ChunkColumns& columns, const std::optional<Polymo
   _chunks.emplace_back(std::make_shared<Chunk>(columns, mvcc_columns, alloc, access_counter));
 }
 
-void Table::append_chunk(const std::shared_ptr<Chunk>& chunk) {
+void Table::append_chunk(const std::shared_ptr<Chunk> chunk) {
 #if IS_DEBUG
   for (const auto& column : chunk->columns()) {
     const auto is_reference_column = std::dynamic_pointer_cast<ReferenceColumn>(column) != nullptr;

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -99,7 +99,7 @@ class Table : private Noncopyable {
    * Appends an existing chunk to this table.
    * Makes sure the columns in the chunk match with the TableType and the MVCC setting is the same as for the table.
    */
-  void append_chunk(const std::shared_ptr<Chunk> chunk);
+  void append_chunk(const std::shared_ptr<Chunk>& chunk);
 
   // Create and append a Chunk consisting of ValueColumns.
   void append_mutable_chunk();
@@ -113,7 +113,7 @@ class Table : private Noncopyable {
 
   // inserts a row at the end of the table
   // note this is slow and not thread-safe and should be used for testing purposes only
-  void append(std::vector<AllTypeVariant> values);
+  void append(const std::vector<AllTypeVariant>& values);
 
   // returns one materialized value
   // multiversion concurrency control values of chunks are ignored

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -99,7 +99,7 @@ class Table : private Noncopyable {
    * Appends an existing chunk to this table.
    * Makes sure the columns in the chunk match with the TableType and the MVCC setting is the same as for the table.
    */
-  void append_chunk(const std::shared_ptr<Chunk>& chunk);
+  void append_chunk(const std::shared_ptr<Chunk> chunk);
 
   // Create and append a Chunk consisting of ValueColumns.
   void append_mutable_chunk();
@@ -113,7 +113,7 @@ class Table : private Noncopyable {
 
   // inserts a row at the end of the table
   // note this is slow and not thread-safe and should be used for testing purposes only
-  void append(const std::vector<AllTypeVariant>& values);
+  void append(std::vector<AllTypeVariant> values);
 
   // returns one materialized value
   // multiversion concurrency control values of chunks are ignored

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -39,7 +39,7 @@ void ChunkCompressionTask::_on_execute() {
 bool ChunkCompressionTask::_chunk_is_completed(const std::shared_ptr<Chunk>& chunk, const uint32_t max_chunk_size) {
   if (chunk->size() != max_chunk_size) return false;
 
-  auto mvcc_columns = chunk->lock_mvcc_columns();
+  auto mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
 
   for (const auto begin_cid : mvcc_columns->begin_cids) {
     if (begin_cid == MvccColumns::MAX_COMMIT_ID) return false;

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -39,7 +39,7 @@ void ChunkCompressionTask::_on_execute() {
 bool ChunkCompressionTask::_chunk_is_completed(const std::shared_ptr<Chunk>& chunk, const uint32_t max_chunk_size) {
   if (chunk->size() != max_chunk_size) return false;
 
-  auto mvcc_columns = chunk->mvcc_columns();
+  auto mvcc_columns = chunk->lock_mvcc_columns();
 
   for (const auto begin_cid : mvcc_columns->begin_cids) {
     if (begin_cid == MvccColumns::MAX_COMMIT_ID) return false;

--- a/src/lib/tasks/chunk_compression_task.hpp
+++ b/src/lib/tasks/chunk_compression_task.hpp
@@ -27,10 +27,6 @@ class Chunk;
  * full and all of their end-cids must be smaller than infinity. This task calls
  * those chunks “completed”.
  *
- * After the columns have been replaced, the task calls Chunk::shrink_lock_mvcc_columns()
- * in order to reduce fragmentation of the MVCC columns. The MVCC columns are locked
- * exclusively during this step.
- *
  * Note: Reference columns are not invalidated by this task because the order in which
  *       records are stored does not change.
  */

--- a/src/lib/tasks/chunk_compression_task.hpp
+++ b/src/lib/tasks/chunk_compression_task.hpp
@@ -27,7 +27,7 @@ class Chunk;
  * full and all of their end-cids must be smaller than infinity. This task calls
  * those chunks “completed”.
  *
- * After the columns have been replaced, the task calls Chunk::shrink_mvcc_columns()
+ * After the columns have been replaced, the task calls Chunk::shrink_lock_mvcc_columns()
  * in order to reduce fragmentation of the MVCC columns. The MVCC columns are locked
  * exclusively during this step.
  *

--- a/src/lib/tasks/chunk_migration_task.cpp
+++ b/src/lib/tasks/chunk_migration_task.cpp
@@ -45,7 +45,7 @@ bool ChunkMigrationTask::chunk_is_completed(const std::shared_ptr<const Chunk>& 
   if (chunk->size() != max_chunk_size) return false;
 
   if (chunk->has_mvcc_columns()) {
-    auto mvcc_columns = chunk->lock_mvcc_columns();
+    auto mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
 
     for (const auto begin_cid : mvcc_columns->begin_cids) {
       if (begin_cid == MvccColumns::MAX_COMMIT_ID) return false;

--- a/src/lib/tasks/chunk_migration_task.cpp
+++ b/src/lib/tasks/chunk_migration_task.cpp
@@ -45,7 +45,7 @@ bool ChunkMigrationTask::chunk_is_completed(const std::shared_ptr<const Chunk>& 
   if (chunk->size() != max_chunk_size) return false;
 
   if (chunk->has_mvcc_columns()) {
-    auto mvcc_columns = chunk->mvcc_columns();
+    auto mvcc_columns = chunk->lock_mvcc_columns();
 
     for (const auto begin_cid : mvcc_columns->begin_cids) {
       if (begin_cid == MvccColumns::MAX_COMMIT_ID) return false;

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
     test_table->append(values);
 
     auto chunk = test_table->get_chunk(static_cast<ChunkID>(test_table->chunk_count() - 1));
-    auto mvcc_columns = chunk->mvcc_columns();
+    auto mvcc_columns = chunk->lock_mvcc_columns();
     mvcc_columns->begin_cids.back() = 0;
   }
   return test_table;

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -55,7 +55,7 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
     test_table->append(values);
 
     auto chunk = test_table->get_chunk(static_cast<ChunkID>(test_table->chunk_count() - 1));
-    auto mvcc_columns = chunk->lock_mvcc_columns();
+    auto mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
     mvcc_columns->begin_cids.back() = 0;
   }
   return test_table;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -89,6 +89,7 @@ set(
     statistics/table_statistics_test.cpp
     optimizer/lqp_translator_test.cpp
     optimizer/optimizer_test.cpp
+    optimizer/strategy/column_pruning_rule_test.cpp
     optimizer/strategy/chunk_pruning_test.cpp
     optimizer/strategy/constant_calculation_rule_test.cpp
     optimizer/strategy/index_scan_rule_test.cpp

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -87,4 +87,29 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_C) {
   EXPECT_EQ(*actual_expression, *expected_expression);
 }
 
+TEST_F(LQPUtilsTest, VisitLQP) {
+  const auto expected_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{
+    PredicateNode::make(greater_than_(a_a, 4)),
+    UnionNode::make(UnionMode::Positions),
+    PredicateNode::make(less_than_(a_a, 4)),
+    PredicateNode::make(equals_(a_a, 4)),
+    node_a
+  };
+
+  expected_nodes[0]->set_left_input(expected_nodes[1]);
+  expected_nodes[1]->set_left_input(expected_nodes[2]);
+  expected_nodes[1]->set_right_input(expected_nodes[3]);
+  expected_nodes[2]->set_left_input(node_a);
+  expected_nodes[3]->set_left_input(node_a);
+
+  auto actual_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+  visit_lqp(expected_nodes[0], [&](const auto& node) {
+    actual_nodes.emplace_back(node);
+    return LQPVisitation::VisitInputs;
+  });
+
+  EXPECT_EQ(actual_nodes, expected_nodes);
+
+}
+
 }  // namespace opossum

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -89,12 +89,8 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_C) {
 
 TEST_F(LQPUtilsTest, VisitLQP) {
   const auto expected_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{
-    PredicateNode::make(greater_than_(a_a, 4)),
-    UnionNode::make(UnionMode::Positions),
-    PredicateNode::make(less_than_(a_a, 4)),
-    PredicateNode::make(equals_(a_a, 4)),
-    node_a
-  };
+      PredicateNode::make(greater_than_(a_a, 4)), UnionNode::make(UnionMode::Positions),
+      PredicateNode::make(less_than_(a_a, 4)), PredicateNode::make(equals_(a_a, 4)), node_a};
 
   expected_nodes[0]->set_left_input(expected_nodes[1]);
   expected_nodes[1]->set_left_input(expected_nodes[2]);
@@ -109,7 +105,6 @@ TEST_F(LQPUtilsTest, VisitLQP) {
   });
 
   EXPECT_EQ(actual_nodes, expected_nodes);
-
 }
 
 }  // namespace opossum

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -53,9 +53,9 @@ void OperatorsDeleteTest::helper(bool commit) {
 
   delete_op->execute();
 
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->tids.at(0u), transaction_context->transaction_id());
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->tids.at(1u), 0u);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->tids.at(2u), transaction_context->transaction_id());
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(0u), transaction_context->transaction_id());
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(1u), 0u);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(2u), transaction_context->transaction_id());
 
   // Table has three rows initially.
   ASSERT_NE(_table->table_statistics(), nullptr);
@@ -76,15 +76,15 @@ void OperatorsDeleteTest::helper(bool commit) {
     EXPECT_EQ(_table->table_statistics()->row_count(), 3u);
   }
 
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->end_cids.at(0u), expected_end_cid);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->end_cids.at(1u), MvccColumns::MAX_COMMIT_ID);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->end_cids.at(2u), expected_end_cid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids.at(0u), expected_end_cid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids.at(1u), MvccColumns::MAX_COMMIT_ID);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids.at(2u), expected_end_cid);
 
   auto expected_tid = commit ? transaction_context->transaction_id() : 0u;
 
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->tids.at(0u), expected_tid);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->tids.at(1u), 0u);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->mvcc_columns()->tids.at(2u), expected_tid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(0u), expected_tid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(1u), 0u);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(2u), expected_tid);
 }
 
 TEST_F(OperatorsDeleteTest, ExecuteAndCommit) { helper(true); }

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -53,9 +53,11 @@ void OperatorsDeleteTest::helper(bool commit) {
 
   delete_op->execute();
 
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(0u), transaction_context->transaction_id());
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(1u), 0u);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(2u), transaction_context->transaction_id());
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids.at(0u),
+            transaction_context->transaction_id());
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids.at(1u), 0u);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids.at(2u),
+            transaction_context->transaction_id());
 
   // Table has three rows initially.
   ASSERT_NE(_table->table_statistics(), nullptr);
@@ -76,15 +78,15 @@ void OperatorsDeleteTest::helper(bool commit) {
     EXPECT_EQ(_table->table_statistics()->row_count(), 3u);
   }
 
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids.at(0u), expected_end_cid);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids.at(1u), MvccColumns::MAX_COMMIT_ID);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids.at(2u), expected_end_cid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids.at(0u), expected_end_cid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids.at(1u), MvccColumns::MAX_COMMIT_ID);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids.at(2u), expected_end_cid);
 
   auto expected_tid = commit ? transaction_context->transaction_id() : 0u;
 
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(0u), expected_tid);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(1u), 0u);
-  EXPECT_EQ(_table->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids.at(2u), expected_tid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids.at(0u), expected_tid);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids.at(1u), 0u);
+  EXPECT_EQ(_table->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids.at(2u), expected_tid);
 }
 
 TEST_F(OperatorsDeleteTest, ExecuteAndCommit) { helper(true); }

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -60,10 +60,36 @@ TEST_F(OperatorsProjectionTest, ForwardsIfPossibleDataTable) {
   const auto projection = std::make_shared<opossum::Projection>(table_wrapper_a, expression_vector(a_b, a_a));
   projection->execute();
 
-  EXPECT_EQ(table_wrapper_a->get_output()->get_chunk(ChunkID{0})->get_column(ColumnID{1}),
-            projection->get_output()->get_chunk(ChunkID{0})->get_column(ColumnID{0}));
-  EXPECT_EQ(table_wrapper_a->get_output()->get_chunk(ChunkID{0})->get_column(ColumnID{0}),
-            projection->get_output()->get_chunk(ChunkID{0})->get_column(ColumnID{1}));
+  const auto input_chunk = table_wrapper_a->get_output()->get_chunk(ChunkID{0});
+  const auto output_chunk = projection->get_output()->get_chunk(ChunkID{0});
+
+  EXPECT_EQ(input_chunk->get_column(ColumnID{1}), output_chunk->get_column(ColumnID{0}));
+  EXPECT_EQ(input_chunk->get_column(ColumnID{0}), output_chunk->get_column(ColumnID{1}));
+}
+
+TEST_F(OperatorsProjectionTest, ForwardsIfPossibleDataTableAndExpression) {
+  const auto projection = std::make_shared<opossum::Projection>(table_wrapper_a, expression_vector(a_b, a_a, add_(a_b, a_a)));
+  projection->execute();
+
+  const auto input_chunk = table_wrapper_a->get_output()->get_chunk(ChunkID{0});
+  const auto output_chunk = projection->get_output()->get_chunk(ChunkID{0});
+
+  EXPECT_EQ(input_chunk->get_column(ColumnID{1}), output_chunk->get_column(ColumnID{0}));
+  EXPECT_EQ(input_chunk->get_column(ColumnID{0}), output_chunk->get_column(ColumnID{1}));
+}
+
+TEST_F(OperatorsProjectionTest, DontForwardReferencesWithExpression) {
+  const auto table_scan =
+  std::make_shared<TableScan>(table_wrapper_a, ColumnID{0}, PredicateCondition::LessThan, 100'000);
+  table_scan->execute();
+  const auto projection = std::make_shared<opossum::Projection>(table_scan, expression_vector(a_b, a_a, add_(a_b, a_a)));
+  projection->execute();
+
+  const auto input_chunk = table_wrapper_a->get_output()->get_chunk(ChunkID{0});
+  const auto output_chunk = projection->get_output()->get_chunk(ChunkID{0});
+
+  EXPECT_NE(input_chunk->get_column(ColumnID{1}), output_chunk->get_column(ColumnID{0}));
+  EXPECT_NE(input_chunk->get_column(ColumnID{0}), output_chunk->get_column(ColumnID{1}));
 }
 
 TEST_F(OperatorsProjectionTest, ForwardsIfPossibleReferenceTable) {

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -68,7 +68,8 @@ TEST_F(OperatorsProjectionTest, ForwardsIfPossibleDataTable) {
 }
 
 TEST_F(OperatorsProjectionTest, ForwardsIfPossibleDataTableAndExpression) {
-  const auto projection = std::make_shared<opossum::Projection>(table_wrapper_a, expression_vector(a_b, a_a, add_(a_b, a_a)));
+  const auto projection =
+      std::make_shared<opossum::Projection>(table_wrapper_a, expression_vector(a_b, a_a, add_(a_b, a_a)));
   projection->execute();
 
   const auto input_chunk = table_wrapper_a->get_output()->get_chunk(ChunkID{0});
@@ -80,9 +81,10 @@ TEST_F(OperatorsProjectionTest, ForwardsIfPossibleDataTableAndExpression) {
 
 TEST_F(OperatorsProjectionTest, DontForwardReferencesWithExpression) {
   const auto table_scan =
-  std::make_shared<TableScan>(table_wrapper_a, ColumnID{0}, PredicateCondition::LessThan, 100'000);
+      std::make_shared<TableScan>(table_wrapper_a, ColumnID{0}, PredicateCondition::LessThan, 100'000);
   table_scan->execute();
-  const auto projection = std::make_shared<opossum::Projection>(table_scan, expression_vector(a_b, a_a, add_(a_b, a_a)));
+  const auto projection =
+      std::make_shared<opossum::Projection>(table_scan, expression_vector(a_b, a_a, add_(a_b, a_a)));
   projection->execute();
 
   const auto input_chunk = table_wrapper_a->get_output()->get_chunk(ChunkID{0});

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -39,7 +39,7 @@ class OperatorsValidateTest : public BaseTest {
 void OperatorsValidateTest::set_all_records_visible(Table& table) {
   for (ChunkID chunk_id{0}; chunk_id < table.chunk_count(); ++chunk_id) {
     auto chunk = table.get_chunk(chunk_id);
-    auto mvcc_columns = chunk->lock_mvcc_columns();
+    auto mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
 
     for (auto i = 0u; i < chunk->size(); ++i) {
       mvcc_columns->begin_cids[i] = 0u;
@@ -49,7 +49,7 @@ void OperatorsValidateTest::set_all_records_visible(Table& table) {
 }
 
 void OperatorsValidateTest::set_record_invisible_for(Table& table, RowID row, CommitID end_cid) {
-  table.get_chunk(row.chunk_id)->lock_mvcc_columns()->end_cids[row.chunk_offset] = end_cid;
+  table.get_chunk(row.chunk_id)->get_scoped_mvcc_columns_lock()->end_cids[row.chunk_offset] = end_cid;
 }
 
 TEST_F(OperatorsValidateTest, SimpleValidate) {

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -39,7 +39,7 @@ class OperatorsValidateTest : public BaseTest {
 void OperatorsValidateTest::set_all_records_visible(Table& table) {
   for (ChunkID chunk_id{0}; chunk_id < table.chunk_count(); ++chunk_id) {
     auto chunk = table.get_chunk(chunk_id);
-    auto mvcc_columns = chunk->mvcc_columns();
+    auto mvcc_columns = chunk->lock_mvcc_columns();
 
     for (auto i = 0u; i < chunk->size(); ++i) {
       mvcc_columns->begin_cids[i] = 0u;
@@ -49,7 +49,7 @@ void OperatorsValidateTest::set_all_records_visible(Table& table) {
 }
 
 void OperatorsValidateTest::set_record_invisible_for(Table& table, RowID row, CommitID end_cid) {
-  table.get_chunk(row.chunk_id)->mvcc_columns()->end_cids[row.chunk_offset] = end_cid;
+  table.get_chunk(row.chunk_id)->lock_mvcc_columns()->end_cids[row.chunk_offset] = end_cid;
 }
 
 TEST_F(OperatorsValidateTest, SimpleValidate) {

--- a/src/test/operators/validate_visibility_test.cpp
+++ b/src/test/operators/validate_visibility_test.cpp
@@ -47,9 +47,9 @@ class OperatorsValidateVisibilityTest : public BaseTest {
 TEST_F(OperatorsValidateVisibilityTest, Impossible) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 2;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -61,9 +61,9 @@ TEST_F(OperatorsValidateVisibilityTest, Impossible) {
 TEST_F(OperatorsValidateVisibilityTest, PastDelete) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 42;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 42;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 2;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -75,9 +75,9 @@ TEST_F(OperatorsValidateVisibilityTest, PastDelete) {
 TEST_F(OperatorsValidateVisibilityTest, Impossible2) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 4;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 1;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 4;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 1;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -89,9 +89,9 @@ TEST_F(OperatorsValidateVisibilityTest, Impossible2) {
 TEST_F(OperatorsValidateVisibilityTest, OwnDeleteUncommitted) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 1;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 6;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 1;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 6;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -103,9 +103,9 @@ TEST_F(OperatorsValidateVisibilityTest, OwnDeleteUncommitted) {
 TEST_F(OperatorsValidateVisibilityTest, Impossible3) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 50;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 3;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 1;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 50;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 1;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -117,9 +117,9 @@ TEST_F(OperatorsValidateVisibilityTest, Impossible3) {
 TEST_F(OperatorsValidateVisibilityTest, OwnInsert) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 3;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 3;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -131,9 +131,9 @@ TEST_F(OperatorsValidateVisibilityTest, OwnInsert) {
 TEST_F(OperatorsValidateVisibilityTest, PastInsertOrFutureDelete) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 99;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 2;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 99;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 3;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -145,9 +145,9 @@ TEST_F(OperatorsValidateVisibilityTest, PastInsertOrFutureDelete) {
 TEST_F(OperatorsValidateVisibilityTest, UncommittedInsertOrFutureInsert) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->mvcc_columns()->tids[0] = 99;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->begin_cids[0] = 3;
-  t->get_chunk(ChunkID{0})->mvcc_columns()->end_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 99;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 3;
 
   validate->set_transaction_context(context);
   validate->execute();

--- a/src/test/operators/validate_visibility_test.cpp
+++ b/src/test/operators/validate_visibility_test.cpp
@@ -47,9 +47,9 @@ class OperatorsValidateVisibilityTest : public BaseTest {
 TEST_F(OperatorsValidateVisibilityTest, Impossible) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 2;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -61,9 +61,9 @@ TEST_F(OperatorsValidateVisibilityTest, Impossible) {
 TEST_F(OperatorsValidateVisibilityTest, PastDelete) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 42;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 42;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 2;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -75,9 +75,9 @@ TEST_F(OperatorsValidateVisibilityTest, PastDelete) {
 TEST_F(OperatorsValidateVisibilityTest, Impossible2) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 4;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 1;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 4;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 1;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -89,9 +89,9 @@ TEST_F(OperatorsValidateVisibilityTest, Impossible2) {
 TEST_F(OperatorsValidateVisibilityTest, OwnDeleteUncommitted) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 1;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 6;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 1;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 6;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -103,9 +103,9 @@ TEST_F(OperatorsValidateVisibilityTest, OwnDeleteUncommitted) {
 TEST_F(OperatorsValidateVisibilityTest, Impossible3) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 50;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 3;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 1;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 50;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 1;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -117,9 +117,9 @@ TEST_F(OperatorsValidateVisibilityTest, Impossible3) {
 TEST_F(OperatorsValidateVisibilityTest, OwnInsert) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 3;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 3;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -131,9 +131,9 @@ TEST_F(OperatorsValidateVisibilityTest, OwnInsert) {
 TEST_F(OperatorsValidateVisibilityTest, PastInsertOrFutureDelete) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 99;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 2;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 99;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 2;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 3;
 
   validate->set_transaction_context(context);
   validate->execute();
@@ -145,9 +145,9 @@ TEST_F(OperatorsValidateVisibilityTest, PastInsertOrFutureDelete) {
 TEST_F(OperatorsValidateVisibilityTest, UncommittedInsertOrFutureInsert) {
   auto context = std::make_shared<TransactionContext>(2, 2);
 
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->tids[0] = 99;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->begin_cids[0] = 3;
-  t->get_chunk(ChunkID{0})->lock_mvcc_columns()->end_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->tids[0] = 99;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->begin_cids[0] = 3;
+  t->get_chunk(ChunkID{0})->get_scoped_mvcc_columns_lock()->end_cids[0] = 3;
 
   validate->set_transaction_context(context);
   validate->execute();

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -1,12 +1,12 @@
 #include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
+#include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/mock_node.hpp"
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
-#include "logical_query_plan/join_node.hpp"
-#include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/union_node.hpp"
 #include "optimizer/strategy/column_pruning_rule.hpp"
 
 #include "strategy_base_test.hpp"
@@ -16,11 +16,13 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class ColumnPruningRuleTest: public StrategyBaseTest {
+class ColumnPruningRuleTest : public StrategyBaseTest {
  public:
   void SetUp() override {
-    node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::Int, "c"}}, "a");
-    node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "u"}, {DataType::Int, "v"}, {DataType::Int, "w"}}, "b");
+    node_a = MockNode::make(
+        MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::Int, "c"}}, "a");
+    node_b = MockNode::make(
+        MockNode::ColumnDefinitions{{DataType::Int, "u"}, {DataType::Int, "v"}, {DataType::Int, "w"}}, "b");
     node_c = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}}, "c");
 
     a = node_a->get_column("a");

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -1,0 +1,123 @@
+#include "gtest/gtest.h"
+
+#include "expression/expression_functional.hpp"
+#include "logical_query_plan/mock_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/join_node.hpp"
+#include "logical_query_plan/union_node.hpp"
+#include "logical_query_plan/sort_node.hpp"
+#include "optimizer/strategy/column_pruning_rule.hpp"
+
+#include "strategy_base_test.hpp"
+#include "testing_assert.hpp"
+
+using namespace opossum::expression_functional;  // NOLINT
+
+namespace opossum {
+
+class ColumnPruningRuleTest: public StrategyBaseTest {
+ public:
+  void SetUp() override {
+    node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::Int, "c"}}, "a");
+    node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "u"}, {DataType::Int, "v"}, {DataType::Int, "w"}}, "b");
+    node_c = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}}, "c");
+
+    a = node_a->get_column("a");
+    b = node_a->get_column("b");
+    c = node_a->get_column("c");
+    u = node_b->get_column("u");
+    v = node_b->get_column("v");
+    w = node_b->get_column("w");
+    x = node_c->get_column("x");
+    y = node_c->get_column("y");
+
+    rule = std::make_shared<ColumnPruningRule>();
+  }
+
+  std::shared_ptr<ColumnPruningRule> rule;
+  std::shared_ptr<MockNode> node_a, node_b, node_c;
+  LQPColumnReference a, b, c, u, v, w, x, y;
+};
+
+TEST_F(ColumnPruningRuleTest, NoUnion) {
+  // clang-format off
+  const auto lqp =
+  ProjectionNode::make(expression_vector(add_(mul_(a, u), 5)),
+    PredicateNode::make(greater_than_(5, c),
+      JoinNode::make(JoinMode::Inner, greater_than_(v, a),
+        node_a,
+        SortNode::make(expression_vector(w), std::vector<OrderByMode>{OrderByMode::Ascending},  // NOLINT
+          node_b))));
+  // clang-format on
+
+  // clang-format off
+  const auto expected_lqp =
+  ProjectionNode::make(expression_vector(add_(mul_(a, u), 5)),
+    PredicateNode::make(greater_than_(5, c),
+      JoinNode::make(JoinMode::Inner, greater_than_(v, a),
+        ProjectionNode::make(expression_vector(a, c),
+          node_a),
+        SortNode::make(expression_vector(w), std::vector<OrderByMode>{OrderByMode::Ascending},  // NOLINT
+          node_b))));
+  // clang-format on
+
+  const auto actual_lqp = apply_rule(rule, lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(ColumnPruningRuleTest, WithUnion) {
+  // clang-format off
+  const auto lqp =
+  ProjectionNode::make(expression_vector(a),
+    UnionNode::make(UnionMode::Positions,
+      PredicateNode::make(greater_than_(a, 5), node_a),
+      PredicateNode::make(greater_than_(b, 5), node_a)));
+  // clang-format on
+
+  // clang-format off
+  const auto expected_lqp =
+  ProjectionNode::make(expression_vector(a),
+    UnionNode::make(UnionMode::Positions,
+      PredicateNode::make(greater_than_(a, 5),
+        ProjectionNode::make(expression_vector(a, b),
+          node_a)),
+        PredicateNode::make(greater_than_(b, 5),
+          ProjectionNode::make(expression_vector(a, b),
+            node_a))));
+  // clang-format on
+
+  const auto actual_lqp = apply_rule(rule, lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(ColumnPruningRuleTest, WithMultipleProjections) {
+  // clang-format off
+  const auto lqp =
+  ProjectionNode::make(expression_vector(a),
+    PredicateNode::make(greater_than_(mul_(a, b), 5),
+      ProjectionNode::make(expression_vector(a, b, mul_(a, b), c),
+        PredicateNode::make(greater_than_(mul_(a, 2), 5),
+          ProjectionNode::make(expression_vector(a, b, mul_(a, 2), c),
+            node_a)))));
+  // clang-format on
+
+  // clang-format off
+  const auto expected_lqp =
+  ProjectionNode::make(expression_vector(a),
+    PredicateNode::make(greater_than_(mul_(a, b), 5),
+      ProjectionNode::make(expression_vector(a, b, mul_(a, b)),
+        PredicateNode::make(greater_than_(mul_(a, 2), 5),
+          ProjectionNode::make(expression_vector(a, b, mul_(a, 2)),
+            ProjectionNode::make(expression_vector(a, b),
+              node_a))))));
+  // clang-format on
+
+  const auto actual_lqp = apply_rule(rule, lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+}  // namespace opossum

--- a/src/test/sql/sql_query_plan_test.cpp
+++ b/src/test/sql/sql_query_plan_test.cpp
@@ -36,15 +36,17 @@ TEST_F(SQLQueryPlanTest, SQLQueryPlanCloneTest) {
   // Get the query plan.
   const auto& plan1 = pipeline_statement.get_query_plan();
   auto tasks = plan1->create_tasks();
-  ASSERT_EQ(2u, tasks.size());
+  ASSERT_EQ(3u, tasks.size());
   EXPECT_EQ("GetTable", tasks[0]->get_operator()->name());
   EXPECT_EQ("Projection", tasks[1]->get_operator()->name());
+  EXPECT_EQ("Projection", tasks[2]->get_operator()->name());
 
   const auto plan2 = plan1->deep_copy();
   auto cloned_tasks = plan2.create_tasks();
-  ASSERT_EQ(2u, cloned_tasks.size());
+  ASSERT_EQ(3u, cloned_tasks.size());
   EXPECT_EQ("GetTable", cloned_tasks[0]->get_operator()->name());
   EXPECT_EQ("Projection", cloned_tasks[1]->get_operator()->name());
+  EXPECT_EQ("Projection", cloned_tasks[2]->get_operator()->name());
 
   // Execute both task lists.
   for (auto task : tasks) {

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -95,7 +95,7 @@ TEST_F(StorageTableTest, ShrinkingMvccColumnsHasNoSideEffects) {
 
   {
     // acquiring mvcc_columns locks them
-    auto mvcc_columns = chunk->lock_mvcc_columns();
+    auto mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
 
     mvcc_columns->tids[0u] = values[0u];
     mvcc_columns->tids[1u] = values[1u];
@@ -107,12 +107,12 @@ TEST_F(StorageTableTest, ShrinkingMvccColumnsHasNoSideEffects) {
 
   const auto previous_size = chunk->size();
 
-  chunk->lock_mvcc_columns()->shrink();
+  chunk->get_scoped_mvcc_columns_lock()->shrink();
 
   ASSERT_EQ(previous_size, chunk->size());
   ASSERT_TRUE(chunk->has_mvcc_columns());
 
-  auto new_mvcc_columns = chunk->lock_mvcc_columns();
+  auto new_mvcc_columns = chunk->get_scoped_mvcc_columns_lock();
 
   for (auto i = 0u; i < chunk->size(); ++i) {
     EXPECT_EQ(new_mvcc_columns->tids[i], values[i]);

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -95,7 +95,7 @@ TEST_F(StorageTableTest, ShrinkingMvccColumnsHasNoSideEffects) {
 
   {
     // acquiring mvcc_columns locks them
-    auto mvcc_columns = chunk->mvcc_columns();
+    auto mvcc_columns = chunk->lock_mvcc_columns();
 
     mvcc_columns->tids[0u] = values[0u];
     mvcc_columns->tids[1u] = values[1u];
@@ -107,12 +107,12 @@ TEST_F(StorageTableTest, ShrinkingMvccColumnsHasNoSideEffects) {
 
   const auto previous_size = chunk->size();
 
-  chunk->mvcc_columns()->shrink();
+  chunk->lock_mvcc_columns()->shrink();
 
   ASSERT_EQ(previous_size, chunk->size());
   ASSERT_TRUE(chunk->has_mvcc_columns());
 
-  auto new_mvcc_columns = chunk->mvcc_columns();
+  auto new_mvcc_columns = chunk->lock_mvcc_columns();
 
   for (auto i = 0u; i < chunk->size(); ++i) {
     EXPECT_EQ(new_mvcc_columns->tids[i], values[i]);


### PR DESCRIPTION
Closes #771 
Closes #975 

This PR does away with `Chunk::get_mutable_column()`: Any column you obtain from a Chunk is "mutable", even if the Chunk itself is not. This is really the only way we can forward encoded columns and prune the ones we do not need. I think the risk that someone misuses this to manipulate encoded columns is low, though we can debate this in person. (Insert, Update should be the only entities actually manipulating column/table/chunk data. And they only operate on stored tables.)

Projection now forwards MVCC columns as well, so we can prune columns before Validate and also: why not?

@Bouncner I think we talked about this rule, here it is. Not as pretty as I would have liked it to be and only prunes base relation columns (as opposed to pruning columns as soon as they are not needed anymore).

TPC-H sf=0.04

```
+-----------+-----------------+------+-----------------+------+--------+-----------------------------------------------+
| Benchmark | prev. iter/s    | runs | new iter/s      | runs | change |               p-value (significant if <0.001) |
+-----------+-----------------+------+-----------------+------+--------+-----------------------------------------------+
| TPC-H 1   | 1.0651307106    | 6    | 2.06607890129   | 11   | +94%   | (run time too short) (not enough runs) 0.0000 |
| TPC-H 2   | 18.3471298218   | 92   | 20.6960201263   | 104  | +13%   |                   (run time too short) 0.0000 |
| TPC-H 3   | 13.4517555237   | 68   | 22.995470047    | 115  | +71%   |                   (run time too short) 0.0000 |
| TPC-H 4   | 0.591675639153  | 3    | 0.532443642616  | 3    | -10%   | (run time too short) (not enough runs) 0.0000 |
| TPC-H 5   | 5.97967910767   | 30   | 8.3367767334    | 42   | +39%   |                   (run time too short) 0.0000 |
| TPC-H 6   | 48.717464447    | 244  | 100.009208679   | 501  | +105%  |                   (run time too short) 0.0000 |
| TPC-H 7   | 1.00689733028   | 6    | 3.07879686356   | 16   | +206%  | (run time too short) (not enough runs) 0.0000 |
| TPC-H 8   | 0.0148216197267 | 1    | 0.0145005695522 | 1    | -2%    |                         (not enough runs) nan |
| TPC-H 9   | 2.50074863434   | 13   | 2.87144875526   | 15   | +15%   |                   (run time too short) 0.0000 |
| TPC-H 10  | 9.98580169678   | 51   | 17.0945415497   | 86   | +71%   |                   (run time too short) 0.0000 |
| TPC-H 11  | 28.2993850708   | 142  | 40.1598014832   | 201  | +42%   |                   (run time too short) 0.0000 |
| TPC-H 12  | 5.06855297089   | 26   | 10.8040647507   | 55   | +113%  |                   (run time too short) 0.0000 |
| TPC-H 13  | 17.0435581207   | 86   | 23.5082759857   | 118  | +38%   |                   (run time too short) 0.0000 |
| TPC-H 14  | 15.3754711151   | 77   | 48.9335708618   | 245  | +218%  |                   (run time too short) 0.0000 |
| TPC-H 15  | 0.142473608255  | 1    | 0.547702729702  | 3    | +284%  |    (run time too short) (not enough runs) nan |
| TPC-H 16  | 2.65850663185   | 14   | 7.00055265427   | 36   | +163%  |                   (run time too short) 0.0000 |
| TPC-H 17  | 5.19491624832   | 26   | 4.99947118759   | 25   | -4%    |                   (run time too short) 0.0000 |
| TPC-H 18  | 0.016650006175  | 1    | 0.0234165210277 | 1    | +41%   |    (run time too short) (not enough runs) nan |
| TPC-H 19  | 0.628937542439  | 4    | 2.21278548241   | 12   | +252%  | (run time too short) (not enough runs) 0.0000 |
| TPC-H 20  | 0.0200077872723 | 1    | 0.0181093160063 | 1    | -9%    |    (run time too short) (not enough runs) nan |
| TPC-H 21  | 0.210590690374  | 2    | 0.191756725311  | 1    | -9%    |    (run time too short) (not enough runs) nan |
| TPC-H 22  | 1.24333620071   | 7    | 1.18919682503   | 6    | -4%    | (run time too short) (not enough runs) 0.0005 |
| average   |                 |      |                 |      | +78%   |                                               |
+-----------+-----------------+------+-----------------+------+--------+-----------------------------------------------+

```

sf=0.08
```
+-----------+------------------+------+------------------+------+--------+-----------------------------------------------+
| Benchmark | prev. iter/s     | runs | new iter/s       | runs | change |               p-value (significant if <0.001) |
+-----------+------------------+------+------------------+------+--------+-----------------------------------------------+
| TPC-H 1   | 0.456806451082   | 3    | 0.923095166683   | 5    | +102%  | (run time too short) (not enough runs) 0.0000 |
| TPC-H 2   | 8.48152637482    | 43   | 9.94643783569    | 50   | +17%   |                   (run time too short) 0.0000 |
| TPC-H 3   | 6.95575237274    | 35   | 11.9043359756    | 60   | +71%   |                   (run time too short) 0.0000 |
| TPC-H 4   | 0.150655910373   | 1    | 0.13534411788    | 1    | -10%   |    (run time too short) (not enough runs) nan |
| TPC-H 5   | 3.06972885132    | 16   | 3.91123867035    | 20   | +27%   |                   (run time too short) 0.0000 |
| TPC-H 6   | 20.3051128387    | 102  | 43.0475578308    | 216  | +112%  |                   (run time too short) 0.0000 |
| TPC-H 7   | 0.434734106064   | 3    | 1.32922422886    | 7    | +206%  | (run time too short) (not enough runs) 0.0000 |
| TPC-H 8   | 0.00345600303262 | 1    | 0.00366564327851 | 1    | +6%    |                         (not enough runs) nan |
| TPC-H 9   | 1.3634314537     | 7    | 1.34053885937    | 7    | -2%    | (run time too short) (not enough runs) 0.5230 |
| TPC-H 10  | 6.34907054901    | 32   | 9.04208469391    | 46   | +42%   |                   (run time too short) 0.0000 |
| TPC-H 11  | 15.8550815582    | 80   | 18.922870636     | 95   | +19%   |                   (run time too short) 0.0000 |
| TPC-H 12  | 3.14661335945    | 16   | 5.07123327255    | 26   | +61%   |                   (run time too short) 0.0000 |
| TPC-H 13  | 9.08446502686    | 46   | 8.65683555603    | 44   | -5%    |                   (run time too short) 0.0000 |
| TPC-H 14  | 9.14037895203    | 46   | 29.2090911865    | 147  | +220%  |                   (run time too short) 0.0000 |
| TPC-H 15  | 0.0423160456121  | 1    | 0.162103697658   | 1    | +283%  |    (run time too short) (not enough runs) nan |
| TPC-H 16  | 1.49360859394    | 8    | 3.68354201317    | 19   | +147%  | (run time too short) (not enough runs) 0.0000 |
| TPC-H 17  | 1.5679962635     | 8    | 1.42957699299    | 8    | -9%    | (run time too short) (not enough runs) 0.0000 |
| TPC-H 18  | 0.00774409528822 | 1    | 0.00683729723096 | 1    | -12%   |                         (not enough runs) nan |
| TPC-H 19  | 0.337606877089   | 2    | 0.994909107685   | 5    | +195%  | (run time too short) (not enough runs) 0.0000 |
| TPC-H 20  | 0.00528021389619 | 1    | 0.00475244736299 | 1    | -10%   |                         (not enough runs) nan |
| TPC-H 21  | 0.0289966836572  | 1    | 0.0260984506458  | 1    | -10%   |    (run time too short) (not enough runs) nan |
| TPC-H 22  | 0.327019065619   | 2    | 0.299595952034   | 2    | -8%    | (run time too short) (not enough runs) 0.0017 |
| average   |                  |      |                  |      | +66%   |                                               |
+-----------+------------------+------+------------------+------+--------+-----------------------------------------------+
```