### PR TITLE
Benchmarks: When using global encoding, fall back to Unencoded if not compatible with column type

### DIFF
--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[]) {
     const auto& table_name = opossum::tpch_table_names.at(tpch_table.first);
     auto& table = tpch_table.second;
 
-    opossum::BenchmarkTableEncoder::encode(table_name, table, config->encoding_config);
+    opossum::BenchmarkTableEncoder::encode(table_name, table, config->encoding_config, config->out);
     opossum::StorageManager::get().add_table(table_name, table);
   }
   config->out << "- ... done." << std::endl;

--- a/src/benchmarklib/benchmark_utils.hpp
+++ b/src/benchmarklib/benchmark_utils.hpp
@@ -93,11 +93,6 @@ struct EncodingConfig {
   static const char* description;
 };
 
-class BenchmarkTableEncoder {
- public:
-  static void encode(const std::string& table_name, const std::shared_ptr<Table>& table, const EncodingConfig& config);
-};
-
 // View BenchmarkConfig::description to see format of the JSON-version
 struct BenchmarkConfig {
   BenchmarkConfig(const BenchmarkMode benchmark_mode, const bool verbose, const ChunkOffset chunk_size,
@@ -127,6 +122,13 @@ struct BenchmarkConfig {
 
  private:
   BenchmarkConfig() : out(std::cout) {}
+};
+
+class BenchmarkTableEncoder {
+ public:
+  // @param out   stream for logging info
+  static void encode(const std::string& table_name, const std::shared_ptr<Table>& table, const EncodingConfig& config,
+                     std::ostream& stream);
 };
 
 class CLIConfigParser {

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -528,7 +528,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_table(const std::string& tab
 }
 
 void TpccTableGenerator::_encode_table(const std::string& table_name, const std::shared_ptr<Table>& table) {
-  BenchmarkTableEncoder::encode(table_name, table, _encoding_config);
+  BenchmarkTableEncoder::encode(table_name, table, _encoding_config, std::cout);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
Fix #1326

```
 - Column 'region.r_regionkey' of type int cannot be encoded as FixedStringDictionary and is left Unencoded.
 - Column 'nation.n_nationkey' of type int cannot be encoded as FixedStringDictionary and is left Unencoded.
```

Note that if you specify an illegal encoding in the Column, you will still get an error.