### PR TITLE
Support BETWEEN in table scan

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -215,6 +215,8 @@ set(
     operators/table_scan/base_single_column_table_scan_impl.cpp
     operators/table_scan/base_single_column_table_scan_impl.hpp
     operators/table_scan/base_table_scan_impl.hpp
+    operators/table_scan/between_table_scan_impl.cpp
+    operators/table_scan/between_table_scan_impl.hpp
     operators/table_scan/column_comparison_table_scan_impl.cpp
     operators/table_scan/column_comparison_table_scan_impl.hpp
     operators/table_scan/is_null_table_scan_impl.cpp
@@ -372,6 +374,7 @@ set(
     storage/dictionary_segment/attribute_vector_iterable.hpp
     storage/dictionary_segment/dictionary_encoder.hpp
     storage/dictionary_segment/dictionary_segment_iterable.hpp
+    storage/encoding_type.cpp
     storage/encoding_type.hpp
     storage/fixed_string_dictionary_segment.cpp
     storage/fixed_string_dictionary_segment.hpp

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -169,8 +169,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_ta
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_index_scan(
     const std::shared_ptr<PredicateNode>& node, const std::shared_ptr<AbstractOperator>& input_operator) const {
   /**
-   * Not using OperatorScanPredicate, since the IndexScan still wants to do BETWEEN in one step and splitting it up
-   * in two doesn't work as you can only do a single IndexScan per Table.
+   * Not using OperatorScanPredicate, since it splits up BETWEEN into two scans for some cases that TableScan cannot handle
    */
 
   auto column_id = ColumnID{0};

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -47,8 +47,9 @@ std::shared_ptr<TableStatistics> PredicateNode::derive_statistics_from(
   auto output_statistics = left_input->get_statistics();
 
   for (const auto& operator_predicate : *operator_predicates) {
-    output_statistics = std::make_shared<TableStatistics>(output_statistics->estimate_predicate(
-        operator_predicate.column_id, operator_predicate.predicate_condition, operator_predicate.value));
+    output_statistics = std::make_shared<TableStatistics>(
+        output_statistics->estimate_predicate(operator_predicate.column_id, operator_predicate.predicate_condition,
+                                              operator_predicate.value, operator_predicate.value2));
   }
 
   return output_statistics;

--- a/src/lib/operators/operator_scan_predicate.cpp
+++ b/src/lib/operators/operator_scan_predicate.cpp
@@ -7,6 +7,7 @@
 #include "expression/value_expression.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "utils/assert.hpp"
+#include "utils/performance_warning.hpp"
 
 namespace {
 
@@ -47,6 +48,11 @@ std::string OperatorScanPredicate::to_string(const std::shared_ptr<const Table>&
 
   std::stringstream stream;
   stream << column_name_left << " " << predicate_condition_to_string.left.at(predicate_condition) << " " << right;
+
+  if (predicate_condition == PredicateCondition::Between) {
+    stream << " AND " << *value2;
+  }
+
   return stream.str();
 }
 
@@ -58,23 +64,6 @@ std::optional<std::vector<OperatorScanPredicate>> OperatorScanPredicate::from_ex
   Assert(!predicate->arguments.empty(), "Expect PredicateExpression to have one or more arguments");
 
   auto predicate_condition = predicate->predicate_condition;
-
-  // Split up the redundant abomination that is BETWEEN into two expressions
-  if (predicate_condition == PredicateCondition::Between) {
-    Assert(predicate->arguments.size() == 3, "Expect ternary PredicateExpression to have three arguments");
-
-    auto lower_bound_predicates =
-        from_expression(*greater_than_equals_(predicate->arguments[0], predicate->arguments[1]), node);
-    auto upper_bound_predicates =
-        from_expression(*less_than_equals_(predicate->arguments[0], predicate->arguments[2]), node);
-
-    if (!lower_bound_predicates || !upper_bound_predicates) return std::nullopt;
-
-    auto predicates = *lower_bound_predicates;
-    predicates.insert(predicates.end(), upper_bound_predicates->begin(), upper_bound_predicates->end());
-
-    return predicates;
-  }
 
   auto argument_a = resolve_all_parameter_variant(*predicate->arguments[0], node);
   if (!argument_a) return std::nullopt;
@@ -93,6 +82,41 @@ std::optional<std::vector<OperatorScanPredicate>> OperatorScanPredicate::from_ex
   auto argument_b = resolve_all_parameter_variant(*expression.arguments[1], node);
   if (!argument_b) return std::nullopt;
 
+  // We can handle x BETWEEN a AND b if a and b are scalar values of the same data type. Otherwise, the condition gets
+  // translated into two columns. Theoretically, we could also implement all variations where x, a and b are
+  // non-scalar and of varying types, but as these are used less frequently, would require more code, and increase
+  // compile time, we don't do that for now.
+  if (predicate_condition == PredicateCondition::Between) {
+    Assert(predicate->arguments.size() == 3, "Expect ternary PredicateExpression to have three arguments");
+
+    auto argument_c = resolve_all_parameter_variant(*expression.arguments[2], node);
+    if (!argument_c) return std::nullopt;
+
+    if (is_column_id(*argument_a) && is_variant(*argument_b) && is_variant(*argument_c) &&
+        predicate->arguments[1]->data_type() == predicate->arguments[2]->data_type() &&
+        !variant_is_null(boost::get<AllTypeVariant>(*argument_b)) &&
+        !variant_is_null(boost::get<AllTypeVariant>(*argument_c))) {
+      // This is the BETWEEN case that we can handle
+      return std::vector<OperatorScanPredicate>{
+          OperatorScanPredicate{boost::get<ColumnID>(*argument_a), predicate_condition, *argument_b, *argument_c}};
+    }
+
+    PerformanceWarning("BETWEEN handled as two table scans because no BETWEEN specialization was available");
+
+    // We can't handle the case, so we translate it into two predicates
+    auto lower_bound_predicates =
+        from_expression(*greater_than_equals_(predicate->arguments[0], predicate->arguments[1]), node);
+    auto upper_bound_predicates =
+        from_expression(*less_than_equals_(predicate->arguments[0], predicate->arguments[2]), node);
+
+    if (!lower_bound_predicates || !upper_bound_predicates) return std::nullopt;
+
+    auto predicates = *lower_bound_predicates;
+    predicates.insert(predicates.end(), upper_bound_predicates->begin(), upper_bound_predicates->end());
+
+    return predicates;
+  }
+
   if (!is_column_id(*argument_a) && is_column_id(*argument_b)) {
     std::swap(argument_a, argument_b);
     predicate_condition = flip_predicate_condition(predicate_condition);
@@ -103,7 +127,8 @@ std::optional<std::vector<OperatorScanPredicate>> OperatorScanPredicate::from_ex
 }
 
 OperatorScanPredicate::OperatorScanPredicate(const ColumnID column_id, const PredicateCondition predicate_condition,
-                                             const AllParameterVariant& value)
-    : column_id(column_id), predicate_condition(predicate_condition), value(value) {}
+                                             const AllParameterVariant& value,
+                                             const std::optional<AllParameterVariant>& value2)
+    : column_id(column_id), predicate_condition(predicate_condition), value(value), value2(value2) {}
 
 }  // namespace opossum

--- a/src/lib/operators/operator_scan_predicate.hpp
+++ b/src/lib/operators/operator_scan_predicate.hpp
@@ -26,7 +26,8 @@ struct OperatorScanPredicate {
 
   OperatorScanPredicate() = default;
   OperatorScanPredicate(const ColumnID column_id, const PredicateCondition predicate_condition,
-                        const AllParameterVariant& value = NullValue{});
+                        const AllParameterVariant& value = NullValue{},
+                        const std::optional<AllParameterVariant>& value2 = std::nullopt);
 
   // Returns a string representation of the predicate, using an optionally given table that is used to resolve column
   // ids to names.
@@ -35,6 +36,7 @@ struct OperatorScanPredicate {
   ColumnID column_id{INVALID_COLUMN_ID};
   PredicateCondition predicate_condition{PredicateCondition::Equals};
   AllParameterVariant value;
+  std::optional<AllParameterVariant> value2;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -19,6 +19,7 @@
 #include "storage/proxy_chunk.hpp"
 #include "storage/reference_segment.hpp"
 #include "storage/table.hpp"
+#include "table_scan/between_table_scan_impl.hpp"
 #include "table_scan/column_comparison_table_scan_impl.hpp"
 #include "table_scan/is_null_table_scan_impl.hpp"
 #include "table_scan/like_table_scan_impl.hpp"
@@ -46,12 +47,15 @@ const std::string TableScan::description(DescriptionMode description_mode) const
 const OperatorScanPredicate& TableScan::predicate() const { return _predicate; }
 
 void TableScan::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {
-  if (!is_parameter_id(_predicate.value)) return;
+  if (is_parameter_id(_predicate.value)) {
+    const auto value_iter = parameters.find(boost::get<ParameterID>(_predicate.value));
+    if (value_iter != parameters.end()) _predicate.value = value_iter->second;
+  }
 
-  const auto value_iter = parameters.find(boost::get<ParameterID>(_predicate.value));
-  if (value_iter == parameters.end()) return;
-
-  _predicate.value = value_iter->second;
+  if (_predicate.value2 && is_parameter_id(*_predicate.value2)) {
+    const auto value_iter = parameters.find(boost::get<ParameterID>(*_predicate.value2));
+    if (value_iter != parameters.end()) _predicate.value2 = value_iter->second;
+  }
 }
 
 std::shared_ptr<AbstractOperator> TableScan::_on_deep_copy(
@@ -177,14 +181,28 @@ void TableScan::_init_scan() {
     return;
   }
 
-  if (is_variant(parameter)) {
+  if (condition == PredicateCondition::Between) {
+    const auto left_value = boost::get<AllTypeVariant>(parameter);
+
+    DebugAssert(_predicate.value2, "Expected right value for BETWEEN");
+    const auto right_value = boost::get<AllTypeVariant>(*_predicate.value2);
+
+    DebugAssert(left_value.which() == right_value.which(),
+                "Expected left and right value to be of the same type (see operator_scan_predicate.cpp)");
+    DebugAssert(!variant_is_null(left_value) && !variant_is_null(right_value),
+                "Expected BETWEEN values to be non-null");
+
+    _impl = std::make_unique<BetweenTableScanImpl>(_in_table, column_id, left_value, right_value);
+  } else if (is_variant(parameter)) {
     const auto right_value = boost::get<AllTypeVariant>(parameter);
 
     _impl = std::make_unique<SingleColumnTableScanImpl>(_in_table, column_id, condition, right_value);
-  } else /* is_column_name(parameter) */ {
+  } else if (is_column_id(parameter)) {
     const auto right_column_id = boost::get<ColumnID>(parameter);
 
     _impl = std::make_unique<ColumnComparisonTableScanImpl>(_in_table, column_id, condition, right_column_id);
+  } else {
+    Fail("Never expected to end up here...");
   }
 }
 

--- a/src/lib/operators/table_scan/between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/between_table_scan_impl.cpp
@@ -1,0 +1,106 @@
+#include "between_table_scan_impl.hpp"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+
+#include "storage/chunk.hpp"
+#include "storage/create_iterable_from_segment.hpp"
+#include "storage/segment_iterables/create_iterable_from_attribute_vector.hpp"
+#include "storage/table.hpp"
+
+#include "utils/assert.hpp"
+
+#include "resolve_type.hpp"
+#include "type_comparison.hpp"
+
+namespace opossum {
+
+BetweenTableScanImpl::BetweenTableScanImpl(const std::shared_ptr<const Table>& in_table, const ColumnID left_column_id,
+                                           const AllTypeVariant& left_value, const AllTypeVariant& right_value)
+    : BaseSingleColumnTableScanImpl{in_table, left_column_id, PredicateCondition::Between},
+      _left_value{left_value},
+      _right_value{right_value} {}
+
+void BetweenTableScanImpl::handle_segment(const BaseValueSegment& base_segment,
+                                          std::shared_ptr<SegmentVisitorContext> base_context) {
+  auto context = std::static_pointer_cast<Context>(base_context);
+  auto& matches_out = context->_matches_out;
+  const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
+  const auto chunk_id = context->_chunk_id;
+
+  // TODO A lot of code is duplicated here, below, and in the other table scans.
+  // This can be increased once we have #1145.
+
+  const auto left_column_type = _in_table->column_data_type(_left_column_id);
+
+  resolve_data_type(left_column_type, [&](auto type) {
+    using ColumnDataType = typename decltype(type)::type;
+
+    auto& left_segment = static_cast<const ValueSegment<ColumnDataType>&>(base_segment);
+
+    auto left_segment_iterable = create_iterable_from_segment(left_segment);
+
+    left_segment_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
+      _between_scan_with_value<true>(left_it, left_end, type_cast<ColumnDataType>(_left_value),
+                                     type_cast<ColumnDataType>(_right_value), chunk_id, matches_out);
+    });
+  });
+}
+
+void BetweenTableScanImpl::handle_segment(const BaseEncodedSegment& base_segment,
+                                          std::shared_ptr<SegmentVisitorContext> base_context) {
+  auto context = std::static_pointer_cast<Context>(base_context);
+  auto& matches_out = context->_matches_out;
+  const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
+  const auto chunk_id = context->_chunk_id;
+
+  const auto left_column_type = _in_table->column_data_type(_left_column_id);
+
+  resolve_data_type(left_column_type, [&](auto type) {
+    using Type = typename decltype(type)::type;
+
+    resolve_encoded_segment_type<Type>(base_segment, [&](const auto& typed_segment) {
+      auto left_segment_iterable = create_iterable_from_segment(typed_segment);
+
+      left_segment_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
+        _between_scan_with_value<true>(left_it, left_end, type_cast<Type>(_left_value), type_cast<Type>(_right_value),
+                                       chunk_id, matches_out);
+      });
+    });
+  });
+}
+
+void BetweenTableScanImpl::handle_segment(const BaseDictionarySegment& base_segment,
+                                          std::shared_ptr<SegmentVisitorContext> base_context) {
+  auto context = std::static_pointer_cast<Context>(base_context);
+  auto& matches_out = context->_matches_out;
+  const auto chunk_id = context->_chunk_id;
+  const auto& mapped_chunk_offsets = context->_mapped_chunk_offsets;
+
+  const auto left_value_id = base_segment.lower_bound(_left_value);
+  const auto right_value_id = base_segment.upper_bound(_right_value);
+
+  auto column_iterable = create_iterable_from_attribute_vector(base_segment);
+
+  if (left_value_id == ValueID{0} && right_value_id == static_cast<ValueID>(base_segment.unique_values_count())) {
+    // all values match
+    column_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
+      static const auto always_true = [](const auto&) { return true; };
+      this->_unary_scan(always_true, left_it, left_end, chunk_id, matches_out);
+    });
+
+    return;
+  }
+
+  if (left_value_id == INVALID_VALUE_ID || left_value_id == right_value_id) {
+    // no values match
+    return;
+  }
+
+  column_iterable.with_iterators(mapped_chunk_offsets.get(), [&](auto left_it, auto left_end) {
+    this->_between_scan_with_value<false>(left_it, left_end, left_value_id, right_value_id, chunk_id, matches_out);
+  });
+}
+
+}  // namespace opossum

--- a/src/lib/operators/table_scan/between_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/between_table_scan_impl.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+
+#include "base_single_column_table_scan_impl.hpp"
+
+#include "all_type_variant.hpp"
+#include "types.hpp"
+
+namespace opossum {
+
+class Table;
+
+/**
+ * @brief Compares a column to two scalar values (... WHERE col BETWEEN left_value and right_value)
+ *
+ * Limitations:
+ * - We expect left_value and right_value to be scalar values, not columns
+ * - They are also expected to have the same data type
+ *
+ * Both of these limitations are to keep the code complexity and the number of template instantiations low,
+ * more complicated cases are handled by two scans, see operator_scan_predicate.cpp
+ */
+class BetweenTableScanImpl : public BaseSingleColumnTableScanImpl {
+ public:
+  BetweenTableScanImpl(const std::shared_ptr<const Table>& in_table, const ColumnID left_column_id,
+                       const AllTypeVariant& left_value, const AllTypeVariant& right_value);
+
+  void handle_segment(const BaseValueSegment& base_segment,
+                      std::shared_ptr<SegmentVisitorContext> base_context) override;
+
+  void handle_segment(const BaseDictionarySegment& base_segment,
+                      std::shared_ptr<SegmentVisitorContext> base_context) override;
+
+  void handle_segment(const BaseEncodedSegment& base_segment,
+                      std::shared_ptr<SegmentVisitorContext> base_context) override;
+
+  using BaseSingleColumnTableScanImpl::handle_segment;
+
+ private:
+  const AllTypeVariant _left_value;
+  const AllTypeVariant _right_value;
+};
+
+}  // namespace opossum

--- a/src/lib/statistics/table_statistics.cpp
+++ b/src/lib/statistics/table_statistics.cpp
@@ -25,7 +25,7 @@ const std::vector<std::shared_ptr<const BaseColumnStatistics>>& TableStatistics:
 TableStatistics TableStatistics::estimate_predicate(const ColumnID column_id,
                                                     const PredicateCondition predicate_condition,
                                                     const AllParameterVariant& value,
-                                                    const std::optional<AllTypeVariant>& value2) const {
+                                                    const std::optional<AllParameterVariant>& value2) const {
   // Early out, the code below would fail for _row_count == 0
   if (_row_count == 0) return {*this};
 
@@ -35,6 +35,7 @@ TableStatistics TableStatistics::estimate_predicate(const ColumnID column_id,
 
   // Estimate "a BETWEEN 5 and 6" by combining "a >= 5" with "a <= 6"
   if (predicate_condition == PredicateCondition::Between) {
+    DebugAssert(value2, "Expected second value to be passed in for BETWEEN");
     auto table_statistics = estimate_predicate(column_id, PredicateCondition::GreaterThanEquals, value);
     return table_statistics.estimate_predicate(column_id, PredicateCondition::LessThanEquals, *value2);
   }

--- a/src/lib/statistics/table_statistics.hpp
+++ b/src/lib/statistics/table_statistics.hpp
@@ -43,7 +43,7 @@ class TableStatistics final {
    */
   TableStatistics estimate_predicate(const ColumnID column_id, const PredicateCondition predicate_condition,
                                      const AllParameterVariant& value,
-                                     const std::optional<AllTypeVariant>& value2 = std::nullopt) const;
+                                     const std::optional<AllParameterVariant>& value2 = std::nullopt) const;
 
   TableStatistics estimate_cross_join(const TableStatistics& right_table_statistics) const;
 

--- a/src/lib/storage/base_dictionary_segment.hpp
+++ b/src/lib/storage/base_dictionary_segment.hpp
@@ -21,7 +21,7 @@ class BaseDictionarySegment : public BaseEncodedSegment {
    * @brief Returns index (i.e. ValueID) of first dictionary entry >= search value
    *
    * @param value the search value
-   * @return INVALID_VALUE_ID if entries are smaller than value
+   * @return INVALID_VALUE_ID if all entries are smaller than value
    */
   virtual ValueID lower_bound(const AllTypeVariant& value) const = 0;
 
@@ -29,7 +29,7 @@ class BaseDictionarySegment : public BaseEncodedSegment {
    * @brief Returns index (i.e. ValueID) of first dictionary entry > search value
    *
    * @param value the search value
-   * @return INVALID_VALUE_ID if entries are smaller than or equal to value
+   * @return INVALID_VALUE_ID if all entries are smaller than or equal to value
    */
   virtual ValueID upper_bound(const AllTypeVariant& value) const = 0;
 

--- a/src/lib/storage/encoding_type.cpp
+++ b/src/lib/storage/encoding_type.cpp
@@ -1,0 +1,30 @@
+#include "encoding_type.hpp"
+
+#include <boost/hana/for_each.hpp>
+
+#include "constant_mappings.hpp"
+
+namespace opossum {
+
+namespace hana = boost::hana;
+
+bool encoding_supports_data_type(EncodingType encoding_type, DataType data_type) {
+  bool result = false;
+
+  hana::for_each(supported_data_types_for_encoding_type, [&](auto encoding_pair) {
+    if (hana::first(encoding_pair).value == encoding_type) {
+      hana::for_each(data_type_pairs, [&](auto data_type_pair) {
+        if (hana::first(data_type_pair) == data_type) {
+          result = hana::contains(hana::at_key(supported_data_types_for_encoding_type, hana::first(encoding_pair)),
+                                  hana::second(data_type_pair));
+          return;
+        }
+      });
+      return;
+    }
+  });
+
+  return result;
+}
+
+}  // namespace opossum

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -28,13 +28,11 @@ enum class EncodingType : uint8_t { Unencoded, Dictionary, RunLength, FixedStrin
  * Use data_types if the encoding supports all data types.
  */
 constexpr auto supported_data_types_for_encoding_type = hana::make_map(
+    hana::make_pair(enum_c<EncodingType, EncodingType::Unencoded>, data_types),
     hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, data_types),
     hana::make_pair(enum_c<EncodingType, EncodingType::RunLength>, data_types),
     hana::make_pair(enum_c<EncodingType, EncodingType::FixedStringDictionary>, hana::tuple_t<std::string>),
     hana::make_pair(enum_c<EncodingType, EncodingType::FrameOfReference>, hana::tuple_t<int32_t, int64_t>));
-
-//  Example for an encoding that doesn’t support all data types:
-//  hana::make_pair(enum_c<EncodingType, EncodingType::NewEncoding>, hana::tuple_t<int32_t, int64_t>)
 
 /**
  * @return an integral constant implicitly convertible to bool
@@ -46,5 +44,8 @@ template <typename SegmentEncodingType, typename ColumnDataType>
 constexpr auto encoding_supports_data_type(SegmentEncodingType encoding_type, ColumnDataType data_type) {
   return hana::contains(hana::at_key(supported_data_types_for_encoding_type, encoding_type), data_type);
 }
+
+// Version for when EncodingType and DataType are only known at runtime
+bool encoding_supports_data_type(EncodingType encoding_type, DataType data_type);
 
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -79,8 +79,10 @@ set(
     operators/product_test.cpp
     operators/projection_test.cpp
     operators/sort_test.cpp
+    operators/table_scan_between_test.cpp
     operators/table_scan_string_test.cpp
     operators/table_scan_test.cpp
+    operators/typed_operator_base_test.hpp
     operators/union_all_test.cpp
     operators/union_positions_test.cpp
     operators/update_test.cpp
@@ -93,8 +95,8 @@ set(
     optimizer/lqp_translator_test.cpp
     optimizer/optimizer_test.cpp
     optimizer/strategy/chunk_pruning_test.cpp
-    optimizer/strategy/constant_calculation_rule_test.cpp
     optimizer/strategy/column_pruning_rule_test.cpp
+    optimizer/strategy/constant_calculation_rule_test.cpp
     optimizer/strategy/index_scan_rule_test.cpp
     optimizer/strategy/join_detection_rule_test.cpp
     optimizer/strategy/join_ordering_rule_test.cpp
@@ -116,8 +118,8 @@ set(
     sql/sql_translator_test.cpp
     sql/sqlite_testrunner/sqlite_testrunner.cpp
     sql/sqlite_testrunner/sqlite_wrapper_test.cpp
-    statistics/chunk_statistics/range_filter_test.cpp
     statistics/chunk_statistics/min_max_filter_test.cpp
+    statistics/chunk_statistics/range_filter_test.cpp
     statistics/column_statistics_test.cpp
     statistics/generate_table_statistics_test.cpp
     statistics/statistics_import_export_test.cpp

--- a/src/test/operators/operator_scan_predicate_test.cpp
+++ b/src/test/operators/operator_scan_predicate_test.cpp
@@ -49,7 +49,21 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
   EXPECT_EQ(operator_predicate_a.column_id, ColumnID{0});
   EXPECT_EQ(operator_predicate_a.predicate_condition, PredicateCondition::LessThan);
   EXPECT_EQ(operator_predicate_a.value, AllParameterVariant{5});
+}
 
+TEST_F(OperatorScanPredicateTest, SimpleBetween) {
+  const auto operator_predicates_a = OperatorScanPredicate::from_expression(*between(a, 5, 7), *node);
+  ASSERT_TRUE(operator_predicates_a);
+  ASSERT_EQ(operator_predicates_a->size(), 1u);
+  const auto& operator_predicate_a = operator_predicates_a->at(0);
+  EXPECT_EQ(operator_predicate_a.column_id, ColumnID{0});
+  EXPECT_EQ(operator_predicate_a.predicate_condition, PredicateCondition::Between);
+  EXPECT_EQ(operator_predicate_a.value, AllParameterVariant{5});
+  EXPECT_TRUE(operator_predicate_a.value2);
+  EXPECT_EQ(*operator_predicate_a.value2, AllParameterVariant{7});
+}
+
+TEST_F(OperatorScanPredicateTest, ComplicatedBetween) {
   // `5 BETWEEN a AND b` becomes `a <= 5 AND b >= 5`
   const auto operator_predicates_b = OperatorScanPredicate::from_expression(*between(5, a, b), *node);
   ASSERT_TRUE(operator_predicates_b);

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -17,7 +17,7 @@
 
 namespace opossum {
 
-class OperatorsSortTest : public BaseTest, public ::testing::WithParamInterface<EncodingType> {
+class OperatorsSortTest : public BaseTestWithParam<EncodingType> {
  protected:
   void SetUp() override {
     _encoding_type = GetParam();

--- a/src/test/operators/table_scan_between_test.cpp
+++ b/src/test/operators/table_scan_between_test.cpp
@@ -1,0 +1,125 @@
+#include "typed_operator_base_test.hpp"
+
+#include "operators/operator_scan_predicate.hpp"
+#include "operators/table_scan.hpp"
+#include "operators/table_wrapper.hpp"
+#include "resolve_type.hpp"
+#include "storage/chunk_encoder.hpp"
+#include "storage/table.hpp"
+
+namespace opossum {
+
+class TableScanBetweenTest : public TypedOperatorBaseTest {
+ protected:
+  std::shared_ptr<AbstractOperator> _data_table_wrapper;
+
+  void SetUp() override {
+    // For the test, we create a table with the data type that is to be scanned as the first column and a control int
+    // in the second column:
+    //
+    // a<DataType>  b<int>
+    // 10.25         0
+    // 12.25         1
+    // 14.25 / NULL  2       (each third row is nulled if the table is marked as nullable)
+    // 16.25         3
+    // ...
+    // 30.25         10
+    //
+    // As the first column is type casted, it contains 10 for an int column, the string "10.25" for a string column etc.
+    // We chose .25 because that can be exactly expressed in a float.
+
+    const auto& [data_type, encoding, nullable] = GetParam();
+
+    auto column_definitions = TableColumnDefinitions{{"a", data_type, nullable}, {"b", DataType::Int, nullable}};
+
+    const auto data_table = std::make_shared<Table>(column_definitions, TableType::Data, 6);
+
+    // `nullable=nullable` is a dirty hack to work around C++ defect 2313.
+    resolve_data_type(data_type, [&, nullable = nullable](const auto type) {
+      using DataType = typename decltype(type)::type;
+      for (auto i = 0; i <= 10; ++i) {
+        auto value = type_cast<DataType>(10.25 + i * 2.0);
+        if (nullable && i % 3 == 2) {
+          data_table->append({NullValue{}, i});
+        } else {
+          data_table->append({value, i});
+        }
+      }
+    });
+
+    // We have two full chunks and one open chunk, we only encode the full chunks
+    for (auto chunk_id = ChunkID{0}; chunk_id < 2; ++chunk_id) {
+      ChunkEncoder::encode_chunk(data_table->get_chunk(chunk_id), {data_type, DataType::Int},
+                                 {encoding, EncodingType::Unencoded});
+    }
+
+    _data_table_wrapper = std::make_shared<TableWrapper>(data_table);
+    _data_table_wrapper->execute();
+  }
+};
+
+TEST_P(TableScanBetweenTest, ExactBoundaries) {
+  auto tests = std::vector<std::tuple<AllTypeVariant, AllTypeVariant, std::vector<int>>>{
+      {12.25, 16.25, {1, 2, 3}},                          // Both boundaries exact match
+      {12.0, 16.25, {1, 2, 3}},                           // Left boundary open match
+      {12.25, 16.75, {1, 2, 3}},                          // Right boundary open match
+      {12.0, 16.75, {1, 2, 3}},                           // Both boundaries open match
+      {0.0, 16.75, {0, 1, 2, 3}},                         // Left boundary before first value
+      {16.0, 50.75, {3, 4, 5, 6, 7, 8, 9, 10}},           // Right boundary after last value
+      {0.25, 50.75, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},  // Matching all values
+      {0.25, 0.75, {}}                                    // Matching no value
+  };
+
+  const auto& [data_type, encoding, nullable] = GetParam();
+  resolve_data_type(data_type, [&, nullable = nullable](const auto type) {
+    for (const auto& [left, right, expected_with_null] : tests) {
+      SCOPED_TRACE(std::string("BETWEEN ") + std::to_string(boost::get<double>(left)) + " AND " +
+                   std::to_string(boost::get<double>(right)));
+
+      const auto predicate = OperatorScanPredicate{ColumnID{0}, PredicateCondition::Between, left, right};
+      auto scan = std::make_shared<TableScan>(_data_table_wrapper, predicate);
+      scan->execute();
+
+      const auto& result_table = *scan->get_output();
+      auto result_ints = std::vector<int>{};
+      for (const auto& chunk : result_table.chunks()) {
+        const auto segment_b = chunk->get_segment(ColumnID{1});
+        for (auto offset = ChunkOffset{0}; offset < segment_b->size(); ++offset) {
+          result_ints.emplace_back(boost::get<int>((*segment_b)[offset]));
+        }
+      }
+      std::sort(result_ints.begin(), result_ints.end());
+
+      auto expected = expected_with_null;
+      if (nullable) {
+        // Remove the positions that should not be included because they are NULL
+        expected.erase(std::remove_if(expected.begin(), expected.end(), [](int x) { return x % 3 == 2; }),
+                       expected.end());
+      }
+
+      ASSERT_EQ(result_ints, expected);
+    }
+  });
+}
+
+TEST_P(TableScanBetweenTest, MismatchingTypes) {
+  const auto predicate = OperatorScanPredicate{ColumnID{0}, PredicateCondition::Between, 1, 2.0f};
+  auto scan = std::make_shared<TableScan>(_data_table_wrapper, predicate);
+  EXPECT_THROW(scan->execute(), std::logic_error);
+}
+
+TEST_P(TableScanBetweenTest, NullValueAsParameter) {
+  const auto& [data_type, encoding, nullable] = GetParam();
+  resolve_data_type(data_type, [&](const auto type) {
+    using DataType = typename decltype(type)::type;
+    const auto predicate =
+        OperatorScanPredicate{ColumnID{0}, PredicateCondition::Between, type_cast<DataType>(1), NullValue{}};
+    auto scan = std::make_shared<TableScan>(_data_table_wrapper, predicate);
+    EXPECT_THROW(scan->execute(), std::logic_error);
+  });
+}
+
+INSTANTIATE_TEST_CASE_P(TableScanBetweenTestInstances, TableScanBetweenTest, testing::ValuesIn(create_param_pairs()),
+                        TypedOperatorBaseTest::format);
+
+}  // namespace opossum

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -667,6 +667,14 @@ TEST_P(OperatorsTableScanTest, SetParameters) {
   scan_c->set_parameters(parameters);
   EXPECT_EQ(scan_c->predicate().column_id, ColumnID{0});
   EXPECT_EQ(scan_c->predicate().value, AllParameterVariant{ParameterID{4}});
+
+  const auto scan_d = std::make_shared<TableScan>(
+      _int_int_compressed,
+      OperatorScanPredicate{ColumnID{1}, PredicateCondition::Between, ParameterID{2}, ParameterID{3}});
+  scan_d->set_parameters(parameters);
+  EXPECT_EQ(scan_d->predicate().column_id, ColumnID{1});
+  EXPECT_EQ(scan_d->predicate().value, AllParameterVariant{6});
+  EXPECT_EQ(*scan_d->predicate().value2, AllParameterVariant{5});
 }
 
 }  // namespace opossum

--- a/src/test/operators/typed_operator_base_test.hpp
+++ b/src/test/operators/typed_operator_base_test.hpp
@@ -1,0 +1,43 @@
+#include "base_test.hpp"
+
+#include <boost/hana/for_each.hpp>
+
+#include "all_type_variant.hpp"
+#include "constant_mappings.hpp"
+#include "storage/encoding_type.hpp"
+
+namespace opossum {
+
+using ParamType = std::tuple<DataType, EncodingType, bool /* nullable */>;
+
+// This is the base class for all tests that should run on every possible combination of data type and encoding.
+// A sample table is generate in TableScanBetweenTest. Depending on how other tests will use this, it might make sense
+// to have a single instantiation here.
+class TypedOperatorBaseTest : public BaseTestWithParam<ParamType> {
+ public:
+  static std::string format(testing::TestParamInfo<ParamType> info) {
+    const auto& [data_type, encoding, nullable] = info.param;
+
+    return data_type_to_string.left.at(data_type) + encoding_type_to_string.left.at(encoding) +
+           (nullable ? "" : "Not") + "Nullable";
+  };
+};
+
+static std::vector<ParamType> create_param_pairs() {
+  std::vector<ParamType> pairs;
+
+  hana::for_each(data_type_pairs, [&](auto pair) {
+    const auto& data_type = hana::first(pair);
+
+    for (auto it = encoding_type_to_string.begin(); it != encoding_type_to_string.end(); ++it) {
+      const auto& encoding = it->left;
+      if (!encoding_supports_data_type(encoding, data_type)) continue;
+      pairs.emplace_back(data_type, encoding, true);
+      pairs.emplace_back(data_type, encoding, false);
+    }
+  });
+
+  return pairs;
+}
+
+}  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -115,12 +115,6 @@ TEST_P(SQLiteTestRunner, CompareToSQLite) {
       << "Query failed: " << query;
 }
 
-auto formatter = [](const testing::TestParamInfo<std::string>) {
-  // stupid, but otherwise Wextra complains about the unused macro parameter
-  static int test = 1;
-  return std::to_string(test++);
-};
-INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerInstances, SQLiteTestRunner, testing::ValuesIn(read_queries_from_file()),
-                        formatter);
+INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerInstances, SQLiteTestRunner, testing::ValuesIn(read_queries_from_file()), );
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -14,7 +14,9 @@ SELECT * FROM mixed WHERE a = 'a' AND c < 65.31;
 SELECT * FROM mixed WHERE a = 'a' AND c <= 65.31;
 SELECT * FROM mixed WHERE 40 >= b;
 SELECT * FROM mixed WHERE b >= 21 AND c < 72.76;
+SELECT * FROM mixed WHERE b BETWEEN 0 AND 99999;
 SELECT * FROM mixed WHERE b BETWEEN 20 AND 45;
+SELECT * FROM mixed WHERE b BETWEEN 20 AND 45.5;
 SELECT * FROM mixed WHERE b = 10 OR b BETWEEN 45 AND 20; -- valid SQL with expected empty result
 SELECT * FROM mixed WHERE b BETWEEN c AND 45;
 SELECT * FROM mixed WHERE b >= 21 OR c < 72.76;


### PR DESCRIPTION
```
 TPC-H 7   | 7.621        | 8.107      | +6%
 TPC-H 8   | 34.466       | 36.912     | +7%
```

This will have more effect once we translate things like `l_shipdate >= '1994-01-01' AND l_shipdate < '1995-01-01'` into a non-inclusive BETWEEN. Also, the pushdown does not yet work properly, e.g., in query 6.