### PR TITLE
Faster type erasure for iterators

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -396,6 +396,7 @@ set(
     storage/chunk_encoder.cpp
     storage/chunk_encoder.hpp
     storage/create_iterable_from_segment.hpp
+    storage/create_iterable_from_segment.ipp
     storage/dictionary_segment.cpp
     storage/dictionary_segment.hpp
     storage/dictionary_segment/attribute_vector_iterable.hpp

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -27,45 +27,45 @@ class ReferenceSegmentIterable;
  * @{
  */
 
-template <typename T>
+template <typename T, bool EraseType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const ValueSegment<T>& segment) {
-  if constexpr (HYRISE_DEBUG) {
+  if constexpr (EraseType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return ValueSegmentIterable<T>{segment};
   }
 }
 
-template <typename T>
+template <typename T, bool EraseType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
-  if constexpr (HYRISE_DEBUG) {
+  if constexpr (EraseType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
   }
 }
 
-template <typename T>
+template <typename T, bool EraseType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
-  if constexpr (HYRISE_DEBUG) {
+  if constexpr (EraseType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return RunLengthSegmentIterable<T>{segment};
   }
 }
 
-template <typename T>
+template <typename T, bool EraseType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
-  if constexpr (HYRISE_DEBUG) {
+  if constexpr (EraseType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return DictionarySegmentIterable<T, FixedStringVector>{segment};
   }
 }
 
-template <typename T>
+template <typename T, bool EraseType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
-  if constexpr (HYRISE_DEBUG) {
+  if constexpr (EraseType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return FrameOfReferenceIterable<T>{segment};
@@ -76,7 +76,7 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
  * This function must be forward-declared because ReferenceSegmentIterable
  * includes this file leading to a circular dependency
  */
-template <typename T>
+template <typename T, bool EraseType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 /**@}*/

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -1,17 +1,14 @@
 #pragma once
 
-#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
-#include "storage/encoding_type.hpp"
-#include "storage/segment_iterables/any_segment_iterable.hpp"
-
-#include "resolve_type.hpp"
-#include "storage/frame_of_reference/frame_of_reference_iterable.hpp"
-#include "storage/reference_segment.hpp"
-#include "storage/run_length_segment/run_length_segment_iterable.hpp"
-#include "storage/value_segment/value_segment_iterable.hpp"
+#include "storage/dictionary_segment/dictionary_segment_iterable.hpp" // NEEDEDINCLUDE
+#include "storage/frame_of_reference/frame_of_reference_iterable.hpp" // NEEDEDINCLUDE
+#include "storage/run_length_segment/run_length_segment_iterable.hpp" // NEEDEDINCLUDE
+#include "storage/value_segment/value_segment_iterable.hpp" // NEEDEDINCLUDE
+#include "storage/segment_iterables/any_segment_iterable.hpp" // NEEDEDINCLUDE
 
 namespace opossum {
 
+class ReferenceSegment;
 template <typename T>
 class ReferenceSegmentIterable;
 
@@ -32,27 +29,47 @@ class ReferenceSegmentIterable;
 
 template <typename T>
 auto create_iterable_from_segment(const ValueSegment<T>& segment) {
-  return erase_type_from_iterable_if_debug(ValueSegmentIterable<T>{segment});
+  if constexpr (HYRISE_DEBUG) {
+  	return create_any_segment_iterable<T>(segment);
+  } else {
+  	return ValueSegmentIterable<T>{segment};
+  }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
-  return erase_type_from_iterable_if_debug(DictionarySegmentIterable<T, pmr_vector<T>>{segment});
+  if constexpr (HYRISE_DEBUG) {
+  	return create_any_segment_iterable<T>(segment);
+  } else {
+  	return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
+  }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
-  return erase_type_from_iterable_if_debug(RunLengthSegmentIterable<T>{segment});
+  if constexpr (HYRISE_DEBUG) {
+  	return create_any_segment_iterable<T>(segment);
+  } else {
+  	return RunLengthSegmentIterable<T>{segment};
+  }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
-  return erase_type_from_iterable_if_debug(DictionarySegmentIterable<T, FixedStringVector>{segment});
+  if constexpr (HYRISE_DEBUG) {
+  	return create_any_segment_iterable<T>(segment);
+  } else {
+  	return DictionarySegmentIterable<T, FixedStringVector>{segment};
+  }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
-  return erase_type_from_iterable_if_debug(FrameOfReferenceIterable<T>{segment});
+  if constexpr (HYRISE_DEBUG) {
+  	return create_any_segment_iterable<T>(segment);
+  } else {
+  	return FrameOfReferenceIterable<T>{segment};
+  }
 }
 
 /**
@@ -66,4 +83,4 @@ auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 }  // namespace opossum
 
-#include "create_iterable_from_segment.ipp"
+#include "create_iterable_from_segment.ipp" // NEEDEDINCLUDE

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -1,18 +1,10 @@
 #pragma once
 
-<<<<<<< HEAD
-#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"  // NEEDEDINCLUDE
-#include "storage/frame_of_reference/frame_of_reference_iterable.hpp"  // NEEDEDINCLUDE
-#include "storage/run_length_segment/run_length_segment_iterable.hpp"  // NEEDEDINCLUDE
-#include "storage/segment_iterables/any_segment_iterable.hpp"          // NEEDEDINCLUDE
-#include "storage/value_segment/value_segment_iterable.hpp"            // NEEDEDINCLUDE
-=======
 #include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
 #include "storage/frame_of_reference/frame_of_reference_iterable.hpp"
 #include "storage/run_length_segment/run_length_segment_iterable.hpp"
 #include "storage/value_segment/value_segment_iterable.hpp"
 #include "storage/segment_iterables/any_segment_iterable.hpp"
->>>>>>> ce77f37614840783e89195e6f697d89996ccd226
 
 namespace opossum {
 

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "storage/dictionary_segment/dictionary_segment_iterable.hpp" // NEEDEDINCLUDE
-#include "storage/frame_of_reference/frame_of_reference_iterable.hpp" // NEEDEDINCLUDE
-#include "storage/run_length_segment/run_length_segment_iterable.hpp" // NEEDEDINCLUDE
-#include "storage/value_segment/value_segment_iterable.hpp" // NEEDEDINCLUDE
-#include "storage/segment_iterables/any_segment_iterable.hpp" // NEEDEDINCLUDE
+#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"  // NEEDEDINCLUDE
+#include "storage/frame_of_reference/frame_of_reference_iterable.hpp"  // NEEDEDINCLUDE
+#include "storage/run_length_segment/run_length_segment_iterable.hpp"  // NEEDEDINCLUDE
+#include "storage/segment_iterables/any_segment_iterable.hpp"          // NEEDEDINCLUDE
+#include "storage/value_segment/value_segment_iterable.hpp"            // NEEDEDINCLUDE
 
 namespace opossum {
 
@@ -30,45 +30,45 @@ class ReferenceSegmentIterable;
 template <typename T>
 auto create_iterable_from_segment(const ValueSegment<T>& segment) {
   if constexpr (HYRISE_DEBUG) {
-  	return create_any_segment_iterable<T>(segment);
+    return create_any_segment_iterable<T>(segment);
   } else {
-  	return ValueSegmentIterable<T>{segment};
+    return ValueSegmentIterable<T>{segment};
   }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
   if constexpr (HYRISE_DEBUG) {
-  	return create_any_segment_iterable<T>(segment);
+    return create_any_segment_iterable<T>(segment);
   } else {
-  	return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
+    return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
   }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
   if constexpr (HYRISE_DEBUG) {
-  	return create_any_segment_iterable<T>(segment);
+    return create_any_segment_iterable<T>(segment);
   } else {
-  	return RunLengthSegmentIterable<T>{segment};
+    return RunLengthSegmentIterable<T>{segment};
   }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
   if constexpr (HYRISE_DEBUG) {
-  	return create_any_segment_iterable<T>(segment);
+    return create_any_segment_iterable<T>(segment);
   } else {
-  	return DictionarySegmentIterable<T, FixedStringVector>{segment};
+    return DictionarySegmentIterable<T, FixedStringVector>{segment};
   }
 }
 
 template <typename T>
 auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
   if constexpr (HYRISE_DEBUG) {
-  	return create_any_segment_iterable<T>(segment);
+    return create_any_segment_iterable<T>(segment);
   } else {
-  	return FrameOfReferenceIterable<T>{segment};
+    return FrameOfReferenceIterable<T>{segment};
   }
 }
 
@@ -83,4 +83,4 @@ auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 }  // namespace opossum
 
-#include "create_iterable_from_segment.ipp" // NEEDEDINCLUDE
+#include "create_iterable_from_segment.ipp"  // NEEDEDINCLUDE

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -27,45 +27,45 @@ class ReferenceSegmentIterable;
  * @{
  */
 
-template <typename T, bool EraseType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const ValueSegment<T>& segment) {
-  if constexpr (EraseType) {
+  if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return ValueSegmentIterable<T>{segment};
   }
 }
 
-template <typename T, bool EraseType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
-  if constexpr (EraseType) {
+  if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
   }
 }
 
-template <typename T, bool EraseType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
-  if constexpr (EraseType) {
+  if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return RunLengthSegmentIterable<T>{segment};
   }
 }
 
-template <typename T, bool EraseType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
-  if constexpr (EraseType) {
+  if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return DictionarySegmentIterable<T, FixedStringVector>{segment};
   }
 }
 
-template <typename T, bool EraseType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
-  if constexpr (EraseType) {
+  if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return FrameOfReferenceIterable<T>{segment};
@@ -76,7 +76,7 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
  * This function must be forward-declared because ReferenceSegmentIterable
  * includes this file leading to a circular dependency
  */
-template <typename T, bool EraseType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 /**@}*/

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -4,9 +4,9 @@
 
 namespace opossum {
 
-template <typename T>
+template <typename T, bool EraseType>
 auto create_iterable_from_segment(const ReferenceSegment& segment) {
-  if constexpr (HYRISE_DEBUG) {
+  if constexpr (EraseType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return ReferenceSegmentIterable<T>{segment};

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -1,12 +1,16 @@
 #pragma once
 
-#include "reference_segment/reference_segment_iterable.hpp"
+#include "reference_segment/reference_segment_iterable.hpp" // NEEDEDINCLUDE
 
 namespace opossum {
 
 template <typename T>
 auto create_iterable_from_segment(const ReferenceSegment& segment) {
-  return erase_type_from_iterable_if_debug(ReferenceSegmentIterable<T>{segment});
+  if constexpr (HYRISE_DEBUG) {
+  	return create_any_segment_iterable<T>(segment);
+  } else {
+  	return ReferenceSegmentIterable<T>{segment};
+  }
 }
 
 }  // namespace opossum

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "reference_segment/reference_segment_iterable.hpp" // NEEDEDINCLUDE
+#include "reference_segment/reference_segment_iterable.hpp"  // NEEDEDINCLUDE
 
 namespace opossum {
 
 template <typename T>
 auto create_iterable_from_segment(const ReferenceSegment& segment) {
   if constexpr (HYRISE_DEBUG) {
-  	return create_any_segment_iterable<T>(segment);
+    return create_any_segment_iterable<T>(segment);
   } else {
-  	return ReferenceSegmentIterable<T>{segment};
+    return ReferenceSegmentIterable<T>{segment};
   }
 }
 

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -4,9 +4,9 @@
 
 namespace opossum {
 
-template <typename T, bool EraseType>
+template <typename T, bool EraseSegmentType>
 auto create_iterable_from_segment(const ReferenceSegment& segment) {
-  if constexpr (EraseType) {
+  if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
     return ReferenceSegmentIterable<T>{segment};

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -15,8 +15,6 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
     any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
   });
 
-  DebugAssert(any_segment_iterable, "Could not create iterable");
-
   return std::move(*any_segment_iterable);
 }
 

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -11,9 +11,11 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
   auto any_segment_iterable = std::optional<AnySegmentIterable<T>>{};
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
-    const auto actual_iterable = create_iterable_from_segment<T>(segment);
+    const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
     any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
   });
+
+  DebugAssert(any_segment_iterable, "Could not create iterable");
 
   return std::move(*any_segment_iterable);
 }

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -67,6 +67,8 @@ add_library(
     cqf/src/cqf32.cpp
 )
 
+target_compile_options(cqf PRIVATE -Wno-format)
+
 target_include_directories(
     cqf
 


### PR DESCRIPTION
This reduces the compile time for the debug build as typed iterators are created once by `any_segment_iterable.cpp`, not every time `create_iterable_from_segment.hpp` is used.

You won't see any effect just with this, but it is blocking some bigger compile time reductions that I am working on.

(Also, it removes the pesky cqf warnings)