### PR TITLE
Prevent division by zero in BenchmarkRunner::_create_report().

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -55,7 +55,10 @@ for old, new in zip(old_data['benchmarks'], new_data['benchmarks']):
 	if old['name'] != new['name']:
 		print("Benchmark name mismatch")
 		exit()
-	diff = float(new['items_per_second']) / float(old['items_per_second']) - 1
+	if float(old['items_per_second']) - 1 > 0.0:
+		diff = float(new['items_per_second']) / float(old['items_per_second']) - 1
+	else:
+		diff = float('nan')
 	average_diff_sum += diff
 	diff_formatted = format_diff(diff)
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -294,7 +294,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     const auto duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(query_result.duration).count();
     const auto duration_seconds = static_cast<float>(duration_ns) / 1'000'000'000;
     const auto items_per_second = static_cast<float>(query_result.num_iterations) / duration_seconds;
-    const auto time_per_query = duration_ns / query_result.num_iterations;
+    const auto time_per_query = query_result.num_iterations > 0 ? duration_ns / query_result.num_iterations : 0.f;
 
     // Transform iteration Durations into numerical representation
     auto iteration_durations = std::vector<double>();

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -294,7 +294,8 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     const auto duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(query_result.duration).count();
     const auto duration_seconds = static_cast<float>(duration_ns) / 1'000'000'000;
     const auto items_per_second = static_cast<float>(query_result.num_iterations) / duration_seconds;
-    const auto time_per_query = query_result.num_iterations > 0 ? duration_ns / query_result.num_iterations : std::nanf("");
+    const auto time_per_query =
+        query_result.num_iterations > 0 ? duration_ns / query_result.num_iterations : std::nanf("");
 
     // Transform iteration Durations into numerical representation
     auto iteration_durations = std::vector<double>();

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -294,7 +294,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     const auto duration_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(query_result.duration).count();
     const auto duration_seconds = static_cast<float>(duration_ns) / 1'000'000'000;
     const auto items_per_second = static_cast<float>(query_result.num_iterations) / duration_seconds;
-    const auto time_per_query = query_result.num_iterations > 0 ? duration_ns / query_result.num_iterations : 0.f;
+    const auto time_per_query = query_result.num_iterations > 0 ? duration_ns / query_result.num_iterations : std::nanf("");
 
     // Transform iteration Durations into numerical representation
     auto iteration_durations = std::vector<double>();

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -295,7 +295,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     const auto duration_seconds = static_cast<float>(duration_ns) / 1'000'000'000;
     const auto items_per_second = static_cast<float>(query_result.num_iterations) / duration_seconds;
     const auto time_per_query =
-        query_result.num_iterations > 0 ? duration_ns / query_result.num_iterations : std::nanf("");
+        query_result.num_iterations > 0 ? static_cast<float>(duration_ns) / query_result.num_iterations : std::nanf("");
 
     // Transform iteration Durations into numerical representation
     auto iteration_durations = std::vector<double>();

--- a/src/benchmarklib/benchmark_utils.cpp
+++ b/src/benchmarklib/benchmark_utils.cpp
@@ -54,13 +54,9 @@ bool BenchmarkState::keep_running() {
   return true;
 }
 
-void BenchmarkState::set_done() {
-  state = State::Over;
-}
+void BenchmarkState::set_done() { state = State::Over; }
 
-bool BenchmarkState::is_done() {
-  return state == State::Over;
-}
+bool BenchmarkState::is_done() { return state == State::Over; }
 
 BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const bool verbose, const ChunkOffset chunk_size,
                                  const EncodingConfig& encoding_config, const size_t max_num_query_runs,
@@ -292,10 +288,11 @@ std::string CLIConfigParser::detailed_help(const cxxopts::Options& options) {
 
 EncodingConfig::EncodingConfig() : EncodingConfig{SegmentEncodingSpec{EncodingType::Dictionary}} {}
 
-EncodingConfig::EncodingConfig(SegmentEncodingSpec default_encoding_spec)
+EncodingConfig::EncodingConfig(const SegmentEncodingSpec default_encoding_spec)
     : EncodingConfig{default_encoding_spec, {}, {}} {}
 
-EncodingConfig::EncodingConfig(SegmentEncodingSpec default_encoding_spec, DataTypeEncodingMapping type_encoding_mapping,
+EncodingConfig::EncodingConfig(const SegmentEncodingSpec& default_encoding_spec,
+                               DataTypeEncodingMapping type_encoding_mapping,
                                TableSegmentEncodingMapping encoding_mapping)
     : default_encoding_spec{default_encoding_spec},
       type_encoding_mapping{std::move(type_encoding_mapping)},

--- a/src/benchmarklib/benchmark_utils.cpp
+++ b/src/benchmarklib/benchmark_utils.cpp
@@ -293,11 +293,11 @@ std::string CLIConfigParser::detailed_help(const cxxopts::Options& options) {
 EncodingConfig::EncodingConfig() : EncodingConfig{SegmentEncodingSpec{EncodingType::Dictionary}} {}
 
 EncodingConfig::EncodingConfig(SegmentEncodingSpec default_encoding_spec)
-    : EncodingConfig{std::move(default_encoding_spec), {}, {}} {}
+    : EncodingConfig{default_encoding_spec, {}, {}} {}
 
 EncodingConfig::EncodingConfig(SegmentEncodingSpec default_encoding_spec, DataTypeEncodingMapping type_encoding_mapping,
                                TableSegmentEncodingMapping encoding_mapping)
-    : default_encoding_spec{std::move(default_encoding_spec)},
+    : default_encoding_spec{default_encoding_spec},
       type_encoding_mapping{std::move(type_encoding_mapping)},
       custom_encoding_mapping{std::move(encoding_mapping)} {}
 

--- a/src/benchmarklib/benchmark_utils.cpp
+++ b/src/benchmarklib/benchmark_utils.cpp
@@ -288,7 +288,7 @@ std::string CLIConfigParser::detailed_help(const cxxopts::Options& options) {
 
 EncodingConfig::EncodingConfig() : EncodingConfig{SegmentEncodingSpec{EncodingType::Dictionary}} {}
 
-EncodingConfig::EncodingConfig(const SegmentEncodingSpec default_encoding_spec)
+EncodingConfig::EncodingConfig(const SegmentEncodingSpec& default_encoding_spec)
     : EncodingConfig{default_encoding_spec, {}, {}} {}
 
 EncodingConfig::EncodingConfig(const SegmentEncodingSpec& default_encoding_spec,

--- a/src/benchmarklib/benchmark_utils.hpp
+++ b/src/benchmarklib/benchmark_utils.hpp
@@ -70,9 +70,9 @@ struct BenchmarkState {
 // View EncodingConfig::description to see format of encoding JSON
 struct EncodingConfig {
   EncodingConfig();
-  EncodingConfig(SegmentEncodingSpec default_encoding_spec, DataTypeEncodingMapping type_encoding_mapping,
+  EncodingConfig(const SegmentEncodingSpec& default_encoding_spec, DataTypeEncodingMapping type_encoding_mapping,
                  TableSegmentEncodingMapping encoding_mapping);
-  explicit EncodingConfig(SegmentEncodingSpec default_encoding_spec);
+  explicit EncodingConfig(const SegmentEncodingSpec& default_encoding_spec);
 
   static EncodingConfig unencoded();
 


### PR DESCRIPTION
This triggered a Floating Point Exception when a benchmark ran for 0 iterations in the given time.

Was considering setting the value to `-1.f` instead of `0.f`. Strong feelings anyone?