### PR TITLE
Add encodings to Console and Print

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -339,6 +339,7 @@ _CPP_HEADERS = frozenset([
     'condition_variable',
     'deque',
     'exception',
+    'filesystem',
     'forward_list',
     'fstream',
     'functional',

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -1,5 +1,6 @@
 #include <json.hpp>
 
+#include <boost/range/adaptors.hpp>
 #include <random>
 
 #include "cxxopts.hpp"
@@ -432,23 +433,10 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
 cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& benchmark_name) {
   cxxopts::Options cli_options{benchmark_name};
 
-  // Make sure all current encoding types are shown
-  std::vector<std::string> encoding_strings;
-  encoding_strings.reserve(encoding_type_to_string.right.size());
-  for (const auto& encoding : encoding_type_to_string.right) {
-    encoding_strings.emplace_back(encoding.first);
-  }
-
-  const auto encoding_strings_option = boost::algorithm::join(encoding_strings, ", ");
-
-  // Make sure all current compression types are shown
-  std::vector<std::string> compression_strings;
-  compression_strings.reserve(vector_compression_type_to_string.right.size());
-  for (const auto& vector_compression : vector_compression_type_to_string.right) {
-    compression_strings.emplace_back(vector_compression.first);
-  }
-
-  const auto compression_strings_option = boost::algorithm::join(compression_strings, ", ");
+  const auto get_first = boost::adaptors::transformed([](auto it) { return it.first; });
+  const auto encoding_strings_option = boost::algorithm::join(encoding_type_to_string.right | get_first, ", ");
+  const auto compression_strings_option =
+      boost::algorithm::join(vector_compression_type_to_string.right | get_first, ", ");
 
   // If you add a new option here, make sure to edit CLIConfigParser::basic_cli_options_to_json() so it contains the
   // newest options. Sadly, there is no way to to get all option keys to do this automatically.

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -433,6 +433,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
 cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& benchmark_name) {
   cxxopts::Options cli_options{benchmark_name};
 
+  // Create a comma separated strings with the encoding and compression options
   const auto get_first = boost::adaptors::transformed([](auto it) { return it.first; });
   const auto encoding_strings_option = boost::algorithm::join(encoding_type_to_string.right | get_first, ", ");
   const auto compression_strings_option =

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -474,7 +474,7 @@ int Console::_generate_tpch(const std::string& args) {
 int Console::_load_table(const std::string& args) {
   std::vector<std::string> arguments = trim_and_split(args);
 
-  if (arguments.size() < 1 || arguments.size() > 3) {
+  if (arguments.empty() || arguments.size() > 3) {
     out("Usage:\n");
     out("  load FILEPATH [TABLENAME [ENCODING]]\n");
     return ReturnCode::Error;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -3,12 +3,15 @@
 #include <readline/history.h>
 #include <readline/readline.h>
 #include <sys/stat.h>
+#include <boost/algorithm/string/join.hpp>
+#include <boost/range/adaptors.hpp>
 
 #include <chrono>
 #include <csetjmp>
 #include <csignal>
 #include <cstdlib>
 #include <ctime>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -19,6 +22,7 @@
 #include "SQLParser.h"
 #include "concurrency/transaction_context.hpp"
 #include "concurrency/transaction_manager.hpp"
+#include "constant_mappings.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "operators/export_binary.hpp"
 #include "operators/export_csv.hpp"
@@ -36,6 +40,7 @@
 #include "sql/sql_pipeline_statement.hpp"
 #include "sql/sql_plan_cache.hpp"
 #include "sql/sql_translator.hpp"
+#include "storage/chunk_encoder.hpp"
 #include "storage/storage_manager.hpp"
 #include "tpcc/tpcc_table_generator.hpp"
 #include "tpch/tpch_table_generator.hpp"
@@ -351,14 +356,26 @@ void Console::out(const std::shared_ptr<const Table>& table, uint32_t flags) {
 int Console::_exit(const std::string&) { return Console::ReturnCode::Quit; }
 
 int Console::_help(const std::string&) {
+  auto encoding_options = std::string{"                                               Encoding options: "};
+  encoding_options += boost::algorithm::join(
+      encoding_type_to_string.right | boost::adaptors::transformed([](auto it) { return it.first; }), ", ");
+  // Split the encoding options in lines of 120 and add padding
+  auto line_wrap = std::regex{"(.{1,120})(?: +|$)"};
+  encoding_options =
+      regex_replace(encoding_options, line_wrap, "$1\n                                                 ");
+  // Remove line added at the end
+  encoding_options.resize(encoding_options.size() - 50);
+
   // clang-format off
   out("HYRISE SQL Interface\n\n");
   out("Available commands:\n");
   out("  generate_tpcc [TABLENAME]               - Generate available TPC-C tables, or a specific table if TABLENAME is specified\n");  // NOLINT
   out("  generate_tpch SCALE_FACTOR [CHUNK_SIZE] - Generate all TPC-H tables\n");
-  out("  load FILEPATH TABLENAME                 - Load table from disk specified by filepath FILEPATH, store it with name TABLENAME\n");  // NOLINT
+  out("  load FILEPATH [TABLENAME [ENCODING]]    - Load table from disk specified by filepath FILEPATH, store it with name TABLENAME\n");  // NOLINT
   out("                                               The import type is chosen by the type of FILEPATH.\n");
   out("                                                 Supported types: '.bin', '.csv', '.tbl'\n");
+  out("                                               If no table name is specified, the filename without extension is used\n");
+  out(encoding_options + "\n");  // NOLINT
   out("  export TABLENAME FILEPATH               - Export table named TABLENAME from storage manager to filepath FILEPATH\n");  // NOLINT
   out("                                               The export type is chosen by the type of FILEPATH.\n");
   out("                                                 Supported types: '.bin', '.csv'\n");
@@ -455,20 +472,18 @@ int Console::_generate_tpch(const std::string& args) {
 int Console::_load_table(const std::string& args) {
   std::vector<std::string> arguments = trim_and_split(args);
 
-  if (arguments.size() != 2) {
+  if (arguments.size() < 1 || arguments.size() > 3) {
     out("Usage:\n");
-    out("  load FILEPATH TABLENAME\n");
+    out("  load FILEPATH [TABLENAME [ENCODING]]\n");
     return ReturnCode::Error;
   }
 
-  const std::string& filepath = arguments[0];
-  const std::string& tablename = arguments[1];
+  const auto filepath = std::filesystem::path{arguments[0]};
+  const auto extension = std::string{filepath.extension()};
 
-  std::vector<std::string> file_parts;
-  boost::algorithm::split(file_parts, filepath, boost::is_any_of("."));
-  const std::string& extension = file_parts.back();
+  const auto tablename = arguments.size() >= 2 ? arguments[1] : std::string{filepath.stem()};
 
-  out("Loading " + filepath + " into table \"" + tablename + "\" ...\n");
+  out("Loading " + std::string{filepath} + " into table \"" + tablename + "\"\n");
 
   auto& storage_manager = StorageManager::get();
   if (storage_manager.has_table(tablename)) {
@@ -476,34 +491,51 @@ int Console::_load_table(const std::string& args) {
     out("Table " + tablename + " already existed. Replacing it.\n");
   }
 
-  if (extension == "csv") {
+  if (extension == ".csv") {
     auto importer = std::make_shared<ImportCsv>(filepath, Chunk::DEFAULT_SIZE, tablename);
     try {
       importer->execute();
     } catch (const std::exception& exception) {
-      out("Exception thrown while importing CSV:\n  " + std::string(exception.what()) + "\n");
+      out("Error: Exception thrown while importing CSV:\n  " + std::string(exception.what()) + "\n");
       return ReturnCode::Error;
     }
-  } else if (extension == "tbl") {
+  } else if (extension == ".tbl") {
     try {
       auto table = load_table(filepath);
 
       StorageManager::get().add_table(tablename, table);
     } catch (const std::exception& exception) {
-      out("Exception thrown while importing TBL:\n  " + std::string(exception.what()) + "\n");
+      out("Error: Exception thrown while importing TBL:\n  " + std::string(exception.what()) + "\n");
       return ReturnCode::Error;
     }
-  } else if (extension == "bin") {
+  } else if (extension == ".bin") {
     auto importer = std::make_shared<ImportBinary>(filepath, tablename);
     try {
       importer->execute();
     } catch (const std::exception& exception) {
-      out("Exception thrown while importing binary file:\n  " + std::string(exception.what()) + "\n");
+      out("Error: Exception thrown while importing binary file:\n  " + std::string(exception.what()) + "\n");
       return ReturnCode::Error;
     }
   } else {
     out("Error: Unsupported file extension '" + extension + "'\n");
     return ReturnCode::Error;
+  }
+
+  const std::string encoding = arguments.size() == 3 ? arguments[2] : "Unencoded";
+
+  const auto type = encoding_type_to_string.right.find(encoding);
+  if (type == encoding_type_to_string.right.end()) {
+    const auto encoding_options = boost::algorithm::join(
+        encoding_type_to_string.right | boost::adaptors::transformed([](auto it) { return it.first; }), ", ");
+    out("Error: Invalid encoding type: '" + encoding + "', try one of these: " + encoding_options + "\n");
+    return ReturnCode::Error;
+  }
+
+  out("Encoding \"" + tablename + "\" using " + encoding + "\n");
+  try {
+    ChunkEncoder::encode_all_chunks(StorageManager::get().get_table(tablename), type->second);
+  } catch (const std::exception& exception) {
+    out("Exception while encoding - table left partially unencoded:\n  " + std::string(exception.what()) + "\n");
   }
 
   return ReturnCode::Ok;
@@ -523,7 +555,7 @@ int Console::_export_table(const std::string& args) {
 
   auto& storage_manager = StorageManager::get();
   if (!storage_manager.has_table(tablename)) {
-    out("Table does not exist in StorageManager");
+    out("Error: Table does not exist in StorageManager");
     return ReturnCode::Error;
   }
 
@@ -547,7 +579,7 @@ int Console::_export_table(const std::string& args) {
       return ReturnCode::Error;
     }
   } catch (const std::exception& exception) {
-    out("Exception thrown while exporting:\n  " + std::string(exception.what()) + "\n");
+    out("Error: Exception thrown while exporting:\n  " + std::string(exception.what()) + "\n");
     return ReturnCode::Error;
   }
 
@@ -569,7 +601,7 @@ int Console::_print_table(const std::string& args) {
   try {
     gt->execute();
   } catch (const std::exception& exception) {
-    out("Exception thrown while loading table:\n  " + std::string(exception.what()) + "\n");
+    out("Error: Exception thrown while loading table:\n  " + std::string(exception.what()) + "\n");
     return ReturnCode::Error;
   }
 
@@ -632,12 +664,12 @@ int Console::_visualize(const std::string& input) {
   // If there is no pipeline (i.e., neither was SQL passed in with the visualize command,
   // nor was there a previous execution), return an error
   if (!_sql_pipeline) {
-    out("Nothing to visualize.\n");
+    out("Error: Nothing to visualize.\n");
     return ReturnCode::Error;
   }
 
   if (no_execute && !sql.empty() && _sql_pipeline->requires_execution()) {
-    out("We do not support the visualization of multiple dependant statements in 'noexec' mode.\n");
+    out("Error: We do not support the visualization of multiple dependant statements in 'noexec' mode.\n");
     return ReturnCode::Error;
   }
 
@@ -736,7 +768,7 @@ int Console::_change_runtime_setting(const std::string& input) {
     return 0;
   }
 
-  out("Unknown property\n");
+  out("Error: Unknown property\n");
   return 1;
 }
 
@@ -791,7 +823,7 @@ void Console::handle_signal(int sig) {
 int Console::_begin_transaction(const std::string& input) {
   if (_explicitly_created_transaction_context != nullptr) {
     const auto transaction_id = std::to_string(_explicitly_created_transaction_context->transaction_id());
-    out("There is already an active transaction (" + transaction_id + "). ");
+    out("Error: There is already an active transaction (" + transaction_id + "). ");
     out("Type `rollback` or `commit` before beginning a new transaction.\n");
     return ReturnCode::Error;
   }

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -374,7 +374,7 @@ int Console::_help(const std::string&) {
   out("  load FILEPATH [TABLENAME [ENCODING]]    - Load table from disk specified by filepath FILEPATH, store it with name TABLENAME\n");  // NOLINT
   out("                                               The import type is chosen by the type of FILEPATH.\n");
   out("                                                 Supported types: '.bin', '.csv', '.tbl'\n");
-  out("                                               If no table name is specified, the filename without extension is used\n");
+  out("                                               If no table name is specified, the filename without extension is used\n");  // NOLINT
   out(encoding_options + "\n");  // NOLINT
   out("  export TABLENAME FILEPATH               - Export table named TABLENAME from storage manager to filepath FILEPATH\n");  // NOLINT
   out("                                               The export type is chosen by the type of FILEPATH.\n");
@@ -483,7 +483,7 @@ int Console::_load_table(const std::string& args) {
 
   const auto tablename = arguments.size() >= 2 ? arguments[1] : std::string{filepath.stem()};
 
-  out("Loading " + std::string{filepath} + " into table \"" + tablename + "\"\n");
+  out("Loading " + std::string(filepath) + " into table \"" + tablename + "\"\n");
 
   auto& storage_manager = StorageManager::get();
   if (storage_manager.has_table(tablename)) {

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -175,6 +175,9 @@ std::string Print::_segment_type(const std::shared_ptr<BaseSegment>& segment) co
     segment_type += "ReferS";
   } else if (const auto& encoded_segment = std::dynamic_pointer_cast<BaseEncodedSegment>(segment)) {
     switch (encoded_segment->encoding_type()) {
+      case EncodingType::Unencoded: {
+        Fail("An actual segment should never have this type");
+      }
       case EncodingType::Dictionary: {
         segment_type += "Dic:";
         break;

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<const Table> Print::_on_execute() {
     for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
       const auto column_width = widths[column_id];
       const auto& segment = chunk->get_segment(column_id);
-      _out << "|" << std::setw(column_width - 2) << _segment_type(segment) << std::setw(0);
+      _out << "|" << std::setw(column_width) << _segment_type(segment) << std::setw(0);
     }
     if (_flags & PrintMvcc) _out << "||";
     _out << std::endl;
@@ -179,43 +179,41 @@ std::string Print::_segment_type(const std::shared_ptr<BaseSegment>& segment) co
         Fail("An actual segment should never have this type");
       }
       case EncodingType::Dictionary: {
-        segment_type += "Dic:";
+        segment_type += "Dic";
         break;
       }
       case EncodingType::RunLength: {
-        segment_type += "RLE:";
+        segment_type += "RLE";
         break;
       }
       case EncodingType::FixedStringDictionary: {
-        segment_type += "FSD:";
+        segment_type += "FSD";
         break;
       }
       case EncodingType::FrameOfReference: {
-        segment_type += "FoR:";
+        segment_type += "FoR";
         break;
       }
     }
     if (encoded_segment->compressed_vector_type()) {
       switch (*encoded_segment->compressed_vector_type()) {
         case CompressedVectorType::FixedSize4ByteAligned: {
-          segment_type += "4B";
+          segment_type += ":4B";
           break;
         }
         case CompressedVectorType::FixedSize2ByteAligned: {
-          segment_type += "2B";
+          segment_type += ":2B";
           break;
         }
         case CompressedVectorType::FixedSize1ByteAligned: {
-          segment_type += "1B";
+          segment_type += ":1B";
           break;
         }
         case CompressedVectorType::SimdBp128: {
-          segment_type += "BP";
+          segment_type += ":BP";
           break;
         }
       }
-    } else {
-      segment_type += "--";
     }
   } else {
     Fail("Unknown segment type");

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -191,7 +191,6 @@ std::string Print::_segment_type(const std::shared_ptr<BaseSegment>& segment) co
         segment_type += "FoR:";
         break;
       }
-      default: { Fail("Unknown encoding type"); }
     }
     if (encoded_segment->compressed_vector_type()) {
       switch (*encoded_segment->compressed_vector_type()) {

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -213,7 +213,7 @@ std::string Print::_segment_type(const std::shared_ptr<BaseSegment>& segment) co
         }
       }
     } else {
-      segment_type += "-";
+      segment_type += "--";
     }
   } else {
     Fail("Unknown segment type");

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -9,7 +9,10 @@
 
 #include "constant_mappings.hpp"
 #include "operators/table_wrapper.hpp"
+#include "storage/base_encoded_segment.hpp"
 #include "storage/base_segment.hpp"
+#include "storage/base_value_segment.hpp"
+#include "storage/reference_segment.hpp"
 #include "type_cast.hpp"
 #include "utils/performance_warning.hpp"
 
@@ -83,6 +86,15 @@ std::shared_ptr<const Table> Print::_on_execute() {
       continue;
     }
 
+    // print the encoding information
+    for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
+      const auto column_width = widths[column_id];
+      const auto& segment = chunk->get_segment(column_id);
+      _out << "|" << std::setw(column_width - 2) << _segment_type(segment) << std::setw(0);
+    }
+    if (_flags & PrintMvcc) _out << "||";
+    _out << std::endl;
+
     // print the rows in the chunk
     for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk->size(); ++chunk_offset) {
       _out << "|";
@@ -150,6 +162,64 @@ std::string Print::_truncate_cell(const AllTypeVariant& cell, uint16_t max_width
     return cell_string.substr(0, max_width - 3) + "...";
   }
   return cell_string;
+}
+
+std::string Print::_segment_type(const std::shared_ptr<BaseSegment>& segment) const {
+  std::string segment_type;
+  segment_type.reserve(8);
+  segment_type += "<";
+
+  if (std::dynamic_pointer_cast<BaseValueSegment>(segment)) {
+    segment_type += "ValueS";
+  } else if (std::dynamic_pointer_cast<ReferenceSegment>(segment)) {
+    segment_type += "ReferS";
+  } else if (const auto& encoded_segment = std::dynamic_pointer_cast<BaseEncodedSegment>(segment)) {
+    switch (encoded_segment->encoding_type()) {
+      case EncodingType::Dictionary: {
+        segment_type += "Dic:";
+        break;
+      }
+      case EncodingType::RunLength: {
+        segment_type += "RLE:";
+        break;
+      }
+      case EncodingType::FixedStringDictionary: {
+        segment_type += "FSD:";
+        break;
+      }
+      case EncodingType::FrameOfReference: {
+        segment_type += "FoR:";
+        break;
+      }
+      default: { Fail("Unknown encoding type"); }
+    }
+    if (encoded_segment->compressed_vector_type()) {
+      switch (*encoded_segment->compressed_vector_type()) {
+        case CompressedVectorType::FixedSize4ByteAligned: {
+          segment_type += "4B";
+          break;
+        }
+        case CompressedVectorType::FixedSize2ByteAligned: {
+          segment_type += "2B";
+          break;
+        }
+        case CompressedVectorType::FixedSize1ByteAligned: {
+          segment_type += "1B";
+          break;
+        }
+        case CompressedVectorType::SimdBp128: {
+          segment_type += "BP";
+          break;
+        }
+      }
+    } else {
+      segment_type += "-";
+    }
+  } else {
+    Fail("Unknown segment type");
+  }
+  segment_type += ">";
+  return segment_type;
 }
 
 }  // namespace opossum

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -92,8 +92,8 @@ std::shared_ptr<const Table> Print::_on_execute() {
       const auto& segment = chunk->get_segment(column_id);
       _out << "|" << std::setw(column_width) << _segment_type(segment) << std::setw(0);
     }
-    if (_flags & PrintMvcc) _out << "||";
-    _out << std::endl;
+    if (_flags & PrintMvcc) _out << "|";
+    _out << "|" << std::endl;
 
     // print the rows in the chunk
     for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk->size(); ++chunk_offset) {

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<const Table> Print::_on_execute() {
     for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
       const auto column_width = widths[column_id];
       const auto& segment = chunk->get_segment(column_id);
-      _out << "|" << std::setw(column_width) << _segment_type(segment) << std::setw(0);
+      _out << "|" << std::setw(column_width) << std::left << _segment_type(segment) << std::right << std::setw(0);
     }
     if (_flags & PrintMvcc) _out << "|";
     _out << "|" << std::endl;

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -27,6 +27,7 @@ class Print : public AbstractReadOnlyOperator {
   std::vector<uint16_t> _column_string_widths(uint16_t min, uint16_t max,
                                               const std::shared_ptr<const Table>& table) const;
   std::string _truncate_cell(const AllTypeVariant& cell, uint16_t max_width) const;
+  std::string _segment_type(const std::shared_ptr<BaseSegment>& segment) const;
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_input_left,

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -313,22 +313,25 @@ TEST_F(OperatorsPrintTest, NullableColumnPrinting) {
 TEST_F(OperatorsPrintTest, SegmentType) {
   auto table = load_table("resources/test_data/tbl/int_float.tbl", 2);
 
-  ChunkEncoder::encode_chunks(table, {ChunkID{0}});
+  ChunkEncoder::encode_chunks(table, {ChunkID{0}}, EncodingType::Dictionary);
+  ChunkEncoder::encode_chunks(table, {ChunkID{1}}, EncodingType::RunLength);
 
-  Print::print(table, 2, output);
+  Print::print(table, 1, output);
 
   auto expected_output =
       "=== Columns\n"
-      "|       a|       b||        MVCC        |\n"
-      "|     int|   float||_BEGIN|_END  |_TID  |\n"
-      "|not null|not null||      |      |      |\n"
+      "|       a|       b|\n"
+      "|     int|   float|\n"
+      "|not null|not null|\n"
       "=== Chunk 0 ===\n"
-      "|<Dic:1B>|<Dic:1B>||\n"
-      "|   12345|   458.7||     0|      |      |\n"
-      "|     123|   456.7||     0|      |      |\n"
+      "|<Dic:1B>|<Dic:1B>|\n"
+      "|   12345|   458.7|\n"
       "=== Chunk 1 ===\n"
-      "|<ValueS>|<ValueS>||\n"
-      "|    1234|   457.7||     0|      |      |\n";
+      "|<RLE>   |<RLE>   |\n"
+      "|     123|   456.7|\n"
+      "=== Chunk 2===\n"
+      "|<ValueS>|<ValueS>|\n"
+      "|    1234|   457.7|\n";
   EXPECT_EQ(output.str(), expected_output);
 }
 

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -311,7 +311,7 @@ TEST_F(OperatorsPrintTest, NullableColumnPrinting) {
 }
 
 TEST_F(OperatorsPrintTest, SegmentType) {
-  auto table = load_table("resources/test_data/tbl/int_float.tbl", 2);
+  auto table = load_table("resources/test_data/tbl/int_float.tbl", 1);
 
   ChunkEncoder::encode_chunks(table, {ChunkID{0}}, EncodingType::Dictionary);
   ChunkEncoder::encode_chunks(table, {ChunkID{1}}, EncodingType::RunLength);

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -8,6 +8,7 @@
 #include "operators/get_table.hpp"
 #include "operators/print.hpp"
 #include "operators/table_wrapper.hpp"
+#include "storage/chunk_encoder.hpp"
 #include "storage/storage_manager.hpp"
 #include "storage/table.hpp"
 
@@ -94,7 +95,7 @@ TEST_F(OperatorsPrintTest, FilledTable) {
 
   // check the line count of the output string
   size_t line_count = std::count(output_string.begin(), output_string.end(), '\n');
-  size_t expected_line_count = 4 + 11 * chunk_count;  // 4 header lines + all 10-line chunks with chunk header
+  size_t expected_line_count = 4 + 12 * chunk_count;  // 4 header lines + all 10-line chunks with chunk header
   EXPECT_EQ(line_count, expected_line_count);
 
   EXPECT_TRUE(output_string.find("Chunk 0") != std::string::npos);
@@ -264,9 +265,11 @@ TEST_F(OperatorsPrintTest, MVCCTableLoad) {
       "|     int|   float||_BEGIN|_END  |_TID  |\n"
       "|not null|not null||      |      |      |\n"
       "=== Chunk 0 ===\n"
+      "|<ValueS>|<ValueS>||\n"
       "|   12345|   458.7||     0|      |      |\n"
       "|     123|   456.7||     0|      |      |\n"
       "=== Chunk 1 ===\n"
+      "|<ValueS>|<ValueS>||\n"
       "|    1234|   457.7||     0|      |      |\n";
   EXPECT_EQ(output.str(), expected_output);
 }
@@ -304,6 +307,28 @@ TEST_F(OperatorsPrintTest, NullableColumnPrinting) {
 
   Print::print(tab, 0, output);
 
+  EXPECT_EQ(output.str(), expected_output);
+}
+
+TEST_F(OperatorsPrintTest, SegmentType) {
+  auto table = load_table("resources/test_data/tbl/int_float.tbl", 2);
+
+  ChunkEncoder::encode_chunks(table, {ChunkID{0}});
+
+  Print::print(table, 2, output);
+
+  auto expected_output =
+      "=== Columns\n"
+      "|       a|       b||        MVCC        |\n"
+      "|     int|   float||_BEGIN|_END  |_TID  |\n"
+      "|not null|not null||      |      |      |\n"
+      "=== Chunk 0 ===\n"
+      "|<Dic:1B>|<Dic:1B>||\n"
+      "|   12345|   458.7||     0|      |      |\n"
+      "|     123|   456.7||     0|      |      |\n"
+      "=== Chunk 1 ===\n"
+      "|<ValueS>|<ValueS>||\n"
+      "|    1234|   457.7||     0|      |      |\n";
   EXPECT_EQ(output.str(), expected_output);
 }
 

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -329,7 +329,7 @@ TEST_F(OperatorsPrintTest, SegmentType) {
       "=== Chunk 1 ===\n"
       "|<RLE>   |<RLE>   |\n"
       "|     123|   456.7|\n"
-      "=== Chunk 2===\n"
+      "=== Chunk 2 ===\n"
       "|<ValueS>|<ValueS>|\n"
       "|    1234|   457.7|\n";
   EXPECT_EQ(output.str(), expected_output);


### PR DESCRIPTION
fixes #1363

## Adds encoding options to `load` command in console

```
(debug)> load ../resources/test_data/csv/float_int.csv t Dictionary
Loading ../resources/test_data/csv/float_int.csv into table "t"
Encoding "t" using Dictionary
```

## Removes the need for specifying a table name

```
(debug)> load ../resources/test_data/csv/float_int.csv
Loading ../resources/test_data/csv/float_int.csv into table "float_int"
Encoding "float_int" using Unencoded
```

## Enables printing of segment encoding information
```
(debug)> print t
=== Columns
|       b|       a||        MVCC        |
|   float|     int||_BEGIN|_END  |_TID  |
|not null|not null||      |      |      |
=== Chunk 0 ===
|<Dic:1B>|<Dic:1B>||
|   458.7|   12345||     0|      |      |
```