### PR TITLE
Move hash join applicability test

### DIFF
--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -35,13 +35,6 @@ class JoinEquiTest : public JoinTest {};
 using JoinEquiTypes = ::testing::Types<JoinNestedLoop, JoinHash, JoinSortMerge, JoinIndex, JoinMPSM>;
 TYPED_TEST_CASE(JoinEquiTest, JoinEquiTypes, );  // NOLINT(whitespace/parens)
 
-TYPED_TEST(JoinEquiTest, WrongJoinOperator) {
-  if (!HYRISE_DEBUG) GTEST_SKIP();
-  EXPECT_THROW(std::make_shared<JoinHash>(this->_table_wrapper_a, this->_table_wrapper_b, JoinMode::Left,
-                                          ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::GreaterThan),
-               std::logic_error);
-}
-
 TYPED_TEST(JoinEquiTest, LeftJoin) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_a, this->_table_wrapper_b, ColumnIDPair(ColumnID{0}, ColumnID{0}),


### PR DESCRIPTION
I found this while working on the sort-merge join and it bothered me. Test is executed for every join method but everytime the test actually just tests the same hash join call.

Further, the test is now covering more supported and unsupported cases.