### PR TITLE
Removes SSE2-specific code from SIMD-BP128 implementation

### DIFF
--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_compressor.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_compressor.cpp
@@ -61,7 +61,7 @@ void SimdBp128Compressor::_finish() {
 bool SimdBp128Compressor::_meta_block_complete() { return (Packing::meta_block_size - _meta_block_index) <= 0u; }
 
 void SimdBp128Compressor::_pack_meta_block() {
-  const auto bits_needed = _bits_needed_per_block();
+  alignas(16) const auto bits_needed = _bits_needed_per_block();
   _write_meta_info(bits_needed);
   _pack_blocks(Packing::blocks_in_meta_block, bits_needed);
 
@@ -72,7 +72,7 @@ void SimdBp128Compressor::_pack_incomplete_meta_block() {
   // Fill remaining elements with zero
   std::fill(_pending_meta_block.begin() + _meta_block_index, _pending_meta_block.end(), 0u);
 
-  const auto bits_needed = _bits_needed_per_block();
+  alignas(16) const auto bits_needed = _bits_needed_per_block();
   _write_meta_info(bits_needed);
 
   // Returns ceiling of integer division

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_compressor.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_compressor.hpp
@@ -41,7 +41,7 @@ class SimdBp128Compressor : public BaseVectorCompressor {
   std::unique_ptr<pmr_vector<uint128_t>> _data;
   size_t _data_index;
 
-  std::array<uint32_t, Packing::meta_block_size> _pending_meta_block;
+  alignas(16) std::array<uint32_t, Packing::meta_block_size> _pending_meta_block;
   size_t _meta_block_index;
 
   size_t _size;

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.hpp
@@ -52,7 +52,7 @@ class SimdBp128Iterator : public BaseCompressedVectorIterator<SimdBp128Iterator>
   size_t _data_index;
   size_t _absolute_index;
 
-  std::array<uint8_t, Packing::blocks_in_meta_block> _current_meta_info{};
+ alignas(16) std::array<uint8_t, Packing::blocks_in_meta_block> _current_meta_info{};
 
   const std::unique_ptr<std::array<uint32_t, Packing::meta_block_size>> _current_meta_block;
   size_t _current_meta_block_index;

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.hpp
@@ -52,7 +52,7 @@ class SimdBp128Iterator : public BaseCompressedVectorIterator<SimdBp128Iterator>
   size_t _data_index;
   size_t _absolute_index;
 
- alignas(16) std::array<uint8_t, Packing::blocks_in_meta_block> _current_meta_info{};
+  alignas(16) std::array<uint8_t, Packing::blocks_in_meta_block> _current_meta_info{};
 
   const std::unique_ptr<std::array<uint32_t, Packing::meta_block_size>> _current_meta_block;
   size_t _current_meta_block_index;

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
@@ -4,6 +4,7 @@
 
 #include "utils/assert.hpp"
 
+// When casting into this data type, make sure that the underlying data is properly aligned to 16 byte boundaries.
 using simd_type = uint32_t __attribute__((vector_size(16)));
 
 namespace opossum {

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_packing.cpp
@@ -1,15 +1,10 @@
 #include "simd_bp128_packing.hpp"
 
-#ifdef __SSE2__
-#include <emmintrin.h>
-using simd_type = __m128i;
-#else
-using simd_type = unsigned int __attribute__((vector_size(16)));
-#endif
-
 #include <algorithm>
 
 #include "utils/assert.hpp"
+
+using simd_type = uint32_t __attribute__((vector_size(16)));
 
 namespace opossum {
 
@@ -42,13 +37,8 @@ struct Pack128Bit {
     // Fill the four 32-bit sub-blocks simultaneously by bit shifting
     for (auto i = 0u; i < I_MAX; ++i) {
       const auto offset = carry_over + i * bit_size;
-#ifdef __SSE2__
-      in_reg = _mm_and_si128(_mm_loadu_si128(in++), mask);
-      out_reg = _mm_or_si128(out_reg, _mm_slli_epi32(in_reg, offset));
-#else
       in_reg = *in++ & mask;
       out_reg = out_reg | (in_reg << offset);
-#endif
     }
 
     constexpr auto NEXT_OFFSET = carry_over + I_MAX * bit_size;
@@ -56,15 +46,6 @@ struct Pack128Bit {
 
     // Check if integers need to be split
     if (NEXT_OFFSET < BITS_IN_WORD) {
-#ifdef __SSE2__
-      in_reg = _mm_and_si128(_mm_loadu_si128(in++), mask);
-      out_reg = _mm_or_si128(out_reg, _mm_slli_epi32(in_reg, NEXT_OFFSET));
-
-      _mm_store_si128(out, out_reg);
-      ++out;
-
-      out_reg = _mm_srli_epi32(in_reg, NUM_FIRST_BITS);
-#else
       in_reg = *in++ & mask;
       out_reg = out_reg | (in_reg << NEXT_OFFSET);
 
@@ -72,20 +53,12 @@ struct Pack128Bit {
       ++out;
 
       out_reg = in_reg >> NUM_FIRST_BITS;
-#endif
     } else {
-#ifdef __SSE2__
-      _mm_store_si128(out, out_reg);
-      ++out;
-
-      out_reg = _mm_setzero_si128();
-#else
       *out = out_reg;
       out++;
 
       simd_type zero_reg = {0, 0, 0, 0};
       out_reg = zero_reg;
-#endif
     }
 
     // Calculate the new carry over
@@ -114,13 +87,8 @@ struct Unpack128Bit {
 
     for (auto i = 0u; i < I_MAX; ++i) {
       const auto offset = carry_over + i * bit_size;
-#ifdef __SSE2__
-      out_reg = _mm_and_si128(_mm_srli_epi32(in_reg, offset), mask);
-      _mm_storeu_si128(out++, out_reg);
-#else
       out_reg = (in_reg >> offset) & mask;
       *out++ = out_reg;
-#endif
     }
 
     constexpr auto NEXT_OFFSET = carry_over + I_MAX * bit_size;
@@ -128,29 +96,17 @@ struct Unpack128Bit {
 
     // Check if integers have been split across the 128-bit block boundary
     if (NEXT_OFFSET < BITS_IN_WORD) {
-#ifdef __SSE2__
-      out_reg = _mm_srli_epi32(in_reg, NEXT_OFFSET);
-      in_reg = _mm_load_si128(in++);
-
-      out_reg = _mm_or_si128(out_reg, _mm_and_si128(_mm_slli_epi32(in_reg, NUM_FIRST_BITS), mask));
-      _mm_storeu_si128(out++, out_reg);
-#else
       out_reg = in_reg >> NEXT_OFFSET;
       in_reg = *in++;
 
       out_reg = out_reg | ((in_reg << NUM_FIRST_BITS) & mask);
       *out++ = out_reg;
-#endif
     } else {
       constexpr auto LAST_RECURSION = 1u;
 
       // Only load another 128-bit block if it’s not the last recursion
       if (remaining_recursions > LAST_RECURSION) {
-#ifdef __SSE2__
-        in_reg = _mm_load_si128(in++);
-#else
         in_reg = *in++;
-#endif
       }
     }
 
@@ -177,40 +133,24 @@ void SimdBp128Packing::write_meta_info(const uint8_t* in, uint128_t* out) {
   const auto simd_in = reinterpret_cast<const simd_type*>(in);
   auto simd_out = reinterpret_cast<simd_type*>(out);
 
-#ifdef __SSE2__
-  const auto meta_block_info_rgtr = _mm_loadu_si128(simd_in);
-  _mm_store_si128(simd_out, meta_block_info_rgtr);
-#else
   *simd_out = *simd_in;
-#endif
 }
 
 void SimdBp128Packing::read_meta_info(const uint128_t* in, uint8_t* out) {
   const auto simd_in = reinterpret_cast<const simd_type*>(in);
   auto simd_out = reinterpret_cast<simd_type*>(out);
 
-#ifdef __SSE2__
-  auto meta_info_block_rgtr = _mm_load_si128(simd_in);
-  _mm_storeu_si128(simd_out, meta_info_block_rgtr);
-#else
   *simd_out = *simd_in;
-#endif
 }
 
 void SimdBp128Packing::pack_block(const uint32_t* in, uint128_t* out, const uint8_t bit_size) {
   auto simd_in = reinterpret_cast<const simd_type*>(in);
   auto simd_out = reinterpret_cast<simd_type*>(out);
 
-#ifdef __SSE2__
-  auto in_reg = _mm_setzero_si128();
-  auto out_reg = _mm_setzero_si128();
-  const auto mask = _mm_set1_epi32((1ul << bit_size) - 1);
-#else
   simd_type in_reg = {0, 0, 0, 0};
   simd_type out_reg = {0, 0, 0, 0};
   unsigned int one_mask = (1ul << bit_size) - 1;
   const simd_type mask = {one_mask, one_mask, one_mask, one_mask};
-#endif
 
   switch (bit_size) {
     case 0u:
@@ -360,16 +300,10 @@ void SimdBp128Packing::unpack_block(const uint128_t* in, uint32_t* out, const ui
   auto simd_in = reinterpret_cast<const simd_type*>(in);
   auto simd_out = reinterpret_cast<simd_type*>(out);
 
-#ifdef __SSE2__
-  auto in_reg = _mm_load_si128(simd_in++);
-  auto out_reg = _mm_setzero_si128();
-  const auto mask = _mm_set1_epi32((1ul << bit_size) - 1);
-#else
   simd_type in_reg = *simd_in++;
   simd_type out_reg = {0, 0, 0, 0};
   unsigned int one_mask = (1ul << bit_size) - 1;
   const simd_type mask = {one_mask, one_mask, one_mask, one_mask};
-#endif
 
   switch (bit_size) {
     case 1u:


### PR DESCRIPTION
The SIMD-BP128 implementation was full of `#ifdef __SSE2__ #else`  switches to support non-SSE platforms.  These switches are unnecessary as the manually written SIMD code is not faster as code that is automatically vectorised by the compiler. I have checked that for TPC-H and might also take a look at a micro benchmark for this.

This PR removes the switches and platform-dependent code.