### PR TITLE
macOS 10.14 and cmake 3.12.2 boost linkage problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ find_package(Readline REQUIRED)
 find_package(Curses REQUIRED)
 find_package(Sqlite3 REQUIRED)
 find_package(PQ REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(Boost REQUIRED COMPONENTS container system thread)
 
 add_definitions(-DBOOST_THREAD_VERSION=5)
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -529,7 +529,7 @@ set(
     LIBRARIES
     pthread
     sqlparser
-    boost_container
+    ${Boost_CONTAINER_LIBRARY}
     ${TBB_LIBRARY}
 )
 


### PR DESCRIPTION
There seems to be a problem with linking the boost container library after the update to macOS 10.14 and new cmake versions. If this passes FullCI, somebody should check it locally on a Mac with macOS 10.13 to avoid further fun.