### PR TITLE
FixedStringDictionary: compare addresses

### DIFF
--- a/src/lib/storage/fixed_string_dictionary_column/fixed_string_vector_iterator.hpp
+++ b/src/lib/storage/fixed_string_dictionary_column/fixed_string_vector_iterator.hpp
@@ -37,7 +37,7 @@ class FixedStringIterator : public boost::iterator_facade<FixedStringIterator<On
   // We have a couple of NOLINTs here becaues the facade expects these method names:
 
   bool equal(FixedStringIterator const& other) const {  // NOLINT
-    return _chars == other._chars && _pos == other._pos;
+    return &_chars == &other._chars && _pos == other._pos;
   }
 
   size_t distance_to(FixedStringIterator const& other) const {  // NOLINT


### PR DESCRIPTION
Fixes #1043. `_chars == other._chars` compares each element in the vector.

The encoding took ~13 seconds with scale factor 0.1 and this encoding config:
```
{
  "default": {
    "encoding": "Dictionary"
  },

  "type": {
    "string": {
      "encoding": "FixedStringDictionary"
    }
  }
}
```