### PR TITLE
Standardize template stuff

### DIFF
--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -300,7 +300,7 @@ ExpressionEvaluator::_evaluate_in_expression<ExpressionEvaluator::Bool>(const In
       _resolve_to_expression_result_view(left_expression, [&](const auto& left_view) {
         using ValueDataType = typename std::decay_t<decltype(left_view)>::Type;
 
-        if constexpr (EqualsEvaluator::supports<ExpressionEvaluator::Bool, ValueDataType, SelectDataType>::value) {
+        if constexpr (EqualsEvaluator::supports_v<ExpressionEvaluator::Bool, ValueDataType, SelectDataType>) {
           const auto result_size = _result_size(left_view.size(), select_results.size());
 
           result_values.resize(result_size, 0);
@@ -441,7 +441,7 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_case_ex
         std::vector<bool> nulls(result_size);
 
         // clang-format off
-      if constexpr (CaseEvaluator::template supports<Result, ThenResultType, ElseResultType>::value) {
+      if constexpr (CaseEvaluator::supports_v<Result, ThenResultType, ElseResultType>) {
         for (auto chunk_offset = ChunkOffset{0};
              chunk_offset < result_size; ++chunk_offset) {
           if (when->value(chunk_offset) && !when->is_null(chunk_offset)) {

--- a/src/lib/expression/evaluation/expression_functors.hpp
+++ b/src/lib/expression/evaluation/expression_functors.hpp
@@ -88,6 +88,9 @@ struct STLComparisonFunctorWrapper {
   };
 
   template <typename Result, typename ArgA, typename ArgB>
+  inline static constexpr bool supports_v = supports<Result, ArgA, ArgB>::value;
+
+  template <typename Result, typename ArgA, typename ArgB>
   void operator()(Result& result, const ArgA& a, const ArgB& b) {
     if constexpr (std::is_same_v<NullValue, ArgA> || std::is_same_v<NullValue, ArgB>) {
       result = Result{};
@@ -195,6 +198,9 @@ struct CaseEvaluator {
     static constexpr bool value = (std::is_same_v<std::string, ArgA> == std::is_same_v<std::string, ArgB>)&&(
         std::is_same_v<std::string, ArgA> == std::is_same_v<std::string, Result>);
   };
+
+  template <typename Result, typename ArgA, typename ArgB>
+  inline static constexpr bool supports_v = supports<Result, ArgA, ArgB>::value;
 
   // Implementation is in ExpressionEvaluator::_evaluate_case_expression
 };

--- a/src/lib/logical_query_plan/enable_make_for_lqp_node.hpp
+++ b/src/lib/logical_query_plan/enable_make_for_lqp_node.hpp
@@ -26,7 +26,7 @@ template <typename DerivedNode>
 class EnableMakeForLQPNode {
  public:
   template <int N, typename... Ts>
-  using NthTypeOf = typename std::tuple_element<N, std::tuple<Ts...>>::type;
+  using NthTypeOf = std::tuple_element_t<N, std::tuple<Ts...>>;
 
   template <typename... Args>
   static std::shared_ptr<DerivedNode> make(Args&&... args) {

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -620,8 +620,8 @@ They are separate and templated to avoid compiler errors for invalid type/functi
 */
 // MIN, MAX, SUM write the current aggregated value
 template <typename ColumnType, typename AggregateType, AggregateFunction func, typename AggregateKey>
-typename std::enable_if<
-    func == AggregateFunction::Min || func == AggregateFunction::Max || func == AggregateFunction::Sum, void>::type
+std::enable_if_t<func == AggregateFunction::Min || func == AggregateFunction::Max || func == AggregateFunction::Sum,
+                 void>
 write_aggregate_values(std::shared_ptr<ValueSegment<AggregateType>> segment,
                        std::shared_ptr<std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>,
                                                           std::hash<AggregateKey>>>
@@ -647,7 +647,7 @@ write_aggregate_values(std::shared_ptr<ValueSegment<AggregateType>> segment,
 
 // COUNT writes the aggregate counter
 template <typename ColumnType, typename AggregateType, AggregateFunction func, typename AggregateKey>
-typename std::enable_if<func == AggregateFunction::Count, void>::type write_aggregate_values(
+std::enable_if_t<func == AggregateFunction::Count, void> write_aggregate_values(
     std::shared_ptr<ValueSegment<AggregateType>> segment,
     std::shared_ptr<
         std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>, std::hash<AggregateKey>>>
@@ -666,7 +666,7 @@ typename std::enable_if<func == AggregateFunction::Count, void>::type write_aggr
 
 // COUNT(DISTINCT) writes the number of distinct values
 template <typename ColumnType, typename AggregateType, AggregateFunction func, typename AggregateKey>
-typename std::enable_if<func == AggregateFunction::CountDistinct, void>::type write_aggregate_values(
+std::enable_if_t<func == AggregateFunction::CountDistinct, void> write_aggregate_values(
     std::shared_ptr<ValueSegment<AggregateType>> segment,
     std::shared_ptr<
         std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>, std::hash<AggregateKey>>>
@@ -685,11 +685,11 @@ typename std::enable_if<func == AggregateFunction::CountDistinct, void>::type wr
 
 // AVG writes the calculated average from current aggregate and the aggregate counter
 template <typename ColumnType, typename AggregateType, AggregateFunction func, typename AggregateKey>
-typename std::enable_if<func == AggregateFunction::Avg && std::is_arithmetic<AggregateType>::value, void>::type
-write_aggregate_values(std::shared_ptr<ValueSegment<AggregateType>> segment,
-                       std::shared_ptr<std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>,
-                                                          std::hash<AggregateKey>>>
-                           results) {
+std::enable_if_t<func == AggregateFunction::Avg && std::is_arithmetic_v<AggregateType>, void> write_aggregate_values(
+    std::shared_ptr<ValueSegment<AggregateType>> segment,
+    std::shared_ptr<
+        std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>, std::hash<AggregateKey>>>
+        results) {
   DebugAssert(segment->is_nullable(), "Aggregate: Output segment needs to be nullable");
 
   auto& values = segment->values();
@@ -711,10 +711,10 @@ write_aggregate_values(std::shared_ptr<ValueSegment<AggregateType>> segment,
 
 // AVG is not defined for non-arithmetic types. Avoiding compiler errors.
 template <typename ColumnType, typename AggregateType, AggregateFunction func, typename AggregateKey>
-typename std::enable_if<func == AggregateFunction::Avg && !std::is_arithmetic<AggregateType>::value, void>::type
-write_aggregate_values(std::shared_ptr<ValueSegment<AggregateType>>,
-                       std::shared_ptr<std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>,
-                                                          std::hash<AggregateKey>>>) {
+std::enable_if_t<func == AggregateFunction::Avg && !std::is_arithmetic_v<AggregateType>, void> write_aggregate_values(
+    std::shared_ptr<ValueSegment<AggregateType>>,
+    std::shared_ptr<
+        std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>, std::hash<AggregateKey>>>) {
   Fail("Invalid aggregate");
 }
 

--- a/src/lib/operators/aggregate/aggregate_traits.hpp
+++ b/src/lib/operators/aggregate/aggregate_traits.hpp
@@ -39,7 +39,7 @@ struct AggregateTraits<
 template <typename ColumnType, AggregateFunction function>
 struct AggregateTraits<
     ColumnType, function,
-    typename std::enable_if_t<function == AggregateFunction::Avg && std::is_arithmetic<ColumnType>::value, void>> {
+    typename std::enable_if_t<function == AggregateFunction::Avg && std::is_arithmetic_v<ColumnType>, void>> {
   typedef double AggregateType;
   static constexpr DataType AGGREGATE_DATA_TYPE = DataType::Double;
 };
@@ -48,7 +48,7 @@ struct AggregateTraits<
 template <typename ColumnType, AggregateFunction function>
 struct AggregateTraits<
     ColumnType, function,
-    typename std::enable_if_t<function == AggregateFunction::Sum && std::is_integral<ColumnType>::value, void>> {
+    typename std::enable_if_t<function == AggregateFunction::Sum && std::is_integral_v<ColumnType>, void>> {
   typedef int64_t AggregateType;
   static constexpr DataType AGGREGATE_DATA_TYPE = DataType::Long;
 };
@@ -57,7 +57,7 @@ struct AggregateTraits<
 template <typename ColumnType, AggregateFunction function>
 struct AggregateTraits<
     ColumnType, function,
-    typename std::enable_if_t<function == AggregateFunction::Sum && std::is_floating_point<ColumnType>::value, void>> {
+    typename std::enable_if_t<function == AggregateFunction::Sum && std::is_floating_point_v<ColumnType>, void>> {
   typedef double AggregateType;
   static constexpr DataType AGGREGATE_DATA_TYPE = DataType::Double;
 };
@@ -66,7 +66,7 @@ struct AggregateTraits<
 template <typename ColumnType, AggregateFunction function>
 struct AggregateTraits<
     ColumnType, function,
-    typename std::enable_if_t<!std::is_arithmetic<ColumnType>::value &&
+    typename std::enable_if_t<!std::is_arithmetic_v<ColumnType> &&
                                   (function == AggregateFunction::Avg || function == AggregateFunction::Sum),
                               void>> {
   typedef ColumnType AggregateType;

--- a/src/lib/operators/jit_operator/jit_operations.hpp
+++ b/src/lib/operators/jit_operator/jit_operations.hpp
@@ -220,7 +220,7 @@ __attribute__((noinline)) void jit_aggregate_compute(const T& op_func, const Jit
   // the result.
   const auto store_result_wrapper = [&](const auto typed_lhs,
                                         const auto typed_rhs) -> decltype(op_func(typed_lhs, typed_rhs), void()) {
-    using ResultType = typename std::remove_const<decltype(typed_rhs)>::type;
+    using ResultType = std::remove_const_t<decltype(typed_rhs)>;
     rhs.set<ResultType>(op_func(typed_lhs, typed_rhs), rhs_index, context);
   };
 

--- a/src/lib/operators/jit_operator/operators/jit_aggregate.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_aggregate.cpp
@@ -56,7 +56,7 @@ void JitAggregate::before_query(Table& out_table, JitRuntimeContext& context) co
 // We thus rely on the SFINAE pattern to provide a fallback implementation that throws an exception.
 // This is why this operation must be performed in a separate function.
 template <typename ColumnDataType>
-typename std::enable_if<std::is_arithmetic<ColumnDataType>::value, void>::type compute_averages(
+std::enable_if_t<std::is_arithmetic_v<ColumnDataType>, void> compute_averages(
     const std::vector<ColumnDataType>& sum_values, const std::vector<int64_t>& count_values,
     std::vector<double>& avg_values) {
   for (auto i = 0u; i < sum_values.size(); ++i) {
@@ -72,7 +72,7 @@ typename std::enable_if<std::is_arithmetic<ColumnDataType>::value, void>::type c
 
 // Fallback implementation for non-numeric data types to make the compiler happy (see above).
 template <typename ColumnDataType>
-typename std::enable_if<!std::is_arithmetic<ColumnDataType>::value, void>::type compute_averages(
+std::enable_if_t<!std::is_arithmetic_v<ColumnDataType>, void> compute_averages(
     const std::vector<ColumnDataType>& sum_values, const std::vector<int64_t>& count_values,
     std::vector<double>& avg_values) {
   Fail("Invalid aggregate");

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -255,7 +255,7 @@ std::shared_ptr<Partition<T>> materialize_input(const std::shared_ptr<const Tabl
             Instead, we use the index in the ReferenceSegment itself. This way we can later correctly dereference
             values from different inputs (important for Multi Joins).
             */
-            if constexpr (std::is_same<std::decay<decltype(typed_segment)>, ReferenceSegment>::value) {
+            if constexpr (std::is_same_v<std::decay<decltype(typed_segment)>, ReferenceSegment>) {
               *(output_iterator++) =
                   PartitionedElement<T>{RowID{chunk_id, reference_chunk_offset}, hashed_value, value.value()};
             } else {
@@ -267,7 +267,7 @@ std::shared_ptr<Partition<T>> materialize_input(const std::shared_ptr<const Tabl
             histogram[radix]++;
           }
           // reference_chunk_offset is only used for ReferenceSegments
-          if constexpr (std::is_same<std::decay<decltype(typed_segment)>, ReferenceSegment>::value) {
+          if constexpr (std::is_same_v<std::decay<decltype(typed_segment)>, ReferenceSegment>) {
             reference_chunk_offset++;
           }
         });

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -120,15 +120,13 @@ class RadixClusterSortNUMA {
 
   // Radix calculation for arithmetic types
   template <typename T2>
-  static typename std::enable_if<std::is_arithmetic<T2>::value, uint32_t>::type get_radix(T2 value,
-                                                                                          uint32_t radix_bitmask) {
+  static std::enable_if_t<std::is_arithmetic_v<T2>, uint32_t> get_radix(T2 value, uint32_t radix_bitmask) {
     return static_cast<uint32_t>(value) & radix_bitmask;
   }
 
   // Radix calculation for non-arithmetic types
   template <typename T2>
-  static typename std::enable_if<std::is_same<T2, std::string>::value, uint32_t>::type get_radix(
-      T2 value, uint32_t radix_bitmask) {
+  static std::enable_if_t<std::is_same_v<T2, std::string>, uint32_t> get_radix(T2 value, uint32_t radix_bitmask) {
     uint32_t radix;
     std::memcpy(&radix, value.c_str(), std::min(value.size(), sizeof(radix)));
     return radix & radix_bitmask;

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -120,15 +120,13 @@ class RadixClusterSort {
 
   // Radix calculation for arithmetic types
   template <typename T2>
-  static typename std::enable_if<std::is_arithmetic<T2>::value, uint32_t>::type get_radix(T2 value,
-                                                                                          uint32_t radix_bitmask) {
+  static std::enable_if_t<std::is_arithmetic_v<T2>, uint32_t> get_radix(T2 value, uint32_t radix_bitmask) {
     return static_cast<uint32_t>(value) & radix_bitmask;
   }
 
   // Radix calculation for non-arithmetic types
   template <typename T2>
-  static typename std::enable_if<std::is_same<T2, std::string>::value, uint32_t>::type get_radix(
-      T2 value, uint32_t radix_bitmask) {
+  static std::enable_if_t<std::is_same_v<T2, std::string>, uint32_t> get_radix(T2 value, uint32_t radix_bitmask) {
     uint32_t radix;
     std::memcpy(&radix, value.c_str(), std::min(value.size(), sizeof(radix)));
     return radix & radix_bitmask;

--- a/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_comparison_table_scan_impl.cpp
@@ -31,8 +31,8 @@ std::shared_ptr<PosList> ColumnComparisonTableScanImpl::scan_chunk(ChunkID chunk
 
   resolve_data_and_segment_type(*left_segment, [&](auto left_type, auto& typed_left_segment) {
     resolve_data_and_segment_type(*right_segment, [&](auto right_type, auto& typed_right_segment) {
-      using LeftSegmentType = typename std::decay<decltype(typed_left_segment)>::type;
-      using RightSegmentType = typename std::decay<decltype(typed_right_segment)>::type;
+      using LeftSegmentType = std::decay_t<decltype(typed_left_segment)>;
+      using RightSegmentType = std::decay_t<decltype(typed_right_segment)>;
 
       using LeftType = typename decltype(left_type)::type;
       using RightType = typename decltype(right_type)::type;

--- a/src/lib/resolve_type.hpp
+++ b/src/lib/resolve_type.hpp
@@ -190,11 +190,11 @@ void resolve_data_type(DataType data_type, const Functor& func) {
  *   });
  */
 template <typename In, typename Out>
-using ConstOutIfConstIn = std::conditional_t<std::is_const<In>::value, const Out, Out>;
+using ConstOutIfConstIn = std::conditional_t<std::is_const_v<In>, const Out, Out>;
 
 template <typename ColumnDataType, typename BaseSegmentType, typename Functor>
 // BaseSegmentType allows segment to be const and non-const
-std::enable_if_t<std::is_same<BaseSegment, std::remove_const_t<BaseSegmentType>>::value>
+std::enable_if_t<std::is_same_v<BaseSegment, std::remove_const_t<BaseSegmentType>>>
 /*void*/ resolve_segment_type(BaseSegmentType& segment, const Functor& func) {
   using ValueSegmentPtr = ConstOutIfConstIn<BaseSegmentType, ValueSegment<ColumnDataType>>*;
   using ReferenceSegmentPtr = ConstOutIfConstIn<BaseSegmentType, ReferenceSegment>*;
@@ -235,7 +235,7 @@ std::enable_if_t<std::is_same<BaseSegment, std::remove_const_t<BaseSegmentType>>
  *   });
  */
 template <typename Functor, typename BaseSegmentType>  // BaseSegmentType allows segment to be const and non-const
-std::enable_if_t<std::is_same<BaseSegment, std::remove_const_t<BaseSegmentType>>::value>
+std::enable_if_t<std::is_same_v<BaseSegment, std::remove_const_t<BaseSegmentType>>>
 /*void*/ resolve_data_and_segment_type(BaseSegmentType& segment, const Functor& func) {
   resolve_data_type(segment.data_type(), [&](auto type) {
     using ColumnDataType = typename decltype(type)::type;

--- a/src/lib/statistics/chunk_statistics/segment_statistics.cpp
+++ b/src/lib/statistics/chunk_statistics/segment_statistics.cpp
@@ -44,7 +44,7 @@ std::shared_ptr<SegmentStatistics> SegmentStatistics::build_statistics(
     DataType data_type, const std::shared_ptr<const BaseSegment>& segment) {
   std::shared_ptr<SegmentStatistics> statistics;
   resolve_data_and_segment_type(*segment, [&statistics](auto type, auto& typed_segment) {
-    using SegmentType = typename std::decay<decltype(typed_segment)>::type;
+    using SegmentType = std::decay_t<decltype(typed_segment)>;
     using DataTypeT = typename decltype(type)::type;
 
     // clang-format off

--- a/src/lib/storage/dictionary_segment/dictionary_segment_iterable.hpp
+++ b/src/lib/storage/dictionary_segment/dictionary_segment_iterable.hpp
@@ -79,7 +79,7 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
 
       if (is_null) return SegmentIteratorValue<T>{T{}, true, _chunk_offset};
 
-      if constexpr (std::is_same<Dictionary, FixedStringVector>::value) {
+      if constexpr (std::is_same_v<Dictionary, FixedStringVector>) {
         return SegmentIteratorValue<T>{_dictionary.get_string_at(value_id), false, _chunk_offset};
       } else {
         return SegmentIteratorValue<T>{_dictionary[value_id], false, _chunk_offset};
@@ -115,7 +115,7 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
 
       if (is_null) return SegmentIteratorValue<T>{T{}, true, chunk_offsets.into_referencing};
 
-      if constexpr (std::is_same<Dictionary, FixedStringVector>::value) {
+      if constexpr (std::is_same_v<Dictionary, FixedStringVector>) {
         return SegmentIteratorValue<T>{_dictionary.get_string_at(value_id), false, chunk_offsets.into_referencing};
       } else {
         return SegmentIteratorValue<T>{_dictionary[value_id], false, chunk_offsets.into_referencing};

--- a/src/lib/storage/index/group_key/variable_length_key_base.cpp
+++ b/src/lib/storage/index/group_key/variable_length_key_base.cpp
@@ -28,7 +28,7 @@ VariableLengthKeyBase::VariableLengthKeyBase(VariableLengthKeyWord* data, Compos
     : _data(data), _size(size) {}
 
 VariableLengthKeyBase& VariableLengthKeyBase::operator|=(uint64_t other) {
-  static_assert(std::is_same<VariableLengthKeyWord, uint8_t>::value, "Changes for new word type required.");
+  static_assert(std::is_same_v<VariableLengthKeyWord, uint8_t>, "Changes for new word type required.");
   auto raw_other = reinterpret_cast<VariableLengthKeyWord*>(&other);
   auto operation_width = std::min(static_cast<CompositeKeyLength>(sizeof(other)), _size);
   for (CompositeKeyLength i = 0; i < operation_width; ++i) {
@@ -42,7 +42,7 @@ VariableLengthKeyBase& VariableLengthKeyBase::operator|=(uint64_t other) {
 }
 
 VariableLengthKeyBase& VariableLengthKeyBase::operator<<=(CompositeKeyLength shift) {
-  static_assert(std::is_same<VariableLengthKeyWord, uint8_t>::value, "Changes for new word type required.");
+  static_assert(std::is_same_v<VariableLengthKeyWord, uint8_t>, "Changes for new word type required.");
   const auto byte_shift = shift / CHAR_BIT;
   const auto bit_shift = shift % CHAR_BIT;
   if (byte_shift >= _size) {
@@ -89,7 +89,7 @@ bool operator==(const VariableLengthKeyBase& left, const VariableLengthKeyBase& 
 bool operator!=(const VariableLengthKeyBase& left, const VariableLengthKeyBase& right) { return !(left == right); }
 
 bool operator<(const VariableLengthKeyBase& left, const VariableLengthKeyBase& right) {
-  static_assert(std::is_same<VariableLengthKeyWord, uint8_t>::value, "Changes for new word type required.");
+  static_assert(std::is_same_v<VariableLengthKeyWord, uint8_t>, "Changes for new word type required.");
   if (left._size != right._size) return left._size < right._size;
 
   if constexpr (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) {

--- a/src/lib/storage/index/group_key/variable_length_key_store.hpp
+++ b/src/lib/storage/index/group_key/variable_length_key_store.hpp
@@ -123,8 +123,7 @@ class VariableLengthKeyStore {
      * Creates new instance copying the other iterator iff the other proxy type is convertible into the own type.
      * This is required since a mutable constructor can be used every time when a const iterator is expected.
      */
-    template <typename OtherProxy,
-              typename = typename std::enable_if<std::is_convertible<OtherProxy, Proxy>::value>::type>
+    template <typename OtherProxy, typename = std::enable_if_t<std::is_convertible_v<OtherProxy, Proxy>>>
     IteratorBase(const IteratorBase<OtherProxy>& other)  // NOLINT(runtime/explicit)
         : _bytes_per_key(other._bytes_per_key), _key_alignment(other._key_alignment), _data(other._data) {}
 

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -43,10 +43,10 @@
   template <>                                                                                                     \
                                                                                                                   \
   struct numeric_limits<::opossum::D> {                                                                           \
-    static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> min() {                          \
+    static typename std::enable_if_t<std::is_arithmetic_v<T>, ::opossum::D> min() {                               \
       return ::opossum::D(numeric_limits<T>::min());                                                              \
     }                                                                                                             \
-    static typename std::enable_if_t<std::is_arithmetic<T>::value, ::opossum::D> max() {                          \
+    static typename std::enable_if_t<std::is_arithmetic_v<T>, ::opossum::D> max() {                               \
       return ::opossum::D(numeric_limits<T>::max());                                                              \
     }                                                                                                             \
   };                                                                                                              \

--- a/src/lib/type_comparison.hpp
+++ b/src/lib/type_comparison.hpp
@@ -13,85 +13,79 @@ namespace opossum {
 // source: http://stackoverflow.com/questions/16893992/check-if-type-can-be-explicitly-converted
 template <class From, class To>
 struct is_explicitly_convertible {
-  enum { value = std::is_constructible<To, From>::value && !std::is_convertible<From, To>::value };
+  enum { value = std::is_constructible_v<To, From> && !std::is_convertible_v<From, To> };
 };
 
 // source: http://stackoverflow.com/questions/27709461/check-if-type-can-be-an-argument-to-boostlexical-caststring
 template <typename T, typename = void>
-struct IsLexCastable : std::false_type {};
+struct is_lex_castable : std::false_type {};
 
 template <typename T>
-struct IsLexCastable<T, decltype(void(std::declval<std::ostream&>() << std::declval<T>()))> : std::true_type {};
+struct is_lex_castable<T, decltype(void(std::declval<std::ostream&>() << std::declval<T>()))> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_lex_castable_v = is_lex_castable<T>::value;
 
 /* EQUAL */
 // L and R are implicitly convertible
 template <typename L, typename R>
-typename std::enable_if<std::is_convertible<L, R>::value && std::is_convertible<R, L>::value, bool>::type value_equal(
-    L l, R r) {
+std::enable_if_t<std::is_convertible_v<L, R> && std::is_convertible_v<R, L>, bool> value_equal(L l, R r) {
   return l == r;
 }
 
 // L is arithmetic, R is explicitly convertible to L
 template <typename L, typename R>
-typename std::enable_if<std::is_arithmetic<L>::value && IsLexCastable<R>::value && !std::is_arithmetic<R>::value,
-                        bool>::type
-value_equal(L l, R r) {
+std::enable_if_t<std::is_arithmetic_v<L> && is_lex_castable_v<R> && !std::is_arithmetic_v<R>, bool> value_equal(L l,
+                                                                                                                R r) {
   return boost::lexical_cast<L>(r) == l;
 }
 
 // R is arithmetic, L is explicitly convertible to R
 template <typename L, typename R>
-typename std::enable_if<std::is_arithmetic<R>::value && IsLexCastable<L>::value && !std::is_arithmetic<L>::value,
-                        bool>::type
-value_equal(L l, R r) {
+std::enable_if_t<std::is_arithmetic_v<R> && is_lex_castable_v<L> && !std::is_arithmetic_v<L>, bool> value_equal(L l,
+                                                                                                                R r) {
   return boost::lexical_cast<R>(l) == r;
 }
 
 /* SMALLER */
 // L and R are implicitly convertible
 template <typename L, typename R>
-typename std::enable_if<std::is_convertible<L, R>::value && std::is_convertible<R, L>::value, bool>::type value_smaller(
-    L l, R r) {
+std::enable_if_t<std::is_convertible_v<L, R> && std::is_convertible_v<R, L>, bool> value_smaller(L l, R r) {
   return l < r;
 }
 
 // L is arithmetic, R is explicitly convertible to L
 template <typename L, typename R>
-typename std::enable_if<std::is_arithmetic<L>::value && IsLexCastable<R>::value && !std::is_arithmetic<R>::value,
-                        bool>::type
-value_smaller(L l, R r) {
+std::enable_if_t<std::is_arithmetic_v<L> && is_lex_castable_v<R> && !std::is_arithmetic_v<R>, bool> value_smaller(L l,
+                                                                                                                  R r) {
   return boost::lexical_cast<L>(r) < l;
 }
 
 // R is arithmetic, L is explicitly convertible to R
 template <typename L, typename R>
-typename std::enable_if<std::is_arithmetic<R>::value && IsLexCastable<L>::value && !std::is_arithmetic<L>::value,
-                        bool>::type
-value_smaller(L l, R r) {
+std::enable_if_t<std::is_arithmetic_v<R> && is_lex_castable_v<L> && !std::is_arithmetic_v<L>, bool> value_smaller(L l,
+                                                                                                                  R r) {
   return boost::lexical_cast<R>(l) < r;
 }
 
 /* GREATER > */
 // L and R are implicitly convertible
 template <typename L, typename R>
-typename std::enable_if<std::is_convertible<L, R>::value && std::is_convertible<R, L>::value, bool>::type value_greater(
-    L l, R r) {
+std::enable_if_t<std::is_convertible_v<L, R> && std::is_convertible_v<R, L>, bool> value_greater(L l, R r) {
   return l > r;
 }
 
 // L is arithmetic, R is explicitly convertible to L
 template <typename L, typename R>
-typename std::enable_if<std::is_arithmetic<L>::value && IsLexCastable<R>::value && !std::is_arithmetic<R>::value,
-                        bool>::type
-value_greater(L l, R r) {
+std::enable_if_t<std::is_arithmetic_v<L> && is_lex_castable_v<R> && !std::is_arithmetic_v<R>, bool> value_greater(L l,
+                                                                                                                  R r) {
   return boost::lexical_cast<L>(r) > l;
 }
 
 // R is arithmetic, L is explicitly convertible to R
 template <typename L, typename R>
-typename std::enable_if<std::is_arithmetic<R>::value && IsLexCastable<L>::value && !std::is_arithmetic<L>::value,
-                        bool>::type
-value_greater(L l, R r) {
+std::enable_if_t<std::is_arithmetic_v<R> && is_lex_castable_v<L> && !std::is_arithmetic_v<L>, bool> value_greater(L l,
+                                                                                                                  R r) {
   return boost::lexical_cast<R>(l) > r;
 }
 

--- a/src/lib/utils/copyable_atomic.hpp
+++ b/src/lib/utils/copyable_atomic.hpp
@@ -23,7 +23,7 @@ namespace opossum {
  */
 template <typename T>
 class copyable_atomic {
-  static_assert(std::is_trivially_copyable<T>::value, "T must be trivially copyable.");
+  static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable.");
 
  public:
   copyable_atomic() noexcept = default;

--- a/src/lib/utils/enum_constant.hpp
+++ b/src/lib/utils/enum_constant.hpp
@@ -49,13 +49,16 @@ template <typename EnumType, EnumType enum_value>
 [[maybe_unused]] constexpr auto enum_c = enum_constant<EnumType, enum_value>{};
 
 /**
- * Definition of our own hana concept “EnumConstant”
+ * Definition of our own hana concept “is_enum_constant”
  */
 template <typename T>
-struct EnumConstant : std::false_type {};
+struct is_enum_constant : std::false_type {};
 
 template <typename EnumType>
-struct EnumConstant<enum_constant_tag<EnumType>> : std::true_type {};
+struct is_enum_constant<enum_constant_tag<EnumType>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_enum_constant_v = is_enum_constant<T>::value;
 
 /**@}*/
 
@@ -67,7 +70,7 @@ namespace boost::hana {
  * Implementation of hana::value in order to meet requirements for concept “Constant”
  */
 template <typename E>
-struct value_impl<E, when<opossum::EnumConstant<E>::value>> {
+struct value_impl<E, when<opossum::is_enum_constant_v<E>>> {
   template <typename C>
   static constexpr auto apply() {
     return C::value;
@@ -78,7 +81,7 @@ struct value_impl<E, when<opossum::EnumConstant<E>::value>> {
  * Implementation of hana::hash in order to meet requirements for concept “Hashable”
  */
 template <typename E>
-struct hash_impl<E, when<opossum::EnumConstant<E>::value>> {
+struct hash_impl<E, when<opossum::is_enum_constant_v<E>>> {
   template <typename X>
   static constexpr auto apply(const X& x) {
     return type_c<opossum::enum_constant<decltype(X::value), X::value>>;

--- a/src/lib/utils/murmur_hash.hpp
+++ b/src/lib/utils/murmur_hash.hpp
@@ -9,13 +9,13 @@ unsigned int murmur_hash2(const void* key, unsigned int len, unsigned int seed);
 
 // murmur hash for builtin number types (int, double)
 template <typename T>
-typename std::enable_if<std::is_arithmetic<T>::value, unsigned int>::type murmur2(T key, unsigned int seed) {
+std::enable_if_t<std::is_arithmetic_v<T>, unsigned int> murmur2(T key, unsigned int seed) {
   return murmur_hash2(&key, sizeof(T), seed);
 }
 
 // murmur hash for std::string
 template <typename T>
-typename std::enable_if<std::is_same<T, std::string>::value, unsigned int>::type murmur2(T key, unsigned int seed) {
+std::enable_if_t<std::is_same_v<T, std::string>, unsigned int> murmur2(T key, unsigned int seed) {
   return murmur_hash2(key.c_str(), key.size(), seed);
 }
 

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -27,8 +27,8 @@ class Table;
 extern std::string test_data_path;
 
 template <typename ParamType>
-class BaseTestWithParam : public std::conditional<std::is_same<ParamType, void>::value, ::testing::Test,
-                                                  ::testing::TestWithParam<ParamType>>::type {
+class BaseTestWithParam
+    : public std::conditional_t<std::is_same_v<ParamType, void>, ::testing::Test, ::testing::TestWithParam<ParamType>> {
  protected:
   // creates a dictionary segment with the given type and values
   template <typename T>

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -49,7 +49,7 @@ TYPED_TEST(JoinEquiTest, LeftJoin) {
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinIntFloat) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value || std::is_same<TypeParam, JoinMPSM>::value) {
+  if constexpr (std::is_same_v<TypeParam, JoinSortMerge> || std::is_same_v<TypeParam, JoinMPSM>) {
     return;
   }
 
@@ -65,7 +65,7 @@ TYPED_TEST(JoinEquiTest, InnerJoinIntFloat) {
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinIntFloatRadixBit) {
-  if (std::is_same<TypeParam, JoinHash>::value) {
+  if constexpr (std::is_same_v<TypeParam, JoinHash>) {
     // float with int
     // radix bits = 1
     std::shared_ptr<Table> expected_result = load_table("src/test/tables/joinoperators/float_int_inner.tbl", 1);
@@ -78,7 +78,7 @@ TYPED_TEST(JoinEquiTest, InnerJoinIntFloatRadixBit) {
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinIntDouble) {
-  if (std::is_same<TypeParam, JoinSortMerge>::value || std::is_same<TypeParam, JoinMPSM>::value) {
+  if constexpr (std::is_same_v<TypeParam, JoinSortMerge> || std::is_same_v<TypeParam, JoinMPSM>) {
     return;
   }
 
@@ -94,7 +94,7 @@ TYPED_TEST(JoinEquiTest, InnerJoinIntDouble) {
 }
 
 TYPED_TEST(JoinEquiTest, InnerJoinIntString) {
-  if (!std::is_same<TypeParam, JoinHash>::value) {
+  if constexpr (!std::is_same_v<TypeParam, JoinHash>) {
     return;
   }
 
@@ -116,7 +116,7 @@ TYPED_TEST(JoinEquiTest, RightJoin) {
 }
 
 TYPED_TEST(JoinEquiTest, OuterJoin) {
-  if (std::is_same<TypeParam, JoinHash>::value) {
+  if constexpr (std::is_same_v<TypeParam, JoinHash>) {
     return;
   }
   this->template test_join_output<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b,

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -60,11 +60,13 @@ class RangeFilterTest : public ::testing::Test {
       auto end = begin + length;
       EXPECT_FALSE(filter->can_prune({begin}, PredicateCondition::Equals));
       EXPECT_FALSE(filter->can_prune({end}, PredicateCondition::Equals));
-      if (std::numeric_limits<T>::is_iec559) {
+      if constexpr (std::numeric_limits<T>::is_iec559) {
         auto value_in_gap = begin + 0.5 * length;
         EXPECT_TRUE(filter->can_prune({value_in_gap}, PredicateCondition::Equals));
-      } else if (std::is_integral<T>::value && length > 1) {
-        EXPECT_TRUE(filter->can_prune({++begin}, PredicateCondition::Equals));
+      } else if constexpr (std::is_integral_v<T>) {
+        if (length > 1) {
+          EXPECT_TRUE(filter->can_prune({++begin}, PredicateCondition::Equals));
+        }
       }
     }
 

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -63,7 +63,7 @@ class RangeFilterTest : public ::testing::Test {
       if constexpr (std::numeric_limits<T>::is_iec559) {
         auto value_in_gap = begin + 0.5 * length;
         EXPECT_TRUE(filter->can_prune({value_in_gap}, PredicateCondition::Equals));
-      } else if constexpr (std::is_integral_v<T>) {
+      } else if constexpr (std::is_integral_v<T>) {  // NOLINT
         if (length > 1) {
           EXPECT_TRUE(filter->can_prune({++begin}, PredicateCondition::Equals));
         }


### PR DESCRIPTION
I was annoyed by our inconsistent use of various template helpers such as `std::enable_if` and `std::enable_if_t`.
So I set out to unify it, which worked in all but [one case](https://github.com/hyrise/hyrise/blob/master/src/lib/expression/evaluation/expression_evaluator.cpp#L825):

```c++
if constexpr (Functor::template supports<Result, LeftDataType, RightDataType>::value) {
...
}
```

I tried changing it to 

```c++
if constexpr (Functor::template supports_v<Result, LeftDataType, RightDataType>) {
...
}
```

after adding 

```c++
template <typename Result, typename ArgA, typename ArgB>
inline static constexpr bool supports_v = supports<Result, ArgA, ArgB>::value;
```

to all the structs defined in [expression_functors.hpp](https://github.com/hyrise/hyrise/blob/master/src/lib/expression/evaluation/expression_functors.hpp), but that does not compile.
Maybe any of the template wizards have an idea why and cannot wait to teach me?