### PR TITLE
Change default chunk size to 100,000 for benchmarks

### DIFF
--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -454,7 +454,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("help", "print this help message")
     ("v,verbose", "Print log messages", cxxopts::value<bool>()->default_value("false"))
     ("r,runs", "Maximum number of runs of a single query (set)", cxxopts::value<size_t>()->default_value("10000")) // NOLINT
-    ("c,chunk_size", "ChunkSize, default is 2^32-1", cxxopts::value<ChunkOffset>()->default_value(std::to_string(Chunk::MAX_SIZE))) // NOLINT
+    ("c,chunk_size", "ChunkSize, default is 100,000", cxxopts::value<ChunkOffset>()->default_value("100000")) // NOLINT
     ("t,time", "Maximum seconds that a query (set) is run", cxxopts::value<size_t>()->default_value("60")) // NOLINT
     ("o,output", "File to output results to, don't specify for stdout", cxxopts::value<std::string>()->default_value("")) // NOLINT
     ("m,mode", "IndividualQueries or PermutedQuerySet, default is IndividualQueries", cxxopts::value<std::string>()->default_value("IndividualQueries")) // NOLINT

--- a/src/benchmarklib/benchmark_utils.hpp
+++ b/src/benchmarklib/benchmark_utils.hpp
@@ -107,7 +107,7 @@ struct BenchmarkConfig {
 
   const BenchmarkMode benchmark_mode = BenchmarkMode::IndividualQueries;
   const bool verbose = false;
-  const ChunkOffset chunk_size = Chunk::MAX_SIZE;
+  const ChunkOffset chunk_size = 100'000;
   const EncodingConfig encoding_config = EncodingConfig{};
   const size_t max_num_query_runs = 1000;
   const Duration max_duration = std::chrono::seconds(5);


### PR DESCRIPTION
For years, we have preached that chunks are the superior main memory database storage layout concept. Until now, our benchmarks are executed with a single chunk of `MAX_CHUNK_SIZE`.  Recent experiments have shown that a chunk size of roughly 100,000 records achieves the best performance.

TPC-H performance for chunk size 100,000 compared to a single chunk of size `MAX_CHUNK_SIZE`:

<img width="805" alt="screenshot 2018-10-09 at 14 46 40" src="https://user-images.githubusercontent.com/1655756/46670961-d6f94b00-cbd3-11e8-99c7-57bc074a2c7c.png">

Detailed analysis for different chunk sizes.
[queries.pdf](https://github.com/hyrise/hyrise/files/2460463/queries.pdf)

The large benefit for query 21 is explainable with a much better applicability of chunk pruning for the first correlated subquery:

![chunks](https://user-images.githubusercontent.com/1655756/46671119-3f482c80-cbd4-11e8-8a1a-76d597c8ae56.png)

