### PR TITLE
Remove benchmarking Lib from playground

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -27,7 +27,6 @@ add_executable(
 target_link_libraries(
     hyrisePlayground
     hyrise
-    hyriseBenchmarkLib
 )
 
 # Configure tpchTableGenerator


### PR DESCRIPTION
Similar to #1071, the playground unnecessarily linked the benchmark lib. Remove it.