### PR TITLE
Make full use of single chunk guarantee of PosLists in TableScan and Validate

### DIFF
--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -135,6 +135,9 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
 
           if (!filtered_pos_list) {
             filtered_pos_list = std::make_shared<PosList>(matches_out->size());
+            if (pos_list_in->references_single_chunk()) {
+              filtered_pos_list->guarantee_single_chunk();
+            }
 
             size_t offset = 0;
             for (const auto& match : *matches_out) {

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
         
         pos_list_out->guarantee_single_chunk();
 
-        const auto referenced_chunk = referenced_table->get_chunk(pos_list_in.front().chunk_id);
+        const auto referenced_chunk = referenced_table->get_chunk(pos_list_in.common_chunk_id());
         auto mvcc_data = referenced_chunk->get_scoped_mvcc_data_lock();
 
         for (auto row_id : pos_list_in) {

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -86,6 +86,9 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
           pos_list_out->emplace_back(row_id);
         }
       }
+      if (ref_segment_in->pos_list()->references_single_chunk()) {
+        pos_list_out->guarantee_single_chunk();
+      }
 
       // Construct the actual ReferenceSegment objects and add them to the chunk.
       for (ColumnID column_id{0}; column_id < chunk_in->column_count(); ++column_id) {
@@ -101,6 +104,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
       referenced_table = in_table;
       DebugAssert(chunk_in->has_mvcc_data(), "Trying to use Validate on a table that has no MVCC data");
       const auto mvcc_data = chunk_in->get_scoped_mvcc_data_lock();
+      pos_list_out->guarantee_single_chunk();
 
       // Generate pos_list_out.
       auto chunk_size = chunk_in->size();  // The compiler fails to optimize this in the for clause :(

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
       const auto& pos_list_in = *ref_segment_in->pos_list();
       if (pos_list_in.references_single_chunk() && !pos_list_in.empty()) {
         // Fast path - we are looking at a single referenced chunk and thus need to get the MVCC data vector only once.
-        
+
         pos_list_out->guarantee_single_chunk();
 
         const auto referenced_chunk = referenced_table->get_chunk(pos_list_in.common_chunk_id());
@@ -94,7 +94,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
 
       } else {
         // Slow path - we are looking at multiple referenced chunks and need to get the MVCC data vector for every row.
-        
+
         for (auto row_id : pos_list_in) {
           const auto referenced_chunk = referenced_table->get_chunk(row_id.chunk_id);
 

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -120,5 +120,5 @@ TEST_F(OperatorsValidateTest, ValidateReferenceSegmentWithMultipleChunks) {
 
   EXPECT_TABLE_EQ_UNORDERED(validate->get_output(), expected_result);
 }
- 
+
 }  // namespace opossum

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -85,4 +85,40 @@ TEST_F(OperatorsValidateTest, ScanValidate) {
   EXPECT_TABLE_EQ_UNORDERED(validate->get_output(), expected_result);
 }
 
+TEST_F(OperatorsValidateTest, ValidateReferenceSegmentWithMultipleChunks) {
+  // If Validate has a reference table as input, it can usually optimize the evaluation of the MVCC data.
+  // This optimization is possible, if a PosList of a reference segment references only one chunk.
+  // Here, the fallback implementation for a PosList with multiple chunks is tested.
+
+  auto context = std::make_shared<TransactionContext>(1u, 3u);
+
+  std::shared_ptr<Table> expected_result = load_table("src/test/tables/validate_output_validated.tbl", 2u);
+
+  // Create a PosList referencing more than one chunk
+  auto pos_list = std::make_shared<PosList>();
+  for (ChunkID chunk_id{0}; chunk_id < _test_table->chunk_count(); ++chunk_id) {
+    const auto chunk_size = _test_table->get_chunk(chunk_id)->size();
+    for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
+      pos_list->emplace_back(chunk_id, chunk_offset);
+    }
+  }
+
+  Segments segments;
+  for (ColumnID column_id{0}; column_id < _test_table->column_count(); ++column_id) {
+    segments.emplace_back(std::make_shared<ReferenceSegment>(_test_table, column_id, pos_list));
+  }
+
+  auto reference_table = std::make_shared<Table>(_test_table->column_definitions(), TableType::References);
+  reference_table->append_chunk(std::make_shared<Chunk>(segments));
+
+  auto table_wrapper = std::make_shared<TableWrapper>(reference_table);
+  table_wrapper->execute();
+
+  auto validate = std::make_shared<Validate>(table_wrapper);
+  validate->set_transaction_context(context);
+  validate->execute();
+
+  EXPECT_TABLE_EQ_UNORDERED(validate->get_output(), expected_result);
+}
+ 
 }  // namespace opossum


### PR DESCRIPTION
The single chunk guarantee of a `PosList` allows the use of a more efficient reference iterator on it as it does not have to retrieve the correct chunk for every `chunk_offset`.

`Tablescan` and `Validate` operator now make make full use of this guarantee:

If the `PosList` of the input segment has a single chunk guarantee, `Tablescan` and `Validate` also give the same guarantee for the new `PosList` in the output segment now.

In addition, the `Validate` operator considers the single chunk guarantee flag during MVCC evaluation now. This ensures that `get_scoped_mvcc_data_lock()` is only called once per chunk instead of for every `chunk_offset`.

Improved runtime by 10% for TPC-H with MVCC and scale factor 0.1:
<img width="491" alt="screenshot 2018-11-18 at 00 42 13" src="https://user-images.githubusercontent.com/7300387/48666920-90004e80-eacb-11e8-81ce-fdebdde32b2d.png">
