### PR TITLE
Fix plugin unload behaviour.

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -877,7 +877,7 @@ int Console::_unload_plugin(const std::string& input) {
 
   if (arguments.size() != 1) {
     out("Usage:\n");
-    out("  unload_plugin PLUGINNAME\n");
+    out("  unload_plugin NAME\n");
     return ReturnCode::Error;
   }
 

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -51,9 +51,9 @@ void PluginManager::reset() { get() = PluginManager(); }
 
 void PluginManager::unload_plugin(const PluginName& name) {
   auto plugin = _plugins.find(name);
-  if (plugin != _plugins.cend()) {
-    _unload_erase_plugin(plugin);
-  }
+  Assert(plugin != _plugins.cend(), "Unloading plugin failed: A plugin with name  " + name + " does not exist.");
+
+  _unload_erase_plugin(plugin);
 }
 
 const std::unordered_map<PluginName, PluginHandleWrapper>::iterator PluginManager::_unload_erase_plugin(


### PR DESCRIPTION
As found out by @Bouncner [here](https://github.com/Bensk1/example-plugin/issues/1), unloading a plugin does not fail or indicate if the plugin did not exist in the first place. This PR is going to fix it and does some minor renamings.