### PR TITLE
Improve testing, handle isNull, and improve between pruning.

### DIFF
--- a/src/lib/statistics/chunk_statistics/min_max_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/min_max_filter.hpp
@@ -18,7 +18,13 @@ class MinMaxFilter : public AbstractFilter {
 
   bool can_prune(const PredicateCondition predicate_type, const AllTypeVariant& variant_value,
                  const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override {
+    // Early exit for NULL variants.
+    if (variant_is_null(variant_value)) {
+      return false;
+    }
+
     const auto value = type_cast_variant<T>(variant_value);
+
     // Operators work as follows: value_from_table <operator> value
     // e.g. OpGreaterThan: value_from_table > value
     // thus we can exclude chunk if value >= _max since then no value from the table can be greater than value

--- a/src/lib/statistics/chunk_statistics/range_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/range_filter.hpp
@@ -71,10 +71,10 @@ class RangeFilter : public AbstractFilter {
         return _ranges.size() == 1 && _ranges.front().first == value && _ranges.front().second == value;
       }
       case PredicateCondition::Between: {
-        /* There are two scenarios, where a between predicate can be pruned:
+        /* There are two scenarios where a between predicate can be pruned:
          *    - both bounds are "outside" (not spanning) the segment's value range (i.e., either both are smaller than
          *      the minimum or both are larger than the maximum
-         *    - both bounds are the same gap
+         *    - both bounds are within the same gap
          */
 
         Assert(static_cast<bool>(variant_value2), "Between operator needs two values.");
@@ -91,12 +91,9 @@ class RangeFilter : public AbstractFilter {
         }
 
         // Get value range or next larger value range if searched value is in a gap.
-        auto start_lower = std::lower_bound(
-            std::begin(_ranges), std::end(_ranges), value,
-            [](std::pair<T, T> range, T compare_value) -> bool { return range.second < compare_value; });
-        auto end_lower = std::lower_bound(
-            std::begin(_ranges), std::end(_ranges), value2,
-            [](std::pair<T, T> range, T compare_value) -> bool { return range.second < compare_value; });
+        const auto range_comp = [](std::pair<T, T> range, T compare_value) -> bool { return range.second < compare_value; };
+        const auto start_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value, range_comp);
+        const auto end_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value2, range_comp);
 
         const bool start_in_value_range = (*start_lower).first <= value && value <= (*start_lower).second;
         const bool end_in_value_range =

--- a/src/lib/statistics/chunk_statistics/range_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/range_filter.hpp
@@ -90,8 +90,10 @@ class RangeFilter : public AbstractFilter {
           return true;
         }
 
+        const auto range_comp = [](std::pair<T, T> range, T compare_value) -> bool {
+          return range.second < compare_value;
+        };
         // Get value range or next larger value range if searched value is in a gap.
-        const auto range_comp = [](std::pair<T, T> range, T compare_value) -> bool { return range.second < compare_value; };
         const auto start_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value, range_comp);
         const auto end_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value2, range_comp);
 

--- a/src/lib/statistics/chunk_statistics/range_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/range_filter.hpp
@@ -31,6 +31,11 @@ class RangeFilter : public AbstractFilter {
 
   bool can_prune(const PredicateCondition predicate_type, const AllTypeVariant& variant_value,
                  const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override {
+    // Early exit for NULL variants.
+    if (variant_is_null(variant_value)) {
+      return false;
+    }
+
     const auto value = type_cast_variant<T>(variant_value);
     // Operators work as follows: value_from_table <operator> value
     // e.g. OpGreaterThan: value_from_table > value
@@ -66,9 +71,43 @@ class RangeFilter : public AbstractFilter {
         return _ranges.size() == 1 && _ranges.front().first == value && _ranges.front().second == value;
       }
       case PredicateCondition::Between: {
+        /* There are two scenarios, where a between predicate can be pruned:
+         *    - both bounds are "outside" (not spanning) the segment's value range (i.e., either both are smaller than
+         *      the minimum or both are larger than the maximum
+         *    - both bounds are the same gap
+         */
+
         Assert(static_cast<bool>(variant_value2), "Between operator needs two values.");
         const auto value2 = type_cast_variant<T>(*variant_value2);
-        return value > _ranges.back().second || value2 < _ranges.front().first;
+
+        // Smaller than the segment's minimum.
+        if (can_prune(PredicateCondition::LessThanEquals, std::max(value, value2))) {
+          return true;
+        }
+
+        // Larger than the segment's maximum.
+        if (can_prune(PredicateCondition::GreaterThanEquals, std::min(value, value2))) {
+          return true;
+        }
+
+        // Get value range or next larger value range if searched value is in a gap.
+        auto start_lower = std::lower_bound(
+            std::begin(_ranges), std::end(_ranges), value,
+            [](std::pair<T, T> range, T compare_value) -> bool { return range.second < compare_value; });
+        auto end_lower = std::lower_bound(
+            std::begin(_ranges), std::end(_ranges), value2,
+            [](std::pair<T, T> range, T compare_value) -> bool { return range.second < compare_value; });
+
+        const bool start_in_value_range = (*start_lower).first <= value && value <= (*start_lower).second;
+        const bool end_in_value_range =
+            (end_lower == std::end(_ranges)) && (*end_lower).first <= value2 && value2 <= (*end_lower).second;
+
+        // Check if both bounds are within the same gap.
+        if (!start_in_value_range && !end_in_value_range && start_lower == end_lower) {
+          return true;
+        }
+
+        return false;
       }
       default:
         return false;

--- a/src/lib/statistics/chunk_statistics/range_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/range_filter.hpp
@@ -97,9 +97,10 @@ class RangeFilter : public AbstractFilter {
         const auto start_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value, range_comp);
         const auto end_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value2, range_comp);
 
-        const bool start_in_value_range = (*start_lower).first <= value && value <= (*start_lower).second;
+        const bool start_in_value_range =
+            (start_lower != std::end(_ranges)) && (*start_lower).first <= value && value <= (*start_lower).second;
         const bool end_in_value_range =
-            (end_lower == std::end(_ranges)) && (*end_lower).first <= value2 && value2 <= (*end_lower).second;
+            (end_lower != std::end(_ranges)) && (*end_lower).first <= value2 && value2 <= (*end_lower).second;
 
         // Check if both bounds are within the same gap.
         if (!start_in_value_range && !end_in_value_range && start_lower == end_lower) {

--- a/src/lib/statistics/chunk_statistics/range_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/range_filter.hpp
@@ -94,13 +94,13 @@ class RangeFilter : public AbstractFilter {
           return range.second < compare_value;
         };
         // Get value range or next larger value range if searched value is in a gap.
-        const auto start_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value, range_comp);
-        const auto end_lower = std::lower_bound(std::begin(_ranges), std::end(_ranges), value2, range_comp);
+        const auto start_lower = std::lower_bound(_ranges.cbegin(), _ranges.cend(), value, range_comp);
+        const auto end_lower = std::lower_bound(_ranges.cbegin(), _ranges.cend(), value2, range_comp);
 
         const bool start_in_value_range =
-            (start_lower != std::end(_ranges)) && (*start_lower).first <= value && value <= (*start_lower).second;
+            (start_lower != _ranges.cend()) && (*start_lower).first <= value && value <= (*start_lower).second;
         const bool end_in_value_range =
-            (end_lower != std::end(_ranges)) && (*end_lower).first <= value2 && value2 <= (*end_lower).second;
+            (end_lower != _ranges.cend()) && (*end_lower).first <= value2 && value2 <= (*end_lower).second;
 
         // Check if both bounds are within the same gap.
         if (!start_in_value_range && !end_in_value_range && start_lower == end_lower) {

--- a/src/test/statistics/chunk_statistics/min_max_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/min_max_filter_test.cpp
@@ -90,7 +90,12 @@ TYPED_TEST(MinMaxFilterTest, CanPruneOnBounds) {
   EXPECT_TRUE(filter->can_prune(PredicateCondition::GreaterThan, {this->_after_range}));
 
   // as null values are not comparable, we never prune them
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, NULL_VALUE));
   EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, {this->_in_between}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, {this->_min_value}, {this->_in_between}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, NULL_VALUE));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, {this->_in_between}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, {this->_min_value}, {this->_in_between}));
 }
 
 }  // namespace opossum

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -180,6 +180,11 @@ TYPED_TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
   EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, {17}));
   EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, NULL_VALUE));
   EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, NULL_VALUE));
+
+  // For the default filter, the following value is prunable.
+  EXPECT_TRUE(filter->can_prune(PredicateCondition::Equals, {this->_in_between}));
+  // But malformed predicates are skipped intentially and are thus not prunable
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Equals, {this->_in_between}, NULL_VALUE));
 }
 
 // this test checks the correct pruning on the bounds (min/max) of the test data for various predicate conditions

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -228,7 +228,7 @@ TYPED_TEST(RangeFilterTest, Between) {
 
   // This one has bounds in gaps, but cannot prune.
   EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {this->_max_value - 1}, {this->_after_range}));
-  
+
   EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {-3000}, {-2000}));
   EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {-999}, {1}));
   EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {104}, {1004}));

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -167,7 +167,7 @@ TYPED_TEST(RangeFilterTest, MoreRangesThanValues) {
   EXPECT_TRUE(filter->can_prune(PredicateCondition::GreaterThan, {this->_max_value}));
 }
 
-// create more ranges than distinct values in the test data
+// Test predicates which are not supported by the range filter
 TYPED_TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
   const auto filter = RangeFilter<TypeParam>::build_filter(this->_values);
 

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -167,6 +167,21 @@ TYPED_TEST(RangeFilterTest, MoreRangesThanValues) {
   EXPECT_TRUE(filter->can_prune(PredicateCondition::GreaterThan, {this->_max_value}));
 }
 
+// create more ranges than distinct values in the test data
+TYPED_TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
+  const auto filter = RangeFilter<TypeParam>::build_filter(this->_values, 5);
+
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Like, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::NotLike, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::In, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::NotIn, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, {17}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, NULL_VALUE));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNotNull, NULL_VALUE));
+}
+
 // this test checks the correct pruning on the bounds (min/max) of the test data for various predicate conditions
 // for better understanding, see min_max_filter_test.cpp
 TYPED_TEST(RangeFilterTest, CanPruneOnBounds) {
@@ -205,6 +220,26 @@ TYPED_TEST(RangeFilterTest, CanPruneOnBounds) {
   EXPECT_FALSE(filter->can_prune(PredicateCondition::GreaterThan, {this->_in_between}));
   EXPECT_TRUE(filter->can_prune(PredicateCondition::GreaterThan, {this->_max_value}));
   EXPECT_TRUE(filter->can_prune(PredicateCondition::GreaterThan, {this->_after_range}));
+}
+
+// Test larger value ranges.
+TYPED_TEST(RangeFilterTest, Between) {
+  const auto filter = RangeFilter<TypeParam>::build_filter(this->_values);
+
+  // This one has bounds in gaps, but cannot prune.
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {this->_max_value - 1}, {this->_after_range}));
+  
+  EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {-3000}, {-2000}));
+  EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {-999}, {1}));
+  EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {104}, {1004}));
+  EXPECT_TRUE(filter->can_prune(PredicateCondition::Between, {10'000'000}, {20'000'000}));
+
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {-3000}, {-500}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {101}, {103}));
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {102}, {1004}));
+
+  // SQL between in inclusive
+  EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {103}, {123456}));
 }
 
 // Test larger value ranges.

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -169,7 +169,7 @@ TYPED_TEST(RangeFilterTest, MoreRangesThanValues) {
 
 // create more ranges than distinct values in the test data
 TYPED_TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
-  const auto filter = RangeFilter<TypeParam>::build_filter(this->_values, 5);
+  const auto filter = RangeFilter<TypeParam>::build_filter(this->_values);
 
   EXPECT_FALSE(filter->can_prune(PredicateCondition::IsNull, {17}));
   EXPECT_FALSE(filter->can_prune(PredicateCondition::Like, {17}));

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -238,7 +238,7 @@ TYPED_TEST(RangeFilterTest, Between) {
   EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {101}, {103}));
   EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {102}, {1004}));
 
-  // SQL between in inclusive
+  // SQL's between is inclusive
   EXPECT_FALSE(filter->can_prune(PredicateCondition::Between, {103}, {123456}));
 }
 


### PR DESCRIPTION
Fixes #1324.

Thing done:
 * Add tests for unsupported predicates. They have been skipped before and returned false, which is fine, but NULL_VALUE parameters have not been handled (which can occur when the predicate is isNull). In these cases, the method crashed as it could not convert the value.
 * To fix the error, NULL parameters are now checked and return false directly.
 * Add tests for between and improve between pruning, which only pruned a few cases before.