### PR TITLE
[Self-Driving] LQP cache

### DIFF
--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -113,6 +113,17 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
     return _optimized_logical_plan;
   }
 
+  // Handle logical query plan if statement has been cached
+  if (const auto cached_plan = SQLQueryCache<std::shared_ptr<AbstractLQPNode>>::get().try_get(_sql_string)) {
+    const auto plan = *cached_plan;
+    DebugAssert(plan, "Optimized logical query plan retrieved from cache is empty.");
+    // MVCC-enabled and MVCC-disabled LQPs will evict each other
+    if (plan->subplan_is_validated() == (_use_mvcc == UseMvcc::Yes)) {
+      _optimized_logical_plan = plan;
+      return _optimized_logical_plan;
+    }
+  }
+
   const auto& unoptimized_lqp = get_unoptimized_logical_plan();
 
   const auto started = std::chrono::high_resolution_clock::now();
@@ -126,6 +137,9 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
   // As the unoptimized LQP is only used for visualization, we can afford to recreate it if necessary.
   _unoptimized_logical_plan = nullptr;
+
+  // Cache newly created plan for the according sql statement
+  SQLQueryCache<std::shared_ptr<AbstractLQPNode>>::get().set(_sql_string, _optimized_logical_plan);
 
   return _optimized_logical_plan;
 }

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -9,6 +9,7 @@
 #include "concurrency/transaction_manager.hpp"
 #include "create_sql_parser_error_message.hpp"
 #include "expression/value_expression.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
 #include "optimizer/optimizer.hpp"
 #include "scheduler/current_scheduler.hpp"
 #include "sql/sql_pipeline_builder.hpp"
@@ -118,7 +119,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
     const auto plan = *cached_plan;
     DebugAssert(plan, "Optimized logical query plan retrieved from cache is empty.");
     // MVCC-enabled and MVCC-disabled LQPs will evict each other
-    if (plan->subplan_is_validated() == (_use_mvcc == UseMvcc::Yes)) {
+    if (lqp_is_validated(plan) == (_use_mvcc == UseMvcc::Yes)) {
       _optimized_logical_plan = plan;
       return _optimized_logical_plan;
     }

--- a/src/lib/sql/sql_query_cache.hpp
+++ b/src/lib/sql/sql_query_cache.hpp
@@ -65,6 +65,7 @@ class SQLQueryCache : public Singleton<SQLQueryCache<Value, Key>> {
 
   // Returns a reference to the underlying cache.
   AbstractCache<Key, Value>& cache() { return *_cache; }
+  const AbstractCache<Key, Value>& cache() const { return *_cache; }
 
   // Replaces the underlying cache by creating a new object
   // of the given cache type.

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -81,6 +81,7 @@ class BaseTestWithParam
     StorageManager::reset();
     TransactionManager::reset();
     SQLQueryCache<SQLQueryPlan>::get().clear();
+    SQLQueryCache<std::shared_ptr<AbstractLQPNode>>::get().clear();
   }
 
   static std::shared_ptr<AbstractExpression> get_column_expression(const std::shared_ptr<AbstractOperator>& op,


### PR DESCRIPTION
One more PR based on #715 .
This adds caching of optimized LQPs in `SQLPipelineStatement`.
As discussed in the original PR, the LQP cache's type is `SQLQueryCache<std::shared_ptr<AbstractLQPNode>>` which is rather ugly. Would it make more sense to rename `SQLQueryCache` to something like `SingletonCache` and then using typedefs / `using` to map `SQLQueryCache<SQLQueryPlan>` back to its original name?