### PR TITLE
Change worker sleep time from 10ms to exponential backoff.

### DIFF
--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -17,7 +17,7 @@
 
 namespace {
 
-static constexpr auto MAX_SLEEP_TIME_NS = std::chrono::nanoseconds{10000000};  // 10 milliseconds
+static constexpr auto MAX_SLEEP_TIME_NS = std::chrono::nanoseconds{10'000'000};  // 10 milliseconds
 
 /**
  * On worker threads, this references the Worker running on this thread, on all other threads, this is empty.

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -17,7 +17,7 @@
 
 namespace {
 
-static const auto MAX_SLEEP_TIME_NS = uint32_t{10000000};  // 10 ms
+static constexpr auto MAX_SLEEP_TIME_NS = std::chrono::nanoseconds{10000000};  // 10 milliseconds
 
 /**
  * On worker threads, this references the Worker running on this thread, on all other threads, this is empty.
@@ -73,12 +73,12 @@ void Worker::_work() {
     // Sleep if there is no ready task in our queue and work stealing was not successful.
     if (!work_stealing_successful) {
       // Exponential Backoff
-      std::this_thread::sleep_for(std::chrono::nanoseconds(_sleep_time_ns));
+      std::this_thread::sleep_for(_sleep_time_ns);
       _sleep_time_ns = std::min(MAX_SLEEP_TIME_NS, _sleep_time_ns*2);
       return;
     }
   }
-  _sleep_time_ns = 1;
+  _sleep_time_ns = std::chrono::nanoseconds{1};
 
   task->execute();
 

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -71,7 +71,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   CpuID _cpu_id;
   std::thread _thread;
   std::atomic<uint64_t> _num_finished_tasks{0};
-  uint32_t _sleep_time_ns{1};
+  std::chrono::nanoseconds _sleep_time_ns{1};
 };
 
 }  // namespace opossum

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -71,6 +71,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   CpuID _cpu_id;
   std::thread _thread;
   std::atomic<uint64_t> _num_finished_tasks{0};
+  uint32_t _sleep_time_ns{1};
 };
 
 }  // namespace opossum


### PR DESCRIPTION
Previously, workers slept for a constant 10ms when no task is available. This is quite long sometimes, especially if there are many small tasks. This PR changes that to follow an exponential backoff algorithm, starting with a sleep of 1ns, doubling every time there still is no work, with an upper limit of 10ms.

TPC-H comparison (on the current master including #1322) with 224 cores, 100 clients, sf 1:
```
+-----------+------------------+-------+------------------+-------+--------+---------------------------------+
| Benchmark | prev. iter/s     | runs  | new iter/s       | runs  | change | p-value (significant if <0.001) |
+-----------+------------------+-------+------------------+-------+--------+---------------------------------+
| TPC-H 1   | 11.2330493927002 | 674   | 11.816180229187  | 709   | +5%    |                          0.0000 |
| TPC-H 2   | 5.46587657928467 | 328   | 27.3655071258545 | 1642  | +401%  |                          0.0000 |
| TPC-H 3   | 66.1910705566406 | 3972  | 68.91650390625   | 4135  | +4%    |                          0.0242 |
| TPC-H 4   | 49.5639915466309 | 2974  | 50.8428764343262 | 3051  | +3%    |                          0.2231 |
| TPC-H 5   | 66.8958892822266 | 4014  | 66.5590744018555 | 3994  | -1%    |                          0.6094 |
| TPC-H 6   | 494.452728271484 | 10000 | 484.125305175781 | 10003 | -2%    |                          0.0000 |
| TPC-H 7   | 46.0259552001953 | 2762  | 45.8783874511719 | 2753  | -0%    |                          0.8490 |
| TPC-H 8   | 84.7737579345703 | 5087  | 88.2499542236328 | 5295  | +4%    |                          0.0710 |
| TPC-H 9   | 37.1288223266602 | 2228  | 36.931209564209  | 2216  | -1%    |                          0.6146 |
| TPC-H 10  | 69.9747924804688 | 4199  | 67.0482330322266 | 4023  | -4%    |                          0.0000 |
| TPC-H 11  | 796.446228027344 | 10004 | 1154.39624023438 | 10000 | +45%   |                          0.0000 |
| TPC-H 12  | 233.180847167969 | 10002 | 242.003021240234 | 10001 | +4%    |                          0.0000 |
| TPC-H 13  | 17.8472366333008 | 1071  | 14.8499202728271 | 891   | -17%   |                          0.0000 |
| TPC-H 14  | 606.259155273438 | 10001 | 615.093322753906 | 10001 | +1%    |                          0.0000 |
| TPC-H 16  | 45.148006439209  | 2709  | 43.2927665710449 | 2598  | -4%    |                          0.0000 |
| TPC-H 18  | 14.6326770782471 | 878   | 11.0824422836304 | 665   | -24%   |                          0.0134 |
| TPC-H 19  | 296.360687255859 | 10001 | 311.095916748047 | 10000 | +5%    |                          0.0000 |
| TPC-H 22  | 258.864624023438 | 10001 | 252.392593383789 | 10005 | -3%    |                          0.0000 |
| average   |                  |       |                  |       | +23%   |                                 |
+-----------+------------------+-------+------------------+-------+--------+---------------------------------+
```

The biggest impact is on TPC-H 2, probably because it schedules 26000 tasks per query.