### PR TITLE
Fix Chunk Pruning for BETWEEN

### DIFF
--- a/src/lib/expression/expression_functional.hpp
+++ b/src/lib/expression/expression_functional.hpp
@@ -137,7 +137,7 @@ inline detail::binary<PredicateCondition::GreaterThan, BinaryPredicateExpression
 inline detail::binary<LogicalOperator::And, LogicalExpression> and_;
 inline detail::binary<LogicalOperator::Or, LogicalExpression> or_;
 
-inline detail::ternary<BetweenExpression> between;
+inline detail::ternary<BetweenExpression> between_;
 inline detail::ternary<CaseExpression> case_;
 
 template <typename... Args>

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -96,7 +96,8 @@ std::set<ChunkID> ChunkPruningRule::_compute_exclude_list(
     auto condition = operator_predicate.predicate_condition;
     for (size_t chunk_id = 0; chunk_id < statistics.size(); ++chunk_id) {
       // statistics[chunk_id] can be a shared_ptr initialized with a nullptr
-      if (statistics[chunk_id] && statistics[chunk_id]->can_prune(operator_predicate.column_id, condition, value, value2)) {
+      if (statistics[chunk_id] &&
+          statistics[chunk_id]->can_prune(operator_predicate.column_id, condition, value, value2)) {
         result.insert(ChunkID(chunk_id));
       }
     }

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -90,12 +90,13 @@ std::set<ChunkID> ChunkPruningRule::_compute_exclude_list(
     if (!is_variant(operator_predicate.value)) {
       return std::set<ChunkID>();
     }
-    // TODO(anyone): add BETWEEN support
-    auto& value = boost::get<AllTypeVariant>(operator_predicate.value);
+    const auto& value = boost::get<AllTypeVariant>(operator_predicate.value);
+    std::optional<AllTypeVariant> value2;
+    if (static_cast<bool>(operator_predicate.value2)) value2 = boost::get<AllTypeVariant>(*operator_predicate.value2);
     auto condition = operator_predicate.predicate_condition;
     for (size_t chunk_id = 0; chunk_id < statistics.size(); ++chunk_id) {
       // statistics[chunk_id] can be a shared_ptr initialized with a nullptr
-      if (statistics[chunk_id] && statistics[chunk_id]->can_prune(operator_predicate.column_id, condition, value)) {
+      if (statistics[chunk_id] && statistics[chunk_id]->can_prune(operator_predicate.column_id, condition, value, value2)) {
         result.insert(ChunkID(chunk_id));
       }
     }

--- a/src/lib/statistics/chunk_statistics/histograms/abstract_histogram.cpp
+++ b/src/lib/statistics/chunk_statistics/histograms/abstract_histogram.cpp
@@ -227,7 +227,7 @@ bool AbstractHistogram<T>::_can_prune(const PredicateCondition predicate_type, c
     }
     case PredicateCondition::Like:
     case PredicateCondition::NotLike:
-      Fail("Predicate NOT LIKE is not supported for non-string columns.");
+      Fail("Predicate (NOT) LIKE is not supported for non-string columns.");
     default:
       // Do not prune predicates we cannot (yet) handle.
       return false;

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -264,14 +264,14 @@ TEST_F(ExpressionEvaluatorTest, PredicatesLiterals) {
   EXPECT_TRUE(test_expression<int32_t>(*equals_("Hello", null_()), {std::nullopt}));
   EXPECT_TRUE(test_expression<int32_t>(*not_equals_(5.5f, 5), {1}));
   EXPECT_TRUE(test_expression<int32_t>(*not_equals_(5.5f, 5.5f), {0}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(3, 3.0, 5.0), {1}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(3, 3.1, 5.0), {0}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(5.0f, 3.1, 5), {1}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(5.1f, 3.1, 5), {0}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(5.1f, 3.1, null_()), {std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(5.1f, null_(), 5), {0}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(null_(), 3.1, 5), {std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(*between(null_(), null_(), null_()), {std::nullopt}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(3, 3.0, 5.0), {1}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(3, 3.1, 5.0), {0}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(5.0f, 3.1, 5), {1}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(5.1f, 3.1, 5), {0}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(5.1f, 3.1, null_()), {std::nullopt}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(5.1f, null_(), 5), {0}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(null_(), 3.1, 5), {std::nullopt}));
+  EXPECT_TRUE(test_expression<int32_t>(*between_(null_(), null_(), null_()), {std::nullopt}));
 }
 
 TEST_F(ExpressionEvaluatorTest, PredicatesSeries) {
@@ -286,9 +286,9 @@ TEST_F(ExpressionEvaluatorTest, PredicatesSeries) {
   EXPECT_TRUE(test_expression<int32_t>(table_a, *less_than_(b, mul_(a, 2)), {0, 1, 1, 1}));
   EXPECT_TRUE(test_expression<int32_t>(table_a, *less_than_equals_(b, mul_(a, 2)), {1, 1, 1, 1}));
   EXPECT_TRUE(test_expression<int32_t>(table_a, *less_than_equals_(c, f), {1, std::nullopt, 0, std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(table_a, *between(b, a, c), {1, std::nullopt, 1, std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(table_a, *between(e, a, f), {1, 0, 0, 0}));
-  EXPECT_TRUE(test_expression<int32_t>(table_a, *between(3.3, a, b), {0, 0, 1, 0}));
+  EXPECT_TRUE(test_expression<int32_t>(table_a, *between_(b, a, c), {1, std::nullopt, 1, std::nullopt}));
+  EXPECT_TRUE(test_expression<int32_t>(table_a, *between_(e, a, f), {1, 0, 0, 0}));
+  EXPECT_TRUE(test_expression<int32_t>(table_a, *between_(3.3, a, b), {0, 0, 1, 0}));
 }
 
 TEST_F(ExpressionEvaluatorTest, CaseLiterals) {

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -59,7 +59,7 @@ TEST_F(ExpressionTest, Equals) {
   EXPECT_EQ(*value_(5), *value_(5));
   EXPECT_NE(*value_(5.0), *value_(5));
   EXPECT_NE(*value_(5.3), *value_(5));
-  EXPECT_EQ(*between(1, a, 3), *between(1, a, 3));
+  EXPECT_EQ(*between_(1, a, 3), *between_(1, a, 3));
   EXPECT_EQ(*greater_than_(1, a), *greater_than_(1, a));
   EXPECT_NE(*greater_than_(1, a), *less_than_(a, 1));
   EXPECT_EQ(*is_null_(a), *is_null_(a));
@@ -102,7 +102,7 @@ TEST_F(ExpressionTest, DeepCopy) {
 
 TEST_F(ExpressionTest, RequiresCalculation) {
   EXPECT_TRUE(sum_(a)->requires_computation());
-  EXPECT_TRUE(between(a, 1, 5)->requires_computation());
+  EXPECT_TRUE(between_(a, 1, 5)->requires_computation());
   EXPECT_TRUE(greater_than_(a, b)->requires_computation());
   EXPECT_TRUE(case_(1, a, b)->requires_computation());
   EXPECT_TRUE(substr_("Hello", 1, 2)->requires_computation());
@@ -142,7 +142,7 @@ TEST_F(ExpressionTest, AsColumnName) {
   EXPECT_EQ(greater_than_(5, 3)->as_column_name(), "5 > 3");
   EXPECT_EQ(equals_(5, 3)->as_column_name(), "5 = 3");
   EXPECT_EQ(not_equals_(5, 3)->as_column_name(), "5 != 3");
-  EXPECT_EQ(between(5, 3, 4)->as_column_name(), "5 BETWEEN 3 AND 4");
+  EXPECT_EQ(between_(5, 3, 4)->as_column_name(), "5 BETWEEN_ 3 AND 4");
   EXPECT_EQ(case_(1, 3, case_(0, 2, 1))->as_column_name(), "CASE WHEN 1 THEN 3 ELSE CASE WHEN 0 THEN 2 ELSE 1 END END");
   EXPECT_EQ(extract_(DatetimeComponent::Month, "1993-03-04")->as_column_name(), "EXTRACT(MONTH FROM '1993-03-04')");
   EXPECT_EQ(substr_("Hello", 1, 2)->as_column_name(), "SUBSTR('Hello', 1, 2)");
@@ -181,12 +181,12 @@ TEST_F(ExpressionTest, AsColumnNameNested) {
   EXPECT_EQ(is_null_(sum_(add_(a, 2)))->as_column_name(), "SUM(a + 2) IS NULL");
   EXPECT_EQ(less_than_(a, b)->as_column_name(), "a < b");
   EXPECT_EQ(less_than_(add_(a, 5), b)->as_column_name(), "a + 5 < b");
-  EXPECT_EQ(between(a, 2, 3)->as_column_name(), "a BETWEEN 2 AND 3");
-  EXPECT_EQ(and_(greater_than_equals_(b, 5), between(a, 2, 3))->as_column_name(), "b >= 5 AND a BETWEEN 2 AND 3");
-  EXPECT_EQ(not_equals_(between(a, 2, 3), 0)->as_column_name(), "(a BETWEEN 2 AND 3) != 0");
+  EXPECT_EQ(between_(a, 2, 3)->as_column_name(), "a BETWEEN_ 2 AND 3");
+  EXPECT_EQ(and_(greater_than_equals_(b, 5), between_(a, 2, 3))->as_column_name(), "b >= 5 AND a BETWEEN_ 2 AND 3");
+  EXPECT_EQ(not_equals_(between_(a, 2, 3), 0)->as_column_name(), "(a BETWEEN_ 2 AND 3) != 0");
 
   EXPECT_EQ(mul_(less_than_(add_(a, 5), b), 3)->as_column_name(), "(a + 5 < b) * 3");
-  EXPECT_EQ(add_(1, between(a, 2, 3))->as_column_name(), "1 + (a BETWEEN 2 AND 3)");
+  EXPECT_EQ(add_(1, between_(a, 2, 3))->as_column_name(), "1 + (a BETWEEN_ 2 AND 3)");
 
   // TODO(anybody) Omit redundant parentheses
   EXPECT_EQ(add_(5, add_(1, 3))->as_column_name(), "5 + (1 + 3)");
@@ -216,7 +216,7 @@ TEST_F(ExpressionTest, DataType) {
 
   EXPECT_EQ(less_than_(1, 2)->data_type(), DataType::Int);
   EXPECT_EQ(less_than_(1.5, 2)->data_type(), DataType::Int);
-  EXPECT_EQ(between(1.5, 2, 3)->data_type(), DataType::Int);
+  EXPECT_EQ(between_(1.5, 2, 3)->data_type(), DataType::Int);
   EXPECT_EQ(and_(1, 1)->data_type(), DataType::Int);
   EXPECT_EQ(or_(1, 1)->data_type(), DataType::Int);
   EXPECT_EQ(is_null_(5)->data_type(), DataType::Int);
@@ -230,8 +230,8 @@ TEST_F(ExpressionTest, DataType) {
 
 TEST_F(ExpressionTest, IsNullable) {
   EXPECT_FALSE(add_(1, 2)->is_nullable());
-  EXPECT_FALSE(between(1, 2, 3)->is_nullable());
-  EXPECT_TRUE(between(1, null_(), 3)->is_nullable());
+  EXPECT_FALSE(between_(1, 2, 3)->is_nullable());
+  EXPECT_TRUE(between_(1, null_(), 3)->is_nullable());
   EXPECT_FALSE(list_(1, 2)->is_nullable());
   EXPECT_TRUE(list_(1, null_())->is_nullable());
   EXPECT_FALSE(and_(1, 1)->is_nullable());

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -142,7 +142,7 @@ TEST_F(ExpressionTest, AsColumnName) {
   EXPECT_EQ(greater_than_(5, 3)->as_column_name(), "5 > 3");
   EXPECT_EQ(equals_(5, 3)->as_column_name(), "5 = 3");
   EXPECT_EQ(not_equals_(5, 3)->as_column_name(), "5 != 3");
-  EXPECT_EQ(between_(5, 3, 4)->as_column_name(), "5 BETWEEN_ 3 AND 4");
+  EXPECT_EQ(between_(5, 3, 4)->as_column_name(), "5 BETWEEN 3 AND 4");
   EXPECT_EQ(case_(1, 3, case_(0, 2, 1))->as_column_name(), "CASE WHEN 1 THEN 3 ELSE CASE WHEN 0 THEN 2 ELSE 1 END END");
   EXPECT_EQ(extract_(DatetimeComponent::Month, "1993-03-04")->as_column_name(), "EXTRACT(MONTH FROM '1993-03-04')");
   EXPECT_EQ(substr_("Hello", 1, 2)->as_column_name(), "SUBSTR('Hello', 1, 2)");
@@ -181,12 +181,12 @@ TEST_F(ExpressionTest, AsColumnNameNested) {
   EXPECT_EQ(is_null_(sum_(add_(a, 2)))->as_column_name(), "SUM(a + 2) IS NULL");
   EXPECT_EQ(less_than_(a, b)->as_column_name(), "a < b");
   EXPECT_EQ(less_than_(add_(a, 5), b)->as_column_name(), "a + 5 < b");
-  EXPECT_EQ(between_(a, 2, 3)->as_column_name(), "a BETWEEN_ 2 AND 3");
-  EXPECT_EQ(and_(greater_than_equals_(b, 5), between_(a, 2, 3))->as_column_name(), "b >= 5 AND a BETWEEN_ 2 AND 3");
-  EXPECT_EQ(not_equals_(between_(a, 2, 3), 0)->as_column_name(), "(a BETWEEN_ 2 AND 3) != 0");
+  EXPECT_EQ(between_(a, 2, 3)->as_column_name(), "a BETWEEN 2 AND 3");
+  EXPECT_EQ(and_(greater_than_equals_(b, 5), between_(a, 2, 3))->as_column_name(), "b >= 5 AND a BETWEEN 2 AND 3");
+  EXPECT_EQ(not_equals_(between_(a, 2, 3), 0)->as_column_name(), "(a BETWEEN 2 AND 3) != 0");
 
   EXPECT_EQ(mul_(less_than_(add_(a, 5), b), 3)->as_column_name(), "(a + 5 < b) * 3");
-  EXPECT_EQ(add_(1, between_(a, 2, 3))->as_column_name(), "1 + (a BETWEEN_ 2 AND 3)");
+  EXPECT_EQ(add_(1, between_(a, 2, 3))->as_column_name(), "1 + (a BETWEEN 2 AND 3)");
 
   // TODO(anybody) Omit redundant parentheses
   EXPECT_EQ(add_(5, add_(1, 3))->as_column_name(), "5 + (1 + 3)");

--- a/src/test/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
+++ b/src/test/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
@@ -76,7 +76,7 @@ class LQPFindSubplanMismatchTest : public ::testing::Test {
     query_nodes.table_c_b = LQPColumnReference{query_nodes.mock_node_b, ColumnID{1}};
 
     query_nodes.predicate_node_a = PredicateNode::make(less_than_(query_nodes.table_a_a, 41));
-    query_nodes.predicate_node_b = PredicateNode::make(between(query_nodes.table_a_a, 42, 45));
+    query_nodes.predicate_node_b = PredicateNode::make(between_(query_nodes.table_a_a, 42, 45));
     query_nodes.union_node = UnionNode::make(UnionMode::Positions);
     query_nodes.limit_node = LimitNode::make(to_expression(10));
     query_nodes.join_node = JoinNode::make(JoinMode::Inner, equals_(query_nodes.table_a_a, query_nodes.table_c_b));
@@ -124,7 +124,7 @@ TEST_F(LQPFindSubplanMismatchTest, EqualsTest) {
 }
 
 TEST_F(LQPFindSubplanMismatchTest, SubplanMismatch) {
-  _query_nodes_rhs.predicate_node_b = PredicateNode::make(between(_query_nodes_rhs.table_a_a, 42, 46));
+  _query_nodes_rhs.predicate_node_b = PredicateNode::make(between_(_query_nodes_rhs.table_a_a, 42, 46));
 
   _build_query_lqps();
 
@@ -135,7 +135,7 @@ TEST_F(LQPFindSubplanMismatchTest, SubplanMismatch) {
 }
 
 TEST_F(LQPFindSubplanMismatchTest, AdditionalNode) {
-  const auto additional_predicate_node = PredicateNode::make(between(_query_nodes_rhs.table_a_a, 42, 45));
+  const auto additional_predicate_node = PredicateNode::make(between_(_query_nodes_rhs.table_a_a, 42, 45));
 
   _build_query_lqps();
 
@@ -149,8 +149,8 @@ TEST_F(LQPFindSubplanMismatchTest, AdditionalNode) {
 }
 
 TEST_F(LQPFindSubplanMismatchTest, TypeMismatch) {
-  const auto first_node = PredicateNode::make(between(_query_nodes_rhs.table_a_a, int32_t{42}, int32_t{45}));
-  const auto second_node = PredicateNode::make(between(_query_nodes_rhs.table_a_a, int64_t{42}, int64_t{45}));
+  const auto first_node = PredicateNode::make(between_(_query_nodes_rhs.table_a_a, int32_t{42}, int32_t{45}));
+  const auto second_node = PredicateNode::make(between_(_query_nodes_rhs.table_a_a, int64_t{42}, int64_t{45}));
 
   first_node->set_left_input(_query_nodes_rhs.stored_table_node_a);
   second_node->set_left_input(_query_nodes_rhs.stored_table_node_a);

--- a/src/test/operators/operator_scan_predicate_test.cpp
+++ b/src/test/operators/operator_scan_predicate_test.cpp
@@ -52,7 +52,7 @@ TEST_F(OperatorScanPredicateTest, FromExpressionColumnRight) {
 }
 
 TEST_F(OperatorScanPredicateTest, SimpleBetween) {
-  const auto operator_predicates_a = OperatorScanPredicate::from_expression(*between(a, 5, 7), *node);
+  const auto operator_predicates_a = OperatorScanPredicate::from_expression(*between_(a, 5, 7), *node);
   ASSERT_TRUE(operator_predicates_a);
   ASSERT_EQ(operator_predicates_a->size(), 1u);
   const auto& operator_predicate_a = operator_predicates_a->at(0);
@@ -65,7 +65,7 @@ TEST_F(OperatorScanPredicateTest, SimpleBetween) {
 
 TEST_F(OperatorScanPredicateTest, ComplicatedBetween) {
   // `5 BETWEEN a AND b` becomes `a <= 5 AND b >= 5`
-  const auto operator_predicates_b = OperatorScanPredicate::from_expression(*between(5, a, b), *node);
+  const auto operator_predicates_b = OperatorScanPredicate::from_expression(*between_(5, a, b), *node);
   ASSERT_TRUE(operator_predicates_b);
   ASSERT_EQ(operator_predicates_b->size(), 2u);
 

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -232,7 +232,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBetween) {
    * LQP resembles:
    *   SELECT * FROM int_float WHERE 5 BETWEEN a AND b;
    */
-  const auto predicate_node = PredicateNode::make(between(5, int_float_a, int_float_b), int_float_node);
+  const auto predicate_node = PredicateNode::make(between_(5, int_float_a, int_float_b), int_float_node);
   const auto pqp = LQPTranslator{}.translate_node(predicate_node);
 
   /**
@@ -429,7 +429,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeSupportedBetweenScan) {
   /**
    * Build LQP and translate to PQP
    */
-  auto predicate_node = PredicateNode::make(between(int_float_a, 42, 1337), int_float_node);
+  auto predicate_node = PredicateNode::make(between_(int_float_a, 42, 1337), int_float_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
   /**
@@ -449,7 +449,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeNonSupportedBetweenScan) {
    */
 
   // Because the BETWEEN TableScan does not handle varying types (yet), two scans should be created
-  auto predicate_node = PredicateNode::make(between(int_float_a, 42, 1337.5), int_float_node);
+  auto predicate_node = PredicateNode::make(between_(int_float_a, 42, 1337.5), int_float_node);
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
   /**
@@ -515,7 +515,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
   table->get_chunk(index_chunk_ids[0])->create_index<GroupKeyIndex>(index_column_ids);
   table->get_chunk(index_chunk_ids[1])->create_index<GroupKeyIndex>(index_column_ids);
 
-  auto predicate_node = PredicateNode::make(between(stored_table_node->get_column("b"), 42, 1337));
+  auto predicate_node = PredicateNode::make(between_(stored_table_node->get_column("b"), 42, 1337));
   predicate_node->set_left_input(stored_table_node);
   predicate_node->scan_type = ScanType::IndexScan;
   const auto op = LQPTranslator{}.translate_node(predicate_node);

--- a/src/test/optimizer/strategy/chunk_pruning_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_test.cpp
@@ -69,6 +69,21 @@ TEST_F(ChunkPruningTest, SimplePruningTest) {
   EXPECT_EQ(excluded, expected);
 }
 
+TEST_F(ChunkPruningTest, BetweenPruningTest) {
+  auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
+
+  auto predicate_node =
+      std::make_shared<PredicateNode>(between_(LQPColumnReference(stored_table_node, ColumnID{1}), 456, 458.0));
+  predicate_node->set_left_input(stored_table_node);
+
+  auto pruned = StrategyBaseTest::apply_rule(_rule, predicate_node);
+
+  EXPECT_EQ(pruned, predicate_node);
+  std::vector<ChunkID> expected = {ChunkID{1}};
+  std::vector<ChunkID> excluded = stored_table_node->excluded_chunk_ids();
+  EXPECT_EQ(excluded, expected);
+}
+
 TEST_F(ChunkPruningTest, NoStatisticsAvailable) {
   auto table = StorageManager::get().get_table("uncompressed");
   auto chunk = table->get_chunk(ChunkID(0));

--- a/src/test/optimizer/strategy/chunk_pruning_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_test.cpp
@@ -73,13 +73,13 @@ TEST_F(ChunkPruningTest, BetweenPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node =
-      std::make_shared<PredicateNode>(between_(LQPColumnReference(stored_table_node, ColumnID{1}), 456, 458.0));
+      std::make_shared<PredicateNode>(between_(LQPColumnReference(stored_table_node, ColumnID{1}), 350, 351));
   predicate_node->set_left_input(stored_table_node);
 
   auto pruned = StrategyBaseTest::apply_rule(_rule, predicate_node);
 
   EXPECT_EQ(pruned, predicate_node);
-  std::vector<ChunkID> expected = {ChunkID{1}};
+  std::vector<ChunkID> expected = {ChunkID{0}};
   std::vector<ChunkID> excluded = stored_table_node->excluded_chunk_ids();
   EXPECT_EQ(excluded, expected);
 }

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -343,7 +343,7 @@ TEST_F(SQLTranslatorTest, WhereWithBetween) {
   // clang-format off
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(int_float_a),
-    PredicateNode::make(between(int_float_a, int_float_b, 5),
+    PredicateNode::make(between_(int_float_a, int_float_b, 5),
       stored_table_node_int_float));  // NOLINT
   // clang-format on
 


### PR DESCRIPTION
Merging #1154 on top of #1118 has revealed a missing implementation. Unfortunately, there were no merge conflicts, so the CI pass of #1154 was based on an outdated master. This PR fixes the result.

On a more general note: If we wanted to, we could prevent these situations by setting a Github setting that only allows us to merge if the PR is based on an up-to-date master. Obviously, this would mean that we would have to do more CI builds. As this is only the second time this has happened and gets caught as soon as the merged master is built, I don't think that doing so is necessary.