### PR TITLE
Fix NULL behavior (#1421)

### DIFF
--- a/resources/test_data/tbl/joinoperators/int_outer_join_sorted_asc.tbl
+++ b/resources/test_data/tbl/joinoperators/int_outer_join_sorted_asc.tbl
@@ -1,0 +1,7 @@
+a|b|a|b
+int_null|float_null|int_null|float_null
+null|null|12|350.7
+123|456.7|123|458.7
+1234|457.7|null|null
+12345|458.7|12345|456.7
+12345|458.7|12345|457.7

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -28,13 +28,12 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
     const auto begin_it = pos_list.begin();
     const auto end_it = pos_list.end();
 
-    // If we are guaranteed that the reference segment refers to a single chunk, we can do some optimizations.
+    // If we are guaranteed that the reference segment refers to a single non-NULL chunk, we can do some optimizations.
     // For example, we can use a single, non-virtual segment accessor instead of having to keep multiple and using
     // virtual method calls.
 
-    if (pos_list.references_single_chunk() && pos_list.size() > 0) {
-      const auto first_chunk_id = begin_it->is_null() ? ChunkID {0u} : begin_it->chunk_id;
-      auto referenced_segment = referenced_table->get_chunk(first_chunk_id)->get_segment(referenced_column_id);
+    if (pos_list.references_single_chunk() && pos_list.size() > 0 && !begin_it->is_null()) {
+      auto referenced_segment = referenced_table->get_chunk(begin_it->chunk_id)->get_segment(referenced_column_id);
       resolve_segment_type<T>(*referenced_segment, [&](const auto& typed_segment) {
         using SegmentType = std::decay_t<decltype(typed_segment)>;
 

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -30,7 +30,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
 
     // If we are guaranteed that the reference segment refers to a single non-NULL chunk, we can do some optimizations.
     // For example, we can use a single, non-virtual segment accessor instead of having to keep multiple and using
-    // virtual method calls.
+    // virtual method calls. If begin_it is NULL, chunk_id will be INVALID_CHUNK_ID. Therefore, we skip this case.
 
     if (pos_list.references_single_chunk() && pos_list.size() > 0 && !begin_it->is_null()) {
       auto referenced_segment = referenced_table->get_chunk(begin_it->chunk_id)->get_segment(referenced_column_id);

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -81,8 +81,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
     bool equal(const SingleChunkIterator& other) const { return _pos_list_it == other._pos_list_it; }
 
     SegmentPosition<T> dereference() const {
-      const auto pos_list_offset =
-          static_cast<ChunkOffset>(std::distance(_begin_pos_list_it, _pos_list_it));
+      const auto pos_list_offset = static_cast<ChunkOffset>(std::distance(_begin_pos_list_it, _pos_list_it));
 
       if (_pos_list_it->is_null()) return SegmentPosition<T>{T{}, true, pos_list_offset};
 
@@ -130,8 +129,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
 
     // TODO(anyone): benchmark if using two maps instead doing the dynamic cast every time really is faster.
     SegmentPosition<T> dereference() const {
-      const auto pos_list_offset =
-          static_cast<ChunkOffset>(std::distance(_begin_pos_list_it, _pos_list_it));
+      const auto pos_list_offset = static_cast<ChunkOffset>(std::distance(_begin_pos_list_it, _pos_list_it));
 
       if (_pos_list_it->is_null()) return SegmentPosition<T>{T{}, true, pos_list_offset};
 

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -88,23 +88,13 @@ class SingleChunkReferenceSegmentAccessor : public BaseSegmentAccessor<T> {
   explicit SingleChunkReferenceSegmentAccessor(const ReferenceSegment& segment)
       : _segment{segment},
         _chunk_id((*_segment.pos_list())[ChunkOffset{0}].chunk_id),
+        // If *_segment.pos_list())[ChunkOffset{0}] is NULL, its chunk_id is INVALID_CHUNK_OFFSET. When the
+        // SingleChunkReferenceSegmentAccessor is used, all entries reference the same chunk_id (INVALID_CHUNK_OFFSET).
+        // Therefore, we can safely assume that all other entries are also NULL and always return std::nullopt.
         _accessor((*_segment.pos_list())[ChunkOffset{0}].is_null() ? nullptr : create_segment_accessor<T>(
             segment.referenced_table()->get_chunk(_chunk_id)->get_segment(_segment.referenced_column_id()))) {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
-    // const auto& referenced_row_id = (*_segment.pos_list())[offset];
-    // if (referenced_row_id.is_null())
-    //   return std::nullopt;
-
-    // const auto& table = _segment.referenced_table();
-    // const auto referenced_column_id = _segment.referenced_column_id();
-    // const auto referenced_chunk_id = referenced_row_id.chunk_id;
-    // const auto referenced_chunk_offset = referenced_row_id.chunk_offset;
-
-    // const auto accessor =
-    //     create_segment_accessor<T>(table->get_chunk(referenced_chunk_id)->get_segment(referenced_column_id));
-    // return accessor->access(referenced_chunk_offset);
-
     if (!_accessor) {
       return std::nullopt;
     }

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -64,8 +64,7 @@ class MultipleChunkReferenceSegmentAccessor : public BaseSegmentAccessor<T> {
 
   const std::optional<T> access(ChunkOffset offset) const final {
     const auto& referenced_row_id = (*_segment.pos_list())[offset];
-    if (referenced_row_id.is_null())
-      return std::nullopt;
+    if (referenced_row_id.is_null()) return std::nullopt;
 
     const auto& table = _segment.referenced_table();
     const auto referenced_column_id = _segment.referenced_column_id();
@@ -91,8 +90,10 @@ class SingleChunkReferenceSegmentAccessor : public BaseSegmentAccessor<T> {
         // If *_segment.pos_list())[ChunkOffset{0}] is NULL, its chunk_id is INVALID_CHUNK_OFFSET. When the
         // SingleChunkReferenceSegmentAccessor is used, all entries reference the same chunk_id (INVALID_CHUNK_OFFSET).
         // Therefore, we can safely assume that all other entries are also NULL and always return std::nullopt.
-        _accessor((*_segment.pos_list())[ChunkOffset{0}].is_null() ? nullptr : create_segment_accessor<T>(
-            segment.referenced_table()->get_chunk(_chunk_id)->get_segment(_segment.referenced_column_id()))) {}
+        _accessor((*_segment.pos_list())[ChunkOffset{0}].is_null()
+                      ? nullptr
+                      : create_segment_accessor<T>(segment.referenced_table()->get_chunk(_chunk_id)->get_segment(
+                            _segment.referenced_column_id()))) {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
     if (!_accessor) {

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -63,8 +63,11 @@ class MultipleChunkReferenceSegmentAccessor : public BaseSegmentAccessor<T> {
   explicit MultipleChunkReferenceSegmentAccessor(const ReferenceSegment& segment) : _segment{segment} {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
-    const auto& table = _segment.referenced_table();
     const auto& referenced_row_id = (*_segment.pos_list())[offset];
+    if (referenced_row_id.is_null())
+      return std::nullopt;
+
+    const auto& table = _segment.referenced_table();
     const auto referenced_column_id = _segment.referenced_column_id();
     const auto referenced_chunk_id = referenced_row_id.chunk_id;
     const auto referenced_chunk_offset = referenced_row_id.chunk_offset;
@@ -85,12 +88,28 @@ class SingleChunkReferenceSegmentAccessor : public BaseSegmentAccessor<T> {
   explicit SingleChunkReferenceSegmentAccessor(const ReferenceSegment& segment)
       : _segment{segment},
         _chunk_id((*_segment.pos_list())[ChunkOffset{0}].chunk_id),
-        _accessor{create_segment_accessor<T>(
-            segment.referenced_table()->get_chunk(_chunk_id)->get_segment(_segment.referenced_column_id()))} {}
+        _accessor((*_segment.pos_list())[ChunkOffset{0}].is_null() ? nullptr : create_segment_accessor<T>(
+            segment.referenced_table()->get_chunk(_chunk_id)->get_segment(_segment.referenced_column_id()))) {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
-    const auto referenced_chunk_offset = (*_segment.pos_list())[offset].chunk_offset;
+    // const auto& referenced_row_id = (*_segment.pos_list())[offset];
+    // if (referenced_row_id.is_null())
+    //   return std::nullopt;
 
+    // const auto& table = _segment.referenced_table();
+    // const auto referenced_column_id = _segment.referenced_column_id();
+    // const auto referenced_chunk_id = referenced_row_id.chunk_id;
+    // const auto referenced_chunk_offset = referenced_row_id.chunk_offset;
+
+    // const auto accessor =
+    //     create_segment_accessor<T>(table->get_chunk(referenced_chunk_id)->get_segment(referenced_column_id));
+    // return accessor->access(referenced_chunk_offset);
+
+    if (!_accessor) {
+      return std::nullopt;
+    }
+
+    const auto referenced_chunk_offset = (*_segment.pos_list())[offset].chunk_offset;
     return _accessor->access(referenced_chunk_offset);
   }
 

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -87,24 +87,26 @@ class SingleChunkReferenceSegmentAccessor : public BaseSegmentAccessor<T> {
   explicit SingleChunkReferenceSegmentAccessor(const ReferenceSegment& segment)
       : _segment{segment},
         _chunk_id((*_segment.pos_list())[ChunkOffset{0}].chunk_id),
-        // If *_segment.pos_list())[ChunkOffset{0}] is NULL, its chunk_id is INVALID_CHUNK_OFFSET. When the
+        // If *_segment.pos_list()[ChunkOffset{0}] is NULL, its chunk_id is INVALID_CHUNK_OFFSET. When the
         // SingleChunkReferenceSegmentAccessor is used, all entries reference the same chunk_id (INVALID_CHUNK_OFFSET).
         // Therefore, we can safely assume that all other entries are also NULL and always return std::nullopt.
         _accessor((*_segment.pos_list())[ChunkOffset{0}].is_null()
-                      ? nullptr
+                      ? std::make_unique<NullAccessor>()
                       : create_segment_accessor<T>(segment.referenced_table()->get_chunk(_chunk_id)->get_segment(
                             _segment.referenced_column_id()))) {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
-    if (!_accessor) {
-      return std::nullopt;
-    }
-
     const auto referenced_chunk_offset = (*_segment.pos_list())[offset].chunk_offset;
     return _accessor->access(referenced_chunk_offset);
   }
 
  protected:
+  class NullAccessor : public BaseSegmentAccessor<T> {
+    const std::optional<T> access(ChunkOffset offset) const final {
+      return std::nullopt;
+    }
+  };
+
   const ReferenceSegment& _segment;
   const ChunkID _chunk_id;
   const std::unique_ptr<BaseSegmentAccessor<T>> _accessor;

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -151,7 +151,9 @@ constexpr ColumnID INVALID_COLUMN_ID{std::numeric_limits<ColumnID::base_type>::m
 
 constexpr NodeID CURRENT_NODE_ID{std::numeric_limits<NodeID::base_type>::max() - 1};
 
-// ... in ReferenceSegments
+// Declaring one part of a RowID as invalid would suffice to represent NULL values. However, this way we add an extra
+// safety net which ensures that NULL values are handled correctly. E.g., getting a chunk with INVALID_CHUNK_ID
+// immediately crashes.
 const RowID NULL_ROW_ID = RowID{INVALID_CHUNK_ID, INVALID_CHUNK_OFFSET};  // TODO(anyone): Couldn’t use constexpr here
 
 // ... in DictionarySegments

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -22,7 +22,7 @@ bool PluginManager::_is_duplicate(AbstractPlugin* plugin) const {
 void PluginManager::load_plugin(const filesystem::path& path) {
   const auto name = plugin_name_from_path(path);
 
-  Assert(!_plugins.count(name), "Loading plugin failed: A plugin with name  " + name + " already exists.");
+  Assert(!_plugins.count(name), "Loading plugin failed: A plugin with name " + name + " already exists.");
 
   PluginHandle plugin_handle = dlopen(path.c_str(), static_cast<uint8_t>(RTLD_NOW) | static_cast<uint8_t>(RTLD_LOCAL));
   Assert(plugin_handle, "Loading plugin failed: " + dlerror());
@@ -51,7 +51,7 @@ void PluginManager::reset() { get() = PluginManager(); }
 
 void PluginManager::unload_plugin(const PluginName& name) {
   auto plugin = _plugins.find(name);
-  Assert(plugin != _plugins.cend(), "Unloading plugin failed: A plugin with name  " + name + " does not exist.");
+  Assert(plugin != _plugins.cend(), "Unloading plugin failed: A plugin with name " + name + " does not exist.");
 
   _unload_erase_plugin(plugin);
 }

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -224,8 +224,6 @@ TEST_P(OperatorsSortTest, DescendingSortOfOneDictSegment) {
 }
 
 TEST_P(OperatorsSortTest, SortAfterOuterJoin) {
-  // auto join = std::make_shared<JoinNestedLoop>(_table_wrapper_join_1, _table_wrapper_join_2, JoinMode::Outer,
-  // ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan);
   auto join = std::make_shared<JoinNestedLoop>(_table_wrapper, _table_wrapper_outer_join, JoinMode::Outer,
                                                ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -6,6 +6,8 @@
 #include "gtest/gtest.h"
 
 #include "operators/abstract_read_only_operator.hpp"
+#include "operators/join_nested_loop.hpp"
+#include "operators/print.hpp"
 #include "operators/sort.hpp"
 #include "operators/table_scan.hpp"
 #include "operators/table_wrapper.hpp"
@@ -38,12 +40,15 @@ class OperatorsSortTest : public BaseTestWithParam<EncodingType> {
     _table_wrapper_null_dict = std::make_shared<TableWrapper>(std::move(table_dict));
     _table_wrapper_null_dict->execute();
 
+    _table_wrapper_outer_join = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float2.tbl", 2));
+    _table_wrapper_outer_join->execute();
+
     _table_wrapper->execute();
     _table_wrapper_null->execute();
   }
 
  protected:
-  std::shared_ptr<TableWrapper> _table_wrapper, _table_wrapper_null, _table_wrapper_dict, _table_wrapper_null_dict;
+  std::shared_ptr<TableWrapper> _table_wrapper, _table_wrapper_null, _table_wrapper_dict, _table_wrapper_null_dict, _table_wrapper_outer_join;
   EncodingType _encoding_type;
 };
 
@@ -214,6 +219,20 @@ TEST_P(OperatorsSortTest, DescendingSortOfOneDictSegment) {
   auto sort = std::make_shared<Sort>(_table_wrapper_dict, ColumnID{0}, OrderByMode::Descending, 2u);
   sort->execute();
 
+  EXPECT_TABLE_EQ_ORDERED(sort->get_output(), expected_result);
+}
+
+TEST_P(OperatorsSortTest, SortAfterOuterJoin) {
+  // auto join = std::make_shared<JoinNestedLoop>(_table_wrapper_join_1, _table_wrapper_join_2, JoinMode::Outer,
+                                               // ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan);
+  auto join = std::make_shared<JoinNestedLoop>(_table_wrapper, _table_wrapper_outer_join, JoinMode::Outer,
+                                               ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
+  join->execute();
+
+  auto sort = std::make_shared<Sort>(join, ColumnID{0}, OrderByMode::Ascending);
+  sort->execute();
+
+  std::shared_ptr<Table> expected_result = load_table("resources/test_data/tbl/joinoperators/int_outer_join_sorted_asc.tbl", 2);
   EXPECT_TABLE_EQ_ORDERED(sort->get_output(), expected_result);
 }
 

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -48,7 +48,8 @@ class OperatorsSortTest : public BaseTestWithParam<EncodingType> {
   }
 
  protected:
-  std::shared_ptr<TableWrapper> _table_wrapper, _table_wrapper_null, _table_wrapper_dict, _table_wrapper_null_dict, _table_wrapper_outer_join;
+  std::shared_ptr<TableWrapper> _table_wrapper, _table_wrapper_null, _table_wrapper_dict, _table_wrapper_null_dict,
+      _table_wrapper_outer_join;
   EncodingType _encoding_type;
 };
 
@@ -224,7 +225,7 @@ TEST_P(OperatorsSortTest, DescendingSortOfOneDictSegment) {
 
 TEST_P(OperatorsSortTest, SortAfterOuterJoin) {
   // auto join = std::make_shared<JoinNestedLoop>(_table_wrapper_join_1, _table_wrapper_join_2, JoinMode::Outer,
-                                               // ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan);
+  // ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::LessThan);
   auto join = std::make_shared<JoinNestedLoop>(_table_wrapper, _table_wrapper_outer_join, JoinMode::Outer,
                                                ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals);
   join->execute();
@@ -232,7 +233,8 @@ TEST_P(OperatorsSortTest, SortAfterOuterJoin) {
   auto sort = std::make_shared<Sort>(join, ColumnID{0}, OrderByMode::Ascending);
   sort->execute();
 
-  std::shared_ptr<Table> expected_result = load_table("resources/test_data/tbl/joinoperators/int_outer_join_sorted_asc.tbl", 2);
+  std::shared_ptr<Table> expected_result =
+      load_table("resources/test_data/tbl/joinoperators/int_outer_join_sorted_asc.tbl", 2);
   EXPECT_TABLE_EQ_ORDERED(sort->get_output(), expected_result);
 }
 

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -218,7 +218,7 @@ TEST_F(IterablesTest, FixedStringDictionarySegmentReferencedIteratorWithIterator
 
 TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
   auto pos_list =
-      PosList{RowID{ChunkID{0u}, 0u}, RowID{ChunkID{0u}, 3u}, RowID{ChunkID{0u}, 1u}, RowID{ChunkID{0u}, 2u}};
+      PosList{RowID{ChunkID{0u}, 0u}, RowID{ChunkID{0u}, 3u}, RowID{ChunkID{0u}, 1u}, RowID{ChunkID{0u}, 2u}, RowID{NULL_ROW_ID}};
 
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
@@ -231,8 +231,27 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
 
   EXPECT_EQ(sum, 24'825u);
   EXPECT_EQ(accessed_offsets,
-            (std::vector<ChunkOffset>{ChunkOffset{0}, ChunkOffset{1}, ChunkOffset{2}, ChunkOffset{3}}));
+            (std::vector<ChunkOffset>{ChunkOffset{0}, ChunkOffset{1}, ChunkOffset{2}, ChunkOffset{3}, ChunkOffset{4}}));
 }
+
+  TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunk) {
+    auto pos_list =
+            PosList{RowID{NULL_ROW_ID}};
+    pos_list.guarantee_single_chunk();
+
+    auto reference_segment =
+            std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
+
+    auto iterable = ReferenceSegmentIterable<int>{*reference_segment};
+
+    auto sum = uint32_t{0};
+    auto accessed_offsets = std::vector<ChunkOffset>{};
+    iterable.with_iterators(SumUpWithIterator{sum, accessed_offsets});
+
+    EXPECT_EQ(sum, 0u);
+    EXPECT_EQ(accessed_offsets,
+              (std::vector<ChunkOffset>{ChunkOffset{0}}));
+  }
 
 TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsReadingParallel) {
   // Ensure that two independant reference segment iterators referencing one chunk use the correct accessor after they

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -236,7 +236,7 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
 
   TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunk) {
     auto pos_list =
-            PosList{RowID{NULL_ROW_ID}};
+            PosList{NULL_ROW_ID};
     pos_list.guarantee_single_chunk();
 
     auto reference_segment =

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -217,8 +217,8 @@ TEST_F(IterablesTest, FixedStringDictionarySegmentReferencedIteratorWithIterator
 }
 
 TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
-  auto pos_list =
-      PosList{RowID{ChunkID{0u}, 0u}, RowID{ChunkID{0u}, 3u}, RowID{ChunkID{0u}, 1u}, RowID{ChunkID{0u}, 2u}, RowID{NULL_ROW_ID}};
+  auto pos_list = PosList{RowID{ChunkID{0u}, 0u}, RowID{ChunkID{0u}, 3u}, RowID{ChunkID{0u}, 1u},
+                          RowID{ChunkID{0u}, 2u}, NULL_ROW_ID};
 
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
@@ -234,24 +234,22 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
             (std::vector<ChunkOffset>{ChunkOffset{0}, ChunkOffset{1}, ChunkOffset{2}, ChunkOffset{3}, ChunkOffset{4}}));
 }
 
-  TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunk) {
-    auto pos_list =
-            PosList{NULL_ROW_ID};
-    pos_list.guarantee_single_chunk();
+TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunk) {
+  auto pos_list = PosList{NULL_ROW_ID};
+  pos_list.guarantee_single_chunk();
 
-    auto reference_segment =
-            std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
+  auto reference_segment =
+      std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
 
-    auto iterable = ReferenceSegmentIterable<int>{*reference_segment};
+  auto iterable = ReferenceSegmentIterable<int>{*reference_segment};
 
-    auto sum = uint32_t{0};
-    auto accessed_offsets = std::vector<ChunkOffset>{};
-    iterable.with_iterators(SumUpWithIterator{sum, accessed_offsets});
+  auto sum = uint32_t{0};
+  auto accessed_offsets = std::vector<ChunkOffset>{};
+  iterable.with_iterators(SumUpWithIterator{sum, accessed_offsets});
 
-    EXPECT_EQ(sum, 0u);
-    EXPECT_EQ(accessed_offsets,
-              (std::vector<ChunkOffset>{ChunkOffset{0}}));
-  }
+  EXPECT_EQ(sum, 0u);
+  EXPECT_EQ(accessed_offsets, (std::vector<ChunkOffset>{ChunkOffset{0}}));
+}
 
 TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsReadingParallel) {
   // Ensure that two independant reference segment iterators referencing one chunk use the correct accessor after they

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -36,15 +36,13 @@ class SegmentAccessorTest : public BaseTest {
                                   TableType::Data);
     tbl->append_chunk(chunk);
 
-    pos_list = std::make_shared<PosList>(PosList{
-        {
-          RowID{ChunkID{0}, ChunkOffset{1}},
-          RowID{ChunkID{0}, ChunkOffset{2}},
-          RowID{ChunkID{0}, ChunkOffset{0}},
-          RowID{ChunkID{0}, ChunkOffset{3}},
-          RowID{NULL_ROW_ID},
-        }
-    });
+    pos_list = std::make_shared<PosList>(PosList{{
+        RowID{ChunkID{0}, ChunkOffset{1}},
+        RowID{ChunkID{0}, ChunkOffset{2}},
+        RowID{ChunkID{0}, ChunkOffset{0}},
+        RowID{ChunkID{0}, ChunkOffset{3}},
+        NULL_ROW_ID,
+    }});
 
     rc_int = std::make_shared<ReferenceSegment>(tbl, ColumnID{0}, pos_list);
     rc_str = std::make_shared<ReferenceSegment>(tbl, ColumnID{1}, pos_list);
@@ -118,17 +116,16 @@ TEST_F(SegmentAccessorTest, TestReferenceSegmentToDictionarySegmentString) {
   EXPECT_FALSE(rc_str_accessor->access(ChunkOffset{4}).has_value());
 }
 
-  TEST_F(SegmentAccessorTest, TestSingleChunkReferenceSegmentAccessorNull) {
-    auto pos_list =
-            PosList{RowID{NULL_ROW_ID}};
-    pos_list.guarantee_single_chunk();
+TEST_F(SegmentAccessorTest, TestSingleChunkReferenceSegmentAccessorNull) {
+  auto pos_list = PosList{NULL_ROW_ID};
+  pos_list.guarantee_single_chunk();
 
-    auto rc_single_chunk =
-            std::make_shared<ReferenceSegment>(tbl, ColumnID{1u}, std::make_shared<PosList>(std::move(pos_list)));
+  auto rc_single_chunk =
+      std::make_shared<ReferenceSegment>(tbl, ColumnID{1u}, std::make_shared<PosList>(std::move(pos_list)));
 
-    auto rc_single_chunk_accessor = create_segment_accessor<std::string>(rc_single_chunk);
-    ASSERT_NE(rc_single_chunk_accessor, nullptr);
-    EXPECT_FALSE(rc_single_chunk_accessor->access(ChunkOffset{0}).has_value());
-  }
+  auto rc_single_chunk_accessor = create_segment_accessor<std::string>(rc_single_chunk);
+  ASSERT_NE(rc_single_chunk_accessor, nullptr);
+  EXPECT_FALSE(rc_single_chunk_accessor->access(ChunkOffset{0}).has_value());
+}
 
 }  // namespace opossum

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -118,4 +118,17 @@ TEST_F(SegmentAccessorTest, TestReferenceSegmentToDictionarySegmentString) {
   EXPECT_FALSE(rc_str_accessor->access(ChunkOffset{4}).has_value());
 }
 
+  TEST_F(SegmentAccessorTest, TestSingleChunkReferenceSegmentAccessorNull) {
+    auto pos_list =
+            PosList{RowID{NULL_ROW_ID}};
+    pos_list.guarantee_single_chunk();
+
+    auto rc_single_chunk =
+            std::make_shared<ReferenceSegment>(tbl, ColumnID{1u}, std::make_shared<PosList>(std::move(pos_list)));
+
+    auto rc_single_chunk_accessor = create_segment_accessor<std::string>(rc_single_chunk);
+    ASSERT_NE(rc_single_chunk_accessor, nullptr);
+    EXPECT_FALSE(rc_single_chunk_accessor->access(ChunkOffset{0}).has_value());
+  }
+
 }  // namespace opossum

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -15,15 +15,17 @@ namespace opossum {
 class SegmentAccessorTest : public BaseTest {
  protected:
   void SetUp() override {
-    vc_int = make_shared_by_data_type<BaseValueSegment, ValueSegment>(DataType::Int);
+    vc_int = make_shared_by_data_type<BaseValueSegment, ValueSegment>(DataType::Int, true);
     vc_int->append(4);
     vc_int->append(6);
     vc_int->append(3);
+    vc_int->append(NULL_VALUE);
 
-    vc_str = make_shared_by_data_type<BaseValueSegment, ValueSegment>(DataType::String);
+    vc_str = make_shared_by_data_type<BaseValueSegment, ValueSegment>(DataType::String, true);
     vc_str->append("Hello,");
     vc_str->append("world");
     vc_str->append("!");
+    vc_str->append(NULL_VALUE);
 
     dc_int = encode_segment(EncodingType::Dictionary, DataType::Int, vc_int);
     dc_str = encode_segment(EncodingType::Dictionary, DataType::String, vc_str);
@@ -35,7 +37,14 @@ class SegmentAccessorTest : public BaseTest {
     tbl->append_chunk(chunk);
 
     pos_list = std::make_shared<PosList>(PosList{
-        {RowID{ChunkID{0}, ChunkOffset{1}}, RowID{ChunkID{0}, ChunkOffset{2}}, RowID{ChunkID{0}, ChunkOffset{0}}}});
+        {
+          RowID{ChunkID{0}, ChunkOffset{1}},
+          RowID{ChunkID{0}, ChunkOffset{2}},
+          RowID{ChunkID{0}, ChunkOffset{0}},
+          RowID{ChunkID{0}, ChunkOffset{3}},
+          RowID{NULL_ROW_ID},
+        }
+    });
 
     rc_int = std::make_shared<ReferenceSegment>(tbl, ColumnID{0}, pos_list);
     rc_str = std::make_shared<ReferenceSegment>(tbl, ColumnID{1}, pos_list);
@@ -59,6 +68,7 @@ TEST_F(SegmentAccessorTest, TestValueSegmentInt) {
   EXPECT_EQ(vc_int_base_accessor->access(ChunkOffset{0}), 4);
   EXPECT_EQ(vc_int_base_accessor->access(ChunkOffset{1}), 6);
   EXPECT_EQ(vc_int_base_accessor->access(ChunkOffset{2}), 3);
+  EXPECT_FALSE(vc_int_base_accessor->access(ChunkOffset{3}).has_value());
 }
 
 TEST_F(SegmentAccessorTest, TestValueSegmentString) {
@@ -67,6 +77,7 @@ TEST_F(SegmentAccessorTest, TestValueSegmentString) {
   EXPECT_EQ(vc_str_accessor->access(ChunkOffset{0}), "Hello,");
   EXPECT_EQ(vc_str_accessor->access(ChunkOffset{1}), "world");
   EXPECT_EQ(vc_str_accessor->access(ChunkOffset{2}), "!");
+  EXPECT_FALSE(vc_str_accessor->access(ChunkOffset{3}).has_value());
 }
 
 TEST_F(SegmentAccessorTest, TestDictionarySegmentInt) {
@@ -75,6 +86,7 @@ TEST_F(SegmentAccessorTest, TestDictionarySegmentInt) {
   EXPECT_EQ(dc_int_accessor->access(ChunkOffset{0}), 4);
   EXPECT_EQ(dc_int_accessor->access(ChunkOffset{1}), 6);
   EXPECT_EQ(dc_int_accessor->access(ChunkOffset{2}), 3);
+  EXPECT_FALSE(dc_int_accessor->access(ChunkOffset{3}).has_value());
 }
 
 TEST_F(SegmentAccessorTest, TestDictionarySegmentString) {
@@ -83,6 +95,7 @@ TEST_F(SegmentAccessorTest, TestDictionarySegmentString) {
   EXPECT_EQ(dc_str_accessor->access(ChunkOffset{0}), "Hello,");
   EXPECT_EQ(dc_str_accessor->access(ChunkOffset{1}), "world");
   EXPECT_EQ(dc_str_accessor->access(ChunkOffset{2}), "!");
+  EXPECT_FALSE(dc_str_accessor->access(ChunkOffset{3}).has_value());
 }
 
 TEST_F(SegmentAccessorTest, TestReferenceSegmentToValueSegmentInt) {
@@ -91,6 +104,8 @@ TEST_F(SegmentAccessorTest, TestReferenceSegmentToValueSegmentInt) {
   EXPECT_EQ(rc_int_accessor->access(ChunkOffset{0}), 6);
   EXPECT_EQ(rc_int_accessor->access(ChunkOffset{1}), 3);
   EXPECT_EQ(rc_int_accessor->access(ChunkOffset{2}), 4);
+  EXPECT_FALSE(rc_int_accessor->access(ChunkOffset{3}).has_value());
+  EXPECT_FALSE(rc_int_accessor->access(ChunkOffset{4}).has_value());
 }
 
 TEST_F(SegmentAccessorTest, TestReferenceSegmentToDictionarySegmentString) {
@@ -99,6 +114,8 @@ TEST_F(SegmentAccessorTest, TestReferenceSegmentToDictionarySegmentString) {
   EXPECT_EQ(rc_str_accessor->access(ChunkOffset{0}), "world");
   EXPECT_EQ(rc_str_accessor->access(ChunkOffset{1}), "!");
   EXPECT_EQ(rc_str_accessor->access(ChunkOffset{2}), "Hello,");
+  EXPECT_FALSE(rc_str_accessor->access(ChunkOffset{3}).has_value());
+  EXPECT_FALSE(rc_str_accessor->access(ChunkOffset{4}).has_value());
 }
 
 }  // namespace opossum


### PR DESCRIPTION
This fixes #1421 and some other nasty NULL cases.

One problem was that the SegmentAccessors did not correctly check for null values and accessed chunks with `INVALID_CHUNK_ID`.

Also, ReferenceSegmentIterables created SegmentPositions with `chunk_offset = 0u` when they were NULL. This way it was impossible to correctly check for `is_null()` afterwards. 

Last but not least, some optimizations that were implemented for `references_single_chunk` assume now that no NULL values are involved.