### PR TITLE
Add jittable Limit Operator

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -618,6 +618,8 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator/operators/jit_expression.hpp
         operators/jit_operator/operators/jit_filter.cpp
         operators/jit_operator/operators/jit_filter.hpp
+        operators/jit_operator/operators/jit_limit.cpp
+        operators/jit_operator/operators/jit_limit.hpp
         operators/jit_operator/operators/jit_read_tuples.cpp
         operators/jit_operator/operators/jit_read_tuples.hpp
         operators/jit_operator/operators/jit_validate.cpp

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -304,10 +304,12 @@ bool JitAwareLQPTranslator::_node_is_jittable(const std::shared_ptr<AbstractLQPN
           return aggregate_expression->aggregate_function == AggregateFunction::CountDistinct ||
                  aggregate_expression->arguments.empty();
         });
+    // Aggregate must be the last node in the jittable operator pipeline. Hence, the the root node in the lpp.
     return is_root_node && !has_unsupported_aggregate;
   }
 
   if (node->type == LQPNodeType::Limit) {
+    // Limit must be the last node in the jittable operator pipeline. Hence, the the root node in the lpp.
     return is_root_node;
   }
 

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -15,6 +15,7 @@
 #include "expression/lqp_column_expression.hpp"
 #include "expression/value_expression.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
+#include "logical_query_plan/limit_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
@@ -22,6 +23,7 @@
 #include "operators/jit_operator/operators/jit_aggregate.hpp"
 #include "operators/jit_operator/operators/jit_compute.hpp"
 #include "operators/jit_operator/operators/jit_filter.hpp"
+#include "operators/jit_operator/operators/jit_limit.hpp"
 #include "operators/jit_operator/operators/jit_read_tuples.hpp"
 #include "operators/jit_operator/operators/jit_validate.hpp"
 #include "operators/jit_operator/operators/jit_write_tuples.hpp"
@@ -116,11 +118,18 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
     return nullptr;
   }
 
+  // limit can only be the root node
+  const bool use_limit = node->type == LQPNodeType::Limit;
+  std::shared_ptr<AbstractExpression> row_count_expression = nullptr;
+  if (use_limit) {
+    row_count_expression = std::static_pointer_cast<LimitNode>(node)->num_rows_expression();
+  }
+
   // The input_node is not being integrated into the operator chain, but instead serves as the input to the JitOperators
   const auto input_node = *input_nodes.begin();
 
   const auto jit_operator = std::make_shared<JitOperatorWrapper>(translate_node(input_node));
-  const auto read_tuples = std::make_shared<JitReadTuples>(use_validate);
+  const auto read_tuples = std::make_shared<JitReadTuples>(use_validate, row_count_expression);
   jit_operator->add_jit_operator(read_tuples);
 
   // "filter_node". The root node of the subplan computed by a JitFilter.
@@ -192,6 +201,8 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
 
     jit_operator->add_jit_operator(aggregate);
   } else {
+    if (use_limit) jit_operator->add_jit_operator(std::make_shared<JitLimit>());
+
     // Add a compute operator for each computed output column (i.e., a column that is not from a stored table).
     auto write_table = std::make_shared<JitWriteTuples>();
     for (const auto& column_expression : node->column_expressions()) {
@@ -279,7 +290,7 @@ std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expre
 }
 
 bool JitAwareLQPTranslator::_node_is_jittable(const std::shared_ptr<AbstractLQPNode>& node,
-                                              const bool allow_aggregate_node) const {
+                                              const bool is_root_node) const {
   if (node->type == LQPNodeType::Aggregate) {
     // We do not support the count distinct function yet and thus need to check all aggregate expressions.
     auto aggregate_node = std::static_pointer_cast<AggregateNode>(node);
@@ -293,7 +304,11 @@ bool JitAwareLQPTranslator::_node_is_jittable(const std::shared_ptr<AbstractLQPN
           return aggregate_expression->aggregate_function == AggregateFunction::CountDistinct ||
                  aggregate_expression->arguments.empty();
         });
-    return allow_aggregate_node && !has_unsupported_aggregate;
+    return is_root_node && !has_unsupported_aggregate;
+  }
+
+  if (node->type == LQPNodeType::Limit) {
+    return is_root_node;
   }
 
   if (auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node)) {

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.hpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.hpp
@@ -50,7 +50,7 @@ class JitAwareLQPTranslator final : public LQPTranslator {
       const std::shared_ptr<AbstractLQPNode>& input_node) const;
 
   // Returns whether an LQP node with its current configuration can be part of an operator pipeline.
-  bool _node_is_jittable(const std::shared_ptr<AbstractLQPNode>& node, const bool allow_aggregate_node) const;
+  bool _node_is_jittable(const std::shared_ptr<AbstractLQPNode>& node, const bool is_root_node) const;
 
   // Traverses the LQP in a breadth-first fashion and passes all visited nodes to a lambda. The boolean returned
   // from the lambda determines whether the current node should be explored further.

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -233,7 +233,7 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
 
 std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(const std::shared_ptr<AbstractLQPNode>& lqp) {
   static const auto whitelist =
-      std::set<LQPNodeType>{LQPNodeType::Projection, LQPNodeType::Sort, LQPNodeType::Validate};
+      std::set<LQPNodeType>{LQPNodeType::Projection, LQPNodeType::Sort, LQPNodeType::Validate, LQPNodeType::Limit};
 
   if (whitelist.count(lqp->type)) return lqp_subplan_to_boolean_expression(lqp->left_input());
 

--- a/src/lib/operators/jit_operator/jit_types.hpp
+++ b/src/lib/operators/jit_operator/jit_types.hpp
@@ -138,6 +138,9 @@ struct JitRuntimeContext {
   JitRuntimeHashmap hashmap;
   Segments out_chunk;
 
+  // Required by JitLimit operator
+  size_t limit_rows;
+
   // Query transaction data required by JitValidate
   TransactionID transaction_id;
   CommitID snapshot_commit_id;

--- a/src/lib/operators/jit_operator/operators/jit_limit.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 std::string JitLimit::description() const { return "[Limit]"; }
 
 void JitLimit::_consume(JitRuntimeContext& context) const {
-  // DebugAssert(context.limit_rows > 0, "JitLimit should not be called with limit_rows = 0");
+  // Function should only called if context.limit_rows > 0 - no DebugAssert here due to specialization issues
   // Decrement row count for every emitted tuple
   if (--context.limit_rows == 0) {
     // If last row is emitted, set chunk_size to 0 to exit the execution hot loop in the JitReadTuples operator.

--- a/src/lib/operators/jit_operator/operators/jit_limit.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 std::string JitLimit::description() const { return "[Limit]"; }
 
 void JitLimit::_consume(JitRuntimeContext& context) const {
-  DebugAssert(context.limit_rows > 0, "JitLimit should not be called with limit_rows = 0");
+  // DebugAssert(context.limit_rows > 0, "JitLimit should not be called with limit_rows = 0");
   // Decrement row count for every emitted tuple
   if (--context.limit_rows == 0) {
     // If last row is emitted, set chunk_size to 0 to exit the execution hot loop in the JitReadTuples operator.

--- a/src/lib/operators/jit_operator/operators/jit_limit.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.cpp
@@ -1,0 +1,15 @@
+#include "jit_limit.hpp"
+
+namespace opossum {
+
+std::string JitLimit::description() const { return "[Limit]"; }
+
+void JitLimit::_consume(JitRuntimeContext& context) const {
+  DebugAssert(context.limit_rows > 0, "JitLimit should not be called with limit_rows = 0");
+  if (--context.limit_rows == 0) {
+    context.chunk_size = 0;
+  }
+  _emit(context);
+}
+
+}  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_limit.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 std::string JitLimit::description() const { return "[Limit]"; }
 
 void JitLimit::_consume(JitRuntimeContext& context) const {
-  // Function should only called if context.limit_rows > 0 - no DebugAssert here due to specialization issues
+  // Function should only be called if context.limit_rows > 0 - no DebugAssert here due to specialization issues
   // Decrement row count for every emitted tuple
   if (--context.limit_rows == 0) {
     // If last row is emitted, set chunk_size to 0 to exit the execution hot loop in the JitReadTuples operator.

--- a/src/lib/operators/jit_operator/operators/jit_limit.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.cpp
@@ -6,7 +6,9 @@ std::string JitLimit::description() const { return "[Limit]"; }
 
 void JitLimit::_consume(JitRuntimeContext& context) const {
   DebugAssert(context.limit_rows > 0, "JitLimit should not be called with limit_rows = 0");
+  // Decrement row count for every emitted tuple
   if (--context.limit_rows == 0) {
+    // If last row is emitted, set chunk_size to 0 to exit the execution hot loop in the JitReadTuples operator.
     context.chunk_size = 0;
   }
   _emit(context);

--- a/src/lib/operators/jit_operator/operators/jit_limit.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.hpp
@@ -9,8 +9,6 @@ namespace opossum {
  */
 class JitLimit : public AbstractJittable {
  public:
-  JitLimit() {}
-
   std::string description() const final;
 
  protected:

--- a/src/lib/operators/jit_operator/operators/jit_limit.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_limit.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "abstract_jittable.hpp"
+#include "types.hpp"
+
+namespace opossum {
+
+/* The JitLimit operator limits the input to n rows.
+ */
+class JitLimit : public AbstractJittable {
+ public:
+  JitLimit() {}
+
+  std::string description() const final;
+
+ protected:
+  void _consume(JitRuntimeContext& context) const final;
+};
+
+}  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -1,14 +1,14 @@
 #include "jit_read_tuples.hpp"
 
 #include "../jit_types.hpp"
-#include "resolve_type.hpp"
 #include "expression/evaluation/expression_evaluator.hpp"
+#include "resolve_type.hpp"
 #include "storage/segment_iterate.hpp"
 
 namespace opossum {
 
-JitReadTuples::JitReadTuples(const bool has_validate, const std::shared_ptr<AbstractExpression>& row_count_expression) :
-_has_validate(has_validate), _row_count_expression(row_count_expression) {}
+JitReadTuples::JitReadTuples(const bool has_validate, const std::shared_ptr<AbstractExpression>& row_count_expression)
+    : _has_validate(has_validate), _row_count_expression(row_count_expression) {}
 
 std::string JitReadTuples::description() const {
   std::stringstream desc;
@@ -45,7 +45,7 @@ void JitReadTuples::before_query(const Table& in_table, JitRuntimeContext& conte
 
   if (_row_count_expression) {
     const auto num_rows_expression_result =
-            ExpressionEvaluator{}.evaluate_expression_to_result<int64_t>(*_row_count_expression);
+        ExpressionEvaluator{}.evaluate_expression_to_result<int64_t>(*_row_count_expression);
     Assert(num_rows_expression_result->size() == 1, "Expected exactly one row for Limit");
     Assert(!num_rows_expression_result->is_null(0), "Expected non-null for Limit");
 
@@ -53,6 +53,8 @@ void JitReadTuples::before_query(const Table& in_table, JitRuntimeContext& conte
     Assert(signed_num_rows >= 0, "Can't Limit to a negative number of Rows");
 
     context.limit_rows = static_cast<size_t>(signed_num_rows);
+  } else {
+    context.limit_rows = std::numeric_limits<size_t>::max();
   }
 }
 

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -2,11 +2,13 @@
 
 #include "../jit_types.hpp"
 #include "resolve_type.hpp"
+#include "expression/evaluation/expression_evaluator.hpp"
 #include "storage/segment_iterate.hpp"
 
 namespace opossum {
 
-JitReadTuples::JitReadTuples(const bool has_validate) : _has_validate(has_validate) {}
+JitReadTuples::JitReadTuples(const bool has_validate, const std::shared_ptr<AbstractExpression>& row_count_expression) :
+_has_validate(has_validate), _row_count_expression(row_count_expression) {}
 
 std::string JitReadTuples::description() const {
   std::stringstream desc;
@@ -39,6 +41,18 @@ void JitReadTuples::before_query(const Table& in_table, JitRuntimeContext& conte
         }
       });
     }
+  }
+
+  if (_row_count_expression) {
+    const auto num_rows_expression_result =
+            ExpressionEvaluator{}.evaluate_expression_to_result<int64_t>(*_row_count_expression);
+    Assert(num_rows_expression_result->size() == 1, "Expected exactly one row for Limit");
+    Assert(!num_rows_expression_result->is_null(0), "Expected non-null for Limit");
+
+    const auto signed_num_rows = num_rows_expression_result->value(0);
+    Assert(signed_num_rows >= 0, "Can't Limit to a negative number of Rows");
+
+    context.limit_rows = static_cast<size_t>(signed_num_rows);
   }
 }
 

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -43,6 +43,7 @@ void JitReadTuples::before_query(const Table& in_table, JitRuntimeContext& conte
     }
   }
 
+  // Not related to reading tuples - evaluate the limit expression if JitLimit operator is used.
   if (_row_count_expression) {
     const auto num_rows_expression_result =
         ExpressionEvaluator{}.evaluate_expression_to_result<int64_t>(*_row_count_expression);
@@ -63,6 +64,7 @@ void JitReadTuples::before_chunk(const Table& in_table, const Chunk& in_chunk, J
   context.chunk_offset = 0;
   context.chunk_size = in_chunk.size();
 
+  // Not related to reading tuples - set MVCC in context if JitValidate operator is used.
   if (_has_validate) {
     if (in_chunk.has_mvcc_data()) {
       // materialize atomic transaction ids as specialization cannot handle atomics
@@ -175,5 +177,7 @@ std::optional<AllTypeVariant> JitReadTuples::find_literal_value(const JitTupleVa
     return {};
   }
 }
+
+std::shared_ptr<AbstractExpression> JitReadTuples::row_count_expression() const { return _row_count_expression; }
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -85,7 +85,8 @@ class JitReadTuples : public AbstractJittable {
   };
 
  public:
-  explicit JitReadTuples(const bool has_validate = false, const std::shared_ptr<AbstractExpression>& row_count_expression = nullptr);
+  explicit JitReadTuples(const bool has_validate = false,
+                         const std::shared_ptr<AbstractExpression>& row_count_expression = nullptr);
 
   std::string description() const final;
 

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -103,6 +103,8 @@ class JitReadTuples : public AbstractJittable {
   std::optional<ColumnID> find_input_column(const JitTupleValue& tuple_value) const;
   std::optional<AllTypeVariant> find_literal_value(const JitTupleValue& tuple_value) const;
 
+  std::shared_ptr<AbstractExpression> row_count_expression() const;
+
   void execute(JitRuntimeContext& context) const;
 
  protected:

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -85,7 +85,7 @@ class JitReadTuples : public AbstractJittable {
   };
 
  public:
-  explicit JitReadTuples(const bool has_validate = false);
+  explicit JitReadTuples(const bool has_validate = false, const std::shared_ptr<AbstractExpression>& row_count_expression = nullptr);
 
   std::string description() const final;
 
@@ -113,6 +113,7 @@ class JitReadTuples : public AbstractJittable {
   void _consume(JitRuntimeContext& context) const final {}
 
   const bool _has_validate;
+  const std::shared_ptr<AbstractExpression> _row_count_expression;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator_wrapper.cpp
+++ b/src/lib/operators/jit_operator_wrapper.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<const Table> JitOperatorWrapper::_on_execute() {
       break;
   }
 
-  for (opossum::ChunkID chunk_id{0}; chunk_id < in_table.chunk_count(); ++chunk_id) {
+  for (opossum::ChunkID chunk_id{0}; chunk_id < in_table.chunk_count() && context.limit_rows; ++chunk_id) {
     const auto& in_chunk = *in_table.get_chunk(chunk_id);
     _source()->before_chunk(in_table, in_chunk, context);
     execute_func(_source().get(), context);

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -255,6 +255,7 @@ if (${ENABLE_JIT_SUPPORT})
         operators/jit_operator/operators/jit_compute_test.cpp
         operators/jit_operator/operators/jit_expression_test.cpp
         operators/jit_operator/operators/jit_filter_test.cpp
+        operators/jit_operator/operators/jit_limit_test.cpp
         operators/jit_operator/operators/jit_read_write_tuple_test.cpp
         operators/jit_operator/operators/jit_validate_test.cpp
         operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp

--- a/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
@@ -12,6 +12,7 @@
 #include "operators/jit_operator/operators/jit_aggregate.hpp"
 #include "operators/jit_operator/operators/jit_compute.hpp"
 #include "operators/jit_operator/operators/jit_filter.hpp"
+#include "operators/jit_operator/operators/jit_limit.hpp"
 #include "operators/jit_operator/operators/jit_read_tuples.hpp"
 #include "operators/jit_operator/operators/jit_validate.hpp"
 #include "operators/jit_operator/operators/jit_write_tuples.hpp"
@@ -522,6 +523,35 @@ TEST_F(JitAwareLQPTranslatorTest, AggregateOperator) {
   ASSERT_EQ(aggregate_columns[4].column_name, "MAX(b)");
   ASSERT_EQ(aggregate_columns[4].function, AggregateFunction::Max);
   ASSERT_EQ(jit_read_tuples->find_input_column(aggregate_columns[4].tuple_value), ColumnID{1});
+}
+
+TEST_F(JitAwareLQPTranslatorTest, LimitOperator) {
+  const auto node_table_a = StoredTableNode::make("table_a");
+  const auto node_table_a_col_a = node_table_a->get_column("a");
+
+  const auto value = std::make_shared<ValueExpression>(static_cast<int64_t>(1));
+  const auto table_scan = PredicateNode::make(equals_(node_table_a_col_a, value), node_table_a);
+  const auto limit = LimitNode::make(value, table_scan);
+
+  const auto jit_operator_wrapper = translate_lqp(limit);
+  ASSERT_NE(jit_operator_wrapper, nullptr);
+
+  // Check the type of jit operators in the operator pipeline
+  const auto jit_operators = jit_operator_wrapper->jit_operators();
+  ASSERT_EQ(jit_operator_wrapper->jit_operators().size(), 5u);
+
+  const auto jit_read_tuples = std::dynamic_pointer_cast<JitReadTuples>(jit_operators[0]);
+  const auto jit_compute = std::dynamic_pointer_cast<JitCompute>(jit_operators[1]);
+  const auto jit_filter = std::dynamic_pointer_cast<JitFilter>(jit_operators[2]);
+  const auto jit_limit = std::dynamic_pointer_cast<JitLimit>(jit_operators[3]);
+  const auto jit_write_tuples = std::dynamic_pointer_cast<JitWriteTuples>(jit_operators[4]);
+  ASSERT_NE(jit_read_tuples, nullptr);
+  ASSERT_NE(jit_compute, nullptr);
+  ASSERT_NE(jit_filter, nullptr);
+  ASSERT_NE(jit_limit, nullptr);
+  ASSERT_NE(jit_write_tuples, nullptr);
+
+  ASSERT_EQ(jit_read_tuples->row_count_expression(), value);
 }
 
 }  // namespace opossum

--- a/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
@@ -529,7 +529,7 @@ TEST_F(JitAwareLQPTranslatorTest, LimitOperator) {
   const auto node_table_a = StoredTableNode::make("table_a");
   const auto node_table_a_col_a = node_table_a->get_column("a");
 
-  const auto value = std::make_shared<ValueExpression>(static_cast<int64_t>(1));
+  const auto value = std::make_shared<ValueExpression>(int64_t{123});
   const auto table_scan = PredicateNode::make(equals_(node_table_a_col_a, value), node_table_a);
   const auto limit = LimitNode::make(value, table_scan);
 

--- a/src/test/operators/jit_operator/operators/jit_limit_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_limit_test.cpp
@@ -8,8 +8,6 @@ namespace {
 // Mock JitOperator that records whether tuples are passed to it
 class MockSink : public AbstractJittable {
  public:
-  MockSink() : AbstractJittable() {}
-
   std::string description() const final { return "MockSink"; }
 
   void reset() const { _consume_was_called = false; }
@@ -23,11 +21,11 @@ class MockSink : public AbstractJittable {
   static bool _consume_was_called;
 };
 
+bool MockSink::_consume_was_called = false;
+
 // Mock JitOperator that passes on individual tuples
 class MockSource : public AbstractJittable {
  public:
-  MockSource() : AbstractJittable() {}
-
   std::string description() const final { return "MockSource"; }
 
   void emit(JitRuntimeContext& context) { _emit(context); }

--- a/src/test/operators/jit_operator/operators/jit_limit_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_limit_test.cpp
@@ -8,7 +8,7 @@ namespace {
 // Mock JitOperator that records whether tuples are passed to it
 class MockSink : public AbstractJittable {
  public:
-  MockSink() : AbstractJittable(JitOperatorType::Write) {}
+  MockSink() : AbstractJittable() {}
 
   std::string description() const final { return "MockSink"; }
 
@@ -26,7 +26,7 @@ class MockSink : public AbstractJittable {
 // Mock JitOperator that passes on individual tuples
 class MockSource : public AbstractJittable {
  public:
-  MockSource() : AbstractJittable(JitOperatorType::Read) {}
+  MockSource() : AbstractJittable() {}
 
   std::string description() const final { return "MockSource"; }
 

--- a/src/test/operators/jit_operator/operators/jit_limit_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_limit_test.cpp
@@ -1,0 +1,62 @@
+#include "../../../base_test.hpp"
+#include "operators/jit_operator/operators/jit_limit.hpp"
+
+namespace opossum {
+
+namespace {
+
+// Mock JitOperator that records whether tuples are passed to it
+class MockSink : public AbstractJittable {
+ public:
+  MockSink() : AbstractJittable(JitOperatorType::Write) {}
+
+  std::string description() const final { return "MockSink"; }
+
+ private:
+  void _consume(JitRuntimeContext& context) const final {}
+};
+
+// Mock JitOperator that passes on individual tuples
+class MockSource : public AbstractJittable {
+ public:
+  MockSource() : AbstractJittable(JitOperatorType::Read) {}
+
+  std::string description() const final { return "MockSource"; }
+
+  void emit(JitRuntimeContext& context) { _emit(context); }
+
+ private:
+  void _consume(JitRuntimeContext& context) const final {}
+};
+
+}  // namespace
+
+class JitLimitTest : public BaseTest {};
+
+TEST_F(JitLimitTest, FiltersTuplesAccordingToLimit) {
+  const uint32_t chunk_size{123};
+
+  JitRuntimeContext context;
+  context.chunk_size = chunk_size;
+  context.limit_rows = 2;
+
+  auto source = std::make_shared<MockSource>();
+  auto limit = std::make_shared<JitLimit>();
+  auto sink = std::make_shared<MockSink>();
+
+  // Link operators to pipeline
+  source->set_next_operator(limit);
+  limit->set_next_operator(sink);
+
+  // limit not reached
+  source->emit(context);
+  ASSERT_EQ(context.chunk_size, chunk_size);
+  ASSERT_EQ(context.limit_rows, 1);
+
+  // limit reached
+  source->emit(context);
+  ASSERT_EQ(context.chunk_size, 0);
+  ASSERT_EQ(context.limit_rows, 0);
+}
+
+}  // namespace opossum

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -100,4 +100,20 @@ TEST_F(JitReadWriteTupleTest, CopyTable) {
                                 FloatComparisonMode::AbsoluteDifference));
 }
 
+TEST_F(JitReadWriteTupleTest, LimitRowCountIsEvaluated) {
+  // Create row count expression
+  const int64_t limit_row_count{123};
+  const auto row_count_expression = std::make_shared<ValueExpression>(limit_row_count);
+
+  // Initialize operator with row count expression
+  auto read_tuples = std::make_shared<JitReadTuples>(false, row_count_expression);
+
+  JitRuntimeContext context;
+  // Since we only test literal values here an empty input table is sufficient
+  Table input_table(TableColumnDefinitions{}, TableType::Data);
+  read_tuples->before_query(input_table, context);
+
+  ASSERT_EQ(context.limit_rows, limit_row_count);
+}
+
 }  // namespace opossum

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -113,6 +113,11 @@ TEST_F(JitOperatorWrapperTest, CallsJitOperatorHooks) {
     EXPECT_CALL(*sink, after_chunk(testing::_, testing::_));
     EXPECT_CALL(*sink, after_query(testing::_, testing::_));
 
+    ON_CALL(*source, before_query(testing::_, testing::_))
+        .WillByDefault(testing::Invoke([](const Table& in_table, JitRuntimeContext& context) {
+          context.limit_rows = std::numeric_limits<size_t>::max();
+        }));
+
     ON_CALL(*source, before_chunk(testing::_, testing::_, testing::_))
         .WillByDefault(testing::Invoke(source.get(), &MockJitSource::forward_before_chunk));
   }

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -4,6 +4,7 @@
 #include "operators/jit_operator/operators/jit_compute.hpp"
 #include "operators/jit_operator/operators/jit_expression.hpp"
 #include "operators/jit_operator/operators/jit_filter.hpp"
+#include "operators/jit_operator/operators/jit_limit.hpp"
 #include "operators/jit_operator/operators/jit_read_tuples.hpp"
 #include "operators/jit_operator/operators/jit_write_tuples.hpp"
 #include "operators/jit_operator_wrapper.hpp"
@@ -118,6 +119,38 @@ TEST_F(JitOperatorWrapperTest, CallsJitOperatorHooks) {
 
   JitOperatorWrapper jit_operator_wrapper(_int_table_wrapper, JitExecutionMode::Interpret);
   jit_operator_wrapper.add_jit_operator(source);
+  jit_operator_wrapper.add_jit_operator(sink);
+  jit_operator_wrapper.execute();
+}
+
+TEST_F(JitOperatorWrapperTest, OperatorChecksLimitRowCount) {
+  // A chunk is only processed if context.limit_rows > 0.
+  // The input table in this test has two chunks which contain 5 rows each.
+  // The row count limit is 5. So the first chunk is processed and the second is not.
+
+  const auto source = std::make_shared<MockJitSource>();
+  const auto limit = std::make_shared<JitLimit>();
+  const auto sink = std::make_shared<MockJitSink>();
+
+  {
+    testing::InSequence dummy;
+    EXPECT_CALL(*source, before_query(testing::Ref(*_int_table), testing::_));
+    EXPECT_CALL(*sink, before_query(testing::_, testing::_));
+    EXPECT_CALL(*source, before_chunk(testing::Ref(*_int_table), testing::Ref(*_int_table->chunks()[0]), testing::_));
+    EXPECT_CALL(*sink, after_chunk(testing::_, testing::_));
+    // before_chunk is called only once, second chunk is not processed
+    EXPECT_CALL(*sink, after_query(testing::_, testing::_));
+
+    ON_CALL(*source, before_query(testing::_, testing::_))
+        .WillByDefault(
+            testing::Invoke([](const Table& in_table, JitRuntimeContext& context) { context.limit_rows = 5; }));
+    ON_CALL(*source, before_chunk(testing::_, testing::_, testing::_))
+        .WillByDefault(testing::Invoke(source.get(), &MockJitSource::forward_before_chunk));
+  }
+
+  JitOperatorWrapper jit_operator_wrapper(_int_table_wrapper, JitExecutionMode::Interpret);
+  jit_operator_wrapper.add_jit_operator(source);
+  jit_operator_wrapper.add_jit_operator(limit);
   jit_operator_wrapper.add_jit_operator(sink);
   jit_operator_wrapper.execute();
 }


### PR DESCRIPTION
This pr introduces a jittable Limit operator.
The `JitAwareLQPTranslator` adds the jittable Limit operator to the jittable operator pipeline if a Limit exists in the lqp.
The row count expression of the limit is evaluated before execution by the first operator in the pipeline, `JitReadTuples` operator.