### PR TITLE
Fix ambiguous names in expression_functional.hpp

### DIFF
--- a/src/lib/expression/expression_functional.cpp
+++ b/src/lib/expression/expression_functional.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<ValueExpression> null_() { // NOLINT - clang-tidy doesn't like t
   return std::make_shared<ValueExpression>(NullValue{});
 }
 
-std::shared_ptr<ParameterExpression> parameter_(const ParameterID parameter_id) {  // NOLINT - clang-tidy doesn't like the suffix
+std::shared_ptr<ParameterExpression> uncorrelated_parameter_(const ParameterID parameter_id) {  // NOLINT - clang-tidy doesn't like the suffix
   return std::make_shared<ParameterExpression>(parameter_id);
 }
 

--- a/src/lib/expression/expression_functional.cpp
+++ b/src/lib/expression/expression_functional.cpp
@@ -30,11 +30,11 @@ std::shared_ptr<ParameterExpression> parameter_(const ParameterID parameter_id) 
   return std::make_shared<ParameterExpression>(parameter_id);
 }
 
-std::shared_ptr<LQPColumnExpression> column_(const LQPColumnReference& column_reference) {  // NOLINT - clang-tidy doesn't like the suffix
+std::shared_ptr<LQPColumnExpression> lqp_column_(const LQPColumnReference& column_reference) {  // NOLINT - clang-tidy doesn't like the suffix
   return std::make_shared<LQPColumnExpression>(column_reference);
 }
 
-std::shared_ptr<PQPColumnExpression> column_(const ColumnID column_id, const DataType data_type, const bool nullable,  // NOLINT - clang-tidy doesn't like the suffix
+std::shared_ptr<PQPColumnExpression> pqp_column_(const ColumnID column_id, const DataType data_type, const bool nullable,  // NOLINT - clang-tidy doesn't like the suffix
                                              const std::string& column_name) {
   return std::make_shared<PQPColumnExpression>(column_id, data_type, nullable, column_name);
 }

--- a/src/lib/expression/expression_functional.hpp
+++ b/src/lib/expression/expression_functional.hpp
@@ -204,13 +204,13 @@ std::shared_ptr<ExtractExpression> extract_(const DatetimeComponent datetime_com
 }
 
 std::shared_ptr<ParameterExpression> parameter_(const ParameterID parameter_id);
-std::shared_ptr<LQPColumnExpression> column_(const LQPColumnReference& column_reference);
-std::shared_ptr<PQPColumnExpression> column_(const ColumnID column_id, const DataType data_type, const bool nullable,
-                                             const std::string& column_name);
+std::shared_ptr<LQPColumnExpression> lqp_column_(const LQPColumnReference& column_reference);
+std::shared_ptr<PQPColumnExpression> pqp_column_(const ColumnID column_id, const DataType data_type,
+                                                 const bool nullable, const std::string& column_name);
 
 template <typename ReferencedExpression>
-std::shared_ptr<ParameterExpression> parameter_(const ParameterID parameter_id,
-                                                const ReferencedExpression& referenced) {
+std::shared_ptr<ParameterExpression> parameter_with_referenced_(const ParameterID parameter_id,
+                                                                const ReferencedExpression& referenced) {
   return std::make_shared<ParameterExpression>(parameter_id, *to_expression(referenced));
 }
 

--- a/src/lib/expression/expression_functional.hpp
+++ b/src/lib/expression/expression_functional.hpp
@@ -141,7 +141,7 @@ inline detail::ternary<BetweenExpression> between_;
 inline detail::ternary<CaseExpression> case_;
 
 template <typename... Args>
-std::shared_ptr<LQPSelectExpression> select_(const std::shared_ptr<AbstractLQPNode>& lqp,  // NOLINT
+std::shared_ptr<LQPSelectExpression> lqp_select_(const std::shared_ptr<AbstractLQPNode>& lqp,  // NOLINT
                                              Args&&... parameter_id_expression_pairs) {
   if constexpr (sizeof...(Args) > 0) {
     // Correlated subselect
@@ -156,7 +156,7 @@ std::shared_ptr<LQPSelectExpression> select_(const std::shared_ptr<AbstractLQPNo
 }
 
 template <typename... Args>
-std::shared_ptr<PQPSelectExpression> select_(const std::shared_ptr<AbstractOperator>& pqp, const DataType data_type,
+std::shared_ptr<PQPSelectExpression> pqp_select_(const std::shared_ptr<AbstractOperator>& pqp, const DataType data_type,
                                              const bool nullable, Args&&... parameter_id_column_id_pairs) {
   if constexpr (sizeof...(Args) > 0) {
     // Correlated subselect
@@ -209,7 +209,7 @@ std::shared_ptr<PQPColumnExpression> pqp_column_(const ColumnID column_id, const
                                                  const bool nullable, const std::string& column_name);
 
 template <typename ReferencedExpression>
-std::shared_ptr<ParameterExpression> parameter_with_referenced_(const ParameterID parameter_id,
+std::shared_ptr<ParameterExpression> correlated_parameter_(const ParameterID parameter_id,
                                                                 const ReferencedExpression& referenced) {
   return std::make_shared<ParameterExpression>(parameter_id, *to_expression(referenced));
 }

--- a/src/lib/expression/expression_functional.hpp
+++ b/src/lib/expression/expression_functional.hpp
@@ -142,7 +142,7 @@ inline detail::ternary<CaseExpression> case_;
 
 template <typename... Args>
 std::shared_ptr<LQPSelectExpression> lqp_select_(const std::shared_ptr<AbstractLQPNode>& lqp,  // NOLINT
-                                             Args&&... parameter_id_expression_pairs) {
+                                                 Args&&... parameter_id_expression_pairs) {
   if constexpr (sizeof...(Args) > 0) {
     // Correlated subselect
     return std::make_shared<LQPSelectExpression>(
@@ -157,7 +157,7 @@ std::shared_ptr<LQPSelectExpression> lqp_select_(const std::shared_ptr<AbstractL
 
 template <typename... Args>
 std::shared_ptr<PQPSelectExpression> pqp_select_(const std::shared_ptr<AbstractOperator>& pqp, const DataType data_type,
-                                             const bool nullable, Args&&... parameter_id_column_id_pairs) {
+                                                 const bool nullable, Args&&... parameter_id_column_id_pairs) {
   if constexpr (sizeof...(Args) > 0) {
     // Correlated subselect
     return std::make_shared<PQPSelectExpression>(
@@ -203,14 +203,14 @@ std::shared_ptr<ExtractExpression> extract_(const DatetimeComponent datetime_com
   return std::make_shared<ExtractExpression>(datetime_component, to_expression(from));
 }
 
-std::shared_ptr<ParameterExpression> parameter_(const ParameterID parameter_id);
+std::shared_ptr<ParameterExpression> uncorrelated_parameter_(const ParameterID parameter_id);
 std::shared_ptr<LQPColumnExpression> lqp_column_(const LQPColumnReference& column_reference);
 std::shared_ptr<PQPColumnExpression> pqp_column_(const ColumnID column_id, const DataType data_type,
                                                  const bool nullable, const std::string& column_name);
 
 template <typename ReferencedExpression>
 std::shared_ptr<ParameterExpression> correlated_parameter_(const ParameterID parameter_id,
-                                                                const ReferencedExpression& referenced) {
+                                                           const ReferencedExpression& referenced) {
   return std::make_shared<ParameterExpression>(parameter_id, *to_expression(referenced));
 }
 

--- a/src/lib/logical_query_plan/show_tables_node.cpp
+++ b/src/lib/logical_query_plan/show_tables_node.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<AbstractLQPNode> ShowTablesNode::_on_shallow_copy(LQPNodeMapping
 const std::vector<std::shared_ptr<AbstractExpression>>& ShowTablesNode::column_expressions() const {
   if (!_column_expressions) {
     _column_expressions.emplace();
-    _column_expressions->emplace_back(column_(LQPColumnReference{shared_from_this(), ColumnID{0}}));
+    _column_expressions->emplace_back(lqp_column_(LQPColumnReference{shared_from_this(), ColumnID{0}}));
   }
 
   return *_column_expressions;

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -576,7 +576,7 @@ TEST_F(ExpressionEvaluatorTest, InSelectCorrelated) {
   //  2      (3, 6, 9, 12)
   //  3      (4, 8, 12, 16)
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);
-  const auto mul_a = mul_(parameter_(ParameterID{0}), PQPColumnExpression::from_table(*table_a, "a"));
+  const auto mul_a = mul_(uncorrelated_parameter_(ParameterID{0}), PQPColumnExpression::from_table(*table_a, "a"));
   const auto pqp_a = std::make_shared<Projection>(table_wrapper_a, expression_vector(mul_a));
   const auto select_a = pqp_select_(pqp_a, DataType::Int, false, std::make_pair(ParameterID{0}, ColumnID{0}));
 
@@ -595,7 +595,7 @@ TEST_F(ExpressionEvaluatorTest, InSelectCorrelated) {
   //  2      (36, NULL, 37, NULL)
   //  3      (37, NULL, 38, NULL)
   const auto table_wrapper_b = std::make_shared<TableWrapper>(table_a);
-  const auto add_b = add_(parameter_(ParameterID{0}), PQPColumnExpression::from_table(*table_a, "c"));
+  const auto add_b = add_(uncorrelated_parameter_(ParameterID{0}), PQPColumnExpression::from_table(*table_a, "c"));
   const auto pqp_b = std::make_shared<Projection>(table_wrapper_b, expression_vector(add_b));
   const auto select_b = pqp_select_(pqp_b, DataType::Int, true, std::make_pair(ParameterID{0}, ColumnID{0}));
 
@@ -619,7 +619,7 @@ TEST_F(ExpressionEvaluatorTest, Exists) {
    *    table_a;
    */
   const auto table_wrapper = std::make_shared<TableWrapper>(table_b);
-  const auto parameter_a = parameter_(ParameterID{0});
+  const auto parameter_a = uncorrelated_parameter_(ParameterID{0});
   const auto a_plus_x_projection =
       std::make_shared<Projection>(table_wrapper, expression_vector(add_(parameter_a, x), x));
   const auto a_plus_x_eq_13_scan = std::make_shared<TableScan>(

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -429,7 +429,7 @@ TEST_F(ExpressionEvaluatorTest, Parameter) {
   const auto a_id = ParameterID{0};
   const auto b_id = ParameterID{1};
 
-  auto a_plus_5_times_b = mul_(add_(parameter_with_referenced_(a_id, a), 5), parameter_with_referenced_(b_id, b));
+  auto a_plus_5_times_b = mul_(add_(correlated_parameter_(a_id, a), 5), correlated_parameter_(b_id, b));
 
   expression_set_parameters(a_plus_5_times_b, {{a_id, 12}, {b_id, 2}});
   EXPECT_TRUE(test_expression<int32_t>(*a_plus_5_times_b, {34}));
@@ -474,13 +474,13 @@ TEST_F(ExpressionEvaluatorTest, InSelectUncorrelatedWithoutPrecalculated) {
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);
   const auto pqp_a =
       std::make_shared<Projection>(table_wrapper_a, expression_vector(PQPColumnExpression::from_table(*table_a, "a")));
-  const auto select_a = select_(pqp_a, DataType::Int, false);
+  const auto select_a = pqp_select_(pqp_a, DataType::Int, false);
 
   // PQP that returns the column "c"
   const auto table_wrapper_b = std::make_shared<TableWrapper>(table_a);
   const auto pqp_b =
       std::make_shared<Projection>(table_wrapper_b, expression_vector(PQPColumnExpression::from_table(*table_a, "c")));
-  const auto select_b = select_(pqp_b, DataType::Int, true);
+  const auto select_b = pqp_select_(pqp_b, DataType::Int, true);
 
   // Test it without pre-calculated uncorrelated_select_results
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(6, select_a), {0}));
@@ -499,13 +499,13 @@ TEST_F(ExpressionEvaluatorTest, InSelectUncorrelatedWithPrecalculated) {
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);
   const auto pqp_a =
       std::make_shared<Projection>(table_wrapper_a, expression_vector(PQPColumnExpression::from_table(*table_a, "a")));
-  const auto select_a = select_(pqp_a, DataType::Int, false);
+  const auto select_a = pqp_select_(pqp_a, DataType::Int, false);
 
   // PQP that returns the column "c"
   const auto table_wrapper_b = std::make_shared<TableWrapper>(table_a);
   const auto pqp_b =
       std::make_shared<Projection>(table_wrapper_b, expression_vector(PQPColumnExpression::from_table(*table_a, "c")));
-  const auto select_b = select_(pqp_b, DataType::Int, true);
+  const auto select_b = pqp_select_(pqp_b, DataType::Int, true);
 
   // Test it with pre-calculated uncorrelated_select_results
   auto uncorrelated_select_results = std::make_shared<ExpressionEvaluator::UncorrelatedSelectResults>();
@@ -536,13 +536,13 @@ TEST_F(ExpressionEvaluatorTest, InSelectUncorrelatedWithBrokenPrecalculated) {
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);
   const auto pqp_a =
       std::make_shared<Projection>(table_wrapper_a, expression_vector(PQPColumnExpression::from_table(*table_a, "a")));
-  const auto select_a = select_(pqp_a, DataType::Int, false);
+  const auto select_a = pqp_select_(pqp_a, DataType::Int, false);
 
   // PQP that returns the column "c"
   const auto table_wrapper_b = std::make_shared<TableWrapper>(table_a);
   const auto pqp_b =
       std::make_shared<Projection>(table_wrapper_b, expression_vector(PQPColumnExpression::from_table(*table_a, "c")));
-  const auto select_b = select_(pqp_b, DataType::Int, true);
+  const auto select_b = pqp_select_(pqp_b, DataType::Int, true);
 
   auto uncorrelated_select_results = std::make_shared<ExpressionEvaluator::UncorrelatedSelectResults>();
   table_wrapper_a->execute();
@@ -560,7 +560,7 @@ TEST_F(ExpressionEvaluatorTest, InSelectUncorrelatedWithBrokenPrecalculated) {
   const auto projection_c =
       std::make_shared<Projection>(table_scan_c, expression_vector(PQPColumnExpression::from_table(*table_a, "b")));
   projection_c->execute();
-  const auto select_c = select_(projection_c, DataType::Int, true);
+  const auto select_c = pqp_select_(projection_c, DataType::Int, true);
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(3, select_c), {0}));
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(4, select_c), {1}));
   EXPECT_THROW(test_expression<int32_t>(table_a, *in_(4, select_c), {0}, uncorrelated_select_results),
@@ -578,7 +578,7 @@ TEST_F(ExpressionEvaluatorTest, InSelectCorrelated) {
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);
   const auto mul_a = mul_(parameter_(ParameterID{0}), PQPColumnExpression::from_table(*table_a, "a"));
   const auto pqp_a = std::make_shared<Projection>(table_wrapper_a, expression_vector(mul_a));
-  const auto select_a = select_(pqp_a, DataType::Int, false, std::make_pair(ParameterID{0}, ColumnID{0}));
+  const auto select_a = pqp_select_(pqp_a, DataType::Int, false, std::make_pair(ParameterID{0}, ColumnID{0}));
 
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(4, select_a), {1, 1, 0, 1}));
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(6, select_a), {0, 1, 1, 0}));
@@ -597,7 +597,7 @@ TEST_F(ExpressionEvaluatorTest, InSelectCorrelated) {
   const auto table_wrapper_b = std::make_shared<TableWrapper>(table_a);
   const auto add_b = add_(parameter_(ParameterID{0}), PQPColumnExpression::from_table(*table_a, "c"));
   const auto pqp_b = std::make_shared<Projection>(table_wrapper_b, expression_vector(add_b));
-  const auto select_b = select_(pqp_b, DataType::Int, true, std::make_pair(ParameterID{0}, ColumnID{0}));
+  const auto select_b = pqp_select_(pqp_b, DataType::Int, true, std::make_pair(ParameterID{0}, ColumnID{0}));
 
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(34, select_b), {1, std::nullopt, std::nullopt, std::nullopt}));
   EXPECT_TRUE(test_expression<int32_t>(table_a, *in_(35, select_b), {1, 1, std::nullopt, std::nullopt}));
@@ -625,7 +625,7 @@ TEST_F(ExpressionEvaluatorTest, Exists) {
   const auto a_plus_x_eq_13_scan = std::make_shared<TableScan>(
       a_plus_x_projection, OperatorScanPredicate{ColumnID{0}, PredicateCondition::Equals, 13});
   const auto pqp_select_expression =
-      select_(a_plus_x_eq_13_scan, DataType::Int, false, std::make_pair(ParameterID{0}, ColumnID{0}));
+      pqp_select_(a_plus_x_eq_13_scan, DataType::Int, false, std::make_pair(ParameterID{0}, ColumnID{0}));
 
   const auto exists_expression = std::make_shared<ExistsExpression>(pqp_select_expression);
   EXPECT_TRUE(test_expression<int32_t>(table_a, *exists_expression, {0, 0, 1, 1}));

--- a/src/test/expression/expression_evaluator_test.cpp
+++ b/src/test/expression/expression_evaluator_test.cpp
@@ -429,7 +429,7 @@ TEST_F(ExpressionEvaluatorTest, Parameter) {
   const auto a_id = ParameterID{0};
   const auto b_id = ParameterID{1};
 
-  auto a_plus_5_times_b = mul_(add_(parameter_(a_id, a), 5), parameter_(b_id, b));
+  auto a_plus_5_times_b = mul_(add_(parameter_with_referenced_(a_id, a), 5), parameter_with_referenced_(b_id, b));
 
   expression_set_parameters(a_plus_5_times_b, {{a_id, 12}, {b_id, 2}});
   EXPECT_TRUE(test_expression<int32_t>(*a_plus_5_times_b, {34}));

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -111,8 +111,8 @@ TEST_F(ExpressionTest, RequiresCalculation) {
   EXPECT_TRUE(and_(1, 0)->requires_computation());
   EXPECT_TRUE(unary_minus_(5)->requires_computation());
   EXPECT_FALSE(parameter_(ParameterID{5})->requires_computation());
-  EXPECT_FALSE(parameter_(ParameterID{5}, a)->requires_computation());
-  EXPECT_FALSE(column_(a)->requires_computation());
+  EXPECT_FALSE(parameter_with_referenced_(ParameterID{5}, a)->requires_computation());
+  EXPECT_FALSE(lqp_column_(a)->requires_computation());
   EXPECT_FALSE(PQPColumnExpression::from_table(*table_int_float, "a")->requires_computation());
   EXPECT_FALSE(value_(5)->requires_computation());
   EXPECT_TRUE(cast_(5, DataType::Int)->requires_computation());
@@ -158,7 +158,7 @@ TEST_F(ExpressionTest, AsColumnName) {
   EXPECT_EQ(null_()->as_column_name(), "NULL");
   EXPECT_EQ(cast_("36", DataType::Float)->as_column_name(), "CAST('36' AS float)");
   EXPECT_EQ(parameter_(ParameterID{0})->as_column_name(), "Parameter[id=0]");
-  EXPECT_EQ(parameter_(ParameterID{0}, a)->as_column_name(), "Parameter[name=a;id=0]");
+  EXPECT_EQ(parameter_with_referenced_(ParameterID{0}, a)->as_column_name(), "Parameter[name=a;id=0]");
 }
 
 TEST_F(ExpressionTest, AsColumnNameNested) {
@@ -240,8 +240,8 @@ TEST_F(ExpressionTest, IsNullable) {
   EXPECT_TRUE(case_(1, 1, null_())->is_nullable());
   EXPECT_TRUE(add_(greater_than_(2, null_()), 1)->is_nullable());
   EXPECT_TRUE(and_(greater_than_(2, null_()), 1)->is_nullable());
-  EXPECT_FALSE(column_(a)->is_nullable());
-  EXPECT_TRUE(column_(a_nullable)->is_nullable());
+  EXPECT_FALSE(lqp_column_(a)->is_nullable());
+  EXPECT_TRUE(lqp_column_(a_nullable)->is_nullable());
   EXPECT_FALSE(cast_(12, DataType::String)->is_nullable());
   EXPECT_TRUE(cast_(null_(), DataType::String)->is_nullable());
   EXPECT_TRUE(sum_(null_())->is_nullable());

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -111,14 +111,14 @@ TEST_F(ExpressionTest, RequiresCalculation) {
   EXPECT_TRUE(and_(1, 0)->requires_computation());
   EXPECT_TRUE(unary_minus_(5)->requires_computation());
   EXPECT_FALSE(parameter_(ParameterID{5})->requires_computation());
-  EXPECT_FALSE(parameter_with_referenced_(ParameterID{5}, a)->requires_computation());
+  EXPECT_FALSE(correlated_parameter_(ParameterID{5}, a)->requires_computation());
   EXPECT_FALSE(lqp_column_(a)->requires_computation());
   EXPECT_FALSE(PQPColumnExpression::from_table(*table_int_float, "a")->requires_computation());
   EXPECT_FALSE(value_(5)->requires_computation());
   EXPECT_TRUE(cast_(5, DataType::Int)->requires_computation());
   EXPECT_TRUE(cast_(5.5, DataType::Int)->requires_computation());
 
-  const auto lqp_select_expression = select_(int_float_node);
+  const auto lqp_select_expression = lqp_select_(int_float_node);
 
   EXPECT_TRUE(lqp_select_expression->requires_computation());
   EXPECT_TRUE(exists_(lqp_select_expression)->requires_computation());
@@ -158,7 +158,7 @@ TEST_F(ExpressionTest, AsColumnName) {
   EXPECT_EQ(null_()->as_column_name(), "NULL");
   EXPECT_EQ(cast_("36", DataType::Float)->as_column_name(), "CAST('36' AS float)");
   EXPECT_EQ(parameter_(ParameterID{0})->as_column_name(), "Parameter[id=0]");
-  EXPECT_EQ(parameter_with_referenced_(ParameterID{0}, a)->as_column_name(), "Parameter[name=a;id=0]");
+  EXPECT_EQ(correlated_parameter_(ParameterID{0}, a)->as_column_name(), "Parameter[name=a;id=0]");
 }
 
 TEST_F(ExpressionTest, AsColumnNameNested) {

--- a/src/test/expression/expression_test.cpp
+++ b/src/test/expression/expression_test.cpp
@@ -65,8 +65,8 @@ TEST_F(ExpressionTest, Equals) {
   EXPECT_EQ(*is_null_(a), *is_null_(a));
   EXPECT_NE(*is_null_(a), *is_null_(b));
   EXPECT_EQ(*is_not_null_(a), *is_not_null_(a));
-  EXPECT_EQ(*parameter_(ParameterID{4}), *parameter_(ParameterID{4}));
-  EXPECT_NE(*parameter_(ParameterID{4}), *parameter_(ParameterID{5}));
+  EXPECT_EQ(*uncorrelated_parameter_(ParameterID{4}), *uncorrelated_parameter_(ParameterID{4}));
+  EXPECT_NE(*uncorrelated_parameter_(ParameterID{4}), *uncorrelated_parameter_(ParameterID{5}));
   EXPECT_EQ(*extract_(DatetimeComponent::Month, "1999-07-30"), *extract_(DatetimeComponent::Month, "1999-07-30"));
   EXPECT_NE(*extract_(DatetimeComponent::Day, "1999-07-30"), *extract_(DatetimeComponent::Month, "1999-07-30"));
   EXPECT_EQ(*unary_minus_(6), *unary_minus_(6));
@@ -110,7 +110,7 @@ TEST_F(ExpressionTest, RequiresCalculation) {
   EXPECT_TRUE(is_null_(null_())->requires_computation());
   EXPECT_TRUE(and_(1, 0)->requires_computation());
   EXPECT_TRUE(unary_minus_(5)->requires_computation());
-  EXPECT_FALSE(parameter_(ParameterID{5})->requires_computation());
+  EXPECT_FALSE(uncorrelated_parameter_(ParameterID{5})->requires_computation());
   EXPECT_FALSE(correlated_parameter_(ParameterID{5}, a)->requires_computation());
   EXPECT_FALSE(lqp_column_(a)->requires_computation());
   EXPECT_FALSE(PQPColumnExpression::from_table(*table_int_float, "a")->requires_computation());
@@ -157,7 +157,7 @@ TEST_F(ExpressionTest, AsColumnName) {
   EXPECT_EQ(value_(3.25)->as_column_name(), "3.25");
   EXPECT_EQ(null_()->as_column_name(), "NULL");
   EXPECT_EQ(cast_("36", DataType::Float)->as_column_name(), "CAST('36' AS float)");
-  EXPECT_EQ(parameter_(ParameterID{0})->as_column_name(), "Parameter[id=0]");
+  EXPECT_EQ(uncorrelated_parameter_(ParameterID{0})->as_column_name(), "Parameter[id=0]");
   EXPECT_EQ(correlated_parameter_(ParameterID{0}, a)->as_column_name(), "Parameter[name=a;id=0]");
 }
 

--- a/src/test/expression/lqp_select_expression_test.cpp
+++ b/src/test/expression/lqp_select_expression_test.cpp
@@ -33,15 +33,15 @@ class LQPSelectExpressionTest : public ::testing::Test {
       ProjectionNode::make(expression_vector(add_(a, parameter_(ParameterID{0}))),
         int_float_node_a));
 
-    parameter_c = parameter_with_referenced_(ParameterID{0}, a);
+    parameter_c = correlated_parameter_(ParameterID{0}, a);
     lqp_c =
     AggregateNode::make(expression_vector(), expression_vector(count_(add_(a, parameter_c))),
       ProjectionNode::make(expression_vector(add_(a, parameter_c)),
         int_float_node_a));
     // clang-format on
 
-    select_a = select_(lqp_a);
-    select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
+    select_a = lqp_select_(lqp_a);
+    select_c = lqp_select_(lqp_c, std::make_pair(ParameterID{0}, a));
   }
 
   void TearDown() { StorageManager::reset(); }
@@ -66,22 +66,22 @@ TEST_F(LQPSelectExpressionTest, DeepEquals) {
 
   const auto int_float_node_b = StoredTableNode::make("int_float");
   const auto a2 = int_float_node_b->get_column("a");
-  const auto parameter_d = parameter_with_referenced_(ParameterID{0}, a2);
+  const auto parameter_d = correlated_parameter_(ParameterID{0}, a2);
   const auto lqp_d =
   AggregateNode::make(expression_vector(), expression_vector(count_(add_(a, parameter_d))),
     ProjectionNode::make(expression_vector(add_(a, parameter_d)),
       int_float_node_a));
 
-  const auto parameter_e = parameter_with_referenced_(ParameterID{0}, b);
+  const auto parameter_e = correlated_parameter_(ParameterID{0}, b);
   const auto lqp_e =
   AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_d))),
     ProjectionNode::make(expression_vector(add_(a, parameter_d)),
       int_float_node_a));
   // clang-format on
 
-  const auto select_b = select_(lqp_b);
-  const auto select_d = select_(lqp_d, std::make_pair(ParameterID{0}, a));
-  const auto select_e = select_(lqp_e, std::make_pair(ParameterID{0}, b));
+  const auto select_b = lqp_select_(lqp_b);
+  const auto select_d = lqp_select_(lqp_d, std::make_pair(ParameterID{0}, a));
+  const auto select_e = lqp_select_(lqp_e, std::make_pair(ParameterID{0}, b));
 
   EXPECT_EQ(*select_a, *select_b);
   EXPECT_NE(*select_a, *select_c);
@@ -127,7 +127,7 @@ TEST_F(LQPSelectExpressionTest, IsNullable) {
       int_float_node_a));
   // clang-format off
 
-  EXPECT_TRUE(select_(lqp_c)->is_nullable());
+  EXPECT_TRUE(lqp_select_(lqp_c)->is_nullable());
 }
 
 TEST_F(LQPSelectExpressionTest, AsColumnName) {

--- a/src/test/expression/lqp_select_expression_test.cpp
+++ b/src/test/expression/lqp_select_expression_test.cpp
@@ -33,7 +33,7 @@ class LQPSelectExpressionTest : public ::testing::Test {
       ProjectionNode::make(expression_vector(add_(a, parameter_(ParameterID{0}))),
         int_float_node_a));
 
-    parameter_c = parameter_(ParameterID{0}, a);
+    parameter_c = parameter_with_referenced_(ParameterID{0}, a);
     lqp_c =
     AggregateNode::make(expression_vector(), expression_vector(count_(add_(a, parameter_c))),
       ProjectionNode::make(expression_vector(add_(a, parameter_c)),
@@ -66,13 +66,13 @@ TEST_F(LQPSelectExpressionTest, DeepEquals) {
 
   const auto int_float_node_b = StoredTableNode::make("int_float");
   const auto a2 = int_float_node_b->get_column("a");
-  const auto parameter_d = parameter_(ParameterID{0}, a2);
+  const auto parameter_d = parameter_with_referenced_(ParameterID{0}, a2);
   const auto lqp_d =
   AggregateNode::make(expression_vector(), expression_vector(count_(add_(a, parameter_d))),
     ProjectionNode::make(expression_vector(add_(a, parameter_d)),
       int_float_node_a));
 
-  const auto parameter_e = parameter_(ParameterID{0}, b);
+  const auto parameter_e = parameter_with_referenced_(ParameterID{0}, b);
   const auto lqp_e =
   AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_d))),
     ProjectionNode::make(expression_vector(add_(a, parameter_d)),

--- a/src/test/expression/lqp_select_expression_test.cpp
+++ b/src/test/expression/lqp_select_expression_test.cpp
@@ -29,8 +29,8 @@ class LQPSelectExpressionTest : public ::testing::Test {
 
     // clang-format off
     lqp_a =
-    AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_(ParameterID{0})))),
-      ProjectionNode::make(expression_vector(add_(a, parameter_(ParameterID{0}))),
+    AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, uncorrelated_parameter_(ParameterID{0})))),
+      ProjectionNode::make(expression_vector(add_(a, uncorrelated_parameter_(ParameterID{0}))),
         int_float_node_a));
 
     parameter_c = correlated_parameter_(ParameterID{0}, a);
@@ -60,8 +60,8 @@ TEST_F(LQPSelectExpressionTest, DeepEquals) {
 
   // clang-format off
   const auto lqp_b =
-  AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_(ParameterID{0})))),
-    ProjectionNode::make(expression_vector(add_(a, parameter_(ParameterID{0}))),
+  AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, uncorrelated_parameter_(ParameterID{0})))),
+    ProjectionNode::make(expression_vector(add_(a, uncorrelated_parameter_(ParameterID{0}))),
       int_float_node_a));
 
   const auto int_float_node_b = StoredTableNode::make("int_float");

--- a/src/test/expression/pqp_select_expression_test.cpp
+++ b/src/test/expression/pqp_select_expression_test.cpp
@@ -27,7 +27,7 @@ class PQPSelectExpressionTest : public ::testing::Test {
     a_b = PQPColumnExpression::from_table(*table_a, "b");
 
     // Build a Select returning a SINGLE NON-NULLABLE VALUE and taking ONE PARAMETER
-    const auto parameter_a = parameter_(ParameterID{2});
+    const auto parameter_a = uncorrelated_parameter_(ParameterID{2});
     const auto get_table_a = std::make_shared<GetTable>("int_float");
     const auto projection_a = std::make_shared<Projection>(get_table_a, expression_vector(add_(a_a, parameter_a)));
     const auto limit_a = std::make_shared<Limit>(projection_a, value_(1));

--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -38,8 +38,8 @@ class AggregateNodeTest : public ::testing::Test {
 
 TEST_F(AggregateNodeTest, OutputColumnExpressions) {
   ASSERT_EQ(_aggregate_node->column_expressions().size(), 4u);
-  EXPECT_EQ(*_aggregate_node->column_expressions().at(0), *column_(_a));
-  EXPECT_EQ(*_aggregate_node->column_expressions().at(1), *column_(_c));
+  EXPECT_EQ(*_aggregate_node->column_expressions().at(0), *lqp_column_(_a));
+  EXPECT_EQ(*_aggregate_node->column_expressions().at(1), *lqp_column_(_c));
   EXPECT_EQ(*_aggregate_node->column_expressions().at(2), *sum_(add_(_a, _b)));
   EXPECT_EQ(*_aggregate_node->column_expressions().at(3), *sum_(add_(_a, _c)));
 }

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -61,11 +61,11 @@ TEST_F(JoinNodeTest, DescriptionAntiJoin) { EXPECT_EQ(_anti_join_node->descripti
 
 TEST_F(JoinNodeTest, OutputColumnExpressions) {
   ASSERT_EQ(_join_node->column_expressions().size(), 5u);
-  EXPECT_EQ(*_join_node->column_expressions().at(0), *column_(_t_a_a));
-  EXPECT_EQ(*_join_node->column_expressions().at(1), *column_(_t_a_b));
-  EXPECT_EQ(*_join_node->column_expressions().at(2), *column_(_t_a_c));
-  EXPECT_EQ(*_join_node->column_expressions().at(3), *column_(_t_b_x));
-  EXPECT_EQ(*_join_node->column_expressions().at(4), *column_(_t_b_y));
+  EXPECT_EQ(*_join_node->column_expressions().at(0), *lqp_column_(_t_a_a));
+  EXPECT_EQ(*_join_node->column_expressions().at(1), *lqp_column_(_t_a_b));
+  EXPECT_EQ(*_join_node->column_expressions().at(2), *lqp_column_(_t_a_c));
+  EXPECT_EQ(*_join_node->column_expressions().at(3), *lqp_column_(_t_b_x));
+  EXPECT_EQ(*_join_node->column_expressions().at(4), *lqp_column_(_t_b_y));
 }
 
 TEST_F(JoinNodeTest, Equals) {
@@ -94,16 +94,16 @@ TEST_F(JoinNodeTest, Copy) {
 
 TEST_F(JoinNodeTest, OutputColumnReferencesSemiJoin) {
   ASSERT_EQ(_semi_join_node->column_expressions().size(), 3u);
-  EXPECT_EQ(*_semi_join_node->column_expressions().at(0), *column_(_t_a_a));
-  EXPECT_EQ(*_semi_join_node->column_expressions().at(1), *column_(_t_a_b));
-  EXPECT_EQ(*_semi_join_node->column_expressions().at(2), *column_(_t_a_c));
+  EXPECT_EQ(*_semi_join_node->column_expressions().at(0), *lqp_column_(_t_a_a));
+  EXPECT_EQ(*_semi_join_node->column_expressions().at(1), *lqp_column_(_t_a_b));
+  EXPECT_EQ(*_semi_join_node->column_expressions().at(2), *lqp_column_(_t_a_c));
 }
 
 TEST_F(JoinNodeTest, OutputColumnReferencesAntiJoin) {
   ASSERT_EQ(_anti_join_node->column_expressions().size(), 3u);
-  EXPECT_EQ(*_anti_join_node->column_expressions().at(0), *column_(_t_a_a));
-  EXPECT_EQ(*_anti_join_node->column_expressions().at(1), *column_(_t_a_b));
-  EXPECT_EQ(*_anti_join_node->column_expressions().at(2), *column_(_t_a_c));
+  EXPECT_EQ(*_anti_join_node->column_expressions().at(0), *lqp_column_(_t_a_a));
+  EXPECT_EQ(*_anti_join_node->column_expressions().at(1), *lqp_column_(_t_a_b));
+  EXPECT_EQ(*_anti_join_node->column_expressions().at(2), *lqp_column_(_t_a_c));
 }
 
 }  // namespace opossum

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -389,7 +389,7 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubselects) {
 }
 
 TEST_F(LogicalQueryPlanTest, DeepCopySubSelects) {
-  const auto parameter_a = parameter_(ParameterID{0}, b1);
+  const auto parameter_a = parameter_with_referenced_(ParameterID{0}, b1);
 
   // clang-format off
   const auto sub_select_lqp =

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -355,11 +355,11 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubselects) {
   // clang-format off
   const auto subselect_b_lqp =
   PredicateNode::make(equals_(a2, 5), node_int_int_int);
-  const auto subselect_b = select_(subselect_b_lqp);
+  const auto subselect_b = lqp_select_(subselect_b_lqp);
 
   const auto subselect_a_lqp =
   PredicateNode::make(equals_(a2, subselect_b), node_int_int_int);
-  const auto subselect_a = select_(subselect_a_lqp);
+  const auto subselect_a = lqp_select_(subselect_a_lqp);
 
   const auto lqp =
   PredicateNode::make(greater_than_(a1, subselect_a), node_int_int);
@@ -389,14 +389,14 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubselects) {
 }
 
 TEST_F(LogicalQueryPlanTest, DeepCopySubSelects) {
-  const auto parameter_a = parameter_with_referenced_(ParameterID{0}, b1);
+  const auto parameter_a = correlated_parameter_(ParameterID{0}, b1);
 
   // clang-format off
   const auto sub_select_lqp =
   AggregateNode::make(expression_vector(), expression_vector(min_(add_(a2, parameter_a))),
     ProjectionNode::make(expression_vector(a2, b2, add_(a2, parameter_a)),
       node_int_int_int));
-  const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, b1));
+  const auto sub_select = lqp_select_(sub_select_lqp, std::make_pair(ParameterID{0}, b1));
 
   const auto lqp =
   ProjectionNode::make(expression_vector(a1, sub_select),

--- a/src/test/logical_query_plan/mock_node_test.cpp
+++ b/src/test/logical_query_plan/mock_node_test.cpp
@@ -39,14 +39,14 @@ TEST_F(MockNodeTest, Description) {
 
 TEST_F(MockNodeTest, OutputColumnExpression) {
   ASSERT_EQ(_mock_node_a->column_expressions().size(), 4u);
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(0), *column_({_mock_node_a, ColumnID{0}}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(1), *column_({_mock_node_a, ColumnID{1}}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(2), *column_({_mock_node_a, ColumnID{2}}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(3), *column_({_mock_node_a, ColumnID{3}}));
+  EXPECT_EQ(*_mock_node_a->column_expressions().at(0), *lqp_column_({_mock_node_a, ColumnID{0}}));
+  EXPECT_EQ(*_mock_node_a->column_expressions().at(1), *lqp_column_({_mock_node_a, ColumnID{1}}));
+  EXPECT_EQ(*_mock_node_a->column_expressions().at(2), *lqp_column_({_mock_node_a, ColumnID{2}}));
+  EXPECT_EQ(*_mock_node_a->column_expressions().at(3), *lqp_column_({_mock_node_a, ColumnID{3}}));
 
   ASSERT_EQ(_mock_node_b->column_expressions().size(), 2u);
-  EXPECT_EQ(*_mock_node_b->column_expressions().at(0), *column_({_mock_node_b, ColumnID{0}}));
-  EXPECT_EQ(*_mock_node_b->column_expressions().at(1), *column_({_mock_node_b, ColumnID{1}}));
+  EXPECT_EQ(*_mock_node_b->column_expressions().at(0), *lqp_column_({_mock_node_b, ColumnID{0}}));
+  EXPECT_EQ(*_mock_node_b->column_expressions().at(1), *lqp_column_({_mock_node_b, ColumnID{1}}));
 }
 
 TEST_F(MockNodeTest, Equals) {

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -117,8 +117,8 @@ TEST_F(OperatorsProjectionTest, SetParameters) {
   const auto projection_a = std::make_shared<Projection>(table_scan_a, expression_vector(b_a));
   const auto select_expression =
       std::make_shared<PQPSelectExpression>(table_scan_a, DataType::Int, false, PQPSelectExpression::Parameters{});
-  const auto projection_b =
-      std::make_shared<Projection>(table_wrapper_a, expression_vector(uncorrelated_parameter_(ParameterID{2}), select_expression));
+  const auto projection_b = std::make_shared<Projection>(
+      table_wrapper_a, expression_vector(uncorrelated_parameter_(ParameterID{2}), select_expression));
 
   const auto parameters = std::unordered_map<ParameterID, AllTypeVariant>{{ParameterID{5}, AllTypeVariant{12}},
                                                                           {ParameterID{2}, AllTypeVariant{13}}};

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -118,7 +118,7 @@ TEST_F(OperatorsProjectionTest, SetParameters) {
   const auto select_expression =
       std::make_shared<PQPSelectExpression>(table_scan_a, DataType::Int, false, PQPSelectExpression::Parameters{});
   const auto projection_b =
-      std::make_shared<Projection>(table_wrapper_a, expression_vector(parameter_(ParameterID{2}), select_expression));
+      std::make_shared<Projection>(table_wrapper_a, expression_vector(uncorrelated_parameter_(ParameterID{2}), select_expression));
 
   const auto parameters = std::unordered_map<ParameterID, AllTypeVariant>{{ParameterID{5}, AllTypeVariant{12}},
                                                                           {ParameterID{2}, AllTypeVariant{13}}};

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -262,8 +262,8 @@ TEST_F(LQPTranslatorTest, SelectExpressionCorrelated) {
    * LQP resembles:
    *   SELECT (SELECT MIN(a + int_float5.d + int_float5.a) FROM int_float), a FROM int_float5;
    */
-  const auto parameter_a = parameter_with_referenced_(ParameterID{0}, int_float5_a);
-  const auto parameter_d = parameter_with_referenced_(ParameterID{1}, int_float5_d);
+  const auto parameter_a = correlated_parameter_(ParameterID{0}, int_float5_a);
+  const auto parameter_d = correlated_parameter_(ParameterID{1}, int_float5_d);
 
   const auto a_plus_a_plus_d = add_(int_float_a, add_(parameter_a, parameter_d));
 
@@ -273,7 +273,7 @@ TEST_F(LQPTranslatorTest, SelectExpressionCorrelated) {
     ProjectionNode::make(expression_vector(a_plus_a_plus_d),
       int_float_node));
 
-  const auto subselect = select_(subselect_lqp, std::make_pair(ParameterID{0}, int_float5_a),
+  const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, int_float5_a),
                                  std::make_pair(ParameterID{1}, int_float5_d));
 
   const auto lqp =
@@ -801,8 +801,8 @@ TEST_F(LQPTranslatorTest, ReuseSelectExpression) {
   ProjectionNode::make(expression_vector(add_(1, 2)),
     DummyTableNode::make());
 
-  const auto select_a = select_(select_lqp);
-  const auto select_b = select_(select_lqp);
+  const auto select_a = lqp_select_(select_lqp);
+  const auto select_b = lqp_select_(select_lqp);
 
   const auto lqp =
   ProjectionNode::make(expression_vector(add_(select_a, 3)),

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -262,8 +262,8 @@ TEST_F(LQPTranslatorTest, SelectExpressionCorrelated) {
    * LQP resembles:
    *   SELECT (SELECT MIN(a + int_float5.d + int_float5.a) FROM int_float), a FROM int_float5;
    */
-  const auto parameter_a = parameter_(ParameterID{0}, int_float5_a);
-  const auto parameter_d = parameter_(ParameterID{1}, int_float5_d);
+  const auto parameter_a = parameter_with_referenced_(ParameterID{0}, int_float5_a);
+  const auto parameter_d = parameter_with_referenced_(ParameterID{1}, int_float5_d);
 
   const auto a_plus_a_plus_d = add_(int_float_a, add_(parameter_a, parameter_d));
 
@@ -786,7 +786,7 @@ TEST_F(LQPTranslatorTest, ReuseInputExpressions) {
   ASSERT_NE(projection_a, nullptr);
   ASSERT_NE(projection_b, nullptr);
 
-  const auto a_plus_b_in_temporary_column = column_(ColumnID{1}, DataType::Float, false, "a + b");
+  const auto a_plus_b_in_temporary_column = pqp_column_(ColumnID{1}, DataType::Float, false, "a + b");
 
   EXPECT_EQ(table_scan->predicate().column_id, ColumnID{0});
   EXPECT_EQ(*projection_a->expressions.at(0), *add_(a_plus_b_in_temporary_column, 3));
@@ -821,7 +821,7 @@ TEST_F(LQPTranslatorTest, ReuseSelectExpression) {
   ASSERT_NE(projection_a, nullptr);
   ASSERT_NE(projection_b, nullptr);
 
-  const auto select_in_temporary_column = column_(ColumnID{1}, DataType::Int, false, "SUBSELECT");
+  const auto select_in_temporary_column = pqp_column_(ColumnID{1}, DataType::Int, false, "SUBSELECT");
 
   EXPECT_EQ(*projection_a->expressions.at(0), *add_(select_in_temporary_column, 3));
 }

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -26,9 +26,9 @@ class OptimizerTest : public ::testing::Test {
     y = node_b->get_column("y");
 
     select_lqp_a = LimitNode::make(to_expression(1), node_b);
-    select_a = select_(select_lqp_a);
+    select_a = lqp_select_(select_lqp_a);
     select_lqp_b = LimitNode::make(to_expression(1), PredicateNode::make(greater_than_(x, y), node_b));
-    select_b = select_(select_lqp_b);
+    select_b = lqp_select_(select_lqp_b);
   }
 
   std::shared_ptr<MockNode> node_a, node_b;

--- a/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
+++ b/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
@@ -140,10 +140,10 @@ TEST_F(ExistsReformulationRuleTest, QueryWithNotExists) {
 // Manually construct an exists query and apply the reformulation rule.
 // Compare with the manually created "optimal" plan and check for equality.
 TEST_F(ExistsReformulationRuleTest, ManualSemijoinLQPComparison) {
-  const auto parameter = opossum::expression_functional::parameter_with_referenced_(ParameterID{0}, node_table_a_col_a);
+  const auto parameter = opossum::expression_functional::correlated_parameter_(ParameterID{0}, node_table_a_col_a);
 
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
-  const auto subselect = select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
+  const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
 
   const auto input_lqp = ProjectionNode::make(
       expression_vector(node_table_a_col_a, node_table_a_col_b),
@@ -166,10 +166,10 @@ TEST_F(ExistsReformulationRuleTest, ManualSemijoinLQPComparison) {
 }
 
 TEST_F(ExistsReformulationRuleTest, ManualAntijoinLQPComparison) {
-  const auto parameter = opossum::expression_functional::parameter_with_referenced_(ParameterID{0}, node_table_a_col_a);
+  const auto parameter = opossum::expression_functional::correlated_parameter_(ParameterID{0}, node_table_a_col_a);
 
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
-  const auto subselect = select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
+  const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
 
   const auto input_lqp = ProjectionNode::make(
       expression_vector(node_table_a_col_a, node_table_a_col_b),

--- a/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
+++ b/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
@@ -140,7 +140,7 @@ TEST_F(ExistsReformulationRuleTest, QueryWithNotExists) {
 // Manually construct an exists query and apply the reformulation rule.
 // Compare with the manually created "optimal" plan and check for equality.
 TEST_F(ExistsReformulationRuleTest, ManualSemijoinLQPComparison) {
-  const auto parameter = opossum::expression_functional::correlated_parameter_(ParameterID{0}, node_table_a_col_a);
+  const auto parameter = correlated_parameter_(ParameterID{0}, node_table_a_col_a);
 
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
   const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
@@ -166,7 +166,7 @@ TEST_F(ExistsReformulationRuleTest, ManualSemijoinLQPComparison) {
 }
 
 TEST_F(ExistsReformulationRuleTest, ManualAntijoinLQPComparison) {
-  const auto parameter = opossum::expression_functional::correlated_parameter_(ParameterID{0}, node_table_a_col_a);
+  const auto parameter = correlated_parameter_(ParameterID{0}, node_table_a_col_a);
 
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
   const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));

--- a/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
+++ b/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
@@ -140,7 +140,7 @@ TEST_F(ExistsReformulationRuleTest, QueryWithNotExists) {
 // Manually construct an exists query and apply the reformulation rule.
 // Compare with the manually created "optimal" plan and check for equality.
 TEST_F(ExistsReformulationRuleTest, ManualSemijoinLQPComparison) {
-  const auto parameter = opossum::expression_functional::parameter_(ParameterID{0}, node_table_a_col_a);
+  const auto parameter = opossum::expression_functional::parameter_with_referenced_(ParameterID{0}, node_table_a_col_a);
 
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
   const auto subselect = select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
@@ -166,7 +166,7 @@ TEST_F(ExistsReformulationRuleTest, ManualSemijoinLQPComparison) {
 }
 
 TEST_F(ExistsReformulationRuleTest, ManualAntijoinLQPComparison) {
-  const auto parameter = opossum::expression_functional::parameter_(ParameterID{0}, node_table_a_col_a);
+  const auto parameter = opossum::expression_functional::parameter_with_referenced_(ParameterID{0}, node_table_a_col_a);
 
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
   const auto subselect = select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));

--- a/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
@@ -44,11 +44,11 @@ class PredicatePushdownRuleTest : public StrategyBaseTest {
       auto int_float_node_a = StoredTableNode::make("a");
       auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
 
-      auto parameter_c = parameter_with_referenced_(ParameterID{0}, a);
+      auto parameter_c = correlated_parameter_(ParameterID{0}, a);
       auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
                                        ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
 
-      _select_c = select_(lqp_c, std::make_pair(ParameterID{0}, a));
+      _select_c = lqp_select_(lqp_c, std::make_pair(ParameterID{0}, a));
 
       _projection_pushdown_node = ProjectionNode::make(expression_vector(_a_a, _a_b, _select_c), _table_a);
     }

--- a/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_pushdown_rule_test.cpp
@@ -44,7 +44,7 @@ class PredicatePushdownRuleTest : public StrategyBaseTest {
       auto int_float_node_a = StoredTableNode::make("a");
       auto a = LQPColumnReference{int_float_node_a, ColumnID{0}};
 
-      auto parameter_c = parameter_(ParameterID{0}, a);
+      auto parameter_c = parameter_with_referenced_(ParameterID{0}, a);
       auto lqp_c = AggregateNode::make(expression_vector(), expression_vector(max_(add_(a, parameter_c))),
                                        ProjectionNode::make(expression_vector(add_(a, parameter_c)), int_float_node_a));
 

--- a/src/test/sql/sql_identifier_resolver_test.cpp
+++ b/src/test/sql/sql_identifier_resolver_test.cpp
@@ -137,17 +137,17 @@ TEST_F(SQLIdentifierResolverTest, ResolveOuterExpression) {
   EXPECT_EQ(context.resolve_identifier_relaxed({"b", "T1"}), expression_b);
 
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"b", "Intermediate"}),
-            *parameter_(ParameterID{0}, intermediate_expression_b));
+            *parameter_with_referenced_(ParameterID{0}, intermediate_expression_b));
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"intermediate_a"}),
-            *parameter_(ParameterID{1}, intermediate_expression_a));
+            *parameter_with_referenced_(ParameterID{1}, intermediate_expression_a));
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"b"}),
-            *parameter_(ParameterID{0}, intermediate_expression_b));
+            *parameter_with_referenced_(ParameterID{0}, intermediate_expression_b));
   EXPECT_EQ(intermediate_context_proxy->resolve_identifier_relaxed({"intermediate_a", "Intermediate"}), nullptr);
 
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"outermost_a"}),
-            *parameter_(ParameterID{2}, outermost_expression_a));
+            *parameter_with_referenced_(ParameterID{2}, outermost_expression_a));
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"b", "Outermost"}),
-            *parameter_(ParameterID{3}, outermost_expression_b));
+            *parameter_with_referenced_(ParameterID{3}, outermost_expression_b));
 
   /**
    * Test whether the proxies tracked accesses to their contexts correctly

--- a/src/test/sql/sql_identifier_resolver_test.cpp
+++ b/src/test/sql/sql_identifier_resolver_test.cpp
@@ -137,17 +137,17 @@ TEST_F(SQLIdentifierResolverTest, ResolveOuterExpression) {
   EXPECT_EQ(context.resolve_identifier_relaxed({"b", "T1"}), expression_b);
 
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"b", "Intermediate"}),
-            *parameter_with_referenced_(ParameterID{0}, intermediate_expression_b));
+            *correlated_parameter_(ParameterID{0}, intermediate_expression_b));
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"intermediate_a"}),
-            *parameter_with_referenced_(ParameterID{1}, intermediate_expression_a));
+            *correlated_parameter_(ParameterID{1}, intermediate_expression_a));
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"b"}),
-            *parameter_with_referenced_(ParameterID{0}, intermediate_expression_b));
+            *correlated_parameter_(ParameterID{0}, intermediate_expression_b));
   EXPECT_EQ(intermediate_context_proxy->resolve_identifier_relaxed({"intermediate_a", "Intermediate"}), nullptr);
 
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"outermost_a"}),
-            *parameter_with_referenced_(ParameterID{2}, outermost_expression_a));
+            *correlated_parameter_(ParameterID{2}, outermost_expression_a));
   EXPECT_EQ(*intermediate_context_proxy->resolve_identifier_relaxed({"b", "Outermost"}),
-            *parameter_with_referenced_(ParameterID{3}, outermost_expression_b));
+            *correlated_parameter_(ParameterID{3}, outermost_expression_b));
 
   /**
    * Test whether the proxies tracked accesses to their contexts correctly

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -966,7 +966,8 @@ TEST_F(SQLTranslatorTest, ValuePlaceholders) {
 
   // clang-format off
   const auto expected_lqp =
-  ProjectionNode::make(expression_vector(add_(int_float_a, uncorrelated_parameter_(ParameterID{1})), uncorrelated_parameter_(ParameterID{2})),
+  ProjectionNode::make(expression_vector(add_(int_float_a, uncorrelated_parameter_(ParameterID{1})),
+                                         uncorrelated_parameter_(ParameterID{2})),
     PredicateNode::make(greater_than_(int_float_a, uncorrelated_parameter_(ParameterID{0})),
       stored_table_node_int_float));
   // clang-format on
@@ -1043,7 +1044,8 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
     AggregateNode::make(expression_vector(), expression_vector(min_(int_float2_b)),
       stored_table_node_int_float2));
 
-  const auto expected_sub_select_a = lqp_select_(expected_sub_select_lqp_a, std::make_pair(ParameterID{2}, int_float_a));
+  const auto expected_sub_select_a = lqp_select_(expected_sub_select_lqp_a,
+                                                 std::make_pair(ParameterID{2}, int_float_a));
 
   // "(SELECT int_float2.a + int_float.b)"
   const auto expected_sub_sub_select_lqp =
@@ -1059,7 +1061,8 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
   ProjectionNode::make(expression_vector(add_(add_(max_(int_float2_b), parameter_int_float_b), sub_sub_select)),
     AggregateNode::make(expression_vector(), expression_vector(max_(int_float2_b)),
       stored_table_node_int_float2));
-  const auto expected_sub_select_b = lqp_select_(expected_sub_select_lqp_b, std::make_pair(ParameterID{3}, int_float_b));
+  const auto expected_sub_select_b = lqp_select_(expected_sub_select_lqp_b,
+                                                 std::make_pair(ParameterID{3}, int_float_b));
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(uncorrelated_parameter_(ParameterID{1}),

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -382,10 +382,10 @@ TEST_F(SQLTranslatorTest, WhereExists) {
       compile_query("SELECT * FROM int_float WHERE EXISTS(SELECT * FROM int_float2 WHERE int_float.a = int_float2.a);");
 
   // clang-format off
-  const auto parameter_int_float_a = parameter_with_referenced_(ParameterID{0}, int_float_a);
+  const auto parameter_int_float_a = correlated_parameter_(ParameterID{0}, int_float_a);
   const auto sub_select_lqp =
   PredicateNode::make(equals_(parameter_int_float_a, int_float2_a), stored_table_node_int_float2);
-  const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float_a));
+  const auto sub_select = lqp_select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float_a));
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(int_float_a, int_float_b),
@@ -401,14 +401,14 @@ TEST_F(SQLTranslatorTest, WhereWithCorrelatedSelect) {
   const auto actual_lqp =
       compile_query("SELECT * FROM int_float WHERE a > (SELECT MIN(a + int_float.b) FROM int_float2);");
 
-  const auto parameter_b = parameter_with_referenced_(ParameterID{0}, int_float_b);
+  const auto parameter_b = correlated_parameter_(ParameterID{0}, int_float_b);
 
   // clang-format off
   const auto sub_select_lqp =
   AggregateNode::make(expression_vector(), expression_vector(min_(add_(int_float2_a, parameter_b))),
     ProjectionNode::make(expression_vector(int_float2_a, int_float2_b, add_(int_float2_a, parameter_b)),
       stored_table_node_int_float2));
-  const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float_b));
+  const auto sub_select = lqp_select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float_b));
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(int_float_a, int_float_b),
@@ -596,14 +596,14 @@ TEST_F(SQLTranslatorTest, SubSelectSelectList) {
   const auto actual_lqp = compile_query("SELECT (SELECT MIN(a + d) FROM int_float), a FROM int_float5 AS f");
 
   // clang-format off
-  const auto parameter_d = parameter_with_referenced_(ParameterID{0}, int_float5_d);
+  const auto parameter_d = correlated_parameter_(ParameterID{0}, int_float5_d);
   const auto a_plus_d = add_(int_float_a, parameter_d);
   const auto sub_select_lqp =
   AggregateNode::make(expression_vector(), expression_vector(min_(a_plus_d)),
     ProjectionNode::make(expression_vector(int_float_a, int_float_b, a_plus_d), stored_table_node_int_float));
   // clang-format on
 
-  const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float5_d));
+  const auto sub_select = lqp_select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float5_d));
 
   // clang-format off
   const auto expected_lqp =
@@ -652,7 +652,7 @@ TEST_F(SQLTranslatorTest, InSelect) {
 
   // clang-format off
   const auto sub_select_lqp = stored_table_node_int_float2;
-  const auto sub_select = select_(sub_select_lqp);
+  const auto sub_select = lqp_select_(sub_select_lqp);
 
   const auto a_plus_7_in = in_(add_(int_float_a, 7), sub_select);
 
@@ -673,8 +673,8 @@ TEST_F(SQLTranslatorTest, InCorrelatedSelect) {
       "b)");
 
   // clang-format off
-  const auto parameter_a = parameter_with_referenced_(ParameterID{1}, int_float_a);
-  const auto parameter_b = parameter_with_referenced_(ParameterID{0}, int_float_b);
+  const auto parameter_a = correlated_parameter_(ParameterID{1}, int_float_a);
+  const auto parameter_b = correlated_parameter_(ParameterID{0}, int_float_b);
 
   const auto b_times_a_times_a = mul_(mul_(parameter_b, parameter_a), parameter_a);
 
@@ -684,7 +684,7 @@ TEST_F(SQLTranslatorTest, InCorrelatedSelect) {
       ProjectionNode::make(expression_vector(b_times_a_times_a, int_float2_a, int_float2_b),
         stored_table_node_int_float2)));
 
-  const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{1}, int_float_a),
+  const auto sub_select = lqp_select_(sub_select_lqp, std::make_pair(ParameterID{1}, int_float_a),
                                   std::make_pair(ParameterID{0}, int_float_b));
 
   const auto a_in_sub_select = in_(int_float_a, sub_select);
@@ -935,7 +935,7 @@ TEST_F(SQLTranslatorTest, LimitLiteral) {
 //                        stored_table_node_int_float2);
 //
 //    const auto expected_lqp =
-//    LimitNode::make(add_(3, select_(sub_select)),
+//    LimitNode::make(add_(3, lqp_select_(sub_select)),
 //                    stored_table_node_int_float);
 //    // clang-format on
 //    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -990,14 +990,14 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocationSimple) {
   const auto actual_lqp = sql_translator.translate_parser_result(parser_result).at(0);
 
   // clang-format off
-  const auto parameter_int_float_b = parameter_with_referenced_(ParameterID{1}, int_float_b);
-  const auto parameter_int_float2_a = parameter_with_referenced_(ParameterID{0}, int_float2_a);
+  const auto parameter_int_float_b = correlated_parameter_(ParameterID{1}, int_float_b);
+  const auto parameter_int_float2_a = correlated_parameter_(ParameterID{0}, int_float2_a);
 
   // "(SELECT int_float2.a + int_float.b)"
   const auto expected_sub_sub_select_lqp =
   ProjectionNode::make(expression_vector(add_(parameter_int_float2_a, parameter_int_float_b)),
      DummyTableNode::make());
-  const auto sub_sub_select = select_(expected_sub_sub_select_lqp,
+  const auto sub_sub_select = lqp_select_(expected_sub_sub_select_lqp,
                                       std::make_pair(ParameterID{0}, int_float2_a));
 
 
@@ -1005,7 +1005,7 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocationSimple) {
   const auto expected_sub_select_lqp =
   ProjectionNode::make(expression_vector(sub_sub_select),
     stored_table_node_int_float2);
-  const auto expected_sub_select = select_(expected_sub_select_lqp, std::make_pair(ParameterID{1}, int_float_b));
+  const auto expected_sub_select = lqp_select_(expected_sub_select_lqp, std::make_pair(ParameterID{1}, int_float_b));
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(expected_sub_select),
@@ -1033,9 +1033,9 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
   const auto actual_lqp = sql_translator.translate_parser_result(parser_result).at(0);
 
   // clang-format off
-  const auto parameter_int_float_a = parameter_with_referenced_(ParameterID{2}, int_float_a);
-  const auto parameter_int_float_b = parameter_with_referenced_(ParameterID{3}, int_float_b);
-  const auto parameter_int_float2_a = parameter_with_referenced_(ParameterID{4}, int_float2_a);
+  const auto parameter_int_float_a = correlated_parameter_(ParameterID{2}, int_float_a);
+  const auto parameter_int_float_b = correlated_parameter_(ParameterID{3}, int_float_b);
+  const auto parameter_int_float2_a = correlated_parameter_(ParameterID{4}, int_float2_a);
 
   // "(SELECT MIN(b) + int_float.a FROM int_float2)"
   const auto expected_sub_select_lqp_a =
@@ -1043,14 +1043,14 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
     AggregateNode::make(expression_vector(), expression_vector(min_(int_float2_b)),
       stored_table_node_int_float2));
 
-  const auto expected_sub_select_a = select_(expected_sub_select_lqp_a, std::make_pair(ParameterID{2}, int_float_a));
+  const auto expected_sub_select_a = lqp_select_(expected_sub_select_lqp_a, std::make_pair(ParameterID{2}, int_float_a));
 
   // "(SELECT int_float2.a + int_float.b)"
   const auto expected_sub_sub_select_lqp =
   ProjectionNode::make(expression_vector(add_(parameter_int_float2_a, parameter_int_float_b)),
     DummyTableNode::make());
 
-  const auto sub_sub_select = select_(expected_sub_sub_select_lqp,
+  const auto sub_sub_select = lqp_select_(expected_sub_sub_select_lqp,
                                       std::make_pair(ParameterID{4}, int_float2_a));
 
 
@@ -1059,7 +1059,7 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
   ProjectionNode::make(expression_vector(add_(add_(max_(int_float2_b), parameter_int_float_b), sub_sub_select)),
     AggregateNode::make(expression_vector(), expression_vector(max_(int_float2_b)),
       stored_table_node_int_float2));
-  const auto expected_sub_select_b = select_(expected_sub_select_lqp_b, std::make_pair(ParameterID{3}, int_float_b));
+  const auto expected_sub_select_b = lqp_select_(expected_sub_select_lqp_b, std::make_pair(ParameterID{3}, int_float_b));
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(parameter_(ParameterID{1}),
@@ -1122,7 +1122,7 @@ TEST_F(SQLTranslatorTest, Exists) {
 
   // clang-format off
   const auto expected_lqp =
-  ProjectionNode::make(expression_vector(exists_(select_(stored_table_node_int_float))),
+  ProjectionNode::make(expression_vector(exists_(lqp_select_(stored_table_node_int_float))),
     DummyTableNode::make());
   // clang-format on
 
@@ -1134,7 +1134,7 @@ TEST_F(SQLTranslatorTest, NotExists) {
 
   // clang-format off
   const auto expected_lqp =
-  ProjectionNode::make(expression_vector(equals_(exists_(select_(stored_table_node_int_float)), 0)),
+  ProjectionNode::make(expression_vector(equals_(exists_(lqp_select_(stored_table_node_int_float)), 0)),
     DummyTableNode::make());
   // clang-format on
 
@@ -1147,9 +1147,9 @@ TEST_F(SQLTranslatorTest, ExistsCorrelated) {
 
   // clang-format off
   const auto sub_select_lqp =
-  PredicateNode::make(greater_than_(int_float_a, parameter_with_referenced_(ParameterID{0}, int_float2_b)),
+  PredicateNode::make(greater_than_(int_float_a, correlated_parameter_(ParameterID{0}, int_float2_b)),
     stored_table_node_int_float);
-  const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float2_b));
+  const auto sub_select = lqp_select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float2_b));
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(exists_(sub_select)),

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -382,7 +382,7 @@ TEST_F(SQLTranslatorTest, WhereExists) {
       compile_query("SELECT * FROM int_float WHERE EXISTS(SELECT * FROM int_float2 WHERE int_float.a = int_float2.a);");
 
   // clang-format off
-  const auto parameter_int_float_a = parameter_(ParameterID{0}, int_float_a);
+  const auto parameter_int_float_a = parameter_with_referenced_(ParameterID{0}, int_float_a);
   const auto sub_select_lqp =
   PredicateNode::make(equals_(parameter_int_float_a, int_float2_a), stored_table_node_int_float2);
   const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float_a));
@@ -401,7 +401,7 @@ TEST_F(SQLTranslatorTest, WhereWithCorrelatedSelect) {
   const auto actual_lqp =
       compile_query("SELECT * FROM int_float WHERE a > (SELECT MIN(a + int_float.b) FROM int_float2);");
 
-  const auto parameter_b = parameter_(ParameterID{0}, int_float_b);
+  const auto parameter_b = parameter_with_referenced_(ParameterID{0}, int_float_b);
 
   // clang-format off
   const auto sub_select_lqp =
@@ -596,7 +596,7 @@ TEST_F(SQLTranslatorTest, SubSelectSelectList) {
   const auto actual_lqp = compile_query("SELECT (SELECT MIN(a + d) FROM int_float), a FROM int_float5 AS f");
 
   // clang-format off
-  const auto parameter_d = parameter_(ParameterID{0}, int_float5_d);
+  const auto parameter_d = parameter_with_referenced_(ParameterID{0}, int_float5_d);
   const auto a_plus_d = add_(int_float_a, parameter_d);
   const auto sub_select_lqp =
   AggregateNode::make(expression_vector(), expression_vector(min_(a_plus_d)),
@@ -673,8 +673,8 @@ TEST_F(SQLTranslatorTest, InCorrelatedSelect) {
       "b)");
 
   // clang-format off
-  const auto parameter_a = parameter_(ParameterID{1}, int_float_a);
-  const auto parameter_b = parameter_(ParameterID{0}, int_float_b);
+  const auto parameter_a = parameter_with_referenced_(ParameterID{1}, int_float_a);
+  const auto parameter_b = parameter_with_referenced_(ParameterID{0}, int_float_b);
 
   const auto b_times_a_times_a = mul_(mul_(parameter_b, parameter_a), parameter_a);
 
@@ -990,8 +990,8 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocationSimple) {
   const auto actual_lqp = sql_translator.translate_parser_result(parser_result).at(0);
 
   // clang-format off
-  const auto parameter_int_float_b = parameter_(ParameterID{1}, int_float_b);
-  const auto parameter_int_float2_a = parameter_(ParameterID{0}, int_float2_a);
+  const auto parameter_int_float_b = parameter_with_referenced_(ParameterID{1}, int_float_b);
+  const auto parameter_int_float2_a = parameter_with_referenced_(ParameterID{0}, int_float2_a);
 
   // "(SELECT int_float2.a + int_float.b)"
   const auto expected_sub_sub_select_lqp =
@@ -1033,9 +1033,9 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
   const auto actual_lqp = sql_translator.translate_parser_result(parser_result).at(0);
 
   // clang-format off
-  const auto parameter_int_float_a = parameter_(ParameterID{2}, int_float_a);
-  const auto parameter_int_float_b = parameter_(ParameterID{3}, int_float_b);
-  const auto parameter_int_float2_a = parameter_(ParameterID{4}, int_float2_a);
+  const auto parameter_int_float_a = parameter_with_referenced_(ParameterID{2}, int_float_a);
+  const auto parameter_int_float_b = parameter_with_referenced_(ParameterID{3}, int_float_b);
+  const auto parameter_int_float2_a = parameter_with_referenced_(ParameterID{4}, int_float2_a);
 
   // "(SELECT MIN(b) + int_float.a FROM int_float2)"
   const auto expected_sub_select_lqp_a =
@@ -1147,7 +1147,7 @@ TEST_F(SQLTranslatorTest, ExistsCorrelated) {
 
   // clang-format off
   const auto sub_select_lqp =
-  PredicateNode::make(greater_than_(int_float_a, parameter_(ParameterID{0}, int_float2_b)),
+  PredicateNode::make(greater_than_(int_float_a, parameter_with_referenced_(ParameterID{0}, int_float2_b)),
     stored_table_node_int_float);
   const auto sub_select = select_(sub_select_lqp, std::make_pair(ParameterID{0}, int_float2_b));
 

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -966,8 +966,8 @@ TEST_F(SQLTranslatorTest, ValuePlaceholders) {
 
   // clang-format off
   const auto expected_lqp =
-  ProjectionNode::make(expression_vector(add_(int_float_a, parameter_(ParameterID{1})), parameter_(ParameterID{2})),
-    PredicateNode::make(greater_than_(int_float_a, parameter_(ParameterID{0})),
+  ProjectionNode::make(expression_vector(add_(int_float_a, uncorrelated_parameter_(ParameterID{1})), uncorrelated_parameter_(ParameterID{2})),
+    PredicateNode::make(greater_than_(int_float_a, uncorrelated_parameter_(ParameterID{0})),
       stored_table_node_int_float));
   // clang-format on
 
@@ -1062,10 +1062,10 @@ TEST_F(SQLTranslatorTest, ParameterIDAllocation) {
   const auto expected_sub_select_b = lqp_select_(expected_sub_select_lqp_b, std::make_pair(ParameterID{3}, int_float_b));
 
   const auto expected_lqp =
-  ProjectionNode::make(expression_vector(parameter_(ParameterID{1}),
+  ProjectionNode::make(expression_vector(uncorrelated_parameter_(ParameterID{1}),
                                          expected_sub_select_a,
                                          expected_sub_select_b),
-    PredicateNode::make(greater_than_(int_float_a, parameter_(ParameterID{0})),
+    PredicateNode::make(greater_than_(int_float_a, uncorrelated_parameter_(ParameterID{0})),
       stored_table_node_int_float));
   // clang-format on
 


### PR DESCRIPTION
C++ doesn't like the two functions having the same name:

https://stackoverflow.com/questions/29883977/ambiguous-name-lookup-with-using-directive/29883978

I ran into a compiler error while during a completely unrelated change and had to fix this.