### PR TITLE
Fix CQF compilation on OS X

### DIFF
--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
@@ -82,8 +82,7 @@ size_t CountingQuotientFilter<ElementType>::count(const ElementType& value) cons
 
 template <typename ElementType>
 size_t CountingQuotientFilter<ElementType>::_hash(const ElementType& value) const {
-  auto hash = std::hash<ElementType>{}(value);
-  return static_cast<size_t>(hash);
+  return std::hash<ElementType>{}(value);
 }
 
 template <typename ElementType>

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
@@ -58,7 +58,7 @@ class CountingQuotientFilter : public AbstractFilter, public Noncopyable {
   CountingQuotientFilter operator=(CountingQuotientFilter&&) = delete;
 
  private:
-  uint64_t _hash(const ElementType& value) const;
+  size_t _hash(const ElementType& value) const;
 
   boost::variant<gqf2::QF, gqf4::QF, gqf8::QF, gqf16::QF, gqf32::QF> _quotient_filter;
   const size_t _hash_bits;

--- a/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
@@ -159,7 +159,7 @@ TYPED_TEST(CountingQuotientFilterTest, CanNotPrune) {
  * sanity checking, making sure the FPR is below a very lenient threshold. If these tests fail it is very likely,
  * however not absolutely certain, that there is a bug in the CQF.
  */
-TYPED_TEST(CountingQuotientFilterTest, FalsePositiveRate) {
+TYPED_TEST(CountingQuotientFilterTest, DISABLED_FalsePositiveRate /* #1220 */) {
   this->test_false_positive_rate(this->cqf2);
   this->test_false_positive_rate(this->cqf4);
   this->test_false_positive_rate(this->cqf8);


### PR DESCRIPTION
Mismatching types broke the build on OS X. Also disables a test due to #1220.