### PR TITLE
[Self-Driving] Index memory consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Contact: firstname.lastname@hpi.de
 -	Martin   Fischer
 -	Pedro    Flemming
 -	Johannes Frohnhofen
+-	Adrian   Holfter
 -	Sven     Ihde
 -	Michael  Janke
 -	Max      Jendruk
@@ -113,9 +114,11 @@ Contact: firstname.lastname@hpi.de
 -	Torben   Meyer
 -	Leander  Neiß
 -	David    Schumann
+-	Arthur   Silber
 -	Daniel   Stolpe
 -	Jonathan Striebel
 -	Nils     Thamm
 -	Carsten  Walther
+-	Lukas    Wenzel
 -	Fabian   Wiebe
 -	Tim      Zimmermann

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
@@ -18,7 +18,6 @@ namespace opossum {
 
 size_t AdaptiveRadixTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
                                                            uint32_t value_bytes) {
-  // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
   Fail("AdaptiveRadixTreeIndex::estimate_memory_consumption() is not implemented yet");
 }
 

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
@@ -16,6 +16,12 @@
 
 namespace opossum {
 
+size_t AdaptiveRadixTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count,
+                                                           uint32_t value_bytes) {
+  // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
+  Fail("AdaptiveRadixTreeIndex::estimate_memory_consumption() is not implemented yet");
+}
+
 AdaptiveRadixTreeIndex::AdaptiveRadixTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index)
     : BaseIndex{get_index_type_of<AdaptiveRadixTreeIndex>()},
       _indexed_segment(std::dynamic_pointer_cast<const BaseDictionarySegment>(segments_to_index.front())) {
@@ -122,6 +128,11 @@ std::shared_ptr<ARTNode> AdaptiveRadixTreeIndex::_bulk_insert(
 
 std::vector<std::shared_ptr<const BaseSegment>> AdaptiveRadixTreeIndex::_get_indexed_segments() const {
   return {_indexed_segment};
+}
+
+size_t AdaptiveRadixTreeIndex::_memory_consumption() const {
+  // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
+  Fail("AdaptiveRadixTreeIndex::_memory_consumption() is not implemented yet");
 }
 
 AdaptiveRadixTreeIndex::BinaryComparable::BinaryComparable(ValueID value) : _parts(sizeof(value)) {

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
@@ -16,7 +16,7 @@
 
 namespace opossum {
 
-size_t AdaptiveRadixTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count,
+size_t AdaptiveRadixTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
                                                            uint32_t value_bytes) {
   // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
   Fail("AdaptiveRadixTreeIndex::estimate_memory_consumption() is not implemented yet");

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -37,6 +37,12 @@ class AdaptiveRadixTreeIndex : public BaseIndex {
   friend class AdaptiveRadixTreeIndexTest_BinaryComparableFromChunkOffset_Test;
 
  public:
+  /**
+   * Predicts the memory consumption in bytes of creating this index.
+   * See BaseIndex::estimate_memory_consumption()
+   */
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+
   explicit AdaptiveRadixTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);
 
   AdaptiveRadixTreeIndex(AdaptiveRadixTreeIndex&&) = default;
@@ -80,6 +86,8 @@ class AdaptiveRadixTreeIndex : public BaseIndex {
                                         size_t depth, Iterator& it);
 
   std::vector<std::shared_ptr<const BaseSegment>> _get_indexed_segments() const;
+
+  size_t _memory_consumption() const final;
 
   const std::shared_ptr<const BaseDictionarySegment> _indexed_segment;
   std::vector<ChunkOffset> _chunk_offsets;

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -41,7 +41,7 @@ class AdaptiveRadixTreeIndex : public BaseIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See BaseIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
 
   explicit AdaptiveRadixTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);
 

--- a/src/lib/storage/index/b_tree/b_tree_index.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.cpp
@@ -7,7 +7,6 @@ namespace opossum {
 
 size_t BTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
                                                uint32_t value_bytes) {
-  // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
   Fail("BTreeIndex::estimate_memory_consumption() is not implemented yet");
 }
 

--- a/src/lib/storage/index/b_tree/b_tree_index.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.cpp
@@ -5,6 +5,11 @@
 
 namespace opossum {
 
+size_t BTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes) {
+  // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
+  Fail("BTreeIndex::estimate_memory_consumption() is not implemented yet");
+}
+
 BTreeIndex::BTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index)
     : BaseIndex{get_index_type_of<BTreeIndex>()}, _indexed_segments(segments_to_index[0]) {
   Assert((segments_to_index.size() == 1), "BTreeIndex only works with a single segment.");
@@ -12,7 +17,7 @@ BTreeIndex::BTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& se
       make_shared_by_data_type<BaseBTreeIndexImpl, BTreeIndexImpl>(_indexed_segments->data_type(), _indexed_segments);
 }
 
-uint64_t BTreeIndex::memory_consumption() const { return _impl->memory_consumption(); }
+size_t BTreeIndex::_memory_consumption() const { return _impl->memory_consumption(); }
 
 BTreeIndex::Iterator BTreeIndex::_lower_bound(const std::vector<AllTypeVariant>& values) const {
   return _impl->lower_bound(values);

--- a/src/lib/storage/index/b_tree/b_tree_index.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.cpp
@@ -5,7 +5,8 @@
 
 namespace opossum {
 
-size_t BTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes) {
+size_t BTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
+                                               uint32_t value_bytes) {
   // ToDo(anyone): If you use this index in combination with the Tuning subsystem, you need to properly implement this.
   Fail("BTreeIndex::estimate_memory_consumption() is not implemented yet");
 }

--- a/src/lib/storage/index/b_tree/b_tree_index.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.hpp
@@ -20,7 +20,7 @@ class BTreeIndex : public BaseIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See BaseIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
 
   BTreeIndex() = delete;
   explicit BTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);

--- a/src/lib/storage/index/b_tree/b_tree_index.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.hpp
@@ -16,10 +16,16 @@ class BTreeIndex : public BaseIndex {
  public:
   using Iterator = std::vector<ChunkOffset>::const_iterator;
 
+  /**
+   * Predicts the memory consumption in bytes of creating this index.
+   * See BaseIndex::estimate_memory_consumption()
+   */
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+
   BTreeIndex() = delete;
   explicit BTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);
 
-  virtual uint64_t memory_consumption() const;
+  size_t _memory_consumption() const override;
 
  protected:
   Iterator _lower_bound(const std::vector<AllTypeVariant>&) const override;

--- a/src/lib/storage/index/b_tree/b_tree_index.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.hpp
@@ -25,14 +25,13 @@ class BTreeIndex : public BaseIndex {
   BTreeIndex() = delete;
   explicit BTreeIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);
 
-  size_t _memory_consumption() const override;
-
  protected:
   Iterator _lower_bound(const std::vector<AllTypeVariant>&) const override;
   Iterator _upper_bound(const std::vector<AllTypeVariant>&) const override;
   Iterator _cbegin() const override;
   Iterator _cend() const override;
   std::vector<std::shared_ptr<const BaseSegment>> _get_indexed_segments() const override;
+  size_t _memory_consumption() const override;
 
   std::shared_ptr<const BaseSegment> _indexed_segments;
   std::shared_ptr<BaseBTreeIndexImpl> _impl;

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
@@ -9,7 +9,8 @@
 namespace opossum {
 
 template <typename DataType>
-BTreeIndexImpl<DataType>::BTreeIndexImpl(const std::shared_ptr<const BaseSegment>& segments_to_index) {
+BTreeIndexImpl<DataType>::BTreeIndexImpl(const std::shared_ptr<const BaseSegment>& segments_to_index)
+    : _heap_bytes_used{0} {
   _bulk_insert(segments_to_index);
 }
 
@@ -62,7 +63,6 @@ size_t BTreeIndexImpl<DataType>::memory_consumption() const {
 template <typename DataType>
 void BTreeIndexImpl<DataType>::_bulk_insert(const std::shared_ptr<const BaseSegment>& segment) {
   std::vector<std::pair<ChunkOffset, DataType>> values;
-  _heap_bytes_used = 0;
 
   // Materialize
   resolve_segment_type<DataType>(*segment, [&](const auto& typed_segment) {

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
@@ -55,12 +55,14 @@ BaseBTreeIndexImpl::Iterator BTreeIndexImpl<DataType>::upper_bound(DataType valu
 
 template <typename DataType>
 size_t BTreeIndexImpl<DataType>::memory_consumption() const {
-  return sizeof(std::vector<ChunkOffset>) + sizeof(ChunkOffset) * _chunk_offsets.size() + _btree.bytes_used();
+  return sizeof(std::vector<ChunkOffset>) + sizeof(ChunkOffset) * _chunk_offsets.size() + _btree.bytes_used() +
+         _heap_bytes_used;
 }
 
 template <typename DataType>
 void BTreeIndexImpl<DataType>::_bulk_insert(const std::shared_ptr<const BaseSegment>& segment) {
   std::vector<std::pair<ChunkOffset, DataType>> values;
+  _heap_bytes_used = 0;
 
   // Materialize
   resolve_segment_type<DataType>(*segment, [&](const auto& typed_segment) {
@@ -81,11 +83,27 @@ void BTreeIndexImpl<DataType>::_bulk_insert(const std::shared_ptr<const BaseSegm
   // Build index
   DataType current_value = values[0].second;
   _btree[current_value] = 0;
+  _add_to_heap_memory_usage(current_value);
   for (size_t i = 0; i < values.size(); i++) {
     if (values[i].second != current_value) {
       current_value = values[i].second;
       _btree[current_value] = i;
+      _add_to_heap_memory_usage(current_value);
     }
+  }
+}
+
+template <typename DataType>
+void BTreeIndexImpl<DataType>::_add_to_heap_memory_usage(const DataType&) {
+  // Except for std::string (see below), no supported data type uses heap allocations
+}
+
+template <>
+void BTreeIndexImpl<std::string>::_add_to_heap_memory_usage(const std::string& value) {
+  // Track only strings that are longer than the reserved stack space for short string optimization (SSO)
+  static const auto short_string_threshold = std::string("").capacity();
+  if (value.size() > short_string_threshold) {
+    _heap_bytes_used += value.size();
   }
 }
 

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
@@ -54,7 +54,7 @@ BaseBTreeIndexImpl::Iterator BTreeIndexImpl<DataType>::upper_bound(DataType valu
 }
 
 template <typename DataType>
-uint64_t BTreeIndexImpl<DataType>::memory_consumption() const {
+size_t BTreeIndexImpl<DataType>::memory_consumption() const {
   return sizeof(std::vector<ChunkOffset>) + sizeof(ChunkOffset) * _chunk_offsets.size() + _btree.bytes_used();
 }
 

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.hpp
@@ -68,8 +68,10 @@ class BTreeIndexImpl : public BaseBTreeIndexImpl {
 
  protected:
   void _bulk_insert(const std::shared_ptr<const BaseSegment>&);
+  void _add_to_heap_memory_usage(const DataType&);
 
   btree::btree_map<DataType, size_t> _btree;
+  size_t _heap_bytes_used;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.hpp
@@ -27,7 +27,7 @@ class BaseBTreeIndexImpl {
   virtual ~BaseBTreeIndexImpl() = default;
 
   using Iterator = std::vector<ChunkOffset>::const_iterator;
-  virtual uint64_t memory_consumption() const = 0;
+  virtual size_t memory_consumption() const = 0;
   virtual Iterator lower_bound(const std::vector<AllTypeVariant>&) const = 0;
   virtual Iterator upper_bound(const std::vector<AllTypeVariant>&) const = 0;
   virtual Iterator cbegin() const = 0;
@@ -56,7 +56,7 @@ class BTreeIndexImpl : public BaseBTreeIndexImpl {
   BTreeIndexImpl(BTreeIndexImpl&&) = default;
   BTreeIndexImpl& operator=(BTreeIndexImpl&&) = default;
 
-  uint64_t memory_consumption() const override;
+  size_t memory_consumption() const override;
 
   Iterator lower_bound(DataType value) const;
   Iterator upper_bound(DataType value) const;

--- a/src/lib/storage/index/base_index.cpp
+++ b/src/lib/storage/index/base_index.cpp
@@ -10,17 +10,17 @@
 
 namespace opossum {
 
-size_t BaseIndex::estimate_memory_consumption(SegmentIndexType type, ChunkOffset row_count, ChunkOffset value_count,
+size_t BaseIndex::estimate_memory_consumption(SegmentIndexType type, ChunkOffset row_count, ChunkOffset distinct_count,
                                               uint32_t value_bytes) {
   switch (type) {
     case SegmentIndexType::GroupKey:
-      return GroupKeyIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+      return GroupKeyIndex::estimate_memory_consumption(row_count, distinct_count, value_bytes);
     case SegmentIndexType::CompositeGroupKey:
-      return CompositeGroupKeyIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+      return CompositeGroupKeyIndex::estimate_memory_consumption(row_count, distinct_count, value_bytes);
     case SegmentIndexType::AdaptiveRadixTree:
-      return AdaptiveRadixTreeIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+      return AdaptiveRadixTreeIndex::estimate_memory_consumption(row_count, distinct_count, value_bytes);
     case SegmentIndexType::BTree:
-      return BTreeIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+      return BTreeIndex::estimate_memory_consumption(row_count, distinct_count, value_bytes);
     default:
       Fail("estimate_memory_consumption() is not implemented for the given index type");
   }

--- a/src/lib/storage/index/base_index.cpp
+++ b/src/lib/storage/index/base_index.cpp
@@ -3,7 +3,28 @@
 #include <memory>
 #include <vector>
 
+#include "storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp"
+#include "storage/index/b_tree/b_tree_index.hpp"
+#include "storage/index/group_key/composite_group_key_index.hpp"
+#include "storage/index/group_key/group_key_index.hpp"
+
 namespace opossum {
+
+size_t BaseIndex::estimate_memory_consumption(SegmentIndexType type, ChunkOffset row_count, ChunkOffset value_count,
+                                              uint32_t value_bytes) {
+  switch (type) {
+    case SegmentIndexType::GroupKey:
+      return GroupKeyIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+    case SegmentIndexType::CompositeGroupKey:
+      return CompositeGroupKeyIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+    case SegmentIndexType::AdaptiveRadixTree:
+      return AdaptiveRadixTreeIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+    case SegmentIndexType::BTree:
+      return BTreeIndex::estimate_memory_consumption(row_count, value_count, value_bytes);
+    default:
+      Fail("estimate_memory_consumption() is not implemented for the given index type");
+  }
+}
 
 BaseIndex::BaseIndex(const SegmentIndexType type) : _type{type} {}
 
@@ -37,5 +58,7 @@ BaseIndex::Iterator BaseIndex::cbegin() const { return _cbegin(); }
 BaseIndex::Iterator BaseIndex::cend() const { return _cend(); }
 
 SegmentIndexType BaseIndex::type() const { return _type; }
+
+size_t BaseIndex::memory_consumption() const { return _memory_consumption(); }
 
 }  // namespace opossum

--- a/src/lib/storage/index/base_index.hpp
+++ b/src/lib/storage/index/base_index.hpp
@@ -39,6 +39,19 @@ class BaseIndex : private Noncopyable {
   using Iterator = std::vector<ChunkOffset>::const_iterator;
 
   /**
+   * Predicts the memory consumption in bytes of creating an index with the specific index implementation <type>
+   * on a Chunk with the following statistics:
+   *
+   * row_count - overall number of rows
+   * value_count - number of distinct values
+   * value_bytes - (average) size of a single value in bytes
+   *
+   * If no prediction is possible, this shall fail.
+   */
+  static size_t estimate_memory_consumption(SegmentIndexType type, ChunkOffset row_count, ChunkOffset value_count,
+                                            uint32_t value_bytes);
+
+  /**
    * Creates an index on all given segments. Since all indices are composite indices the order of
    * the provided segments matters. Creating two indices with the same segments, but in different orders
    * leads to very different indices.
@@ -108,6 +121,11 @@ class BaseIndex : private Noncopyable {
 
   SegmentIndexType type() const;
 
+  /**
+   * Returns the memory consumption of this Index in bytes
+   */
+  size_t memory_consumption() const;
+
  protected:
   /**
    * Seperate the public interface of the index from the interface for programmers implementing own
@@ -118,6 +136,7 @@ class BaseIndex : private Noncopyable {
   virtual Iterator _cbegin() const = 0;
   virtual Iterator _cend() const = 0;
   virtual std::vector<std::shared_ptr<const BaseSegment>> _get_indexed_segments() const = 0;
+  virtual size_t _memory_consumption() const = 0;
 
  private:
   const SegmentIndexType _type;

--- a/src/lib/storage/index/base_index.hpp
+++ b/src/lib/storage/index/base_index.hpp
@@ -43,12 +43,12 @@ class BaseIndex : private Noncopyable {
    * on a Chunk with the following statistics:
    *
    * row_count - overall number of rows
-   * value_count - number of distinct values
+   * distinct_count - number of distinct values
    * value_bytes - (average) size of a single value in bytes
    *
-   * If no prediction is possible, this shall fail.
+   * If no prediction is possible (or it is not implemented yet), this shall fail.
    */
-  static size_t estimate_memory_consumption(SegmentIndexType type, ChunkOffset row_count, ChunkOffset value_count,
+  static size_t estimate_memory_consumption(SegmentIndexType type, ChunkOffset row_count, ChunkOffset distinct_count,
                                             uint32_t value_bytes);
 
   /**

--- a/src/lib/storage/index/group_key/composite_group_key_index.cpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.cpp
@@ -19,9 +19,9 @@
 
 namespace opossum {
 
-size_t CompositeGroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count,
+size_t CompositeGroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
                                                            uint32_t value_bytes) {
-  return ((row_count + value_count) * sizeof(ChunkOffset) + value_count * value_bytes);
+  return ((row_count + distinct_count) * sizeof(ChunkOffset) + distinct_count * value_bytes);
 }
 
 CompositeGroupKeyIndex::CompositeGroupKeyIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index)
@@ -181,7 +181,7 @@ std::vector<std::shared_ptr<const BaseSegment>> CompositeGroupKeyIndex::_get_ind
 }
 
 size_t CompositeGroupKeyIndex::_memory_consumption() const {
-  uintptr_t byte_count = _keys.size() * _keys.key_size();
+  size_t byte_count = _keys.size() * _keys.key_size();
   byte_count += _key_offsets.size() * sizeof(ChunkOffset);
   byte_count += _position_list.size() * sizeof(ChunkOffset);
   return byte_count;

--- a/src/lib/storage/index/group_key/composite_group_key_index.cpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.cpp
@@ -19,6 +19,11 @@
 
 namespace opossum {
 
+size_t CompositeGroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count,
+                                                           uint32_t value_bytes) {
+  return ((row_count + value_count) * sizeof(ChunkOffset) + value_count * value_bytes);
+}
+
 CompositeGroupKeyIndex::CompositeGroupKeyIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index)
     : BaseIndex{get_index_type_of<CompositeGroupKeyIndex>()} {
   Assert(!segments_to_index.empty(), "CompositeGroupKeyIndex requires at least one segment to be indexed.");
@@ -173,6 +178,13 @@ std::vector<std::shared_ptr<const BaseSegment>> CompositeGroupKeyIndex::_get_ind
     result.emplace_back(indexed_segment);
   }
   return result;
+}
+
+size_t CompositeGroupKeyIndex::_memory_consumption() const {
+  uintptr_t byte_count = _keys.size() * _keys.key_size();
+  byte_count += _key_offsets.size() * sizeof(ChunkOffset);
+  byte_count += _position_list.size() * sizeof(ChunkOffset);
+  return byte_count;
 }
 
 }  // namespace opossum

--- a/src/lib/storage/index/group_key/composite_group_key_index.hpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.hpp
@@ -48,7 +48,7 @@ class CompositeGroupKeyIndex : public BaseIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See BaseIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
 
   CompositeGroupKeyIndex(CompositeGroupKeyIndex&&) = default;
   CompositeGroupKeyIndex& operator=(CompositeGroupKeyIndex&&) = default;

--- a/src/lib/storage/index/group_key/composite_group_key_index.hpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.hpp
@@ -44,6 +44,12 @@ class CompositeGroupKeyIndex : public BaseIndex {
   friend class CompositeGroupKeyIndexTest;
 
  public:
+  /**
+   * Predicts the memory consumption in bytes of creating this index.
+   * See BaseIndex::estimate_memory_consumption()
+   */
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+
   CompositeGroupKeyIndex(CompositeGroupKeyIndex&&) = default;
   CompositeGroupKeyIndex& operator=(CompositeGroupKeyIndex&&) = default;
   ~CompositeGroupKeyIndex() = default;
@@ -56,6 +62,8 @@ class CompositeGroupKeyIndex : public BaseIndex {
   Iterator _cbegin() const final;
   Iterator _cend() const final;
   std::vector<std::shared_ptr<const BaseSegment>> _get_indexed_segments() const final;
+
+  size_t _memory_consumption() const final;
 
   /**
    * Creates a VariableLengthKey using the values given as parameters.

--- a/src/lib/storage/index/group_key/group_key_index.cpp
+++ b/src/lib/storage/index/group_key/group_key_index.cpp
@@ -8,9 +8,9 @@
 
 namespace opossum {
 
-size_t GroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count,
+size_t GroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
                                                   uint32_t value_bytes) {
-  return row_count * sizeof(ChunkOffset) + value_count * sizeof(std::size_t);
+  return row_count * sizeof(ChunkOffset) + distinct_count * sizeof(std::size_t);
 }
 
 GroupKeyIndex::GroupKeyIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index)
@@ -97,7 +97,7 @@ std::vector<std::shared_ptr<const BaseSegment>> GroupKeyIndex::_get_indexed_segm
 }
 
 size_t GroupKeyIndex::_memory_consumption() const {
-  uintptr_t bytes = sizeof(_indexed_segments);
+  size_t bytes = sizeof(_indexed_segments);
   bytes += sizeof(std::size_t) * _index_offsets.size();
   bytes += sizeof(ChunkOffset) * _index_postings.size();
   return bytes;

--- a/src/lib/storage/index/group_key/group_key_index.cpp
+++ b/src/lib/storage/index/group_key/group_key_index.cpp
@@ -8,6 +8,11 @@
 
 namespace opossum {
 
+size_t GroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count,
+                                                  uint32_t value_bytes) {
+  return row_count * sizeof(ChunkOffset) + value_count * sizeof(std::size_t);
+}
+
 GroupKeyIndex::GroupKeyIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index)
     : BaseIndex{get_index_type_of<GroupKeyIndex>()},
       _indexed_segments(std::dynamic_pointer_cast<const BaseDictionarySegment>(segments_to_index[0])) {
@@ -89,6 +94,13 @@ GroupKeyIndex::Iterator GroupKeyIndex::_get_postings_iterator_at(ValueID value_i
 
 std::vector<std::shared_ptr<const BaseSegment>> GroupKeyIndex::_get_indexed_segments() const {
   return {_indexed_segments};
+}
+
+size_t GroupKeyIndex::_memory_consumption() const {
+  uintptr_t bytes = sizeof(_indexed_segments);
+  bytes += sizeof(std::size_t) * _index_offsets.size();
+  bytes += sizeof(ChunkOffset) * _index_postings.size();
+  return bytes;
 }
 
 }  // namespace opossum

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -43,6 +43,12 @@ class GroupKeyIndex : public BaseIndex {
   friend class GroupKeyIndexTest;
 
  public:
+  /**
+   * Predicts the memory consumption in bytes of creating this index.
+   * See BaseIndex::estimate_memory_consumption()
+   */
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+
   GroupKeyIndex() = delete;
 
   GroupKeyIndex(const GroupKeyIndex&) = delete;
@@ -70,6 +76,8 @@ class GroupKeyIndex : public BaseIndex {
   Iterator _get_postings_iterator_at(ValueID value_id) const;
 
   std::vector<std::shared_ptr<const BaseSegment>> _get_indexed_segments() const;
+
+  size_t _memory_consumption() const final;
 
  private:
   const std::shared_ptr<const BaseDictionarySegment> _indexed_segments;

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -47,7 +47,7 @@ class GroupKeyIndex : public BaseIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See BaseIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset value_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
 
   GroupKeyIndex() = delete;
 

--- a/src/test/storage/group_key_index_test.cpp
+++ b/src/test/storage/group_key_index_test.cpp
@@ -43,6 +43,8 @@ TEST_F(GroupKeyIndexTest, IndexOffsets) {
   EXPECT_EQ(expected_offsets, *index_offsets);
 }
 
+TEST_F(GroupKeyIndexTest, IndexMemoryConsumption) { EXPECT_EQ(index->memory_consumption(), 104u); }
+
 TEST_F(GroupKeyIndexTest, IndexPostings) {
   // check if there are no duplicates in postings
   auto distinct_values = std::unordered_set<ChunkOffset>(index_postings->begin(), index_postings->end());


### PR DESCRIPTION
In order to re-integrate the results of the self-driving PR #715 together with the new plugin architecture, here's the first round of changes: Indexes can now report their memory consumption and can estimate memory consumption for a hypothetical index.

This straightforward implementation modifies the index structures themselves and is not part of a plugin.

Not all indexes are completely supported (no support means runtime errors):

- Group Key Index: Supported
- Composite Group Key Index: Supported
- B-Tree Index: Reporting supported, estimation not supported
- Adaptive Radix Tree Index: Neither reporting nor estimation supported