### PR TITLE
ExpressionEvaluator: Shortcut for IN if list holds only values 

### DIFF
--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1139,11 +1139,12 @@ std::shared_ptr<AbstractExpression> SQLTranslator::_translate_hsql_expr(
           } else {
             // `a IN (x, y, z)`
             std::vector<std::shared_ptr<AbstractExpression>> arguments;
-            if (expr.exprList) {
-              arguments.reserve(expr.exprList->size());
-              for (const auto* hsql_argument : *expr.exprList) {
-                arguments.emplace_back(_translate_hsql_expr(*hsql_argument, sql_identifier_resolver));
-              }
+
+            AssertInput(expr.exprList && !expr.exprList->empty(), "IN clauses with an empty list are invalid");
+
+            arguments.reserve(expr.exprList->size());
+            for (const auto* hsql_argument : *expr.exprList) {
+              arguments.emplace_back(_translate_hsql_expr(*hsql_argument, sql_identifier_resolver));
             }
 
             const auto array = std::make_shared<ListExpression>(arguments);

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -441,14 +441,16 @@ TEST_F(ExpressionEvaluatorTest, Parameter) {
 TEST_F(ExpressionEvaluatorTest, InListLiterals) {
   EXPECT_TRUE(test_expression<int32_t>(*in_(null_(), list_(null_())), {std::nullopt}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(null_(), list_(null_(), 3)), {std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(*in_(null_(), list_()), {0}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(null_(), list_(1, 2, 3, 4)), {std::nullopt}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(null_(), list_(null_(), 2, 3, 4)), {std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_()), {0}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(null_(), 5, null_())), {1}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(null_(), add_(2, 3), null_())), {1}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(null_(), 6, null_())), {std::nullopt}));
+  EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(1, 3)), {0}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(1.0, 3.0)), {0}));
+  EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(1.0, 5.0)), {1}));
+  EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(1.0, add_(1.0, 3.0))), {0}));
+  EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(1.0, add_(2.0, 3.0))), {1}));
 }
 
 TEST_F(ExpressionEvaluatorTest, InListSeries) {

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -446,6 +446,7 @@ TEST_F(ExpressionEvaluatorTest, InListLiterals) {
   EXPECT_TRUE(test_expression<int32_t>(*in_(null_(), list_(null_(), 2, 3, 4)), {std::nullopt}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_()), {0}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(null_(), 5, null_())), {1}));
+  EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(null_(), add_(2, 3), null_())), {1}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(null_(), 6, null_())), {std::nullopt}));
   EXPECT_TRUE(test_expression<int32_t>(*in_(5, list_(1.0, 3.0)), {0}));
 }


### PR DESCRIPTION
(Also an exercise to get more familiar with the ExpressionEvaluator)

```
 Benchmark | prev. iter/s | new iter/s | change
-----------+--------------+------------+---------------
 TPC-H 1   | 3.808        | 3.737      | -2%
 TPC-H 2   | 89.732       | 89.66      | -0%
 TPC-H 3   | 39.409       | 39.684     | +1%
 TPC-H 4   | 16.387       | 16.173     | -1%
 TPC-H 5   | 26.012       | 25.937     | -0%
 TPC-H 6   | 60.353       | 60.087     | -0%
 TPC-H 7   | 7.564        | 7.537      | -0%
 TPC-H 8   | 33.835       | 34.784     | +3%
 TPC-H 9   | 16.567       | 16.647     | +0%
 TPC-H 10  | 21.306       | 21.486     | +1%
 TPC-H 11  | 118.809      | 118.71     | -0%
 TPC-H 12  | 35.046       | 34.853     | -1%
 TPC-H 13  | 24.746       | 25.255     | +2%
 TPC-H 14  | 86.308       | 85.807     | -1%
 TPC-H 15  | 40.739       | 40.634     | -0%
 TPC-H 16  | 17.256       | 17.613     | +2%
 TPC-H 17  | 4.384        | 4.294      | -2%
 TPC-H 18  | 3.351        | 3.314      | -1%
 TPC-H 19  | 2.426        | 2.627      | +8%
 TPC-H 20  | 0.031        | 0.031      | -1%
 TPC-H 21  | 0.293        | 0.302      | +3%
 TPC-H 22  | 49.897       | 59.202     | +19%
 average   |              |            | +1%
```