### PR TITLE
Remove unnecessary linking of benchmarkingLib from hyriseTest

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -253,7 +253,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Configure hyriseTest
 add_executable(hyriseTest ${HYRISE_UNIT_TEST_SOURCES})
-target_link_libraries(hyriseTest hyrise hyriseBenchmarkLib ${LIBRARIES})
+target_link_libraries(hyriseTest hyrise ${LIBRARIES})
 
 # Configure hyriseSystemTest
 add_executable(hyriseSystemTest ${SYSTEM_TEST_SOURCES})


### PR DESCRIPTION
I know this is a tiny change, but I believe it's unnecessary to link this here and it was starting to annoy me while watching make do its work.