### PR TITLE
Reduce compile time of Aggregate

### DIFF
--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -33,16 +33,19 @@ namespace {
   template <typename ResultIds, typename Results, typename AggregateKey>
   typename Results::reference get_or_add_result(ResultIds& result_ids, Results& results, const AggregateKey& key, const RowID& row_id) {
     // Get the result id for the current key or add it to the id map
-    auto result_id_inserted = result_ids.emplace(key, results.size());
+    auto it = result_ids.find(key);
+    if (it != result_ids.end()) return results[it->second];
+
+    auto result_id = results.size();
+
+    result_ids.emplace_hint(it, key, result_id);
 
     // If it was added to the id map, add the current row id to the result list so that we can revert the
     // value(s) -> key mapping
-    if (result_id_inserted.second) {
-      results.emplace_back();
-      results[result_id_inserted.first->second].row_id = row_id;
-    }
+    results[result_id].row_id = row_id;
+    results.emplace_back();
 
-    return results[result_id_inserted.first->second];
+    return results[result_id];
   }
 }
 

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -109,17 +109,23 @@ AggregateKey, the AggregateContext is the "full" version.
 */
 template <typename ColumnDataType, typename AggregateType>
 struct AggregateResultContext : SegmentVisitorContext {
+  using AggregateResultAllocator = PolymorphicAllocator<AggregateResults<ColumnDataType, AggregateType>>;
+
+  AggregateResultContext() : results(
+    AggregateResultAllocator{&buffer}
+  ) {}
+
+  boost::container::pmr::monotonic_buffer_resource buffer;
   AggregateResults<ColumnDataType, AggregateType> results;
 };
 
 template <typename ColumnDataType, typename AggregateType, typename AggregateKey>
-struct AggregateContext : AggregateResultContext<ColumnDataType, AggregateType> {
+struct AggregateContext : public AggregateResultContext<ColumnDataType, AggregateType> {
   AggregateContext() {
-    auto allocator = AggregateResultIdMapAllocator<AggregateKey>{&buffer};
+    auto allocator = AggregateResultIdMapAllocator<AggregateKey>{&this->buffer};
     result_ids = std::make_unique<AggregateResultIdMap<AggregateKey>>(allocator);
   }
 
-  boost::container::pmr::monotonic_buffer_resource buffer;
   std::unique_ptr<AggregateResultIdMap<AggregateKey>> result_ids;
 };
 

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -23,6 +23,29 @@
 #include "utils/assert.hpp"
 #include "utils/performance_warning.hpp"
 
+namespace {
+  using namespace opossum;
+
+  // Given an AggregateKey key, and a RowId row_id where this AggregateKey was encountered, this first checks if the
+  // AggregateKey was seen before. If not, a new aggregate result is inserted into results and connected to the row id.
+  // This is important so that we can reconstruct the original values later. In any case, a reference to the result is
+  // returned so that result information, such as the aggregate's count or sum, can be modified by the caller.
+  template <typename ResultIds, typename Results, typename AggregateKey>
+  typename Results::reference get_or_add_result(ResultIds& result_ids, Results& results, const AggregateKey& key, const RowID& row_id) {
+    // Get the result id for the current key or add it to the id map
+    auto result_id_inserted = result_ids.emplace(key, results.size());
+
+    // If it was added to the id map, add the current row id to the result list so that we can revert the
+    // value(s) -> key mapping
+    if (result_id_inserted.second) {
+      results.emplace_back();
+      results[result_id_inserted.first->second].row_id = row_id;
+    }
+
+    return results[result_id_inserted.first->second];
+  }
+}
+
 namespace opossum {
 
 Aggregate::Aggregate(const std::shared_ptr<AbstractOperator>& in,
@@ -186,9 +209,7 @@ void Aggregate::_aggregate_segment(ChunkID chunk_id, ColumnID column_index, cons
 
   ChunkOffset chunk_offset{0};
   segment_iterate<ColumnDataType>(base_segment, [&](const auto& position) {
-    auto& result_id = result_ids[hash_keys[chunk_offset]];
-    auto& result = results[result_id];
-    result.row_id = RowID(chunk_id, chunk_offset);
+    auto& result = get_or_add_result(result_ids, results, hash_keys[chunk_offset], RowID(chunk_id, chunk_offset));
 
     /**
     * If the value is NULL, the current aggregate value does not change.
@@ -426,9 +447,7 @@ void Aggregate::_aggregate() {
 
       for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
         // Make sure the value or combination of values is added to the list of distinct value(s)
-        auto& result_id = result_ids[hash_keys[chunk_offset]];
-        auto& result = results[result_id];
-        result.row_id = RowID(chunk_id, chunk_offset);
+        get_or_add_result(result_ids, results, hash_keys[chunk_offset], RowID{chunk_id, chunk_offset});
       }
     } else {
       ColumnID column_index{0};
@@ -449,9 +468,7 @@ void Aggregate::_aggregate() {
 
           // count occurrences for each group key
           for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
-            auto& result_id = result_ids[hash_keys[chunk_offset]];
-            auto& result = results[result_id];
-            result.row_id = RowID(chunk_id, chunk_offset);
+            auto& result = get_or_add_result(result_ids, results, hash_keys[chunk_offset], RowID{chunk_id, chunk_offset});
             ++result.aggregate_count;
           }
 

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -42,8 +42,8 @@ namespace {
 
     // If it was added to the id map, add the current row id to the result list so that we can revert the
     // value(s) -> key mapping
-    results[result_id].row_id = row_id;
     results.emplace_back();
+    results[result_id].row_id = row_id;
 
     return results[result_id];
   }

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -24,7 +24,7 @@
 #include "utils/performance_warning.hpp"
 
 namespace {
-using namespace opossum;
+using namespace opossum;  // NOLINT
 
 // Given an AggregateKey key, and a RowId row_id where this AggregateKey was encountered, this first checks if the
 // AggregateKey was seen before. If not, a new aggregate result is inserted into results and connected to the row id.

--- a/src/lib/operators/aggregate.cpp
+++ b/src/lib/operators/aggregate.cpp
@@ -24,28 +24,29 @@
 #include "utils/performance_warning.hpp"
 
 namespace {
-using namespace opossum;  // NOLINT
+  using namespace opossum;
 
-// Given an AggregateKey key, and a RowId row_id where this AggregateKey was encountered, this first checks if the
-// AggregateKey was seen before. If not, a new aggregate result is inserted into results and connected to the row id.
-// This is important so that we can reconstruct the original values later. In any case, a reference to the result is
-// returned so that result information, such as the aggregate's count or sum, can be modified by the caller.
-template <typename ResultIds, typename Results, typename AggregateKey>
-typename Results::reference get_or_add_result(ResultIds& result_ids, Results& results, const AggregateKey& key,
-                                              const RowID& row_id) {
-  // Get the result id for the current key or add it to the id map
-  auto result_id_inserted = result_ids.try_emplace(key, results.size());
-  const auto& result_id = result_id_inserted.first->second;
+  // Given an AggregateKey key, and a RowId row_id where this AggregateKey was encountered, this first checks if the
+  // AggregateKey was seen before. If not, a new aggregate result is inserted into results and connected to the row id.
+  // This is important so that we can reconstruct the original values later. In any case, a reference to the result is
+  // returned so that result information, such as the aggregate's count or sum, can be modified by the caller.
+  template <typename ResultIds, typename Results, typename AggregateKey>
+  typename Results::reference get_or_add_result(ResultIds& result_ids, Results& results, const AggregateKey& key, const RowID& row_id) {
+    // Get the result id for the current key or add it to the id map
+    auto it = result_ids.find(key);
+    if (it != result_ids.end()) return results[it->second];
 
-  // If it was added to the id map, add the current row id to the result list so that we can revert the
-  // value(s) -> key mapping
-  if (result_id_inserted.second) {
+    auto result_id = results.size();
+
+    result_ids.emplace_hint(it, key, result_id);
+
+    // If it was added to the id map, add the current row id to the result list so that we can revert the
+    // value(s) -> key mapping
     results.emplace_back();
     results[result_id].row_id = row_id;
-  }
 
-  return results[result_id];
-}
+    return results[result_id];
+  }
 }  // namespace
 
 namespace opossum {

--- a/src/lib/operators/aggregate.hpp
+++ b/src/lib/operators/aggregate.hpp
@@ -108,7 +108,7 @@ class Aggregate : public AbstractReadOnlyOperator {
   const std::string description(DescriptionMode description_mode) const override;
 
   // write the aggregated output for a given aggregate column
-  template <typename ColumnDataType, AggregateFunction function, typename AggregateKey>
+  template <typename ColumnDataType, AggregateFunction function>
   void write_aggregate_output(ColumnID column_index);
 
  protected:
@@ -125,7 +125,7 @@ class Aggregate : public AbstractReadOnlyOperator {
 
   void _on_cleanup() override;
 
-  template <typename AggregateKey, typename ColumnDataType>
+  template <typename ColumnDataType>
   void _write_aggregate_output(boost::hana::basic_type<ColumnDataType> type, ColumnID column_index,
                                AggregateFunction function);
 

--- a/src/lib/operators/aggregate.hpp
+++ b/src/lib/operators/aggregate.hpp
@@ -66,16 +66,14 @@ template <typename ColumnDataType, typename AggregateType>
 using AggregateResults = pmr_vector<AggregateResult<ColumnDataType, AggregateType>>;
 using AggregateResultId = size_t;
 
-
 // The AggregateResultIdMap maps AggregateKeys to their index in the list of aggregate results.
 template <typename AggregateKey>
-using AggregateResultIdMapAllocator =
-    PolymorphicAllocator<std::pair<const AggregateKey, AggregateResultId>>;
+using AggregateResultIdMapAllocator = PolymorphicAllocator<std::pair<const AggregateKey, AggregateResultId>>;
 
 template <typename AggregateKey>
 using AggregateResultIdMap =
-    std::unordered_map<AggregateKey, AggregateResultId, std::hash<AggregateKey>,
-                       std::equal_to<AggregateKey>, AggregateResultIdMapAllocator<AggregateKey>>;
+    std::unordered_map<AggregateKey, AggregateResultId, std::hash<AggregateKey>, std::equal_to<AggregateKey>,
+                       AggregateResultIdMapAllocator<AggregateKey>>;
 
 /*
 The key type that is used for the aggregation map.

--- a/src/lib/operators/aggregate.hpp
+++ b/src/lib/operators/aggregate.hpp
@@ -49,6 +49,7 @@ For implementation details, please check the wiki: https://github.com/hyrise/hyr
 */
 
 /*
+For each group in the output, one AggregateResult is created.
 Current aggregated value and the number of rows that were used.
 The latter is used for AVG and COUNT.
 */
@@ -60,11 +61,13 @@ struct AggregateResult {
   RowID row_id;
 };
 
+// This vector holds the results for every group that was encountered and is indexed by AggregateResultId.
 template <typename ColumnDataType, typename AggregateType>
 using AggregateResults = pmr_vector<AggregateResult<ColumnDataType, AggregateType>>;
-
 using AggregateResultId = size_t;
 
+
+// The AggregateResultIdMap maps AggregateKeys to their index in the list of aggregate results.
 template <typename AggregateKey>
 using AggregateResultIdMapAllocator =
     PolymorphicAllocator<std::pair<const AggregateKey, AggregateResultId>>;

--- a/src/lib/operators/aggregate.hpp
+++ b/src/lib/operators/aggregate.hpp
@@ -52,7 +52,7 @@ For implementation details, please check the wiki: https://github.com/hyrise/hyr
 Current aggregated value and the number of rows that were used.
 The latter is used for AVG and COUNT.
 */
-template <typename AggregateType, typename ColumnDataType>
+template <typename ColumnDataType, typename AggregateType>
 struct AggregateResult {
   std::optional<AggregateType> current_aggregate;
   size_t aggregate_count = 0;
@@ -60,14 +60,19 @@ struct AggregateResult {
   RowID row_id;
 };
 
-template <typename AggregateKey, typename AggregateType, typename ColumnDataType>
-using ResultMapAllocator =
-    PolymorphicAllocator<std::pair<const AggregateKey, AggregateResult<AggregateType, ColumnDataType>>>;
+template <typename ColumnDataType, typename AggregateType>
+using AggregateResults = pmr_vector<AggregateResult<ColumnDataType, AggregateType>>;
 
-template <typename AggregateKey, typename AggregateType, typename ColumnDataType>
-using AggregateResultMap =
-    std::unordered_map<AggregateKey, AggregateResult<AggregateType, ColumnDataType>, std::hash<AggregateKey>,
-                       std::equal_to<AggregateKey>, ResultMapAllocator<AggregateKey, AggregateType, ColumnDataType>>;
+using AggregateResultId = size_t;
+
+template <typename AggregateKey>
+using AggregateResultIdMapAllocator =
+    PolymorphicAllocator<std::pair<const AggregateKey, AggregateResultId>>;
+
+template <typename AggregateKey>
+using AggregateResultIdMap =
+    std::unordered_map<AggregateKey, AggregateResultId, std::hash<AggregateKey>,
+                       std::equal_to<AggregateKey>, AggregateResultIdMapAllocator<AggregateKey>>;
 
 /*
 The key type that is used for the aggregation map.
@@ -103,7 +108,7 @@ class Aggregate : public AbstractReadOnlyOperator {
   const std::string description(DescriptionMode description_mode) const override;
 
   // write the aggregated output for a given aggregate column
-  template <typename ColumnType, AggregateFunction function, typename AggregateKey>
+  template <typename ColumnDataType, AggregateFunction function, typename AggregateKey>
   void write_aggregate_output(ColumnID column_index);
 
  protected:
@@ -120,8 +125,8 @@ class Aggregate : public AbstractReadOnlyOperator {
 
   void _on_cleanup() override;
 
-  template <typename AggregateKey, typename ColumnType>
-  void _write_aggregate_output(boost::hana::basic_type<ColumnType> type, ColumnID column_index,
+  template <typename AggregateKey, typename ColumnDataType>
+  void _write_aggregate_output(boost::hana::basic_type<ColumnDataType> type, ColumnID column_index,
                                AggregateFunction function);
 
   void _write_groupby_output(PosList& pos_list);


### PR DESCRIPTION
This mostly moves around code in the aggregate operator. It is not the oh-so-much needed cleanup/rewrite, but at least reduces the compile time:

Previously (my laptop, debug): 0m35.766s
Now: 0m22.158s

Details:
* Removes unused GroupByContext struct.
* Splits up AggregateContext so that we can use it without the caller being templated on AggregateKey.
* Stores AggregateResult in a vector instead of the AggregateResultMap. This reduces the number of instantiations of that map. Also, it allows for the output step to be independent of AggregateKey.

Performance, just to show that I didn't break anything (not TPC-H, because that is not using the operator heavily enough; measured on nemea):

```
(release)> generate_tpch 10
(release)> SELECT COUNT(*) FROM lineitem GROUP BY l_suppkey LIMIT 10

# Old: EXECUTE: 5 s 847 ms // 5 s 795 ms // 5 s 733 ms
# New: EXECUTE: 5 s 807 ms // 5 s 699 ms // 5 s 590 ms
```