### PR TITLE
Reduce level of IBM Z non-support

### DIFF
--- a/cmake/EmbedLLVM.cmake
+++ b/cmake/EmbedLLVM.cmake
@@ -61,10 +61,12 @@ function(EMBED_LLVM OUTPUT_FILE SYMBOL_NAME)
         .global _${MANGLED_SYMBOL}
         .global ${MANGLED_SIZE_SYMBOL}
         .global _${MANGLED_SIZE_SYMBOL}
+        .p2align 3
         ${MANGLED_SYMBOL}:
         _${MANGLED_SYMBOL}:
         .incbin \"${LLVM_BUNDLE_FILE}\"
         1:
+        .p2align 3
         ${MANGLED_SIZE_SYMBOL}:
         _${MANGLED_SIZE_SYMBOL}:
         .8byte 1b - ${MANGLED_SYMBOL}"

--- a/cmake/FindFS.cmake
+++ b/cmake/FindFS.cmake
@@ -4,7 +4,7 @@
 #  FILESYSTEM_FOUND    : True if found.
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR UNIX AND NOT APPLE)
-    FIND_LIBRARY(FILESYSTEM_LIBRARY NAME libstdc++fs.a HINTS $ENV{HOME}/local/lib64 $ENV{HOME}/local/lib /usr/local/lib64 /usr/local/lib /opt/local/lib64 /opt/local/lib /usr/lib64 /usr/lib /usr/lib/gcc/x86_64-linux-gnu/*/ /usr/local/Cellar/gcc/*/lib/gcc/*/)
+    FIND_LIBRARY(FILESYSTEM_LIBRARY NAME libstdc++fs.a HINTS $ENV{HOME}/local/lib64 $ENV{HOME}/local/lib /usr/local/lib64 /usr/local/lib /opt/local/lib64 /opt/local/lib /usr/lib64 /usr/lib /usr/lib/gcc/*/*/ /usr/local/Cellar/gcc/*/lib/gcc/*/)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     FIND_LIBRARY(FILESYSTEM_LIBRARY NAME libc++experimental.a HINTS $ENV{HOME}/local/lib64 $ENV{HOME}/local/lib /usr/local/lib64 /usr/local/lib /opt/local/lib64 /opt/local/lib /usr/lib64 /usr/lib /usr/local/Cellar/llvm/*/lib)
 endif()

--- a/src/lib/storage/proxy_chunk.cpp
+++ b/src/lib/storage/proxy_chunk.cpp
@@ -6,9 +6,15 @@
 // Although RDTSCP would provide more accurate cycles counts, the precision
 // is not required for the chunk access tracking.
 uint64_t rdtsc() {
+#ifdef __s390__
+  uint64_t tsc;
+  __asm__ __volatile__("stckf %0" : "=Q"(tsc) : : "cc");
+  return tsc;
+#else
   unsigned int lo, hi;
   __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
   return (static_cast<uint64_t>(hi) << 32u) | lo;
+#endif
 }
 
 namespace opossum {

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_compressor.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_compressor.cpp
@@ -1,7 +1,5 @@
 #include "simd_bp128_compressor.hpp"
 
-#include <emmintrin.h>
-
 #include <algorithm>
 #include <array>
 

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.cpp
@@ -1,7 +1,5 @@
 #include "simd_bp128_iterator.hpp"
 
-#include <emmintrin.h>
-
 namespace opossum {
 
 SimdBp128Iterator::SimdBp128Iterator(const pmr_vector<uint128_t>* data, size_t size, size_t absolute_index)

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
@@ -1,6 +1,11 @@
 #include "simd_bp128_packing.hpp"
 
+#ifdef __SSE2__
 #include <emmintrin.h>
+typedef __m128i simd_type;
+#else
+typedef unsigned int __attribute__((vector_size(16))) simd_type;
+#endif
 
 #include <algorithm>
 
@@ -27,7 +32,8 @@ namespace {
  */
 template <uint8_t bit_size, uint8_t carry_over = 0u, uint8_t remaining_recursions = bit_size>
 struct Pack128Bit {
-  void operator()(const __m128i* in, __m128i* out, __m128i& in_reg, __m128i& out_reg, const __m128i& mask) const {
+  void operator()(const simd_type* in, simd_type* out, simd_type& in_reg, simd_type& out_reg,
+                  const simd_type& mask) const {
     constexpr auto BITS_IN_WORD = 32u;
 
     // Number of integers that fit completely into the 32-bit sub-blocks
@@ -36,8 +42,13 @@ struct Pack128Bit {
     // Fill the four 32-bit sub-blocks simultaneously by bit shifting
     for (auto i = 0u; i < I_MAX; ++i) {
       const auto offset = carry_over + i * bit_size;
+#ifdef __SSE2__
       in_reg = _mm_and_si128(_mm_loadu_si128(in++), mask);
       out_reg = _mm_or_si128(out_reg, _mm_slli_epi32(in_reg, offset));
+#else
+      in_reg = *in++ & mask;
+      out_reg = out_reg | (in_reg << offset);
+#endif
     }
 
     constexpr auto NEXT_OFFSET = carry_over + I_MAX * bit_size;
@@ -45,6 +56,7 @@ struct Pack128Bit {
 
     // Check if integers need to be split
     if (NEXT_OFFSET < BITS_IN_WORD) {
+#ifdef __SSE2__
       in_reg = _mm_and_si128(_mm_loadu_si128(in++), mask);
       out_reg = _mm_or_si128(out_reg, _mm_slli_epi32(in_reg, NEXT_OFFSET));
 
@@ -52,11 +64,28 @@ struct Pack128Bit {
       ++out;
 
       out_reg = _mm_srli_epi32(in_reg, NUM_FIRST_BITS);
+#else
+      in_reg = *in++ & mask;
+      out_reg = out_reg | (in_reg << NEXT_OFFSET);
+
+      *out = out_reg;
+      ++out;
+
+      out_reg = in_reg >> NUM_FIRST_BITS;
+#endif
     } else {
+#ifdef __SSE2__
       _mm_store_si128(out, out_reg);
       ++out;
 
       out_reg = _mm_setzero_si128();
+#else
+      *out = out_reg;
+      out++;
+
+      simd_type zero_reg = {0, 0, 0, 0};
+      out_reg = zero_reg;
+#endif
     }
 
     // Calculate the new carry over
@@ -67,7 +96,8 @@ struct Pack128Bit {
 
 template <uint8_t bit_size, uint8_t carry_over>
 struct Pack128Bit<bit_size, carry_over, 0u> {
-  void operator()(const __m128i* in, __m128i* out, __m128i& in_reg, __m128i& out_reg, const __m128i& mask) const {}
+  void operator()(const simd_type* in, simd_type* out, simd_type& in_reg, simd_type& out_reg,
+                  const simd_type& mask) const {}
 };
 
 /**
@@ -75,7 +105,8 @@ struct Pack128Bit<bit_size, carry_over, 0u> {
  */
 template <uint8_t bit_size, uint8_t carry_over = 0u, uint8_t remaining_recursions = bit_size>
 struct Unpack128Bit {
-  void operator()(const __m128i* in, __m128i* out, __m128i& in_reg, __m128i& out_reg, const __m128i& mask) const {
+  void operator()(const simd_type* in, simd_type* out, simd_type& in_reg, simd_type& out_reg,
+                  const simd_type& mask) const {
     constexpr auto BITS_IN_WORD = 32u;
 
     // Number of integers that fit completely into the 32-bit sub-blocks
@@ -83,8 +114,13 @@ struct Unpack128Bit {
 
     for (auto i = 0u; i < I_MAX; ++i) {
       const auto offset = carry_over + i * bit_size;
+#ifdef __SSE2__
       out_reg = _mm_and_si128(_mm_srli_epi32(in_reg, offset), mask);
       _mm_storeu_si128(out++, out_reg);
+#else
+      out_reg = (in_reg >> offset) & mask;
+      *out++ = out_reg;
+#endif
     }
 
     constexpr auto NEXT_OFFSET = carry_over + I_MAX * bit_size;
@@ -92,17 +128,29 @@ struct Unpack128Bit {
 
     // Check if integers have been split across the 128-bit block boundary
     if (NEXT_OFFSET < BITS_IN_WORD) {
+#ifdef __SSE2__
       out_reg = _mm_srli_epi32(in_reg, NEXT_OFFSET);
       in_reg = _mm_load_si128(in++);
 
       out_reg = _mm_or_si128(out_reg, _mm_and_si128(_mm_slli_epi32(in_reg, NUM_FIRST_BITS), mask));
       _mm_storeu_si128(out++, out_reg);
+#else
+      out_reg = in_reg >> NEXT_OFFSET;
+      in_reg = *in++;
+
+      out_reg = out_reg | ((in_reg << NUM_FIRST_BITS) & mask);
+      *out++ = out_reg;
+#endif
     } else {
       constexpr auto LAST_RECURSION = 1u;
 
       // Only load another 128-bit block if it’s not the last recursion
       if (remaining_recursions > LAST_RECURSION) {
+#ifdef __SSE2__
         in_reg = _mm_load_si128(in++);
+#else
+        in_reg = *in++;
+#endif
       }
     }
 
@@ -114,7 +162,8 @@ struct Unpack128Bit {
 
 template <uint8_t bit_size, uint8_t carry_over>
 struct Unpack128Bit<bit_size, carry_over, 0u> {
-  void operator()(const __m128i* in, __m128i* out, __m128i& in_reg, __m128i& out_reg, const __m128i& mask) const {}
+  void operator()(const simd_type* in, simd_type* out, simd_type& in_reg, simd_type& out_reg,
+                  const simd_type& mask) const {}
 };
 
 void unpack_128_zeros(uint32_t* out) {
@@ -125,28 +174,43 @@ void unpack_128_zeros(uint32_t* out) {
 }  // namespace
 
 void SimdBp128Packing::write_meta_info(const uint8_t* in, uint128_t* out) {
-  const auto simd_in = reinterpret_cast<const __m128i*>(in);
-  auto simd_out = reinterpret_cast<__m128i*>(out);
+  const auto simd_in = reinterpret_cast<const simd_type*>(in);
+  auto simd_out = reinterpret_cast<simd_type*>(out);
 
+#ifdef __SSE2__
   const auto meta_block_info_rgtr = _mm_loadu_si128(simd_in);
   _mm_store_si128(simd_out, meta_block_info_rgtr);
+#else
+  *simd_out = *simd_in;
+#endif
 }
 
 void SimdBp128Packing::read_meta_info(const uint128_t* in, uint8_t* out) {
-  const auto simd_in = reinterpret_cast<const __m128i*>(in);
-  auto simd_out = reinterpret_cast<__m128i*>(out);
+  const auto simd_in = reinterpret_cast<const simd_type*>(in);
+  auto simd_out = reinterpret_cast<simd_type*>(out);
 
+#ifdef __SSE2__
   auto meta_info_block_rgtr = _mm_load_si128(simd_in);
   _mm_storeu_si128(simd_out, meta_info_block_rgtr);
+#else
+  *simd_out = *simd_in;
+#endif
 }
 
 void SimdBp128Packing::pack_block(const uint32_t* in, uint128_t* out, const uint8_t bit_size) {
-  auto simd_in = reinterpret_cast<const __m128i*>(in);
-  auto simd_out = reinterpret_cast<__m128i*>(out);
+  auto simd_in = reinterpret_cast<const simd_type*>(in);
+  auto simd_out = reinterpret_cast<simd_type*>(out);
 
+#ifdef __SSE2__
   auto in_reg = _mm_setzero_si128();
   auto out_reg = _mm_setzero_si128();
   const auto mask = _mm_set1_epi32((1ul << bit_size) - 1);
+#else
+  simd_type in_reg = {0, 0, 0, 0};
+  simd_type out_reg = {0, 0, 0, 0};
+  unsigned int one_mask = (1ul << bit_size) - 1;
+  const simd_type mask = {one_mask, one_mask, one_mask, one_mask};
+#endif
 
   switch (bit_size) {
     case 0u:
@@ -293,12 +357,19 @@ void SimdBp128Packing::unpack_block(const uint128_t* in, uint32_t* out, const ui
     return;
   }
 
-  auto simd_in = reinterpret_cast<const __m128i*>(in);
-  auto simd_out = reinterpret_cast<__m128i*>(out);
+  auto simd_in = reinterpret_cast<const simd_type*>(in);
+  auto simd_out = reinterpret_cast<simd_type*>(out);
 
+#ifdef __SSE2__
   auto in_reg = _mm_load_si128(simd_in++);
   auto out_reg = _mm_setzero_si128();
   const auto mask = _mm_set1_epi32((1ul << bit_size) - 1);
+#else
+  simd_type in_reg = *simd_in++;
+  simd_type out_reg = {0, 0, 0, 0};
+  unsigned int one_mask = (1ul << bit_size) - 1;
+  const simd_type mask = {one_mask, one_mask, one_mask, one_mask};
+#endif
 
   switch (bit_size) {
     case 1u:

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
@@ -2,9 +2,9 @@
 
 #ifdef __SSE2__
 #include <emmintrin.h>
-typedef __m128i simd_type;
+using simd_type = __m128i;
 #else
-typedef unsigned int __attribute__((vector_size(16))) simd_type;
+using simd_type = unsigned int __attribute__((vector_size(16)));
 #endif
 
 #include <algorithm>

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -252,8 +252,8 @@ TEST_F(JitExpressionTest, StringComparison) {
   ASSERT_EQ(not_like_expression.result().data_type(), DataType::Bool);
 
   for (auto i = 0; i < 10; ++i) {
-    auto left_value = std::string(1, 'a' + abs(static_cast<char>(std::rand())) % 5);
-    auto right_value = std::string(1, 'a' + abs(static_cast<char>(std::rand())) % 5);
+    auto left_value = std::string(1, 'a' + abs(static_cast<signed char>(std::rand())) % 5);
+    auto right_value = std::string(1, 'a' + abs(static_cast<signed char>(std::rand())) % 5);
 
     left_tuple_value.set(left_value, context);
     right_tuple_value.set(right_value, context);

--- a/src/test/storage/variable_length_key_base_test.cpp
+++ b/src/test/storage/variable_length_key_base_test.cpp
@@ -144,8 +144,13 @@ TEST_F(VariableLengthKeyBaseTest, OrAssignmentWithKeyLongerThan64Bit) {
   uint64_t expected_low = 0xFF00FF00F0F0FF00u;
   uint64_t expected_high = 0x0000000000000000u;
 
-  EXPECT_EQ(expected_high, memory[1]);
-  EXPECT_EQ(expected_low, memory[0]);
+  if constexpr (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
+    EXPECT_EQ(expected_high, memory[1]);
+    EXPECT_EQ(expected_low, memory[0]);
+  } else {
+    EXPECT_EQ(expected_high, memory[0]);
+    EXPECT_EQ(expected_low, memory[1]);
+  }
 }
 
 TEST_F(VariableLengthKeyBaseTest, ShiftAssignment) {
@@ -172,8 +177,13 @@ TEST_F(VariableLengthKeyBaseTest, ShiftAssignment) {
 
 TEST_F(VariableLengthKeyBaseTest, ShiftAndSet) {
   uint64_t memory = 0xFF000000F0F0FF00u;
-  // create key pointing to lower half of memory (on little endian architecture)
-  auto key = VariableLengthKeyBase(reinterpret_cast<VariableLengthKeyWord*>(&memory), sizeof(uint32_t));
+  VariableLengthKeyWord* key;
+  // create key pointing to lower half of memory
+  if constexpr (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
+    key = VariableLengthKeyBase(reinterpret_cast<VariableLengthKeyWord*>(&memory), sizeof(uint32_t));
+  } else {
+    key = VariableLengthKeyBase(reinterpret_cast<VariableLengthKeyWord*>(&memory) + sizeof(uint32_t), sizeof(uint32_t));
+  }
 
   uint8_t small_value = 0xFFu;
   key.shift_and_set(small_value, sizeof(uint8_t) * 8);

--- a/src/test/storage/variable_length_key_base_test.cpp
+++ b/src/test/storage/variable_length_key_base_test.cpp
@@ -177,7 +177,7 @@ TEST_F(VariableLengthKeyBaseTest, ShiftAssignment) {
 
 TEST_F(VariableLengthKeyBaseTest, ShiftAndSet) {
   uint64_t memory = 0xFF000000F0F0FF00u;
-  VariableLengthKeyWord key;
+  VariableLengthKeyBase key;
   // create key pointing to lower half of memory
   if constexpr (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
     key = VariableLengthKeyBase(reinterpret_cast<VariableLengthKeyWord*>(&memory), sizeof(uint32_t));

--- a/src/test/storage/variable_length_key_base_test.cpp
+++ b/src/test/storage/variable_length_key_base_test.cpp
@@ -177,7 +177,7 @@ TEST_F(VariableLengthKeyBaseTest, ShiftAssignment) {
 
 TEST_F(VariableLengthKeyBaseTest, ShiftAndSet) {
   uint64_t memory = 0xFF000000F0F0FF00u;
-  VariableLengthKeyWord* key;
+  VariableLengthKeyWord key;
   // create key pointing to lower half of memory
   if constexpr (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {
     key = VariableLengthKeyBase(reinterpret_cast<VariableLengthKeyWord*>(&memory), sizeof(uint32_t));


### PR DESCRIPTION
Someone took the time to generalize some of the intel-specific code and add generic code for systems without SSE2. This makes it possible to run Hyrise on IBM Z machines. I'll tell you more about this on Wednesday.

Since the amount of changes is quite small, does not affect the architecture, and the introduced ifdefs only cover a couple of lines, I think we can bring it in.

This does not mean that we add "official" support for IBM Z. Not only do the binary tests (import/export) still fail, but since we do not have a CI machine, we cannot guarantee that things work.