### PR TITLE
Reverse check if tasks are completed in Worker::_wait_for_tasks().

### DIFF
--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -46,8 +46,8 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   template <typename TaskType>
   void _wait_for_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {
     auto tasks_completed = [&tasks]() {
-      for (auto& task : tasks) {
-        if (!task->is_done()) {
+      for (auto it = tasks.rbegin() ; it != tasks.rend() ; ++it) {
+        if (!(*it)->is_done()) {
           return false;
         }
       }

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -46,6 +46,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   template <typename TaskType>
   void _wait_for_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {
     auto tasks_completed = [&tasks]() {
+      // Reversely iterate through the list of tasks, because unfinished tasks are likely at the end of the list.
       for (auto it = tasks.rbegin() ; it != tasks.rend() ; ++it) {
         if (!(*it)->is_done()) {
           return false;


### PR DESCRIPTION
This doesn't change anything if we don't assume we know the scheduler implementation, but for the current implementation it is more likely that non-finished tasks are in the end of the vector when a worker has to `_wait_for_tasks()`.