### PR TITLE
Enable forced colored output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,8 @@ if(NOT CMAKE_BUILD_TYPE IN_LIST BUILD_TYPES)
     message(FATAL_ERROR "Unknown Build Type: ${CMAKE_BUILD_TYPE}")
 endif()
 
-# Flag to enforce colored output. When compilers recognize output to terminals, recent version automatically
-# use colored output. However, when using Ninja, the output is not directly sent to the terminal. With this
-# flag enabled, also Ninja builds have colored outputs.
-if (${FORCE_COLORED_OUTPUT})
+# Enforce colored output when generator is Ninja.
+if ("${CMAKE_GENERATOR}" STREQUAL "Ninja")
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
        add_compile_options(-fdiagnostics-color=always)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,17 @@ if(NOT CMAKE_BUILD_TYPE IN_LIST BUILD_TYPES)
     message(FATAL_ERROR "Unknown Build Type: ${CMAKE_BUILD_TYPE}")
 endif()
 
+# Flag to enforce colored output. When compiler recognize output to terminals, recent version automatically
+# set colored output. However, when using Ninja, the output is not directly the terminal. With this flag enabled,
+# also Ninja build will have colored outputs.
+if (${FORCE_COLORED_OUTPUT})
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+       add_compile_options (-fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+       add_compile_options (-fcolor-diagnostics)
+    endif ()
+endif ()
+
 # CMake settings
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH}) # To allow CMake to locate our Find*.cmake files
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}) # Put binaries into root of build tree

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,14 +66,14 @@ if(NOT CMAKE_BUILD_TYPE IN_LIST BUILD_TYPES)
     message(FATAL_ERROR "Unknown Build Type: ${CMAKE_BUILD_TYPE}")
 endif()
 
-# Flag to enforce colored output. When compiler recognize output to terminals, recent version automatically
-# set colored output. However, when using Ninja, the output is not directly the terminal. With this flag enabled,
-# also Ninja build will have colored outputs.
+# Flag to enforce colored output. When compilers recognize output to terminals, recent version automatically
+# use colored output. However, when using Ninja, the output is not directly sent to the terminal. With this
+# flag enabled, also Ninja builds have colored outputs.
 if (${FORCE_COLORED_OUTPUT})
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-       add_compile_options (-fdiagnostics-color=always)
+       add_compile_options(-fdiagnostics-color=always)
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-       add_compile_options (-fcolor-diagnostics)
+       add_compile_options(-fcolor-diagnostics)
     endif ()
 endif ()
 


### PR DESCRIPTION
Flag to enable "forced colored output". Not necessary for make, but for Ninja.
More information can be found here: https://medium.com/@alasher/colored-c-compiler-output-with-ninja-clang-gcc-10bfe7f2b949

Usage:
`cmake -DFORCE_COLORED_OUTPUT=ON -G Ninja ..`