### PR TITLE
Change execution time from us to ns, fix format_duration

### DIFF
--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -255,11 +255,11 @@ std::string SQLPipelineMetrics::to_string() const {
 
   std::ostringstream info_string;
   info_string << "Execution info: [";
-  info_string << "PARSE: " << format_duration(parse_time_nanos) << " µs, ";
-  info_string << "TRANSLATE: " << format_duration(total_translate_nanos) << " µs, ";
-  info_string << "OPTIMIZE: " << format_duration(total_optimize_nanos) << " µs, ";
-  info_string << "COMPILE: " << format_duration(total_compile_nanos) << " µs, ";
-  info_string << "EXECUTE: " << format_duration(total_execute_nanos) << " µs (wall time) | ";
+  info_string << "PARSE: " << format_duration(parse_time_nanos) << ", ";
+  info_string << "TRANSLATE: " << format_duration(total_translate_nanos) << ", ";
+  info_string << "OPTIMIZE: " << format_duration(total_optimize_nanos) << ", ";
+  info_string << "COMPILE: " << format_duration(total_compile_nanos) << ", ";
+  info_string << "EXECUTE: " << format_duration(total_execute_nanos) << " (wall time) | ";
   info_string << "QUERY PLAN CACHE HITS: " << num_cache_hits << "/" << query_plan_cache_hits.size() << " statement(s)";
   info_string << "]\n";
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -235,20 +235,17 @@ const SQLPipelineMetrics& SQLPipeline::metrics() {
 }
 
 std::string SQLPipelineMetrics::to_string() const {
-  auto total_translate_micros = std::chrono::microseconds::zero();
-  auto total_optimize_micros = std::chrono::microseconds::zero();
-  auto total_compile_micros = std::chrono::microseconds::zero();
-  auto total_execute_micros = std::chrono::microseconds::zero();
+  auto total_translate_nanos = std::chrono::nanoseconds::zero();
+  auto total_optimize_nanos = std::chrono::nanoseconds::zero();
+  auto total_compile_nanos = std::chrono::nanoseconds::zero();
+  auto total_execute_nanos = std::chrono::nanoseconds::zero();
   std::vector<bool> query_plan_cache_hits;
 
   for (const auto& statement_metric : statement_metrics) {
-    total_translate_micros +=
-        std::chrono::duration_cast<std::chrono::microseconds>(statement_metric->translate_time_nanos);
-    total_optimize_micros +=
-        std::chrono::duration_cast<std::chrono::microseconds>(statement_metric->optimize_time_nanos);
-    total_compile_micros += std::chrono::duration_cast<std::chrono::microseconds>(statement_metric->compile_time_nanos);
-    total_execute_micros +=
-        std::chrono::duration_cast<std::chrono::microseconds>(statement_metric->execution_time_nanos);
+    total_translate_nanos += statement_metric->translate_time_nanos;
+    total_optimize_nanos += statement_metric->optimize_time_nanos;
+    total_compile_nanos += statement_metric->compile_time_nanos;
+    total_execute_nanos += statement_metric->execution_time_nanos;
 
     query_plan_cache_hits.push_back(statement_metric->query_plan_cache_hit);
   }
@@ -257,11 +254,16 @@ std::string SQLPipelineMetrics::to_string() const {
 
   std::ostringstream info_string;
   info_string << "Execution info: [";
-  info_string << "PARSE: " << parse_time_nanos.count() << " µs, ";
-  info_string << "TRANSLATE: " << total_translate_micros.count() << " µs, ";
-  info_string << "OPTIMIZE: " << total_optimize_micros.count() << " µs, ";
-  info_string << "COMPILE: " << total_compile_micros.count() << " µs, ";
-  info_string << "EXECUTE: " << total_execute_micros.count() << " µs (wall time) | ";
+  info_string << "PARSE: " << std::chrono::duration_cast<std::chrono::microseconds>(parse_time_nanos.count())
+              << " µs, ";
+  info_string << "TRANSLATE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_translate_nanos).count()
+              << " µs, ";
+  info_string << "OPTIMIZE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_optimize_nanos).count()
+              << " µs, ";
+  info_string << "COMPILE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_compile_nanos).count()
+              << " µs, ";
+  info_string << "EXECUTE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_execute_nanos).count()
+              << " µs (wall time) | ";
   info_string << "QUERY PLAN CACHE HITS: " << num_cache_hits << "/" << query_plan_cache_hits.size() << " statement(s)";
   info_string << "]\n";
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -8,6 +8,7 @@
 #include "SQLParser.h"
 #include "create_sql_parser_error_message.hpp"
 #include "utils/assert.hpp"
+#include "utils/format_duration.hpp"
 #include "utils/tracing/probes.hpp"
 
 namespace opossum {
@@ -254,16 +255,11 @@ std::string SQLPipelineMetrics::to_string() const {
 
   std::ostringstream info_string;
   info_string << "Execution info: [";
-  info_string << "PARSE: " << std::chrono::duration_cast<std::chrono::microseconds>(parse_time_nanos.count())
-              << " µs, ";
-  info_string << "TRANSLATE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_translate_nanos).count()
-              << " µs, ";
-  info_string << "OPTIMIZE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_optimize_nanos).count()
-              << " µs, ";
-  info_string << "COMPILE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_compile_nanos).count()
-              << " µs, ";
-  info_string << "EXECUTE: " << std::chrono::duration_cast<std::chrono::microseconds>(total_execute_nanos).count()
-              << " µs (wall time) | ";
+  info_string << "PARSE: " << format_duration(parse_time_nanos) << " µs, ";
+  info_string << "TRANSLATE: " << format_duration(total_translate_nanos) << " µs, ";
+  info_string << "OPTIMIZE: " << format_duration(total_optimize_nanos) << " µs, ";
+  info_string << "COMPILE: " << format_duration(total_compile_nanos) << " µs, ";
+  info_string << "EXECUTE: " << format_duration(total_execute_nanos) << " µs (wall time) | ";
   info_string << "QUERY PLAN CACHE HITS: " << num_cache_hits << "/" << query_plan_cache_hits.size() << " statement(s)";
   info_string << "]\n";
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -19,7 +19,7 @@ struct SQLPipelineMetrics {
   std::vector<std::shared_ptr<const SQLPipelineStatementMetrics>> statement_metrics;
 
   // This is different from the other measured times as we only get this for all statements at once
-  std::chrono::microseconds parse_time_micros{0};
+  std::chrono::nanoseconds parse_time_nanos{0};
 
   std::string to_string() const;
 };

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -103,7 +103,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
   _unoptimized_logical_plan = lqp_roots.front();
 
   const auto done = std::chrono::high_resolution_clock::now();
-  _metrics->translate_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _metrics->translate_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
 
   return _unoptimized_logical_plan;
 }
@@ -120,7 +120,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   _optimized_logical_plan = _optimizer->optimize(unoptimized_lqp);
 
   const auto done = std::chrono::high_resolution_clock::now();
-  _metrics->optimize_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _metrics->optimize_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -227,7 +227,7 @@ const std::shared_ptr<SQLQueryPlan>& SQLPipelineStatement::get_query_plan() {
     SQLQueryCache<SQLQueryPlan>::get().set(_sql_string, *_query_plan);
   }
 
-  _metrics->compile_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _metrics->compile_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
 
   return _query_plan;
 }
@@ -260,7 +260,7 @@ const std::shared_ptr<const Table>& SQLPipelineStatement::get_result_table() {
   if (statement->isType(hsql::kStmtPrepare)) {
     _query_has_output = false;
     const auto done = std::chrono::high_resolution_clock::now();
-    _metrics->execution_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+    _metrics->execution_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
     return _result_table;
   }
 
@@ -273,15 +273,15 @@ const std::shared_ptr<const Table>& SQLPipelineStatement::get_result_table() {
   }
 
   const auto done = std::chrono::high_resolution_clock::now();
-  _metrics->execution_time_micros = std::chrono::duration_cast<std::chrono::microseconds>(done - started);
+  _metrics->execution_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
 
   // Get output from the last task
   _result_table = tasks.back()->get_operator()->get_output();
   if (_result_table == nullptr) _query_has_output = false;
 
-  DTRACE_PROBE8(HYRISE, SUMMARY, _sql_string.c_str(), _metrics->translate_time_micros.count(),
-                _metrics->optimize_time_micros.count(), _metrics->compile_time_micros.count(),
-                _metrics->execution_time_micros.count(), _metrics->query_plan_cache_hit, get_tasks().size(),
+  DTRACE_PROBE8(HYRISE, SUMMARY, _sql_string.c_str(), _metrics->translate_time_nanos.count(),
+                _metrics->optimize_time_nanos.count(), _metrics->compile_time_nanos.count(),
+                _metrics->execution_time_nanos.count(), _metrics->query_plan_cache_hit, get_tasks().size(),
                 reinterpret_cast<uintptr_t>(this));
   return _result_table;
 }

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -16,10 +16,10 @@ using PreparedStatementCache = SQLQueryCache<SQLQueryPlan>;
 
 // Holds relevant information about the execution of an SQLPipelineStatement.
 struct SQLPipelineStatementMetrics {
-  std::chrono::microseconds translate_time_micros{};
-  std::chrono::microseconds optimize_time_micros{};
-  std::chrono::microseconds compile_time_micros{};
-  std::chrono::microseconds execution_time_micros{};
+  std::chrono::nanoseconds translate_time_nanos{};
+  std::chrono::nanoseconds optimize_time_nanos{};
+  std::chrono::nanoseconds compile_time_nanos{};
+  std::chrono::nanoseconds execution_time_nanos{};
 
   bool query_plan_cache_hit = false;
 };

--- a/src/lib/utils/format_duration.cpp
+++ b/src/lib/utils/format_duration.cpp
@@ -1,36 +1,48 @@
 #include "format_duration.hpp"
 
+#include <cmath>
 #include <sstream>
+
+#include "utils/assert.hpp"
 
 namespace opossum {
 
 std::string format_duration(const std::chrono::nanoseconds& total_nanoseconds) {
+  // Returns the result of a positive integer division rounded both to zero and to the nearest int
+  const auto div_both = [](const auto a, const auto b) {
+    DebugAssert(a >= 0 && b > 0, "Can only operate on positive integers");
+    const auto round_to_zero = a / b;
+    auto round_to_nearest = a / b;
+    if (a - round_to_zero * b >= b / 2) round_to_nearest += 1;
+    return std::pair<decltype(a), decltype(a)>{round_to_zero, round_to_nearest};
+  };
+
   auto nanoseconds_remaining = total_nanoseconds.count();
 
-  const auto minutes = nanoseconds_remaining / 60'000'000'000;
-  nanoseconds_remaining -= minutes * 60'000'000'000;
+  const auto minutes = div_both(nanoseconds_remaining, 60'000'000'000);
+  nanoseconds_remaining -= minutes.first * 60'000'000'000;
 
-  const auto seconds = nanoseconds_remaining / 1'000'000'000;
-  nanoseconds_remaining -= seconds * 1'000'000'000;
+  const auto seconds = div_both(nanoseconds_remaining, 1'000'000'000);
+  nanoseconds_remaining -= seconds.first * 1'000'000'000;
 
-  const auto milliseconds = nanoseconds_remaining / 1'000'000;
-  nanoseconds_remaining -= milliseconds * 1'000'000;
+  const auto milliseconds = div_both(nanoseconds_remaining, 1'000'000);
+  nanoseconds_remaining -= milliseconds.first * 1'000'000;
 
-  const auto microseconds = nanoseconds_remaining / 1'000;
-  nanoseconds_remaining -= microseconds * 1'000;
+  const auto microseconds = div_both(nanoseconds_remaining, 1'000);
+  nanoseconds_remaining -= microseconds.first * 1'000;
 
   const auto nanoseconds = nanoseconds_remaining;
 
   std::stringstream stream;
 
-  if (minutes > 0) {
-    stream << minutes << " min " << seconds << " s";
-  } else if (seconds > 0) {
-    stream << seconds << " s " << milliseconds << " ms";
-  } else if (milliseconds > 0) {
-    stream << milliseconds << " ms " << microseconds << " µs";
-  } else if (microseconds > 0) {
-    stream << microseconds << " µs " << nanoseconds << " ns";
+  if (minutes.first > 0) {
+    stream << minutes.first << " min " << seconds.second << " s";
+  } else if (seconds.first > 0) {
+    stream << seconds.first << " s " << milliseconds.second << " ms";
+  } else if (milliseconds.first > 0) {
+    stream << milliseconds.first << " ms " << microseconds.second << " µs";
+  } else if (microseconds.first > 0) {
+    stream << microseconds.first << " µs " << nanoseconds << " ns";
   } else {
     stream << nanoseconds << " ns";
   }

--- a/src/lib/utils/format_duration.cpp
+++ b/src/lib/utils/format_duration.cpp
@@ -8,7 +8,8 @@
 namespace opossum {
 
 std::string format_duration(const std::chrono::nanoseconds& total_nanoseconds) {
-  // Returns the result of a positive integer division rounded both to zero and to the nearest int
+  // Returns the result of a positive integer division rounded both to zero and to the nearest int so that 60900ms
+  // are returned as 61s, not 60s
   const auto div_both = [](const auto a, const auto b) {
     DebugAssert(a >= 0 && b > 0, "Can only operate on positive integers");
     const auto round_to_zero = a / b;

--- a/src/lib/utils/format_duration.cpp
+++ b/src/lib/utils/format_duration.cpp
@@ -14,7 +14,7 @@ std::string format_duration(const std::chrono::nanoseconds& total_nanoseconds) {
     const auto round_to_zero = a / b;
     auto round_to_nearest = a / b;
     if (a - round_to_zero * b >= b / 2) round_to_nearest += 1;
-    return std::pair<decltype(a), decltype(a)>{round_to_zero, round_to_nearest};
+    return std::make_pair(round_to_zero, round_to_nearest);
   };
 
   auto nanoseconds_remaining = total_nanoseconds.count();

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -9,6 +9,8 @@
 #include "gtest/gtest.h"
 #include "operators/abstract_operator.hpp"
 #include "scheduler/current_scheduler.hpp"
+#include "sql/sql_query_cache.hpp"
+#include "sql/sql_query_plan.hpp"
 #include "storage/dictionary_segment.hpp"
 #include "storage/numa_placement_manager.hpp"
 #include "storage/segment_encoding_utils.hpp"
@@ -74,6 +76,7 @@ class BaseTestWithParam
     PluginManager::reset();
     StorageManager::reset();
     TransactionManager::reset();
+    SQLQueryCache<SQLQueryPlan>::get().clear();
   }
 };
 

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -17,6 +17,8 @@
 #include "scheduler/topology.hpp"
 #include "sql/sql_pipeline_builder.hpp"
 #include "sql/sql_pipeline_statement.hpp"
+#include "sql/sql_query_cache.hpp"
+#include "sql/sql_query_plan.hpp"
 #include "storage/storage_manager.hpp"
 
 namespace {
@@ -331,10 +333,10 @@ TEST_F(SQLPipelineStatementTest, GetQueryPlanTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_query_plan();
-  auto duration = sql_pipeline.metrics()->compile_time_micros;
+  auto duration = sql_pipeline.metrics()->compile_time_nanos;
 
   const auto& plan = sql_pipeline.get_query_plan();
-  auto duration2 = sql_pipeline.metrics()->compile_time_micros;
+  auto duration2 = sql_pipeline.metrics()->compile_time_nanos;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -426,10 +428,10 @@ TEST_F(SQLPipelineStatementTest, GetResultTableTwice) {
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   sql_pipeline.get_result_table();
-  auto duration = sql_pipeline.metrics()->execution_time_micros;
+  auto duration = sql_pipeline.metrics()->execution_time_nanos;
 
   const auto& table = sql_pipeline.get_result_table();
-  auto duration2 = sql_pipeline.metrics()->execution_time_micros;
+  auto duration2 = sql_pipeline.metrics()->execution_time_nanos;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -477,23 +479,26 @@ TEST_F(SQLPipelineStatementTest, GetResultTableNoMVCC) {
 }
 
 TEST_F(SQLPipelineStatementTest, GetTimes) {
+  const auto& cache = SQLQueryCache<SQLQueryPlan>::get();
+  EXPECT_EQ(cache.size(), 0u);
+
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline_statement();
 
   const auto& metrics = sql_pipeline.metrics();
-  const auto zero_duration = std::chrono::microseconds::zero();
+  const auto zero_duration = std::chrono::nanoseconds::zero();
 
-  EXPECT_EQ(metrics->translate_time_micros, zero_duration);
-  EXPECT_EQ(metrics->optimize_time_micros, zero_duration);
-  EXPECT_EQ(metrics->compile_time_micros, zero_duration);
-  EXPECT_EQ(metrics->execution_time_micros, zero_duration);
+  EXPECT_EQ(metrics->translate_time_nanos, zero_duration);
+  EXPECT_EQ(metrics->optimize_time_nanos, zero_duration);
+  EXPECT_EQ(metrics->compile_time_nanos, zero_duration);
+  EXPECT_EQ(metrics->execution_time_nanos, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(metrics->translate_time_micros, zero_duration);
-  EXPECT_GT(metrics->optimize_time_micros, zero_duration);
-  EXPECT_GT(metrics->compile_time_micros, zero_duration);
-  EXPECT_GT(metrics->execution_time_micros, zero_duration);
+  EXPECT_GT(metrics->translate_time_nanos, zero_duration);
+  EXPECT_GT(metrics->optimize_time_nanos, zero_duration);
+  EXPECT_GT(metrics->compile_time_nanos, zero_duration);
+  EXPECT_GT(metrics->execution_time_nanos, zero_duration);
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -276,10 +276,10 @@ TEST_F(SQLPipelineTest, GetQueryPlanTwice) {
 
   sql_pipeline.get_query_plans();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  auto duration = metrics.statement_metrics[0]->compile_time_micros;
+  auto duration = metrics.statement_metrics[0]->compile_time_nanos;
 
   const auto& plans = sql_pipeline.get_query_plans();
-  auto duration2 = metrics.statement_metrics[0]->compile_time_micros;
+  auto duration2 = metrics.statement_metrics[0]->compile_time_nanos;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -357,11 +357,11 @@ TEST_F(SQLPipelineTest, GetResultTableTwice) {
 
   sql_pipeline.get_result_table();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  auto duration = metrics.statement_metrics[0]->execution_time_micros;
+  auto duration = metrics.statement_metrics[0]->execution_time_nanos;
 
   const auto& table = sql_pipeline.get_result_table();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
-  auto duration2 = metrics.statement_metrics[0]->execution_time_micros;
+  auto duration2 = metrics.statement_metrics[0]->execution_time_nanos;
 
   // Make sure this was not run twice
   EXPECT_EQ(duration, duration2);
@@ -431,27 +431,30 @@ TEST_F(SQLPipelineTest, GetResultTableNoOutput) {
 }
 
 TEST_F(SQLPipelineTest, GetTimes) {
+  const auto& cache = SQLQueryCache<SQLQueryPlan>::get();
+  EXPECT_EQ(cache.size(), 0u);
+
   auto sql_pipeline = SQLPipelineBuilder{_select_query_a}.create_pipeline();
 
   const auto& metrics = sql_pipeline.metrics();
   ASSERT_EQ(metrics.statement_metrics.size(), 1u);
   const auto& statement_metrics = metrics.statement_metrics[0];
 
-  const auto zero_duration = std::chrono::microseconds::zero();
+  const auto zero_duration = std::chrono::nanoseconds::zero();
 
-  EXPECT_EQ(statement_metrics->translate_time_micros, zero_duration);
-  EXPECT_EQ(statement_metrics->optimize_time_micros, zero_duration);
-  EXPECT_EQ(statement_metrics->compile_time_micros, zero_duration);
-  EXPECT_EQ(statement_metrics->execution_time_micros, zero_duration);
+  EXPECT_EQ(statement_metrics->translate_time_nanos, zero_duration);
+  EXPECT_EQ(statement_metrics->optimize_time_nanos, zero_duration);
+  EXPECT_EQ(statement_metrics->compile_time_nanos, zero_duration);
+  EXPECT_EQ(statement_metrics->execution_time_nanos, zero_duration);
 
   // Run to get times
   sql_pipeline.get_result_table();
 
-  EXPECT_GT(metrics.parse_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics->translate_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics->optimize_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics->compile_time_micros, zero_duration);
-  EXPECT_GT(statement_metrics->execution_time_micros, zero_duration);
+  EXPECT_GT(metrics.parse_time_nanos, zero_duration);
+  EXPECT_GT(statement_metrics->translate_time_nanos, zero_duration);
+  EXPECT_GT(statement_metrics->optimize_time_nanos, zero_duration);
+  EXPECT_GT(statement_metrics->compile_time_nanos, zero_duration);
+  EXPECT_GT(statement_metrics->execution_time_nanos, zero_duration);
 }
 
 TEST_F(SQLPipelineTest, RequiresExecutionVariations) {

--- a/src/test/utils/format_duration_test.cpp
+++ b/src/test/utils/format_duration_test.cpp
@@ -12,10 +12,14 @@ TEST(Format, Duration) {
   EXPECT_EQ(format_duration(11ns), "11 ns");
   EXPECT_EQ(format_duration(1000ns), "1 µs 0 ns");
   EXPECT_EQ(format_duration(1234ns), "1 µs 234 ns");
-  EXPECT_EQ(format_duration(12345678ns), "12 ms 345 µs");
-  EXPECT_EQ(format_duration(1234567890ns), "1 s 234 ms");
+  EXPECT_EQ(format_duration(12345100ns), "12 ms 345 µs");
+  EXPECT_EQ(format_duration(12345678ns), "12 ms 346 µs");
+  EXPECT_EQ(format_duration(1234421012ns), "1 s 234 ms");
+  EXPECT_EQ(format_duration(1234567890ns), "1 s 235 ms");
   EXPECT_EQ(format_duration(60000000000ns), "1 min 0 s");
+  EXPECT_EQ(format_duration(60000000001ns), "1 min 0 s");
   EXPECT_EQ(format_duration(61234567890ns), "1 min 1 s");
+  EXPECT_EQ(format_duration(61834567890ns), "1 min 2 s");
 }
 
 }  // namespace opossum


### PR DESCRIPTION
If the CPU is too fast, the time spent in preparing a query might be less than a microsecond. Changing that to nanoseconds should solve the problem for this processor generation and the next. ;)

Also moves resetting the SQL plan cache to BaseTest. While this was never a problem, we should make sure that nothing ever lingers around there.

blocked by #1190 