### PR TITLE
Fix Delete'ing from pruned Table

### DIFF
--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -9,23 +9,22 @@
 
 namespace opossum {
 
-DeleteNode::DeleteNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Delete), table_name(table_name) {}
+DeleteNode::DeleteNode() : AbstractLQPNode(LQPNodeType::Delete) {}
 
 std::string DeleteNode::description() const {
   std::ostringstream desc;
 
-  desc << "[Delete] Table: '" << table_name << "'";
+  desc << "[Delete]";
 
   return desc.str();
 }
 
 std::shared_ptr<AbstractLQPNode> DeleteNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return DeleteNode::make(table_name);
+  return DeleteNode::make();
 }
 
 bool DeleteNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
-  const auto& delete_node_rhs = static_cast<const DeleteNode&>(rhs);
-  return table_name == delete_node_rhs.table_name;
+  return true;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -12,11 +12,9 @@ namespace opossum {
  */
 class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNode {
  public:
-  explicit DeleteNode(const std::string& table_name);
+  DeleteNode();
 
   std::string description() const override;
-
-  const std::string table_name;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -381,7 +381,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_delete_node(
     const std::shared_ptr<AbstractLQPNode>& node) const {
   const auto input_operator = translate_node(node->left_input());
   auto delete_node = std::dynamic_pointer_cast<DeleteNode>(node);
-  return std::make_shared<Delete>(delete_node->table_name, input_operator);
+  return std::make_shared<Delete>(input_operator);
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_update_node(

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -193,8 +193,8 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
         break;
       case LQPNodeType::Delete: {
         visit_lqp(node->left_input(), [&](const auto& sub_delete_node) {
-          if (const auto stored_stable_node = std::dynamic_pointer_cast<StoredTableNode>(sub_delete_node)) {
-            modified_tables.insert(stored_stable_node->table_name);
+          if (const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(sub_delete_node)) {
+            modified_tables.insert(stored_table_node->table_name);
           } else if (const auto mock_node = std::dynamic_pointer_cast<MockNode>(sub_delete_node)) {
             if (mock_node->name) {
               modified_tables.insert(*mock_node->name);

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -7,7 +7,9 @@
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/delete_node.hpp"
 #include "logical_query_plan/insert_node.hpp"
+#include "logical_query_plan/mock_node.hpp"
 #include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
 #include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/update_node.hpp"
 #include "utils/assert.hpp"
@@ -189,9 +191,18 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
       case LQPNodeType::Update:
         modified_tables.insert(std::static_pointer_cast<UpdateNode>(node)->table_name);
         break;
-      case LQPNodeType::Delete:
-        modified_tables.insert(std::static_pointer_cast<DeleteNode>(node)->table_name);
-        break;
+      case LQPNodeType::Delete: {
+        visit_lqp(node->left_input(), [&](const auto& sub_delete_node) {
+          if (const auto stored_stable_node = std::dynamic_pointer_cast<StoredTableNode>(sub_delete_node)) {
+            modified_tables.insert(stored_stable_node->table_name);
+          } else if (const auto mock_node = std::dynamic_pointer_cast<MockNode>(sub_delete_node)) {
+            if (mock_node->name) {
+              modified_tables.insert(*mock_node->name);
+            }
+          }
+          return LQPVisitation::VisitInputs;
+        });
+      } break;
       case LQPNodeType::CreateTable:
       case LQPNodeType::CreatePreparedPlan:
       case LQPNodeType::DropTable:

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -13,16 +13,16 @@ using namespace std::string_literals;  // NOLINT
 namespace opossum {
 
 MockNode::MockNode(const ColumnDefinitions& column_definitions, const std::optional<std::string>& name)
-    : AbstractLQPNode(LQPNodeType::Mock), _name(name), _column_definitions(column_definitions) {}
+    : AbstractLQPNode(LQPNodeType::Mock), name(name), _column_definitions(column_definitions) {}
 
-LQPColumnReference MockNode::get_column(const std::string& name) const {
+LQPColumnReference MockNode::get_column(const std::string& column_name) const {
   const auto& column_definitions = this->column_definitions();
 
   for (auto column_id = ColumnID{0}; column_id < column_definitions.size(); ++column_id) {
-    if (column_definitions[column_id].second == name) return LQPColumnReference{shared_from_this(), column_id};
+    if (column_definitions[column_id].second == column_name) return LQPColumnReference{shared_from_this(), column_id};
   }
 
-  Fail("Couldn't find column named '"s + name + "' in MockNode");
+  Fail("Couldn't find column named '"s + column_name + "' in MockNode");
 }
 
 const MockNode::ColumnDefinitions& MockNode::column_definitions() const { return _column_definitions; }
@@ -42,7 +42,7 @@ const std::vector<std::shared_ptr<AbstractExpression>>& MockNode::column_express
   return *_column_expressions;
 }
 
-std::string MockNode::description() const { return "[MockNode '"s + _name.value_or("Unnamed") + "']"; }
+std::string MockNode::description() const { return "[MockNode '"s + name.value_or("Unnamed") + "']"; }
 
 std::shared_ptr<TableStatistics> MockNode::derive_statistics_from(
     const std::shared_ptr<AbstractLQPNode>& left_input, const std::shared_ptr<AbstractLQPNode>& right_input) const {

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -40,12 +40,13 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
   void set_statistics(const std::shared_ptr<TableStatistics>& statistics);
 
+  std::optional<std::string> name;
+
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 
  private:
-  std::optional<std::string> _name;
   mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _column_expressions;
 
   // Constructor args to keep around for deep_copy()

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -26,7 +26,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
   explicit MockNode(const ColumnDefinitions& column_definitions, const std::optional<std::string>& name = {});
 
-  LQPColumnReference get_column(const std::string& name) const;
+  LQPColumnReference get_column(const std::string& column_name) const;
 
   const ColumnDefinitions& column_definitions() const;
 

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -39,8 +39,6 @@ void AbstractReadWriteOperator::commit_records(const CommitID commit_id) {
   Assert(_state == ReadWriteOperatorState::Executed, "Operator needs to have state Executed in order to be committed.");
 
   _on_commit_records(commit_id);
-  _finish_commit();
-
   _state = ReadWriteOperatorState::Committed;
 }
 

--- a/src/lib/operators/abstract_read_write_operator.hpp
+++ b/src/lib/operators/abstract_read_write_operator.hpp
@@ -74,12 +74,6 @@ class AbstractReadWriteOperator : public AbstractOperator {
   virtual void _on_commit_records(const CommitID commit_id) = 0;
 
   /**
-   * Called immediately after commit_records().
-   * This is the place to do any work after modifying operators were successful, e.g. updating statistics.
-   */
-  virtual void _finish_commit() {}
-
-  /**
    * Called by rollback_records.
    */
   virtual void _on_rollback_records() = 0;

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -12,8 +12,8 @@
 
 namespace opossum {
 
-Delete::Delete(const std::shared_ptr<const AbstractOperator>& _referencing_table)
-    : AbstractReadWriteOperator{OperatorType::Delete, _referencing_table}, _transaction_id{0} {}
+Delete::Delete(const std::shared_ptr<const AbstractOperator>& referencing_table_op)
+    : AbstractReadWriteOperator{OperatorType::Delete, referencing_table_op}, _transaction_id{0} {}
 
 const std::string Delete::name() const { return "Delete"; }
 

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -12,59 +12,27 @@
 
 namespace opossum {
 
-Delete::Delete(const std::string& table_name, const std::shared_ptr<const AbstractOperator>& values_to_delete)
-    : AbstractReadWriteOperator{OperatorType::Delete, values_to_delete}, _table_name{table_name}, _transaction_id{0} {}
+Delete::Delete(const std::shared_ptr<const AbstractOperator>& _referencing_table)
+    : AbstractReadWriteOperator{OperatorType::Delete, _referencing_table}, _transaction_id{0} {}
 
 const std::string Delete::name() const { return "Delete"; }
 
 std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionContext> context) {
-  const auto values_to_delete = input_table_left();
+  _referencing_table = input_table_left();
 
-  DebugAssert(values_to_delete->type() == TableType::References, "values_to_delete needs to reference another table");
-  DebugAssert(values_to_delete->column_count() > 0, "values_to_delete needs columns to determine referenced table");
-
-  // If there is nothing to delete, early out. Code below expects there to be Chunks in values_to_delete
-  if (values_to_delete->chunk_count() == 0) {
-    return nullptr;
-  }
-
-  // The first segment of the first Chunk of values_to_delete determines the referenced_table all other
-  // ReferenceSegments are expected to reference
-  const auto upper_left_reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(
-      values_to_delete->get_chunk(ChunkID{0})->get_segment(ColumnID{0}));
-  const auto referenced_table = upper_left_reference_segment->referenced_table();
+  DebugAssert(_referencing_table->type() == TableType::References,
+              "_referencing_table needs to reference another table");
+  DebugAssert(_referencing_table->column_count() > 0, "_referencing_table needs columns to determine referenced table");
 
   context->register_read_write_operator(std::static_pointer_cast<AbstractReadWriteOperator>(shared_from_this()));
 
-  _stored_table = StorageManager::get().get_table(_table_name);
   _transaction_id = context->transaction_id();
 
-  // If values_to_delete references a pruned table (and not the stored table itself), build a mapping from ChunkIDs in
-  // the pruned table (`referenced_table`) to the actual ChunkIDs in the stored_table
-  auto stored_chunk_id_by_referenced_chunk_id = std::optional<std::vector<ChunkID>>{};
-  if (_stored_table != referenced_table) {
-    auto stored_chunk_id_by_chunk = std::unordered_map<std::shared_ptr<const Chunk>, ChunkID>{};
-    for (auto stored_chunk_id = ChunkID{0}; stored_chunk_id < _stored_table->chunk_count(); ++stored_chunk_id) {
-      stored_chunk_id_by_chunk.emplace(_stored_table->get_chunk(stored_chunk_id), stored_chunk_id);
-    }
+  for (ChunkID chunk_id{0}; chunk_id < _referencing_table->chunk_count(); ++chunk_id) {
+    const auto chunk = _referencing_table->get_chunk(chunk_id);
 
-    stored_chunk_id_by_referenced_chunk_id.emplace(referenced_table->chunk_count());
-    for (auto referenced_chunk_id = ChunkID{0}; referenced_chunk_id < referenced_table->chunk_count();
-         ++referenced_chunk_id) {
-      const auto stored_chunk_id = stored_chunk_id_by_chunk.at(referenced_table->get_chunk(referenced_chunk_id));
-      (*stored_chunk_id_by_referenced_chunk_id)[referenced_chunk_id] = stored_chunk_id;
-    }
-  }
-
-  for (ChunkID chunk_id{0}; chunk_id < values_to_delete->chunk_count(); ++chunk_id) {
-    const auto chunk = values_to_delete->get_chunk(chunk_id);
-
-    DebugAssert(
-        std::dynamic_pointer_cast<const ReferenceSegment>(chunk->get_segment(ColumnID{0}))->referenced_table() ==
-            referenced_table,
-        "All segments in values_to_delete must reference the same table");
     DebugAssert(chunk->references_exactly_one_table(),
-                "All segments in values_to_delete must reference the same table");
+                "All segments in _referencing_table must reference the same table");
 
     const auto first_segment = std::static_pointer_cast<const ReferenceSegment>(chunk->get_segment(ColumnID{0}));
     const auto pos_list = first_segment->pos_list();
@@ -77,17 +45,10 @@ std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionCont
                               // pointers is sufficient
                               return segment_pos_list == pos_list;
                             }),
-                "All segments of a Chunk in values_to_delete must have the same PosList");
+                "All segments of a Chunk in _referencing_table must have the same PosList");
 
     for (auto row_id : *pos_list) {
-      // If the `referenced_table` is a pruned version of the stored_table, rewrite the chunk_id to point into the
-      // stored table
-      if (stored_chunk_id_by_referenced_chunk_id) {
-        DebugAssert(row_id.chunk_id < referenced_table->chunk_count(), "RowID out of range");
-        row_id.chunk_id = (*stored_chunk_id_by_referenced_chunk_id)[row_id.chunk_id];
-      }
-
-      auto referenced_chunk = _stored_table->get_chunk(row_id.chunk_id);
+      auto referenced_chunk = first_segment->referenced_table()->get_chunk(row_id.chunk_id);
 
       auto expected = 0u;
 
@@ -112,8 +73,6 @@ std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionCont
           }
         }
       }
-
-      _deleted_rows.emplace_back(row_id);
     }
   }
 
@@ -121,42 +80,58 @@ std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionCont
 }
 
 void Delete::_on_commit_records(const CommitID cid) {
-  for (const auto& row_id : _deleted_rows) {
-    auto chunk = _stored_table->get_chunk(row_id.chunk_id);
+  for (ChunkID referencing_chunk_id{0}; referencing_chunk_id < _referencing_table->chunk_count();
+       ++referencing_chunk_id) {
+    const auto referencing_chunk = _referencing_table->get_chunk(referencing_chunk_id);
+    const auto referencing_segment =
+        std::static_pointer_cast<const ReferenceSegment>(referencing_chunk->get_segment(ColumnID{0}));
+    const auto referenced_table = referencing_segment->referenced_table();
 
-    chunk->get_scoped_mvcc_data_lock()->end_cids[row_id.chunk_offset] = cid;
-    // We do not unlock the rows so subsequent transactions properly fail when attempting to update these rows.
-  }
-}
+    for (const auto& row_id : *referencing_segment->pos_list()) {
+      auto referenced_chunk = referenced_table->get_chunk(row_id.chunk_id);
 
-void Delete::_finish_commit() {
-  const auto table_statistics = _stored_table->table_statistics();
-  if (table_statistics) {
-    table_statistics->increase_invalid_row_count(_deleted_rows.size());
+      referenced_chunk->get_scoped_mvcc_data_lock()->end_cids[row_id.chunk_offset] = cid;
+      // We do not unlock the rows so subsequent transactions properly fail when attempting to update these rows.
+    }
+
+    // Update statistics about deleted rows
+    const auto table_statistics = referenced_table->table_statistics();
+    if (table_statistics) {
+      table_statistics->increase_invalid_row_count(referencing_segment->pos_list()->size());
+    }
   }
 }
 
 void Delete::_on_rollback_records() {
-  for (const auto& row_id : _deleted_rows) {
-    auto chunk = _stored_table->get_chunk(row_id.chunk_id);
+  for (ChunkID referencing_chunk_id{0}; referencing_chunk_id < _referencing_table->chunk_count();
+       ++referencing_chunk_id) {
+    const auto referencing_chunk = _referencing_table->get_chunk(referencing_chunk_id);
+    const auto referencing_segment =
+        std::static_pointer_cast<const ReferenceSegment>(referencing_chunk->get_segment(ColumnID{0}));
+    const auto referenced_table = referencing_segment->referenced_table();
 
-    auto expected = _transaction_id;
+    for (const auto& row_id : *referencing_segment->pos_list()) {
+      auto expected = _transaction_id;
 
-    // unlock all rows locked in _on_execute
-    const auto result =
-        chunk->get_scoped_mvcc_data_lock()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
+      auto referenced_chunk = referenced_table->get_chunk(row_id.chunk_id);
 
-    // If the above operation fails, it means the row is locked by another transaction. This must have been
-    // the reason why the rollback was initiated. Since _on_execute stopped at this row, we can stop
-    // unlocking rows here as well.
-    if (!result) return;
+      // unlock all rows locked in _on_execute
+      const auto result =
+          referenced_chunk->get_scoped_mvcc_data_lock()->tids[row_id.chunk_offset].compare_exchange_strong(expected,
+                                                                                                           0u);
+
+      // If the above operation fails, it means the row is locked by another transaction. This must have been
+      // the reason why the rollback was initiated. Since _on_execute stopped at this row, we can stop
+      // unlocking rows here as well.
+      if (!result) return;
+    }
   }
 }
 
 std::shared_ptr<AbstractOperator> Delete::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_input_left,
     const std::shared_ptr<AbstractOperator>& copied_input_right) const {
-  return std::make_shared<Delete>(_table_name, copied_input_left);
+  return std::make_shared<Delete>(copied_input_left);
 }
 
 void Delete::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -13,127 +13,144 @@
 namespace opossum {
 
 Delete::Delete(const std::string& table_name, const std::shared_ptr<const AbstractOperator>& values_to_delete)
-    : AbstractReadWriteOperator{OperatorType::Delete, values_to_delete},
-      _table_name{table_name},
-      _transaction_id{0},
-      _num_rows_deleted{0} {}
+    : AbstractReadWriteOperator{OperatorType::Delete, values_to_delete}, _table_name{table_name}, _transaction_id{0} {}
 
 const std::string Delete::name() const { return "Delete"; }
 
 std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionContext> context) {
-  DebugAssert(_execution_input_valid(context), "Input to Delete isn't valid");
+  const auto values_to_delete = input_table_left();
+
+  DebugAssert(values_to_delete->type() == TableType::References, "values_to_delete needs to reference another table");
+  DebugAssert(values_to_delete->column_count() > 0, "values_to_delete needs columns to determine referenced table");
+
+  // If there is nothing to delete, early out. Code below expects there to be Chunks in values_to_delete
+  if (values_to_delete->chunk_count() == 0) {
+    return nullptr;
+  }
+
+  // The first segment of the first Chunk of values_to_delete determines the referenced_table all other
+  // ReferenceSegments are expected to reference
+  const auto upper_left_reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(
+      values_to_delete->get_chunk(ChunkID{0})->get_segment(ColumnID{0}));
+  const auto referenced_table = upper_left_reference_segment->referenced_table();
 
   context->register_read_write_operator(std::static_pointer_cast<AbstractReadWriteOperator>(shared_from_this()));
 
-  _table = StorageManager::get().get_table(_table_name);
+  _stored_table = StorageManager::get().get_table(_table_name);
   _transaction_id = context->transaction_id();
 
-  const auto values_to_delete = input_table_left();
+  // If values_to_delete references a pruned table (and not the stored table itself), build a mapping from ChunkIDs in
+  // the pruned table (`referenced_table`) to the actual ChunkIDs in the stored_table
+  auto stored_chunk_id_by_referenced_chunk_id = std::optional<std::vector<ChunkID>>{};
+  if (_stored_table != referenced_table) {
+    auto stored_chunk_id_by_chunk = std::unordered_map<std::shared_ptr<const Chunk>, ChunkID>{};
+    for (auto stored_chunk_id = ChunkID{0}; stored_chunk_id < _stored_table->chunk_count(); ++stored_chunk_id) {
+      stored_chunk_id_by_chunk.emplace(_stored_table->get_chunk(stored_chunk_id), stored_chunk_id);
+    }
+
+    stored_chunk_id_by_referenced_chunk_id.emplace(referenced_table->chunk_count());
+    for (auto referenced_chunk_id = ChunkID{0}; referenced_chunk_id < referenced_table->chunk_count();
+         ++referenced_chunk_id) {
+      const auto stored_chunk_id = stored_chunk_id_by_chunk.at(referenced_table->get_chunk(referenced_chunk_id));
+      (*stored_chunk_id_by_referenced_chunk_id)[referenced_chunk_id] = stored_chunk_id;
+    }
+  }
 
   for (ChunkID chunk_id{0}; chunk_id < values_to_delete->chunk_count(); ++chunk_id) {
     const auto chunk = values_to_delete->get_chunk(chunk_id);
 
-    // we have already verified that all segments reference the same table
+    DebugAssert(
+        std::dynamic_pointer_cast<const ReferenceSegment>(chunk->get_segment(ColumnID{0}))->referenced_table() ==
+            referenced_table,
+        "All segments in values_to_delete must reference the same table");
+    DebugAssert(chunk->references_exactly_one_table(),
+                "All segments in values_to_delete must reference the same table");
+
     const auto first_segment = std::static_pointer_cast<const ReferenceSegment>(chunk->get_segment(ColumnID{0}));
     const auto pos_list = first_segment->pos_list();
 
-    _pos_lists.emplace_back(pos_list);
+    DebugAssert(std::all_of(chunk->segments().begin(), chunk->segments().end(),
+                            [&](const auto& segment) {
+                              const auto segment_pos_list =
+                                  std::dynamic_pointer_cast<const ReferenceSegment>(segment)->pos_list();
+                              // We could additionally check for `*segment_pos_list == *pos_list`, but atm comparing
+                              // pointers is sufficient
+                              return segment_pos_list == pos_list;
+                            }),
+                "All segments of a Chunk in values_to_delete must have the same PosList");
 
-    for (const auto& row_id : *pos_list) {
-      auto referenced_chunk = _table->get_chunk(row_id.chunk_id);
-
-      auto expected = 0u;
-      // Actual row lock for delete happens here
-      const auto success =
-          referenced_chunk->get_scoped_mvcc_data_lock()->tids[row_id.chunk_offset].compare_exchange_strong(
-              expected, _transaction_id);
-
-      if (success) continue;
-
-      // If the row has a set TID, it might be a row that our TX inserted
-      // No need to compare-and-swap here, because we can only run into conflicts when two transactions try to
-      // change this row from the initial tid
-      if (auto mvcc_data = referenced_chunk->get_scoped_mvcc_data_lock();
-          mvcc_data->tids[row_id.chunk_offset] == _transaction_id) {
-        // Make sure that even we don't see it anymore
-        mvcc_data->tids[row_id.chunk_offset] = TransactionManager::INVALID_TRANSACTION_ID;
-        continue;
+    for (auto row_id : *pos_list) {
+      // If the `referenced_table` is a pruned version of the stored_table, rewrite the chunk_id to point into the
+      // stored table
+      if (stored_chunk_id_by_referenced_chunk_id) {
+        DebugAssert(row_id.chunk_id < referenced_table->chunk_count(), "RowID out of range");
+        row_id.chunk_id = (*stored_chunk_id_by_referenced_chunk_id)[row_id.chunk_id];
       }
 
-      // the row is already locked by someone else and the transaction needs to be rolled back
-      _mark_as_failed();
-      return nullptr;
+      auto referenced_chunk = _stored_table->get_chunk(row_id.chunk_id);
+
+      auto expected = 0u;
+
+      // Scope for the lock on the MVCC data
+      {
+        auto mvcc_data = referenced_chunk->get_scoped_mvcc_data_lock();
+        // Actual row lock for delete happens here
+        const auto success = mvcc_data->tids[row_id.chunk_offset].compare_exchange_strong(expected, _transaction_id);
+
+        if (!success) {
+          // If the row has a set TID, it might be a row that our TX inserted
+          // No need to compare-and-swap here, because we can only run into conflicts when two transactions try to
+          // change this row from the initial tid
+
+          if (mvcc_data->tids[row_id.chunk_offset] == _transaction_id) {
+            // Make sure that even we don't see it anymore
+            mvcc_data->tids[row_id.chunk_offset] = TransactionManager::INVALID_TRANSACTION_ID;
+          } else {
+            // the row is already locked by someone else and the transaction needs to be rolled back
+            _mark_as_failed();
+            return nullptr;
+          }
+        }
+      }
+
+      _deleted_rows.emplace_back(row_id);
     }
   }
-
-  _num_rows_deleted = input_table_left()->row_count();
 
   return nullptr;
 }
 
 void Delete::_on_commit_records(const CommitID cid) {
-  for (const auto& pos_list : _pos_lists) {
-    for (const auto& row_id : *pos_list) {
-      auto chunk = _table->get_chunk(row_id.chunk_id);
+  for (const auto& row_id : _deleted_rows) {
+    auto chunk = _stored_table->get_chunk(row_id.chunk_id);
 
-      chunk->get_scoped_mvcc_data_lock()->end_cids[row_id.chunk_offset] = cid;
-      // We do not unlock the rows so subsequent transactions properly fail when attempting to update these rows.
-    }
+    chunk->get_scoped_mvcc_data_lock()->end_cids[row_id.chunk_offset] = cid;
+    // We do not unlock the rows so subsequent transactions properly fail when attempting to update these rows.
   }
 }
 
 void Delete::_finish_commit() {
-  const auto table_statistics = _table->table_statistics();
+  const auto table_statistics = _stored_table->table_statistics();
   if (table_statistics) {
-    table_statistics->increase_invalid_row_count(_num_rows_deleted);
+    table_statistics->increase_invalid_row_count(_deleted_rows.size());
   }
 }
 
 void Delete::_on_rollback_records() {
-  for (const auto& pos_list : _pos_lists) {
-    for (const auto& row_id : *pos_list) {
-      auto chunk = _table->get_chunk(row_id.chunk_id);
+  for (const auto& row_id : _deleted_rows) {
+    auto chunk = _stored_table->get_chunk(row_id.chunk_id);
 
-      auto expected = _transaction_id;
+    auto expected = _transaction_id;
 
-      // unlock all rows locked in _on_execute
-      const auto result =
-          chunk->get_scoped_mvcc_data_lock()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
+    // unlock all rows locked in _on_execute
+    const auto result =
+        chunk->get_scoped_mvcc_data_lock()->tids[row_id.chunk_offset].compare_exchange_strong(expected, 0u);
 
-      // If the above operation fails, it means the row is locked by another transaction. This must have been
-      // the reason why the rollback was initiated. Since _on_execute stopped at this row, we can stop
-      // unlocking rows here as well.
-      if (!result) return;
-    }
+    // If the above operation fails, it means the row is locked by another transaction. This must have been
+    // the reason why the rollback was initiated. Since _on_execute stopped at this row, we can stop
+    // unlocking rows here as well.
+    if (!result) return;
   }
-}
-
-/**
- * values_to_delete must be a table either without chunks or with at least one ReferenceSegment
- * where all segments reference the table specified by table_name.
- */
-bool Delete::_execution_input_valid(const std::shared_ptr<TransactionContext>& context) const {
-  if (context == nullptr) return false;
-
-  const auto values_to_delete = input_table_left();
-
-  if (!StorageManager::get().has_table(_table_name)) return false;
-
-  const auto table = StorageManager::get().get_table(_table_name);
-
-  for (ChunkID chunk_id{0}; chunk_id < values_to_delete->chunk_count(); ++chunk_id) {
-    const auto chunk = values_to_delete->get_chunk(chunk_id);
-
-    if (chunk->column_count() == 0u) return false;
-
-    if (!chunk->references_exactly_one_table()) return false;
-
-    const auto first_segment = std::static_pointer_cast<const ReferenceSegment>(chunk->get_segment(ColumnID{0}));
-
-    if (table != first_segment->referenced_table()) return false;
-  }
-
-  return true;
 }
 
 std::shared_ptr<AbstractOperator> Delete::_on_deep_copy(

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -12,6 +12,7 @@ namespace opossum {
 
 /**
  * Operator that marks the rows referenced by its input table as MVCC-expired.
+ * Assumption: The input has been validated before.
  */
 class Delete : public AbstractReadWriteOperator {
  public:

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -15,7 +15,7 @@ namespace opossum {
  */
 class Delete : public AbstractReadWriteOperator {
  public:
-  explicit Delete(const std::shared_ptr<const AbstractOperator>& values_to_delete);
+  explicit Delete(const std::shared_ptr<const AbstractOperator>& referencing_table_op);
 
   const std::string name() const override;
 

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -34,16 +34,9 @@ class Delete : public AbstractReadWriteOperator {
   void _on_rollback_records() override;
 
  private:
-  /**
-   * Validates the context and the input table
-   */
-  bool _execution_input_valid(const std::shared_ptr<TransactionContext>& context) const;
-
- private:
   const std::string _table_name;
-  std::shared_ptr<Table> _table;
+  std::shared_ptr<Table> _stored_table;
   TransactionID _transaction_id;
-  std::vector<std::shared_ptr<const PosList>> _pos_lists;
-  uint64_t _num_rows_deleted;
+  PosList _deleted_rows;
 };
 }  // namespace opossum

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -11,15 +11,11 @@
 namespace opossum {
 
 /**
- * Operator that deletes a number of rows from one table.
- * Expects a table with one chunk referencing only one table which
- * is passed via the AbstractOperator in the constructor.
- *
- * Assumption: The input has been validated before.
+ * Operator that marks the rows referenced by its input table as MVCC-expired.
  */
 class Delete : public AbstractReadWriteOperator {
  public:
-  explicit Delete(const std::string& table_name, const std::shared_ptr<const AbstractOperator>& values_to_delete);
+  explicit Delete(const std::shared_ptr<const AbstractOperator>& values_to_delete);
 
   const std::string name() const override;
 
@@ -30,13 +26,11 @@ class Delete : public AbstractReadWriteOperator {
       const std::shared_ptr<AbstractOperator>& copied_input_right) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
   void _on_commit_records(const CommitID cid) override;
-  void _finish_commit() override;
   void _on_rollback_records() override;
 
  private:
-  const std::string _table_name;
-  std::shared_ptr<Table> _stored_table;
   TransactionID _transaction_id;
-  PosList _deleted_rows;
+
+  std::shared_ptr<const Table> _referencing_table;
 };
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/jit_types.hpp
+++ b/src/lib/operators/jit_operator/jit_types.hpp
@@ -144,12 +144,12 @@ struct JitRuntimeContext {
 
   // MVCC data from the current input chunk required by JitValidate
   // If the input table is a data table, its MVCC data is used.
-  std::shared_ptr<const MvccData> mvcc_data;
+  std::shared_ptr<MvccData> mvcc_data;
   // The MVCC data is locked with a SharedScopedLockingPtr. The SharedScopedLockingPtr is stored within a unique ptr as
   // a SharedScopedLockingPtr has not the required copy assignment operator due to its reference data member.
   // The SharedScopedLockingPtr is only used to lock and not to access MVCC as this construct requires two ptr
   // dereferencings instead of one to access the MVCC data.
-  std::unique_ptr<SharedScopedLockingPtr<const MvccData>> mvcc_data_lock;
+  std::unique_ptr<SharedScopedLockingPtr<MvccData>> mvcc_data_lock;
   // The transaction ids are materialized as specialization cannot handle the atomics holding the transaction ids.
   pmr_vector<TransactionID> row_tids;
 

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -56,8 +56,7 @@ void JitReadTuples::before_chunk(const Table& in_table, const Chunk& in_chunk, J
         *itr++ = tid.load();
       }
       // Lock MVCC data before accessing it.
-      context.mvcc_data_lock =
-          std::make_unique<SharedScopedLockingPtr<const MvccData>>(in_chunk.get_scoped_mvcc_data_lock());
+      context.mvcc_data_lock = std::make_unique<SharedScopedLockingPtr<MvccData>>(in_chunk.get_scoped_mvcc_data_lock());
       context.mvcc_data = in_chunk.mvcc_data();
     } else {
       DebugAssert(in_chunk.references_exactly_one_table(),

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -32,15 +32,6 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
   DebugAssert(input_table_left()->column_data_types() == input_table_right()->column_data_types(),
               "Update required identical layouts from its input tables");
 
-  for (const auto& chunk : input_table_left()->chunks()) {
-    DebugAssert(chunk->references_exactly_one_table(),
-                "Update left input must be a reference table referencing exactly one table");
-
-    const auto first_segment = std::static_pointer_cast<const ReferenceSegment>(chunk->get_segment(ColumnID{0}));
-    DebugAssert(table_to_update == first_segment->referenced_table(),
-                "Update left input must reference the table that is supposed to be updated");
-  }
-
   // 1. Delete obsolete data with the Delete operator.
   //    Delete doesn't accept empty input data
   if (input_table_left()->row_count() > 0) {

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -35,7 +35,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
   // 1. Delete obsolete data with the Delete operator.
   //    Delete doesn't accept empty input data
   if (input_table_left()->row_count() > 0) {
-    _delete = std::make_shared<Delete>(_table_to_update_name, _input_left);
+    _delete = std::make_shared<Delete>(_input_left);
     _delete->set_transaction_context(context);
     _delete->execute();
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -373,7 +373,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_delete(const hsql::De
     data_to_delete_node = _translate_predicate_expression(delete_where_expression, data_to_delete_node);
   }
 
-  return DeleteNode::make(delete_statement.tableName, data_to_delete_node);
+  return DeleteNode::make(data_to_delete_node);
 }
 
 std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_update(const hsql::UpdateStatement& update) {

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -77,13 +77,7 @@ uint32_t Chunk::size() const {
 bool Chunk::has_mvcc_data() const { return _mvcc_data != nullptr; }
 bool Chunk::has_access_counter() const { return _access_counter != nullptr; }
 
-SharedScopedLockingPtr<MvccData> Chunk::get_scoped_mvcc_data_lock() {
-  DebugAssert((has_mvcc_data()), "Chunk does not have mvcc data");
-
-  return {*_mvcc_data, _mvcc_data->_mutex};
-}
-
-SharedScopedLockingPtr<const MvccData> Chunk::get_scoped_mvcc_data_lock() const {
+SharedScopedLockingPtr<MvccData> Chunk::get_scoped_mvcc_data_lock() const {
   DebugAssert((has_mvcc_data()), "Chunk does not have mvcc data");
 
   return {*_mvcc_data, _mvcc_data->_mutex};

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -96,8 +96,7 @@ class Chunk : private Noncopyable {
    *
    * @return a locking ptr to the MVCC data
    */
-  SharedScopedLockingPtr<MvccData> get_scoped_mvcc_data_lock();
-  SharedScopedLockingPtr<const MvccData> get_scoped_mvcc_data_lock() const;
+  SharedScopedLockingPtr<MvccData> get_scoped_mvcc_data_lock() const;
 
   std::shared_ptr<MvccData> mvcc_data() const;
   void set_mvcc_data(const std::shared_ptr<MvccData>& mvcc_data);

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -146,8 +146,7 @@ class Table : private Noncopyable {
 
   void set_table_statistics(std::shared_ptr<TableStatistics> table_statistics) { _table_statistics = table_statistics; }
 
-  std::shared_ptr<TableStatistics> table_statistics() { return _table_statistics; }
-  std::shared_ptr<const TableStatistics> table_statistics() const { return _table_statistics; }
+  std::shared_ptr<TableStatistics> table_statistics() const { return _table_statistics; }
 
   std::vector<IndexInfo> get_indexes() const;
 

--- a/src/test/logical_query_plan/delete_node_test.cpp
+++ b/src/test/logical_query_plan/delete_node_test.cpp
@@ -9,17 +9,16 @@ namespace opossum {
 
 class DeleteNodeTest : public BaseTest {
  protected:
-  void SetUp() override { _delete_node = DeleteNode::make("table_a"); }
+  void SetUp() override { _delete_node = DeleteNode::make(); }
 
   std::shared_ptr<DeleteNode> _delete_node;
 };
 
-TEST_F(DeleteNodeTest, Description) { EXPECT_EQ(_delete_node->description(), "[Delete] Table: 'table_a'"); }
+TEST_F(DeleteNodeTest, Description) { EXPECT_EQ(_delete_node->description(), "[Delete]"); }
 
 TEST_F(DeleteNodeTest, Equals) {
-  EXPECT_EQ(*_delete_node, *_delete_node);
-  const auto different_delete_node = DeleteNode::make("table_b");
-  EXPECT_NE(*_delete_node, *different_delete_node);
+  const auto another_delete_node = DeleteNode::make();
+  EXPECT_EQ(*_delete_node, *another_delete_node);
 }
 
 TEST_F(DeleteNodeTest, NodeExpressions) { ASSERT_EQ(_delete_node->node_expressions.size(), 0u); }

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -22,8 +22,8 @@ namespace opossum {
 class LQPUtilsTest : public BaseTest {
  public:
   void SetUp() override {
-    node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}});
-    node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}});
+    node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}}, "node_a");
+    node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}}, "node_b");
 
     a_a = node_a->get_column("a");
     a_b = node_a->get_column("b");
@@ -172,11 +172,11 @@ TEST_F(LQPUtilsTest, LQPFindModifiedTables) {
   EXPECT_EQ(insert_tables.size(), 1);
   EXPECT_NE(insert_tables.find("insert_table_name"), insert_tables.end());
 
-  const auto delete_lqp = DeleteNode::make("delete_table_name", node_a);
+  const auto delete_lqp = DeleteNode::make(node_a);
   const auto delete_tables = lqp_find_modified_tables(delete_lqp);
 
   EXPECT_EQ(delete_tables.size(), 1);
-  EXPECT_NE(delete_tables.find("delete_table_name"), delete_tables.end());
+  EXPECT_NE(delete_tables.find("node_a"), delete_tables.end());
 }
 
 }  // namespace opossum

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -40,7 +40,7 @@ class OperatorsDeleteTest : public BaseTest {
   }
 
   std::string _table_name, _table2_name;
-  std::shared_ptr<GetTable> _gt, _gt2;
+  std::shared_ptr<GetTable> _gt;
   std::shared_ptr<Table> _table, _table2;
 
   void helper(bool commit);
@@ -54,7 +54,7 @@ void OperatorsDeleteTest::helper(bool commit) {
 
   table_scan->execute();
 
-  auto delete_op = std::make_shared<Delete>(_table_name, table_scan);
+  auto delete_op = std::make_shared<Delete>(table_scan);
   delete_op->set_transaction_context(transaction_context);
 
   delete_op->execute();
@@ -115,10 +115,10 @@ TEST_F(OperatorsDeleteTest, DetectDirtyWrite) {
   EXPECT_EQ(table_scan1->get_output()->chunk_count(), 1u);
   EXPECT_EQ(table_scan1->get_output()->get_chunk(ChunkID{0})->column_count(), 2u);
 
-  auto delete_op1 = std::make_shared<Delete>(_table_name, table_scan1);
+  auto delete_op1 = std::make_shared<Delete>(table_scan1);
   delete_op1->set_transaction_context(t1_context);
 
-  auto delete_op2 = std::make_shared<Delete>(_table_name, table_scan2);
+  auto delete_op2 = std::make_shared<Delete>(table_scan2);
   delete_op2->set_transaction_context(t2_context);
 
   delete_op1->execute();
@@ -150,7 +150,7 @@ TEST_F(OperatorsDeleteTest, EmptyDelete) {
 
   EXPECT_EQ(table_scan->get_output()->chunk_count(), 0u);
 
-  auto delete_op = std::make_shared<Delete>(_table_name, table_scan);
+  auto delete_op = std::make_shared<Delete>(table_scan);
   delete_op->set_transaction_context(tx_context_modification);
 
   delete_op->execute();
@@ -183,7 +183,7 @@ TEST_F(OperatorsDeleteTest, UpdateAfterDeleteFails) {
   validate1->execute();
   validate2->execute();
 
-  auto delete_op = std::make_shared<Delete>(_table_name, validate1);
+  auto delete_op = std::make_shared<Delete>(validate1);
   delete_op->set_transaction_context(t1_context);
 
   delete_op->execute();
@@ -230,7 +230,7 @@ TEST_F(OperatorsDeleteTest, DeleteOwnInsert) {
     table_scan1->execute();
     EXPECT_EQ(table_scan1->get_output()->row_count(), 2);
 
-    auto delete_op = std::make_shared<Delete>(_table_name, table_scan1);
+    auto delete_op = std::make_shared<Delete>(table_scan1);
     delete_op->set_transaction_context(context);
     delete_op->execute();
 
@@ -281,13 +281,13 @@ TEST_F(OperatorsDeleteTest, UseTransactionContextAfterCommit) {
   validate1->set_transaction_context(t1_context);
   validate1->execute();
 
-  auto delete_op = std::make_shared<Delete>(_table_name, validate1);
+  auto delete_op = std::make_shared<Delete>(validate1);
   delete_op->set_transaction_context(t1_context);
   delete_op->execute();
 
   t1_context->commit();
 
-  auto delete_op2 = std::make_shared<Delete>(_table_name, validate1);
+  auto delete_op2 = std::make_shared<Delete>(validate1);
   delete_op->set_transaction_context(t1_context);
 
   EXPECT_THROW(delete_op->execute(), std::logic_error);
@@ -308,7 +308,7 @@ TEST_F(OperatorsDeleteTest, PrunedInputTable) {
   table_scan->execute();
 
   //
-  const auto delete_op = std::make_shared<Delete>("table_b", table_scan);
+  const auto delete_op = std::make_shared<Delete>(table_scan);
   delete_op->set_transaction_context(transaction_context);
   delete_op->execute();
   transaction_context->commit();

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -1418,7 +1418,7 @@ TEST_F(SQLTranslatorTest, DeleteSimple) {
 
   // clang-format off
   const auto expected_lqp =
-  DeleteNode::make("int_float",
+  DeleteNode::make(
     ValidateNode::make(
       StoredTableNode::make("int_float")));
   // clang-format on
@@ -1431,7 +1431,7 @@ TEST_F(SQLTranslatorTest, DeleteConditional) {
 
   // clang-format off
   const auto expected_lqp =
-  DeleteNode::make("int_float",
+  DeleteNode::make(
     PredicateNode::make(greater_than_(int_float_a, 5),
       ValidateNode::make(
         stored_table_node_int_float)));

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -5,8 +5,10 @@
 namespace opossum {
 
 // TODO(anybody) Remove blockers in #1269 and activate this
-// INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
-//                        testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
-//                                         testing::ValuesIn({EncodingType::Dictionary})), );  // NOLINT
+INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
+                        testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
+                                         testing::ValuesIn({EncodingType::Dictionary, EncodingType::RunLength,
+                                                            EncodingType::FixedStringDictionary,
+                                                            EncodingType::FrameOfReference})), );  // NOLINT
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
@@ -4,10 +4,12 @@ namespace opossum {
 
 #if HYRISE_JIT_SUPPORT
 
+// Test JIT with unencoded and dictionary encoded tables (the latter just for good measure)
 INSTANTIATE_TEST_CASE_P(
     SQLiteTestRunnerJIT, SQLiteTestRunner,
     testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({true}),
-                     testing::ValuesIn({EncodingType::Unencoded})), );  // NOLINT(whitespace/parens)  // NOLINT
+                     testing::ValuesIn({EncodingType::Unencoded,
+                                        EncodingType::Dictionary})), );  // NOLINT(whitespace/parens)  // NOLINT
 
 #endif
 

--- a/src/test/statistics/chunk_statistics/histograms/histogram_utils_test.cpp
+++ b/src/test/statistics/chunk_statistics/histograms/histogram_utils_test.cpp
@@ -203,6 +203,6 @@ TEST_F(HistogramUtilsTest, NextValueBruteForce) {
                    supported_characters, prefix_length);
     EXPECT_EQ(number_string, next_value_of_previous_number);
   }
-}gin
+}
 
 }  // namespace opossum

--- a/src/test/statistics/chunk_statistics/histograms/histogram_utils_test.cpp
+++ b/src/test/statistics/chunk_statistics/histograms/histogram_utils_test.cpp
@@ -203,6 +203,6 @@ TEST_F(HistogramUtilsTest, NextValueBruteForce) {
                    supported_characters, prefix_length);
     EXPECT_EQ(number_string, next_value_of_previous_number);
   }
-}
+}gin
 
 }  // namespace opossum


### PR DESCRIPTION
Fix #1083 
Closes #1269

The `Delete` operator can now work on "pruned" versions of stored Tables. Such Tables contain a subset of the Chunks of a stored Table and are generated if `GetTable` is instructed to exclude Chunks.

* Removes the "table_name" fields from `Delete` and `DeleteNode`
* Enables the `SQLiteTestrunner` for all encodings (and JIT + Dictionary for good measure)
* Fix a bug in the `SQLiteTestrunner` that made it not reset the SQLite version of a Table when running the same query for multiple encodings.