### PR TITLE
Fix Pagination CTRL+C behaviour

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -447,7 +447,7 @@ int Console::_generate_tpch(const std::string& args) {
   auto args_valid = !arguments.empty() && arguments.size() <= 2;
 
   // `arguments[0].empty()` is necessary since boost::algorithm::split() will create ["", ] for an empty input string
-  // and that's not actually an argument
+  // and that's not actually an argument.
   auto scale_factor = 1.0f;
   if (!arguments.empty() && !arguments[0].empty()) {
     scale_factor = std::stof(arguments[0]);

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -821,16 +821,21 @@ int Console::_exec_script(const std::string& script_file) {
 }
 
 void Console::handle_signal(int sig) {
-  auto& console = Console::get();
-  if (sig == SIGINT && !console._pagination_active) {
-    // Reset console state
-    console._out << "\n";
-    console._multiline_input = "";
-    console.set_prompt("!> ");
-    console._verbose = false;
-    // Restore program state stored in jmp_env set with sigsetjmp(2).
-    // See comment on jmp_env for details
-    siglongjmp(jmp_env, 1);
+  if (sig == SIGINT) {
+    auto& console = Console::get();
+    // When in pagination mode, just quit pagination. Otherwise, reset Console.
+    if (console._pagination_active) {
+      Pagination::push_ctrl_c();
+    } else {
+      // Reset console state
+      console._out << "\n";
+      console._multiline_input = "";
+      console.set_prompt("!> ");
+      console._verbose = false;
+      // Restore program state stored in jmp_env set with sigsetjmp(2).
+      // See comment on jmp_env for details
+      siglongjmp(jmp_env, 1);
+    }
   }
 }
 

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -147,6 +147,7 @@ class Console : public Singleton<Console> {
   std::ostream _out;
   std::ofstream _log;
   bool _verbose;
+  bool _pagination_active;
 
   std::unique_ptr<SQLPipeline> _sql_pipeline;
   std::shared_ptr<TransactionContext> _explicitly_created_transaction_context;

--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 
+#define CURSES_CTRL_C ('c' & 0x1f)
+
 namespace opossum {
 
 Pagination::Pagination(std::stringstream& input) {
@@ -20,6 +22,8 @@ void Pagination::display() {
   noecho();
   keypad(stdscr, TRUE);
   curs_set(0);
+  // The time (in ms) that getch() waits for input. Having a timeout is important for catching a forwarded CTRL-C.
+  timeout(1000);
 
   getmaxyx(stdscr, _size_y, _size_x);
 
@@ -35,7 +39,7 @@ void Pagination::display() {
   _print_page(current_line);
 
   int key_pressed;
-  while ((key_pressed = getch()) != 'q') {
+  while ((key_pressed = getch()) != 'q' && key_pressed != CURSES_CTRL_C) {
     switch (key_pressed) {
       case 'j':
       case KEY_DOWN: {
@@ -151,10 +155,14 @@ void Pagination::_print_help_screen() {
   wrefresh(help_screen);
 
   int key_pressed;
-  while ((key_pressed = getch()) != 'q') {
+  while ((key_pressed = getch()) != 'q' && key_pressed != CURSES_CTRL_C) {
   }
 
   delwin(help_screen);
+}
+
+void Pagination::push_ctrl_c() {
+  ungetch(CURSES_CTRL_C);
 }
 
 }  // namespace opossum

--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#define CURSES_CTRL_C ('c' & 0x1f)
+#define CURSES_CTRL_C (uint('c') & 31u)
 
 namespace opossum {
 

--- a/src/bin/console/pagination.hpp
+++ b/src/bin/console/pagination.hpp
@@ -20,6 +20,11 @@ class Pagination {
    */
   void display();
 
+  /*
+   * This calls ungetch() to push the character for CTRL_C into the input queue.
+   */
+  static void push_ctrl_c();
+
  protected:
   /*
    * Prints a number of lines to fill the current terminal screen.


### PR DESCRIPTION
Closes #1426.

Just ignoring CTRL+C during pagination is simple (first commit of this PR), we just don't handle the signal.
To make CTRL+C behave the same way as 'q' during pagination, I made it push the curses character code for CTRL+C onto the input stack (with ungetch()), and also add a generous timeout to the getch() loop, so that the simulated keypress actually gets captured without a second input.

A bit hacky, but since we catch the signal in the console, it is not passed on to the pagination window, therefore we have to manually push it back.