### PR TITLE
Trim down docs on SQLPipeline(Statement)

### DIFF
--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -25,20 +25,11 @@ struct SQLPipelineMetrics {
 };
 
 /**
- * This is the unified interface to handle SQL queries and related operations.
- * This should be preferred over using SQLPipelineStatement directly, unless you really know why you need it.
+ * The SQLPipeline represents the flow from the basic SQL string to the result table with all intermediate steps. Use
+ * the SQLPipelineBuilder to construct it.
  *
- * The SQLPipeline represents the flow from the basic SQL string to the result table with all intermediate steps.
- *
- * The basic idea of the SQLPipeline is that is splits a given SQL string into its single SQL statements and wraps each
- * statement in an SQLPipelineStatement. If a single statement is present, it creates just one SQLPipelineStatement.
- * If N statements are present, it creates N SQLPipelineStatements.
- *
- * The advantage of using this over a self created vector of SQLPipelineStatements is that some sanity checks are
- * performed here, e.g. TransactionContexts and dependent statements (CREATE VIEW X followed by SELECT * FROM X)
- *
- * The SQLPipeline holds all results and only hands them out as const references. If the SQLPipeline goes out of scope
- * while the results are still needed, the result references are invalid (except maybe the result table).
+ * The SQLPipeline splits a given SQL string into its single SQL statements and wraps each statement in an
+ * SQLPipelineStatement.
  */
 class SQLPipeline : public Noncopyable {
  public:
@@ -48,29 +39,18 @@ class SQLPipeline : public Noncopyable {
               const std::shared_ptr<PreparedStatementCache>& prepared_statements,
               const CleanupTemporaries cleanup_temporaries);
 
-  // Returns the SQL string for each statement.
+  // Vectors containing one element for each SQL statement
   const std::vector<std::string>& get_sql_strings();
-
-  // Returns the parsed SQL string for each statement.
   const std::vector<std::shared_ptr<hsql::SQLParserResult>>& get_parsed_sql_statements();
-
-  // Returns the unoptimized LQP root for each statement.
   const std::vector<std::shared_ptr<AbstractLQPNode>>& get_unoptimized_logical_plans();
-
-  // Returns the optimized LQP root for each statement.
   const std::vector<std::shared_ptr<AbstractLQPNode>>& get_optimized_logical_plans();
-
-  // Returns the SQLQueryPlan for each statement.
-  // For now, this always uses the optimized LQP.
+  // The plans are either retrieved from the SQLPlanCache or, if unavailable, translated from the optimized LQPs
   const std::vector<std::shared_ptr<SQLQueryPlan>>& get_query_plans();
 
-  // Returns all tasks for each statement that need to be executed for this query.
   const std::vector<std::vector<std::shared_ptr<OperatorTask>>>& get_tasks();
 
   // get_result_tables().back()
   std::shared_ptr<const Table> get_result_table();
-
-  // Executes all tasks, waits for them to finish, and returns the resulting tables
   const std::vector<std::shared_ptr<const Table>>& get_result_tables();
 
   // Returns the TransactionContext that was passed to the SQLPipelineStatement, or nullptr if none was passed in.
@@ -79,10 +59,10 @@ class SQLPipeline : public Noncopyable {
   // This returns the SQLPipelineStatement that aborted the transaction, if any
   std::shared_ptr<SQLPipelineStatement> failed_pipeline_statement() const;
 
-  // Returns the number of SQLPipelineStatements present in this pipeline
   size_t statement_count() const;
 
-  // Returns whether the pipeline requires execution to handle all statements
+  // Returns whether the pipeline requires execution to handle all statements (e.g, one statement creates a Table,
+  // another uses it)
   bool requires_execution() const;
 
   const SQLPipelineMetrics& metrics();
@@ -102,7 +82,7 @@ class SQLPipeline : public Noncopyable {
   std::vector<std::vector<std::shared_ptr<OperatorTask>>> _tasks;
   std::vector<std::shared_ptr<const Table>> _result_tables;
 
-  // Indicates whether get_result_table has been run successfully
+  // Indicates whether get_result_table() has been run successfully
   bool _pipeline_was_executed{false};
 
   // Indicates whether translating a statement in the pipeline requires the execution of a previous statement

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -25,8 +25,8 @@ struct SQLPipelineMetrics {
 };
 
 /**
- * The SQLPipeline represents the flow from the basic SQL string to the result table with all intermediate steps. Use
- * the SQLPipelineBuilder to construct it.
+ * The SQLPipeline represents the flow from the basic SQL string (containing one or more statements) to the result
+ * table(s) with all intermediate steps. Use the SQLPipelineBuilder to construct it.
  *
  * The SQLPipeline splits a given SQL string into its single SQL statements and wraps each statement in an
  * SQLPipelineStatement.

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -58,8 +58,9 @@ class SQLPipeline : public Noncopyable {
   // Returns all tasks for each statement that need to be executed for this query.
   const std::vector<std::vector<std::shared_ptr<OperatorTask>>>& get_tasks();
 
-  // // Executes all tasks, waits for them to finish, and returns the resulting tables
+  // Executes all tasks, waits for them to finish, and returns the resulting tables
   const std::vector<std::shared_ptr<const Table>>& get_result_tables();
+  
   // Shorthand for `get_result_tables().back()`
   std::shared_ptr<const Table> get_result_table();
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -60,7 +60,7 @@ class SQLPipeline : public Noncopyable {
 
   // Executes all tasks, waits for them to finish, and returns the resulting tables
   const std::vector<std::shared_ptr<const Table>>& get_result_tables();
-  
+
   // Shorthand for `get_result_tables().back()`
   std::shared_ptr<const Table> get_result_table();
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -47,11 +47,13 @@ class SQLPipeline : public Noncopyable {
   // The plans are either retrieved from the SQLPlanCache or, if unavailable, translated from the optimized LQPs
   const std::vector<std::shared_ptr<SQLQueryPlan>>& get_query_plans();
 
+  // Returns all tasks for each statement that need to be executed for this query.
   const std::vector<std::vector<std::shared_ptr<OperatorTask>>>& get_tasks();
 
-  // get_result_tables().back()
-  std::shared_ptr<const Table> get_result_table();
+  // // Executes all tasks, waits for them to finish, and returns the resulting tables
   const std::vector<std::shared_ptr<const Table>>& get_result_tables();
+  // Shorthand for `get_result_tables().back()`
+  std::shared_ptr<const Table> get_result_table();
 
   // Returns the TransactionContext that was passed to the SQLPipelineStatement, or nullptr if none was passed in.
   std::shared_ptr<TransactionContext> transaction_context() const;

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -38,19 +38,19 @@ class SQLPipeline : public Noncopyable {
               const std::shared_ptr<LQPTranslator>& lqp_translator, const std::shared_ptr<Optimizer>& optimizer,
               const std::shared_ptr<PreparedStatementCache>& prepared_statements,
               const CleanupTemporaries cleanup_temporaries);
-  
+
   // Returns the SQL string for each statement.
   const std::vector<std::string>& get_sql_strings();
-  
+
   // Returns the parsed SQL string for each statement.
   const std::vector<std::shared_ptr<hsql::SQLParserResult>>& get_parsed_sql_statements();
-  
+
   // Returns the unoptimized LQP root for each statement.
   const std::vector<std::shared_ptr<AbstractLQPNode>>& get_unoptimized_logical_plans();
-    
+
   // Returns the optimized LQP root for each statement
   const std::vector<std::shared_ptr<AbstractLQPNode>>& get_optimized_logical_plans();
-  
+
   // Returns the Physical Plans for each statement.
   // The plans are either retrieved from the SQLPlanCache or, if unavailable, translated from the optimized LQPs
   const std::vector<std::shared_ptr<SQLQueryPlan>>& get_query_plans();

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -38,12 +38,20 @@ class SQLPipeline : public Noncopyable {
               const std::shared_ptr<LQPTranslator>& lqp_translator, const std::shared_ptr<Optimizer>& optimizer,
               const std::shared_ptr<PreparedStatementCache>& prepared_statements,
               const CleanupTemporaries cleanup_temporaries);
-
-  // Vectors containing one element for each SQL statement
+  
+  // Returns the SQL string for each statement.
   const std::vector<std::string>& get_sql_strings();
+  
+  // Returns the parsed SQL string for each statement.
   const std::vector<std::shared_ptr<hsql::SQLParserResult>>& get_parsed_sql_statements();
+  
+  // Returns the unoptimized LQP root for each statement.
   const std::vector<std::shared_ptr<AbstractLQPNode>>& get_unoptimized_logical_plans();
+    
+  // Returns the optimized LQP root for each statement
   const std::vector<std::shared_ptr<AbstractLQPNode>>& get_optimized_logical_plans();
+  
+  // Returns the Physical Plans for each statement.
   // The plans are either retrieved from the SQLPlanCache or, if unavailable, translated from the optimized LQPs
   const std::vector<std::shared_ptr<SQLQueryPlan>>& get_query_plans();
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -26,12 +26,12 @@ struct SQLPipelineStatementMetrics {
 
 /**
  * The SQLPipelineStatement represents the flow from a *single* SQL statement to the result table with all intermediate
- * steps. These intermediate steps call the previous step that is required. The intermediate
- * results are all cached so calling a method twice will return the already existing value.
+ * steps. Don't construct this class directly, use the SQLPipelineBuilder instead
  *
- * E.g: calling sql_pipeline_statement.get_result_table() will result in the following "call stack"
- * get_result_table() -> get_tasks() -> get_pyhsical_plan_plan() -> get_optimized_logical_plan() ->
- * get_unoptimized_logical_plan() -> get_parsed_sql()
+ * Note:
+ *  Calling get_result_table() will result in the following "call stack"
+ *  get_result_table() -> get_tasks() -> get_pyhsical_plan_plan() -> get_optimized_logical_plan() ->
+ *  get_unoptimized_logical_plan() -> get_parsed_sql()
  *
  * NOTE:
  *  If a physical plan for an SQL statement is in the SQLPlanCache, it will be used instead of translating the optimized

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -49,23 +49,23 @@ class SQLPipelineStatement : public Noncopyable {
 
   // Returns the raw SQL string.
   const std::string& get_sql_string();
-  
+
   // Returns the parsed SQL string.
   const std::shared_ptr<hsql::SQLParserResult>& get_parsed_sql_statement();
-  
+
   // Returns the unoptimized LQP for this statement.
   const std::shared_ptr<AbstractLQPNode>& get_unoptimized_logical_plan();
-    
+
   // Returns the optimized LQP for this statement.
   const std::shared_ptr<AbstractLQPNode>& get_optimized_logical_plan();
-  
+
   // Returns the PQP for this statement.
   // The physical plan is either retrieved from the SQLPlanCache or, if unavailable, translated from the optimized LQP
   const std::shared_ptr<SQLQueryPlan>& get_query_plan();
-  
+
   // Returns all tasks that need to be executed for this query.
   const std::vector<std::shared_ptr<OperatorTask>>& get_tasks();
-  
+
   // Executes all tasks, waits for them to finish, and returns the resulting table.
   const std::shared_ptr<const Table>& get_result_table();
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -47,15 +47,26 @@ class SQLPipelineStatement : public Noncopyable {
                        const std::shared_ptr<PreparedStatementCache>& prepared_statements,
                        const CleanupTemporaries cleanup_temporaries);
 
+  // Returns the raw SQL string.
   const std::string& get_sql_string();
+  
+  // Returns the parsed SQL string.
   const std::shared_ptr<hsql::SQLParserResult>& get_parsed_sql_statement();
+  
+  // Returns the unoptimized LQP for this statement.
   const std::shared_ptr<AbstractLQPNode>& get_unoptimized_logical_plan();
+    
+  // Returns the optimized LQP for this statement.
   const std::shared_ptr<AbstractLQPNode>& get_optimized_logical_plan();
-
+  
+  // Returns the PQP for this statement.
   // The physical plan is either retrieved from the SQLPlanCache or, if unavailable, translated from the optimized LQP
   const std::shared_ptr<SQLQueryPlan>& get_query_plan();
-
+  
+  // Returns all tasks that need to be executed for this query.
   const std::vector<std::shared_ptr<OperatorTask>>& get_tasks();
+  
+  // Executes all tasks, waits for them to finish, and returns the resulting table.
   const std::shared_ptr<const Table>& get_result_table();
 
   // Returns the TransactionContext that was either passed to or created by the SQLPipelineStatement.


### PR DESCRIPTION
Fix #1261 

Get rid of some commenting in SQLPipeline(Statement). The important comments will not be read if they are hidden inside overwhelming comment blocks of self-evident noise.