### PR TITLE
Update googletest, use GTEST_SKIP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
-	url = https://github.com/google/googletest.git
+	url = https://github.com/abseil/googletest.git
 [submodule "third_party/benchmark"]
 	path = third_party/benchmark
 	url = https://github.com/google/benchmark.git

--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -237,7 +237,7 @@ class CacheTest : public BaseTest {};
 // here we define all Join types
 using CacheTypes = ::testing::Types<LRUCache<int, int>, LRUKCache<2, int, int>, GDSCache<int, int>, GDFSCache<int, int>,
                                     RandomCache<int, int>>;
-TYPED_TEST_CASE(CacheTest, CacheTypes);
+TYPED_TEST_CASE(CacheTest, CacheTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(CacheTest, Size) {
   TypeParam cache(3);

--- a/src/test/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/expression/expression_evaluator_to_values_test.cpp
@@ -541,7 +541,7 @@ TEST_F(ExpressionEvaluatorToValuesTest, InSelectUncorrelatedWithPrecalculated) {
 
 TEST_F(ExpressionEvaluatorToValuesTest, InSelectUncorrelatedWithBrokenPrecalculated) {
   // Make sure the expression evaluator complains if it has been given a list of preevaluated selects but one is missing
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   // PQP that returns the column "a"
   const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);

--- a/src/test/operators/difference_test.cpp
+++ b/src/test/operators/difference_test.cpp
@@ -61,7 +61,7 @@ TEST_F(OperatorsDifferenceTest, DifferneceOnReferenceTables) {
 }
 
 TEST_F(OperatorsDifferenceTest, ThrowWrongColumnNumberException) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   auto table_wrapper_c = std::make_shared<TableWrapper>(load_table("src/test/tables/int.tbl", 2));
   table_wrapper_c->execute();
 
@@ -71,7 +71,7 @@ TEST_F(OperatorsDifferenceTest, ThrowWrongColumnNumberException) {
 }
 
 TEST_F(OperatorsDifferenceTest, ThrowWrongColumnOrderException) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   auto table_wrapper_d = std::make_shared<TableWrapper>(load_table("src/test/tables/float_int.tbl", 2));
   table_wrapper_d->execute();

--- a/src/test/operators/index_scan_test.cpp
+++ b/src/test/operators/index_scan_test.cpp
@@ -92,7 +92,7 @@ typedef ::testing::Types<GroupKeyIndex, AdaptiveRadixTreeIndex, CompositeGroupKe
                          BTreeIndex /* add further indices */>
     DerivedIndices;
 
-TYPED_TEST_CASE(OperatorsIndexScanTest, DerivedIndices);
+TYPED_TEST_CASE(OperatorsIndexScanTest, DerivedIndices, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanOnDataTable) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -33,10 +33,10 @@ class JoinEquiTest : public JoinTest {};
 
 // here we define all Join types
 using JoinEquiTypes = ::testing::Types<JoinNestedLoop, JoinHash, JoinSortMerge, JoinIndex, JoinMPSM>;
-TYPED_TEST_CASE(JoinEquiTest, JoinEquiTypes);
+TYPED_TEST_CASE(JoinEquiTest, JoinEquiTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   EXPECT_THROW(std::make_shared<JoinHash>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
                                           ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan),
                std::logic_error);

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -30,10 +30,10 @@ class JoinFullTest : public JoinTest {};
 
 // here we define all Join types
 typedef ::testing::Types<JoinNestedLoop, JoinSortMerge, JoinIndex> JoinFullTypes;
-TYPED_TEST_CASE(JoinFullTest, JoinFullTypes);
+TYPED_TEST_CASE(JoinFullTest, JoinFullTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinFullTest, CrossJoin) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   EXPECT_THROW(std::make_shared<TypeParam>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Cross,
                                            ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals),

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -191,7 +191,7 @@ TEST_F(JoinHashStepsTest, DetermineChunkOffsets) {
 }
 
 TEST_F(JoinHashStepsTest, ThrowWhenNoNullValuesArePassed) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   size_t radix_bit_count = 0;
   std::vector<std::vector<size_t>> histograms;

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -48,7 +48,7 @@ void test_hash_map(const std::vector<T>& values) {
 }
 
 using DataTypes = ::testing::Types<int, float, double>;
-TYPED_TEST_CASE(JoinHashTypesTest, DataTypes);
+TYPED_TEST_CASE(JoinHashTypesTest, DataTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinHashTypesTest, BuildSingleValueLargePosList) {
   int test_item_count = 500;

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -121,7 +121,7 @@ class JoinIndexTest : public BaseTest {
 typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex /* , GroupKeyIndex */>
     DerivedIndices;
 
-TYPED_TEST_CASE(JoinIndexTest, DerivedIndices);
+TYPED_TEST_CASE(JoinIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinIndexTest, LeftJoinFallBack) {
   this->test_join_output(this->_table_wrapper_a_no_index, this->_table_wrapper_b_no_index,

--- a/src/test/operators/join_null_test.cpp
+++ b/src/test/operators/join_null_test.cpp
@@ -57,7 +57,7 @@ class JoinNullTest : public JoinTest {
 };
 
 using JoinNullTypes = ::testing::Types<JoinHash, JoinSortMerge, JoinNestedLoop, JoinMPSM>;
-TYPED_TEST_CASE(JoinNullTest, JoinNullTypes);
+TYPED_TEST_CASE(JoinNullTest, JoinNullTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinNullTest, InnerJoinWithNull) {
   this->template test_join_output<TypeParam>(

--- a/src/test/operators/operator_deep_copy_test.cpp
+++ b/src/test/operators/operator_deep_copy_test.cpp
@@ -56,7 +56,7 @@ class DeepCopyTestJoin : public OperatorDeepCopyTest {};
 
 // here we define all Join types
 using JoinTypes = ::testing::Types<JoinNestedLoop, JoinHash, JoinSortMerge, JoinMPSM>;
-TYPED_TEST_CASE(DeepCopyTestJoin, JoinTypes);
+TYPED_TEST_CASE(DeepCopyTestJoin, JoinTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(DeepCopyTestJoin, DeepCopyJoin) {
   std::shared_ptr<Table> expected_result = load_table("src/test/tables/joinoperators/int_left_join.tbl", 1);

--- a/src/test/operators/union_all_test.cpp
+++ b/src/test/operators/union_all_test.cpp
@@ -55,7 +55,7 @@ TEST_F(OperatorsUnionAllTest, UnionOfValueReferenceTables) {
 }
 
 TEST_F(OperatorsUnionAllTest, ThrowWrongColumnNumberException) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   std::shared_ptr<Table> test_table_c = load_table("src/test/tables/int.tbl", 2);
   auto gt_c = std::make_shared<TableWrapper>(std::move(test_table_c));
   gt_c->execute();
@@ -66,7 +66,7 @@ TEST_F(OperatorsUnionAllTest, ThrowWrongColumnNumberException) {
 }
 
 TEST_F(OperatorsUnionAllTest, ThrowWrongColumnOrderException) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   std::shared_ptr<Table> test_table_d = load_table("src/test/tables/float_int.tbl", 2);
   auto gt_d = std::make_shared<TableWrapper>(std::move(test_table_d));
   gt_d->execute();

--- a/src/test/optimizer/lqp_translator_test.cpp
+++ b/src/test/optimizer/lqp_translator_test.cpp
@@ -510,7 +510,7 @@ TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
 }
 
 TEST_F(LQPTranslatorTest, PredicateNodeIndexScanFailsWhenNotApplicable) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   /**
    * Build LQP and translate to PQP

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -532,7 +532,7 @@ TEST_F(SQLPipelineStatementTest, GetTimes) {
 }
 
 TEST_F(SQLPipelineStatementTest, ParseErrorDebugMessage) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   auto sql_pipeline = SQLPipelineBuilder{_invalid_sql}.create_pipeline_statement();
   try {

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
@@ -4,9 +4,10 @@ namespace opossum {
 
 #if HYRISE_JIT_SUPPORT
 
-INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerJIT, SQLiteTestRunner,
-                        testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({true}),
-                                         testing::ValuesIn({EncodingType::Unencoded})), );  // NOLINT
+INSTANTIATE_TEST_CASE_P(
+    SQLiteTestRunnerJIT, SQLiteTestRunner,
+    testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({true}),
+                     testing::ValuesIn({EncodingType::Unencoded})), );  // NOLINT(whitespace/parens)  // NOLINT
 
 #endif
 

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
@@ -2,8 +2,9 @@
 
 namespace opossum {
 
-INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerUnencoded, SQLiteTestRunner,
-                        testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
-                                         testing::ValuesIn({EncodingType::Unencoded})), );  // NOLINT
+INSTANTIATE_TEST_CASE_P(
+    SQLiteTestRunnerUnencoded, SQLiteTestRunner,
+    testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
+                     testing::ValuesIn({EncodingType::Unencoded})), );  // NOLINT(whitespace/parens)  // NOLINT
 
 }  // namespace opossum

--- a/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
@@ -136,7 +136,7 @@ class CountingQuotientFilterTest : public BaseTest {
 };
 
 using Types = ::testing::Types<int32_t, int64_t, float, double, std::string>;
-TYPED_TEST_CASE(CountingQuotientFilterTest, Types);
+TYPED_TEST_CASE(CountingQuotientFilterTest, Types, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(CountingQuotientFilterTest, ValueCounts) {
   this->test_value_counts(this->cqf2);

--- a/src/test/statistics/chunk_statistics/histograms/abstract_histogram_test.cpp
+++ b/src/test/statistics/chunk_statistics/histograms/abstract_histogram_test.cpp
@@ -22,7 +22,7 @@ class AbstractHistogramIntTest : public BaseTest {
 
 using HistogramIntTypes =
     ::testing::Types<EqualDistinctCountHistogram<int32_t>, EqualWidthHistogram<int32_t>, EqualHeightHistogram<int32_t>>;
-TYPED_TEST_CASE(AbstractHistogramIntTest, HistogramIntTypes);
+TYPED_TEST_CASE(AbstractHistogramIntTest, HistogramIntTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(AbstractHistogramIntTest, EqualsPruning) {
   const auto hist = TypeParam::from_segment(this->_int_float4->get_chunk(ChunkID{0})->get_segment(ColumnID{0}), 2u);
@@ -155,7 +155,7 @@ class AbstractHistogramStringTest : public BaseTest {
 
 using HistogramStringTypes = ::testing::Types<EqualDistinctCountHistogram<std::string>,
                                               EqualWidthHistogram<std::string>, EqualHeightHistogram<std::string>>;
-TYPED_TEST_CASE(AbstractHistogramStringTest, HistogramStringTypes);
+TYPED_TEST_CASE(AbstractHistogramStringTest, HistogramStringTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(AbstractHistogramStringTest, StringConstructorTests) {
   // Histogram checks prefix length for overflow.

--- a/src/test/statistics/chunk_statistics/min_max_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/min_max_filter_test.cpp
@@ -47,7 +47,7 @@ class MinMaxFilterTest<std::string> : public ::testing::Test {
 };
 
 using FilterTypes = ::testing::Types<int, float, double, std::string>;
-TYPED_TEST_CASE(MinMaxFilterTest, FilterTypes);
+TYPED_TEST_CASE(MinMaxFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(MinMaxFilterTest, CanPruneOnBounds) {
   auto filter = std::make_unique<MinMaxFilter<TypeParam>>(this->_values.front(), this->_values.back());

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -92,7 +92,7 @@ T get_random_number(std::mt19937& rng, distribution<T> distribution) {
 }
 
 using FilterTypes = ::testing::Types<int, float, double>;
-TYPED_TEST_CASE(RangeFilterTest, FilterTypes);
+TYPED_TEST_CASE(RangeFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
   // Create vector with a huge gap in the middle whose length exceeds the type's limits.
@@ -111,7 +111,7 @@ TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
 }
 
 TYPED_TEST(RangeFilterTest, ThrowOnUnsortedData) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
 
   const pmr_vector<TypeParam> test_vector{std::numeric_limits<TypeParam>::max(),
                                           std::numeric_limits<TypeParam>::lowest()};

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -71,10 +71,9 @@ TEST_F(StorageChunkTest, RetrieveSegment) {
 
 TEST_F(StorageChunkTest, UnknownColumnType) {
   // Exception will only be thrown in debug builds
-  if (HYRISE_DEBUG) {
-    auto wrapper = []() { make_shared_by_data_type<BaseSegment, ValueSegment>(DataType::Null); };
-    EXPECT_THROW(wrapper(), std::logic_error);
-  }
+  if (!HYRISE_DEBUG) GTEST_SKIP();
+  auto wrapper = []() { make_shared_by_data_type<BaseSegment, ValueSegment>(DataType::Null); };
+  EXPECT_THROW(wrapper(), std::logic_error);
 }
 
 TEST_F(StorageChunkTest, AddIndexByColumnID) {

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -151,8 +151,9 @@ TEST_P(MaterializeTest, MaterializeNullsTwoSegments) {
   EXPECT_EQ(expected, nulls);
 }
 
-INSTANTIATE_TEST_CASE_P(MaterializeTestInstances, MaterializeTest,
-                        ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                                            std::end(all_segment_encoding_specs)), );  // NOLINT
+INSTANTIATE_TEST_CASE_P(
+    MaterializeTestInstances, MaterializeTest,
+    ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
+                        std::end(all_segment_encoding_specs)), );  // NOLINT(whitespace/parens)  // NOLINT
 
 }  // namespace opossum

--- a/src/test/storage/multi_segment_index_test.cpp
+++ b/src/test/storage/multi_segment_index_test.cpp
@@ -50,7 +50,7 @@ class MultiSegmentIndexTest : public BaseTest {
 
 // List of indices to test
 typedef ::testing::Types<CompositeGroupKeyIndex> DerivedIndices;
-TYPED_TEST_CASE(MultiSegmentIndexTest, DerivedIndices);
+TYPED_TEST_CASE(MultiSegmentIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(MultiSegmentIndexTest, FullRange) {
   auto begin_int_str = this->index_int_str->cbegin();
@@ -165,7 +165,7 @@ TYPED_TEST(MultiSegmentIndexTest, RangeQueryOpenBegin) {
 }
 
 TYPED_TEST(MultiSegmentIndexTest, TooManyReferenceValues) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   EXPECT_THROW(this->index_int_str->lower_bound({1, "baz", 3.0f}), std::logic_error);
   EXPECT_THROW(this->index_int_str->upper_bound({1, "baz", 3.0f}), std::logic_error);
 }

--- a/src/test/storage/single_segment_index_test.cpp
+++ b/src/test/storage/single_segment_index_test.cpp
@@ -49,7 +49,7 @@ class SingleSegmentIndexTest : public BaseTest {
 // List of indices to test
 typedef ::testing::Types<GroupKeyIndex, CompositeGroupKeyIndex, AdaptiveRadixTreeIndex /* add further indices */>
     DerivedIndices;
-TYPED_TEST_CASE(SingleSegmentIndexTest, DerivedIndices);
+TYPED_TEST_CASE(SingleSegmentIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(SingleSegmentIndexTest, FullRange) {
   auto begin_int = this->index_int->cbegin();
@@ -172,7 +172,7 @@ TYPED_TEST(SingleSegmentIndexTest, IsIndexForTest) {
 }
 
 TYPED_TEST(SingleSegmentIndexTest, IndexOnNonDictionaryThrows) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   auto vs_int = std::make_shared<ValueSegment<int>>();
   vs_int->append(4);
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -158,7 +158,7 @@ TEST_F(StorageTableTest, EmplaceChunkDoesNotReplaceIfNumberOfChunksGreaterOne) {
 }
 
 TEST_F(StorageTableTest, ChunkSizeZeroThrows) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   TableColumnDefinitions column_definitions{};
   EXPECT_THROW(Table(column_definitions, TableType::Data, 0), std::logic_error);
 }

--- a/src/test/storage/variable_length_key_store_test.cpp
+++ b/src/test/storage/variable_length_key_store_test.cpp
@@ -188,7 +188,7 @@ TEST_F(VariableLengthKeyStoreTest, WriteAccessViaBracketsOperator) {
 }
 
 TEST_F(VariableLengthKeyStoreTest, WriteNonFittingKeys) {
-  if (!HYRISE_DEBUG) return;
+  if (!HYRISE_DEBUG) GTEST_SKIP();
   // _store is created with 4 bytes per entry
   auto short_key = VariableLengthKey(sizeof(uint16_t));
   auto long_key = VariableLengthKey(sizeof(uint64_t));

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -122,13 +122,13 @@ TEST_P(TPCHTest, TPCHQueryTest) {
 
 INSTANTIATE_TEST_CASE_P(TPCHTestNoJIT, TPCHTest,
                         testing::Combine(testing::ValuesIn(TPCHQueryGenerator{}.selected_queries()),
-                                         testing::ValuesIn({false})), );  // NOLINT
+                                         testing::ValuesIn({false})), );  // NOLINT(whitespace/parens)  // NOLINT
 
 #if HYRISE_JIT_SUPPORT
 
 INSTANTIATE_TEST_CASE_P(TPCHTestJIT, TPCHTest,
                         testing::Combine(testing::ValuesIn(TPCHQueryGenerator{}.selected_queries()),
-                                         testing::ValuesIn({true})), );  // NOLINT
+                                         testing::ValuesIn({true})), );  // NOLINT(whitespace/parens)  // NOLINT
 
 #endif
 


### PR DESCRIPTION
In #1339, @cmfcmf made us aware of `GTEST_SKIP`, which is a better solution for tests that should not run in the release mode. This updates googletest and changes those test files.