### PR TITLE
Fix NotEquals scan on Dictionaries

### DIFF
--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -113,14 +113,15 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(const BaseDictionarySe
       return predicate_comparator(position.value(), search_value_id);
     };
     iterable.with_iterators(position_filter, [&](auto it, auto end) {
-      if (_predicate_condition == PredicateCondition::GreaterThan ||
-          _predicate_condition == PredicateCondition::GreaterThanEquals) {
-        // For GreaterThan(Equals), INVALID_VALUE_ID would compare greater than the search_value_id, even though the
-        // value is NULL. Thus, we need to check for is_null as well.
-        _scan_with_iterators<true>(comparator, it, end, chunk_id, matches);
-      } else {
-        // No need for NULL checks here, because INVALID_VALUE_ID is always greater.
+      // INVALID_VALUE_ID (i.e. MAX_UINT) represents a NULL in the AttributeVector. For some PredicateConditions, we can
+      // avoid explicitly checking for it, since the condition (e.g., LessThan) would never return true for MAX_UINT
+      // anyway.
+      if (_predicate_condition == PredicateCondition::Equals ||
+          _predicate_condition == PredicateCondition::LessThanEquals ||
+          _predicate_condition == PredicateCondition::LessThan) {
         _scan_with_iterators<false>(comparator, it, end, chunk_id, matches);
+      } else {
+        _scan_with_iterators<true>(comparator, it, end, chunk_id, matches);
       }
     });
   });

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -113,9 +113,9 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(const BaseDictionarySe
       return predicate_comparator(position.value(), search_value_id);
     };
     iterable.with_iterators(position_filter, [&](auto it, auto end) {
-      // INVALID_VALUE_ID (i.e. MAX_UINT) represents a NULL in the AttributeVector. For some PredicateConditions, we can
-      // avoid explicitly checking for it, since the condition (e.g., LessThan) would never return true for MAX_UINT
-      // anyway.
+      // dictionary.size() represents a NULL in the AttributeVector. For some PredicateConditions, we can
+      // avoid explicitly checking for it, since the condition (e.g., LessThan) would never return true for
+      // dictionary.size() anyway.
       if (_predicate_condition == PredicateCondition::Equals ||
           _predicate_condition == PredicateCondition::LessThanEquals ||
           _predicate_condition == PredicateCondition::LessThan) {

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -50,8 +50,8 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     _int_int_partly_compressed->execute();
   }
 
-  std::shared_ptr<TableWrapper> load_and_encode_table(const std::string& path) {
-    const auto table = load_table(path, 2);
+  std::shared_ptr<TableWrapper> load_and_encode_table(const std::string& path, const ChunkOffset chunk_size = 2) {
+    const auto table = load_table(path, chunk_size);
 
     auto chunk_encoding_spec = ChunkEncodingSpec{};
     for (const auto& column_definition : table->column_definitions()) {
@@ -78,8 +78,8 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     return load_and_encode_table("resources/test_data/tbl/int_string.tbl");
   }
 
-  std::shared_ptr<TableWrapper> get_int_float_with_null_op() {
-    return load_and_encode_table("resources/test_data/tbl/int_float_with_null.tbl");
+  std::shared_ptr<TableWrapper> get_int_float_with_null_op(const ChunkOffset chunk_size = 2) {
+    return load_and_encode_table("resources/test_data/tbl/int_float_with_null.tbl", chunk_size);
   }
 
   std::shared_ptr<TableWrapper> get_table_op_filtered() {
@@ -703,6 +703,23 @@ TEST_P(OperatorsTableScanTest, ScanWithExcludedFirstChunk) {
   scan->execute();
 
   ASSERT_COLUMN_EQ(scan->get_output(), ColumnID{1}, expected);
+}
+
+TEST_P(OperatorsTableScanTest, BinaryScanOnNullable) {
+  auto predicates = std::vector<std::tuple<ColumnID, PredicateCondition, AllTypeVariant, std::vector<AllTypeVariant>>>{
+      {ColumnID{0}, PredicateCondition::Equals, 1234, {1234}},
+      {ColumnID{0}, PredicateCondition::NotEquals, 123, {12345, 1234}},
+      {ColumnID{0}, PredicateCondition::GreaterThan, 123, {12345, 1234}},
+      {ColumnID{0}, PredicateCondition::GreaterThanEquals, 124, {12345, 1234}},
+      {ColumnID{0}, PredicateCondition::LessThan, 1235, {123, 1234}},
+      {ColumnID{0}, PredicateCondition::LessThanEquals, 1234, {123, 1234}}};
+
+  const auto table = get_int_float_with_null_op(Chunk::MAX_SIZE);
+  for (const auto& [column_id, predicate_condition, value, expected_values] : predicates) {
+    const auto scan = create_table_scan(table, column_id, predicate_condition, value);
+    scan->execute();
+    ASSERT_COLUMN_EQ(scan->get_output(), column_id, expected_values);
+  }
 }
 
 TEST_P(OperatorsTableScanTest, SetParameters) {


### PR DESCRIPTION
Another day, another bug that the TableScan unit tests didn't catch.