### PR TITLE
Worker sleep times (Follow-up on #1379)

### DIFF
--- a/src/lib/scheduler/task_queue.cpp
+++ b/src/lib/scheduler/task_queue.cpp
@@ -24,6 +24,7 @@ void TaskQueue::push(const std::shared_ptr<AbstractTask>& task, uint32_t priorit
   _queues[priority].push(task);
 
   _num_tasks++;
+  new_task.notify_one();
 }
 
 std::shared_ptr<AbstractTask> TaskQueue::pull() {

--- a/src/lib/scheduler/task_queue.hpp
+++ b/src/lib/scheduler/task_queue.hpp
@@ -4,8 +4,8 @@
 #include <tbb/concurrent_queue.h>
 #include <array>
 #include <atomic>
-#include <memory>
 #include <condition_variable>
+#include <memory>
 
 #include "types.hpp"
 

--- a/src/lib/scheduler/task_queue.hpp
+++ b/src/lib/scheduler/task_queue.hpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <atomic>
 #include <memory>
+#include <condition_variable>
 
 #include "types.hpp"
 
@@ -36,6 +37,11 @@ class TaskQueue {
    * Returns a Tasks that is ready to be executed and removes it from one of the stealable queues
    */
   std::shared_ptr<AbstractTask> steal();
+
+  /**
+   * Notifies one worker as soon as a new task gets pushed into the queue
+   */
+  std::condition_variable new_task;
 
  private:
   NodeID _node_id;

--- a/src/lib/scheduler/task_queue.hpp
+++ b/src/lib/scheduler/task_queue.hpp
@@ -43,6 +43,11 @@ class TaskQueue {
    */
   std::condition_variable new_task;
 
+  /**
+   * Mutex accessed by workers in order to notify them using condition variable
+   */
+  std::mutex lock;
+
  private:
   NodeID _node_id;
   std::array<tbb::concurrent_queue<std::shared_ptr<AbstractTask>>, NUM_PRIORITY_LEVELS> _queues;

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -91,10 +91,6 @@ void Worker::start() { _thread = std::thread(&Worker::operator(), this); }
 
 void Worker::join() {
   Assert(!CurrentScheduler::get()->active(), "Worker can't be join()-ed while the scheduler is still active");
-  // The scheduler will only shut down if all tasks within the queue are done. After that, the worker threads will be
-  // stuck in the while loop waiting for a new task. Hence, we notify all workers, so that it runs the loop once.
-  // Since the loop condition will no longer be true, the worker is going to shutdown.
-  _queue->new_task.notify_all();
   _thread.join();
 }
 

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -25,6 +25,9 @@ namespace {
 thread_local std::weak_ptr<opossum::Worker> this_thread_worker;
 }  // namespace
 
+// The sleep time was determined experimentally
+static constexpr auto WORKER_SLEEP_TIME = std::chrono::microseconds(300);
+
 namespace opossum {
 
 std::shared_ptr<Worker> Worker::get_this_thread_worker() { return ::this_thread_worker.lock(); }
@@ -74,7 +77,7 @@ void Worker::_work() {
     if (!work_stealing_successful) {
       {
         std::unique_lock<std::mutex> unique_lock(_queue->lock);
-        _queue->new_task.wait_for(unique_lock, std::chrono::microseconds(200));
+        _queue->new_task.wait_for(unique_lock, WORKER_SLEEP_TIME);
       }
       return;
     }

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -52,8 +52,8 @@ void Worker::operator()() {
   while (CurrentScheduler::get()->active()) {
     queues_are_empty = _work();
     if (queues_are_empty) {
-        // Wait for new task pushed to the current node's task queue or perform work stealing after 100 µs.
-        _queue->new_task.wait_for(unique_lock, std::chrono::microseconds(100));
+      // Wait for new task pushed to the current node's task queue or perform work stealing after 100 µs.
+      _queue->new_task.wait_for(unique_lock, std::chrono::microseconds(100));
     }
   }
 }

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -41,7 +41,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
 
  protected:
   void operator()();
-  bool _work();
+  void _work();
 
   template <typename TaskType>
   void _wait_for_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -41,7 +41,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
 
  protected:
   void operator()();
-  void _work();
+  bool _work();
 
   template <typename TaskType>
   void _wait_for_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {


### PR DESCRIPTION
I'm currently benchmarking the pipeline creation for my thesis. I noticed a big spreading of execution times (min: 78 µs, median: 2300 µs, max: 18000 µs for query `select 1;`). The strongly fluctuating times are a result of the worker sleep time of 10 ms. As discussed in PR #1379 we actually don't want to have a sleep timer for the workers. Hence, I implemented a solution using `std::condition_variable`s. I changed the current implementation in such a way, that the node's task queue notifies a worker (on the same node) as soon as a new job gets pushed into the queue. Work stealing is performed by waking up each worker every 100µs (debatable).

However, benchmark performance on numa systems using many clients will **decrease** tremendously (see screenshot below). This is because of the bad job scheduling behavior. Tasks are currently scheduled to Node 0 only (Correct me if I'm wrong or I missed a configuration option). All other nodes are performing work stealing only.

Comparison current master and this PR (SF1, 100 clients, 240 cores, 8 nodes)
![screenshot from 2019-01-28 17-23-44](https://user-images.githubusercontent.com/11941962/51850704-952b1680-2322-11e9-9b6c-63b9913966b2.png)

When we only use one node of the system (so no numa) we get the following results (SF1, 1 client, 30 cores, 1 node)
![screenshot from 2019-01-28 17-25-56](https://user-images.githubusercontent.com/11941962/51850720-9c522480-2322-11e9-9bf3-b8a862199b2a.png)

Any thoughts about this?

