### PR TITLE
Hash Join: variable radix bit counts

### DIFF
--- a/src/benchmark/operators/join_benchmark.cpp
+++ b/src/benchmark/operators/join_benchmark.cpp
@@ -17,9 +17,9 @@ constexpr auto NUMBER_OF_CHUNKS = size_t{50};
 
 // These numbers were arbitrarily chosen to form a representative group of JoinBenchmarks
 // that run in a tolerable amount of time
-constexpr auto TABLE_SIZE_SMALL = size_t{1000};
-constexpr auto TABLE_SIZE_MEDIUM = size_t{100000};
-constexpr auto TABLE_SIZE_BIG = size_t{10000000};
+constexpr auto TABLE_SIZE_SMALL = size_t{1'000};
+constexpr auto TABLE_SIZE_MEDIUM = size_t{100'000};
+constexpr auto TABLE_SIZE_BIG = size_t{10'000'000};
 }  // namespace
 
 namespace opossum {
@@ -79,7 +79,7 @@ void bm_join_impl(benchmark::State& state, std::shared_ptr<TableWrapper> table_w
 }
 
 template <class C>
-void BM_Join_Small(benchmark::State& state) {  // NOLINT 1,000 x 1,000
+void BM_Join_SmallAndSmall(benchmark::State& state) {  // NOLINT 1,000 x 1,000
   auto table_wrapper_left = generate_table(TABLE_SIZE_SMALL);
   auto table_wrapper_right = generate_table(TABLE_SIZE_SMALL);
 
@@ -87,7 +87,7 @@ void BM_Join_Small(benchmark::State& state) {  // NOLINT 1,000 x 1,000
 }
 
 template <class C>
-void BM_Join_Skewed(benchmark::State& state) {  // NOLINT 1,000 x 10,000,000
+void BM_Join_SmallAndBig(benchmark::State& state) {  // NOLINT 1,000 x 10,000,000
   auto table_wrapper_left = generate_table(TABLE_SIZE_SMALL);
   auto table_wrapper_right = generate_table(TABLE_SIZE_BIG);
 
@@ -95,29 +95,29 @@ void BM_Join_Skewed(benchmark::State& state) {  // NOLINT 1,000 x 10,000,000
 }
 
 template <class C>
-void BM_Join_Big(benchmark::State& state) {  // NOLINT 100,000 x 100,000
+void BM_Join_MediumAndMedium(benchmark::State& state) {  // NOLINT 100,000 x 100,000
   auto table_wrapper_left = generate_table(TABLE_SIZE_MEDIUM);
   auto table_wrapper_right = generate_table(TABLE_SIZE_MEDIUM);
 
   bm_join_impl<C>(state, table_wrapper_left, table_wrapper_right);
 }
 
-BENCHMARK_TEMPLATE(BM_Join_Small, JoinNestedLoop);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndSmall, JoinNestedLoop);
 
-BENCHMARK_TEMPLATE(BM_Join_Small, JoinIndex);
-BENCHMARK_TEMPLATE(BM_Join_Skewed, JoinIndex);
-BENCHMARK_TEMPLATE(BM_Join_Big, JoinIndex);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndSmall, JoinIndex);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndBig, JoinIndex);
+BENCHMARK_TEMPLATE(BM_Join_MediumAndMedium, JoinIndex);
 
-BENCHMARK_TEMPLATE(BM_Join_Small, JoinHash);
-BENCHMARK_TEMPLATE(BM_Join_Skewed, JoinHash);
-BENCHMARK_TEMPLATE(BM_Join_Big, JoinHash);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndSmall, JoinHash);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndBig, JoinHash);
+BENCHMARK_TEMPLATE(BM_Join_MediumAndMedium, JoinHash);
 
-BENCHMARK_TEMPLATE(BM_Join_Small, JoinSortMerge);
-BENCHMARK_TEMPLATE(BM_Join_Skewed, JoinSortMerge);
-BENCHMARK_TEMPLATE(BM_Join_Big, JoinSortMerge);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndSmall, JoinSortMerge);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndBig, JoinSortMerge);
+BENCHMARK_TEMPLATE(BM_Join_MediumAndMedium, JoinSortMerge);
 
-BENCHMARK_TEMPLATE(BM_Join_Small, JoinMPSM);
-BENCHMARK_TEMPLATE(BM_Join_Skewed, JoinMPSM);
-BENCHMARK_TEMPLATE(BM_Join_Big, JoinMPSM);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndSmall, JoinMPSM);
+BENCHMARK_TEMPLATE(BM_Join_SmallAndBig, JoinMPSM);
+BENCHMARK_TEMPLATE(BM_Join_MediumAndMedium, JoinMPSM);
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -664,22 +664,15 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
           const auto adaption_factor = 2.0f; // don't occupy the whole L2 cache
           const auto cluster_count = std::max(1.0f, (adaption_factor * complete_hash_map_size) / l2_cache_size);
-          const size_t radix_bits_build_relation = std::ceil(std::log2(cluster_count));
 
-          // Usually, only the left relation is considered. But since the hash join parallelizes over the clusters,
-          // we also consider the right relation and create a cluster for every 100,000 rows.
-          const size_t radix_bits_probe_relation = std::max(0.0, std::floor(std::log2(probe_relation_size / 100'000)));
-
-          // std::cout << radix_bits_build_relation << " --- " << radix_bits_probe_relation << std::endl;
-
-          _radix_bits = std::max(radix_bits_build_relation, radix_bits_probe_relation);
+          _radix_bits = std::ceil(std::log2(cluster_count));
 
           auto const env_var_radix_bits = std::getenv("HYRISE_RADIX_BITS");
           if (env_var_radix_bits != nullptr) {
             _radix_bits = std::stoi(env_var_radix_bits);
           }
-          // std::cout << "Joining " << build_relation_size << "x" << probe_relation_size << " -- ";
-          // std::cout << "Radix bits: " << _radix_bits  << ". Probe size: " << complete_hash_map_size << " bytes." << std::endl; 
+          std::cout << "Joining " << build_relation_size << "x" << probe_relation_size << " -- ";
+          std::cout << "Radix bits: " << _radix_bits  << ". Probe size: " << complete_hash_map_size << " bytes." << std::endl; 
         }
 
  protected:

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -669,13 +669,6 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
           const auto cluster_count = std::max(1.0f, (adaption_factor * complete_hash_map_size) / l2_cache_size);
 
           _radix_bits = std::ceil(std::log2(cluster_count));
-
-          auto const env_var_radix_bits = std::getenv("HYRISE_RADIX_BITS");
-          if (env_var_radix_bits != nullptr) {
-            _radix_bits = std::stoi(env_var_radix_bits);
-          }
-          std::cout << "Joining " << build_relation_size << "x" << probe_relation_size << " -- ";
-          std::cout << "Radix bits: " << _radix_bits  << ". Probe size: " << complete_hash_map_size << " bytes." << std::endl; 
         }
 
  protected:

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -266,7 +266,7 @@ std::shared_ptr<Partition<T>> materialize_input(const std::shared_ptr<const Tabl
                   PartitionedElement<T>{RowID{chunk_id, value.chunk_offset()}, hashed_value, value.value()};
             }
 
-            const Hash radix = (hashed_value >> (32 - radix_bits * (pass + 1))) & mask;
+            const Hash radix = hashed_value & mask;
             histogram[radix]++;
           }
           // reference_column_offset is only used for ReferenceColumns
@@ -341,7 +341,7 @@ RadixContainer<T> partition_radix_parallel(const std::shared_ptr<Partition<T>>& 
           continue;
         }
 
-        const size_t radix = (element.partition_hash >> (32 - radix_bits * (pass + 1))) & mask;
+        const size_t radix = element.partition_hash & mask;
 
         out[output_offsets[radix]++] = element;
       }


### PR DESCRIPTION
New PR for the automated setting of radix bit counts for the hash join. fixes #1045

The reviews comments from PR #1049 should all be addressed.

TPC benchmark: `hyriseBenchmarkTPCH --scale 0.1 --time=720`
```
+-----------+---------------------+------+---------------------+------+---------+---------------------------------+
| Benchmark | prev. iter/s        | runs | new iter/s          | runs | change  | p-value (significant if <0.001) |
+-----------+---------------------+------+---------------------+------+---------+---------------------------------+
| TPC-H 1   | 2.72465515136719    | 1000 | 2.74556469917297    | 1000 | +1%     |                          0.0000 |
| TPC-H 2   | 21.2441997528076    | 1000 | 43.3155403137207    | 1000 | +104%   |     (run time too short) 0.0000 |
| TPC-H 3   | 19.9956378936768    | 1000 | 32.0532913208008    | 1000 | +60%    |     (run time too short) 0.0000 |
| TPC-H 4   | 0.310515403747559   | 224  | 0.311020076274872   | 224  | +0%     |                          0.4757 |
| TPC-H 5   | 15.5644903182983    | 1000 | 21.7481861114502    | 1000 | +40%    |     (run time too short) 0.0000 |
| TPC-H 6   | 50.2312278747559    | 1000 | 49.9696350097656    | 1000 | -1%     |     (run time too short) 0.0000 |
| TPC-H 7   | 4.71117353439331    | 1000 | 5.47914123535156    | 1000 | +16%    |                          0.0000 |
| TPC-H 8   | 3.26432061195374    | 1000 | 3.39146399497986    | 1000 | +4%     |                          0.0000 |
| TPC-H 9   | 1.90977990627289    | 1000 | 2.18742704391479    | 1000 | +15%    |                          0.0000 |
| TPC-H 10  | 15.5401010513306    | 1000 | 18.8029460906982    | 1000 | +21%    |     (run time too short) 0.0000 |
| TPC-H 11  | 43.7453155517578    | 1000 | 60.879035949707     | 1000 | +39%    |     (run time too short) 0.0000 |
| TPC-H 12  | 19.3144836425781    | 1000 | 27.0078945159912    | 1000 | +40%    |     (run time too short) 0.0000 |
| TPC-H 13  | 18.3297138214111    | 1000 | 19.1953983306885    | 1000 | +5%     |     (run time too short) 0.0000 |
| TPC-H 14  | 40.4100151062012    | 1000 | 67.9950332641602    | 1000 | +68%    |     (run time too short) 0.0000 |
| TPC-H 15  | 0.278847515583038   | 201  | 58.3825149536133    | 1000 | +20837% |     (run time too short) 0.0000 |
| TPC-H 16  | 6.90262794494629    | 1000 | 10.9350290298462    | 1000 | +58%    |                          0.0000 |
| TPC-H 17  | 1.37187445163727    | 988  | 1.36521983146667    | 983  | -0%     |                          0.0034 |
| TPC-H 18  | 0.0323572233319283  | 24   | 0.237914875149727   | 172  | +635%   |                          0.0000 |
| TPC-H 19  | 1.75965893268585    | 1000 | 1.85826230049133    | 1000 | +6%     |                          0.0000 |
| TPC-H 20  | 0.00561679294332862 | 5    | 0.00561118358746171 | 5    | -0%     |        (not enough runs) 0.5985 |
| TPC-H 21  | 0.185014992952347   | 134  | 0.185903683304787   | 134  | +0%     |                          0.0016 |
| TPC-H 22  | 0.307335644960403   | 222  | 0.302841901779175   | 219  | -1%     |                          0.0000 |
| average   |                     |      |                     |      | +998%   |                                 |
+-----------+---------------------+------+---------------------+------+---------+---------------------------------+
```