### PR TITLE
Change keepRunning to range for loop

### DIFF
--- a/src/benchmark/benchmark_playground.cpp
+++ b/src/benchmark/benchmark_playground.cpp
@@ -59,7 +59,7 @@ class BenchmarkPlaygroundFixture : public MicroBenchmarkBasicFixture {
 BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::State& state) {
   // Add some benchmark-specific setup here
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     std::vector<size_t> result;
     benchmark::DoNotOptimize(result.data());  // Do not optimize out the vector
     const auto size = _vec.size();
@@ -78,7 +78,7 @@ BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_Reference)(benchmark::Stat
 BENCHMARK_F(BenchmarkPlaygroundFixture, BM_Playground_PreAllocate)(benchmark::State& state) {
   // Add some benchmark-specific setup here
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     std::vector<size_t> result;
     benchmark::DoNotOptimize(result.data());  // Do not optimize out the vector
     // pre-allocate result vector

--- a/src/benchmark/operators/aggregate_benchmark.cpp
+++ b/src/benchmark/operators/aggregate_benchmark.cpp
@@ -18,7 +18,7 @@ BENCHMARK_F(MicroBenchmarkBasicFixture, BM_Aggregate)(benchmark::State& state) {
 
   auto warm_up = std::make_shared<Aggregate>(_table_wrapper_a, aggregates, groupby);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto aggregate = std::make_shared<Aggregate>(_table_wrapper_a, aggregates, groupby);
     aggregate->execute();
   }

--- a/src/benchmark/operators/difference_benchmark.cpp
+++ b/src/benchmark/operators/difference_benchmark.cpp
@@ -13,7 +13,7 @@ BENCHMARK_F(MicroBenchmarkBasicFixture, BM_Difference)(benchmark::State& state) 
   _clear_cache();
   auto warm_up = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto difference = std::make_shared<Difference>(_table_wrapper_a, _table_wrapper_b);
     difference->execute();
   }

--- a/src/benchmark/operators/join_benchmark.cpp
+++ b/src/benchmark/operators/join_benchmark.cpp
@@ -66,7 +66,7 @@ void bm_join_impl(benchmark::State& state, std::shared_ptr<TableWrapper> table_w
       std::make_shared<C>(table_wrapper_left, table_wrapper_right, JoinMode::Inner,
                           std::pair<ColumnID, ColumnID>{ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto join =
         std::make_shared<C>(table_wrapper_left, table_wrapper_right, JoinMode::Inner,
                             std::pair<ColumnID, ColumnID>(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);

--- a/src/benchmark/operators/projection_benchmark.cpp
+++ b/src/benchmark/operators/projection_benchmark.cpp
@@ -19,7 +19,7 @@ void benchmark_projection_impl(benchmark::State& state, const std::shared_ptr<co
                                const std::vector<std::shared_ptr<AbstractExpression>>& expressions) {
   auto warm_up = std::make_shared<Projection>(in, expressions);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto projection = std::make_shared<Projection>(in, expressions);
     projection->execute();
   }

--- a/src/benchmark/operators/sort_benchmark.cpp
+++ b/src/benchmark/operators/sort_benchmark.cpp
@@ -13,7 +13,7 @@ BENCHMARK_F(MicroBenchmarkBasicFixture, BM_Sort)(benchmark::State& state) {
 
   auto warm_up = std::make_shared<Sort>(_table_wrapper_a, ColumnID{0} /* "a" */, OrderByMode::Ascending);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto sort = std::make_shared<Sort>(_table_wrapper_a, ColumnID{0} /* "a" */, OrderByMode::Ascending);
     sort->execute();
   }

--- a/src/benchmark/operators/sql_benchmark.cpp
+++ b/src/benchmark/operators/sql_benchmark.cpp
@@ -32,8 +32,8 @@ class SQLBenchmark : public MicroBenchmarkBasicFixture {
   }
 
   // Run a benchmark that compiles the given SQL query.
-  void BM_CompileQuery(benchmark::State& st) {  // NOLINT
-    while (st.KeepRunning()) {
+  void BM_CompileQuery(benchmark::State& state) {
+    for (auto _ : state) {
       SQLParserResult result;
       SQLParser::parseSQLString(query, &result);
       auto result_node = SQLTranslator{UseMvcc::No}.translate_parser_result(result)[0];
@@ -42,30 +42,30 @@ class SQLBenchmark : public MicroBenchmarkBasicFixture {
   }
 
   // Run a benchmark that only parses the given SQL query.
-  void BM_ParseQuery(benchmark::State& st) {  // NOLINT
-    while (st.KeepRunning()) {
+  void BM_ParseQuery(benchmark::State& state) {
+    for (auto _ : state) {
       SQLParserResult result;
       SQLParser::parseSQLString(query, &result);
     }
   }
 
   // Run a benchmark that only plans the given SQL query.
-  void BM_PlanQuery(benchmark::State& st) {  // NOLINT
+  void BM_PlanQuery(benchmark::State& state) {
     SQLParserResult result;
     SQLParser::parseSQLString(query, &result);
-    while (st.KeepRunning()) {
+    for (auto _ : state) {
       auto result_node = SQLTranslator{UseMvcc::No}.translate_parser_result(result)[0];
       LQPTranslator{}.translate_node(result_node);
     }
   }
 
   // Run a benchmark that plans the query operator with the given query with enabled query plan caching.
-  void BM_QueryPlanCache(benchmark::State& st) {  // NOLINT
+  void BM_QueryPlanCache(benchmark::State& state) {
     // Enable query plan cache.
     SQLPhysicalPlanCache::get().clear();
     SQLPhysicalPlanCache::get().resize(16);
 
-    while (st.KeepRunning()) {
+    for (auto _ : state) {
       auto pipeline_statement = SQLPipelineBuilder{query}.create_pipeline_statement();
       pipeline_statement.get_physical_plan();
     }

--- a/src/benchmark/operators/table_scan_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_benchmark.cpp
@@ -32,7 +32,7 @@ void benchmark_tablescan_impl(benchmark::State& state, const std::shared_ptr<con
 
   auto warm_up = std::make_shared<TableScan>(in, predicate);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto table_scan = std::make_shared<TableScan>(in, predicate);
     table_scan->execute();
   }
@@ -72,7 +72,7 @@ BENCHMARK_F(MicroBenchmarkBasicFixture, BM_TableScan_Like)(benchmark::State& sta
       {"l_comment", "%quick_y__above%even%"},
   });
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (const auto& column_name_and_pattern : column_names_and_patterns) {
       const auto column_id = lineitem_table->column_id_by_name(column_name_and_pattern.first);
       const auto column = pqp_column_(column_id, DataType::String, false, "");

--- a/src/benchmark/operators/union_all_benchmark.cpp
+++ b/src/benchmark/operators/union_all_benchmark.cpp
@@ -12,7 +12,7 @@ BENCHMARK_F(MicroBenchmarkBasicFixture, BM_UnionAll)(benchmark::State& state) {
   _clear_cache();
   auto warm_up = std::make_shared<UnionAll>(_table_wrapper_a, _table_wrapper_b);
   warm_up->execute();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto union_all = std::make_shared<UnionAll>(_table_wrapper_a, _table_wrapper_b);
     union_all->execute();
   }

--- a/src/benchmark/operators/union_positions_benchmark.cpp
+++ b/src/benchmark/operators/union_positions_benchmark.cpp
@@ -103,7 +103,7 @@ void BM_UnionPositions(::benchmark::State& state) {  // NOLINT
       std::make_shared<TableWrapper>(create_reference_table(referenced_table, num_rows, num_columns));
   table_wrapper_right->execute();
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     auto set_union = std::make_shared<UnionPositions>(table_wrapper_left, table_wrapper_right);
     set_union->execute();
   }
@@ -120,7 +120,7 @@ void BM_UnionPositionsBaseLine(::benchmark::State& state) {  // NOLINT
   auto pos_list_left = generate_pos_list(num_table_rows * 0.2f, num_table_rows);
   auto pos_list_right = generate_pos_list(num_table_rows * 0.2f, num_table_rows);
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     // Create copies, this would need to be done the UnionPositions Operator as well
     auto& left = *pos_list_left;
     auto& right = *pos_list_right;

--- a/src/benchmark/statistics/generate_table_statistics_benchmark.cpp
+++ b/src/benchmark/statistics/generate_table_statistics_benchmark.cpp
@@ -11,7 +11,7 @@ BENCHMARK_DEFINE_F(MicroBenchmarkBasicFixture, BM_GenerateTableStatistics_TPCH)(
 
   const auto tables = TpchDbGenerator{state.range(0) / 1000.0f}.generate();
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (const auto& pair : tables) {
       generate_table_statistics(*pair.second);
     }

--- a/src/benchmark/tpch_db_generator_benchmark.cpp
+++ b/src/benchmark/tpch_db_generator_benchmark.cpp
@@ -10,7 +10,7 @@ namespace opossum {
  * @param state
  */
 static void BM_TpchDbGenerator(benchmark::State& state) {  // NOLINT
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     TpchDbGenerator(0.5f, 1000).generate();
   }
 }


### PR DESCRIPTION
As recommended by Google, range for loops have a smaller overhead that the currently used while(keepRunning) loops (see https://github.com/google/benchmark#a-faster-keeprunning-loop).

This PR changes the loops accordingly.