### PR TITLE
Remove automatic AllTypeVariant conversion in type_cast

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -189,15 +189,8 @@ Hashes the given value into the HashedType that is defined by the current Hash T
 Performs a lexical cast first, if necessary.
 */
 template <typename OriginalType, typename HashedType>
-constexpr Hash hash_value(const OriginalType& value, const unsigned int seed) {
-  // clang-format off
-  // doesn't deal with constexpr nicely
-  if constexpr(!std::is_same_v<OriginalType, HashedType>) {
-    return murmur2<HashedType>(type_cast<HashedType>(value), seed);
-  } else {
-    return murmur2<HashedType>(value, seed);
-  }
-  // clang-format on
+constexpr Radix hash_value(const OriginalType& value, const unsigned int seed) {
+  return murmur2<HashedType>(type_cast<HashedType>(value), seed);
 }
 
 template <typename T, typename HashedType>

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -189,7 +189,7 @@ Hashes the given value into the HashedType that is defined by the current Hash T
 Performs a lexical cast first, if necessary.
 */
 template <typename OriginalType, typename HashedType>
-constexpr Radix hash_value(const OriginalType& value, const unsigned int seed) {
+constexpr Hash hash_value(const OriginalType& value, const unsigned int seed) {
   return murmur2<HashedType>(type_cast<HashedType>(value), seed);
 }
 

--- a/src/lib/type_cast.hpp
+++ b/src/lib/type_cast.hpp
@@ -45,7 +45,7 @@ inline __attribute__((always_inline)) auto&& type_cast(U&& value) {
 // If trivial conversion failed, continues here:
 // Template specialization for everything but integral types
 template <typename T, typename U>
-std::enable_if_t<!std::is_integral<T>::value, T> type_cast(const U& value) {
+std::enable_if_t<!std::is_integral_v<T>, T> type_cast(const U& value) {
   // For AllTypeVariants, check if it contains the type that we want. In that case, we don't need to convert anything.
   if constexpr (std::is_same_v<U, AllTypeVariant>) {
     if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
@@ -56,7 +56,7 @@ std::enable_if_t<!std::is_integral<T>::value, T> type_cast(const U& value) {
 
 // Template specialization for integral types
 template <typename T, typename U>
-std::enable_if_t<std::is_integral<T>::value, T> type_cast(const U& value) {
+std::enable_if_t<std::is_integral_v<T>, T> type_cast(const U& value) {
   if constexpr (std::is_same_v<U, AllTypeVariant>) {
     if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
   }

--- a/src/lib/type_cast.hpp
+++ b/src/lib/type_cast.hpp
@@ -35,16 +35,18 @@ const T& get(const AllTypeVariant& value) {
 
 // cast methods - from one type to another
 
-// For convenience, allow `type_cast<T>(T bla);`, but it shouldn't do anything
-template <typename T, typename U, typename = std::enable_if_t<std::is_same_v<T, U>>>
+// For convenience, allow `type_cast<T>(T bla);`, but it shouldn't do anything.
+// Conversions that don't require lexical_cast handling (e.g., float->double or float->int) are handled here as well.
+template <typename T, typename U, typename = std::enable_if_t<std::is_convertible_v<std::decay<U>, std::decay<T>>>>
 inline __attribute__((always_inline)) auto&& type_cast(U&& value) {
-  return std::forward<U>(value);
+  return std::forward<T>(value);
 }
 
+// If trivial conversion failed, continues here:
 // Template specialization for everything but integral types
 template <typename T, typename U>
 std::enable_if_t<!std::is_integral<T>::value, T> type_cast(const U& value) {
-  // For AllTypeVariants, check if it contains the type that we want. In that case, we don't need to convert anything
+  // For AllTypeVariants, check if it contains the type that we want. In that case, we don't need to convert anything.
   if constexpr (std::is_same_v<U, AllTypeVariant>) {
     if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
   }

--- a/src/lib/type_cast.hpp
+++ b/src/lib/type_cast.hpp
@@ -33,20 +33,31 @@ const T& get(const AllTypeVariant& value) {
   return boost::get<T>(value);
 }
 
-// cast methods - from variant to specific type
+// cast methods - from one type to another
+
+// For convenience, allow `type_cast<T>(T bla);`, but it shouldn't do anything
+template <typename T, typename U, typename = std::enable_if_t<std::is_same_v<T, U>>>
+inline __attribute__((always_inline)) auto&& type_cast(U&& value) {
+  return std::forward<U>(value);
+}
 
 // Template specialization for everything but integral types
-template <typename T>
-std::enable_if_t<!std::is_integral<T>::value, T> type_cast(const AllTypeVariant& value) {
-  if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
+template <typename T, typename U>
+std::enable_if_t<!std::is_integral<T>::value, T> type_cast(const U& value) {
+  // For AllTypeVariants, check if it contains the type that we want. In that case, we don't need to convert anything
+  if constexpr (std::is_same_v<U, AllTypeVariant>) {
+    if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
+  }
 
   return boost::lexical_cast<T>(value);
 }
 
 // Template specialization for integral types
-template <typename T>
-std::enable_if_t<std::is_integral<T>::value, T> type_cast(const AllTypeVariant& value) {
-  if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
+template <typename T, typename U>
+std::enable_if_t<std::is_integral<T>::value, T> type_cast(const U& value) {
+  if constexpr (std::is_same_v<U, AllTypeVariant>) {
+    if (value.which() == detail::index_of(data_types_including_null, hana::type_c<T>)) return get<T>(value);
+  }
 
   T converted_value;
 


### PR DESCRIPTION
Currently, the join hash implicitly wraps the type into an AllTypeVariant. That is a bad thing. ;)

TPC-H 17, 20 and 22 are better because the performance regression from #1095 is gone. No idea why exactly those three queries have somewhat nondeterministic performance characteristics. Maybe that's because I keep forgetting to pin the execution to a single node?

```
 Benchmark | prev. iter/s | new iter/s | change
-----------+--------------+------------+---------------
 TPC-H 1   | 3.548        | 3.531      | -0%
 TPC-H 2   | 85.881       | 99.25      | +16%
 TPC-H 3   | 37.21        | 39.871     | +7%
 TPC-H 4   | 0.512        | 0.521      | +2%
 TPC-H 5   | 24.307       | 25.398     | +4%
 TPC-H 6   | 59.488       | 60.878     | +2%
 TPC-H 7   | 7.281        | 7.666      | +5%
 TPC-H 8   | 32.221       | 34.223     | +6%
 TPC-H 9   | 14.893       | 15.723     | +6%
 TPC-H 10  | 21.219       | 22.052     | +4%
 TPC-H 11  | 113.365      | 119.581    | +5%
 TPC-H 12  | 32.763       | 34.042     | +4%
 TPC-H 13  | 24.511       | 25.494     | +4%
 TPC-H 14  | 84.535       | 87.862     | +4%
 TPC-H 15  | 40.813       | 41.717     | +2%
 TPC-H 16  | 16.635       | 17.091     | +3%
 TPC-H 17  | 4.295        | 5.688      | +32%
 TPC-H 18  | 3.097        | 3.204      | +3%
 TPC-H 19  | 2.705        | 2.824      | +4%
 TPC-H 20  | 0.032        | 0.042      | +30%
 TPC-H 21  | 0.308        | 0.312      | +1%
 TPC-H 22  | 1.161        | 1.521      | +31%
 average   |              |            | +8%
```