### PR TITLE
Use configure_file to generate jit_llvm_bundle.s

### DIFF
--- a/cmake/EmbedLLVM.cmake
+++ b/cmake/EmbedLLVM.cmake
@@ -56,21 +56,14 @@ function(EMBED_LLVM OUTPUT_FILE SYMBOL_NAME)
     set(MANGLED_SYMBOL _ZN7opossum${SYMBOL_NAME_LENGTH}${SYMBOL_NAME}E)
     math(EXPR SYMBOL_NAME_SIZE_LENGTH "${SYMBOL_NAME_LENGTH} + 5")
     set(MANGLED_SIZE_SYMBOL _ZN7opossum${SYMBOL_NAME_SIZE_LENGTH}${SYMBOL_NAME}_sizeE)
-    file(WRITE ${ASM_FILE} "
-        .global ${MANGLED_SYMBOL}
-        .global _${MANGLED_SYMBOL}
-        .global ${MANGLED_SIZE_SYMBOL}
-        .global _${MANGLED_SIZE_SYMBOL}
-        .p2align 3
-        ${MANGLED_SYMBOL}:
-        _${MANGLED_SYMBOL}:
-        .incbin \"${LLVM_BUNDLE_FILE}\"
-        1:
-        .p2align 3
-        ${MANGLED_SIZE_SYMBOL}:
-        _${MANGLED_SIZE_SYMBOL}:
-        .8byte 1b - ${MANGLED_SYMBOL}"
+        
+    configure_file("${CMAKE_SOURCE_DIR}/src/lib/operators/jit_operator/specialization/llvm/jit_llvm_bundle.s" ${ASM_FILE})
+
+    set_source_files_properties(
+        ${ASM_FILE}
+        PROPERTIES
+            OBJECT_DEPENDS ${LLVM_BUNDLE_FILE}
     )
-    set_source_files_properties(${ASM_FILE} PROPERTIES GENERATED TRUE OBJECT_DEPENDS ${LLVM_BUNDLE_FILE})
+
     set(${OUTPUT_FILE} ${ASM_FILE} PARENT_SCOPE)
 endfunction()

--- a/cmake/EmbedLLVM.cmake
+++ b/cmake/EmbedLLVM.cmake
@@ -56,9 +56,13 @@ function(EMBED_LLVM OUTPUT_FILE SYMBOL_NAME)
     set(MANGLED_SYMBOL _ZN7opossum${SYMBOL_NAME_LENGTH}${SYMBOL_NAME}E)
     math(EXPR SYMBOL_NAME_SIZE_LENGTH "${SYMBOL_NAME_LENGTH} + 5")
     set(MANGLED_SIZE_SYMBOL _ZN7opossum${SYMBOL_NAME_SIZE_LENGTH}${SYMBOL_NAME}_sizeE)
-        
-    configure_file("${CMAKE_SOURCE_DIR}/src/lib/operators/jit_operator/specialization/llvm/jit_llvm_bundle.s" ${ASM_FILE})
 
+    # We use `configure_file` to copy the .s template file to the build directory and configure it with variables
+    # specific to the build (MANGLED_SYMBOL, LLVM_BUNDLE_FILE, ...)
+    # Using configure_file() means that this configuration will only happen when cmake runs; there is NO dependency
+    # checking at build time, so if you change ".../specialization/llvm/jit_llvm_bundle.s", this will have no effect
+    # on the build unless cmake is run again.
+    configure_file("${CMAKE_SOURCE_DIR}/src/lib/operators/jit_operator/specialization/llvm/jit_llvm_bundle.s" ${ASM_FILE})
     set_source_files_properties(
         ${ASM_FILE}
         PROPERTIES

--- a/cmake/EmbedLLVM.cmake
+++ b/cmake/EmbedLLVM.cmake
@@ -61,7 +61,8 @@ function(EMBED_LLVM OUTPUT_FILE SYMBOL_NAME)
     # specific to the build (MANGLED_SYMBOL, LLVM_BUNDLE_FILE, ...)
     # Using configure_file() means that this configuration will only happen when cmake runs; there is NO dependency
     # checking at build time, so if you change ".../specialization/llvm/jit_llvm_bundle.s", this will have no effect
-    # on the build unless cmake is run again.
+    # on the build unless cmake is run again. For now, using `add_custom_command` to properly solve this seems
+    # unnecessary, but is possible if this becomes a problem.
     configure_file("${CMAKE_SOURCE_DIR}/src/lib/operators/jit_operator/specialization/llvm/jit_llvm_bundle.s" ${ASM_FILE})
     set_source_files_properties(
         ${ASM_FILE}

--- a/src/lib/operators/jit_operator/specialization/llvm/jit_llvm_bundle.s
+++ b/src/lib/operators/jit_operator/specialization/llvm/jit_llvm_bundle.s
@@ -1,0 +1,13 @@
+.global ${MANGLED_SYMBOL}
+.global _${MANGLED_SYMBOL}
+.global ${MANGLED_SIZE_SYMBOL}
+.global _${MANGLED_SIZE_SYMBOL}
+.p2align 3
+${MANGLED_SYMBOL}:
+_${MANGLED_SYMBOL}:
+.incbin "${LLVM_BUNDLE_FILE}"
+1:
+.p2align 3
+${MANGLED_SIZE_SYMBOL}:
+_${MANGLED_SIZE_SYMBOL}:
+.8byte 1b - ${MANGLED_SYMBOL} 

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -41,7 +41,7 @@
 
 // TRIMMED_FILENAME is __FILE__ with irrelevant leading chars trimmed
 #ifndef TRIMMED_FILENAME
-#define TRIMMED_FILENAME (__FILE__ + SOURCE_PATH_SIZE)
+#define TRIMMED_FILENAME (__FILE__)
 #endif
 
 namespace opossum {

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -41,7 +41,7 @@
 
 // TRIMMED_FILENAME is __FILE__ with irrelevant leading chars trimmed
 #ifndef TRIMMED_FILENAME
-#define TRIMMED_FILENAME (__FILE__)
+#define TRIMMED_FILENAME (__FILE__ + SOURCE_PATH_SIZE)
 #endif
 
 namespace opossum {


### PR DESCRIPTION
Fix #1328

@FabianWiebe this is pretty much precisely your proposed fix - what about this doesn't work? This will copy `jit_llvm_bundle.s` to the build directly and configure it. It isn't deleted when running `ninja clean`.