### PR TITLE
Fix sort merge join when joining columns containing NULL

### DIFF
--- a/resources/test_data/tbl/joinoperators/int_smaller_outer_join_null.tbl
+++ b/resources/test_data/tbl/joinoperators/int_smaller_outer_join_null.tbl
@@ -1,0 +1,11 @@
+a|b|a|b
+int_null|float_null|int_null|float_null
+123|458.7|12345|458.7
+12|350.7|12345|458.7
+12|350.7|123|456.7
+123|458.7|1234|457.7
+12|350.7|1234|457.7
+12345|456.7|null|null
+12345|457.7|null|null
+null|342|null|null
+null|234|null|null

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -137,7 +137,7 @@ class ColumnMaterializer {
         for (; value_id_it != attribute_vector.cend(); ++value_id_it, ++chunk_offset) {
           auto value_id = static_cast<ValueID>(*value_id_it);
 
-          if (value_id != NULL_VALUE_ID) {
+          if (value_id != segment.null_value_id()) {
             rows_with_value[value_id].push_back(RowID{chunk_id, chunk_offset});
           } else {
             if (_materialize_null) {

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -134,10 +134,12 @@ class ColumnMaterializer {
       resolve_compressed_vector_type(*base_attribute_vector, [&](const auto& attribute_vector) {
         auto chunk_offset = ChunkOffset{0u};
         auto value_id_it = attribute_vector.cbegin();
+        auto null_value_id = segment.null_value_id();
+
         for (; value_id_it != attribute_vector.cend(); ++value_id_it, ++chunk_offset) {
           auto value_id = static_cast<ValueID>(*value_id_it);
 
-          if (value_id != segment.null_value_id()) {
+          if (value_id != null_value_id) {
             rows_with_value[value_id].push_back(RowID{chunk_id, chunk_offset});
           } else {
             if (_materialize_null) {

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -154,9 +154,6 @@ constexpr NodeID CURRENT_NODE_ID{std::numeric_limits<NodeID::base_type>::max() -
 // ... in ReferenceSegments
 const RowID NULL_ROW_ID = RowID{INVALID_CHUNK_ID, INVALID_CHUNK_OFFSET};  // TODO(anyone): Couldn’t use constexpr here
 
-// ... in DictionarySegments
-constexpr ValueID NULL_VALUE_ID{std::numeric_limits<ValueID::base_type>::max()};
-
 constexpr ValueID INVALID_VALUE_ID{std::numeric_limits<ValueID::base_type>::max()};
 
 // The Scheduler currently supports just these 3 priorities, subject to change.

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -253,7 +253,8 @@ TYPED_TEST(JoinFullTest, SmallerOuterJoin) {
 TYPED_TEST(JoinFullTest, SmallerOuterJoinWithNull) {
   this->template test_join_output<TypeParam>(
       this->_table_wrapper_m_dict, this->_table_wrapper_a_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
-      PredicateCondition::LessThan, JoinMode::Outer, "resources/test_data/tbl/joinoperators/int_smaller_outer_join_null.tbl", 1);
+      PredicateCondition::LessThan, JoinMode::Outer,
+      "resources/test_data/tbl/joinoperators/int_smaller_outer_join_null.tbl", 1);
 }
 
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin) {

--- a/src/test/operators/join_full_test.cpp
+++ b/src/test/operators/join_full_test.cpp
@@ -250,6 +250,12 @@ TYPED_TEST(JoinFullTest, SmallerOuterJoin) {
                                              "resources/test_data/tbl/joinoperators/int_smaller_outer_join.tbl", 1);
 }
 
+TYPED_TEST(JoinFullTest, SmallerOuterJoinWithNull) {
+  this->template test_join_output<TypeParam>(
+      this->_table_wrapper_m_dict, this->_table_wrapper_a_dict, ColumnIDPair(ColumnID{0}, ColumnID{0}),
+      PredicateCondition::LessThan, JoinMode::Outer, "resources/test_data/tbl/joinoperators/int_smaller_outer_join_null.tbl", 1);
+}
+
 TYPED_TEST(JoinFullTest, SmallerEqualInnerJoin) {
   // Joining two Integer columns
   this->template test_join_output<TypeParam>(


### PR DESCRIPTION
Previously, we had `NULL_VALUE_ID{std::numeric_limits<ValueID::base_type>::max()}`. Now NULL values are represented by a ValueID that equals the size of the dictionary. The ColumnMaterializer did still use the old way to represent NULL values.

Looking over the code, there should be the opportunity for some simple optimizations taking into account if the column is nullable or not. E.g., the branch in the hot loop that is comparing `value_id != null_value_id` could be avoided.