### PR TITLE
Fix test_data_path variable declaration

### DIFF
--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -24,7 +24,7 @@ namespace opossum {
 class AbstractLQPNode;
 class Table;
 
-extern std::string test_data_path;  // NOLINT
+extern std::string test_data_path;
 
 template <typename ParamType>
 class BaseTestWithParam : public std::conditional<std::is_same<ParamType, void>::value, ::testing::Test,

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -24,7 +24,7 @@ namespace opossum {
 class AbstractLQPNode;
 class Table;
 
-static std::string test_data_path;  // NOLINT
+extern std::string test_data_path;  // NOLINT
 
 template <typename ParamType>
 class BaseTestWithParam : public std::conditional<std::is_same<ParamType, void>::value, ::testing::Test,

--- a/src/test/gtest_main.cpp
+++ b/src/test/gtest_main.cpp
@@ -5,7 +5,7 @@
 #include "utils/filesystem.hpp"
 #include "utils/performance_warning.hpp"
 
-std::string opossum::test_data_path;
+std::string opossum::test_data_path;  // NOLINT
 
 void create_test_data_directory(std::optional<std::string>& prefix) {
   Assert(!filesystem::exists(opossum::test_data_path),

--- a/src/test/gtest_main.cpp
+++ b/src/test/gtest_main.cpp
@@ -5,6 +5,8 @@
 #include "utils/filesystem.hpp"
 #include "utils/performance_warning.hpp"
 
+std::string opossum::test_data_path;
+
 void create_test_data_directory(std::optional<std::string>& prefix) {
   Assert(!filesystem::exists(opossum::test_data_path),
          "Cannot create directory for test data: \"" + opossum::test_data_path + "\" already exists.");


### PR DESCRIPTION
The variable `test_data_path` is used for storing test data in specified directories to separate test instances from each other. It was a static variable until now which means that every test case had its own instance. Therefore, it was unset in test cases which relied on it being set.