### PR TITLE
clang_tidy_wrapper: reference executable that actually exists.

### DIFF
--- a/scripts/clang_tidy_wrapper.sh
+++ b/scripts/clang_tidy_wrapper.sh
@@ -13,5 +13,5 @@ if grep "$file_relative_to_source" $cmake_source_dir/.clang-tidy-ignore > /dev/n
 	echo "clang-tidy: Ignoring $file_relative_to_source"
 	exit 0
 else
-	exec clang-tidy-6.0 -header-filter=$1/src/ $file $@
+	exec `which clang-tidy-7.0 clang-tidy-6.0 clang-tidy | head -n 1` -header-filter=$1/src/ $file $@
 fi

--- a/scripts/clang_tidy_wrapper.sh
+++ b/scripts/clang_tidy_wrapper.sh
@@ -13,5 +13,5 @@ if grep "$file_relative_to_source" $cmake_source_dir/.clang-tidy-ignore > /dev/n
 	echo "clang-tidy: Ignoring $file_relative_to_source"
 	exit 0
 else
-	exec clang-tidy -header-filter=$1/src/ $file $@
+	exec clang-tidy-6.0 -header-filter=$1/src/ $file $@
 fi

--- a/scripts/clang_tidy_wrapper.sh
+++ b/scripts/clang_tidy_wrapper.sh
@@ -13,5 +13,5 @@ if grep "$file_relative_to_source" $cmake_source_dir/.clang-tidy-ignore > /dev/n
 	echo "clang-tidy: Ignoring $file_relative_to_source"
 	exit 0
 else
-	exec `which clang-tidy-7.0 clang-tidy-6.0 clang-tidy | head -n 1` -header-filter=$1/src/ $file $@
+	exec $(which clang-tidy-7.0 clang-tidy-6.0 clang-tidy | head -n 1) -header-filter=$1/src/ $file $@
 fi


### PR DESCRIPTION
@mrks Just a quick proposal to hard-code the clang-tidy version to use. Ubuntu 18.04, at least, doesn't install a `clang-tidy` executable/link at all, just `clang-tidy-*.0`