### PR TITLE
Add optimization rule to add a Limit node to the subquery of an Exists expression

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -287,6 +287,8 @@ set(
     optimizer/strategy/exists_reformulation_rule.hpp
     optimizer/strategy/index_scan_rule.cpp
     optimizer/strategy/index_scan_rule.hpp
+    optimizer/strategy/insert_limit_in_exists.cpp
+    optimizer/strategy/insert_limit_in_exists.hpp
     optimizer/strategy/join_detection_rule.cpp
     optimizer/strategy/join_detection_rule.hpp
     optimizer/strategy/join_ordering_rule.cpp

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   optimizer->add_rule(std::make_shared<ColumnPruningRule>());
 
   optimizer->add_rule(std::make_shared<ExistsReformulationRule>());
-  
+
   optimizer->add_rule(std::make_shared<InsertLimitInExistsRule>());
 
   optimizer->add_rule(std::make_shared<ChunkPruningRule>());

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -14,6 +14,7 @@
 #include "strategy/constant_calculation_rule.hpp"
 #include "strategy/exists_reformulation_rule.hpp"
 #include "strategy/index_scan_rule.hpp"
+#include "strategy/insert_limit_in_exists.hpp"
 #include "strategy/join_detection_rule.hpp"
 #include "strategy/join_ordering_rule.hpp"
 #include "strategy/logical_reduction_rule.hpp"
@@ -104,6 +105,8 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   // Bring predicates into the desired order once the PredicateReorderingRule has positioned them as desired
   optimizer->add_rule(std::make_shared<PredicateReorderingRule>());
+
+  optimizer->add_rule(std::make_shared<InsertLimitInExistsRule>());
 
   optimizer->add_rule(std::make_shared<IndexScanRule>());
 

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -94,6 +94,8 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   optimizer->add_rule(std::make_shared<ColumnPruningRule>());
 
   optimizer->add_rule(std::make_shared<ExistsReformulationRule>());
+  
+  optimizer->add_rule(std::make_shared<InsertLimitInExistsRule>());
 
   optimizer->add_rule(std::make_shared<ChunkPruningRule>());
 
@@ -105,8 +107,6 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   // Bring predicates into the desired order once the PredicateReorderingRule has positioned them as desired
   optimizer->add_rule(std::make_shared<PredicateReorderingRule>());
-
-  optimizer->add_rule(std::make_shared<InsertLimitInExistsRule>());
 
   optimizer->add_rule(std::make_shared<IndexScanRule>());
 

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
@@ -1,42 +1,42 @@
 #include "insert_limit_in_exists.hpp"
 
 #include "expression/exists_expression.hpp"
+#include "expression/expression_utils.hpp"
 #include "expression/lqp_select_expression.hpp"
 #include "expression/value_expression.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/limit_node.hpp"
-#include "logical_query_plan/predicate_node.hpp"
-#include "logical_query_plan/projection_node.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
 
 namespace opossum {
 
-std::string InsertLimitInExistsRule::name() const { return "Insert Limit in Exists Rule"; }
+std::string InsertLimitInExistsRule::name() const { return "Insert Limit in Exists Expression Rule"; }
 
 void InsertLimitInExistsRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
-  if (const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node)) {
-    _apply_to_expressions({predicate_node->predicate()});
-  } else if (const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(node)) {
-    _apply_to_expressions(projection_node->column_expressions());
-  }
-  _apply_to_inputs(node);
-}
+  visit_lqp(node, [&](const auto sub_node) {
+    // Iterate over all expressions of a lqp node
+    for (auto expression : sub_node->node_expressions) {
+      visit_expression(expression, [&](const auto sub_expression) {
+        if (const auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(sub_expression)) {
+          this->apply_to(select_expression->lqp);
+        }
+        return ExpressionVisitation::VisitArguments;
+      });
 
-void InsertLimitInExistsRule::_apply_to_expressions(
-    const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const {
-  for (auto& expression : expressions) {
-    if (auto exists_node = std::dynamic_pointer_cast<ExistsExpression>(expression)) {
-      auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(exists_node->select());
-      const auto lqp = select_expression->lqp;
-      if (lqp->type != LQPNodeType::Limit) {
-        int64_t num_rows = 1;
-        const auto num_rows_expression = std::make_shared<ValueExpression>(num_rows);
-        select_expression->lqp = LimitNode::make(num_rows_expression, lqp);
+      if (auto exists_node = std::dynamic_pointer_cast<ExistsExpression>(expression)) {
+        // Add limit to exists subquery
+        auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(exists_node->select());
+        const auto lqp = select_expression->lqp;
+        if (lqp->type != LQPNodeType::Limit) {
+          int64_t num_rows = 1;
+          const auto num_rows_expression = std::make_shared<ValueExpression>(num_rows);
+          select_expression->lqp = LimitNode::make(num_rows_expression, lqp);
+        }
       }
-    } else if (auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(expression)) {
-      apply_to(select_expression->lqp);
     }
-    _apply_to_expressions(expression->arguments);
-  }
+
+    return LQPVisitation::VisitInputs;
+  });
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
@@ -13,20 +13,20 @@ namespace opossum {
 std::string InsertLimitInExistsRule::name() const { return "Insert Limit in Exists Expression Rule"; }
 
 void InsertLimitInExistsRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
-  visit_lqp(node, [&](const auto sub_node) {
+  visit_lqp(node, [&](const auto& sub_node) {
     // Iterate over all expressions of a lqp node
     for (const auto& expression : sub_node->node_expressions) {
       // Recursively iterate over each nested expression
-      visit_expression(expression, [&](const auto sub_expression) {
+      visit_expression(expression, [&](const auto& sub_expression) {
         // Apply rule for every subquery
         if (const auto subquery_expression = std::dynamic_pointer_cast<LQPSelectExpression>(sub_expression)) {
-          this->apply_to(subquery_expression->lqp);
+          apply_to(subquery_expression->lqp);
         }
 
         // Add limit to exists subquery
         if (const auto exists_expression = std::dynamic_pointer_cast<ExistsExpression>(sub_expression)) {
           const auto subquery_expression = std::dynamic_pointer_cast<LQPSelectExpression>(exists_expression->select());
-          const auto lqp = subquery_expression->lqp;
+          const auto& lqp = subquery_expression->lqp;
           if (lqp->type != LQPNodeType::Limit) {
             const auto num_rows_expression = std::make_shared<ValueExpression>(int64_t{1});
             subquery_expression->lqp = LimitNode::make(num_rows_expression, lqp);

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
@@ -21,7 +21,8 @@ void InsertLimitInExistsRule::apply_to(const std::shared_ptr<AbstractLQPNode>& n
   _apply_to_inputs(node);
 }
 
-void InsertLimitInExistsRule::_apply_to_expressions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const {
+void InsertLimitInExistsRule::_apply_to_expressions(
+    const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const {
   for (auto& expression : expressions) {
     if (auto exists_node = std::dynamic_pointer_cast<ExistsExpression>(expression)) {
       auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(exists_node->select());

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.cpp
@@ -1,0 +1,41 @@
+#include "insert_limit_in_exists.hpp"
+
+#include "expression/exists_expression.hpp"
+#include "expression/lqp_select_expression.hpp"
+#include "expression/value_expression.hpp"
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/limit_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/projection_node.hpp"
+
+namespace opossum {
+
+std::string InsertLimitInExistsRule::name() const { return "Insert Limit in Exists Rule"; }
+
+void InsertLimitInExistsRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
+  if (const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node)) {
+    _apply_to_expressions({predicate_node->predicate()});
+  } else if (const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(node)) {
+    _apply_to_expressions(projection_node->column_expressions());
+  }
+  _apply_to_inputs(node);
+}
+
+void InsertLimitInExistsRule::_apply_to_expressions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const {
+  for (auto& expression : expressions) {
+    if (auto exists_node = std::dynamic_pointer_cast<ExistsExpression>(expression)) {
+      auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(exists_node->select());
+      const auto lqp = select_expression->lqp;
+      if (lqp->type != LQPNodeType::Limit) {
+        int64_t num_rows = 1;
+        const auto num_rows_expression = std::make_shared<ValueExpression>(num_rows);
+        select_expression->lqp = LimitNode::make(num_rows_expression, lqp);
+      }
+    } else if (auto select_expression = std::dynamic_pointer_cast<LQPSelectExpression>(expression)) {
+      apply_to(select_expression->lqp);
+    }
+    _apply_to_expressions(expression->arguments);
+  }
+}
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
@@ -21,9 +21,6 @@ class InsertLimitInExistsRule : public AbstractRule {
  public:
   std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
-
- private:
-  void _apply_to_expressions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
@@ -22,7 +22,7 @@ class InsertLimitInExistsRule : public AbstractRule {
   std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
-private:
+ private:
   void _apply_to_expressions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const;
 };
 

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "abstract_rule.hpp"
+
+namespace opossum {
+
+class AbstractLQPNode;
+class AbstractExpression;
+
+// This optimizer rule is responsible for inserting limits in the correlated subquery of an exists expression
+class InsertLimitInExistsRule : public AbstractRule {
+ public:
+  std::string name() const override;
+  void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
+
+private:
+  void _apply_to_expressions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions) const;
+};
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
@@ -11,7 +11,7 @@ namespace opossum {
 class AbstractLQPNode;
 class AbstractExpression;
 
-// This optimizer rule is responsible for inserting limits in the correlated subquery of an exists expression
+// This optimizer rule is responsible for inserting a limit node in the correlated subquery of an exists expression
 class InsertLimitInExistsRule : public AbstractRule {
  public:
   std::string name() const override;

--- a/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists.hpp
@@ -11,7 +11,12 @@ namespace opossum {
 class AbstractLQPNode;
 class AbstractExpression;
 
-// This optimizer rule is responsible for inserting a limit node in the correlated subquery of an exists expression
+/**
+ * This optimizer rule is responsible for inserting a limit node in the correlated subquery of an exists expression.
+ * The query         SELECT * FROM T WHERE EXISTS ( SELECT * FROM T WHERE C = 1 );
+ * is transformed to SELECT * FROM T WHERE EXISTS ( SELECT * FROM T WHERE C = 1 LIMIT 1 );
+ * Jittable operators profit from the additional limit as this allows them to terminate early during processing.
+ */
 class InsertLimitInExistsRule : public AbstractRule {
  public:
   std::string name() const override;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -113,6 +113,7 @@ set(
     optimizer/strategy/constant_calculation_rule_test.cpp
     optimizer/strategy/exists_reformulation_rule_test.cpp
     optimizer/strategy/index_scan_rule_test.cpp
+    optimizer/strategy/insert_limit_in_exists_test.cpp
     optimizer/strategy/join_detection_rule_test.cpp
     optimizer/strategy/join_ordering_rule_test.cpp
     optimizer/strategy/logical_reduction_rule_test.cpp

--- a/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
+++ b/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
@@ -1,0 +1,82 @@
+#include "gtest/gtest.h"
+
+#include "strategy_base_test.hpp"
+#include "testing_assert.hpp"
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/limit_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "optimizer/strategy/insert_limit_in_exists.hpp"
+#include "storage/storage_manager.hpp"
+#include "utils/load_table.hpp"
+
+using namespace opossum::expression_functional;  // NOLINT
+
+namespace opossum {
+
+class ExistsInsertLimitInExistsRuleTest : public StrategyBaseTest {
+public:
+  void SetUp() override {
+    StorageManager::get().add_table("table_a", load_table("resources/test_data/tbl/int_int2.tbl"));
+    StorageManager::get().add_table("table_b", load_table("resources/test_data/tbl/int_int3.tbl"));
+
+    node_table_a = StoredTableNode::make("table_a");
+    node_table_a_col_a = node_table_a->get_column("a");
+
+    node_table_b = StoredTableNode::make("table_b");
+    node_table_b_col_a = node_table_b->get_column("a");
+
+    _rule = std::make_shared<InsertLimitInExistsRule>();
+  }
+
+  std::shared_ptr<InsertLimitInExistsRule> _rule;
+
+  std::shared_ptr<StoredTableNode> node_table_a, node_table_b;
+  LQPColumnReference node_table_a_col_a, node_table_b_col_a;
+};
+
+TEST_F(ExistsInsertLimitInExistsRuleTest, AddLimitInSimpleExists) {
+  const auto parameter = correlated_parameter_(ParameterID{0}, node_table_a_col_a);
+
+  // clang-format off
+  const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
+
+  const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
+
+  const auto input_lqp = PredicateNode::make(exists_(subselect), node_table_a);
+
+  int64_t num_rows = 1;
+  const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(num_rows), subselect_lqp);
+
+  const auto limit_subselect = lqp_select_(limit_subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
+
+  const auto expected_lqp = PredicateNode::make(exists_(limit_subselect), node_table_a);
+  // clang-format on
+
+  const auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(ExistsInsertLimitInExistsRuleTest, DoNotAddLimitIfLimitExists) {
+  const auto parameter = correlated_parameter_(ParameterID{0}, node_table_a_col_a);
+
+  // clang-format off
+  const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
+
+  int64_t num_rows = 2;
+  const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(num_rows), subselect_lqp);
+
+  const auto limit_subselect = lqp_select_(limit_subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
+
+  const auto lqp = PredicateNode::make(exists_(limit_subselect), node_table_a);
+  // clang-format on
+
+  const auto actual_lqp = StrategyBaseTest::apply_rule(_rule, lqp);
+
+  // If a limit node exists within the subselect of an exists expression, the lqp is not changed.
+  EXPECT_LQP_EQ(actual_lqp, lqp);
+}
+
+}  // namespace opossum

--- a/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
+++ b/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
@@ -41,15 +41,11 @@ TEST_F(ExistsInsertLimitInExistsRuleTest, AddLimitInSimpleExists) {
 
   // clang-format off
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
-
   const auto subselect = lqp_select_(subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
-
   const auto input_lqp = PredicateNode::make(exists_(subselect), node_table_a);
 
   const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(int64_t{1}), subselect_lqp);
-
   const auto limit_subselect = lqp_select_(limit_subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
-
   const auto expected_lqp = PredicateNode::make(exists_(limit_subselect), node_table_a);
   // clang-format on
 
@@ -63,11 +59,8 @@ TEST_F(ExistsInsertLimitInExistsRuleTest, DoNotAddLimitIfLimitExists) {
 
   // clang-format off
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
-
   const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(int64_t{2}), subselect_lqp);
-
   const auto limit_subselect = lqp_select_(limit_subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
-
   const auto lqp = PredicateNode::make(exists_(limit_subselect), node_table_a);
   // clang-format on
 

--- a/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
+++ b/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
@@ -46,8 +46,7 @@ TEST_F(ExistsInsertLimitInExistsRuleTest, AddLimitInSimpleExists) {
 
   const auto input_lqp = PredicateNode::make(exists_(subselect), node_table_a);
 
-  int64_t num_rows = 1;
-  const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(num_rows), subselect_lqp);
+  const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(int64_t{1}), subselect_lqp);
 
   const auto limit_subselect = lqp_select_(limit_subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
 
@@ -65,8 +64,7 @@ TEST_F(ExistsInsertLimitInExistsRuleTest, DoNotAddLimitIfLimitExists) {
   // clang-format off
   const auto subselect_lqp = PredicateNode::make(equals_(node_table_b_col_a, parameter), node_table_b);
 
-  int64_t num_rows = 2;
-  const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(num_rows), subselect_lqp);
+  const auto limit_subselect_lqp = LimitNode::make(std::make_shared<ValueExpression>(int64_t{2}), subselect_lqp);
 
   const auto limit_subselect = lqp_select_(limit_subselect_lqp, std::make_pair(ParameterID{0}, node_table_a_col_a));
 

--- a/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
+++ b/src/test/optimizer/strategy/insert_limit_in_exists_test.cpp
@@ -16,7 +16,7 @@ using namespace opossum::expression_functional;  // NOLINT
 namespace opossum {
 
 class ExistsInsertLimitInExistsRuleTest : public StrategyBaseTest {
-public:
+ public:
   void SetUp() override {
     StorageManager::get().add_table("table_a", load_table("resources/test_data/tbl/int_int2.tbl"));
     StorageManager::get().add_table("table_b", load_table("resources/test_data/tbl/int_int3.tbl"));


### PR DESCRIPTION
This pr introduces a new optimization rule, which allows jittable operators to terminate early during processing of the subexpression of an exists expression.

The optimization rule adds a limit node to the the subquery of an exists expression if the subquery does not contain one.