### PR TITLE
Add functionality to create empty tables from meta info

### DIFF
--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -79,6 +79,11 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const std::
   return table;
 }
 
+std::shared_ptr<Table> CsvParser::create_table_from_meta_file(const std::string& filename) {
+  _meta = process_csv_meta_file(filename);
+  return _create_table_from_meta();
+}
+
 std::shared_ptr<Table> CsvParser::_create_table_from_meta() {
   TableColumnDefinitions column_definitions;
   for (const auto& column_meta : _meta.columns) {

--- a/src/lib/import_export/csv_parser.hpp
+++ b/src/lib/import_export/csv_parser.hpp
@@ -36,6 +36,7 @@ class CsvParser {
    * @returns             The table that was created from the csv file.
    */
   std::shared_ptr<Table> parse(const std::string& filename, const std::optional<CsvMeta>& csv_meta = std::nullopt);
+  std::shared_ptr<Table> create_table_from_meta_file(const std::string& filename);
 
  protected:
   /*

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -11,10 +11,7 @@
 
 namespace opossum {
 
-std::shared_ptr<Table> create_table_from_header(const std::string& file_name, size_t chunk_size) {
-  std::ifstream infile(file_name);
-  Assert(infile.is_open(), "load_table: Could not find file " + file_name);
-
+std::shared_ptr<Table> create_table_from_header(std::ifstream& infile, size_t chunk_size) {
   std::string line;
   std::getline(infile, line);
   std::vector<std::string> column_names = _split<std::string>(line, '|');
@@ -41,11 +38,17 @@ std::shared_ptr<Table> create_table_from_header(const std::string& file_name, si
   return std::make_shared<Table>(column_definitions, TableType::Data, chunk_size, UseMvcc::Yes);
 }
 
-std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_size) {
-  auto table = create_table_from_header(file_name, chunk_size);
-
+std::shared_ptr<Table> create_table_from_header(const std::string& file_name, size_t chunk_size) {
   std::ifstream infile(file_name);
   Assert(infile.is_open(), "load_table: Could not find file " + file_name);
+  return create_table_from_header(infile, chunk_size);
+}
+
+std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_size) {
+  std::ifstream infile(file_name);
+  Assert(infile.is_open(), "load_table: Could not find file " + file_name);
+
+  auto table = create_table_from_header(infile, chunk_size);
 
   std::string line;
   while (std::getline(infile, line)) {

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -11,7 +11,7 @@
 
 namespace opossum {
 
-std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_size) {
+std::shared_ptr<Table> create_table_from_header(const std::string& file_name, size_t chunk_size) {
   std::ifstream infile(file_name);
   Assert(infile.is_open(), "load_table: Could not find file " + file_name);
 
@@ -37,28 +37,35 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
            std::string("Invalid data type ") + column_types[i] + " for column " + column_names[i]);
     column_definitions.emplace_back(column_names[i], data_type->second, column_nullable[i]);
   }
-  std::shared_ptr<Table> test_table =
-      std::make_shared<Table>(column_definitions, TableType::Data, chunk_size, UseMvcc::Yes);
 
+  return std::make_shared<Table>(column_definitions, TableType::Data, chunk_size, UseMvcc::Yes);
+}
+
+std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_size) {
+  auto table = create_table_from_header(file_name, chunk_size);
+
+  std::ifstream infile(file_name);
+  Assert(infile.is_open(), "load_table: Could not find file " + file_name);
+
+  std::string line;
   while (std::getline(infile, line)) {
     std::vector<AllTypeVariant> values = _split<AllTypeVariant>(line, '|');
 
-    for (auto column_id = 0u; column_id < values.size(); ++column_id) {
+    for (auto column_id = ColumnID{0}; column_id < values.size(); ++column_id) {
       auto& value = values[column_id];
-      auto nullable = column_nullable[column_id];
 
-      if (nullable && (value == AllTypeVariant{"null"})) {
+      if (table->column_is_nullable(column_id) && (value == AllTypeVariant{"null"})) {
         value = NULL_VALUE;
       }
     }
 
-    test_table->append(values);
+    table->append(values);
 
-    auto chunk = test_table->get_chunk(static_cast<ChunkID>(test_table->chunk_count() - 1));
+    auto chunk = table->get_chunk(static_cast<ChunkID>(table->chunk_count() - 1));
     auto mvcc_data = chunk->get_scoped_mvcc_data_lock();
     mvcc_data->begin_cids.back() = 0;
   }
-  return test_table;
+  return table;
 }
 
 }  // namespace opossum

--- a/src/lib/utils/load_table.hpp
+++ b/src/lib/utils/load_table.hpp
@@ -30,5 +30,6 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
  * Creates an empty table based on the meta information in the first lines of the file without loading the data itself.
  */
 std::shared_ptr<Table> create_table_from_header(const std::string& file_name, size_t chunk_size = Chunk::MAX_SIZE);
+std::shared_ptr<Table> create_table_from_header(std::ifstream& infile, size_t chunk_size);
 
 }  // namespace opossum

--- a/src/lib/utils/load_table.hpp
+++ b/src/lib/utils/load_table.hpp
@@ -26,4 +26,9 @@ std::vector<T> _split(const std::string& str, char delimiter) {
 
 std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_size = Chunk::MAX_SIZE);
 
+/**
+ * Creates an empty table based on the meta information in the first lines of the file without loading the data itself.
+ */
+std::shared_ptr<Table> create_table_from_header(const std::string& file_name, size_t chunk_size = Chunk::MAX_SIZE);
+
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -25,8 +25,10 @@ set(
     import_export/csv_meta_test.cpp
     lib/all_parameter_variant_test.cpp
     lib/all_type_variant_test.cpp
+    lib/import_export/csv_parser_test.cpp
     lib/fixed_string_test.cpp
     lib/null_value_test.cpp
+    lib/utils/load_table_test.cpp
     logical_query_plan/aggregate_node_test.cpp
     logical_query_plan/alias_node_test.cpp
     logical_query_plan/create_view_node_test.cpp

--- a/src/test/lib/import_export/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv_parser_test.cpp
@@ -1,0 +1,21 @@
+#include "base_test.hpp"
+#include "gtest/gtest.h"
+
+#include "import_export/csv_parser.hpp"
+#include "storage/table.hpp"
+
+namespace opossum {
+
+class CsvParserTest : public BaseTest {};
+
+TEST_F(CsvParserTest, EmptyTableFromMetaFile) {
+    CsvParser parser;
+    const auto csv_meta_table = parser.create_table_from_meta_file("src/test/csv/float_int.csv.json");
+    const auto expected_table = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float},
+                                                        {"a", DataType::Int}}, TableType::Data);
+
+    EXPECT_EQ(csv_meta_table->row_count(), 0);
+    EXPECT_TABLE_EQ_UNORDERED(csv_meta_table, expected_table);
+}
+
+}  // namespace opossum

--- a/src/test/lib/utils/load_table_test.cpp
+++ b/src/test/lib/utils/load_table_test.cpp
@@ -1,0 +1,20 @@
+#include "base_test.hpp"
+#include "gtest/gtest.h"
+
+#include "storage/table.hpp"
+#include "utils/load_table.hpp"
+
+namespace opossum {
+
+class LoadTableTest : public BaseTest {};
+
+TEST_F(LoadTableTest, EmptyTableFromHeader) {
+    const auto tbl_header_table = create_table_from_header("src/test/tables/float_int.tbl");
+    const auto expected_table = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float},
+                                                        {"a", DataType::Int}}, TableType::Data);
+
+    EXPECT_EQ(tbl_header_table->row_count(), 0);
+    EXPECT_TABLE_EQ_UNORDERED(tbl_header_table, expected_table);
+}
+
+}  // namespace opossum


### PR DESCRIPTION
This PR adds functionality to parse the meta information in a tbl file / json file to create empty tables without loading the whole tbl/csv file.

I was using this during evaluation for my thesis and thought it might be useful for some other people in the future.