### PR TITLE
Delete only visible rows

### DIFF
--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -288,4 +288,19 @@ TEST_F(OperatorsDeleteTest, UseTransactionContextAfterCommit) {
 
   EXPECT_THROW(delete_op->execute(), std::logic_error);
 }
+
+TEST_F(OperatorsDeleteTest, RunOnUnvalidatedTable) {
+  if (!HYRISE_DEBUG) GTEST_SKIP();
+
+  auto t1_context = TransactionManager::get().new_transaction_context();
+
+  auto get_table = std::make_shared<GetTable>(_table_name);
+  get_table->execute();
+
+  auto delete_op = std::make_shared<Delete>(_table_name, get_table);
+  delete_op->set_transaction_context(t1_context);
+
+  EXPECT_THROW(delete_op->execute(), std::logic_error);
+}
+
 }  // namespace opossum


### PR DESCRIPTION
When deleting rows that have not been validated, delete fails, but its error message is not helpful. #1424 tried to implement #1344 and track if the input table has been validated. But even the latter was already on the wrong track.

If we want to make sure that the rows given to delete are visible, why don't we... well... check that?

Stupid.

fixes #1344.