### PR TITLE
Performance improvements in Aggregate and FixedSizeByteAlignedVector

### DIFF
--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -236,7 +236,8 @@ void Aggregate::_aggregate_column(ChunkID chunk_id, ColumnID column_index, const
             // increase value counter
             ++hash_entry.aggregate_count;
 
-            if constexpr (function == AggregateFunction::CountDistinct) {
+            if constexpr (function == AggregateFunction::CountDistinct) {  // NOLINT
+              // clang-tidy error: https://bugs.llvm.org/show_bug.cgi?id=35824
               // for the case of CountDistinct, insert this value into the set to keep track of distinct values
               hash_entry.distinct_values.insert(value.value());
             }

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -344,7 +344,8 @@ void Aggregate::_aggregate() {
         */
 
         // This time, we have no idea how much space we need, so we take some memory and then rely on the automatic
-        // resizing
+        // resizing. The size is quite random, but since single memory allocations do not cost too much, we rather
+        // allocate a bit too much.
         auto temp_buffer = boost::container::pmr::monotonic_buffer_resource(1'000'000);
         auto allocator = PolymorphicAllocator<std::pair<const ColumnDataType, AggregateKeyEntry>>{&temp_buffer};
 

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -200,12 +200,12 @@ struct AggregateFunctionBuilder<ColumnType, AggregateType, AggregateFunction::Co
   }
 };
 
-template <typename ColumnDataType, AggregateFunction Function, typename AggregateKey>
+template <typename ColumnDataType, AggregateFunction function, typename AggregateKey>
 void Aggregate::_aggregate_column(ChunkID chunk_id, ColumnID column_index, const BaseColumn& base_column,
                                   const KeysPerChunk<AggregateKey>& keys_per_chunk) {
-  using AggregateType = typename AggregateTraits<ColumnDataType, Function>::AggregateType;
+  using AggregateType = typename AggregateTraits<ColumnDataType, function>::AggregateType;
 
-  auto aggregator = AggregateFunctionBuilder<ColumnDataType, AggregateType, Function>().get_aggregate_function();
+  auto aggregator = AggregateFunctionBuilder<ColumnDataType, AggregateType, function>().get_aggregate_function();
 
   auto& context = *std::static_pointer_cast<AggregateContext<ColumnDataType, AggregateType, AggregateKey>>(
       _contexts_per_column[column_index]);
@@ -236,7 +236,7 @@ void Aggregate::_aggregate_column(ChunkID chunk_id, ColumnID column_index, const
             // increase value counter
             ++hash_entry.aggregate_count;
 
-            if constexpr (Function == AggregateFunction::CountDistinct) {
+            if constexpr (function == AggregateFunction::CountDistinct) {
               // for the case of CountDistinct, insert this value into the set to keep track of distinct values
               hash_entry.distinct_values.insert(value.value());
             }

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -343,7 +343,8 @@ void Aggregate::_aggregate() {
         The ID 0 is reserved for NULL values. The combined IDs build an AggregateKey for each row.
         */
 
-        // This time, we have no idea how much space we need, so we take some memory and then rely on the automatic resizing
+        // This time, we have no idea how much space we need, so we take some memory and then rely on the automatic
+        // resizing
         auto temp_buffer = boost::container::pmr::monotonic_buffer_resource(1'000'000);
         auto allocator = PolymorphicAllocator<std::pair<const ColumnDataType, AggregateKeyEntry>>{&temp_buffer};
 

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -133,7 +133,7 @@ class ColumnMaterializer {
         auto chunk_offset = ChunkOffset{0u};
         auto value_id_it = attribute_vector.cbegin();
         for (; value_id_it != attribute_vector.cend(); ++value_id_it, ++chunk_offset) {
-          auto value_id = *value_id_it;
+          auto value_id = static_cast<ValueID>(*value_id_it);
 
           if (value_id != NULL_VALUE_ID) {
             rows_with_value[value_id].push_back(RowID{chunk_id, chunk_offset});

--- a/src/lib/storage/dictionary_column/dictionary_column_iterable.hpp
+++ b/src/lib/storage/dictionary_column/dictionary_column_iterable.hpp
@@ -74,7 +74,7 @@ class DictionaryColumnIterable : public PointAccessibleColumnIterable<Dictionary
     bool equal(const Iterator& other) const { return _attribute_it == other._attribute_it; }
 
     ColumnIteratorValue<T> dereference() const {
-      const auto value_id = *_attribute_it;
+      const auto value_id = static_cast<ValueID>(*_attribute_it);
       const auto is_null = (value_id == _null_value_id);
 
       if (is_null) return ColumnIteratorValue<T>{T{}, true, _chunk_offset};

--- a/src/lib/storage/index/group_key/group_key_index.cpp
+++ b/src/lib/storage/index/group_key/group_key_index.cpp
@@ -42,7 +42,7 @@ GroupKeyIndex::GroupKeyIndex(const std::vector<std::shared_ptr<const BaseColumn>
     auto value_id_it = attribute_vector.cbegin();
     auto position = 0u;
     for (; value_id_it != attribute_vector.cend(); ++value_id_it, ++position) {
-      const auto& value_id = *value_id_it;
+      const auto& value_id = static_cast<ValueID>(*value_id_it);
       _index_postings[index_offset_copy[value_id]] = position;
 
       // increase the write-offset in the copy by one to ensure that further writes

--- a/src/lib/storage/vector_compression/fixed_size_byte_aligned/fixed_size_byte_aligned_vector.hpp
+++ b/src/lib/storage/vector_compression/fixed_size_byte_aligned/fixed_size_byte_aligned_vector.hpp
@@ -3,15 +3,10 @@
 #include <boost/hana/contains.hpp>
 #include <boost/hana/tuple.hpp>
 #include <boost/hana/type.hpp>
-
-#include <boost/iterator/transform_iterator.hpp>
-
 #include <memory>
 
-#include "storage/vector_compression/base_compressed_vector.hpp"
-
 #include "fixed_size_byte_aligned_decompressor.hpp"
-
+#include "storage/vector_compression/base_compressed_vector.hpp"
 #include "types.hpp"
 
 namespace opossum {
@@ -42,30 +37,13 @@ class FixedSizeByteAlignedVector : public CompressedVector<FixedSizeByteAlignedV
 
   auto on_create_decoder() const { return std::make_unique<FixedSizeByteAlignedDecompressor<UnsignedIntType>>(_data); }
 
-  auto on_begin() const {
-    if constexpr (std::is_same_v<UnsignedIntType, uint32_t>) {
-      return _data.cbegin();
-    } else {
-      return boost::make_transform_iterator(_data.cbegin(), cast_to_uint32);
-    }
-  }
+  auto on_begin() const { return _data.cbegin(); }
 
-  auto on_end() const {
-    if constexpr (std::is_same_v<UnsignedIntType, uint32_t>) {
-      return _data.cend();
-    } else {
-      return boost::make_transform_iterator(_data.cend(), cast_to_uint32);
-    }
-  }
+  auto on_end() const { return _data.cend(); }
 
   std::unique_ptr<const BaseCompressedVector> on_copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const {
     auto data_copy = pmr_vector<UnsignedIntType>{_data, alloc};
     return std::make_unique<FixedSizeByteAlignedVector<UnsignedIntType>>(std::move(data_copy));
-  }
-
- private:
-  static uint32_t __attribute__((always_inline)) cast_to_uint32(UnsignedIntType value) {
-    return static_cast<uint32_t>(value);
   }
 
  private:


### PR DESCRIPTION
see commit descriptions for details.

```
+-----------+-----------------+------+------------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s    | runs | new iter/s       | runs | change | p-value (significant if <0.001) |
+-----------+-----------------+------+------------------+------+--------+---------------------------------+
| TPC-H 1   | 1.37261760235   | 83   | 1.41345322132    | 85   | +3%    |                          0.0000 |
| TPC-H 2   | 16.5763473511   | 995  | 20.17436409      | 1211 | +22%   |                          0.0000 |
| TPC-H 3   | 12.8522357941   | 772  | 12.9413614273    | 777  | +1%    |                          0.0017 |
| TPC-H 4   | 0.253401845694  | 16   | 0.252252727747   | 16   | -0%    |                          0.0001 |
| TPC-H 5   | 8.54904937744   | 513  | 8.57800960541    | 515  | +0%    |                          0.0000 |
| TPC-H 6   | 31.3255748749   | 1880 | 31.7543735504    | 1906 | +1%    |                          0.0000 |
| TPC-H 7   | 2.44779729843   | 147  | 2.4636285305     | 148  | +1%    |                          0.0000 |
| TPC-H 8   | 2.29970312119   | 138  | 2.19360184669    | 132  | -5%    |                          0.0000 |
| TPC-H 9   | 1.29532730579   | 78   | 1.27718150616    | 77   | -1%    |                          0.0000 |
| TPC-H 10  | 9.50793743134   | 571  | 9.67540073395    | 581  | +2%    |                          0.0000 |
| TPC-H 11  | 23.4549064636   | 1408 | 23.2467269897    | 1395 | -1%    |                          0.0000 |
| TPC-H 12  | 12.9700460434   | 779  | 13.0157251358    | 781  | +0%    |                          0.0000 |
| TPC-H 13  | 13.0507335663   | 784  | 13.3878583908    | 804  | +3%    |                          0.0000 |
| TPC-H 14  | 28.7720069885   | 1727 | 29.3560657501    | 1762 | +2%    |                          0.0000 |
| TPC-H 15  | 0.176708579063  | 11   | 0.193941622972   | 12   | +10%   |                          0.0000 |
| TPC-H 16  | 3.93403959274   | 237  | 3.91800189018    | 236  | -0%    |                          0.0000 |
| TPC-H 17  | 0.888237953186  | 54   | 1.88799989223    | 114  | +113%  |                          0.0000 |
| TPC-H 18  | 0.0235875397921 | 2    | 0.0263603962958  | 2    | +12%   |        (not enough runs) 0.0065 |
| TPC-H 19  | 1.0000847578    | 61   | 1.00760364532    | 61   | +1%    |                          0.0000 |
| TPC-H 20  | 0.0036663771607 | 1    | 0.00778483552858 | 1    | +112%  |           (not enough runs) nan |
| TPC-H 21  | 0.149339050055  | 9    | 0.149376347661   | 9    | +0%    |        (not enough runs) 0.8230 |
| TPC-H 22  | 0.199161544442  | 12   | 0.428601384163   | 26   | +115%  |                          0.0000 |
| average   |                 |      |                  |      | +18%   |                                 |
+-----------+-----------------+------+------------------+------+--------+---------------------------------+
```

(pella, sf 0,1, clang)