### PR TITLE
Fix AggregateExpression::is_nullable()

### DIFF
--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -91,11 +91,7 @@ DataType AggregateExpression::data_type() const {
 bool AggregateExpression::is_nullable() const {
   // Aggregates except the COUNTs will return NULL when executed on an empty group -
   // thus they are always nullable
-  if (aggregate_function == AggregateFunction::Count || aggregate_function == AggregateFunction::CountDistinct) {
-    return AbstractExpression::is_nullable();
-  } else {
-    return true;
-  }
+  return aggregate_function != AggregateFunction::Count && aggregate_function != AggregateFunction::CountDistinct;
 }
 
 bool AggregateExpression::_shallow_equals(const AbstractExpression& expression) const {

--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -88,6 +88,11 @@ DataType AggregateExpression::data_type() const {
   return aggregate_data_type;
 }
 
+bool AggregateExpression::is_nullable() const {
+  // Aggregates will return NULL when executed on an empty group - thus AggregateExpressions are always nullable
+  return true;
+}
+
 bool AggregateExpression::_shallow_equals(const AbstractExpression& expression) const {
   return aggregate_function == static_cast<const AggregateExpression&>(expression).aggregate_function;
 }

--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -89,8 +89,13 @@ DataType AggregateExpression::data_type() const {
 }
 
 bool AggregateExpression::is_nullable() const {
-  // Aggregates will return NULL when executed on an empty group - thus AggregateExpressions are always nullable
-  return true;
+  // Aggregates except the COUNTs will return NULL when executed on an empty group -
+  // thus they are always nullable
+  if (aggregate_function == AggregateFunction::Count || aggregate_function == AggregateFunction::CountDistinct) {
+    return AbstractExpression::is_nullable();
+  } else {
+    return true;
+  }
 }
 
 bool AggregateExpression::_shallow_equals(const AbstractExpression& expression) const {

--- a/src/lib/expression/aggregate_expression.hpp
+++ b/src/lib/expression/aggregate_expression.hpp
@@ -19,6 +19,7 @@ class AggregateExpression : public AbstractExpression {
   std::shared_ptr<AbstractExpression> deep_copy() const override;
   std::string as_column_name() const override;
   DataType data_type() const override;
+  bool is_nullable() const override;
 
   const AggregateFunction aggregate_function;
 

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -577,6 +577,7 @@ TEST_F(ExpressionEvaluatorTest, CastLiterals) {
   EXPECT_TRUE(test_expression<int32_t>(*cast_("Hello", DataType::Int), {0}));
   EXPECT_TRUE(test_expression<float>(*cast_("Hello", DataType::Float), {0.0f}));
 }
+
 TEST_F(ExpressionEvaluatorTest, CastSeries) {
   EXPECT_TRUE(test_expression<int32_t>(table_a, *cast_(a, DataType::Int), {1, 2, 3, 4}));
   EXPECT_TRUE(test_expression<float>(table_a, *cast_(a, DataType::Float), {1.0f, 2.0f, 3.0f, 4.0f}));

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -248,7 +248,7 @@ TEST_F(ExpressionTest, IsNullable) {
   EXPECT_TRUE(sum_(add_(1, 2))->is_nullable());
   EXPECT_FALSE(count_star_()->is_nullable());
   EXPECT_FALSE(count_(5)->is_nullable());
-  EXPECT_TRUE(count_(null_())->is_nullable());
+  EXPECT_FALSE(count_(null_())->is_nullable());
 
   // Division by zero could be nullable, thus division and modulo are always nullable
   EXPECT_TRUE(div_(1, 2)->is_nullable());

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -246,6 +246,9 @@ TEST_F(ExpressionTest, IsNullable) {
   EXPECT_TRUE(cast_(null_(), DataType::String)->is_nullable());
   EXPECT_TRUE(sum_(null_())->is_nullable());
   EXPECT_TRUE(sum_(add_(1, 2))->is_nullable());
+  EXPECT_FALSE(count_star_()->is_nullable());
+  EXPECT_FALSE(count_(5)->is_nullable());
+  EXPECT_TRUE(count_(null_())->is_nullable());
 
   // Division by zero could be nullable, thus division and modulo are always nullable
   EXPECT_TRUE(div_(1, 2)->is_nullable());

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -244,6 +244,8 @@ TEST_F(ExpressionTest, IsNullable) {
   EXPECT_TRUE(column_(a_nullable)->is_nullable());
   EXPECT_FALSE(cast_(12, DataType::String)->is_nullable());
   EXPECT_TRUE(cast_(null_(), DataType::String)->is_nullable());
+  EXPECT_TRUE(sum_(null_())->is_nullable());
+  EXPECT_TRUE(sum_(add_(1, 2))->is_nullable());
 
   // Division by zero could be nullable, thus division and modulo are always nullable
   EXPECT_TRUE(div_(1, 2)->is_nullable());

--- a/src/test/expression/lqp_select_expression_test.cpp
+++ b/src/test/expression/lqp_select_expression_test.cpp
@@ -35,7 +35,7 @@ class LQPSelectExpressionTest : public ::testing::Test {
 
     parameter_c = parameter_(ParameterID{0}, a);
     lqp_c =
-    AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
+    AggregateNode::make(expression_vector(), expression_vector(count_(add_(a, parameter_c))),
       ProjectionNode::make(expression_vector(add_(a, parameter_c)),
         int_float_node_a));
     // clang-format on
@@ -68,7 +68,7 @@ TEST_F(LQPSelectExpressionTest, DeepEquals) {
   const auto a2 = int_float_node_b->get_column("a");
   const auto parameter_d = parameter_(ParameterID{0}, a2);
   const auto lqp_d =
-  AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_d))),
+  AggregateNode::make(expression_vector(), expression_vector(count_(add_(a, parameter_d))),
     ProjectionNode::make(expression_vector(add_(a, parameter_d)),
       int_float_node_a));
 
@@ -113,13 +113,11 @@ TEST_F(LQPSelectExpressionTest, DataType) {
   // Can't determine the DataType of this Select, since it depends on a parameter
   EXPECT_ANY_THROW(select_a->data_type());
 
-  EXPECT_EQ(select_c->data_type(), DataType::Int);
+  EXPECT_EQ(select_c->data_type(), DataType::Long);
 }
 
 TEST_F(LQPSelectExpressionTest, IsNullable) {
-  // Can't determine the nullability of this Select, since it depends on a parameter
-  EXPECT_ANY_THROW(select_a->is_nullable());
-
+  EXPECT_TRUE(select_a->is_nullable());
   EXPECT_FALSE(select_c->is_nullable());
 
   // clang-format off


### PR DESCRIPTION
`Aggregates will return NULL when executed on an empty group - thus AggregateExpressions are always nullable`

Fixes this ...comment: https://github.com/hyrise/hyrise/issues/946#issuecomment-405103835