### PR TITLE
Use alternative hash map in hash join.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "third_party/cpp-btree"]
 	path = third_party/cpp-btree
 	url = https://github.com/algorithm-ninja/cpp-btree
+[submodule "flat_hash_map"]
+	path = third_party/flat_hash_map
+	url = https://github.com/skarupke/flat_hash_map.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -71,6 +71,7 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/third_party/json
     ${PROJECT_SOURCE_DIR}/third_party/sql-parser/src
     ${PROJECT_SOURCE_DIR}/third_party/cpp-btree
+    ${PROJECT_SOURCE_DIR}/third_party/flat_hash_map
 
     ${PROJECT_SOURCE_DIR}/src/benchmarklib/
     ${PROJECT_SOURCE_DIR}/src/lib/

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -25,8 +25,9 @@
 
 namespace opossum {
 
+// As the ska* hash maps provide an own very fast hashing algorithms, we do not use std::hash<AggregateKey> here.
 template <typename AggregateKey, typename AggregateType, typename ColumnType>
-using HashTable = std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnType>, std::hash<AggregateKey>>;
+using HashTable = ska::bytell_hash_map<AggregateKey, AggregateResult<AggregateType, ColumnType>>;
 
 Aggregate::Aggregate(const std::shared_ptr<AbstractOperator>& in,
                      const std::vector<AggregateColumnDefinition>& aggregates,

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -24,13 +24,6 @@
 
 namespace opossum {
 
-<<<<<<< HEAD
-// As the ska* hash maps provide an own very fast hashing algorithms, we do not use std::hash<AggregateKey> here.
-template <typename AggregateKey, typename AggregateType, typename ColumnType>
-using HashTable = ska::bytell_hash_map<AggregateKey, AggregateResult<AggregateType, ColumnType>>;
-
-=======
->>>>>>> parent of ef0d475b3... Simplify hash table usage in aggregate (still std)
 Aggregate::Aggregate(const std::shared_ptr<AbstractOperator>& in,
                      const std::vector<AggregateColumnDefinition>& aggregates,
                      const std::vector<ColumnID>& groupby_column_ids)

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -118,9 +118,9 @@ using Partition = std::conditional_t<std::is_trivially_destructible_v<T>, uninit
 // smaller side.
 using SmallPosList = boost::container::small_vector<RowID, 1>;
 
+// In case we consider runtime to be more relevant, the flat hash map is a better performing (measured to be mostly on par with
+// bytell hash map and in some cases up to 5%  faster), but significantly larger alternative to the bytell map.
 template <typename T>
-// In case we consider runtime to be more relevant, the flat hash map
-// is a better performing but significantly larger alternative to the bytell map.
 using HashTable = ska::bytell_hash_map<T, SmallPosList>;
 
 /*

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -645,16 +645,16 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     const auto l2_cache_size = 256'000;  // bytes
 
     // To get a pessimistic estimation (ensure that the hash table fits within the cache), we assume
-    // that each value maps to a PosLis with a single RowID. For the used small_vector's, we assume a
+    // that each value maps to a PosList with a single RowID. For the used small_vector's, we assume a
     // size of 2*RowID per PosList. For sizing, see comments:
     // https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
     const auto complete_hash_map_size =
-      // number of items in map
-      (build_relation_size *
-      // key + value (and one byte overhead, see link above)
-      (sizeof(LeftType) + 2 * sizeof(RowID) + 1))
-      // fill factor
-      / 0.8;
+        // number of items in map
+        (build_relation_size *
+         // key + value (and one byte overhead, see link above)
+         (sizeof(LeftType) + 2 * sizeof(RowID) + 1))
+        // fill factor
+        / 0.8;
 
     const auto adaption_factor = 2.0f;  // don't occupy the whole L2 cache
     const auto cluster_count = std::max(1.0, (adaption_factor * complete_hash_map_size) / l2_cache_size);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -175,13 +175,6 @@ std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<Lef
         } else {
           hashtable.emplace(casted_value, SmallPosList{element.row_id});
         }
-
-        // auto [it, inserted] =  // NOLINT
-        //     hashtable.try_emplace(type_cast<HashedType>(std::move(element.value)), SmallPosList{element.row_id});
-        // if (!inserted) {
-        //   // We already have the value in the map
-        //   it->second.emplace_back(element.row_id);
-        // }
       }
 
       hashtables[current_partition_id] = std::move(hashtable);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -119,6 +119,8 @@ using Partition = std::conditional_t<std::is_trivially_destructible_v<T>, uninit
 using SmallPosList = boost::container::small_vector<RowID, 1>;
 
 template <typename T>
+// In case we consider runtime to be more relevant, the flat hash map
+// is a better performing but significantly larger alternative to the bytell map.
 using HashTable = ska::bytell_hash_map<T, SmallPosList>;
 
 /*
@@ -160,10 +162,8 @@ std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<Lef
     jobs.emplace_back(std::make_shared<JobTask>([&, partition_left_begin, partition_left_end, current_partition_id,
                                                  partition_size]() {
       auto& partition_left = static_cast<Partition<LeftType>&>(*radix_container.elements);
-
-      // Potentially oversizing the hash table when values are often repeated.
-      // But rather have slightly too large hash tables than paying for complete rehashing/resizing.
-      auto hashtable = HashTable<HashedType>(partition_size);
+      // slightly oversize the hash table to avoid unnecessary rebuilds
+      auto hashtable = HashTable<HashedType>(static_cast<size_t>(partition_size * 1.2));
 
       for (size_t partition_offset = partition_left_begin; partition_offset < partition_left_end; ++partition_offset) {
         auto& element = partition_left[partition_offset];
@@ -644,17 +644,20 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
     const auto l2_cache_size = 256'000;  // bytes
 
-    // We assume an std::unordered_map with a linked list within the buckets.
     // To get a pessimistic estimation (ensure that the hash table fits within the cache), we assume
-    // that each value maps to two RowIDs.
+    // that each value maps to a PosLis with a single RowID. For the used small_vector's, we assume a
+    // size of 2*RowID per PosList. For sizing, see comments:
+    // https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
     const auto complete_hash_map_size =
-        // hash map
-        build_relation_size * (sizeof(LeftType) + sizeof(void*)) +
-        // PosLists
-        (build_relation_size / 2) * (sizeof(PosList) + 2 * sizeof(RowID));
+      // number of items in map
+      (build_relation_size *
+      // key + value (and one byte overhead, see link above)
+      (sizeof(LeftType) + 2 * sizeof(RowID) + 1))
+      // fill factor
+      / 0.8;
 
     const auto adaption_factor = 2.0f;  // don't occupy the whole L2 cache
-    const auto cluster_count = std::max(1.0f, (adaption_factor * complete_hash_map_size) / l2_cache_size);
+    const auto cluster_count = std::max(1.0, (adaption_factor * complete_hash_map_size) / l2_cache_size);
 
     _radix_bits = std::ceil(std::log2(cluster_count));
   }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -118,8 +118,8 @@ using Partition = std::conditional_t<std::is_trivially_destructible_v<T>, uninit
 // smaller side.
 using SmallPosList = boost::container::small_vector<RowID, 1>;
 
-// In case we consider runtime to be more relevant, the flat hash map is a better performing (measured to be mostly on par with
-// bytell hash map and in some cases up to 5%  faster), but significantly larger alternative to the bytell map.
+// In case we consider runtime to be more relevant, the flat hash map performs better (measured to be mostly on par
+// with bytell hash map and in some cases up to 5% faster) but is significantly larger than the bytell hash map.
 template <typename T>
 using HashTable = ska::bytell_hash_map<T, SmallPosList>;
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "bytell_hash_map.hpp"
 #include "join_hash/hash_traits.hpp"
 #include "resolve_type.hpp"
 #include "scheduler/abstract_task.hpp"
@@ -25,7 +26,6 @@
 #include "utils/murmur_hash.hpp"
 #include "utils/timer.hpp"
 #include "utils/uninitialized_vector.hpp"
-#include "bytell_hash_map.hpp"
 
 namespace opossum {
 


### PR DESCRIPTION
This PR changes the hash map usage in the `join_hash` operator from `std::unordered_map` to `ska::bytell_hash_map`.
The bytell map is interface compliant, but not yet with C++17. Consequently, we cannot use `emplace_back`.

```+-----------+--------------------+------+--------------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s       | runs | new iter/s         | runs | change | p-value (significant if <0.001) |
+-----------+--------------------+------+--------------------+------+--------+---------------------------------+
| TPC-H 1   | 2.87656950950623   | 173  | 2.83660435676575   | 171  | -1%    |                          0.0000 |
| TPC-H 2   | 101.251907348633   | 6076 | 88.3616485595703   | 5302 | -13%   |     (run time too short) 0.0000 |
| TPC-H 3   | 50.6876220703125   | 3042 | 59.3017387390137   | 3559 | +17%   |     (run time too short) 0.0000 |
| TPC-H 4   | 23.4108047485352   | 1405 | 26.3407497406006   | 1581 | +13%   |     (run time too short) 0.0000 |
| TPC-H 5   | 33.4468765258789   | 2007 | 45.9001007080078   | 2755 | +37%   |     (run time too short) 0.0000 |
| TPC-H 6   | 55.9871559143066   | 3360 | 54.0999450683594   | 3247 | -3%    |     (run time too short) 0.0000 |
| TPC-H 7   | 6.66117906570435   | 400  | 7.26728916168213   | 437  | +9%    |     (run time too short) 0.0000 |
| TPC-H 8   | 44.2819061279297   | 2657 | 67.7506866455078   | 4066 | +53%   |     (run time too short) 0.0000 |
| TPC-H 9   | 19.288610458374    | 1158 | 24.961404800415    | 1498 | +29%   |     (run time too short) 0.0000 |
| TPC-H 10  | 25.1999549865723   | 1512 | 26.7133541107178   | 1603 | +6%    |     (run time too short) 0.0000 |
| TPC-H 11  | 121.234954833984   | 7275 | 130.297454833984   | 7818 | +7%    |     (run time too short) 0.0000 |
| TPC-H 12  | 38.5186614990234   | 2312 | 41.5834808349609   | 2496 | +8%    |     (run time too short) 0.0000 |
| TPC-H 13  | 29.7314968109131   | 1784 | 28.4732303619385   | 1709 | -4%    |     (run time too short) 0.0000 |
| TPC-H 14  | 105.693504333496   | 6342 | 112.362030029297   | 6742 | +6%    |     (run time too short) 0.0000 |
| TPC-H 15  | 47.6279144287109   | 2858 | 47.2937545776367   | 2838 | -1%    |     (run time too short) 0.0000 |
| TPC-H 16  | 12.4951829910278   | 750  | 12.8225126266479   | 770  | +3%    |     (run time too short) 0.0000 |
| TPC-H 17  | 4.26351261138916   | 256  | 3.13524436950684   | 189  | -26%   |                          0.0000 |
| TPC-H 18  | 2.71632623672485   | 163  | 2.76291036605835   | 166  | +2%    |     (run time too short) 0.0000 |
| TPC-H 19  | 2.2849018573761    | 138  | 2.35911393165588   | 142  | +3%    |     (run time too short) 0.0000 |
| TPC-H 20  | 0.0299961809068918 | 2    | 0.0221507363021374 | 2    | -26%   |        (not enough runs) 0.0007 |
| TPC-H 21  | 0.285482466220856  | 18   | 0.205741420388222  | 13   | -28%   |                          0.0000 |
| TPC-H 22  | 58.0406112670898   | 3483 | 59.235912322998    | 3555 | +2%    |     (run time too short) 0.0000 |
| average   |                    |      |                    |      | +4%    |                                 |
+-----------+--------------------+------+--------------------+------+--------+---------------------------------+```

I am currently looking into the queries that suffered from the change. @mrks : I first thought of #1122 but it's reproducible on nemea.