### PR TITLE
Join Order Benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 obj/*
+imdb_data
 .DS_STORE
 build/*
 build-*/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "flat_hash_map"]
 	path = third_party/flat_hash_map
 	url = https://github.com/skarupke/flat_hash_map.git
+[submodule "third_party/join-order-benchmark"]
+	path = third_party/join-order-benchmark
+	url = https://github.com/gregrahn/join-order-benchmark.git

--- a/scripts/setup_imdb.py
+++ b/scripts/setup_imdb.py
@@ -1,0 +1,98 @@
+import hashlib
+import os
+import sys
+import urllib.request
+import zipfile
+
+
+def clean_up(including_table_dir=False):
+    if os.path.exists(FILE_NAME):
+        os.remove(FILE_NAME)
+
+    if including_table_dir and os.path.exists(table_dir):
+        for file in os.listdir(table_dir):
+            os.remove("./%s/%s" % (table_dir, file))
+        os.rmdir(table_dir)
+
+
+def is_setup():
+    for table_name in TABLE_NAMES:
+        if not os.path.exists(os.path.join(table_dir, table_name + ".csv")):
+            return False
+        if not os.path.exists(os.path.join(table_dir, table_name + ".csv.json")):
+            return False
+
+    return True
+
+
+# [cmd, table_dir]
+assert len(sys.argv) == 2
+table_dir = sys.argv[1]
+
+LOCATION = "https://www.dropbox.com/s/ckh4nyqpol70ri3/imdb.zip?dl=1"
+FILE_NAME = "imdb.zip"
+TABLE_NAMES = ["aka_name", "aka_title", "cast_info", "char_name", "company_name", "company_type", "comp_cast_type", "complete_cast", "info_type",
+                    "keyword", "kind_type", "link_type", "movie_companies", "movie_info", "movie_info_idx", "movie_keyword", "movie_link", "name",
+                    "person_info", "role_type", "title"]
+
+if is_setup():
+    print("IMDB setup already complete, no setup action required")
+    sys.exit(0)
+
+# We are going to calculate the md5 hash later, on-the-fly while downloading
+hash_md5 = hashlib.md5()
+
+url = urllib.request.urlopen(LOCATION)
+meta = url.info()
+file_size = int(meta['Content-Length'])
+
+file = open(FILE_NAME, 'wb')
+
+print("Retrieving the IMDB dataset.")
+print("Downloading: %s %.2f GB" % (FILE_NAME, file_size / 1000 / 1000 / 1000))
+
+already_retrieved = 0
+block_size = 8192
+try:
+    while True:
+        buffer = url.read(block_size)
+        if not buffer:
+            break
+
+        hash_md5.update(buffer)
+
+        already_retrieved += len(buffer)
+        file.write(buffer)
+        status = r"Retrieved %3.2f%% of the data" % (already_retrieved * 100. / file_size)
+        status = status + chr(8) * (len(status) + 1)
+        print(status, end='\r')
+except:
+    print("Aborting. Something went wrong during the download. Cleaning up.")
+    clean_up()
+    sys.exit(1)
+
+file.close()
+print()
+print("Validating integrity...")
+
+hash_dl = hash_md5.hexdigest()
+
+if hash_dl != "79e4c71f8ec0dae17d6aa9182fdab835":
+    print("Aborting. Data was modified during the download. Cleaning up.")
+    clean_up()
+    sys.exit(2)
+
+print("Downloaded file is valid.")
+print("Unzipping the file...")
+
+try:
+    zip = zipfile.ZipFile("imdb.zip", "r")
+    zip.extractall(table_dir)
+    zip.close()
+except:
+    print("Aborting. Something went wrong during unzipping. Cleaning up.")
+    clean_up(including_table_dir=True)
+    sys.exit(3)
+
+print("Success. Deleting the archive.")
+clean_up()

--- a/scripts/setup_imdb.py
+++ b/scripts/setup_imdb.py
@@ -1,3 +1,9 @@
+#!/usr/bin/python3
+
+# This script is meant to be called by hyriseBenchmarkJoinOrder, but nothing stops you from calling it yourself.
+# It downloads the IMDB used by the JoinOrderBenchmark and unzips it. We do this in Python and not in C++ because
+# downloading and unzipping is straight forward in Python.
+
 import hashlib
 import os
 import sys
@@ -50,7 +56,7 @@ file_size = int(meta['Content-Length'])
 
 file = open(FILE_NAME, 'wb')
 
-print("  Downloading: %s %.2f GB" % (FILE_NAME, file_size / 1000 / 1000 / 1000))
+print("  Downloading: %s (%.2f GB)" % (FILE_NAME, file_size / 1000 / 1000 / 1000))
 
 already_retrieved = 0
 block_size = 8192
@@ -79,7 +85,7 @@ print("  Validating integrity...")
 hash_dl = hash_md5.hexdigest()
 
 if hash_dl != "79e4c71f8ec0dae17d6aa9182fdab835":
-    print("  Aborting. Data was modified during the download. Cleaning up.")
+    print("  Aborting. MD5 checksum mismatch. Cleaning up.")
     clean_up()
     sys.exit(2)
 
@@ -95,5 +101,6 @@ except:
     clean_up(including_table_dir=True)
     sys.exit(3)
 
-print("  Success. Deleting the archive.")
+print("  Deleting the archive file.")
 clean_up()
+print("  imdb_setup.py ran sucessfully.")

--- a/scripts/setup_imdb.py
+++ b/scripts/setup_imdb.py
@@ -49,7 +49,7 @@ file_size = int(meta['Content-Length'])
 file = open(FILE_NAME, 'wb')
 
 print("Retrieving the IMDB dataset.")
-print("Downloading: %s %.2f GB" % (FILE_NAME, file_size / 1000 / 1000 / 1000))
+print("  Downloading: %s %.2f GB" % (FILE_NAME, file_size / 1000 / 1000 / 1000))
 
 already_retrieved = 0
 block_size = 8192
@@ -63,36 +63,36 @@ try:
 
         already_retrieved += len(buffer)
         file.write(buffer)
-        status = r"Retrieved %3.2f%% of the data" % (already_retrieved * 100. / file_size)
+        status = r"  Retrieved %3.2f%% of the data" % (already_retrieved * 100. / file_size)
         status = status + chr(8) * (len(status) + 1)
         print(status, end='\r')
 except:
-    print("Aborting. Something went wrong during the download. Cleaning up.")
+    print("  Aborting. Something went wrong during the download. Cleaning up.")
     clean_up()
     sys.exit(1)
 
 file.close()
 print()
-print("Validating integrity...")
+print("  Validating integrity...")
 
 hash_dl = hash_md5.hexdigest()
 
 if hash_dl != "79e4c71f8ec0dae17d6aa9182fdab835":
-    print("Aborting. Data was modified during the download. Cleaning up.")
+    print("  Aborting. Data was modified during the download. Cleaning up.")
     clean_up()
     sys.exit(2)
 
-print("Downloaded file is valid.")
-print("Unzipping the file...")
+print("  Downloaded file is valid.")
+print("  Unzipping the file...")
 
 try:
     zip = zipfile.ZipFile("imdb.zip", "r")
     zip.extractall(table_dir)
     zip.close()
 except:
-    print("Aborting. Something went wrong during unzipping. Cleaning up.")
+    print("  Aborting. Something went wrong during unzipping. Cleaning up.")
     clean_up(including_table_dir=True)
     sys.exit(3)
 
-print("Success. Deleting the archive.")
+print("  Success. Deleting the archive.")
 clean_up()

--- a/scripts/setup_imdb.py
+++ b/scripts/setup_imdb.py
@@ -35,8 +35,10 @@ TABLE_NAMES = ["aka_name", "aka_title", "cast_info", "char_name", "company_name"
                     "keyword", "kind_type", "link_type", "movie_companies", "movie_info", "movie_info_idx", "movie_keyword", "movie_link", "name",
                     "person_info", "role_type", "title"]
 
+print("Retrieving the IMDB dataset.")
+
 if is_setup():
-    print("IMDB setup already complete, no setup action required")
+    print("  IMDB setup already complete, no setup action required")
     sys.exit(0)
 
 # We are going to calculate the md5 hash later, on-the-fly while downloading
@@ -48,7 +50,6 @@ file_size = int(meta['Content-Length'])
 
 file = open(FILE_NAME, 'wb')
 
-print("Retrieving the IMDB dataset.")
 print("  Downloading: %s %.2f GB" % (FILE_NAME, file_size / 1000 / 1000 / 1000))
 
 already_retrieved = 0

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -65,3 +65,17 @@ target_link_libraries(
     hyrise
     hyriseBenchmarkLib
 )
+
+# Configure hyriseBenchmarkJOB
+add_executable(
+    hyriseBenchmarkJOB
+
+    join_order_benchmark.cpp
+)
+
+target_link_libraries(
+    hyriseBenchmarkJOB
+
+    hyrise
+    hyriseBenchmarkLib
+)

--- a/src/benchmark/CMakeLists.txt
+++ b/src/benchmark/CMakeLists.txt
@@ -66,15 +66,15 @@ target_link_libraries(
     hyriseBenchmarkLib
 )
 
-# Configure hyriseBenchmarkJOB
+# Configure hyriseBenchmarkJoinOrder
 add_executable(
-    hyriseBenchmarkJOB
+    hyriseBenchmarkJoinOrder
 
     join_order_benchmark.cpp
 )
 
 target_link_libraries(
-    hyriseBenchmarkJOB
+    hyriseBenchmarkJoinOrder
 
     hyrise
     hyriseBenchmarkLib

--- a/src/benchmark/file_based_benchmark.cpp
+++ b/src/benchmark/file_based_benchmark.cpp
@@ -23,19 +23,23 @@ int main(int argc, char* argv[]) {
 
   // clang-format off
   cli_options.add_options()
-      ("tables", "Specify directory from which tables are loaded", cxxopts::value<std::string>()->default_value("")) // NOLINT
-      ("queries", "Specify queries to run, either a single .sql file or a directory with these files", cxxopts::value<std::string>()->default_value("")); // NOLINT
+      ("table_path", "Directory containing the Tables", cxxopts::value<std::string>()->default_value("")) // NOLINT
+      ("query_path", "Directory/file containing the queries", cxxopts::value<std::string>()->default_value("")) // NOLINT
+      ("queries", "Subset of queries to run", cxxopts::value<std::string>()->default_value("all")); // NOLINT
   // clang-format on
 
   std::shared_ptr<BenchmarkConfig> benchmark_config;
   std::string query_path;
   std::string table_path;
+  // Comma-separated query names
+  std::string queries_str;
 
   if (CLIConfigParser::cli_has_json_config(argc, argv)) {
     // JSON config file was passed in
     const auto json_config = CLIConfigParser::parse_json_config_file(argv[1]);
-    table_path = json_config.value("tables", "");
-    query_path = json_config.value("queries", "");
+    table_path = json_config.value("table_path", "");
+    query_path = json_config.value("query_path", "");
+    queries_str = json_config.value("queries", "all");
 
     benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_options_json_config(json_config));
 
@@ -49,15 +53,16 @@ int main(int argc, char* argv[]) {
       return 0;
     }
 
-    query_path = cli_parse_result["queries"].as<std::string>();
-    table_path = cli_parse_result["tables"].as<std::string>();
+    query_path = cli_parse_result["table_path"].as<std::string>();
+    table_path = cli_parse_result["query_path"].as<std::string>();
+    queries_str = cli_parse_result["queries"].as<std::string>();
 
     benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
   }
 
-  // Check that the options 'queries' and 'tables' were specifiedc
+  // Check that the options "query_path" and "table_path" were specified
   if (query_path.empty() || table_path.empty()) {
-    std::cerr << "Need to specify --queries=path/to/queries and --tables=path/to/tables" << std::endl;
+    std::cerr << "Need to specify --query_path=path/to/queries and --table_path=path/to/tables" << std::endl;
     std::cerr << cli_options.help({}) << std::endl;
     return 1;
   }
@@ -65,10 +70,22 @@ int main(int argc, char* argv[]) {
   benchmark_config->out << "- Benchmarking queries from " << query_path << std::endl;
   benchmark_config->out << "- Running on tables from " << table_path << std::endl;
 
+  std::optional<std::vector<std::string>> query_whitelist;
+  if (queries_str == "all") {
+    benchmark_config->out << "- Running all queries from specified path" << std::endl;
+  } else {
+    query_whitelist.emplace();
+    boost::algorithm::split(*query_whitelist, queries_str, boost::is_any_of(","));
+    benchmark_config->out << "- Running subset of queries: " << queries_str << std::endl;
+  }
+
+  // Ignore no .sql files in the directory for now (TODO(anybody): add CLI option if required)
+  const auto query_filename_blacklist = std::unordered_set<std::string>{};
+
   // Run the benchmark
   auto context = BenchmarkRunner::create_context(*benchmark_config);
   auto table_generator = std::make_unique<FileBasedTableGenerator>(benchmark_config, table_path);
-  auto query_generator = std::make_unique<FileBasedQueryGenerator>(*benchmark_config, query_path);
+  auto query_generator = std::make_unique<FileBasedQueryGenerator>(*benchmark_config, query_path, query_filename_blacklist, query_whitelist);
 
   BenchmarkRunner{*benchmark_config, std::move(query_generator), std::move(table_generator), context}.run();
 }

--- a/src/benchmark/join_order_benchmark.cpp
+++ b/src/benchmark/join_order_benchmark.cpp
@@ -1,0 +1,79 @@
+#include <stdlib.h>
+
+#include <boost/algorithm/string.hpp>
+#include <cxxopts.hpp>
+
+#include "benchmark_runner.hpp"
+#include "cli_config_parser.hpp"
+#include "file_based_query_generator.hpp"
+#include "file_based_table_generator.hpp"
+#include "import_export/csv_parser.hpp"
+#include "scheduler/current_scheduler.hpp"
+#include "scheduler/node_queue_scheduler.hpp"
+#include "scheduler/topology.hpp"
+#include "storage/storage_manager.hpp"
+#include "storage/table.hpp"
+#include "types.hpp"
+#include "utils/filesystem.hpp"
+#include "utils/load_table.hpp"
+#include "utils/performance_warning.hpp"
+
+using namespace opossum;  // NOLINT
+using namespace std::string_literals;  // NOLINT
+
+int main(int argc, char* argv[]) {
+  auto cli_options = BenchmarkRunner::get_basic_cli_options("Hyrise Join Order Benchmark");
+
+  const auto DEFAULT_TABLE_PATH = "imdb_data";
+  const auto DEFAULT_QUERY_PATH = "third_party/join-order-benchmark";
+
+  // clang-format off
+  cli_options.add_options()
+  ("tables", "Specify directory from which tables are loaded", cxxopts::value<std::string>()->default_value(DEFAULT_TABLE_PATH)) // NOLINT
+  ("queries", "Specify queries to run, either a single .sql file or a directory with these files", cxxopts::value<std::string>()->default_value(DEFAULT_QUERY_PATH)); // NOLINT
+  // clang-format on
+
+  std::shared_ptr<BenchmarkConfig> benchmark_config;
+  std::string query_path;
+  std::string table_path;
+
+  if (CLIConfigParser::cli_has_json_config(argc, argv)) {
+    // JSON config file was passed in
+    const auto json_config = CLIConfigParser::parse_json_config_file(argv[1]);
+    table_path = json_config.value("tables", DEFAULT_TABLE_PATH);
+    query_path = json_config.value("queries", DEFAULT_QUERY_PATH);
+
+    benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_options_json_config(json_config));
+
+  } else {
+    // Parse regular command line args
+    const auto cli_parse_result = cli_options.parse(argc, argv);
+
+    // Display usage and quit
+    if (cli_parse_result.count("help")) {
+      std::cout << CLIConfigParser::detailed_help(cli_options) << std::endl;
+      return 0;
+    }
+
+    query_path = cli_parse_result["queries"].as<std::string>();
+    table_path = cli_parse_result["tables"].as<std::string>();
+
+    benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
+  }
+
+  const auto setup_imdb_command = "python3 scripts/setup_imdb.py "s + table_path;
+  const auto setup_imdb_return_code = system(setup_imdb_command.c_str());
+  Assert(setup_imdb_return_code == 0, "setup_imdb.py failed");
+
+  const auto non_query_file_names = std::unordered_set<std::string>{"fkindexes.sql", "schema.sql"};
+
+  benchmark_config->out << "- Benchmarking queries from " << query_path << std::endl;
+  benchmark_config->out << "- Running on tables from " << table_path << std::endl;
+
+  // Run the benchmark
+  auto context = BenchmarkRunner::create_context(*benchmark_config);
+  auto table_generator = std::make_unique<FileBasedTableGenerator>(benchmark_config, table_path);
+  auto query_generator = std::make_unique<FileBasedQueryGenerator>(*benchmark_config, query_path, non_query_file_names);
+
+  BenchmarkRunner{*benchmark_config, std::move(query_generator), std::move(table_generator), context}.run();
+}

--- a/src/benchmark/join_order_benchmark.cpp
+++ b/src/benchmark/join_order_benchmark.cpp
@@ -18,7 +18,7 @@
 #include "utils/load_table.hpp"
 #include "utils/performance_warning.hpp"
 
-using namespace opossum;  // NOLINT
+using namespace opossum;               // NOLINT
 using namespace std::string_literals;  // NOLINT
 
 int main(int argc, char* argv[]) {

--- a/src/benchmark/join_order_benchmark.cpp
+++ b/src/benchmark/join_order_benchmark.cpp
@@ -61,10 +61,15 @@ int main(int argc, char* argv[]) {
     benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
   }
 
+  /**
+   * Use a Python script to download and unzip the IMDB. We do this in Python and not in C++ because downloading and
+   * unzipping is straight forward in Python.
+   */
   const auto setup_imdb_command = "python3 scripts/setup_imdb.py "s + table_path;
   const auto setup_imdb_return_code = system(setup_imdb_command.c_str());
   Assert(setup_imdb_return_code == 0, "setup_imdb.py failed");
 
+  // The join-order-benchmark ships with these, but we do not want to run them (and hyrise can't, as a matter of fact)
   const auto non_query_file_names = std::unordered_set<std::string>{"fkindexes.sql", "schema.sql"};
 
   benchmark_config->out << "- Benchmarking queries from " << query_path << std::endl;

--- a/src/benchmarklib/abstract_query_generator.cpp
+++ b/src/benchmarklib/abstract_query_generator.cpp
@@ -4,10 +4,6 @@ namespace opossum {
 
 std::string AbstractQueryGenerator::get_preparation_queries() const { return ""; }
 
-const std::vector<std::string>& AbstractQueryGenerator::query_names() const { return _query_names; }
-
-size_t AbstractQueryGenerator::available_query_count() const { return _query_names.size(); }
-
 size_t AbstractQueryGenerator::selected_query_count() const { return _selected_queries.size(); }
 
 const std::vector<QueryID>& AbstractQueryGenerator::selected_queries() const { return _selected_queries; }

--- a/src/benchmarklib/abstract_query_generator.hpp
+++ b/src/benchmarklib/abstract_query_generator.hpp
@@ -24,10 +24,10 @@ class AbstractQueryGenerator {
   virtual std::string build_query(const QueryID query_id) = 0;
 
   // Returns the names of the individual queries (e.g., "TPC-H 1")
-  const std::vector<std::string>& query_names() const;
+  virtual std::string query_name(const QueryID query_id) const = 0;
 
   // Returns the number of queries supported by the benchmark
-  size_t available_query_count() const;
+  virtual size_t available_query_count() const = 0;
 
   // Returns the number of queries selected for execution
   size_t selected_query_count() const;
@@ -40,9 +40,6 @@ class AbstractQueryGenerator {
 
   // PREPARE and other statements that should be executed first
   std::vector<std::string> _preparation_queries;
-
-  // Contains ALL query names, not only the selected ones
-  std::vector<std::string> _query_names;
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -113,7 +113,7 @@ void BenchmarkRunner::run() {
 
       if (lqps.empty()) continue;
 
-      auto name = _query_generator->query_names()[query_id];
+      auto name = _query_generator->query_name(query_id);
       boost::replace_all(name, " ", "_");
 
       GraphvizConfig graphviz_config;
@@ -200,7 +200,7 @@ void BenchmarkRunner::_benchmark_individual_queries() {
   for (const auto& query_id : _query_generator->selected_queries()) {
     _warmup_query(query_id);
 
-    const auto& name = _query_generator->query_names()[query_id];
+    const auto& name = _query_generator->query_name(query_id);
     _config.out << "- Benchmarking Query " << name << std::endl;
 
     // The atomic uints are modified by other threads when finishing a query, to keep track of when we can
@@ -257,7 +257,7 @@ void BenchmarkRunner::_warmup_query(const QueryID query_id) {
     return;
   }
 
-  const auto& name = _query_generator->query_names()[query_id];
+  const auto& name = _query_generator->query_name(query_id);
   _config.out << "- Warming up for Query " << name << std::endl;
 
   // The atomic uints are modified by other threads when finishing a query, to keep track of when we can
@@ -355,7 +355,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
   nlohmann::json benchmarks;
 
   for (const auto& query_id : _query_generator->selected_queries()) {
-    const auto& name = _query_generator->query_names()[query_id];
+    const auto& name = _query_generator->query_name(query_id);
     const auto& query_result = _query_results[query_id];
     Assert(query_result.iteration_durations.size() == query_result.num_iterations,
            "number of iterations and number of iteration durations does not match");

--- a/src/benchmarklib/file_based_query_generator.cpp
+++ b/src/benchmarklib/file_based_query_generator.cpp
@@ -10,9 +10,8 @@
 
 namespace opossum {
 
-FileBasedQueryGenerator::FileBasedQueryGenerator(const BenchmarkConfig& config,
-const std::string& query_path,
-const std::unordered_set<std::string>& filename_blacklist) {
+FileBasedQueryGenerator::FileBasedQueryGenerator(const BenchmarkConfig& config, const std::string& query_path,
+                                                 const std::unordered_set<std::string>& filename_blacklist) {
   const auto is_sql_file = [](const std::string& filename) { return boost::algorithm::ends_with(filename, ".sql"); };
 
   filesystem::path path{query_path};

--- a/src/benchmarklib/file_based_query_generator.cpp
+++ b/src/benchmarklib/file_based_query_generator.cpp
@@ -11,7 +11,8 @@
 namespace opossum {
 
 FileBasedQueryGenerator::FileBasedQueryGenerator(const BenchmarkConfig& config, const std::string& query_path,
-                                                 const std::unordered_set<std::string>& filename_blacklist) {
+                                                 const std::unordered_set<std::string>& filename_blacklist,
+                                                 const std::optional<std::unordered_set<std::string>>& query_subset) {
   const auto is_sql_file = [](const std::string& filename) { return boost::algorithm::ends_with(filename, ".sql"); };
 
   filesystem::path path{query_path};
@@ -19,7 +20,7 @@ FileBasedQueryGenerator::FileBasedQueryGenerator(const BenchmarkConfig& config, 
 
   if (filesystem::is_regular_file(path)) {
     Assert(is_sql_file(query_path), "Specified file '" + query_path + "' is not an .sql file");
-    _parse_query_file(query_path);
+    _parse_query_file(query_path, query_subset);
   } else {
     // Recursively walk through the specified directory and add all files on the way
     for (const auto& entry : filesystem::recursive_directory_iterator(path)) {
@@ -27,16 +28,26 @@ FileBasedQueryGenerator::FileBasedQueryGenerator(const BenchmarkConfig& config, 
         if (filename_blacklist.find(entry.path().filename()) != filename_blacklist.end()) {
           continue;
         }
-        _parse_query_file(entry.path());
+        _parse_query_file(entry.path(), query_subset);
       }
     }
   }
 
-  _selected_queries.resize(_query_names.size());
+  _selected_queries.resize(_queries.size());
   std::iota(_selected_queries.begin(), _selected_queries.end(), QueryID{0});
+
+  // Sort queries by name
+  std::sort(_queries.begin(), _queries.end(), [](const Query& lhs, const Query& rhs) { return lhs.name < rhs.name; });
 }
 
-void FileBasedQueryGenerator::_parse_query_file(const std::filesystem::path& query_file_path) {
+std::string FileBasedQueryGenerator::build_query(const QueryID query_id) { return _queries[query_id].sql; }
+
+std::string FileBasedQueryGenerator::query_name(const QueryID query_id) const { return _queries[query_id].name; }
+
+size_t FileBasedQueryGenerator::available_query_count() const { return _queries.size(); }
+
+void FileBasedQueryGenerator::_parse_query_file(const std::filesystem::path& query_file_path,
+                                                const std::optional<std::unordered_set<std::string>>& query_subset) {
   std::ifstream file(query_file_path);
 
   // The names of queries from, e.g., "queries/TPCH-7.sql" will be prefixed with "TPCH-7."
@@ -53,23 +64,30 @@ void FileBasedQueryGenerator::_parse_query_file(const std::filesystem::path& que
   hsql::SQLParser::parse(content, &parse_result);
   Assert(parse_result.isValid(), create_sql_parser_error_message(content, parse_result));
 
+  std::vector<Query> queries_in_file{parse_result.size()};
+
   size_t sql_string_offset{0u};
   for (auto statement_idx = size_t{0}; statement_idx < parse_result.size(); ++statement_idx) {
     const auto query_name = query_name_prefix + '.' + std::to_string(statement_idx);
     const auto statement_string_length = parse_result.getStatement(statement_idx)->stringLength;
     const auto statement_string = boost::trim_copy(content.substr(sql_string_offset, statement_string_length));
     sql_string_offset += statement_string_length;
-    _query_names.emplace_back(query_name);
-    _queries.emplace_back(statement_string);
+    queries_in_file[statement_idx] = {query_name, statement_string};
   }
 
-  // More convenient names if there is only one query per file
-  if (_queries.size() == 1) {
-    auto& query_name = _query_names[0];
-    query_name.erase(query_name.end() - 2, query_name.end());  // -2 because .0 at end of name
+  // Remove ".0" from the end of the query name if there is only one file
+  if (queries_in_file.size() == 1) {
+    queries_in_file.front().name.erase(queries_in_file.front().name.end() - 2, queries_in_file.front().name.end());
+  }
+
+  /**
+   * Add queries to _queries and _query_names, if query_subset allows it
+   */
+  for (const auto& query : queries_in_file) {
+    if (!query_subset || query_subset->count(query.name)) {
+      _queries.emplace_back(query);
+    }
   }
 }
-
-std::string FileBasedQueryGenerator::build_query(const QueryID query_id) { return _queries[query_id]; }
 
 }  // namespace opossum

--- a/src/benchmarklib/file_based_query_generator.hpp
+++ b/src/benchmarklib/file_based_query_generator.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_set>
+
 #include "abstract_query_generator.hpp"
 #include "benchmark_config.hpp"
 
@@ -8,12 +10,15 @@ namespace opossum {
 class FileBasedQueryGenerator : public AbstractQueryGenerator {
  public:
   // query_path can be either a folder or a single .sql file
-  FileBasedQueryGenerator(const BenchmarkConfig& config, const std::string& query_path);
+  // @param filename_blacklist    list of filenames to ignore
+  FileBasedQueryGenerator(const BenchmarkConfig& config,
+  const std::string& query_path,
+  const std::unordered_set<std::string>& filename_blacklist = {});
   std::string build_query(const QueryID query_id) override;
 
  protected:
   // Get all queries from a given file
-  void _parse_query_file(const std::string& query_file_path);
+  void _parse_query_file(const std::filesystem::path& query_file_path);
 
   std::vector<std::string> _queries;
 };

--- a/src/benchmarklib/file_based_query_generator.hpp
+++ b/src/benchmarklib/file_based_query_generator.hpp
@@ -9,17 +9,29 @@ namespace opossum {
 
 class FileBasedQueryGenerator : public AbstractQueryGenerator {
  public:
-  // query_path can be either a folder or a single .sql file
+  // @param query_path            can be either a folder or a single .sql file
   // @param filename_blacklist    list of filenames to ignore
+  // @param query_subset          if set, only the queries with the specified names (derived from the filename) will be
+  //                              generated. If "q7.sql" contains a single query, the query has the name "q7". If
+  //                              it contains multiple queries, they are called "q7.0", "q7.1", ...
   FileBasedQueryGenerator(const BenchmarkConfig& config, const std::string& query_path,
-                          const std::unordered_set<std::string>& filename_blacklist = {});
+                          const std::unordered_set<std::string>& filename_blacklist = {},
+                          const std::optional<std::unordered_set<std::string>>& query_subset = {});
   std::string build_query(const QueryID query_id) override;
+  std::string query_name(const QueryID query_id) const override;
+  size_t available_query_count() const override;
 
  protected:
-  // Get all queries from a given file
-  void _parse_query_file(const std::filesystem::path& query_file_path);
+  struct Query {
+    std::string name;
+    std::string sql;
+  };
 
-  std::vector<std::string> _queries;
+  // Get all queries from a given file
+  void _parse_query_file(const std::filesystem::path& query_file_path,
+                         const std::optional<std::unordered_set<std::string>>& query_subset);
+
+  std::vector<Query> _queries;
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/file_based_query_generator.hpp
+++ b/src/benchmarklib/file_based_query_generator.hpp
@@ -11,9 +11,8 @@ class FileBasedQueryGenerator : public AbstractQueryGenerator {
  public:
   // query_path can be either a folder or a single .sql file
   // @param filename_blacklist    list of filenames to ignore
-  FileBasedQueryGenerator(const BenchmarkConfig& config,
-  const std::string& query_path,
-  const std::unordered_set<std::string>& filename_blacklist = {});
+  FileBasedQueryGenerator(const BenchmarkConfig& config, const std::string& query_path,
+                          const std::unordered_set<std::string>& filename_blacklist = {});
   std::string build_query(const QueryID query_id) override;
 
  protected:

--- a/src/benchmarklib/file_based_table_generator.cpp
+++ b/src/benchmarklib/file_based_table_generator.cpp
@@ -83,7 +83,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
     _benchmark_config->out << "- Loading table '" << table_name << "' ";
 
     // Pick a source file to load a table from, prefer the binary version
-    if (table_info.binary_file_path && !table_info.binary_file_out_of_date) {
+    if (table_info.binary_file_path && !table_info.binary_file_out_of_datxe) {
       _benchmark_config->out << "from " << *table_info.binary_file_path << std::flush;
       table_info.table = ImportBinary::read_binary(*table_info.binary_file_path);
       table_info.loaded_from_binary = true;

--- a/src/benchmarklib/file_based_table_generator.cpp
+++ b/src/benchmarklib/file_based_table_generator.cpp
@@ -83,7 +83,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
     _benchmark_config->out << "- Loading table '" << table_name << "' ";
 
     // Pick a source file to load a table from, prefer the binary version
-    if (table_info.binary_file_path && !table_info.binary_file_out_of_datxe) {
+    if (table_info.binary_file_path && !table_info.binary_file_out_of_date) {
       _benchmark_config->out << "from " << *table_info.binary_file_path << std::flush;
       table_info.table = ImportBinary::read_binary(*table_info.binary_file_path);
       table_info.loaded_from_binary = true;

--- a/src/benchmarklib/tpch/tpch_query_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_query_generator.cpp
@@ -12,22 +12,13 @@ namespace opossum {
 
 TPCHQueryGenerator::TPCHQueryGenerator(bool use_prepared_statements)
     : _use_prepared_statements(use_prepared_statements) {
-  _generate_names();
   _selected_queries.resize(22);
   std::iota(_selected_queries.begin(), _selected_queries.end(), QueryID{0});
 }
 
 TPCHQueryGenerator::TPCHQueryGenerator(bool use_prepared_statements, const std::vector<QueryID>& selected_queries)
     : _use_prepared_statements(use_prepared_statements) {
-  _generate_names();
   _selected_queries = selected_queries;
-}
-
-void TPCHQueryGenerator::_generate_names() {
-  _query_names.reserve(22);
-  for (auto i = 0; i < 22; ++i) {
-    _query_names.emplace_back(std::string("TPC-H ") + std::to_string(i + 1));
-  }
 }
 
 std::string TPCHQueryGenerator::get_preparation_queries() const {
@@ -94,6 +85,13 @@ std::string TPCHQueryGenerator::build_query(const QueryID query_id) {
 
   return _build_executable_query(query_id, parameter_values[query_id]);
 }
+
+std::string TPCHQueryGenerator::query_name(const QueryID query_id) const {
+  Assert(query_id < available_query_count(), "query_id out of range");
+  return std::string("TPC-H ") + std::to_string(query_id + 1);
+}
+
+size_t TPCHQueryGenerator::available_query_count() const { return 22u; }
 
 std::string TPCHQueryGenerator::_build_executable_query(const QueryID query_id,
                                                         const std::vector<std::string>& parameter_values) {

--- a/src/benchmarklib/tpch/tpch_query_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_query_generator.hpp
@@ -14,11 +14,10 @@ class TPCHQueryGenerator : public AbstractQueryGenerator {
 
   std::string get_preparation_queries() const override;
   std::string build_query(const QueryID query_id) override;
+  std::string query_name(const QueryID query_id) const override;
+  size_t available_query_count() const override;
 
  protected:
-  // Generates the names of the queries (e.g., TPCH1)
-  void _generate_names();
-
   // Generates the PREPARE queries (if needed)
   void _generate_preparation_queries();
 


### PR DESCRIPTION
Adds a new target `hyriseBenchmarkJoinOrder` which lazily downloads the IMDB from @Bensk1 dropbox and otherwise functions just as the `hyriseBenchmarkFileBased`.

The queries are acquired from the new `third_party/join-order-benchmark` submodule.

Following [some dude's](https://twitter.com/SebAaltonen/status/1080076144089665537) advice on twitter, I didn't seek to introduce an abstraction layer that both `hyriseBenchmarkJoinOrder` and `hyriseBenchmarkFileBased` can use but instead c/p'ed the code. Roast me.