### PR TITLE
Rename IS_DEBUG to HYRISE_IS_DEBUG

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    add_definitions(-DHYRISE_IS_DEBUG=1)
+    add_definitions(-DHYRISE_DEBUG=1)
 else()
-    add_definitions(-DHYRISE_IS_DEBUG=0)
+    add_definitions(-DHYRISE_DEBUG=0)
 endif()
 
 # Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    add_definitions(-DIS_DEBUG=1)
+    add_definitions(-DHYRISE_IS_DEBUG=1)
 else()
-    add_definitions(-DIS_DEBUG=0)
+    add_definitions(-DHYRISE_IS_DEBUG=0)
 endif()
 
 # Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -441,7 +441,7 @@ nlohmann::json BenchmarkRunner::create_context(const BenchmarkConfig& config) {
       {"date", timestamp_stream.str()},
       {"chunk_size", config.chunk_size},
       {"compiler", compiler.str()},
-      {"build_type", IS_DEBUG ? "debug" : "release"},
+      {"build_type", HYRISE_IS_DEBUG ? "debug" : "release"},
       {"encoding", config.encoding_config.to_json()},
       {"benchmark_mode",
        config.benchmark_mode == BenchmarkMode::IndividualQueries ? "IndividualQueries" : "PermutedQuerySet"},

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -441,7 +441,7 @@ nlohmann::json BenchmarkRunner::create_context(const BenchmarkConfig& config) {
       {"date", timestamp_stream.str()},
       {"chunk_size", config.chunk_size},
       {"compiler", compiler.str()},
-      {"build_type", HYRISE_IS_DEBUG ? "debug" : "release"},
+      {"build_type", HYRISE_DEBUG ? "debug" : "release"},
       {"encoding", config.encoding_config.to_json()},
       {"benchmark_mode",
        config.benchmark_mode == BenchmarkMode::IndividualQueries ? "IndividualQueries" : "PermutedQuerySet"},

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -286,7 +286,7 @@ void Console::register_command(const std::string& name, const CommandFunction& f
 Console::RegisteredCommands Console::commands() { return _commands; }
 
 void Console::set_prompt(const std::string& prompt) {
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     _prompt = ANSI_COLOR_RED_RL "(debug)" ANSI_COLOR_RESET_RL + prompt;
   } else {
     _prompt = ANSI_COLOR_GREEN_RL "(release)" ANSI_COLOR_RESET_RL + prompt;
@@ -1025,7 +1025,7 @@ int main(int argc, char** argv) {
     console.out("Type 'help' for more information.\n\n");
 
     console.out("Hyrise is running a ");
-    if (IS_DEBUG) {
+    if (HYRISE_IS_DEBUG) {
       console.out(ANSI_COLOR_RED "(debug)" ANSI_COLOR_RESET);
     } else {
       console.out(ANSI_COLOR_GREEN "(release)" ANSI_COLOR_RESET);

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -286,7 +286,7 @@ void Console::register_command(const std::string& name, const CommandFunction& f
 Console::RegisteredCommands Console::commands() { return _commands; }
 
 void Console::set_prompt(const std::string& prompt) {
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     _prompt = ANSI_COLOR_RED_RL "(debug)" ANSI_COLOR_RESET_RL + prompt;
   } else {
     _prompt = ANSI_COLOR_GREEN_RL "(release)" ANSI_COLOR_RESET_RL + prompt;
@@ -1025,7 +1025,7 @@ int main(int argc, char** argv) {
     console.out("Type 'help' for more information.\n\n");
 
     console.out("Hyrise is running a ");
-    if (HYRISE_IS_DEBUG) {
+    if (HYRISE_DEBUG) {
       console.out(ANSI_COLOR_RED "(debug)" ANSI_COLOR_RESET);
     } else {
       console.out(ANSI_COLOR_GREEN "(release)" ANSI_COLOR_RESET);

--- a/src/lib/expression/binary_predicate_expression.cpp
+++ b/src/lib/expression/binary_predicate_expression.cpp
@@ -13,7 +13,7 @@ BinaryPredicateExpression::BinaryPredicateExpression(const PredicateCondition pr
                                                      const std::shared_ptr<AbstractExpression>& left_operand,
                                                      const std::shared_ptr<AbstractExpression>& right_operand)
     : AbstractPredicateExpression(predicate_condition, {left_operand, right_operand}) {
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   const auto valid_predicate_conditions = {PredicateCondition::Equals,      PredicateCondition::NotEquals,
                                            PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals,
                                            PredicateCondition::LessThan,    PredicateCondition::LessThanEquals,

--- a/src/lib/expression/binary_predicate_expression.cpp
+++ b/src/lib/expression/binary_predicate_expression.cpp
@@ -13,7 +13,7 @@ BinaryPredicateExpression::BinaryPredicateExpression(const PredicateCondition pr
                                                      const std::shared_ptr<AbstractExpression>& left_operand,
                                                      const std::shared_ptr<AbstractExpression>& right_operand)
     : AbstractPredicateExpression(predicate_condition, {left_operand, right_operand}) {
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   const auto valid_predicate_conditions = {PredicateCondition::Equals,      PredicateCondition::NotEquals,
                                            PredicateCondition::GreaterThan, PredicateCondition::GreaterThanEquals,
                                            PredicateCondition::LessThan,    PredicateCondition::LessThanEquals,

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -21,7 +21,7 @@ AggregateNode::AggregateNode(const std::vector<std::shared_ptr<AbstractExpressio
                              const std::vector<std::shared_ptr<AbstractExpression>>& aggregate_expressions)
     : AbstractLQPNode(LQPNodeType::Aggregate, {/* Expressions added below*/}),
       aggregate_expressions_begin_idx{group_by_expressions.size()} {
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   for (const auto& aggregate_expression : aggregate_expressions) {
     DebugAssert(aggregate_expression->type == ExpressionType::Aggregate,
                 "Expression used as aggregate expression must be of type AggregateExpression.");

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -21,7 +21,7 @@ AggregateNode::AggregateNode(const std::vector<std::shared_ptr<AbstractExpressio
                              const std::vector<std::shared_ptr<AbstractExpression>>& aggregate_expressions)
     : AbstractLQPNode(LQPNodeType::Aggregate, {/* Expressions added below*/}),
       aggregate_expressions_begin_idx{group_by_expressions.size()} {
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   for (const auto& aggregate_expression : aggregate_expressions) {
     DebugAssert(aggregate_expression->type == ExpressionType::Aggregate,
                 "Expression used as aggregate expression must be of type AggregateExpression.");

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -218,7 +218,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
          "UnionPositions doesn't support non-reference tables yet");
 
   /**
-   * Identify the ColumnClusters (verification that this is the same for all chunks happens in the #if HYRISE_IS_DEBUG block
+   * Identify the ColumnClusters (verification that this is the same for all chunks happens in the #if HYRISE_DEBUG block
    * below)
    */
   const auto add = [&](const auto& table) {
@@ -244,7 +244,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
 
   /**
    * Identify the tables referenced in each ColumnCluster (verification that this is the same for all chunks happens
-   * in the #if HYRISE_IS_DEBUG block below)
+   * in the #if HYRISE_DEBUG block below)
    */
   const auto first_chunk_left = input_table_left()->get_chunk(ChunkID{0});
   for (const auto& cluster_begin : _column_cluster_offsets) {
@@ -255,7 +255,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
 
   /**
    * Identify the column_ids referenced by each column (verification that this is the same for all chunks happens
-   * in the #if HYRISE_IS_DEBUG block below)
+   * in the #if HYRISE_DEBUG block below)
    */
   for (auto column_id = ColumnID{0}; column_id < input_table_left()->column_count(); ++column_id) {
     const auto segment = first_chunk_left->get_segment(column_id);
@@ -263,7 +263,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
     _referenced_column_ids.emplace_back(ref_segment->referenced_column_id());
   }
 
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   /**
    * Make sure all chunks have the same ColumnClusters and actually reference the tables and column_ids that the
    * segments in the first chunk of the left input table reference

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -218,7 +218,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
          "UnionPositions doesn't support non-reference tables yet");
 
   /**
-   * Identify the ColumnClusters (verification that this is the same for all chunks happens in the #if IS_DEBUG block
+   * Identify the ColumnClusters (verification that this is the same for all chunks happens in the #if HYRISE_IS_DEBUG block
    * below)
    */
   const auto add = [&](const auto& table) {
@@ -244,7 +244,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
 
   /**
    * Identify the tables referenced in each ColumnCluster (verification that this is the same for all chunks happens
-   * in the #if IS_DEBUG block below)
+   * in the #if HYRISE_IS_DEBUG block below)
    */
   const auto first_chunk_left = input_table_left()->get_chunk(ChunkID{0});
   for (const auto& cluster_begin : _column_cluster_offsets) {
@@ -255,7 +255,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
 
   /**
    * Identify the column_ids referenced by each column (verification that this is the same for all chunks happens
-   * in the #if IS_DEBUG block below)
+   * in the #if HYRISE_IS_DEBUG block below)
    */
   for (auto column_id = ColumnID{0}; column_id < input_table_left()->column_count(); ++column_id) {
     const auto segment = first_chunk_left->get_segment(column_id);
@@ -263,7 +263,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
     _referenced_column_ids.emplace_back(ref_segment->referenced_column_id());
   }
 
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   /**
    * Make sure all chunks have the same ColumnClusters and actually reference the tables and column_ids that the
    * segments in the first chunk of the left input table reference

--- a/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
+++ b/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
@@ -22,7 +22,7 @@ EnumerateCcp::EnumerateCcp(const size_t num_vertices, std::vector<std::pair<size
   // DPccp should not be used for queries with a table count on the scale of 64 because of complexity reasons
   Assert(num_vertices < sizeof(unsigned long) * 8, "Too many vertices, EnumerateCcp relies on to_ulong()");  // NOLINT
 
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   // Test the input data for validity, i.e. whether all mentioned vertex indices in the edges are smaller than
   // _num_vertices
   for (const auto& edge : _edges) {
@@ -61,7 +61,7 @@ std::vector<std::pair<JoinGraphVertexSet, JoinGraphVertexSet>> EnumerateCcp::ope
     }
   }
 
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   // Assert that the algorithm didn't create duplicates and that all created ccps contain only previously enumerated
   // subsets, i.e., that the enumeration order is correct
 

--- a/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
+++ b/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
@@ -22,7 +22,7 @@ EnumerateCcp::EnumerateCcp(const size_t num_vertices, std::vector<std::pair<size
   // DPccp should not be used for queries with a table count on the scale of 64 because of complexity reasons
   Assert(num_vertices < sizeof(unsigned long) * 8, "Too many vertices, EnumerateCcp relies on to_ulong()");  // NOLINT
 
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   // Test the input data for validity, i.e. whether all mentioned vertex indices in the edges are smaller than
   // _num_vertices
   for (const auto& edge : _edges) {
@@ -61,7 +61,7 @@ std::vector<std::pair<JoinGraphVertexSet, JoinGraphVertexSet>> EnumerateCcp::ope
     }
   }
 
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   // Assert that the algorithm didn't create duplicates and that all created ccps contain only previously enumerated
   // subsets, i.e., that the enumeration order is correct
 

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -20,7 +20,7 @@ namespace opossum {
 NodeQueueScheduler::NodeQueueScheduler() { _worker_id_allocator = std::make_shared<UidAllocator>(); }
 
 NodeQueueScheduler::~NodeQueueScheduler() {
-  if (IS_DEBUG && _active) {
+  if (HYRISE_IS_DEBUG && _active) {
     // We cannot throw an exception because destructors are noexcept by default.
     std::cerr << "NodeQueueScheduler::finish() wasn't called prior to destroying it" << std::endl;
     std::exit(EXIT_FAILURE);
@@ -67,7 +67,7 @@ void NodeQueueScheduler::finish() {
   }
 
   // All queues SHOULD be empty by now
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     for ([[maybe_unused]] auto& queue : _queues) {
       DebugAssert(queue->empty(), "NodeQueueScheduler bug: Queue wasn't empty even though all tasks finished");
     }

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -20,7 +20,7 @@ namespace opossum {
 NodeQueueScheduler::NodeQueueScheduler() { _worker_id_allocator = std::make_shared<UidAllocator>(); }
 
 NodeQueueScheduler::~NodeQueueScheduler() {
-  if (HYRISE_IS_DEBUG && _active) {
+  if (HYRISE_DEBUG && _active) {
     // We cannot throw an exception because destructors are noexcept by default.
     std::cerr << "NodeQueueScheduler::finish() wasn't called prior to destroying it" << std::endl;
     std::exit(EXIT_FAILURE);
@@ -67,7 +67,7 @@ void NodeQueueScheduler::finish() {
   }
 
   // All queues SHOULD be empty by now
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     for ([[maybe_unused]] auto& queue : _queues) {
       DebugAssert(queue->empty(), "NodeQueueScheduler bug: Queue wasn't empty even though all tasks finished");
     }

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -21,7 +21,7 @@ Chunk::Chunk(const Segments& segments, const std::shared_ptr<MvccData>& mvcc_dat
              const std::optional<PolymorphicAllocator<Chunk>>& alloc,
              const std::shared_ptr<ChunkAccessCounter>& access_counter)
     : _segments(segments), _mvcc_data(mvcc_data), _access_counter(access_counter) {
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   const auto chunk_size = segments.empty() ? 0u : segments[0]->size();
   Assert(!_mvcc_data || _mvcc_data->size() == chunk_size, "Invalid MvccData size");
   for (const auto& segment : segments) {

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -21,7 +21,7 @@ Chunk::Chunk(const Segments& segments, const std::shared_ptr<MvccData>& mvcc_dat
              const std::optional<PolymorphicAllocator<Chunk>>& alloc,
              const std::shared_ptr<ChunkAccessCounter>& access_counter)
     : _segments(segments), _mvcc_data(mvcc_data), _access_counter(access_counter) {
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   const auto chunk_size = segments.empty() ? 0u : segments[0]->size();
   Assert(!_mvcc_data || _mvcc_data->size() == chunk_size, "Invalid MvccData size");
   for (const auto& segment : segments) {

--- a/src/lib/storage/index/group_key/composite_group_key_index.cpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.cpp
@@ -28,7 +28,7 @@ CompositeGroupKeyIndex::CompositeGroupKeyIndex(const std::vector<std::shared_ptr
     : BaseIndex{get_index_type_of<CompositeGroupKeyIndex>()} {
   Assert(!segments_to_index.empty(), "CompositeGroupKeyIndex requires at least one segment to be indexed.");
 
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     auto first_size = segments_to_index.front()->size();
     [[maybe_unused]] auto all_segments_have_same_size =
         std::all_of(segments_to_index.cbegin(), segments_to_index.cend(),

--- a/src/lib/storage/index/group_key/composite_group_key_index.cpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.cpp
@@ -28,7 +28,7 @@ CompositeGroupKeyIndex::CompositeGroupKeyIndex(const std::vector<std::shared_ptr
     : BaseIndex{get_index_type_of<CompositeGroupKeyIndex>()} {
   Assert(!segments_to_index.empty(), "CompositeGroupKeyIndex requires at least one segment to be indexed.");
 
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     auto first_size = segments_to_index.front()->size();
     [[maybe_unused]] auto all_segments_have_same_size =
         std::all_of(segments_to_index.cbegin(), segments_to_index.cend(),

--- a/src/lib/storage/segment_iterables/any_segment_iterable.hpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.hpp
@@ -109,7 +109,7 @@ auto erase_type_from_iterable(const IterableT& iterable) {
 
 template <typename IterableT>
 decltype(auto) erase_type_from_iterable_if_debug(const IterableT& iterable) {
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   return erase_type_from_iterable(iterable);
 #else
   return iterable;

--- a/src/lib/storage/segment_iterables/any_segment_iterable.hpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.hpp
@@ -109,7 +109,7 @@ auto erase_type_from_iterable(const IterableT& iterable) {
 
 template <typename IterableT>
 decltype(auto) erase_type_from_iterable_if_debug(const IterableT& iterable) {
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   return erase_type_from_iterable(iterable);
 #else
   return iterable;

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -144,7 +144,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
                          const std::shared_ptr<ChunkAccessCounter>& access_counter) {
   const auto chunk_size = segments.empty() ? 0u : segments[0]->size();
 
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   for (const auto& segment : segments) {
     DebugAssert(segment->size() == chunk_size, "Segments don't have the same length");
     const auto is_reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment) != nullptr;
@@ -169,7 +169,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
 }
 
 void Table::append_chunk(const std::shared_ptr<Chunk>& chunk) {
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   for (const auto& segment : chunk->segments()) {
     const auto is_reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment) != nullptr;
     switch (_type) {

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -144,7 +144,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
                          const std::shared_ptr<ChunkAccessCounter>& access_counter) {
   const auto chunk_size = segments.empty() ? 0u : segments[0]->size();
 
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   for (const auto& segment : segments) {
     DebugAssert(segment->size() == chunk_size, "Segments don't have the same length");
     const auto is_reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment) != nullptr;
@@ -169,7 +169,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
 }
 
 void Table::append_chunk(const std::shared_ptr<Chunk>& chunk) {
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   for (const auto& segment : chunk->segments()) {
     const auto is_reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment) != nullptr;
     switch (_type) {

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -64,7 +64,7 @@ namespace opossum {
     throw InvalidInputException(std::string("Invalid input error: ") + msg); \
   }
 
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
 #define DebugAssert(expr, msg) Assert(expr, msg)
 #else
 #define DebugAssert(expr, msg)

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -64,7 +64,7 @@ namespace opossum {
     throw InvalidInputException(std::string("Invalid input error: ") + msg); \
   }
 
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
 #define DebugAssert(expr, msg) Assert(expr, msg)
 #else
 #define DebugAssert(expr, msg)

--- a/src/lib/utils/performance_warning.cpp
+++ b/src/lib/utils/performance_warning.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 bool PerformanceWarningClass::_disabled = []() {  // NOLINT
 // static initializer hack to print some warnings in various binaries
 
-#if IS_DEBUG
+#if HYRISE_IS_DEBUG
   PerformanceWarning("Hyrise is running as a debug build.");
 #endif
 

--- a/src/lib/utils/performance_warning.cpp
+++ b/src/lib/utils/performance_warning.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 bool PerformanceWarningClass::_disabled = []() {  // NOLINT
 // static initializer hack to print some warnings in various binaries
 
-#if HYRISE_IS_DEBUG
+#if HYRISE_DEBUG
   PerformanceWarning("Hyrise is running as a debug build.");
 #endif
 

--- a/src/test/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/expression/expression_evaluator_to_values_test.cpp
@@ -541,7 +541,7 @@ TEST_F(ExpressionEvaluatorToValuesTest, InSelectUncorrelatedWithPrecalculated) {
 
 TEST_F(ExpressionEvaluatorToValuesTest, InSelectUncorrelatedWithBrokenPrecalculated) {
   // Make sure the expression evaluator complains if it has been given a list of preevaluated selects but one is missing
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   // PQP that returns the column "a"
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);

--- a/src/test/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/expression/expression_evaluator_to_values_test.cpp
@@ -541,7 +541,7 @@ TEST_F(ExpressionEvaluatorToValuesTest, InSelectUncorrelatedWithPrecalculated) {
 
 TEST_F(ExpressionEvaluatorToValuesTest, InSelectUncorrelatedWithBrokenPrecalculated) {
   // Make sure the expression evaluator complains if it has been given a list of preevaluated selects but one is missing
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   // PQP that returns the column "a"
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);

--- a/src/test/lib/fixed_string_test.cpp
+++ b/src/test/lib/fixed_string_test.cpp
@@ -26,7 +26,7 @@ TEST_F(FixedStringTest, Constructors) {
   auto str2 = FixedString(str1);
   EXPECT_EQ(str2, "foo");
 
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     EXPECT_THROW(str1 = FixedString(&charvector2[0], 6u), std::exception);
   } else {
     str1 = FixedString(&charvector2[0], 6u);

--- a/src/test/lib/fixed_string_test.cpp
+++ b/src/test/lib/fixed_string_test.cpp
@@ -26,7 +26,7 @@ TEST_F(FixedStringTest, Constructors) {
   auto str2 = FixedString(str1);
   EXPECT_EQ(str2, "foo");
 
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     EXPECT_THROW(str1 = FixedString(&charvector2[0], 6u), std::exception);
   } else {
     str1 = FixedString(&charvector2[0], 6u);

--- a/src/test/operators/difference_test.cpp
+++ b/src/test/operators/difference_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OperatorsDifferenceTest, DifferneceOnReferenceTables) {
 }
 
 TEST_F(OperatorsDifferenceTest, ThrowWrongColumnNumberException) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   auto table_wrapper_c = std::make_shared<TableWrapper>(load_table("src/test/tables/int.tbl", 2));
   table_wrapper_c->execute();
 
@@ -71,7 +71,7 @@ TEST_F(OperatorsDifferenceTest, ThrowWrongColumnNumberException) {
 }
 
 TEST_F(OperatorsDifferenceTest, ThrowWrongColumnOrderException) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   auto table_wrapper_d = std::make_shared<TableWrapper>(load_table("src/test/tables/float_int.tbl", 2));
   table_wrapper_d->execute();

--- a/src/test/operators/difference_test.cpp
+++ b/src/test/operators/difference_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OperatorsDifferenceTest, DifferneceOnReferenceTables) {
 }
 
 TEST_F(OperatorsDifferenceTest, ThrowWrongColumnNumberException) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   auto table_wrapper_c = std::make_shared<TableWrapper>(load_table("src/test/tables/int.tbl", 2));
   table_wrapper_c->execute();
 
@@ -71,7 +71,7 @@ TEST_F(OperatorsDifferenceTest, ThrowWrongColumnNumberException) {
 }
 
 TEST_F(OperatorsDifferenceTest, ThrowWrongColumnOrderException) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   auto table_wrapper_d = std::make_shared<TableWrapper>(load_table("src/test/tables/float_int.tbl", 2));
   table_wrapper_d->execute();

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -235,7 +235,7 @@ TEST_F(JitOperationsTest, JitAnd) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     const JitTupleValue long_value{DataType::Long, false, 0};
     EXPECT_THROW(jit_and(true_value, long_value, result_value, context), std::logic_error);
   }
@@ -299,7 +299,7 @@ TEST_F(JitOperationsTest, JitOr) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     const JitTupleValue long_value{DataType::Long, false, 0};
     EXPECT_THROW(jit_or(true_value, long_value, result_value, context), std::logic_error);
   }
@@ -335,7 +335,7 @@ TEST_F(JitOperationsTest, JitNot) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     const JitTupleValue int_value{DataType::Long, false, 0};
     EXPECT_THROW(jit_not(int_value, result_value, context), std::logic_error);
   }

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -235,7 +235,7 @@ TEST_F(JitOperationsTest, JitAnd) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     const JitTupleValue long_value{DataType::Long, false, 0};
     EXPECT_THROW(jit_and(true_value, long_value, result_value, context), std::logic_error);
   }
@@ -299,7 +299,7 @@ TEST_F(JitOperationsTest, JitOr) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     const JitTupleValue long_value{DataType::Long, false, 0};
     EXPECT_THROW(jit_or(true_value, long_value, result_value, context), std::logic_error);
   }
@@ -335,7 +335,7 @@ TEST_F(JitOperationsTest, JitNot) {
   }
 
   // Check that invalid data type combinations are rejected
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     const JitTupleValue int_value{DataType::Long, false, 0};
     EXPECT_THROW(jit_not(int_value, result_value, context), std::logic_error);
   }

--- a/src/test/operators/jit_operator/operators/jit_aggregate_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_aggregate_test.cpp
@@ -80,7 +80,7 @@ TEST_F(JitAggregateTest, AddsAggregateColumnsToOutputTable) {
 // Check, that aggregates on invalid data types are rejected.
 TEST_F(JitAggregateTest, InvalidAggregatesAreRejected) {
   // Test case is only run in debug mode as checks are DebugAsserts, which are not present in release mode.
-  if constexpr (HYRISE_IS_DEBUG) {
+  if constexpr (HYRISE_DEBUG) {
     EXPECT_THROW(
         _aggregate->add_aggregate_column("invalid", JitTupleValue(DataType::String, false, 0), AggregateFunction::Avg),
         std::logic_error);

--- a/src/test/operators/jit_operator/operators/jit_aggregate_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_aggregate_test.cpp
@@ -80,7 +80,7 @@ TEST_F(JitAggregateTest, AddsAggregateColumnsToOutputTable) {
 // Check, that aggregates on invalid data types are rejected.
 TEST_F(JitAggregateTest, InvalidAggregatesAreRejected) {
   // Test case is only run in debug mode as checks are DebugAsserts, which are not present in release mode.
-  if constexpr (IS_DEBUG) {
+  if constexpr (HYRISE_IS_DEBUG) {
     EXPECT_THROW(
         _aggregate->add_aggregate_column("invalid", JitTupleValue(DataType::String, false, 0), AggregateFunction::Avg),
         std::logic_error);

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -79,7 +79,7 @@ TEST_F(JitExpressionTest, Not) {
     expression.compute(context);
     ASSERT_TRUE(context.tuple.get<bool>(result_index));
   }
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     // Not can only be computed on boolean values
     auto input_value = JitTupleValue{DataType::Long, false, 0};
     JitExpression expression(std::make_shared<JitExpression>(input_value), JitExpressionType::Not, result_index);

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -79,7 +79,7 @@ TEST_F(JitExpressionTest, Not) {
     expression.compute(context);
     ASSERT_TRUE(context.tuple.get<bool>(result_index));
   }
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     // Not can only be computed on boolean values
     auto input_value = JitTupleValue{DataType::Long, false, 0};
     JitExpression expression(std::make_shared<JitExpression>(input_value), JitExpressionType::Not, result_index);

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -36,7 +36,7 @@ using JoinEquiTypes = ::testing::Types<JoinNestedLoop, JoinHash, JoinSortMerge, 
 TYPED_TEST_CASE(JoinEquiTest, JoinEquiTypes);
 
 TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   EXPECT_THROW(std::make_shared<JoinHash>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
                                           ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan),
                std::logic_error);

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -36,7 +36,7 @@ using JoinEquiTypes = ::testing::Types<JoinNestedLoop, JoinHash, JoinSortMerge, 
 TYPED_TEST_CASE(JoinEquiTest, JoinEquiTypes);
 
 TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   EXPECT_THROW(std::make_shared<JoinHash>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
                                           ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan),
                std::logic_error);

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -33,7 +33,7 @@ typedef ::testing::Types<JoinNestedLoop, JoinSortMerge, JoinIndex> JoinFullTypes
 TYPED_TEST_CASE(JoinFullTest, JoinFullTypes);
 
 TYPED_TEST(JoinFullTest, CrossJoin) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   EXPECT_THROW(std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Cross,
                                            ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals),

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -33,7 +33,7 @@ typedef ::testing::Types<JoinNestedLoop, JoinSortMerge, JoinIndex> JoinFullTypes
 TYPED_TEST_CASE(JoinFullTest, JoinFullTypes);
 
 TYPED_TEST(JoinFullTest, CrossJoin) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   EXPECT_THROW(std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Cross,
                                            ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals),

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -191,7 +191,7 @@ TEST_F(JoinHashStepsTest, DetermineChunkOffsets) {
 }
 
 TEST_F(JoinHashStepsTest, ThrowWhenNoNullValuesArePassed) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   size_t radix_bit_count = 0;
   std::vector<std::vector<size_t>> histograms;

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -191,7 +191,7 @@ TEST_F(JoinHashStepsTest, DetermineChunkOffsets) {
 }
 
 TEST_F(JoinHashStepsTest, ThrowWhenNoNullValuesArePassed) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   size_t radix_bit_count = 0;
   std::vector<std::vector<size_t>> histograms;

--- a/src/test/operators/union_all_test.cpp
+++ b/src/test/operators/union_all_test.cpp
@@ -55,7 +55,7 @@ TEST_F(OperatorsUnionAllTest, UnionOfValueReferenceTables) {
 }
 
 TEST_F(OperatorsUnionAllTest, ThrowWrongColumnNumberException) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   std::shared_ptr<Table> test_table_c = load_table("src/test/tables/int.tbl", 2);
   auto gt_c = std::make_shared<TableWrapper>(std::move(test_table_c));
   gt_c->execute();
@@ -66,7 +66,7 @@ TEST_F(OperatorsUnionAllTest, ThrowWrongColumnNumberException) {
 }
 
 TEST_F(OperatorsUnionAllTest, ThrowWrongColumnOrderException) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   std::shared_ptr<Table> test_table_d = load_table("src/test/tables/float_int.tbl", 2);
   auto gt_d = std::make_shared<TableWrapper>(std::move(test_table_d));
   gt_d->execute();

--- a/src/test/operators/union_all_test.cpp
+++ b/src/test/operators/union_all_test.cpp
@@ -55,7 +55,7 @@ TEST_F(OperatorsUnionAllTest, UnionOfValueReferenceTables) {
 }
 
 TEST_F(OperatorsUnionAllTest, ThrowWrongColumnNumberException) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   std::shared_ptr<Table> test_table_c = load_table("src/test/tables/int.tbl", 2);
   auto gt_c = std::make_shared<TableWrapper>(std::move(test_table_c));
   gt_c->execute();
@@ -66,7 +66,7 @@ TEST_F(OperatorsUnionAllTest, ThrowWrongColumnNumberException) {
 }
 
 TEST_F(OperatorsUnionAllTest, ThrowWrongColumnOrderException) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   std::shared_ptr<Table> test_table_d = load_table("src/test/tables/float_int.tbl", 2);
   auto gt_d = std::make_shared<TableWrapper>(std::move(test_table_d));
   gt_d->execute();

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -510,7 +510,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
 }
 
 TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNotApplicable) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   /**
    * Build LQP and translate to PQP

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -510,7 +510,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
 }
 
 TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNotApplicable) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   /**
    * Build LQP and translate to PQP

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -532,7 +532,7 @@ TEST_F(SQLPipelineStatementTest, GetTimes) {
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   auto sql_pipeline = SQLPipelineBuilder{_invalid_sql}.create_pipeline_statement();
   try {

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -532,7 +532,7 @@ TEST_F(SQLPipelineStatementTest, GetTimes) {
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   auto sql_pipeline = SQLPipelineBuilder{_invalid_sql}.create_pipeline_statement();
   try {

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -111,7 +111,7 @@ TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
 }
 
 TYPED_TEST(RangeFilterTest, ThrowOnUnsortedData) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
 
   const pmr_vector<TypeParam> test_vector{std::numeric_limits<TypeParam>::max(),
                                           std::numeric_limits<TypeParam>::lowest()};

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -111,7 +111,7 @@ TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
 }
 
 TYPED_TEST(RangeFilterTest, ThrowOnUnsortedData) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
 
   const pmr_vector<TypeParam> test_vector{std::numeric_limits<TypeParam>::max(),
                                           std::numeric_limits<TypeParam>::lowest()};

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -54,7 +54,7 @@ TEST_F(StorageChunkTest, AddValuesToChunk) {
   chunk->append({2, "two"});
   EXPECT_EQ(chunk->size(), 4u);
 
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     EXPECT_THROW(chunk->append({}), std::exception);
     EXPECT_THROW(chunk->append({4, "val", 3}), std::exception);
     EXPECT_EQ(chunk->size(), 4u);
@@ -71,7 +71,7 @@ TEST_F(StorageChunkTest, RetrieveSegment) {
 
 TEST_F(StorageChunkTest, UnknownColumnType) {
   // Exception will only be thrown in debug builds
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     auto wrapper = []() { make_shared_by_data_type<BaseSegment, ValueSegment>(DataType::Null); };
     EXPECT_THROW(wrapper(), std::logic_error);
   }

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -54,7 +54,7 @@ TEST_F(StorageChunkTest, AddValuesToChunk) {
   chunk->append({2, "two"});
   EXPECT_EQ(chunk->size(), 4u);
 
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     EXPECT_THROW(chunk->append({}), std::exception);
     EXPECT_THROW(chunk->append({4, "val", 3}), std::exception);
     EXPECT_EQ(chunk->size(), 4u);
@@ -71,7 +71,7 @@ TEST_F(StorageChunkTest, RetrieveSegment) {
 
 TEST_F(StorageChunkTest, UnknownColumnType) {
   // Exception will only be thrown in debug builds
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     auto wrapper = []() { make_shared_by_data_type<BaseSegment, ValueSegment>(DataType::Null); };
     EXPECT_THROW(wrapper(), std::logic_error);
   }

--- a/src/test/storage/fixed_string_vector_test.cpp
+++ b/src/test/storage/fixed_string_vector_test.cpp
@@ -29,7 +29,7 @@ TEST_F(FixedStringVectorTest, SubscriptOperator) {
   EXPECT_EQ((*fixed_string_vector)[0u], "foo");
   EXPECT_EQ((*fixed_string_vector)[1u], "barbaz");
   EXPECT_EQ((*fixed_string_vector)[2u], "str3");
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     EXPECT_THROW(fixed_string_vector->push_back("opossum"), std::exception);
   } else {
     fixed_string_vector->push_back("opossum");
@@ -44,7 +44,7 @@ TEST_F(FixedStringVectorTest, AtOperator) {
 
   EXPECT_EQ(fixed_string_vector->at(1u).string(), "barbaz");
 
-  if (HYRISE_IS_DEBUG) {
+  if (HYRISE_DEBUG) {
     EXPECT_THROW(fixed_string_vector->push_back("opossum"), std::exception);
   } else {
     fixed_string_vector->push_back("opossum");

--- a/src/test/storage/fixed_string_vector_test.cpp
+++ b/src/test/storage/fixed_string_vector_test.cpp
@@ -29,7 +29,7 @@ TEST_F(FixedStringVectorTest, SubscriptOperator) {
   EXPECT_EQ((*fixed_string_vector)[0u], "foo");
   EXPECT_EQ((*fixed_string_vector)[1u], "barbaz");
   EXPECT_EQ((*fixed_string_vector)[2u], "str3");
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     EXPECT_THROW(fixed_string_vector->push_back("opossum"), std::exception);
   } else {
     fixed_string_vector->push_back("opossum");
@@ -44,7 +44,7 @@ TEST_F(FixedStringVectorTest, AtOperator) {
 
   EXPECT_EQ(fixed_string_vector->at(1u).string(), "barbaz");
 
-  if (IS_DEBUG) {
+  if (HYRISE_IS_DEBUG) {
     EXPECT_THROW(fixed_string_vector->push_back("opossum"), std::exception);
   } else {
     fixed_string_vector->push_back("opossum");

--- a/src/test/storage/multi_segment_index_test.cpp
+++ b/src/test/storage/multi_segment_index_test.cpp
@@ -165,7 +165,7 @@ TYPED_TEST(MultiSegmentIndexTest, RangeQueryOpenBegin) {
 }
 
 TYPED_TEST(MultiSegmentIndexTest, TooManyReferenceValues) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   EXPECT_THROW(this->index_int_str->lower_bound({1, "baz", 3.0f}), std::logic_error);
   EXPECT_THROW(this->index_int_str->upper_bound({1, "baz", 3.0f}), std::logic_error);
 }

--- a/src/test/storage/multi_segment_index_test.cpp
+++ b/src/test/storage/multi_segment_index_test.cpp
@@ -165,7 +165,7 @@ TYPED_TEST(MultiSegmentIndexTest, RangeQueryOpenBegin) {
 }
 
 TYPED_TEST(MultiSegmentIndexTest, TooManyReferenceValues) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   EXPECT_THROW(this->index_int_str->lower_bound({1, "baz", 3.0f}), std::logic_error);
   EXPECT_THROW(this->index_int_str->upper_bound({1, "baz", 3.0f}), std::logic_error);
 }

--- a/src/test/storage/single_segment_index_test.cpp
+++ b/src/test/storage/single_segment_index_test.cpp
@@ -172,7 +172,7 @@ TYPED_TEST(SingleSegmentIndexTest, IsIndexForTest) {
 }
 
 TYPED_TEST(SingleSegmentIndexTest, IndexOnNonDictionaryThrows) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   auto vs_int = std::make_shared<ValueSegment<int>>();
   vs_int->append(4);
 

--- a/src/test/storage/single_segment_index_test.cpp
+++ b/src/test/storage/single_segment_index_test.cpp
@@ -172,7 +172,7 @@ TYPED_TEST(SingleSegmentIndexTest, IsIndexForTest) {
 }
 
 TYPED_TEST(SingleSegmentIndexTest, IndexOnNonDictionaryThrows) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   auto vs_int = std::make_shared<ValueSegment<int>>();
   vs_int->append(4);
 

--- a/src/test/storage/variable_length_key_store_test.cpp
+++ b/src/test/storage/variable_length_key_store_test.cpp
@@ -188,7 +188,7 @@ TEST_F(VariableLengthKeyStoreTest, WriteAccessViaBracketsOperator) {
 }
 
 TEST_F(VariableLengthKeyStoreTest, WriteNonFittingKeys) {
-  if (!HYRISE_IS_DEBUG) return;
+  if (!HYRISE_DEBUG) return;
   // _store is created with 4 bytes per entry
   auto short_key = VariableLengthKey(sizeof(uint16_t));
   auto long_key = VariableLengthKey(sizeof(uint64_t));

--- a/src/test/storage/variable_length_key_store_test.cpp
+++ b/src/test/storage/variable_length_key_store_test.cpp
@@ -188,7 +188,7 @@ TEST_F(VariableLengthKeyStoreTest, WriteAccessViaBracketsOperator) {
 }
 
 TEST_F(VariableLengthKeyStoreTest, WriteNonFittingKeys) {
-  if (!IS_DEBUG) return;
+  if (!HYRISE_IS_DEBUG) return;
   // _store is created with 4 bytes per entry
   auto short_key = VariableLengthKey(sizeof(uint16_t));
   auto long_key = VariableLengthKey(sizeof(uint64_t));


### PR DESCRIPTION
Studying the compiler command lines I noticed that we have two flags with the "HYRISE_" prefix (HYRISE_JIT_SUPPORT and DHYRISE_NUMA_SUPPORT) and one without (IS_DEBUG). This PR makes this consistent. 

Also, this makes it 2 * 2 * 2 = 8 possible build configurations of hyrise possible today. Such many, wow.

Reasoning:

1. Consistency.
2. When I see the compiler command line (example below) I want to know which parameters are Hyrise parameters and which are compiler flags. This change makes this easier to spot.
3. IS_DEBUG is a pretty generic name, might be used by a (future) third_party library. If we want flags affecting those, our decision to set them should be concious.
4. Seeing **HYRISE_**IS_DEBUG in the code makes it obvious that this comes from "us" and isn't anything esoteric, e.g., generated by the compiler or something.

```
/usr/bin/clang++-6.0  -DBOOST_THREAD_VERSION=5 -DHYRISE_JIT_SUPPORT=1 -DHYRISE_NUMA_SUPPORT=1 -DIS_DEBUG=1 -DSOURCE_PATH_SIZE=27 -DTEST_PLUGIN_DIR=\"/home/moritz/Coding/hyrise/cmake-build-ninja-clang-debug/lib/\" -DTestPlugin_EXPORTS -I../third_party/googletest/googletest/include -I../third_party/sql-parser/src -I../src/benchmarklib -I../src/lib -I../src/plugin -isystem ../third_party/benchmark/include -isystem ../third_party/cpp-btree -isystem ../third_party/cqf/include -isystem ../third_party/cxxopts/include -isystem ../third_party/flat_hash_map -isystem ../third_party/json -isystem /usr/lib/llvm-6.0/include -isystem ../third_party/pgasus/include -isystem third_party/pgasus/src -g -fPIC   -std=c++17 -pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas -Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-shadow-field-in-constructor -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -MD -MT src/plugins/CMakeFiles/TestPlugin.dir/test_plugin.cpp.o -MF src/plugins/CMakeFiles/TestPlugin.dir/test_plugin.cpp.o.d -o src/plugins/CMakeFiles/TestPlugin.dir/test_plugin.cpp.o -c ../src/plugins/test_plugin.cpp
```