### PR TITLE
Console: Override tables when using generate_*

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -48,8 +48,10 @@ void AbstractTableGenerator::generate_and_store() {
    * Add the Tables to the StorageManager
    */
   _benchmark_config->out << "- Adding Tables to StorageManager" << std::endl;
+  auto& storage_manager = StorageManager::get();
   for (auto& [table_name, table_info] : table_info_by_name) {
-    StorageManager::get().add_table(table_name, table_info.table);
+    if (storage_manager.has_table(table_name)) storage_manager.drop_table(table_name);
+    storage_manager.add_table(table_name, table_info.table);
   }
 }
 

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -133,7 +133,7 @@ Console::Console()
 
   // Register words specifically for command completion purposes, e.g.
   // for TPC-C table generation, 'CUSTOMER', 'DISTRICT', etc
-  auto tpcc_generators = opossum::TpccTableGenerator::table_generator_functions();
+  auto tpcc_generators = TpccTableGenerator::table_generator_functions();
   for (const auto& generator : tpcc_generators) {
     _tpcc_commands.push_back(generator.first);
   }
@@ -391,23 +391,27 @@ int Console::_help(const std::string&) {
 }
 
 int Console::_generate_tpcc(const std::string& tablename) {
+  auto& storage_manager = StorageManager::get();
+
   if (tablename.empty() || "ALL" == tablename) {
     out("Generating TPCC tables (this might take a while) ...\n");
-    auto tables = opossum::TpccTableGenerator().generate_all_tables();
+    auto tables = TpccTableGenerator().generate_all_tables();
     for (auto& [table_name, table] : tables) {
-      StorageManager::get().add_table(table_name, table);
+      if (storage_manager.has_table(table_name)) storage_manager.drop_table(table_name);
+      storage_manager.add_table(table_name, table);
     }
     return ReturnCode::Ok;
   }
 
   out("Generating TPCC table: \"" + tablename + "\" ...\n");
-  auto table = opossum::TpccTableGenerator().generate_table(tablename);
+  auto table = TpccTableGenerator().generate_table(tablename);
   if (table == nullptr) {
     out("Error: No TPCC table named \"" + tablename + "\" available.\n");
     return ReturnCode::Error;
   }
 
-  opossum::StorageManager::get().add_table(tablename, table);
+  if (storage_manager.has_table(tablename)) storage_manager.drop_table(tablename);
+  storage_manager.add_table(tablename, table);
   return ReturnCode::Ok;
 }
 
@@ -482,7 +486,7 @@ int Console::_load_table(const std::string& args) {
     }
   } else if (extension == "tbl") {
     try {
-      auto table = opossum::load_table(filepath);
+      auto table = load_table(filepath);
 
       StorageManager::get().add_table(tablename, table);
     } catch (const std::exception& exception) {
@@ -533,10 +537,10 @@ int Console::_export_table(const std::string& args) {
 
   try {
     if (extension == "bin") {
-      auto ex = std::make_shared<opossum::ExportBinary>(gt, filepath);
+      auto ex = std::make_shared<ExportBinary>(gt, filepath);
       ex->execute();
     } else if (extension == "csv") {
-      auto ex = std::make_shared<opossum::ExportCsv>(gt, filepath);
+      auto ex = std::make_shared<ExportCsv>(gt, filepath);
       ex->execute();
     } else {
       out("Exporting to extension \"" + extension + "\" is not supported.\n");
@@ -720,10 +724,10 @@ int Console::_change_runtime_setting(const std::string& input) {
 
   if (property == "scheduler") {
     if (value == "on") {
-      opossum::CurrentScheduler::set(std::make_shared<opossum::NodeQueueScheduler>());
+      CurrentScheduler::set(std::make_shared<NodeQueueScheduler>());
       out("Scheduler turned on\n");
     } else if (value == "off") {
-      opossum::CurrentScheduler::set(nullptr);
+      CurrentScheduler::set(nullptr);
       out("Scheduler turned off\n");
     } else {
       out("Usage: scheduler (on|off)\n");
@@ -984,7 +988,7 @@ int main(int argc, char** argv) {
   using Return = opossum::Console::ReturnCode;
   auto& console = opossum::Console::get();
 
-  // Bind CTRL-C to behaviour specified in opossum::Console::_handle_signal
+  // Bind CTRL-C to behaviour specified in Console::_handle_signal
   std::signal(SIGINT, &opossum::Console::handle_signal);
 
   console.set_prompt("> ");


### PR DESCRIPTION
fixes #1187 

I don't think we need a prompt for confirmation. If you write `generate_...` it is clear what you want to do.