### PR TITLE
-Walmost-everything (collaborative PR)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,13 +62,12 @@ add_definitions("-DSOURCE_PATH_SIZE=${SOURCE_PATH_SIZE}")
 # Global flags and include directories
 # When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
 # Hence, the `-Wno-dollar-in-identifier-extension` flag is required.
-add_compile_options(-std=c++17 -pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension)
+add_compile_options(-std=c++17 -pthread -Wall -Wextra -Wshadow-all -pedantic -Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-shadow-field-in-constructor -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default)
 
 include_directories(
     ${PROJECT_SOURCE_DIR}/third_party/benchmark/include
     ${PROJECT_SOURCE_DIR}/third_party/googletest/googletest/include
     ${PROJECT_SOURCE_DIR}/third_party/cxxopts/include
-    ${PROJECT_SOURCE_DIR}/third_party/json
     ${PROJECT_SOURCE_DIR}/third_party/sql-parser/src
     ${PROJECT_SOURCE_DIR}/third_party/cpp-btree
 
@@ -78,6 +77,12 @@ include_directories(
 
     ${TBB_INCLUDE_DIR}
     ${Boost_INCLUDE_DIRS}
+)
+
+# Include JSON as system library to silence some warnings
+include_directories(
+    SYSTEM
+    ${PROJECT_SOURCE_DIR}/third_party/json
 )
 
 if (${ENABLE_JIT_SUPPORT})

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -585,7 +585,8 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator_wrapper.hpp
         ${SOURCES}
         ${JIT_EMBEDDED_SOURCES}
-        ${LLVM_BUNDLE_FILE})
+        ${LLVM_BUNDLE_FILE}
+    )
     # Prevent clang from complaining about unused defines when compiling the assembly file
     set_property(SOURCE ${LLVM_BUNDLE_FILE} PROPERTY COMPILE_FLAGS -Qunused-arguments)
     set(LIBRARIES ${LIBRARIES} ${LLVM_LIBRARY})
@@ -614,3 +615,9 @@ target_include_directories(hyrise PUBLIC ${CMAKE_BINARY_DIR})
 
 # -fPIC generates position independent code which is necessary because plugins might access hyrise functions.
 target_compile_options(hyrise PRIVATE -fPIC)
+
+if (${ENABLE_JIT_SUPPORT})
+    # LLVM does not build with -Wshadow-all,-Werror. Overwrite the LLVM include so it is treated as a system library.
+    # This silences some compiler warnings (uses -isystem instead of -I).
+    target_include_directories(hyrise SYSTEM PUBLIC "/usr/local/opt/llvm/include")
+endif()

--- a/src/lib/operators/jit_operator/specialization/jit_code_specializer.hpp
+++ b/src/lib/operators/jit_operator/specialization/jit_code_specializer.hpp
@@ -18,6 +18,7 @@ namespace opossum {
  */
 class JitRTTIHelper {
  private:
+  virtual ~JitRTTIHelper() = default;
   virtual void _() const {}
 };
 

--- a/src/lib/operators/jit_operator/specialization/jit_compiler.cpp
+++ b/src/lib/operators/jit_operator/specialization/jit_compiler.cpp
@@ -27,10 +27,10 @@ JitCompiler::ModuleHandle JitCompiler::add_module(const std::shared_ptr<llvm::Mo
       [&](const std::string& name) -> llvm::JITSymbol {
         // We first try to locate symbols in the modules added to the JIT, then in runtime overrides and finally in
         // the running process.
-        if (auto symbol = _compile_layer.findSymbol(name, true)) {
-          return symbol;
-        } else if (auto symbol = _cxx_runtime_overrides.searchOverrides(name)) {
-          return symbol;
+        if (auto compile_layer_symbol = _compile_layer.findSymbol(name, true)) {
+          return compile_layer_symbol;
+        } else if (auto runtime_override_symbol = _cxx_runtime_overrides.searchOverrides(name)) {
+          return runtime_override_symbol;
         } else {
           return llvm::JITSymbol(llvm::RTDyldMemoryManager::getSymbolAddressInProcess(name),
                                  llvm::JITSymbolFlags::Exported);

--- a/src/lib/operators/jit_operator/specialization/llvm/CloneFunction.cpp
+++ b/src/lib/operators/jit_operator/specialization/llvm/CloneFunction.cpp
@@ -40,6 +40,10 @@
 #include <map>
 using namespace llvm;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow-all"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+
 /// See comments in Cloning.h.
 BasicBlock *llvm::CloneBasicBlock(const BasicBlock *BB, ValueToValueMapTy &VMap,
                                   const Twine &NameSuffix, Function *F,

--- a/src/lib/operators/jit_operator/specialization/llvm/InlineFunction.cpp
+++ b/src/lib/operators/jit_operator/specialization/llvm/InlineFunction.cpp
@@ -78,6 +78,13 @@
 
 using namespace llvm;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow-all"
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+#pragma clang diagnostic ignored "-Wdocumentation-unknown-command"
+#pragma clang diagnostic ignored "-Wrange-loop-analysis"
+#pragma clang diagnostic ignored "-Wold-style-cast"
+
 static cl::opt<bool>
 EnableNoAliasConversion("opossum-enable-noalias-to-md-conversion", cl::init(true),
   cl::Hidden,

--- a/src/lib/operators/jit_operator/specialization/llvm_extensions.cpp
+++ b/src/lib/operators/jit_operator/specialization/llvm_extensions.cpp
@@ -7,6 +7,10 @@
 
 #include "jit_runtime_pointer.hpp"
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow-all"
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+
 namespace opossum {
 
 const std::shared_ptr<const JitRuntimePointer>& GetRuntimePointerForValue(const llvm::Value* value,  // NOLINT

--- a/src/lib/storage/segment_iterables/segment_iterator_values.hpp
+++ b/src/lib/storage/segment_iterables/segment_iterator_values.hpp
@@ -26,6 +26,7 @@ class AbstractSegmentIteratorValue {
  public:
   virtual const T& value() const = 0;
   virtual bool is_null() const = 0;
+  virtual ~AbstractSegmentIteratorValue() = default;
 
   /**
    * @brief Returns the chunk offset of the current value.

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
@@ -93,7 +93,7 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
 
   uint32_t _get_within_cached_meta_block(size_t index) {
     const auto block_index = _index_relative_to_cached_meta_block(index) / Packing::block_size;
-    _unpack_block(block_index);
+    _unpack_block(static_cast<uint8_t>(block_index));
 
     return (*_cached_block)[_index_within_cached_block(index)];
   }

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -100,7 +100,7 @@ struct RowID {
 
   RowID() = default;
 
-  RowID(const ChunkID chunk_id, const ChunkOffset chunk_offset) : chunk_id(chunk_id), chunk_offset(chunk_offset) {
+  RowID(const ChunkID id, const ChunkOffset chunk_offset) : chunk_id(id), chunk_offset(chunk_offset) {
     DebugAssert((chunk_offset == INVALID_CHUNK_OFFSET) == (chunk_id == INVALID_CHUNK_ID),
                 "If you pass in one of the arguments as INVALID/NULL, the other has to be INVALID/NULL as well. This "
                 "makes sure there is just one value representing an invalid row id.");

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -39,9 +39,9 @@
  *     invalid input might want to be caught.
  */
 
-// __FILENAME__ is __FILE__ with irrelevant leading chars trimmed
-#ifndef __FILENAME__
-#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+// TRIMMED_FILENAME is __FILE__ with irrelevant leading chars trimmed
+#ifndef TRIMMED_FILENAME
+#define TRIMMED_FILENAME (__FILE__ + SOURCE_PATH_SIZE)
 #endif
 
 namespace opossum {
@@ -54,9 +54,9 @@ namespace opossum {
 
 }  // namespace opossum
 
-#define Assert(expr, msg)                                                                  \
-  if (!static_cast<bool>(expr)) {                                                          \
-    opossum::Fail(std::string(__FILENAME__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
+#define Assert(expr, msg)                                                                      \
+  if (!static_cast<bool>(expr)) {                                                              \
+    opossum::Fail(std::string(TRIMMED_FILENAME) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
   }
 
 #define AssertInput(expr, msg)                                               \

--- a/src/lib/utils/performance_warning.hpp
+++ b/src/lib/utils/performance_warning.hpp
@@ -57,13 +57,13 @@ class PerformanceWarningDisabler {
   }
 };
 
-#ifndef __FILENAME__
-#define __FILENAME__ (__FILE__ + SOURCE_PATH_SIZE)
+#ifndef TRIMMED_FILENAME
+#define TRIMMED_FILENAME (__FILE__ + SOURCE_PATH_SIZE)
 #endif
-#define PerformanceWarning(text)                                                                 \
-  {                                                                                              \
-    static PerformanceWarningClass warn(std::string(text) + " at " + std::string(__FILENAME__) + \
-                                        ":" BOOST_PP_STRINGIZE(__LINE__));                       \
+#define PerformanceWarning(text)                                                                     \
+  {                                                                                                  \
+    static PerformanceWarningClass warn(std::string(text) + " at " + std::string(TRIMMED_FILENAME) + \
+                                        ":" BOOST_PP_STRINGIZE(__LINE__));                           \
   }  // NOLINT
 
 }  // namespace opossum


### PR DESCRIPTION
We have some warnings that are not yet enabled and that could have prevented #1130. There, it was `-Wshadow-all`, but others could be helpful as well.

Some of the additional warnings of `-Weverything` are good for our code quality:

```
/Users/Markus/Projekte/Opossum/Git/src/lib/operators/table_scan.hpp:25:3: error: '~TableScan' overrides a destructor but is not marked
      'override' [-Werror,-Winconsistent-missing-destructor-override]
  ~TableScan();
```

```
/Users/Markus/Projekte/Opossum/Git/src/lib/storage/segment_iterables/segment_iterator_values.hpp:22:7: error:
      'opossum::AbstractSegmentIteratorValue<boost::blank>' has virtual functions but non-virtual destructor
      [-Werror,-Wnon-virtual-dtor]
class AbstractSegmentIteratorValue {
```

```
/Users/Markus/Projekte/Opossum/Git/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp:29:13: error: declaration shadows a
      type alias in namespace 'opossum' [-Werror,-Wshadow]
      using DataType = typename decltype(type)::type;
```

Others are not as helpful:
```
/Users/Markus/Projekte/Opossum/Git/src/lib/utils/enum_constant.hpp:61:23: error: no previous extern declaration for non-static variable
      'is_enum_constant_v' [-Werror,-Wmissing-variable-declarations]
inline constexpr bool is_enum_constant_v = is_enum_constant<T>::value;
```

We should take the time to fix the issues or disable warnings where we are sure that we don't need them. If you have a few minutes to spare between things, please use them to fix a couple of these issues.