### PR TITLE
Move SQLiteTestrunner to hyriseSystemTest

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -105,7 +105,6 @@ set(
     server/postgres_wire_handler_test.cpp
     server/server_session_test.cpp
     sql/sql_basic_cache_test.cpp
-    sql/sqlite_testrunner/sqlite_testrunner.cpp
     sql/sqlite_testrunner/sqlite_wrapper_test.cpp
     sql/sql_identifier_resolver_test.cpp
     sql/sql_pipeline_statement_test.cpp
@@ -231,6 +230,7 @@ set (
     server/server_test_runner.cpp
     tpc/tpch_test.cpp
     tpc/tpch_db_generator_test.cpp
+    sql/sqlite_testrunner/sqlite_testrunner.cpp
     gtest_main.cpp
 )
 


### PR DESCRIPTION
The SQLiteTestrunner is more of a system test anyway. 

And it takes the vast majority of the runtime of hyriseTest (each sqlite test taking at least 50ms for me), and since these are run very, very often, this is detrimental to the productivity of the hyrise team. ;)
![screenshot from 2018-09-05 00-04-00](https://user-images.githubusercontent.com/2679018/45060483-4c876e00-b0a0-11e8-8917-ce8d6dca6a24.png)
