### PR TITLE
Allow clang-format 7

### DIFF
--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,7 +3,7 @@
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then
 	clang_format="/usr/local/opt/llvm/bin/clang-format"
-	$clang_format --version | grep "version 6.0" >/dev/null
+	$clang_format --version | grep "version [67].0" >/dev/null
 	if [ $? -ne 0 ]; then
 		echo "incompatible clang-format version detected in $clang_format"
 	fi

--- a/src/lib/expression/lqp_select_expression.cpp
+++ b/src/lib/expression/lqp_select_expression.cpp
@@ -58,9 +58,7 @@ bool LQPSelectExpression::is_nullable() const {
   return lqp->column_expressions()[0]->is_nullable();
 }
 
-bool LQPSelectExpression::is_correlated() const {
-  return !arguments.empty();
-}
+bool LQPSelectExpression::is_correlated() const { return !arguments.empty(); }
 
 bool LQPSelectExpression::_shallow_equals(const AbstractExpression& expression) const {
   const auto& lqp_select_expression = static_cast<const LQPSelectExpression&>(expression);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -731,11 +731,11 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     This helps choosing a scheduler node for the radix phase (see below).
     */
     // Scheduler note: parallelize this at some point. Currently, the amount of jobs would be too high
-    auto materialized_left = materialize_input<LeftType, HashedType>(left_in_table, _column_ids.first, histograms_left,
-                                                                     _radix_bits);
+    auto materialized_left =
+        materialize_input<LeftType, HashedType>(left_in_table, _column_ids.first, histograms_left, _radix_bits);
     // 'keep_nulls' makes sure that the relation on the right materializes NULL values when executing an OUTER join.
-    auto materialized_right = materialize_input<RightType, HashedType>(
-        right_in_table, _column_ids.second, histograms_right, _radix_bits, keep_nulls);
+    auto materialized_right = materialize_input<RightType, HashedType>(right_in_table, _column_ids.second,
+                                                                       histograms_right, _radix_bits, keep_nulls);
 
     // Radix Partitioning phase
     /*

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -184,9 +184,8 @@ void TableScan::_init_scan() {
     const auto right_value = boost::get<AllTypeVariant>(*_predicate.value2);
 
     Assert(left_value.which() == right_value.which(),
-                "Expected left and right value to be of the same type (see operator_scan_predicate.cpp)");
-    Assert(!variant_is_null(left_value) && !variant_is_null(right_value),
-                "Expected BETWEEN values to be non-null");
+           "Expected left and right value to be of the same type (see operator_scan_predicate.cpp)");
+    Assert(!variant_is_null(left_value) && !variant_is_null(right_value), "Expected BETWEEN values to be non-null");
 
     _impl = std::make_unique<BetweenTableScanImpl>(_in_table, column_id, left_value, right_value);
   } else if (is_variant(parameter)) {

--- a/src/test/lib/import_export/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv_parser_test.cpp
@@ -9,13 +9,13 @@ namespace opossum {
 class CsvParserTest : public BaseTest {};
 
 TEST_F(CsvParserTest, EmptyTableFromMetaFile) {
-    CsvParser parser;
-    const auto csv_meta_table = parser.create_table_from_meta_file("src/test/csv/float_int.csv.json");
-    const auto expected_table = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float},
-                                                        {"a", DataType::Int}}, TableType::Data);
+  CsvParser parser;
+  const auto csv_meta_table = parser.create_table_from_meta_file("src/test/csv/float_int.csv.json");
+  const auto expected_table =
+      std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float}, {"a", DataType::Int}}, TableType::Data);
 
-    EXPECT_EQ(csv_meta_table->row_count(), 0);
-    EXPECT_TABLE_EQ_UNORDERED(csv_meta_table, expected_table);
+  EXPECT_EQ(csv_meta_table->row_count(), 0);
+  EXPECT_TABLE_EQ_UNORDERED(csv_meta_table, expected_table);
 }
 
 }  // namespace opossum

--- a/src/test/lib/utils/load_table_test.cpp
+++ b/src/test/lib/utils/load_table_test.cpp
@@ -9,12 +9,12 @@ namespace opossum {
 class LoadTableTest : public BaseTest {};
 
 TEST_F(LoadTableTest, EmptyTableFromHeader) {
-    const auto tbl_header_table = create_table_from_header("src/test/tables/float_int.tbl");
-    const auto expected_table = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float},
-                                                        {"a", DataType::Int}}, TableType::Data);
+  const auto tbl_header_table = create_table_from_header("src/test/tables/float_int.tbl");
+  const auto expected_table =
+      std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float}, {"a", DataType::Int}}, TableType::Data);
 
-    EXPECT_EQ(tbl_header_table->row_count(), 0);
-    EXPECT_TABLE_EQ_UNORDERED(tbl_header_table, expected_table);
+  EXPECT_EQ(tbl_header_table->row_count(), 0);
+  EXPECT_TABLE_EQ_UNORDERED(tbl_header_table, expected_table);
 }
 
 }  // namespace opossum

--- a/src/test/operators/table_scan_between_test.cpp
+++ b/src/test/operators/table_scan_between_test.cpp
@@ -1,4 +1,4 @@
-    #include <tuple>
+#include <tuple>
 
 #include "operators/operator_scan_predicate.hpp"
 #include "operators/table_scan.hpp"


### PR DESCRIPTION
If you have already installed llvm 7 on OS X, you get a message complaining about an incompatible clang-format version. I have compared clang-format 6 and 7 and don't seem to get any format differences.

For this PR, I also executed `./scripts/format.sh all`.