### PR TITLE
TPC-H Q1 date selection: filter on shipdate

### DIFF
--- a/src/benchmarklib/tpch/tpch_queries.cpp
+++ b/src/benchmarklib/tpch/tpch_queries.cpp
@@ -38,7 +38,7 @@ const char* const tpch_query_1 =
       SUM(l_extendedprice*(1-l_discount)*(1+l_tax)) as sum_charge, AVG(l_quantity) as avg_qty,
       AVG(l_extendedprice) as avg_price, AVG(l_discount) as avg_disc, COUNT(*) as count_order
       FROM lineitem
-      WHERE l_shipdate <= '1998-12-01'
+      WHERE l_shipdate <= '1998-09-02'
       GROUP BY l_returnflag, l_linestatus
       ORDER BY l_returnflag, l_linestatus;)";
 


### PR DESCRIPTION
As of now in TPC-H Q1, we select all dates before-equals the max shipdate generated by the tpch datagen: `      WHERE l_shipdate <= '1998-12-01'`
This means we have a filter that does not filter out any rows: 
![screen shot 2018-10-01 at 15 48 50](https://user-images.githubusercontent.com/1745857/46293059-b1948d80-c592-11e8-8ff0-211b7e6be728.png)


The TPC-H specification uses this selection: `l_shipdate <= date '1998-12-01' - interval '[DELTA]' day (3)`
where DELTA is `is randomly selected within [60. 120].` (source: TPC-H spec 2.4.1.3)

The PR changes the selection value as if we would choose an interval of 90 days. This is similar to what HyPer did for their last VLDB paper.

The performance impact is neglectable since the filter returns now 5912 instead of 6004 rows on a scale factor of 0.001 (should scale linearly with larger scale factors). According to the specification, the 90 days interval should return 96% of the tuples.