### PR TITLE
Change hashing in Counting Quotient Filters

### DIFF
--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,10 +1,31 @@
 #include <iostream>
+#include <bitset>
 
 #include "types.hpp"
 
 using namespace opossum;  // NOLINT
 
+template <typename T>
+void hashish(T value) {
+	size_t hash = std::hash<T>{}(value);
+	size_t new_hash = (std::hash<T>{}(value) * 11400714819323198485llu) >> 32;
+	std::cout << value << " >> " << std::bitset<64>(hash) << " -- " << std::bitset<64>(new_hash) << std::endl;
+}
+
 int main() {
-  std::cout << "Hello world!!" << std::endl;
+  hashish(1.2f);
+  hashish(12.0f);
+  hashish(120.0f);
+  hashish(1200000000.0f);
+
+  hashish(1.2);
+  hashish(12.0);
+  hashish(120.0);
+  hashish(1200000000.0);
+
+  hashish(1);
+  hashish(12);
+  hashish(120);
+  hashish(1200000000);
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <bitset>
 
+#include <boost/functional/hash.hpp>
+
 #include "statistics/chunk_statistics/counting_quotient_filter.hpp"
 
 #include "types.hpp"
@@ -10,9 +12,11 @@ using namespace opossum;  // NOLINT
 template <typename T>
 void hashish(T value) {
 	size_t hash = std::hash<T>{}(value);
-	size_t fibo = (std::hash<T>{}(value) * 11400714819323198485llu);
-	size_t fibo2 = CountingQuotientFilter<T>::get_hash_bits(static_cast<T>(value), 64);
-	std::cout << value << " >>\n\t\t" << std::bitset<64>(hash) << "\n\t\t" << std::bitset<64>(fibo) << "\n\t\t" << std::bitset<64>(fibo2) << std::endl << std::endl;
+	// size_t fibo = (std::hash<T>{}(value) * 11400714819323198485llu);
+	// size_t fibo2 = CountingQuotientFilter<T>::get_hash_bits(static_cast<T>(value), 64);
+	// std::cout << value << " >>\n\t\t" << std::bitset<64>(hash) << "\n\t\t" << std::bitset<64>(fibo) << "\n\t\t" << std::bitset<64>(fibo2) << std::endl << std::endl;
+	std::cout << value << " >>\t" << std::bitset<64>(hash) << " and boost: " << std::bitset<64>(boost::hash_value(value)) << std::endl;
+
 }
 
 int main() {

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <bitset>
 
+#include "statistics/chunk_statistics/counting_quotient_filter.hpp"
+
 #include "types.hpp"
 
 using namespace opossum;  // NOLINT
@@ -8,24 +10,32 @@ using namespace opossum;  // NOLINT
 template <typename T>
 void hashish(T value) {
 	size_t hash = std::hash<T>{}(value);
-	size_t new_hash = (std::hash<T>{}(value) * 11400714819323198485llu) >> 32;
-	std::cout << value << " >> " << std::bitset<64>(hash) << " -- " << std::bitset<64>(new_hash) << std::endl;
+	size_t fibo = (std::hash<T>{}(value) * 11400714819323198485llu);
+	size_t fibo2 = CountingQuotientFilter<T>::get_hash_bits(static_cast<T>(value), 64);
+	std::cout << value << " >>\n\t\t" << std::bitset<64>(hash) << "\n\t\t" << std::bitset<64>(fibo) << "\n\t\t" << std::bitset<64>(fibo2) << std::endl << std::endl;
 }
 
 int main() {
+  std::cout << "Floats" << std::endl;
   hashish(1.2f);
   hashish(12.0f);
   hashish(120.0f);
+  hashish(123.0f);
   hashish(1200000000.0f);
 
+  std::cout << "Doubles" << std::endl;
   hashish(1.2);
   hashish(12.0);
   hashish(120.0);
+  hashish(123.0);
   hashish(1200000000.0);
 
+  std::cout << "Integers" << std::endl;
   hashish(1);
   hashish(12);
   hashish(120);
+  hashish(123);
   hashish(1200000000);
+
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,45 +1,10 @@
 #include <iostream>
-#include <bitset>
-
-#include <boost/functional/hash.hpp>
-
-#include "statistics/chunk_statistics/counting_quotient_filter.hpp"
 
 #include "types.hpp"
 
 using namespace opossum;  // NOLINT
 
-template <typename T>
-void hashish(T value) {
-	size_t hash = std::hash<T>{}(value);
-	// size_t fibo = (std::hash<T>{}(value) * 11400714819323198485llu);
-	// size_t fibo2 = CountingQuotientFilter<T>::get_hash_bits(static_cast<T>(value), 64);
-	// std::cout << value << " >>\n\t\t" << std::bitset<64>(hash) << "\n\t\t" << std::bitset<64>(fibo) << "\n\t\t" << std::bitset<64>(fibo2) << std::endl << std::endl;
-	std::cout << value << " >>\t" << std::bitset<64>(hash) << " and boost: " << std::bitset<64>(boost::hash_value(value)) << std::endl;
-
-}
-
 int main() {
-  std::cout << "Floats" << std::endl;
-  hashish(1.2f);
-  hashish(12.0f);
-  hashish(120.0f);
-  hashish(123.0f);
-  hashish(1200000000.0f);
-
-  std::cout << "Doubles" << std::endl;
-  hashish(1.2);
-  hashish(12.0);
-  hashish(120.0);
-  hashish(123.0);
-  hashish(1200000000.0);
-
-  std::cout << "Integers" << std::endl;
-  hashish(1);
-  hashish(12);
-  hashish(120);
-  hashish(123);
-  hashish(1200000000);
-
+  std::cout << "Hello world!!" << std::endl;
   return 0;
 }

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
@@ -81,16 +81,12 @@ inline __attribute__((always_inline)) uint64_t CountingQuotientFilter<ElementTyp
   /*
    * Counting Quotient Filters use variable length hash values to build their internal data structures.
    * These can be as low 6 bits. Hence, it has to be ensured that the lower bits include enough entropy.
-   * As a consequence, fibonacci hashing is applied and the most significant bits are returned.
+   * Using std::hash and the least significant bits can lead to ineffective pruning and bad cardality
+   * estimations. As a consequence, fibonacci hashing is applied and the most significant bits are returned
    *      https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-
    *      that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
    */
-  if constexpr (std::is_floating_point<ElementType>::value) {
-    const auto new_value = value * static_cast<ElementType>(1.0000304000000123);
-    return static_cast<uint64_t>((std::hash<ElementType>{}(new_value) * 11400714819323198485llu) >> (64 - bit_count));
-  } else {
-    return static_cast<uint64_t>((std::hash<ElementType>{}(value) * 11400714819323198485llu) >> (64 - bit_count));
-  }
+  return static_cast<uint64_t>((std::hash<ElementType>{}(value) * 11400714819323198485llu) >> (64 - bit_count));
 }
 
 template <typename ElementType>

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
@@ -35,7 +35,7 @@ CountingQuotientFilter<ElementType>::CountingQuotientFilter(const size_t quotien
   } else if (remainder_size == 32) {
     _quotient_filter = gqf32::quotient_filter{};
   } else {
-    Fail("Invalid remainder remainder_size");
+    Fail("Invalid remainder_size");
   }
 
   const auto number_of_slots = static_cast<size_t>(std::pow(2, quotient_size));

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
@@ -82,9 +82,11 @@ inline __attribute__((always_inline)) uint64_t CountingQuotientFilter<ElementTyp
    * Counting Quotient Filters use variable length hash values to build their internal data structures.
    * These can be as low 6 bits. Hence, it has to be ensured that the lower bits include enough entropy.
    * Using std::hash and the least significant bits can lead to ineffective pruning and bad cardality
-   * estimations. As a consequence, fibonacci hashing is applied and the most significant bits are returned
-   *      https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-
-   *      that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
+   * estimations. As a consequence, we use multiply-shift (cf. Richter et al., A Seven-Dimensional
+   * Analysis of Hashing Methods and its Implications on Query Processing, PVLDB 2015) to generate
+   * fast but sufficiently scrambled hashes (here in form of fibonacci hashing, cf.
+   * https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-
+   * that-the-world-forgot-or-a-better-alternative-to-integer-modulo/)
    */
   return static_cast<uint64_t>((std::hash<ElementType>{}(value) * 11400714819323198485llu) >> (64 - bit_count));
 }

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
@@ -77,7 +77,8 @@ size_t CountingQuotientFilter<ElementType>::count(const ElementType& value) cons
 }
 
 template <typename ElementType>
-inline __attribute__((always_inline)) uint64_t CountingQuotientFilter<ElementType>::get_hash_bits(const ElementType& value, const uint64_t bit_count) {
+inline __attribute__((always_inline)) uint64_t CountingQuotientFilter<ElementType>::get_hash_bits(
+    const ElementType& value, const uint64_t bit_count) {
   /*
    * Counting Quotient Filters use variable length hash values to build their internal data structures.
    * These can be as low 6 bits. Hence, it has to be ensured that the lower bits include enough entropy.
@@ -88,7 +89,7 @@ inline __attribute__((always_inline)) uint64_t CountingQuotientFilter<ElementTyp
    * https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-
    * that-the-world-forgot-or-a-better-alternative-to-integer-modulo/)
    */
-  return static_cast<uint64_t>((std::hash<ElementType>{}(value) * 11400714819323198485llu) >> (64 - bit_count));
+  return static_cast<uint64_t>((std::hash<ElementType>{}(value)*11400714819323198485llu) >> (64 - bit_count));
 }
 
 template <typename ElementType>

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.cpp
@@ -79,18 +79,16 @@ size_t CountingQuotientFilter<ElementType>::count(const ElementType& value) cons
 template <typename ElementType>
 inline __attribute__((always_inline)) uint64_t CountingQuotientFilter<ElementType>::get_hash_bits(const ElementType& value, const uint64_t bit_count) {
   /*
-   *  Counting Quotient Filters use variable length hash values to build their internal data structures.
-   *  These can be as low 8 bit. Hence, it has to be ensured that the lower bits include enough
-   *  entropy. For integers                                                                                                                 TODO
-   *
-   *  For non-integral types (e.g., floats), use simplified fibonacci hashing:
+   * Counting Quotient Filters use variable length hash values to build their internal data structures.
+   * These can be as low 6 bits. Hence, it has to be ensured that the lower bits include enough entropy.
+   * As a consequence, fibonacci hashing is applied and the most significant bits are returned.
    *      https://probablydance.com/2018/06/16/fibonacci-hashing-the-optimization-
    *      that-the-world-forgot-or-a-better-alternative-to-integer-modulo/
    */
-  if constexpr (std::is_integral<ElementType>::value) {
-    return static_cast<uint64_t>(std::hash<ElementType>{}(value) % static_cast<ElementType>(std::pow(2, bit_count)));
+  if constexpr (std::is_floating_point<ElementType>::value) {
+    const auto new_value = value * static_cast<ElementType>(1.0000304000000123);
+    return static_cast<uint64_t>((std::hash<ElementType>{}(new_value) * 11400714819323198485llu) >> (64 - bit_count));
   } else {
-    // return static_cast<uint64_t>((std::hash<ElementType>{}(value) * 11400714819323198485llu) % bit_count);
     return static_cast<uint64_t>((std::hash<ElementType>{}(value) * 11400714819323198485llu) >> (64 - bit_count));
   }
 }

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
@@ -52,9 +52,9 @@ class CountingQuotientFilter : public AbstractFilter, public Noncopyable {
                  const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   /**
-   * Calculate hash of value and shift the value to
+   * Calculate hash of value and return requested number of bits.
    * @param value       value to hash
-   * @param bit_mask    the bit mask for modulo remainer calculation of 64bit hash
+   * @param bit_count   the number of bits requested
    *
    * @return            The least significant bit-count bits of the hashed value (if bit_count < sizeof(size_t),
    *                    the most significant bits are zero padded).

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
@@ -68,7 +68,6 @@ class CountingQuotientFilter : public AbstractFilter, public Noncopyable {
   CountingQuotientFilter operator=(CountingQuotientFilter&&) = delete;
 
  private:
-
   boost::variant<gqf2::QF, gqf4::QF, gqf8::QF, gqf16::QF, gqf32::QF> _quotient_filter;
   const size_t _hash_bits;
 };

--- a/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
+++ b/src/lib/statistics/chunk_statistics/counting_quotient_filter.hpp
@@ -51,6 +51,16 @@ class CountingQuotientFilter : public AbstractFilter, public Noncopyable {
   bool can_prune(const PredicateCondition predicate_type, const AllTypeVariant& value,
                  const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
+  /**
+   * Calculate hash of value and shift the value to
+   * @param value       value to hash
+   * @param bit_mask    the bit mask for modulo remainer calculation of 64bit hash
+   *
+   * @return            The least significant bit-count bits of the hashed value (if bit_count < sizeof(size_t),
+   *                    the most significant bits are zero padded).
+   */
+  static uint64_t get_hash_bits(const ElementType& value, const uint64_t bit_count);
+
   // Can't copy CountingQuotientFilter
   CountingQuotientFilter(CountingQuotientFilter&) = delete;
   CountingQuotientFilter(CountingQuotientFilter&&) = delete;
@@ -58,7 +68,6 @@ class CountingQuotientFilter : public AbstractFilter, public Noncopyable {
   CountingQuotientFilter operator=(CountingQuotientFilter&&) = delete;
 
  private:
-  size_t _hash(const ElementType& value) const;
 
   boost::variant<gqf2::QF, gqf4::QF, gqf8::QF, gqf16::QF, gqf32::QF> _quotient_filter;
   const size_t _hash_bits;

--- a/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
@@ -67,6 +67,12 @@ template <>
 double get_test_value<double>(size_t run) {
   return static_cast<double>(123457.0 + run);
 }
+
+// template<typename T, typename T2 = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+// T get_test_value<T>(size_t run) {
+//   return static_cast<T>(T{123457} + run);
+// }
+
 template <>
 std::string get_test_value<std::string>(size_t run) {
   return std::string("test_value") + std::to_string(run);
@@ -159,7 +165,7 @@ TYPED_TEST(CountingQuotientFilterTest, CanNotPrune) {
  * sanity checking, making sure the FPR is below a very lenient threshold. If these tests fail it is very likely,
  * however not absolutely certain, that there is a bug in the CQF.
  */
-TYPED_TEST(CountingQuotientFilterTest, DISABLED_FalsePositiveRate /* #1220 */) {
+TYPED_TEST(CountingQuotientFilterTest, FalsePositiveRate) {
   this->test_false_positive_rate(this->cqf2);
   this->test_false_positive_rate(this->cqf4);
   this->test_false_positive_rate(this->cqf8);

--- a/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
@@ -1,9 +1,9 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 #include <utility>
-#include <type_traits>
 #include <vector>
 
 #include "base_test.hpp"
@@ -133,7 +133,7 @@ class CountingQuotientFilterTest : public BaseTest {
     }
     const auto false_positive_rate = false_positives / static_cast<float>(runs);
     std::cout << "achieved " << false_positive_rate << std::endl;
-    EXPECT_TRUE(false_positive_rate < 0.4f);
+    EXPECT_LT(false_positive_rate, 0.4f);
   }
 };
 
@@ -174,15 +174,16 @@ TYPED_TEST(CountingQuotientFilterTest, HashBits) {
   for (auto bit_count : {8, 16, 32, 64}) {
     if constexpr (std::is_arithmetic<TypeParam>::value) {
       for (auto numeric_value : {-28.938, -0.0, 0.0, 17.1717, 32'323'323.323323}) {
-        const auto return_value = CountingQuotientFilter<TypeParam>::get_hash_bits(static_cast<TypeParam>(numeric_value), bit_count);
-        EXPECT_TRUE(return_value >= 0);
-        EXPECT_TRUE(return_value < std::pow(2, bit_count));
+        const auto return_value =
+            CountingQuotientFilter<TypeParam>::get_hash_bits(static_cast<TypeParam>(numeric_value), bit_count);
+        EXPECT_GE(return_value, 0);
+        EXPECT_LT(return_value, std::pow(2, bit_count));
       }
     } else {
       for (auto& string_value : {"alpha", "beta", "charlie", "zeier"}) {
         const auto return_value = CountingQuotientFilter<TypeParam>::get_hash_bits(string_value, bit_count);
-        EXPECT_TRUE(return_value >= 0);
-        EXPECT_TRUE(return_value < std::pow(2, bit_count));
+        EXPECT_GE(return_value, 0);
+        EXPECT_LT(return_value, std::pow(2, bit_count));
       }
     }
   }

--- a/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/counting_quotient_filter_test.cpp
@@ -132,6 +132,7 @@ class CountingQuotientFilterTest : public BaseTest {
       }
     }
     const auto false_positive_rate = false_positives / static_cast<float>(runs);
+    std::cout << "achieved " << false_positive_rate << std::endl;
     EXPECT_TRUE(false_positive_rate < 0.4f);
   }
 };
@@ -168,19 +169,7 @@ TYPED_TEST(CountingQuotientFilterTest, FalsePositiveRate) {
   this->test_false_positive_rate(this->cqf32);
 }
 
-TYPED_TEST(CountingQuotientFilterTest, StaticHashBits) {
-  if constexpr (!std::is_same<TypeParam, int>::value) {
-    GTEST_SKIP();
-  }
-
-  // Test for integers whether simple values are handled as expected (i.e.,
-  // identity funkcion for integers) and whether they are correctly modulo'ed.
-  EXPECT_EQ(CountingQuotientFilter<int>::get_hash_bits(17, 8), 17);
-  EXPECT_EQ(CountingQuotientFilter<int>::get_hash_bits(17, 16), 17);
-  EXPECT_EQ(CountingQuotientFilter<int>::get_hash_bits(17, 32), 17);
-  EXPECT_EQ(CountingQuotientFilter<int>::get_hash_bits(267, 8), 11);
-}
-
+// Testing the get_hash_bits functions which is used in the CQF.
 TYPED_TEST(CountingQuotientFilterTest, HashBits) {
   for (auto bit_count : {8, 16, 32, 64}) {
     if constexpr (std::is_arithmetic<TypeParam>::value) {


### PR DESCRIPTION
Fixes #1220.

This PR changes the way we hash values for the counting quotient filters. A multiply-shift hashing is used to be more resilient to identity hashing functions as used by boost::hash and std::hash (on MacOS at least).