### PR TITLE
WIP: Improve table scan alignment

### DIFF
--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -25,8 +25,7 @@ class AbstractTableScanImpl {
    */
 
   template <bool CheckForNull, typename BinaryFunctor, typename LeftIterator>
-  static void __attribute__((noinline))
-  _scan_with_iterators(const BinaryFunctor func, LeftIterator left_it, const LeftIterator left_end,
+  static void _scan_with_iterators(const BinaryFunctor func, LeftIterator left_it, const LeftIterator left_end,
                        const ChunkID chunk_id, PosList& matches_out) {
     // Can't use a default argument for this because default arguments are non-type deduced contexts
     auto false_type = std::false_type{};
@@ -34,8 +33,10 @@ class AbstractTableScanImpl {
   }
 
   template <bool CheckForNull, typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-  // noinline reduces compile time drastically
-  static void __attribute__((noinline))
+  // This is a function that is critical for our performance. We want the compiler to try its best in optimizing it.
+  // Also, we want all functions called inside to be inlined (flattened) and the function itself being always aligned
+  // at a page boundary. Finally, it should not be inlined because that might break the alignment.
+  static void __attribute__((hot, flatten, aligned(64), noinline))
   _scan_with_iterators(const BinaryFunctor func, LeftIterator left_it, const LeftIterator left_end,
                        const ChunkID chunk_id, PosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     for (; left_it != left_end; ++left_it) {

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -36,7 +36,7 @@ class AbstractTableScanImpl {
   // This is a function that is critical for our performance. We want the compiler to try its best in optimizing it.
   // Also, we want all functions called inside to be inlined (flattened) and the function itself being always aligned
   // at a page boundary. Finally, it should not be inlined because that might break the alignment.
-  static void __attribute__((hot, flatten, aligned(64), noinline))
+  static void __attribute__((hot, flatten, aligned(256), noinline))
   _scan_with_iterators(const BinaryFunctor func, LeftIterator left_it, const LeftIterator left_end,
                        const ChunkID chunk_id, PosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     for (; left_it != left_end; ++left_it) {


### PR DESCRIPTION
Improves the alignment of the table scan's hot loop. Also, I hope that this improves the stability of the benchmark results. Binary size for the TPC-H grows from 35M to 45M.

```
+-----------+-----------------+------+-----------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s    | runs | new iter/s      | runs | change | p-value (significant if <0.001) |
+-----------+-----------------+------+-----------------+------+--------+---------------------------------+
| TPC-H 1   | 0.564372479916  | 34   | 0.581200122833  | 35   | +3%    |                          0.0002 |
| TPC-H 2   | 7.89877462387   | 474  | 8.54508304596   | 513  | +8%    |     (run time too short) 0.0000 |
| TPC-H 3   | 6.66416120529   | 400  | 6.74540519714   | 405  | +1%    |     (run time too short) 0.0000 |
| TPC-H 4   | 1.93944966793   | 117  | 2.03932404518   | 123  | +5%    |                          0.0000 |
| TPC-H 5   | 3.80517816544   | 229  | 3.90947723389   | 235  | +3%    |                          0.0000 |
| TPC-H 6   | 15.9196434021   | 956  | 15.7012338638   | 943  | -1%    |                          0.0000 |
| TPC-H 7   | 1.38410329819   | 84   | 1.41422951221   | 85   | +2%    |                          0.0000 |
| TPC-H 8   | 4.71690320969   | 284  | 4.84905862808   | 291  | +3%    |     (run time too short) 0.0000 |
| TPC-H 9   | 1.45942437649   | 88   | 1.52486264706   | 92   | +4%    |                          0.0000 |
| TPC-H 10  | 2.32833099365   | 140  | 2.37649703026   | 143  | +2%    |     (run time too short) 0.0000 |
| TPC-H 11  | 32.4417190552   | 1947 | 32.5152015686   | 1951 | +0%    |     (run time too short) 0.2065 |
| TPC-H 12  | 6.68205499649   | 401  | 7.76319932938   | 466  | +16%   |     (run time too short) 0.0000 |
| TPC-H 13  | 1.37996768951   | 83   | 1.92712068558   | 116  | +40%   |                          0.0000 |
| TPC-H 14  | 13.26304245     | 796  | 14.1727466583   | 851  | +7%    |     (run time too short) 0.0000 |
| TPC-H 15  | 8.93082523346   | 536  | 9.97336769104   | 599  | +12%   |     (run time too short) 0.0000 |
| TPC-H 16  | 6.16314077377   | 370  | 6.40446281433   | 385  | +4%    |     (run time too short) 0.0000 |
| TPC-H 17  | 0.137626156211  | 9    | 0.131783038378  | 8    | -4%    |        (not enough runs) 0.2366 |
| TPC-H 18  | 1.59408354759   | 96   | 1.68292081356   | 101  | +6%    |                          0.0000 |
| TPC-H 19  | 5.0752158165    | 305  | 5.51098108292   | 331  | +9%    |                          0.0000 |
| TPC-H 20  | 0.0690092220902 | 5    | 0.0666120126843 | 4    | -3%    |        (not enough runs) 0.0072 |
| TPC-H 21  | 0.114875040948  | 7    | 0.135092377663  | 9    | +18%   |        (not enough runs) 0.0000 |
| TPC-H 22  | 10.2927503586   | 618  | 12.7263679504   | 764  | +24%   |                          0.0000 |
| average   |                 |      |                 |      | +7%    |                                 |
+-----------+-----------------+------+-----------------+------+--------+---------------------------------+
```

fixes #1122 