### PR TITLE
Fix sampling in sort-merge join

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -137,7 +137,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
     if (build_relation_size > probe_relation_size) {
       /*
-        Hash joins perform best for join relations with a small left join partner. In case the
+        Hash joins perform best when the build relation is small. In case the
         optimizer selects the hash join due to such a situation, but neglects that the
         input will be switched (e.g., due to the join type), the user will be warned.
       */

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -368,9 +368,8 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   * Determines the smallest value in a sorted materialized table.
   **/
   T& _table_min_value(std::unique_ptr<MaterializedSegmentList<T>>& sorted_table) {
-    DebugAssert(
-        _op != PredicateCondition::Equals,
-        "Complete table order is required for _table_min_value which is only " + "available in the non-equi case");
+    DebugAssert(_op != PredicateCondition::Equals,
+                "Complete table order is required for _table_min_value() which is only available in the non-equi case");
     DebugAssert(!sorted_table->empty(), "Sorted table has no partitions");
 
     for (const auto& partition : *sorted_table) {
@@ -387,7 +386,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   **/
   T& _table_max_value(std::unique_ptr<MaterializedSegmentList<T>>& sorted_table) {
     DebugAssert(_op != PredicateCondition::Equals,
-                "The table needs to be sorted for _table_max_value which is only " + "the case in the non-equi case");
+                "The table needs to be sorted for _table_max_value() which is only the case in the non-equi case");
     DebugAssert(!sorted_table->empty(), "Sorted table is empty");
 
     for (size_t partition_id = sorted_table->size() - 1; partition_id < sorted_table->size(); --partition_id) {

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -142,7 +142,8 @@ class ColumnMaterializer {
   /**
    * Materialization works of all types of segments
    */
-  std::shared_ptr<MaterializedSegment<T>> _materialize_generic_segment(const BaseSegment& segment, const ChunkID chunk_id,
+  std::shared_ptr<MaterializedSegment<T>> _materialize_generic_segment(const BaseSegment& segment,
+                                                                       const ChunkID chunk_id,
                                                                        std::unique_ptr<PosList>& null_rows_output,
                                                                        SampleRequest<T>& sample_request) {
     auto output = MaterializedSegment<T>{};

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -99,8 +99,7 @@ class ColumnMaterializer {
                                                                   std::unique_ptr<PosList>& null_rows_output,
                                                                   const ChunkID chunk_id,
                                                                   std::shared_ptr<const Table> input,
-                                                                  const ColumnID column_id,
-                                                                  SubSample<T>& subsample) {
+                                                                  const ColumnID column_id, SubSample<T>& subsample) {
     return std::make_shared<JobTask>([this, &output, &null_rows_output, input, column_id, chunk_id, &subsample] {
       auto segment = input->get_chunk(chunk_id)->get_segment(column_id);
 
@@ -132,8 +131,7 @@ class ColumnMaterializer {
       }
 
       // Sequential write of result
-      subsample.samples.insert(subsample.samples.end(),
-                                              collected_samples.begin(), collected_samples.end());
+      subsample.samples.insert(subsample.samples.end(), collected_samples.begin(), collected_samples.end());
     }
   }
 

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -31,17 +31,20 @@ template <typename T>
 using MaterializedSegmentList = std::vector<std::shared_ptr<MaterializedSegment<T>>>;
 
 /**
- * This data structure is passed as a reference to the jobs which materialize
- * the chunks. Each job then adds `samples_to_collect` samples to its passed
- * SampleRequest. All SampleRequests are later merged to gather a global sample
- * list with which the split values for the radix partitioning are determined.
+ * This data structure is passed to the matrialization jobs. Each job collects
+ * `samples_to_collect` samples and writes them to the `sample_list` reference
+ * (using `write_offset`). All SubSamples are later sorted to gather a global
+ * sample list with which the split values for the radix partitioning are determined.
  */
 template <typename T>
-struct SampleRequest {
-  explicit SampleRequest(uint16_t sample_count) : samples_to_collect(sample_count), collected_samples() {}
+struct SubSample {
+  explicit SubSample(ChunkOffset sample_count, ChunkOffset offset, std::vector<T>& samples) :
+    samples_to_collect(sample_count), write_offset(offset), sample_list(samples) {}
 
-  const uint16_t samples_to_collect;
-  std::vector<T> collected_samples;
+  const ChunkOffset samples_to_collect;
+  const ChunkOffset write_offset;
+
+  std::vector<T>& sample_list;
 };
 
 /**
@@ -61,36 +64,32 @@ class ColumnMaterializer {
    **/
   std::tuple<std::unique_ptr<MaterializedSegmentList<T>>, std::unique_ptr<PosList>, std::vector<T>> materialize(
       const std::shared_ptr<const Table> input, const ColumnID column_id) {
-    const uint16_t samples_per_chunk = 10;  // rather arbitrarily chosen number
+    const ChunkOffset samples_per_chunk = 10;  // rather arbitrarily chosen number
     const auto chunk_count = input->chunk_count();
 
     auto output = std::make_unique<MaterializedSegmentList<T>>(chunk_count);
     auto null_rows = std::make_unique<PosList>();
 
-    std::vector<SampleRequest<T>> sample_requests;
-    sample_requests.reserve(chunk_count);
+    std::vector<T> samples;
+    samples.reserve(chunk_count * samples_per_chunk);
+    auto samples_written = ChunkOffset{0};
 
     std::vector<std::shared_ptr<AbstractTask>> jobs;
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
-      const uint16_t samples_to_write =
-          static_cast<uint16_t>(std::min(samples_per_chunk, static_cast<uint16_t>(input->get_chunk(chunk_id)->size())));
-      sample_requests.push_back(SampleRequest<T>(samples_to_write));
+      const auto samples_to_write = std::min(samples_per_chunk, input->get_chunk(chunk_id)->size());
+      SubSample<T> sub_sample(samples_to_write, samples_written, samples);
+
       jobs.push_back(
-          _create_chunk_materialization_job(output, null_rows, chunk_id, input, column_id, sample_requests.back()));
+          _create_chunk_materialization_job(output, null_rows, chunk_id, input, column_id, std::move(sub_sample)));
       jobs.back()->schedule();
+
+      samples_written += samples_to_write;
     }
 
+    samples.resize(samples_written);
     CurrentScheduler::wait_for_tasks(jobs);
 
-    auto gathered_samples = std::vector<T>();
-    gathered_samples.reserve(samples_per_chunk * chunk_count);
-
-    for (const auto& sample_request : sample_requests) {
-      gathered_samples.insert(gathered_samples.end(), sample_request.collected_samples.begin(),
-                              sample_request.collected_samples.end());
-    }
-
-    return {std::move(output), std::move(null_rows), std::move(gathered_samples)};
+    return {std::move(output), std::move(null_rows), std::move(samples)};
   }
 
  private:
@@ -102,7 +101,7 @@ class ColumnMaterializer {
                                                                   const ChunkID chunk_id,
                                                                   std::shared_ptr<const Table> input,
                                                                   const ColumnID column_id,
-                                                                  SampleRequest<T>& sample_request) {
+                                                                  SubSample<T> sample_request) {
     return std::make_shared<JobTask>([this, &output, &null_rows_output, input, column_id, chunk_id, &sample_request] {
       auto segment = input->get_chunk(chunk_id)->get_segment(column_id);
 
@@ -119,13 +118,13 @@ class ColumnMaterializer {
    * Samples values from a materialized segment.
    * We collect samples locally and write once to the global sample collection to limit non-local writes.
    */
-  void _gather_samples_from_segment(const MaterializedSegment<T>& segment, SampleRequest<T>& sample_request) const {
+  void _gather_samples_from_segment(const MaterializedSegment<T>& segment, SubSample<T>& sample_request) const {
     const auto samples_to_collect = sample_request.samples_to_collect;
     std::vector<T> collected_samples;
     collected_samples.reserve(samples_to_collect);
 
     if (segment.size() > 0 && samples_to_collect > 0) {
-      const auto step_width = segment.size() / std::max(static_cast<uint16_t>(1u), samples_to_collect);
+      const auto step_width = segment.size() / std::max(1u, samples_to_collect);
 
       for (uint16_t sample_count = 0; sample_count < samples_to_collect; ++sample_count) {
         // NULL values in passed `segment` vector have already been
@@ -134,8 +133,8 @@ class ColumnMaterializer {
       }
 
       // Sequential write of result
-      sample_request.collected_samples.insert(sample_request.collected_samples.end(), collected_samples.begin(),
-                                              collected_samples.end());
+      sample_request.sample_list.insert(sample_request.sample_list.begin() + sample_request.write_offset,
+                                              collected_samples.begin(), collected_samples.end());
     }
   }
 
@@ -145,7 +144,7 @@ class ColumnMaterializer {
   std::shared_ptr<MaterializedSegment<T>> _materialize_generic_segment(const BaseSegment& segment,
                                                                        const ChunkID chunk_id,
                                                                        std::unique_ptr<PosList>& null_rows_output,
-                                                                       SampleRequest<T>& sample_request) {
+                                                                       SubSample<T>& sample_request) {
     auto output = MaterializedSegment<T>{};
     output.reserve(segment.size());
 
@@ -176,7 +175,7 @@ class ColumnMaterializer {
   std::shared_ptr<MaterializedSegment<T>> _materialize_dictionary_segment(const DictionarySegment<T>& segment,
                                                                           const ChunkID chunk_id,
                                                                           std::unique_ptr<PosList>& null_rows_output,
-                                                                          SampleRequest<T>& sample_request) {
+                                                                          SubSample<T>& sample_request) {
     auto output = MaterializedSegment<T>{};
     output.reserve(segment.size());
 

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -125,7 +125,6 @@ class ColumnMaterializer {
     collected_samples.reserve(samples_to_collect);
 
     if (segment_output.size() > 0 && samples_to_collect > 0) {
-      const auto step_width = segment_output.size() / std::max(1u, samples_to_collect);
 
       for (uint32_t sample_count = 0; sample_count < samples_to_collect; ++sample_count) {
         // output vector does not contain NULL values, thus we do not have to check for NULL samples.
@@ -141,7 +140,7 @@ class ColumnMaterializer {
   /**
    * Materialization works of all types of segments
    */
-  std::shared_ptr<MaterializedSegment<T>> _materialize_generic_segment(const BaseSegment& segment, ChunkID chunk_id,
+  std::shared_ptr<MaterializedSegment<T>> _materialize_generic_segment(const BaseSegment& segment, const ChunkID chunk_id,
                                                                        std::unique_ptr<PosList>& null_rows_output,
                                                                        SampleRequest<T>& sample_request) {
     auto output = MaterializedSegment<T>{};
@@ -172,7 +171,7 @@ class ColumnMaterializer {
    * Specialization for dictionary segments
    */
   std::shared_ptr<MaterializedSegment<T>> _materialize_dictionary_segment(const DictionarySegment<T>& segment,
-                                                                          ChunkID chunk_id,
+                                                                          const ChunkID chunk_id,
                                                                           std::unique_ptr<PosList>& null_rows_output,
                                                                           SampleRequest<T>& sample_request) {
     auto output = MaterializedSegment<T>{};

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -288,23 +288,8 @@ class RadixClusterSort {
       // Find the first split value that is greater or equal to the entry.
       // The split values are sorted in ascending order.
       // Note: can we do this faster? (binary search?)
-      // std::optional<std::pair<T, size_t>> value_and_split_id;
-
-      // if (value_and_split_id && value <= value_and_split_id.value().first) {
-      //   return value_and_split_id.value().second;
-      // }
-
-      // for (size_t cluster_id = 0; cluster_id < cluster_count - 1; ++cluster_id) {
-      //   if (value <= split_values[cluster_id]) {
-      //     value_and_split_id = {split_values[cluster_id], cluster_id};
-      //     return cluster_id;
-      //   }
-      // }
-
       for (size_t cluster_id = 0; cluster_id < cluster_count - 1; ++cluster_id) {
-        // std::cout << ".";
         if (value <= split_values[cluster_id]) {
-          // std::cout << std::endl;
           return cluster_id;
         }
       }

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -255,6 +255,8 @@ class RadixClusterSort {
     std::sort(sample_values.begin(), sample_values.end());
 
     if (sample_values.size() <= _cluster_count - 1) {
+      const auto last = std::unique(sample_values.begin(), sample_values.end());
+      sample_values.erase(last, sample_values.end()); 
       return sample_values;
     }
 
@@ -265,6 +267,8 @@ class RadixClusterSort {
       split_values.push_back(sample_values[static_cast<size_t>((sample_offset + 1) * jump_width)]);
     }
 
+    const auto last_split = std::unique(split_values.begin(), split_values.end());
+    split_values.erase(last_split, split_values.end()); 
     return split_values;
   }
 

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -287,8 +287,6 @@ class RadixClusterSort {
       // Find the first split value that is greater or equal to the entry.
       // The split values are sorted in ascending order.
       // Note: can we do this faster? (binary search?)
-      // TODO(anyone): this is not the most efficient implementation ... by far
-      //        In fact ... pretty dump implementation when rows are sorted.
       for (size_t cluster_id = 0; cluster_id < cluster_count - 1; ++cluster_id) {
         if (value <= split_values[cluster_id]) {
           return cluster_id;

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -256,7 +256,7 @@ class RadixClusterSort {
 
     if (sample_values.size() <= _cluster_count - 1) {
       const auto last = std::unique(sample_values.begin(), sample_values.end());
-      sample_values.erase(last, sample_values.end()); 
+      sample_values.erase(last, sample_values.end());
       return sample_values;
     }
 
@@ -268,7 +268,7 @@ class RadixClusterSort {
     }
 
     const auto last_split = std::unique(split_values.begin(), split_values.end());
-    split_values.erase(last_split, split_values.end()); 
+    split_values.erase(last_split, split_values.end());
     return split_values;
   }
 
@@ -288,8 +288,23 @@ class RadixClusterSort {
       // Find the first split value that is greater or equal to the entry.
       // The split values are sorted in ascending order.
       // Note: can we do this faster? (binary search?)
+      // std::optional<std::pair<T, size_t>> value_and_split_id;
+
+      // if (value_and_split_id && value <= value_and_split_id.value().first) {
+      //   return value_and_split_id.value().second;
+      // }
+
+      // for (size_t cluster_id = 0; cluster_id < cluster_count - 1; ++cluster_id) {
+      //   if (value <= split_values[cluster_id]) {
+      //     value_and_split_id = {split_values[cluster_id], cluster_id};
+      //     return cluster_id;
+      //   }
+      // }
+
       for (size_t cluster_id = 0; cluster_id < cluster_count - 1; ++cluster_id) {
+        // std::cout << ".";
         if (value <= split_values[cluster_id]) {
+          // std::cout << std::endl;
           return cluster_id;
         }
       }

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -323,9 +323,9 @@ class RadixClusterSort {
     // Sort the chunks of the input tables in the non-equi cases
     ColumnMaterializer<T> left_column_materializer(!_equi_case, _materialize_null_left);
     ColumnMaterializer<T> right_column_materializer(!_equi_case, _materialize_null_right);
-    auto [materialized_left_segments, null_rows_left, samples_left] =                          // NOLINT
+    auto [materialized_left_segments, null_rows_left, samples_left] =  // NOLINT
         left_column_materializer.materialize(_input_table_left, _left_column_id);
-    auto [materialized_right_segments, null_rows_right, samples_right] =                       // NOLINT
+    auto [materialized_right_segments, null_rows_right, samples_right] =  // NOLINT
         right_column_materializer.materialize(_input_table_right, _right_column_id);
     output.null_rows_left = std::move(null_rows_left);
     output.null_rows_right = std::move(null_rows_right);

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -261,8 +261,8 @@ class RadixClusterSort {
     std::vector<T> split_values;
     split_values.reserve(_cluster_count - 1);
     auto jump_width = sample_values.size() / _cluster_count;
-    for (auto i = size_t{0}; i < _cluster_count - 1; ++i) {
-      split_values.push_back(sample_values[static_cast<size_t>((i + 1) * jump_width)]);
+    for (auto sample_offset = size_t{0}; sample_offset < _cluster_count - 1; ++sample_offset) {
+      split_values.push_back(sample_values[static_cast<size_t>((sample_offset + 1) * jump_width)]);
     }
 
     return split_values;

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -320,7 +320,7 @@ class RadixClusterSort {
     ColumnMaterializer<T> left_column_materializer(!_equi_case, _materialize_null_left);
     ColumnMaterializer<T> right_column_materializer(!_equi_case, _materialize_null_right);
     auto [materialized_left_segments, null_rows_left, samples_left] = left_column_materializer.materialize(_input_table_left, _left_column_id);
-    auto [materialized_right_segments, null_rows_right, samples_right] = left_column_materializer.materialize(_input_table_right, _right_column_id);
+    auto [materialized_right_segments, null_rows_right, samples_right] = right_column_materializer.materialize(_input_table_right, _right_column_id);
     output.null_rows_left = std::move(null_rows_left);
     output.null_rows_right = std::move(null_rows_right);
 

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -319,12 +319,14 @@ class RadixClusterSort {
     // Sort the chunks of the input tables in the non-equi cases
     ColumnMaterializer<T> left_column_materializer(!_equi_case, _materialize_null_left);
     ColumnMaterializer<T> right_column_materializer(!_equi_case, _materialize_null_right);
-    auto [materialized_left_segments, null_rows_left, samples_left] = left_column_materializer.materialize(_input_table_left, _left_column_id);
-    auto [materialized_right_segments, null_rows_right, samples_right] = right_column_materializer.materialize(_input_table_right, _right_column_id);
+    auto [materialized_left_segments, null_rows_left, samples_left] =                          // NOLINT
+        left_column_materializer.materialize(_input_table_left, _left_column_id);
+    auto [materialized_right_segments, null_rows_right, samples_right] =                       // NOLINT
+        right_column_materializer.materialize(_input_table_right, _right_column_id);
     output.null_rows_left = std::move(null_rows_left);
     output.null_rows_right = std::move(null_rows_right);
 
-    // Append right samples to left samples and sort (reserve not necessarity when insert can 
+    // Append right samples to left samples and sort (reserve not necessarity when insert can
     // determined the new capacity from iterator: https://stackoverflow.com/a/35359472/1147726)
     samples_left.insert(samples_left.end(), samples_right.begin(), samples_right.end());
 

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -248,14 +248,11 @@ class RadixClusterSort {
 
   /**
   * Picks the desired number of split values (i.e., _cluster_count - 1) from the given
-  * sample values. First, values are sorted and duplicates removed, then -- assuming uniform
-  * value distribution - values are picked from the whole sample value range in fixed widths.
+  * sample values. The values are sorted and then are picked from the whole sample value
+  * range in fixed widths. Repeated values are not removed to cover skewed cases.
   **/
   const std::vector<T> _pick_split_values(std::vector<T> sample_values) const {
-    // Sort and delete repeated values
     std::sort(sample_values.begin(), sample_values.end());
-    const auto last_element_iter = std::unique(sample_values.begin(), sample_values.end());
-    sample_values.erase(last_element_iter, sample_values.end());
 
     if (sample_values.size() <= _cluster_count - 1) {
       return sample_values;

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -67,7 +67,8 @@ TYPED_TEST(JoinEquiTest, InnerJoinIntFloatRadixBit) {
     join->execute();
     EXPECT_TABLE_EQ_UNORDERED(join->get_output(), expected_result);
 
-    for (size_t radix_bits : {1, 2, 3, 10, 17}) {
+    for (size_t radix_bits : {1, 2, 8}) {
+      std::cout << radix_bits << std::endl;
       auto join_comp =
           std::make_shared<JoinHash>(this->_table_wrapper_o, this->_table_wrapper_a, JoinMode::Inner,
                                      ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, radix_bits);

--- a/src/test/operators/join_equi_test.cpp
+++ b/src/test/operators/join_equi_test.cpp
@@ -67,8 +67,8 @@ TYPED_TEST(JoinEquiTest, InnerJoinIntFloatRadixBit) {
     join->execute();
     EXPECT_TABLE_EQ_UNORDERED(join->get_output(), expected_result);
 
+    // radix_bits==8 creates 2^8 clusters to check for the case when #clusters > #rows.
     for (size_t radix_bits : {1, 2, 8}) {
-      std::cout << radix_bits << std::endl;
       auto join_comp =
           std::make_shared<JoinHash>(this->_table_wrapper_o, this->_table_wrapper_a, JoinMode::Inner,
                                      ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals, radix_bits);


### PR DESCRIPTION
This PR addresses #1208. Previously, the sampling (apart from being plain wrong) was using the frequency of values to determine splits in the data. Since the chance of sampling the same value multiple times is low (and even then, it does not need to be a good split value), the splitting resulted in highly skewed clusters.

Now, we gather a small `SampleRequest` in which each materialized segment puts some samples. Then, the sample requests are merged, sorted and we select the required number of split values.

I measured the performance with an active scheduler and the change is minimal. I expected it to be better since the values are now (almost) equally sized.

Now:
```
➜  OpossumDB git:(fix/sort_merge_join) ✗ ./rel/hyriseMicroBenchmarks  --benchmark_filter="BM_Sam" --benchmark_repetitions=10
Generating TPC-H data set with scale factor 1 and Dictionary encoding:
[...]
----------------------------------------------------------------------------------------
Benchmark                                                 Time           CPU Iterations
----------------------------------------------------------------------------------------
[...]
TPCHDataMicroBenchmarkFixture/BM_Sampling_mean   1468207936 ns 1006052700 ns          1
TPCHDataMicroBenchmarkFixture/BM_Sampling_median 1464570165 ns 1000790500 ns          1
TPCHDataMicroBenchmarkFixture/BM_Sampling_stddev   23104783 ns   11344929 ns          1
```

Before
```
➜  OpossumDB_master git:(master) ✗ ./rel/hyriseMicroBenchmarks  --benchmark_filter="BM_Sam" --benchmark_repetitions=10
Generating TPC-H data set with scale factor 1 and Dictionary encoding:
[...]
----------------------------------------------------------------------------------------
Benchmark                                                 Time           CPU Iterations
----------------------------------------------------------------------------------------
[...]
TPCHDataMicroBenchmarkFixture/BM_Sampling_mean   1502313768 ns 1017044400 ns          1
TPCHDataMicroBenchmarkFixture/BM_Sampling_median 1515102442 ns 1017976500 ns          1
TPCHDataMicroBenchmarkFixture/BM_Sampling_stddev   68923687 ns   15745084 ns          1
```