### PR TITLE
Try explicit load for AbstractTask::_id in DTRACE macro

### DIFF
--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -92,7 +92,7 @@ void AbstractTask::_join_without_replacement_worker() {
 }
 
 void AbstractTask::execute() {
-  DTRACE_PROBE3(HYRISE, JOB_START, _id, _description.c_str(), reinterpret_cast<uintptr_t>(this));
+  DTRACE_PROBE3(HYRISE, JOB_START, _id.load(), _description.c_str(), reinterpret_cast<uintptr_t>(this));
   DebugAssert(!(_started.exchange(true)), "Possible bug: Trying to execute the same task twice");
   DebugAssert(is_ready(), "Task must not be executed before its dependencies are done");
 


### PR DESCRIPTION
Another attempt to fix #1093