### PR TITLE
Remove SQL from EXISTS test cases

### DIFF
--- a/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
+++ b/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
@@ -223,7 +223,7 @@ TEST_F(ExistsReformulationRuleTest, NoRewriteOfExistsWithOrPredicate) {
 }
 
 /*
-  The following cases tests whether queries we do currently not rewrite are really not modified by the rule.
+  The following cases test whether queries we currently do not rewrite are really not modified by the rule.
   Note, rewriting these cases to joins might be possible but as of now we do not rewrite them.
 */
 TEST_F(ExistsReformulationRuleTest, NoRewriteOfInequalityJoinPredicates) {

--- a/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
+++ b/src/test/optimizer/strategy/exists_reformulation_rule_test.cpp
@@ -215,7 +215,8 @@ TEST_F(ExistsReformulationRuleTest, NoRewriteOfExistsWithOrPredicate) {
       expression_vector(node_table_a_col_a, node_table_a_col_b),
       PredicateNode::make(
           not_equals_(or_(exists_(subselect), less_than_(node_table_a_col_a, 17)), 0),
-          ProjectionNode::make(expression_vector(or_(exists_(subselect), less_than_(node_table_a_col_a, 17)), node_table_a_col_a, node_table_a_col_b),
+          ProjectionNode::make(expression_vector(or_(exists_(subselect), less_than_(node_table_a_col_a, 17)),
+                                                 node_table_a_col_a, node_table_a_col_b),
                                node_table_a)));
 
   EXPECT_LQP_EQ(this->apply_exists_rule(input_lqp), input_lqp);
@@ -241,7 +242,8 @@ TEST_F(ExistsReformulationRuleTest, NoRewriteOfInequalityJoinPredicates) {
 }
 
 TEST_F(ExistsReformulationRuleTest, NoRewriteOfMultipleJoinPredicates) {
-  // SELECT * FROM table_a WHERE NOT EXISTS (SELECT * FROM table_b WHERE table_a.a = table_b.a and table_a.a = table_b.b)
+  // SELECT * FROM table_a WHERE NOT EXISTS (SELECT * FROM table_b
+  //    WHERE table_a.a = table_b.a and table_a.a = table_b.b)
   const auto parameter = correlated_parameter_(ParameterID{0}, node_table_a_col_a);
   const auto subselect_lqp = PredicateNode::make(equals_(parameter, node_table_b_col_b), node_table_b);
   const auto subselect_lqp2 = PredicateNode::make(equals_(parameter, node_table_b_col_a), subselect_lqp);
@@ -257,7 +259,8 @@ TEST_F(ExistsReformulationRuleTest, NoRewriteOfMultipleJoinPredicates) {
 }
 
 TEST_F(ExistsReformulationRuleTest, NoRewriteOfExternalJoinPredicatesMoreThanOnce) {
-  // SELECT * FROM table_a WHERE NOT EXISTS (SELECT * FROM table_b WHERE table_a.a = table_b.a and table_a.a < 17)
+  // SELECT * FROM table_a WHERE NOT EXISTS (SELECT * FROM table_b
+  //    WHERE table_a.a = table_b.a and table_a.a < 17)
   const auto parameter = correlated_parameter_(ParameterID{0}, node_table_a_col_a);
   const auto subselect_lqp = PredicateNode::make(equals_(parameter, node_table_b_col_a), node_table_b);
   const auto subselect_lqp2 = PredicateNode::make(less_than_(parameter, 17), subselect_lqp);

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -92,8 +92,10 @@ SELECT t1.id, t1.a, t2.b, t3.b, t4.c_name FROM mixed AS t1 INNER JOIN mixed_null
 SELECT * FROM mixed AS t1 INNER JOIN mixed_null AS t2 ON t1.b = t2.b INNER JOIN id_int_int_int_100 AS t3 ON t1.b = t3.a WHERE t1.c > 23.0 AND t2.a = 'c';
 
 -- (not) exists to semi(/anti) join reformulation
-SELECT * FROM id_int_int_int_100 WHERE EXISTS (SELECT * FROM int_date WHERE id_int_int_int_100.id = int_date.a)
-SELECT * FROM id_int_int_int_100 WHERE NOT EXISTS (SELECT * FROM int_date WHERE id_int_int_int_100.id = int_date.a)
+SELECT * FROM id_int_int_int_100 WHERE EXISTS (SELECT * FROM int_date WHERE id_int_int_int_100.id = int_date.a);
+SELECT * FROM id_int_int_int_100 WHERE NOT EXISTS (SELECT * FROM int_date WHERE id_int_int_int_100.id = int_date.a);
+-- exists to semi join reformulation: query not rewriteable
+SELECT * FROM id_int_int_int_100 WHERE EXISTS (SELECT * FROM int_date WHERE id_int_int_int_100.id = int_date.a) OR id < 20;
 
 -- Aggregates
 SELECT SUM(b + b) AS sum_b_b FROM mixed;


### PR DESCRIPTION
As (rightfully) brought up by Moritz in #1106, testing the exists reformulation rule should not depend on SQL.

This PR changes the tests accordingly.

Furthermore, I added a test that I think is relatively relevant. It explicitly checks whether an OR besides the EXISTS is rewritten or not.
While some current restrictions of the reformulation rule might later be removed as we cover more scenarios, the OR case should never be optimized (unless implement a new join operator).