### PR TITLE
Format ipp files and add functionality to only format git-staged files

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -20,7 +20,7 @@ elif [ "$1" = "modified" ]; then
     { git diff --diff-filter=d --name-only & git ls-files --others --exclude-standard; } | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"
 elif [ "$1" = "staged" ]; then
     # Run on all files that are staged to be committed.
-    git diff --cached --name-only | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"
+    git diff --diff-filter=d --cached --name-only | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"
 else
     # Run on all changed as well as untracked cpp/hpp files, as compared to the current master. Skip deleted files.
     { git diff --diff-filter=d --name-only master & git ls-files --others --exclude-standard; } | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -14,11 +14,14 @@ fi
 
 
 if [ "${1}" = "all" ]; then
-    find src -iname "*.cpp" -o -iname "*.hpp" | xargs -I{} sh -c "${format_cmd}"
+    find src -iname "*.cpp" -o -iname "*.hpp" -o -iname "*.ipp" | xargs -I{} sh -c "${format_cmd}"
 elif [ "$1" = "modified" ]; then
     # Run on all changed as well as untracked cpp/hpp files, as compared to the current HEAD. Skip deleted files.
-    { git diff --diff-filter=d --name-only & git ls-files --others --exclude-standard; } | grep -E "^src.*\.[ch]pp$" | xargs -I{} sh -c "${format_cmd}"
+    { git diff --diff-filter=d --name-only & git ls-files --others --exclude-standard; } | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"
+elif [ "$1" = "staged" ]; then
+    # Run on all files that are staged to be committed.
+    git diff --cached --name-only | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"
 else
     # Run on all changed as well as untracked cpp/hpp files, as compared to the current master. Skip deleted files.
-    { git diff --diff-filter=d --name-only master & git ls-files --others --exclude-standard; } | grep -E "^src.*\.[ch]pp$" | xargs -I{} sh -c "${format_cmd}"
+    { git diff --diff-filter=d --name-only master & git ls-files --others --exclude-standard; } | grep -E "^src.*\.[chi]pp$" | xargs -I{} sh -c "${format_cmd}"
 fi


### PR DESCRIPTION
I noticed that we have ipp files but do not include them in the format script.

I also added an option to only format files that are staged in git, to speed up formatting as well as avoiding to change files one hasn't touched because of differences in clang-format versions.