### PR TITLE
Remove build-essential from install script, dependencies and docker

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -2,7 +2,6 @@
 
 | Name             | Version          | Platform |                              Optional |
 | ---------------- | ---------------- | -------- | ------------------------------------- |
-| build-essential  | any              |    Linux |                                    No |
 | boost            | >= 1.65.0        |    All   |                                    No |
 | clang            | 6                |    All   |                 Yes, if gcc installed |
 | clang-format     | 6.0 / 2018-01-11 |    All   |                      Yes (formatting) |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
     && apt-get install -y \
         bash-completion \
-        build-essential \
         bc \
         ccache \
         clang-6.0 \

--- a/install.sh
+++ b/install.sh
@@ -54,7 +54,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
                 boostall=$(apt-cache search --names-only '^libboost1.[0-9]+-all-dev$' | sort | tail -n 1 | cut -f1 -d' ')
-                sudo apt-get install --no-install-recommends -y clang-6.0 libclang-6.0-dev clang-tidy-6.0 clang-format-6.0 gcovr python2.7 gcc-8 g++-8 llvm llvm-6.0-tools libnuma-dev libnuma1 libtbb-dev build-essential cmake libreadline-dev libncurses5-dev libsqlite3-dev parallel $boostall libpq-dev systemtap systemtap-sdt-dev &
+                sudo apt-get install --no-install-recommends -y clang-6.0 libclang-6.0-dev clang-tidy-6.0 clang-format-6.0 gcovr python2.7 gcc-8 g++-8 llvm llvm-6.0-tools libnuma-dev libnuma1 libtbb-dev cmake libreadline-dev libncurses5-dev libsqlite3-dev parallel $boostall libpq-dev systemtap systemtap-sdt-dev &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during installation."


### PR DESCRIPTION
Build-essential does depend on gcc-7 which is then unnecessary installed because our scripts install gcc-8 anyways.

I removed build-essential from the install script on a fresh Ubuntu 18.04 image. Either we do not need any of the packages or Ubuntu 18.04 comes with them anyway.

I believe we had to add build-essential for lib tool or something similar to be able to build a former external dependency.