### PR TITLE
Use cached chunk size in ExpressionEvaluator to fix multithreaded bottleneck

### DIFF
--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -110,7 +110,8 @@ int main(int argc, char* argv[]) {
 
   // TODO(leander): Enable support for queries that contain multiple statements requiring execution
   if (config->enable_scheduler) {
-    Assert(std::find(query_ids.begin(), query_ids.end(), opossum::QueryID{15}) == query_ids.end(),
+    // QueryID{14} represents TPC-H query 15 because of the way we generate and store the queries
+    Assert(std::find(query_ids.begin(), query_ids.end(), opossum::QueryID{14}) == query_ids.end(),
            "TPC-H query 15 is not supported for multithreaded benchmarking.");
   }
 

--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -110,7 +110,7 @@ int main(int argc, char* argv[]) {
 
   // TODO(leander): Enable support for queries that contain multiple statements requiring execution
   if (config->enable_scheduler) {
-    // QueryID{14} represents TPC-H query 15 because of the way we generate and store the queries
+    // QueryID{14} represents TPC-H query 15 because we use 0 indexing
     Assert(std::find(query_ids.begin(), query_ids.end(), opossum::QueryID{14}) == query_ids.end(),
            "TPC-H query 15 is not supported for multithreaded benchmarking.");
   }


### PR DESCRIPTION
Some TPC-H queries show a significant drop in performance when scaling up the number of used cores, such as TPC-H 7 and 19. In the ExpressionEvaluator, we use `_chunk->size()` as maximum of some for-loops. `Chunk::size()` in turn calls `Chunk::get_segment()`, which has an `std::atomic_load()`. That causes a major bottleneck the more threads simultaneously try to do that. Just replacing `_chunk->size()` with the `_output_row_count` that we have anyway gives us a small performance boost:
(nemea: `./build-release/hyriseBenchmarkTPCH --scale 1 --scheduler --clients 10 --cores 224`)
```
+-----------+-------------------+-------+--------------------+-------+---------+-----------------------------------------------+
| Benchmark | prev. iter/s      | runs  | new iter/s         | runs  | change  |               p-value (significant if <0.001) |
+-----------+-------------------+-------+--------------------+-------+---------+-----------------------------------------------+
| TPC-H 1   | 4.36615133285522  | 262   | 4.3499813079834    | 261   | -0%     |                                        0.9405 |
| TPC-H 2   | 1.59978568553925  | 96    | 1.76655912399292   | 106   | +10%    |                                        0.2186 |
| TPC-H 3   | 52.2665786743164  | 3136  | 52.376392364502    | 3143  | +0%     |                                        0.5229 |
| TPC-H 4   | 33.4331398010254  | 2006  | 33.3294792175293   | 2000  | -0%     |                                        0.4619 |
| TPC-H 5   | 30.7287921905518  | 1844  | 30.9787864685059   | 1859  | +1%     |                                        0.1492 |
| TPC-H 6   | 196.972305297852  | 10001 | 196.706588745117   | 10000 | -0%     |                                        0.4295 |
| TPC-H 7   | 0.799872219562531 | 48    | 17.6814384460449   | 1061  | +2111%  |                                        0.0000 |
| TPC-H 8   | 44.7800216674805  | 2687  | 48.5134963989258   | 2911  | +8%     |                                        0.0000 |
| TPC-H 9   | 17.6331195831299  | 1058  | 17.7157974243164   | 1063  | +0%     |                                        0.4249 |
| TPC-H 10  | 18.1639080047607  | 1090  | 18.166524887085    | 1090  | +0%     |                                        0.9713 |
| TPC-H 11  | 118.83235168457   | 7130  | 122.702835083008   | 7363  | +3%     |                                        0.0000 |
| TPC-H 12  | 37.9322471618652  | 2276  | 96.2268753051758   | 5774  | +154%   |                                        0.0000 |
| TPC-H 13  | 14.7490749359131  | 885   | 14.4994840621948   | 870   | -2%     |                                        0.0101 |
| TPC-H 14  | 109.266319274902  | 6557  | 107.996383666992   | 6480  | -1%     |                                        0.0007 |
| TPC-H 16  | 3.1497061252594   | 189   | 44.4944648742676   | 2670  | +1313%  |                                        0.0000 |
| TPC-H 17  | 0.0               | 0     | 0.0                | 0     | nan%    |    (run time too short) (not enough runs) nan |
| TPC-H 18  | 2.99956774711609  | 180   | 10.1654663085938   | 610   | +239%   |                                        0.0000 |
| TPC-H 19  | 0.916580498218536 | 55    | 131.436614990234   | 7887  | +14240% |                                        0.0000 |
| TPC-H 20  | 0.149998962879181 | 9     | 0.0333289206027985 | 2     | -78%    | (run time too short) (not enough runs) 0.0474 |
| TPC-H 21  | 0.0               | 0     | 0.0                | 0     | nan%    |    (run time too short) (not enough runs) nan |
| TPC-H 22  | 20.3646640777588  | 1222  | 72.2428131103516   | 4335  | +255%   |                                        0.0000 |
| average   |                   |       |                    |       | +869%   |                                               |
+-----------+-------------------+-------+--------------------+-------+---------+-----------------------------------------------+
```
Another thing that might be worth looking at is caching the chunksize in the Chunk itself once it becomes immutable. That way we can omit the calls to get_segment once the Chunk is "complete". But that is not necessary for this PR, since `_output_row_count` should be used instead of calling `_chunk->size()` anyway.