### PR TITLE
Less CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,6 @@ node {
           if (env.BRANCH_NAME == 'master' || full_ci) {
             sh "mkdir ./clang-debug/run-shuffled"
             sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-            sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
           } else {
             Utils.markStageSkippedForConditional("clangDebugRunShuffled")
           }
@@ -183,24 +182,6 @@ node {
             sh "valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --gen-suppressions=all --num-callers=25 --suppressions=.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
           } else {
             Utils.markStageSkippedForConditional("memcheckReleaseTest")
-          }
-        }
-      }, memcheckReleaseSystemTest1: {
-        stage("memcheck-release-systemtest1") {
-          if (env.BRANCH_NAME == 'master' || full_ci) {
-            sh "mkdir ./clang-release-memcheck-systemtest1"
-            sh "valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --gen-suppressions=all --suppressions=.valgrind-ignore.txt ./clang-release/hyriseSystemTest clang-release-memcheck-systemtest1 --gtest_filter=TPCHTestInstances/TPCHTest.TPCHQueryTest/40"
-          } else {
-            Utils.markStageSkippedForConditional("memcheckReleaseSystemTest1")
-          }
-        }
-      }, memcheckReleaseSystemTest2: {
-        stage("memcheck-release-systemtest2") {
-          if (env.BRANCH_NAME == 'master' || full_ci) {
-            sh "mkdir ./clang-release-memcheck-systemtest2"
-            sh "valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --gen-suppressions=all --num-callers=25 --suppressions=.valgrind-ignore.txt ./clang-release/hyriseSystemTest clang-release-memcheck-systemtest2 --gtest_filter=-TPCHTestInstances/TPCHTest.TPCHQueryTest/40:TPCHTestInstances/TPCHTest.TPCHQueryTest/41"
-          } else {
-            Utils.markStageSkippedForConditional("memcheckReleaseSystemTest2")
           }
         }
       }, memcheckReleaseSystemTest3: {


### PR DESCRIPTION
More of a proposal to reduce CI load and runtime @mrks 

We discussed stressing the system test a bit less, and this is what I would do: No valgrind- and shuffled testing of hyriseSystemTest anymore. The system test is still run in multiple modes (including ASAN), that should be sufficient.