### PR TITLE
Only link libhyrise against CMAKE_DL_LIBS. Remove build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,7 @@ find_package(Readline REQUIRED)
 find_package(Curses REQUIRED)
 find_package(Sqlite3 REQUIRED)
 find_package(PQ REQUIRED)
-find_package(Boost REQUIRED COMPONENTS container system thread program_options)
+find_package(Boost REQUIRED COMPONENTS container system thread)
 
 add_definitions(-DBOOST_THREAD_VERSION=5)
 

--- a/src/benchmarklib/CMakeLists.txt
+++ b/src/benchmarklib/CMakeLists.txt
@@ -50,9 +50,6 @@ set(
 # Configure the regular opossum library used for tests/server/playground...
 add_library(hyriseBenchmarkLib STATIC ${SOURCES})
 
-# Add this magic dependency to run the git_watcher on build
-add_dependencies(hyriseBenchmarkLib AlwaysCheckGit)
-
 target_link_libraries(
     hyriseBenchmarkLib
     hyrise

--- a/src/benchmarklib/CMakeLists.txt
+++ b/src/benchmarklib/CMakeLists.txt
@@ -53,4 +53,7 @@ add_library(hyriseBenchmarkLib STATIC ${SOURCES})
 # Add this magic dependency to run the git_watcher on build
 add_dependencies(hyriseBenchmarkLib AlwaysCheckGit)
 
-target_link_libraries(hyriseBenchmarkLib hyrise tpch_dbgen sqlite3 ${FILESYSTEM_LIBRARY})
+target_link_libraries(
+    hyriseBenchmarkLib
+    hyrise
+    tpch_dbgen)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(
     ${HYRISE_LIBRARY_WITH_ALL_SYMBOLS}
 )
 
+# Add this magic dependency to run the git_watcher on build
+add_dependencies(hyrisePlayground AlwaysCheckGit)
+
 # Configure tpchTableGenerator
 add_executable(tpchTableGenerator tpch_table_generator.cpp)
 target_link_libraries(tpchTableGenerator hyrise hyriseBenchmarkLib)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -28,9 +28,6 @@ target_link_libraries(
     ${HYRISE_LIBRARY_WITH_ALL_SYMBOLS}
 )
 
-# Add this magic dependency to run the git_watcher on build
-add_dependencies(hyrisePlayground AlwaysCheckGit)
-
 # Configure tpchTableGenerator
 add_executable(tpchTableGenerator tpch_table_generator.cpp)
 target_link_libraries(tpchTableGenerator hyrise hyriseBenchmarkLib)

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -14,14 +14,6 @@ add_executable(
 target_link_libraries(
     hyriseServer
     ${HYRISE_LIBRARY_WITH_ALL_SYMBOLS}
-    ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${CMAKE_DL_LIBS}
-)
-target_include_directories(
-    hyriseServer
-
-    PUBLIC
-    ${Boost_INCLUDE_DIRS}
 )
 
 # Configure playground
@@ -34,7 +26,6 @@ add_executable(
 target_link_libraries(
     hyrisePlayground
     ${HYRISE_LIBRARY_WITH_ALL_SYMBOLS}
-    ${CMAKE_DL_LIBS}
 )
 
 # Configure tpchTableGenerator
@@ -44,6 +35,7 @@ target_link_libraries(tpchTableGenerator hyrise hyriseBenchmarkLib)
 # Configure client
 add_executable(
     hyriseClient
+
     client.cpp
     client.hpp
 )
@@ -68,7 +60,6 @@ target_link_libraries(
     hyriseBenchmarkLib
     ncurses
     ${READLINE_LIBRARY}
-    ${CMAKE_DL_LIBS}
 )
 target_include_directories(
     hyriseConsole

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,10 +1,11 @@
 #include <iostream>
 
 #include "types.hpp"
+#include "version.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-  std::cout << "Hello world!!" << std::endl;
+  std::cout << "Hello worlssd!! " << GIT_HEAD_SHA1 << " - " << GIT_IS_DIRTY << std::endl;
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,11 +1,10 @@
 #include <iostream>
 
 #include "types.hpp"
-#include "version.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-  std::cout << "Hello worlssd!! " << GIT_HEAD_SHA1 << " - " << GIT_IS_DIRTY << std::endl;
+  std::cout << "Hello world!!" << std::endl;
   return 0;
 }

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -687,6 +687,10 @@ target_include_directories(hyrise PUBLIC ${CMAKE_BINARY_DIR})
 # -fPIC generates position independent code which is necessary because plugins might access hyrise functions.
 target_compile_options(hyrise PRIVATE -fPIC)
 
+# Dependency hyrise --> git_watcher needs to be added manually, apparently. Otherwise version.hpp, for reasons unknown
+# isn't updated when HEAD changes
+add_dependencies(hyrise AlwaysCheckGit)
+
 if (${ENABLE_JIT_SUPPORT})
     # LLVM does not build with -Wshadow-all,-Werror. Overwrite the LLVM include so it is treated as a system library.
     # This silences some compiler warnings (uses -isystem instead of -I).

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -687,8 +687,6 @@ target_include_directories(hyrise PUBLIC ${CMAKE_BINARY_DIR})
 # -fPIC generates position independent code which is necessary because plugins might access hyrise functions.
 target_compile_options(hyrise PRIVATE -fPIC)
 
-# Add this magic dependency to run the git_watcher on build
-add_dependencies(hyrise AlwaysCheckGit)
 
 if (${ENABLE_JIT_SUPPORT})
     # LLVM does not build with -Wshadow-all,-Werror. Overwrite the LLVM include so it is treated as a system library.

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -687,6 +687,9 @@ target_include_directories(hyrise PUBLIC ${CMAKE_BINARY_DIR})
 # -fPIC generates position independent code which is necessary because plugins might access hyrise functions.
 target_compile_options(hyrise PRIVATE -fPIC)
 
+# Add this magic dependency to run the git_watcher on build
+add_dependencies(hyrise AlwaysCheckGit)
+
 if (${ENABLE_JIT_SUPPORT})
     # LLVM does not build with -Wshadow-all,-Werror. Overwrite the LLVM include so it is treated as a system library.
     # This silences some compiler warnings (uses -isystem instead of -I).

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -687,7 +687,6 @@ target_include_directories(hyrise PUBLIC ${CMAKE_BINARY_DIR})
 # -fPIC generates position independent code which is necessary because plugins might access hyrise functions.
 target_compile_options(hyrise PRIVATE -fPIC)
 
-
 if (${ENABLE_JIT_SUPPORT})
     # LLVM does not build with -Wshadow-all,-Werror. Overwrite the LLVM include so it is treated as a system library.
     # This silences some compiler warnings (uses -isystem instead of -I).

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -599,6 +599,7 @@ set(
     ${Boost_THREAD_LIBRARY}
     ${TBB_LIBRARY}
     ${SQLITE3_LIBRARY}
+    ${CMAKE_DL_LIBS}
 )
 
 if (${ENABLE_JIT_SUPPORT})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -282,7 +282,6 @@ set(
     gmock
     sqlite3
     ${FILESYSTEM_LIBRARY}
-    ${CMAKE_DL_LIBS}
 )
 
 # This warning does not play well with SCOPED_TRACE


### PR DESCRIPTION
Fix #1447

* Remove "hyriseBenchmarkLib --> AlwaysCheckGit" dependency in favor of "hyrise --> AlwaysCheckGit" dependency
* Remove hyriseServer dependency to boost includes, because linking hyriseServer to hyrise already delivers this dependency
* Remove Boost_PROGRAM_OPTIONS_LIBRARY dependency of hyriseServer, because the server doesn't seem to use boost program options?