### PR TITLE
Fix outer join column nullability

### DIFF
--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -42,6 +42,8 @@ class AbstractJoinOperator : public AbstractReadOnlyOperator {
 
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
+  std::shared_ptr<Table> _initialize_output_table() const;
+
   // Some operators need an internal implementation class, mostly in cases where
   // their execute method depends on a template parameter. An example for this is
   // found in join_hash.hpp.

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -77,8 +77,8 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
   auto probe_input = probe_operator->get_output();
 
   _impl = make_unique_by_data_types<AbstractReadOnlyOperatorImpl, JoinHashImpl>(
-      build_input->column_data_type(build_column_id), probe_input->column_data_type(probe_column_id), build_operator,
-      probe_operator, _mode, adjusted_column_ids, _predicate_condition, inputs_swapped, _radix_bits);
+      build_input->column_data_type(build_column_id), probe_input->column_data_type(probe_column_id), *this,
+      build_operator, probe_operator, _mode, adjusted_column_ids, _predicate_condition, inputs_swapped, _radix_bits);
   return _impl->_on_execute();
 }
 
@@ -87,11 +87,12 @@ void JoinHash::_on_cleanup() { _impl.reset(); }
 template <typename LeftType, typename RightType>
 class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
  public:
-  JoinHashImpl(const std::shared_ptr<const AbstractOperator>& left,
+  JoinHashImpl(const JoinHash& join_hash, const std::shared_ptr<const AbstractOperator>& left,
                const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                const ColumnIDPair& column_ids, const PredicateCondition predicate_condition, const bool inputs_swapped,
                const std::optional<size_t>& radix_bits = std::nullopt)
-      : _left(left),
+      : _join_hash(join_hash),
+        _left(left),
         _right(right),
         _mode(mode),
         _column_ids(column_ids),
@@ -105,6 +106,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   }
 
  protected:
+  const JoinHash& _join_hash;
   const std::shared_ptr<const AbstractOperator> _left, _right;
   const JoinMode _mode;
   const ColumnIDPair _column_ids;
@@ -166,28 +168,10 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   }
 
   std::shared_ptr<const Table> _on_execute() override {
-    /*
-    Preparing output table by adding columns from left table.
-    */
-    TableColumnDefinitions output_column_definitions;
-
     auto right_in_table = _right->get_output();
     auto left_in_table = _left->get_output();
 
-    if (_inputs_swapped) {
-      // Semi/Anti joins are always swapped but do not need the outer relation
-      if (_mode == JoinMode::Semi || _mode == JoinMode::Anti) {
-        output_column_definitions = right_in_table->column_definitions();
-      } else {
-        output_column_definitions =
-            concatenated(right_in_table->column_definitions(), left_in_table->column_definitions());
-      }
-    } else {
-      output_column_definitions =
-          concatenated(left_in_table->column_definitions(), right_in_table->column_definitions());
-    }
-
-    _output_table = std::make_shared<Table>(output_column_definitions, TableType::References);
+    _output_table = _join_hash._initialize_output_table();
 
     /*
      * This flag is used in the materialization and probing phases.

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -37,6 +37,8 @@ class JoinHash : public AbstractJoinOperator {
 
   template <typename LeftType, typename RightType>
   class JoinHashImpl;
+  template <typename LeftType, typename RightType>
+  friend class JoinHashImpl;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -44,48 +44,22 @@ std::shared_ptr<AbstractOperator> JoinIndex::_on_deep_copy(
 void JoinIndex::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<const Table> JoinIndex::_on_execute() {
-  _create_table_structure();
+  _output_table = _initialize_output_table();
 
   _perform_join();
 
   return _output_table;
 }
 
-void JoinIndex::_create_table_structure() {
-  _left_in_table = _input_left->get_output();
-  _right_in_table = _input_right->get_output();
-
-  _left_column_id = _column_ids.first;
-  _right_column_id = _column_ids.second;
-
-  const bool left_may_produce_null = (_mode == JoinMode::Right || _mode == JoinMode::Outer);
-  const bool right_may_produce_null = (_mode == JoinMode::Left || _mode == JoinMode::Outer);
-
-  // Preparing output table by adding columns from left and right table
-  TableColumnDefinitions column_definitions;
-  auto add_column_definitions = [&](auto from_table, bool from_may_produce_null) {
-    for (ColumnID column_id{0}; column_id < from_table->column_count(); ++column_id) {
-      auto nullable = (from_may_produce_null || from_table->column_is_nullable(column_id));
-      column_definitions.emplace_back(from_table->column_name(column_id), from_table->column_data_type(column_id),
-                                      nullable);
-    }
-  };
-
-  add_column_definitions(_left_in_table, left_may_produce_null);
-  add_column_definitions(_right_in_table, right_may_produce_null);
-
-  _output_table = std::make_shared<Table>(column_definitions, TableType::References);
-}
-
 void JoinIndex::_perform_join() {
-  _right_matches.resize(_right_in_table->chunk_count());
-  _left_matches.resize(_left_in_table->chunk_count());
+  _right_matches.resize(input_table_right()->chunk_count());
+  _left_matches.resize(input_table_left()->chunk_count());
 
   const auto track_left_matches = (_mode == JoinMode::Left || _mode == JoinMode::Outer);
   if (track_left_matches) {
-    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
+    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < input_table_left()->chunk_count(); ++chunk_id_left) {
       // initialize the data structures for left matches
-      _left_matches[chunk_id_left].resize(_left_in_table->get_chunk(chunk_id_left)->size());
+      _left_matches[chunk_id_left].resize(input_table_left()->get_chunk(chunk_id_left)->size());
     }
   }
 
@@ -94,7 +68,7 @@ void JoinIndex::_perform_join() {
   _pos_list_left = std::make_shared<PosList>();
   _pos_list_right = std::make_shared<PosList>();
 
-  size_t worst_case = _left_in_table->row_count() * _right_in_table->row_count();
+  size_t worst_case = input_table_left()->row_count() * input_table_right()->row_count();
 
   _pos_list_left->reserve(worst_case);
   _pos_list_right->reserve(worst_case);
@@ -102,9 +76,9 @@ void JoinIndex::_perform_join() {
   auto& performance_data = static_cast<PerformanceData&>(*_performance_data);
 
   // Scan all chunks for right input
-  for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < _right_in_table->chunk_count(); ++chunk_id_right) {
-    const auto chunk_right = _right_in_table->get_chunk(chunk_id_right);
-    const auto indices = chunk_right->get_indices(std::vector<ColumnID>{_right_column_id});
+  for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < input_table_right()->chunk_count(); ++chunk_id_right) {
+    const auto chunk_right = input_table_right()->get_chunk(chunk_id_right);
+    const auto indices = chunk_right->get_indices(std::vector<ColumnID>{_column_ids.second});
     if (track_right_matches) _right_matches[chunk_id_right].resize(chunk_right->size());
 
     std::shared_ptr<BaseIndex> index = nullptr;
@@ -117,8 +91,8 @@ void JoinIndex::_perform_join() {
 
     // Scan all chunks from left input
     if (index != nullptr) {
-      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
-        const auto segment_left = _left_in_table->get_chunk(chunk_id_left)->get_segment(_left_column_id);
+      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < input_table_left()->chunk_count(); ++chunk_id_left) {
+        const auto segment_left = input_table_left()->get_chunk(chunk_id_left)->get_segment(_column_ids.first);
 
         resolve_data_and_segment_type(*segment_left, [&](auto left_type, auto& typed_left_segment) {
           using LeftType = typename decltype(left_type)::type;
@@ -134,9 +108,9 @@ void JoinIndex::_perform_join() {
       performance_data.chunks_scanned_with_index++;
     } else {
       // Fall back to NestedLoopJoin
-      const auto segment_right = _right_in_table->get_chunk(chunk_id_right)->get_segment(_right_column_id);
-      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
-        const auto segment_left = _left_in_table->get_chunk(chunk_id_left)->get_segment(_left_column_id);
+      const auto segment_right = input_table_right()->get_chunk(chunk_id_right)->get_segment(_column_ids.second);
+      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < input_table_left()->chunk_count(); ++chunk_id_left) {
+        const auto segment_left = input_table_left()->get_chunk(chunk_id_left)->get_segment(_column_ids.first);
         JoinNestedLoop::JoinParams params{*_pos_list_left,
                                           *_pos_list_right,
                                           _left_matches[chunk_id_left],
@@ -153,7 +127,7 @@ void JoinIndex::_perform_join() {
 
   // For Full Outer and Left Join we need to add all unmatched rows for the left side
   if (_mode == JoinMode::Left || _mode == JoinMode::Outer) {
-    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < _left_in_table->chunk_count(); ++chunk_id_left) {
+    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < input_table_left()->chunk_count(); ++chunk_id_left) {
       for (ChunkOffset chunk_offset{0}; chunk_offset < _left_matches[chunk_id_left].size(); ++chunk_offset) {
         if (!_left_matches[chunk_id_left][chunk_offset]) {
           _pos_list_left->emplace_back(RowID{chunk_id_left, chunk_offset});
@@ -181,8 +155,8 @@ void JoinIndex::_perform_join() {
   // write output chunks
   Segments output_segments;
 
-  _write_output_segments(output_segments, _left_in_table, _pos_list_left);
-  _write_output_segments(output_segments, _right_in_table, _pos_list_right);
+  _write_output_segments(output_segments, input_table_left(), _pos_list_left);
+  _write_output_segments(output_segments, input_table_right(), _pos_list_right);
 
   _output_table->append_chunk(output_segments);
 
@@ -274,8 +248,8 @@ void JoinIndex::_join_two_segments_nested_loop(const BinaryFunctor& func, LeftIt
         }
 
         if (_mode == JoinMode::Outer || _mode == JoinMode::Right) {
-          DebugAssert(chunk_id_right < _right_in_table->chunk_count(), "invalid chunk_id in join_index");
-          DebugAssert(right_value.chunk_offset() < _right_in_table->get_chunk(chunk_id_right)->size(),
+          DebugAssert(chunk_id_right < input_table_right()->chunk_count(), "invalid chunk_id in join_index");
+          DebugAssert(right_value.chunk_offset() < input_table_right()->get_chunk(chunk_id_right)->size(),
                       "invalid chunk_offset in join_index");
           _right_matches[chunk_id_right][right_value.chunk_offset()] = true;
         }
@@ -363,8 +337,6 @@ void JoinIndex::_write_output_segments(Segments& output_segments, const std::sha
 
 void JoinIndex::_on_cleanup() {
   _output_table.reset();
-  _left_in_table.reset();
-  _right_in_table.reset();
   _pos_list_left.reset();
   _pos_list_right.reset();
   _left_matches.clear();

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -57,18 +57,12 @@ class JoinIndex : public AbstractJoinOperator {
   void _append_matches(const BaseIndex::Iterator& range_begin, const BaseIndex::Iterator& range_end,
                        const ChunkOffset chunk_offset_left, const ChunkID chunk_id_left, const ChunkID chunk_id_right);
 
-  void _create_table_structure();
-
   void _write_output_segments(Segments& output_segments, const std::shared_ptr<const Table>& input_table,
                               std::shared_ptr<PosList> pos_list);
 
   void _on_cleanup() override;
 
   std::shared_ptr<Table> _output_table;
-  std::shared_ptr<const Table> _left_in_table;
-  std::shared_ptr<const Table> _right_in_table;
-  ColumnID _left_column_id;
-  ColumnID _right_column_id;
 
   std::shared_ptr<PosList> _pos_list_left;
   std::shared_ptr<PosList> _pos_list_right;

--- a/src/lib/operators/join_mpsm.cpp
+++ b/src/lib/operators/join_mpsm.cpp
@@ -526,12 +526,8 @@ class JoinMPSM::JoinMPSMImpl : public AbstractJoinOperatorImpl {
     _add_output_segments(output_segments, _mpsm_join.input_table_right(), output_right);
 
     // Build the output_table with one Chunk
-    auto output_column_definitions = concatenated(_mpsm_join.input_table_left()->column_definitions(),
-                                                  _mpsm_join.input_table_right()->column_definitions());
-    auto output_table = std::make_shared<Table>(output_column_definitions, TableType::References);
-
+    auto output_table = _mpsm_join._initialize_output_table();
     output_table->append_chunk(output_segments);
-
     return output_table;
   }
 };

--- a/src/lib/operators/join_mpsm.hpp
+++ b/src/lib/operators/join_mpsm.hpp
@@ -38,6 +38,8 @@ class JoinMPSM : public AbstractJoinOperator {
 
   template <typename T>
   class JoinMPSMImpl;
+  template <typename T>
+  friend class JoinMPSMImpl;
 
   std::unique_ptr<AbstractJoinOperatorImpl> _impl;
 };

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -130,9 +130,7 @@ void JoinNestedLoop::_perform_join() {
   if (_mode == JoinMode::Right) {
     // for Right Outer we swap the tables so we have the outer on the "left"
     std::swap(left_table, right_table);
-
-    left_column_id = _column_ids.second;
-    right_column_id = _column_ids.first;
+    std::swap(left_column_id, right_column_id);
   }
 
   _pos_list_left = std::make_shared<PosList>();

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -70,10 +70,6 @@ class JoinNestedLoop : public AbstractJoinOperator {
   void _on_cleanup() override;
 
   std::shared_ptr<Table> _output_table;
-  std::shared_ptr<const Table> _left_in_table;
-  std::shared_ptr<const Table> _right_in_table;
-  ColumnID _left_column_id;
-  ColumnID _right_column_id;
 
   bool _is_outer_join{false};
   std::shared_ptr<PosList> _pos_list_left;

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -684,12 +684,8 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
     _add_output_segments(output_segments, _sort_merge_join.input_table_right(), output_right);
 
     // Build the output_table with one Chunk
-    auto output_column_definitions = concatenated(_sort_merge_join.input_table_left()->column_definitions(),
-                                                  _sort_merge_join.input_table_right()->column_definitions());
-    auto output_table = std::make_shared<Table>(output_column_definitions, TableType::References);
-
+    auto output_table = _sort_merge_join._initialize_output_table();
     output_table->append_chunk(output_segments);
-
     return output_table;
   }
 };

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -39,6 +39,8 @@ class JoinSortMerge : public AbstractJoinOperator {
 
   template <typename T>
   class JoinSortMergeImpl;
+  template <typename T>
+  friend class JoinSortMergeImpl;
 
   std::unique_ptr<AbstractJoinOperatorImpl> _impl;
 };

--- a/src/lib/storage/table_column_definition.hpp
+++ b/src/lib/storage/table_column_definition.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "all_type_variant.hpp"
+#include "constant_mappings.hpp"
 #include "types.hpp"
 
 namespace opossum {
@@ -15,6 +16,14 @@ struct TableColumnDefinition final {
   DataType data_type{DataType::Int};
   bool nullable{false};
 };
+
+// So that google test, e.g., prints readable error messages
+inline std::ostream& operator<<(std::ostream& stream, const TableColumnDefinition& definition) {
+  stream << definition.name << " ";
+  stream << data_type_to_string.left.at(definition.data_type) << " ";
+  stream << (definition.nullable ? "nullable" : "not nullable");
+  return stream;
+}
 
 using TableColumnDefinitions = std::vector<TableColumnDefinition>;
 


### PR DESCRIPTION
The hopefully non-controversial part of fixing #1051: The `TableColumnDefinitions` of the null-supplying input in outer joins should be nullable