### PR TITLE
Allow visit_lqp(xNode)

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
 #include <array>
+#include <unordered_map>
 #include <vector>
 
 #include "enable_make_for_lqp_node.hpp"
-#include "lqp_utils.hpp"
 #include "types.hpp"
 
 namespace opossum {
@@ -44,6 +44,8 @@ struct LQPOutputRelation {
   std::shared_ptr<AbstractLQPNode> output;
   LQPInputSide input_side{LQPInputSide::Left};
 };
+
+using LQPNodeMapping = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
 
 class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, public Noncopyable {
  public:

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -3,8 +3,9 @@
 #include <memory>
 #include <optional>
 #include <queue>
-#include <unordered_map>
 #include <unordered_set>
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
 
 namespace opossum {
 
@@ -12,7 +13,6 @@ class AbstractLQPNode;
 class AbstractExpression;
 enum class LQPInputSide;
 
-using LQPNodeMapping = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<AbstractLQPNode>>;
 using LQPMismatch = std::pair<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<const AbstractLQPNode>>;
 
 /**
@@ -56,19 +56,18 @@ enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
  * as well.
  * Each node is visited exactly once.
  *
- * @tparam LQP          Either `std::shared_ptr<AbstractLQPNode>` or `const std::shared_ptr<AbstractLQPNode>`
  * @tparam Visitor      Functor called with every node as a param.
  *                      Returns `LQPVisitation`
  */
-template <typename LQP, typename Visitor>
-void visit_lqp(LQP& lqp, Visitor visitor) {
-  std::queue<std::decay_t<LQP>> node_queue;
+template <typename Visitor>
+void visit_lqp(const std::shared_ptr<AbstractLQPNode>& lqp, Visitor visitor) {
+  std::queue<std::shared_ptr<AbstractLQPNode>> node_queue;
   node_queue.push(lqp);
 
-  std::unordered_set<std::decay_t<LQP>> visited_nodes;
+  std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
 
   while (!node_queue.empty()) {
-    auto node = node_queue.front();
+    auto& node = node_queue.front();
     node_queue.pop();
 
     if (!visited_nodes.emplace(node).second) continue;

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -67,7 +67,7 @@ void visit_lqp(const std::shared_ptr<AbstractLQPNode>& lqp, Visitor visitor) {
   std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
 
   while (!node_queue.empty()) {
-    auto& node = node_queue.front();
+    auto node = node_queue.front();
     node_queue.pop();
 
     if (!visited_nodes.emplace(node).second) continue;

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -100,13 +100,27 @@ TEST_F(LQPUtilsTest, VisitLQP) {
   expected_nodes[2]->set_left_input(node_a);
   expected_nodes[3]->set_left_input(node_a);
 
-  auto actual_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
-  visit_lqp(expected_nodes[0], [&](const auto& node) {
-    actual_nodes.emplace_back(node);
-    return LQPVisitation::VisitInputs;
-  });
+  {
+    // Visit AbstractLQPNode
+    auto actual_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+    visit_lqp(expected_nodes[0], [&](const auto& node) {
+      actual_nodes.emplace_back(node);
+      return LQPVisitation::VisitInputs;
+    });
 
-  EXPECT_EQ(actual_nodes, expected_nodes);
+    EXPECT_EQ(actual_nodes, expected_nodes);
+  }
+
+  {
+    // Visit PredicateNode
+    auto actual_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+    visit_lqp(std::static_pointer_cast<PredicateNode>(expected_nodes[0]), [&](const auto& node) {
+      actual_nodes.emplace_back(node);
+      return LQPVisitation::VisitInputs;
+    });
+
+    EXPECT_EQ(actual_nodes, expected_nodes);
+  }
 }
 
 TEST_F(LQPUtilsTest, LQPFindSubplanRoots) {


### PR DESCRIPTION
Don't require the argument for `visit_lqp` to be an `shared_ptr<AbstractExpression>` anymore. Also, remove the template that is not needed.

Not as easy for `visit_expression` because of the reference wrapper.

fixes #1107.