### PR TITLE
Tests: Make SchedulerTest run on 4-core-machines

### DIFF
--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -214,19 +214,19 @@ TEST_F(SchedulerTest, MultipleOperators) {
 }
 
 TEST_F(SchedulerTest, VerifyTaskQueueSetup) {
-  Topology::use_non_numa_topology(8);
+  Topology::use_non_numa_topology(4);
   CurrentScheduler::set(std::make_shared<NodeQueueScheduler>());
   EXPECT_EQ(1, CurrentScheduler::get()->queues().size());
 
-  Topology::use_fake_numa_topology(8);
+  Topology::use_fake_numa_topology(4);
   CurrentScheduler::set(std::make_shared<NodeQueueScheduler>());
-  EXPECT_EQ(8, CurrentScheduler::get()->queues().size());
+  EXPECT_EQ(4, CurrentScheduler::get()->queues().size());
 
-  Topology::use_fake_numa_topology(8, 4);
+  Topology::use_fake_numa_topology(4, 2);
   CurrentScheduler::set(std::make_shared<NodeQueueScheduler>());
   EXPECT_EQ(2, CurrentScheduler::get()->queues().size());
 
-  Topology::use_fake_numa_topology(8, 8);
+  Topology::use_fake_numa_topology(4, 4);
   CurrentScheduler::set(std::make_shared<NodeQueueScheduler>());
   EXPECT_EQ(1, CurrentScheduler::get()->queues().size());
 


### PR DESCRIPTION
This changes the number of nodes created in the SchedulerTest from 8 to 4, so that it works correctly on 4-core-machines.

Currently, the number of workers is restricted to the hardware concurrency, which silently reduces the worker count if higher values are requested:
https://github.com/hyrise/hyrise/blob/2bb0cacf31735f95bbcaf00ccbe853dcd418dda8/src/lib/scheduler/topology.cpp#L123-L130

I feel like reducing the node count from 8 to 4 doesn't affect the overall test and will make the test green on most development machines.

It would be even better to use the `GTEST_SKIP`-macro to skip the whole test conditionally if the hardware concurrency on the test machine is too low. However, this is [quite a recent feature of googletest](https://github.com/abseil/googletest/pull/1544) and would require us to update the version we currently use. Let me know if you prefer an update of googletest.

In case it is relevant:
I'm running Hyrise in the Windows Subsystem for Linux on Ubuntu 18.04 with JIT and NUMA disabled: `-DENABLE_JIT_SUPPORT=OFF -DENABLE_NUMA_SUPPORT=OFF`

//cc @aloeser