### PR TITLE
_split() -> split_string_by_delimiter()

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -59,7 +59,6 @@ target_link_libraries(
     hyriseBenchmarkLib
     ncurses
     ${READLINE_LIBRARY}
-    ${FILESYSTEM_LIBRARY}
     ${CMAKE_DL_LIBS}
 )
 target_include_directories(

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -570,6 +570,7 @@ set(
     sqlparser
     cqf
     uninitialized_vector
+    ${FILESYSTEM_LIBRARY}
     ${Boost_CONTAINER_LIBRARY}
     ${Boost_SYSTEM_LIBRARY}
     ${Boost_THREAD_LIBRARY}

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -15,13 +15,13 @@ namespace opossum {
 std::shared_ptr<Table> create_table_from_header(std::ifstream& infile, size_t chunk_size) {
   std::string line;
   std::getline(infile, line);
-  std::vector<std::string> column_names = split_string_by_delimiter<std::string>(line, '|');
+  std::vector<std::string> column_names = split_string_by_delimiter(line, '|');
   std::getline(infile, line);
-  std::vector<std::string> column_types = split_string_by_delimiter<std::string>(line, '|');
+  std::vector<std::string> column_types = split_string_by_delimiter(line, '|');
 
   auto column_nullable = std::vector<bool>{};
   for (auto& type : column_types) {
-    auto type_nullable = split_string_by_delimiter<std::string>(type, '_');
+    auto type_nullable = split_string_by_delimiter(type, '_');
     type = type_nullable[0];
 
     auto nullable = type_nullable.size() > 1 && type_nullable[1] == "null";
@@ -53,17 +53,18 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
 
   std::string line;
   while (std::getline(infile, line)) {
-    std::vector<AllTypeVariant> values = split_string_by_delimiter<AllTypeVariant>(line, '|');
+    const auto string_values = split_string_by_delimiter(line, '|');
+    auto variant_values = std::vector<AllTypeVariant>(string_values.size());
 
-    for (auto column_id = ColumnID{0}; column_id < values.size(); ++column_id) {
-      auto& value = values[column_id];
-
-      if (table->column_is_nullable(column_id) && (value == AllTypeVariant{"null"})) {
-        value = NULL_VALUE;
+    for (auto column_id = ColumnID{0}; column_id < string_values.size(); ++column_id) {
+      if (table->column_is_nullable(column_id) && string_values[column_id] == "null") {
+        variant_values[column_id] = NULL_VALUE;
+      } else {
+        variant_values[column_id] = AllTypeVariant{std::move(string_values[column_id])};
       }
     }
 
-    table->append(values);
+    table->append(variant_values);
 
     auto chunk = table->get_chunk(static_cast<ChunkID>(table->chunk_count() - 1));
     auto mvcc_data = chunk->get_scoped_mvcc_data_lock();

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
 
   std::string line;
   while (std::getline(infile, line)) {
-    const auto string_values = split_string_by_delimiter(line, '|');
+    auto string_values = split_string_by_delimiter(line, '|');
     auto variant_values = std::vector<AllTypeVariant>(string_values.size());
 
     for (auto column_id = ColumnID{0}; column_id < string_values.size(); ++column_id) {

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -8,19 +8,20 @@
 #include "storage/table.hpp"
 
 #include "constant_mappings.hpp"
+#include "string_utils.hpp"
 
 namespace opossum {
 
 std::shared_ptr<Table> create_table_from_header(std::ifstream& infile, size_t chunk_size) {
   std::string line;
   std::getline(infile, line);
-  std::vector<std::string> column_names = _split<std::string>(line, '|');
+  std::vector<std::string> column_names = split_string_by_delimiter<std::string>(line, '|');
   std::getline(infile, line);
-  std::vector<std::string> column_types = _split<std::string>(line, '|');
+  std::vector<std::string> column_types = split_string_by_delimiter<std::string>(line, '|');
 
   auto column_nullable = std::vector<bool>{};
   for (auto& type : column_types) {
-    auto type_nullable = _split<std::string>(type, '_');
+    auto type_nullable = split_string_by_delimiter<std::string>(type, '_');
     type = type_nullable[0];
 
     auto nullable = type_nullable.size() > 1 && type_nullable[1] == "null";
@@ -52,7 +53,7 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
 
   std::string line;
   while (std::getline(infile, line)) {
-    std::vector<AllTypeVariant> values = _split<AllTypeVariant>(line, '|');
+    std::vector<AllTypeVariant> values = split_string_by_delimiter<AllTypeVariant>(line, '|');
 
     for (auto column_id = ColumnID{0}; column_id < values.size(); ++column_id) {
       auto& value = values[column_id];

--- a/src/lib/utils/load_table.hpp
+++ b/src/lib/utils/load_table.hpp
@@ -11,19 +11,6 @@ namespace opossum {
 
 class Table;
 
-template <typename T>
-std::vector<T> _split(const std::string& str, char delimiter) {
-  std::vector<T> internal;
-  std::stringstream ss(str);
-  std::string tok;
-
-  while (std::getline(ss, tok, delimiter)) {
-    internal.push_back(tok);
-  }
-
-  return internal;
-}
-
 std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_size = Chunk::MAX_SIZE);
 
 /**

--- a/src/lib/utils/string_utils.cpp
+++ b/src/lib/utils/string_utils.cpp
@@ -15,6 +15,18 @@ std::vector<std::string> trim_and_split(const std::string& input) {
   return arguments;
 }
 
+std::vector<std::string> split_string_by_delimiter(const std::string& str, char delimiter) {
+  std::vector<std::string> internal;
+  std::stringstream ss(str);
+  std::string tok;
+
+  while (std::getline(ss, tok, delimiter)) {
+    internal.push_back(tok);
+  }
+
+  return internal;
+}
+
 const std::string plugin_name_from_path(const filesystem::path& path) {
   const auto filename = path.stem().string();
 

--- a/src/lib/utils/string_utils.hpp
+++ b/src/lib/utils/string_utils.hpp
@@ -4,9 +4,11 @@
 
 namespace opossum {
 
-// Removes whitspaces from the front and back. Also reduces multiple whitespaces between words to a single one.
+// Removes whitespaces from the front and back. Also reduces multiple whitespaces between words to a single one.
 // Splits the result by whitespace into single words. Intended for usage in the console.
 std::vector<std::string> trim_and_split(const std::string& input);
+
+std::vector<std::string> split_string_by_delimiter(const std::string& str, char delimiter);
 
 // Returns the name of a plugin from its path. The name is the filename without the "lib" prefix and the file extension.
 const std::string plugin_name_from_path(const filesystem::path& path);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -182,7 +182,7 @@ set(
     utils/plugin_test_utils.cpp
     utils/plugin_test_utils.hpp
     utils/singleton_test.cpp
-    utils/string_functions_test.cpp
+    utils/string_utils_test.cpp
 )
 
 if (${ENABLE_JIT_SUPPORT})

--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper.cpp
@@ -13,6 +13,7 @@
 #include "sql/sql_pipeline_builder.hpp"
 #include "storage/table.hpp"
 #include "utils/load_table.hpp"
+#include "utils/string_utils.hpp"
 
 namespace opossum {
 
@@ -33,12 +34,12 @@ void SQLiteWrapper::create_table_from_tbl(const std::string& file, const std::st
 
   std::string line;
   std::getline(infile, line);
-  std::vector<std::string> column_names = _split<std::string>(line, '|');
+  std::vector<std::string> column_names = split_string_by_delimiter(line, '|');
   std::getline(infile, line);
   std::vector<std::string> column_types;
 
-  for (const std::string& type : _split<std::string>(line, '|')) {
-    std::string actual_type = _split<std::string>(type, '_')[0];
+  for (const std::string& type : split_string_by_delimiter(line, '|')) {
+    std::string actual_type = split_string_by_delimiter(type, '_')[0];
     if (actual_type == "int" || actual_type == "long") {
       column_types.push_back("INT");
     } else if (actual_type == "float" || actual_type == "double") {
@@ -63,7 +64,7 @@ void SQLiteWrapper::create_table_from_tbl(const std::string& file, const std::st
 
   while (std::getline(infile, line)) {
     query << "INSERT INTO " << table_name << " VALUES (";
-    std::vector<std::string> values = _split<std::string>(line, '|');
+    std::vector<std::string> values = split_string_by_delimiter(line, '|');
     for (size_t i = 0; i < values.size(); i++) {
       if (column_types[i] == "TEXT" && values[i] != "null") {
         query << "'" << values[i] << "'";

--- a/src/test/utils/string_utils_test.cpp
+++ b/src/test/utils/string_utils_test.cpp
@@ -5,9 +5,9 @@
 
 namespace opossum {
 
-class StringFunctionsTest : public BaseTest {};
+class StringUtilsTest : public BaseTest {};
 
-TEST_F(StringFunctionsTest, trim_and_split) {
+TEST_F(StringUtilsTest, trim_and_split) {
   const std::string test_command = "print opossonauten_table";
 
   auto arguments = trim_and_split(test_command);
@@ -16,7 +16,7 @@ TEST_F(StringFunctionsTest, trim_and_split) {
   EXPECT_EQ(arguments[1], "opossonauten_table");
 }
 
-TEST_F(StringFunctionsTest, trim_and_split_whitespace_padding) {
+TEST_F(StringUtilsTest, trim_and_split_whitespace_padding) {
   const std::string test_command = "   print opossonauten_table  ";
 
   auto arguments = trim_and_split(test_command);
@@ -25,7 +25,7 @@ TEST_F(StringFunctionsTest, trim_and_split_whitespace_padding) {
   EXPECT_EQ(arguments[1], "opossonauten_table");
 }
 
-TEST_F(StringFunctionsTest, trim_and_split_double_spaces) {
+TEST_F(StringUtilsTest, trim_and_split_double_spaces) {
   const std::string test_command = "print  opossonauten_table";
 
   auto arguments = trim_and_split(test_command);


### PR DESCRIPTION
`_split()` was a global function starting with an underscore, which is against our conventions. I renamed it to `split_string_by_delimiter` and moved it to `utils/string_utils.hpp`

Also it being a template was unintuitive, imo.