### PR TITLE
memcheck: remove leak check detail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,7 +198,7 @@ node {
       stage("memcheckReleaseTest") {
         if (env.BRANCH_NAME == 'master' || full_ci) {
           sh "mkdir ./clang-release-memcheck-test"
-          sh "valgrind --tool=memcheck --error-exitcode=1 --leak-check=full --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
+          sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
         } else {
           Utils.markStageSkippedForConditional("memcheckReleaseTest")
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,6 +198,7 @@ node {
       stage("memcheckReleaseTest") {
         if (env.BRANCH_NAME == 'master' || full_ci) {
           sh "mkdir ./clang-release-memcheck-test"
+          // If this shows a leak, try --leak-check=full, which is slower but more precise
           sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
         } else {
           Utils.markStageSkippedForConditional("memcheckReleaseTest")


### PR DESCRIPTION
This should make memcheck run much faster. We will still see leaks, but not where they come from. If that happens, we can still manually run the full check.