### PR TITLE
Fix deleting zero rows

### DIFF
--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -109,8 +109,8 @@ void Delete::_on_rollback_records() {
 }
 
 /**
- * values_to_delete must be a table with at least one chunk, containing at least one ReferenceSegment
- * that all reference the table specified by table_name.
+ * values_to_delete must be a table either without chunks or with at least one ReferenceSegment
+ * where all segments reference the table specified by table_name.
  */
 bool Delete::_execution_input_valid(const std::shared_ptr<TransactionContext>& context) const {
   if (context == nullptr) return false;
@@ -120,8 +120,6 @@ bool Delete::_execution_input_valid(const std::shared_ptr<TransactionContext>& c
   if (!StorageManager::get().has_table(_table_name)) return false;
 
   const auto table = StorageManager::get().get_table(_table_name);
-
-  if (values_to_delete->chunk_count() == 0u) return false;
 
   for (ChunkID chunk_id{0}; chunk_id < values_to_delete->chunk_count(); ++chunk_id) {
     const auto chunk = values_to_delete->get_chunk(chunk_id);

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -137,6 +137,35 @@ TEST_F(OperatorsDeleteTest, DetectDirtyWrite) {
   EXPECT_TABLE_EQ_UNORDERED(validate->get_output(), expected_result->get_output());
 }
 
+TEST_F(OperatorsDeleteTest, EmptyDelete) {
+  auto tx_context = TransactionManager::get().new_transaction_context();
+
+  auto table_scan = create_table_scan(_gt, ColumnID{0}, PredicateCondition::Equals, "112233");
+
+  table_scan->execute();
+
+  EXPECT_EQ(table_scan->get_output()->chunk_count(), 0u);
+
+  auto delete_op = std::make_shared<Delete>(_table_name, table_scan);
+  delete_op->set_transaction_context(tx_context);
+
+  delete_op->execute();
+
+  EXPECT_FALSE(delete_op->execute_failed());
+
+  // MVCC commit.
+  tx_context->commit();
+
+  // Get validated table which should be the original one
+  auto t_context = TransactionManager::get().new_transaction_context();
+  auto validate = std::make_shared<Validate>(_gt);
+  validate->set_transaction_context(t_context);
+
+  validate->execute();
+
+  EXPECT_TABLE_EQ_UNORDERED(validate->get_output(), _gt->get_output());
+}
+
 TEST_F(OperatorsDeleteTest, UpdateAfterDeleteFails) {
   auto t1_context = TransactionManager::get().new_transaction_context();
   auto t2_context = TransactionManager::get().new_transaction_context();

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -138,7 +138,7 @@ TEST_F(OperatorsDeleteTest, DetectDirtyWrite) {
 }
 
 TEST_F(OperatorsDeleteTest, EmptyDelete) {
-  auto tx_context = TransactionManager::get().new_transaction_context();
+  auto tx_context_modification = TransactionManager::get().new_transaction_context();
 
   auto table_scan = create_table_scan(_gt, ColumnID{0}, PredicateCondition::Equals, "112233");
 
@@ -147,19 +147,19 @@ TEST_F(OperatorsDeleteTest, EmptyDelete) {
   EXPECT_EQ(table_scan->get_output()->chunk_count(), 0u);
 
   auto delete_op = std::make_shared<Delete>(_table_name, table_scan);
-  delete_op->set_transaction_context(tx_context);
+  delete_op->set_transaction_context(tx_context_modification);
 
   delete_op->execute();
 
   EXPECT_FALSE(delete_op->execute_failed());
 
   // MVCC commit.
-  tx_context->commit();
+  tx_context_modification->commit();
 
   // Get validated table which should be the original one
-  auto t_context = TransactionManager::get().new_transaction_context();
+  auto tx_context_verification = TransactionManager::get().new_transaction_context();
   auto validate = std::make_shared<Validate>(_gt);
-  validate->set_transaction_context(t_context);
+  validate->set_transaction_context(tx_context_verification);
 
   validate->execute();
 

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_queries.sql
@@ -166,6 +166,7 @@ DELETE FROM id_int_int_int_100; INSERT INTO id_int_int_int_100 VALUES (1, 2, 3, 
 DELETE FROM id_int_int_int_100 WHERE id > 75; SELECT * FROM id_int_int_int_100;
 DELETE FROM id_int_int_int_100 WHERE a > 40 OR b < 20; SELECT * FROM id_int_int_int_100;
 DELETE FROM id_int_int_int_100 WHERE a > 40 OR b < 20; SELECT * FROM id_int_int_int_100;
+DELETE FROM id_int_int_int_100 WHERE a > 9000; SELECT * FROM id_int_int_int_100;
 DELETE FROM id_int_int_int_100 WHERE a = 5 OR b = 6 OR (a > 2 AND b > 80) OR (a = (SELECT MIN(a) FROM id_int_int_int_100)); SELECT * FROM id_int_int_int_100;
 
 -- Update


### PR DESCRIPTION
Zis is German database. We do not tolerate lazyness. Every operator muzt be productive.

However, `Delete` did not work if there was nothing to delete. That should not happen, either.