### PR TITLE
Improved FixedStringDict

### DIFF
--- a/src/lib/storage/fixed_string_dictionary_column.cpp
+++ b/src/lib/storage/fixed_string_dictionary_column.cpp
@@ -34,7 +34,7 @@ const AllTypeVariant FixedStringDictionaryColumn<T>::operator[](const ChunkOffse
     return NULL_VALUE;
   }
 
-  return _dictionary->get_string_at(value_id);
+  return AllTypeVariant{std::move(_dictionary->get_string_at(value_id))};
 }
 
 template <typename T>

--- a/src/lib/storage/fixed_string_dictionary_column/fixed_string_vector.cpp
+++ b/src/lib/storage/fixed_string_dictionary_column/fixed_string_vector.cpp
@@ -48,23 +48,22 @@ ReverseIterator FixedStringVector::rbegin() noexcept { return ReverseIterator(en
 
 ReverseIterator FixedStringVector::rend() noexcept { return ReverseIterator(begin()); }
 
-FixedString FixedStringVector::operator[](const size_t value_id) {
+FixedString FixedStringVector::operator[](const size_t pos) {
   PerformanceWarning("operator[] used");
-  return FixedString(&_chars[value_id * _string_length], _string_length);
+  return FixedString(&_chars[pos * _string_length], _string_length);
 }
 
-FixedString FixedStringVector::at(const size_t value_id) {
-  return FixedString(&_chars.at(value_id * _string_length), _string_length);
+FixedString FixedStringVector::at(const size_t pos) {
+  return FixedString(&_chars.at(pos * _string_length), _string_length);
 }
 
-const std::string FixedStringVector::get_string_at(const size_t value_id) const {
-  const auto string_value = std::string(&_chars[value_id * _string_length], _string_length);
-  const auto pos = string_value.find('\0');
-
-  if (pos == std::string::npos) {
-    return string_value;
+const std::string FixedStringVector::get_string_at(const size_t pos) const {
+  const auto string_start = &_chars[pos * _string_length];
+  if (*(string_start + _string_length - 1) == '\0') {
+    // The string is zero-padded - the std::string constructor takes care of finding the correct length
+    return std::string(string_start);
   } else {
-    return string_value.substr(0, pos);
+    return std::string(string_start, _string_length);
   }
 }
 

--- a/src/lib/storage/fixed_string_dictionary_column/fixed_string_vector.hpp
+++ b/src/lib/storage/fixed_string_dictionary_column/fixed_string_vector.hpp
@@ -38,11 +38,11 @@ class FixedStringVector {
   void push_back(const std::string& string);
 
   // Return the value at a certain position.
-  FixedString operator[](const size_t value_id);
+  FixedString operator[](const size_t pos);
 
-  FixedString at(const size_t value_id);
+  FixedString at(const size_t pos);
 
-  const std::string get_string_at(const size_t value_id) const;
+  const std::string get_string_at(const size_t pos) const;
 
   // Make the FixedStringVector of FixedStrings iterable in different ways
   FixedStringIterator<false> begin() noexcept;


### PR DESCRIPTION
There were too many string copies. fixes #1048

```
+-----------+------------------+------+------------------+------+--------+-----------------------------------------------+
| Benchmark | prev. iter/s     | runs | new iter/s       | runs | change |               p-value (significant if <0.001) |
+-----------+------------------+------+------------------+------+--------+-----------------------------------------------+
| TPC-H 1   | 2.22005701065    | 67   | 2.59907960892    | 78   | +17%   |                   (run time too short) 0.0000 |
| TPC-H 2   | 12.7983808517    | 384  | 13.1744680405    | 396  | +3%    |                   (run time too short) 0.1043 |
| TPC-H 3   | 13.7960586548    | 414  | 15.1589708328    | 455  | +10%   |                   (run time too short) 0.0000 |
| TPC-H 4   | 0.368729293346   | 12   | 0.405958801508   | 13   | +10%   |                   (run time too short) 0.0000 |
| TPC-H 5   | 9.38117980957    | 282  | 10.387386322     | 312  | +11%   |                   (run time too short) 0.0000 |
| TPC-H 6   | 42.8859214783    | 1287 | 44.1834144592    | 1326 | +3%    |                   (run time too short) 0.0003 |
| TPC-H 7   | 2.57988262177    | 78   | 2.93265676498    | 88   | +14%   |                   (run time too short) 0.0004 |
| TPC-H 8   | 2.37951683998    | 72   | 2.59324502945    | 78   | +9%    |                   (run time too short) 0.0010 |
| TPC-H 9   | 1.67968225479    | 51   | 1.64785647392    | 50   | -2%    |                   (run time too short) 0.2402 |
| TPC-H 10  | 8.45245552063    | 254  | 11.6454076767    | 350  | +38%   |                   (run time too short) 0.0000 |
| TPC-H 11  | 25.4575176239    | 764  | 33.0960044861    | 993  | +30%   |                   (run time too short) 0.0000 |
| TPC-H 12  | 14.7838382721    | 444  | 13.1812858582    | 396  | -11%   |                   (run time too short) 0.0000 |
| TPC-H 13  | 13.1142749786    | 394  | 11.0458841324    | 332  | -16%   |                   (run time too short) 0.0000 |
| TPC-H 14  | 29.6732215881    | 891  | 27.5050849915    | 826  | -7%    |                   (run time too short) 0.0000 |
| TPC-H 15  | 0.227994307876   | 7    | 0.220859602094   | 7    | -3%    | (run time too short) (not enough runs) 0.0215 |
| TPC-H 16  | 6.71285581589    | 202  | 4.26525115967    | 128  | -36%   |                   (run time too short) 0.0000 |
| TPC-H 17  | 1.35235917568    | 41   | 1.31912648678    | 40   | -2%    |                   (run time too short) 0.0002 |
| TPC-H 18  | 0.0242068823427  | 1    | 0.0217414479703  | 1    | -10%   |    (run time too short) (not enough runs) nan |
| TPC-H 19  | 1.0495121479     | 32   | 1.33648908138    | 41   | +27%   |                   (run time too short) 0.0013 |
| TPC-H 20  | 0.00504975719377 | 1    | 0.00551926903427 | 1    | +9%    |                         (not enough runs) nan |
| TPC-H 21  | 0.212393224239   | 8    | 0.238464474678   | 8    | +12%   | (run time too short) (not enough runs) 0.2959 |
| TPC-H 22  | 0.288300514221   | 9    | 0.294936984777   | 9    | +2%    | (run time too short) (not enough runs) 0.4361 |
| average   |                  |      |                  |      | +5%    |                                               |
+-----------+------------------+------+------------------+------+--------+-----------------------------------------------+
```

TPC-H query 16 is slower because we work on `s_comment`, a column with both short and long strings. I think we might be better off with storing the actual length of the string first so that we don't have to call `strlen` all the time. Furthermore, we should decide on a per-column level if we want traditional dictionaries or these. We already have that on the list for the seminar.