### PR TITLE
Reduce compile time of ColumnVsColumnTableScanImpl

### DIFF
--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -42,7 +42,8 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
   // We use type erasure here because we currently do not compare, e.g., a ValueSegment with a DictionarySegment,
   // and we don't want the compiler to spend time instantiating unused templates. Whenever the types of the iterators
   // is removed, we also erase the comparator lambda by wrapping it into an std::function. All of this brought the
-  // compile time down by a factor of 5.
+  // compile time down by a factor of 5. This is only relevant for the release build - in the debug build, iterators
+  // are erased anyway.
 
   resolve_data_and_segment_type(left_segment, [&](auto left_type, auto& left_typed_segment) {
     resolve_data_and_segment_type(right_segment, [&](auto right_type, auto& right_typed_segment) {

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -32,81 +32,95 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
   const auto& left_segment = *chunk->get_segment(_left_column_id);
   const auto& right_segment = *chunk->get_segment(_right_column_id);
 
+  std::shared_ptr<PosList> result;
+
   // If the left and the right segment and/or type are not the same, we erase the types even for the release build.
-  // This because we have not worked with those combinations and we don't want the templates to be instantiated.
-  const bool either_is_reference_segment =
-      dynamic_cast<const ReferenceSegment*>(&left_segment) || dynamic_cast<const ReferenceSegment*>(&right_segment);
-  // if (typeid(left_segment) == typeid(right_segment) && either_is_reference_segment) {
-  //   return _typed_scan_chunk<SegmentIterationTypeErasure::OnlyInDebug>(chunk_id);
-  // } else {
-    return _typed_scan_chunk<SegmentIterationTypeErasure::Always>(chunk_id);
-    if (!HYRISE_DEBUG)
-      PerformanceWarning("Using non-specialized (i.e., type-erased) version of ColumnVsColumnTableScan");
-  // }
+  // For example, ValueSegment<int> == ValueSegment<float> will be erased. So will ValueSegment<int> ==
+  // DictionarySegment<int>. ReferenceSegments do not need to be handled differently because we expect a table to
+  // either have only ReferenceSegments or non-ReferenceSegments.
+  //
+  // We use type erasure here because we currently do not compare, e.g., a ValueSegment with a DictionarySegment,
+  // and we don't want the compiler to spend time instantiating unused templates. Whenever the types of the iterators
+  // is removed, we also erase the comparator lambda by wrapping it into an std::function. All of this brought the
+  // compile time down by a factor of 5.
+
+  resolve_data_and_segment_type(left_segment, [&](auto left_type, auto& left_typed_segment) {
+    resolve_data_and_segment_type(right_segment, [&](auto right_type, auto& right_typed_segment) {
+      using LeftType = typename decltype(left_type)::type;
+      using RightType = typename decltype(right_type)::type;
+
+      if constexpr (!HYRISE_DEBUG && std::is_same_v<decltype(left_typed_segment), decltype(right_typed_segment)>) {
+        // Same segment types - do not erase types
+        result = _typed_scan_chunk<SegmentIterationTypeErasure::OnlyInDebug>(
+            chunk_id, create_iterable_from_segment<LeftType>(left_typed_segment),
+            create_iterable_from_segment<RightType>(right_typed_segment));
+      } else {
+        PerformanceWarning("ColumnVsColumnTableScan using type-erased iterators");
+        result = _typed_scan_chunk<SegmentIterationTypeErasure::Always>(
+            chunk_id, create_any_segment_iterable<LeftType>(left_segment),
+            create_any_segment_iterable<RightType>(right_segment));
+      }
+    });
+  });
+
+  return result;
 }
 
-template <SegmentIterationTypeErasure type_erasure>
-std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID chunk_id) const {
+template <SegmentIterationTypeErasure type_erasure, typename LeftIterable, typename RightIterable>
+std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID chunk_id,
+                                                                        const LeftIterable& left_iterable,
+                                                                        const RightIterable& right_iterable) const {
   const auto chunk = _in_table->get_chunk(chunk_id);
-
-  const auto left_segment = chunk->get_segment(_left_column_id);
-  const auto right_segment = chunk->get_segment(_right_column_id);
 
   auto matches_out = std::make_shared<PosList>();
 
-  auto erase_comparator_type = [](auto comparator, const auto& left_it, const auto& right_it) {
-    if constexpr (type_erasure == SegmentIterationTypeErasure::Always) {
-      return comparator;
-    } else {
-      return std::function<bool(const AbstractSegmentPosition<std::decay_t<decltype(left_it->value())>>&,
-                                const AbstractSegmentPosition<std::decay_t<decltype(right_it->value())>>&)>{comparator};
+  using LeftType = typename LeftIterable::ValueType;
+  using RightType = typename RightIterable::ValueType;
+
+  // C++ cannot compare strings and non-strings out of the box:
+  if constexpr (std::is_same_v<LeftType, std::string> == std::is_same_v<RightType, std::string>) {
+    bool flipped = false;
+    auto condition = _predicate_condition;
+    if (condition == PredicateCondition::GreaterThan || condition == PredicateCondition::GreaterThanEquals) {
+      condition = flip_predicate_condition(condition);
+      flipped = true;
     }
-  };
 
-  segment_with_iterators<ResolveDataTypeTag, type_erasure>(*left_segment, [&](auto left_it,
-                                                                              [[maybe_unused]] const auto left_end) {
-    segment_with_iterators<ResolveDataTypeTag, type_erasure>(
-        *right_segment, [&](auto right_it, [[maybe_unused]] const auto right_end) {
-          using LeftType = typename decltype(left_it)::ValueType;
-          using RightType = typename decltype(right_it)::ValueType;
+    auto erase_comparator_type = [](auto comparator, const auto& it1, const auto& it2) {
+      if constexpr (type_erasure == SegmentIterationTypeErasure::Always) {
+        return comparator;
+      } else {
+        return std::function<bool(const AbstractSegmentPosition<std::decay_t<decltype(it1->value())>>&,
+                                  const AbstractSegmentPosition<std::decay_t<decltype(it2->value())>>&)>{comparator};
+      }
+    };
 
-          // C++ cannot compare strings and non-strings out of the box:
-          if constexpr (std::is_same_v<LeftType, std::string> == std::is_same_v<RightType, std::string>) {
-            bool flipped = false;
-            auto condition = _predicate_condition;
-            if (condition == PredicateCondition::GreaterThan || condition == PredicateCondition::GreaterThanEquals) {
-              condition = flip_predicate_condition(condition);
-              flipped = true;
-            }
+    // Dirty hack to avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86740
+    const auto chunk_id_copy = chunk_id;
+    const auto& matches_out_ref = matches_out;
 
-            // Dirty hack to avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86740
-            const auto left_it_copy = left_it;
-            const auto left_end_copy = left_end;
-            const auto right_it_copy = right_it;
-            const auto right_end_copy = right_end;
-            const auto chunk_id_copy = chunk_id;
-            const auto& matches_out_ref = matches_out;
+    left_iterable.with_iterators([&](auto left_it, const auto left_end) {
+      right_iterable.with_iterators([&](auto right_it, const auto right_end) {
+        with_comparator_light(condition, [&](auto predicate_comparator) {
+          const auto comparator = [predicate_comparator](const auto& left, const auto& right) {
+            return predicate_comparator(left.value(), right.value());
+          };
 
-            with_comparator_light(condition, [&](auto predicate_comparator) {
-              const auto comparator = [predicate_comparator](const auto& left, const auto& right) {
-                return predicate_comparator(left.value(), right.value());
-              };
-
-              if (flipped) {
-                const auto erased_comparator = erase_comparator_type(comparator, right_it, left_it);
-                AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it_copy, right_end_copy,
-                                                                  chunk_id_copy, *matches_out_ref, left_it_copy);
-              } else {
-                const auto erased_comparator = erase_comparator_type(comparator, left_it, right_it);
-                AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it_copy, left_end_copy,
-                                                                  chunk_id_copy, *matches_out_ref, right_it_copy);
-              }
-            });
+          if (flipped) {
+            const auto erased_comparator = erase_comparator_type(comparator, right_it, left_it);
+            AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id_copy,
+                                                              *matches_out_ref, left_it);
           } else {
-            Fail("Trying to compare strings and non-strings");
+            const auto erased_comparator = erase_comparator_type(comparator, left_it, right_it);
+            AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it, left_end, chunk_id_copy,
+                                                              *matches_out_ref, right_it);
           }
         });
-  });
+      });
+    });
+  } else {
+    Fail("Trying to compare strings and non-strings");
+  }
 
   return matches_out;
 }

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
     return _typed_scan_chunk<SegmentIterationTypeErasure::OnlyInDebug>(chunk_id);
   } else {
     return _typed_scan_chunk<SegmentIterationTypeErasure::Always>(chunk_id);
-    if (!IS_DEBUG) PerformanceWarning("Using non-specialized (i.e., type-erased) version of ColumnVsColumnTableScan");
+    if (!HYRISE_DEBUG) PerformanceWarning("Using non-specialized (i.e., type-erased) version of ColumnVsColumnTableScan");
   }
 }
 

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -65,16 +65,24 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID 
           flipped = true;
         }
 
+         // Dirty hack to avoid https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86740
+        const auto left_it_copy = left_it;
+        const auto left_end_copy = left_end;
+        const auto right_it_copy = right_it;
+        const auto right_end_copy = right_it;
+        const auto chunk_id_copy = chunk_id;
+        const auto& matches_out_ref = matches_out;
+
         with_comparator_light(condition, [&](auto predicate_comparator) {
           auto comparator = [predicate_comparator](const auto& left, const auto& right) {
             return predicate_comparator(left.value(), right.value());
           };
           if (flipped) {
-            AbstractTableScanImpl::_scan_with_iterators<true>(comparator, right_it, right_end, chunk_id, *matches_out,
-                                                              left_it);
+            AbstractTableScanImpl::_scan_with_iterators<true>(comparator, right_it_copy, right_end_copy, chunk_id_copy, *matches_out_ref,
+                                                              left_it_copy);
           } else {
-            AbstractTableScanImpl::_scan_with_iterators<true>(comparator, left_it, left_end, chunk_id, *matches_out,
-                                                              right_it);
+            AbstractTableScanImpl::_scan_with_iterators<true>(comparator, left_it_copy, left_end_copy, chunk_id_copy, *matches_out_ref,
+                                                              right_it_copy);
           }
         });
       } else {

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -52,8 +52,8 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID 
 
   auto matches_out = std::make_shared<PosList>();
 
-  segment_with_iterators<ResolveDataTypeTag, SegmentIterationTypeErasure>(*left_segment, [&](auto left_it, [[maybe_unused]] const auto left_end) {
-    segment_with_iterators<ResolveDataTypeTag, SegmentIterationTypeErasure>(*right_segment, [&](auto right_it, [[maybe_unused]] const auto right_end) {
+  segment_with_iterators<ResolveDataTypeTag, type_erasure>(*left_segment, [&](auto left_it, [[maybe_unused]] const auto left_end) {
+    segment_with_iterators<ResolveDataTypeTag, type_erasure>(*right_segment, [&](auto right_it, [[maybe_unused]] const auto right_end) {
       using LeftType = typename decltype(left_it)::ValueType;
       using RightType = typename decltype(right_it)::ValueType;
 

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -51,8 +51,8 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID 
 
   auto matches_out = std::make_shared<PosList>();
 
-  segment_with_iterators(*left_segment, [&](auto left_it, const auto left_end) {
-    segment_with_iterators(*right_segment, [&](auto right_it, const auto right_end) {
+  segment_with_iterators(*left_segment, [&](auto left_it, [[maybe_unused]] const auto left_end) {
+    segment_with_iterators(*right_segment, [&](auto right_it, [[maybe_unused]] const auto right_end) {
       using LeftType = typename decltype(left_it)::ValueType;
       using RightType = typename decltype(right_it)::ValueType;
 

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
           flipped = true;
         }
 
-        with_comparator(condition, [&](auto predicate_comparator) {
+        with_comparator_light(condition, [&](auto predicate_comparator) {
           auto comparator = [predicate_comparator](const auto& left, const auto& right) {
             return predicate_comparator(left.value(), right.value());
           };

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
@@ -36,6 +36,9 @@ class ColumnVsColumnTableScanImpl : public AbstractTableScanImpl {
   const ColumnID _left_column_id;
   const PredicateCondition _predicate_condition;
   const ColumnID _right_column_id;
+
+  template<SegmentIterationTypeErasure type_erasure>
+  std::shared_ptr<PosList> _typed_scan_chunk(ChunkID chunk_id) const;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
@@ -37,8 +37,9 @@ class ColumnVsColumnTableScanImpl : public AbstractTableScanImpl {
   const PredicateCondition _predicate_condition;
   const ColumnID _right_column_id;
 
-  template <SegmentIterationTypeErasure type_erasure>
-  std::shared_ptr<PosList> _typed_scan_chunk(ChunkID chunk_id) const;
+  template <SegmentIterationTypeErasure type_erasure, typename LeftIterable, typename RightIterable>
+  std::shared_ptr<PosList> _typed_scan_chunk(ChunkID chunk_id, const LeftIterable& left_iterable,
+                                             const RightIterable& right_iterable) const;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
@@ -37,7 +37,7 @@ class ColumnVsColumnTableScanImpl : public AbstractTableScanImpl {
   const PredicateCondition _predicate_condition;
   const ColumnID _right_column_id;
 
-  template<SegmentIterationTypeErasure type_erasure>
+  template <SegmentIterationTypeErasure type_erasure>
   std::shared_ptr<PosList> _typed_scan_chunk(ChunkID chunk_id) const;
 };
 

--- a/src/lib/storage/segment_iterate.hpp
+++ b/src/lib/storage/segment_iterate.hpp
@@ -39,6 +39,8 @@ namespace opossum {
 
 struct ResolveDataTypeTag {};
 
+enum class SegmentIterationTypeErasure { OnlyInDebug, Always };
+
 // Variant without PosList
 template <typename T = ResolveDataTypeTag,
           SegmentIterationTypeErasure type_erasure = SegmentIterationTypeErasure::OnlyInDebug, typename Functor>

--- a/src/lib/storage/segment_iterate.hpp
+++ b/src/lib/storage/segment_iterate.hpp
@@ -39,8 +39,6 @@ namespace opossum {
 
 struct ResolveDataTypeTag {};
 
-enum class SegmentIterationTypeErasure { OnlyInDebug, Always };
-
 // Variant without PosList
 template <typename T = ResolveDataTypeTag,
           SegmentIterationTypeErasure type_erasure = SegmentIterationTypeErasure::OnlyInDebug, typename Functor>

--- a/src/lib/type_comparison.hpp
+++ b/src/lib/type_comparison.hpp
@@ -89,9 +89,10 @@ std::enable_if_t<std::is_arithmetic_v<R> && is_lex_castable_v<L> && !std::is_ari
   return boost::lexical_cast<R>(l) > r;
 }
 
-// Function that calls a given functor with the correct std comparator
+// Function that calls a given functor with the correct std comparator. The light version is not instantiated for
+// > and >=, reducing the number of instantiated templates by a third.
 template <typename Functor>
-void with_comparator(const PredicateCondition predicate_condition, const Functor& func) {
+void with_comparator_light(const PredicateCondition predicate_condition, const Functor& func) {
   switch (predicate_condition) {
     case PredicateCondition::Equals:
       return func(std::equal_to<void>{});
@@ -104,6 +105,25 @@ void with_comparator(const PredicateCondition predicate_condition, const Functor
 
     case PredicateCondition::LessThanEquals:
       return func(std::less_equal<void>{});
+
+    case PredicateCondition::GreaterThan:
+    case PredicateCondition::GreaterThanEquals:
+      Fail("Operator should have been flipped");
+
+    default:
+      Fail("Unsupported operator");
+  }
+}
+
+// Function that calls a given functor with the correct std comparator
+template <typename Functor>
+void with_comparator(const PredicateCondition predicate_condition, const Functor& func) {
+  switch (predicate_condition) {
+    case PredicateCondition::Equals:
+    case PredicateCondition::NotEquals:
+    case PredicateCondition::LessThan:
+    case PredicateCondition::LessThanEquals:
+      return with_comparator_light(predicate_condition, func);
 
     case PredicateCondition::GreaterThan:
       return func(std::greater<void>{});

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -221,5 +221,4 @@ struct Null {};
 // compile time at the cost of runtime performance.
 enum class SegmentIterationTypeErasure { OnlyInDebug, Always };
 
-
 }  // namespace opossum

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -217,4 +217,9 @@ class Noncopyable {
 // Dummy type, can be used to overload functions with a variant accepting a Null value
 struct Null {};
 
+// Used as a template parameter that decides when iterator types should be erased. Erasing iterator types improves
+// compile time at the cost of runtime performance.
+enum class SegmentIterationTypeErasure { OnlyInDebug, Always };
+
+
 }  // namespace opossum

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -217,9 +217,4 @@ class Noncopyable {
 // Dummy type, can be used to overload functions with a variant accepting a Null value
 struct Null {};
 
-// Used as a template parameter that decides when iterator types should be erased. Erasing iterator types improves
-// compile time at the cost of runtime performance.
-enum class SegmentIterationTypeErasure { OnlyInDebug, Always };
-
-
 }  // namespace opossum


### PR DESCRIPTION
If the left and the right segment and/or type are not the same, we erase the types even for the release build. For example, ValueSegment<int> == ValueSegment<float> will be erased. So will ValueSegment<int> == DictionarySegment<int>. ReferenceSegments do not need to be handled differently because we expect a table to either have only ReferenceSegments or non-ReferenceSegments.

We use type erasure here because we currently do not compare, e.g., a ValueSegment with a DictionarySegment, and we don't want the compiler to spend time instantiating unused templates. Whenever the types of the iterators is removed, we also erase the comparator lambda by wrapping it into an std::function. All of this brought the compile time down by a factor of 5. This is only relevant for the release build - in the debug build, iterators are erased anyway.

Also, compiling that file with GCC now only takes 3,3 GB of memory instead of 9,0 GB. Isn't that great?

Old (nemea, release):
	Elapsed (wall clock) time (h:mm:ss or m:ss): 10:21.41
	Maximum resident set size (kbytes): 9000508

New:
	Elapsed (wall clock) time (h:mm:ss or m:ss): 2:04.83
	Maximum resident set size (kbytes): 3307204

When running the TPC-H, no performance warning is printed, so there should be no performance impact.