### PR TITLE
Reference Segment Iterator stores its accessor by Value - Fix bug #1244

### DIFF
--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -97,7 +97,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
     const PosListIterator _begin_pos_list_it;
     PosListIterator _pos_list_it;
 
-    const Accessor& _accessor;
+    const Accessor _accessor;
   };
 
   // The iterator for cases where we potentially iterate over multiple referenced chunks


### PR DESCRIPTION
The Reference Segment Iterator should store its accessor by value instead of reference.

The issue was introduced with the smart poslists pr #1210 and found by executing the Jit operator reading two columns of the same type in parallel.

Fixes #1244