### PR TITLE
Skip SchedulerTest.VerifyTaskQueueSetup on low core count

### DIFF
--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -215,6 +215,9 @@ TEST_F(SchedulerTest, MultipleOperators) {
 
 TEST_F(SchedulerTest, VerifyTaskQueueSetup) {
   if (std::thread::hardware_concurrency() < 4) {
+    // If the machine has less than 4 cores, the calls to use_non_numa_topology()
+    // below will implicitly reduce the worker count to the number of cores,
+    // therefore failing the assertions.
     GTEST_SKIP();
   }
   Topology::use_non_numa_topology(4);


### PR DESCRIPTION
As discussed in https://github.com/hyrise/hyrise/pull/1342 and https://github.com/hyrise/hyrise/pull/1339.