### PR TITLE
JIT - Add parameter support for jittable operators

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -150,6 +150,7 @@ SELECT a, MIN(b) FROM mixed_null GROUP BY a;
 SELECT a, SUM(b) FROM mixed_null GROUP BY a;
 SELECT a, AVG(b) FROM mixed_null GROUP BY a;
 SELECT a, COUNT(b) FROM mixed_null GROUP BY a;
+SELECT a, COUNT(*) FROM mixed_null GROUP BY a;
 
 -- Checks that output of Aggregate can be worked with correctly.
 SELECT b, sub.min_c, max_b FROM (SELECT a, b, MAX(b) AS max_b, MIN(c) AS min_c FROM mixed GROUP BY a, b) as sub WHERE b BETWEEN 20 AND 50 AND min_c > 15;

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -145,8 +145,7 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
   // If we can reach the input node without encountering a UnionNode or PredicateNode,
   // there is no need to filter any tuples
   if (filter_node != input_node) {
-    const auto boolean_expression = lqp_subplan_to_boolean_expression(
-        filter_node, [&](const std::shared_ptr<AbstractLQPNode>& lqp) { return lqp != input_node; });
+    const auto boolean_expression = lqp_subplan_to_boolean_expression(filter_node, input_node);
     if (!boolean_expression) return nullptr;
 
     const auto jit_boolean_expression =

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -256,13 +256,8 @@ std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expre
 
     case ExpressionType::CorrelatedParameter: {
       const auto parameter = std::dynamic_pointer_cast<const CorrelatedParameterExpression>(expression);
-      if (parameter->value()) {
-        const auto tuple_value = jit_source.add_literal_value(*parameter->value());
-        return std::make_shared<JitExpression>(tuple_value);
-      } else {
-        const auto tuple_value = jit_source.add_parameter(parameter->data_type(), parameter->parameter_id);
-        return std::make_shared<JitExpression>(tuple_value);
-      }
+      const auto tuple_value = jit_source.add_parameter(parameter->data_type(), parameter->parameter_id);
+      return std::make_shared<JitExpression>(tuple_value);
     }
 
     case ExpressionType::LQPColumn:

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -11,6 +11,8 @@
 #include "constant_mappings.hpp"
 #include "expression/abstract_predicate_expression.hpp"
 #include "expression/arithmetic_expression.hpp"
+#include "expression/correlated_parameter_expression.hpp"
+#include "expression/expression_utils.hpp"
 #include "expression/logical_expression.hpp"
 #include "expression/lqp_column_expression.hpp"
 #include "expression/value_expression.hpp"
@@ -48,8 +50,7 @@ const std::unordered_map<PredicateCondition, JitExpressionType> predicate_condit
     {PredicateCondition::Like, JitExpressionType::Like},
     {PredicateCondition::NotLike, JitExpressionType::NotLike},
     {PredicateCondition::IsNull, JitExpressionType::IsNull},
-    {PredicateCondition::IsNotNull, JitExpressionType::IsNotNull},
-    {PredicateCondition::In, JitExpressionType::In}};
+    {PredicateCondition::IsNotNull, JitExpressionType::IsNotNull}};
 
 const std::unordered_map<ArithmeticOperator, JitExpressionType> arithmetic_operator_to_jit_expression_type = {
     {ArithmeticOperator::Addition, JitExpressionType::Addition},
@@ -96,16 +97,16 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
   bool validate_after_filter = false;
 
   // Traverse query tree until a non-jittable nodes is found in each branch
-  _visit(node, [&](auto& current_node) {
+  visit_lqp(node, [&](auto& current_node) {
     const auto is_root_node = current_node == node;
     if (_node_is_jittable(current_node, is_root_node)) {
       use_validate |= current_node->type == LQPNodeType::Validate;
       validate_after_filter |= use_validate && current_node->type == LQPNodeType::Predicate;
       if (requires_computation(current_node)) ++jittable_node_count;
-      return true;
+      return LQPVisitation::VisitInputs;
     } else {
       input_nodes.insert(current_node);
-      return false;
+      return LQPVisitation::DoNotVisitInputs;
     }
   });
 
@@ -144,11 +145,12 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
   // If we can reach the input node without encountering a UnionNode or PredicateNode,
   // there is no need to filter any tuples
   if (filter_node != input_node) {
-    const auto boolean_expression = lqp_subplan_to_boolean_expression(filter_node);
+    const auto boolean_expression = lqp_subplan_to_boolean_expression(
+        filter_node, [&](const std::shared_ptr<AbstractLQPNode>& lqp) { return _node_is_jittable(lqp, false); });
     if (!boolean_expression) return nullptr;
 
     const auto jit_boolean_expression =
-        _try_translate_expression_to_jit_expression(*boolean_expression, *read_tuples, input_node);
+        _try_translate_expression_to_jit_expression(boolean_expression, *read_tuples, input_node);
     if (!jit_boolean_expression) return nullptr;
 
     // make sure that the expression gets computed ...
@@ -171,7 +173,7 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
          ++expression_idx) {
       const auto& groupby_expression = aggregate_node->node_expressions[expression_idx];
       const auto jit_expression =
-          _try_translate_expression_to_jit_expression(*groupby_expression, *read_tuples, input_node);
+          _try_translate_expression_to_jit_expression(groupby_expression, *read_tuples, input_node);
       if (!jit_expression) return nullptr;
       // Create a JitCompute operator for each computed groupby column ...
       if (jit_expression->expression_type() != JitExpressionType::Column) {
@@ -187,16 +189,24 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
       const auto aggregate_expression = std::dynamic_pointer_cast<AggregateExpression>(expression);
       DebugAssert(aggregate_expression, "Expression is not a function.");
 
-      const auto jit_expression =
-          _try_translate_expression_to_jit_expression(*aggregate_expression->arguments[0], *read_tuples, input_node);
-      if (!jit_expression) return nullptr;
-      // Create a JitCompute operator for each aggregate expression on a computed value ...
-      if (jit_expression->expression_type() != JitExpressionType::Column) {
-        jit_operator->add_jit_operator(std::make_shared<JitCompute>(jit_expression));
+      if (aggregate_expression->arguments.empty()) {
+        // count(*)
+        DebugAssert(aggregate_expression->aggregate_function == AggregateFunction::Count,
+                    "Only count can have no arguments");
+        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), {DataType::Long, false, 0},
+                                        aggregate_expression->aggregate_function);
+      } else {
+        const auto jit_expression =
+            _try_translate_expression_to_jit_expression(aggregate_expression->arguments[0], *read_tuples, input_node);
+        if (!jit_expression) return nullptr;
+        // Create a JitCompute operator for each aggregate expression on a computed value ...
+        if (jit_expression->expression_type() != JitExpressionType::Column) {
+          jit_operator->add_jit_operator(std::make_shared<JitCompute>(jit_expression));
+        }
+        // ... and add the aggregate expression to the JitAggregate operator.
+        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), jit_expression->result(),
+                                        aggregate_expression->aggregate_function);
       }
-      // ... and add the aggregate expression to the JitAggregate operator.
-      aggregate->add_aggregate_column(aggregate_expression->as_column_name(), jit_expression->result(),
-                                      aggregate_expression->aggregate_function);
     }
 
     jit_operator->add_jit_operator(aggregate);
@@ -207,7 +217,7 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
     auto write_table = std::make_shared<JitWriteTuples>();
     for (const auto& column_expression : node->column_expressions()) {
       const auto jit_expression =
-          _try_translate_expression_to_jit_expression(*column_expression, *read_tuples, input_node);
+          _try_translate_expression_to_jit_expression(column_expression, *read_tuples, input_node);
       if (!jit_expression) return nullptr;
       // If the JitExpression is of type JitExpressionType::Column, there is no need to add a compute node, since it
       // would not compute anything anyway
@@ -224,22 +234,33 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
 }
 
 std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expression_to_jit_expression(
-    const AbstractExpression& expression, JitReadTuples& jit_source,
+    const std::shared_ptr<AbstractExpression>& expression, JitReadTuples& jit_source,
     const std::shared_ptr<AbstractLQPNode>& input_node) const {
-  const auto input_node_column_id = input_node->find_column_id(expression);
+  const auto input_node_column_id = input_node->find_column_id(*expression);
   if (input_node_column_id) {
     const auto tuple_value = jit_source.add_input_column(
-        expression.data_type(), input_node->is_column_nullable(input_node->get_column_id(expression)),
+        expression->data_type(), input_node->is_column_nullable(input_node->get_column_id(*expression)),
         *input_node_column_id);
     return std::make_shared<JitExpression>(tuple_value);
   }
 
   std::shared_ptr<const JitExpression> left, right;
-  switch (expression.type) {
+  switch (expression->type) {
     case ExpressionType::Value: {
-      const auto* value_expression = dynamic_cast<const ValueExpression*>(&expression);
+      const auto value_expression = std::dynamic_pointer_cast<const ValueExpression>(expression);
       const auto tuple_value = jit_source.add_literal_value(value_expression->value);
       return std::make_shared<JitExpression>(tuple_value);
+    }
+
+    case ExpressionType::CorrelatedParameter: {
+      const auto parameter = std::dynamic_pointer_cast<const CorrelatedParameterExpression>(expression);
+      if (parameter->value()) {
+        const auto tuple_value = jit_source.add_literal_value(*parameter->value());
+        return std::make_shared<JitExpression>(tuple_value);
+      } else {
+        const auto tuple_value = jit_source.add_parameter_value(parameter->data_type(), parameter->parameter_id);
+        return std::make_shared<JitExpression>(tuple_value);
+      }
     }
 
     case ExpressionType::LQPColumn:
@@ -250,8 +271,8 @@ std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expre
     case ExpressionType::Arithmetic:
     case ExpressionType::Logical: {
       std::vector<std::shared_ptr<const JitExpression>> jit_expression_arguments;
-      for (const auto& argument : expression.arguments) {
-        const auto jit_expression = _try_translate_expression_to_jit_expression(*argument, jit_source, input_node);
+      for (const auto& argument : expression->arguments) {
+        const auto jit_expression = _try_translate_expression_to_jit_expression(argument, jit_source, input_node);
         if (!jit_expression) return nullptr;
         jit_expression_arguments.emplace_back(jit_expression);
       }
@@ -290,23 +311,34 @@ std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expre
   }
 }
 
+bool JitAwareLQPTranslator::_expression_is_jittable(const std::shared_ptr<AbstractExpression>& expression) const {
+  switch (expression->type) {
+    case ExpressionType::Predicate: {
+      const auto predicate_expression = std::static_pointer_cast<AbstractPredicateExpression>(expression);
+      return predicate_expression->predicate_condition != PredicateCondition::In &&
+             predicate_expression->predicate_condition != PredicateCondition::NotIn;
+    }
+    case ExpressionType::Aggregate: {
+      const auto aggregate_expression = std::dynamic_pointer_cast<AggregateExpression>(expression);
+      // We do not support the count distinct function yet.
+      return aggregate_expression->aggregate_function != AggregateFunction::CountDistinct;
+    }
+    case ExpressionType::Arithmetic:
+    case ExpressionType::Logical:
+    case ExpressionType::LQPColumn:
+    case ExpressionType::Value:
+    case ExpressionType::CorrelatedParameter:
+      return true;
+    default:
+      return false;
+  }
+}
+
 bool JitAwareLQPTranslator::_node_is_jittable(const std::shared_ptr<AbstractLQPNode>& node,
                                               const bool is_root_node) const {
-  if (node->type == LQPNodeType::Aggregate) {
-    // We do not support the count distinct function yet and thus need to check all aggregate expressions.
-    auto aggregate_node = std::static_pointer_cast<AggregateNode>(node);
-    const auto& expressions = aggregate_node->node_expressions;
-    auto has_unsupported_aggregate = std::any_of(
-        expressions.begin() + aggregate_node->aggregate_expressions_begin_idx, expressions.end(), [](auto& expression) {
-          const auto aggregate_expression = std::dynamic_pointer_cast<AggregateExpression>(expression);
-          Assert(aggregate_expression, "Expected AggregateExpression");
-          // Right now, the JIT doesn't support CountDistinct and Count(*) (which can be recognized by an empty
-          // argument list)
-          return aggregate_expression->aggregate_function == AggregateFunction::CountDistinct ||
-                 aggregate_expression->arguments.empty();
-        });
+  if (node->type == LQPNodeType::Aggregate && !is_root_node) {
     // Aggregate must be the last node in the jittable operator pipeline. Hence, the the root node in the lpp.
-    return is_root_node && !has_unsupported_aggregate;
+    return false;
   }
 
   if (node->type == LQPNodeType::Limit) {
@@ -314,54 +346,56 @@ bool JitAwareLQPTranslator::_node_is_jittable(const std::shared_ptr<AbstractLQPN
     return is_root_node;
   }
 
-  if (auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node)) {
-    return predicate_node->scan_type == ScanType::TableScan;
+  if (const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node)) {
+    if (predicate_node->scan_type == ScanType::IndexScan) return false;
   }
 
-  return node->type == LQPNodeType::Projection || node->type == LQPNodeType::Union ||
-         node->type == LQPNodeType::Validate;
-}
+  if (node->type == LQPNodeType::Predicate || node->type == LQPNodeType::Projection ||
+      node->type == LQPNodeType::Aggregate) {
+    const auto& parent_lqp_node = node->left_input();
+    bool node_is_jittable = true;
+    for (const auto& expression : node->node_expressions) {
+      // Recursively iterate over each nested expression
+      visit_expression(expression, [&](const auto& current_expression) {
+        // Check if expression was already evaluated in a previous node
+        if (parent_lqp_node->find_column_id(*current_expression)) {
+          return ExpressionVisitation::DoNotVisitArguments;
+        }
 
-void JitAwareLQPTranslator::_visit(const std::shared_ptr<AbstractLQPNode>& node,
-                                   const std::function<bool(const std::shared_ptr<AbstractLQPNode>&)>& func) const {
-  std::unordered_set<std::shared_ptr<const AbstractLQPNode>> visited;
-  std::queue<std::shared_ptr<AbstractLQPNode>> queue({node});
-
-  while (!queue.empty()) {
-    auto current_node = queue.front();
-    queue.pop();
-
-    if (!current_node || visited.count(current_node)) {
-      continue;
+        if (_expression_is_jittable(current_expression)) {
+          return ExpressionVisitation::VisitArguments;
+        } else {
+          node_is_jittable = false;
+          return ExpressionVisitation::DoNotVisitArguments;
+        }
+      });
     }
-    visited.insert(current_node);
-
-    if (func(current_node)) {
-      queue.push(current_node->left_input());
-      queue.push(current_node->right_input());
-    }
+    return node_is_jittable;
   }
+
+  return node->type == LQPNodeType::Union || node->type == LQPNodeType::Validate;
 }
 
-JitExpressionType JitAwareLQPTranslator::_expression_to_jit_expression_type(const AbstractExpression& expression) {
-  switch (expression.type) {
+JitExpressionType JitAwareLQPTranslator::_expression_to_jit_expression_type(
+    const std::shared_ptr<AbstractExpression>& expression) {
+  switch (expression->type) {
     case ExpressionType::Arithmetic: {
-      const auto* arithmetic_expression = dynamic_cast<const ArithmeticExpression*>(&expression);
+      const auto arithmetic_expression = std::dynamic_pointer_cast<const ArithmeticExpression>(expression);
       return arithmetic_operator_to_jit_expression_type.at(arithmetic_expression->arithmetic_operator);
     }
 
     case ExpressionType::Predicate: {
-      const auto* predicate_expression = dynamic_cast<const AbstractPredicateExpression*>(&expression);
+      const auto predicate_expression = std::dynamic_pointer_cast<const AbstractPredicateExpression>(expression);
       return predicate_condition_to_jit_expression_type.at(predicate_expression->predicate_condition);
     }
 
     case ExpressionType::Logical: {
-      const auto* logical_expression = dynamic_cast<const LogicalExpression*>(&expression);
+      const auto logical_expression = std::dynamic_pointer_cast<const LogicalExpression>(expression);
       return logical_operator_to_jit_expression.at(logical_expression->logical_operator);
     }
 
     default:
-      Fail("Expression "s + expression.as_column_name() + " is jit incompatible");
+      Fail("Expression "s + expression->as_column_name() + " is jit incompatible");
   }
 }
 

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
   // there is no need to filter any tuples
   if (filter_node != input_node) {
     const auto boolean_expression = lqp_subplan_to_boolean_expression(
-        filter_node, [&](const std::shared_ptr<AbstractLQPNode>& lqp) { return _node_is_jittable(lqp, false); });
+        filter_node, [&](const std::shared_ptr<AbstractLQPNode>& lqp) { return lqp != input_node; });
     if (!boolean_expression) return nullptr;
 
     const auto jit_boolean_expression =
@@ -258,7 +258,7 @@ std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expre
         const auto tuple_value = jit_source.add_literal_value(*parameter->value());
         return std::make_shared<JitExpression>(tuple_value);
       } else {
-        const auto tuple_value = jit_source.add_parameter_value(parameter->data_type(), parameter->parameter_id);
+        const auto tuple_value = jit_source.add_parameter(parameter->data_type(), parameter->parameter_id);
         return std::make_shared<JitExpression>(tuple_value);
       }
     }

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -193,7 +193,10 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
         // COUNT(*)
         DebugAssert(aggregate_expression->aggregate_function == AggregateFunction::Count,
                     "Only the aggregate function COUNT can have no arguments");
-        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), {DataType::Long, false, 0},
+        // JitAggregate requires one value for each aggregate function. This value is ignored for COUNT so that the
+        // first value in the tuple can be used.
+        const size_t tuple_index{0};
+        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), {DataType::Long, false, tuple_index},
                                         aggregate_expression->aggregate_function);
       } else {
         const auto jit_expression =

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -190,9 +190,9 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
       DebugAssert(aggregate_expression, "Expression is not a function.");
 
       if (aggregate_expression->arguments.empty()) {
-        // count(*)
+        // COUNT(*)
         DebugAssert(aggregate_expression->aggregate_function == AggregateFunction::Count,
-                    "Only count can have no arguments");
+                    "Only the aggregate function COUNT can have no arguments");
         aggregate->add_aggregate_column(aggregate_expression->as_column_name(), {DataType::Long, false, 0},
                                         aggregate_expression->aggregate_function);
       } else {

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.hpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.hpp
@@ -52,7 +52,7 @@ class JitAwareLQPTranslator final : public LQPTranslator {
   // Returns whether an LQP node with its current configuration can be part of an operator pipeline.
   bool _node_is_jittable(const std::shared_ptr<AbstractLQPNode>& node, const bool is_root_node) const;
 
-  // Returns whether an expression can be part of an operator pipeline.
+  // Returns whether an expression can be part of a jittable operator pipeline.
   bool _expression_is_jittable(const std::shared_ptr<AbstractExpression>& expression) const;
 
   static JitExpressionType _expression_to_jit_expression_type(const std::shared_ptr<AbstractExpression>& expression);

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.hpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.hpp
@@ -46,18 +46,16 @@ class JitAwareLQPTranslator final : public LQPTranslator {
       const std::shared_ptr<AbstractLQPNode>& node) const;
 
   std::shared_ptr<const JitExpression> _try_translate_expression_to_jit_expression(
-      const AbstractExpression& expression, JitReadTuples& jit_source,
+      const std::shared_ptr<AbstractExpression>& expression, JitReadTuples& jit_source,
       const std::shared_ptr<AbstractLQPNode>& input_node) const;
 
   // Returns whether an LQP node with its current configuration can be part of an operator pipeline.
   bool _node_is_jittable(const std::shared_ptr<AbstractLQPNode>& node, const bool is_root_node) const;
 
-  // Traverses the LQP in a breadth-first fashion and passes all visited nodes to a lambda. The boolean returned
-  // from the lambda determines whether the current node should be explored further.
-  void _visit(const std::shared_ptr<AbstractLQPNode>& node,
-              const std::function<bool(const std::shared_ptr<AbstractLQPNode>&)>& func) const;
+  // Returns whether an expression can be part of an operator pipeline.
+  bool _expression_is_jittable(const std::shared_ptr<AbstractExpression>& expression) const;
 
-  static JitExpressionType _expression_to_jit_expression_type(const AbstractExpression& expression);
+  static JitExpressionType _expression_to_jit_expression_type(const std::shared_ptr<AbstractExpression>& expression);
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -488,7 +488,7 @@ std::shared_ptr<AbstractExpression> LQPTranslator::_translate_expression(
       const auto subquery_expression = std::dynamic_pointer_cast<LQPSubqueryExpression>(expression);
       Assert(subquery_expression, "Expected LQPSubqueryExpression");
 
-      const auto subquery_pqp = LQPTranslator{}.translate_node(subquery_expression->lqp);
+      const auto subquery_pqp = translate_node(subquery_expression->lqp);
 
       auto subquery_parameters = PQPSubqueryExpression::Parameters{};
       subquery_parameters.reserve(subquery_expression->parameter_count());

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -231,7 +231,11 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
   return modified_tables;
 }
 
-std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(const std::shared_ptr<AbstractLQPNode>& lqp) {
+std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(
+    const std::shared_ptr<AbstractLQPNode>& lqp,
+    const std::function<bool(const std::shared_ptr<AbstractLQPNode>& lqp)>& node_is_allowed) {
+  if (!node_is_allowed(lqp)) return nullptr;
+
   static const auto whitelist =
       std::set<LQPNodeType>{LQPNodeType::Projection, LQPNodeType::Sort, LQPNodeType::Validate, LQPNodeType::Limit};
 

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -232,7 +232,7 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
 }
 
 std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(
-    const std::shared_ptr<AbstractLQPNode>& begin, const std::optional<const std::shared_ptr<AbstractLQPNode>> end) {
+    const std::shared_ptr<AbstractLQPNode>& begin, const std::optional<const std::shared_ptr<AbstractLQPNode>>& end) {
   if (end && begin == *end) return nullptr;
 
   static const auto whitelist =

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -57,9 +57,12 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
 
 /**
  * Create a boolean expression from an LQP by considering PredicateNodes and UnionNodes. It traverses the LQP from the
- * begin node until it reaches the end node or an LQP node which is a not a Predicate, Union, Projection, Sort,
- * Validate or Limit node. Subsequent Predicate nodes are turned into a LogicalExpression with AND. UnionNodes into a
- * LogicalExpression with OR. Projection, Sort, Validate or Limit LQP nodes are ignored during the traversal.
+ * begin node until it reaches the end node if set or an LQP node which is a not a Predicate, Union, Projection, Sort,
+ * Validate or Limit node. The end node is necessary if a certain Predicate should not be part of the created expression
+ * (e.g., the jit-aware LQP translator uses it to prevent that non-jittable Predicate nodes are added to the boolean
+ * expression used to create jittable expressions). Subsequent Predicate nodes are turned into a LogicalExpression with
+ * AND. UnionNodes into a LogicalExpression with OR. Projection, Sort, Validate or Limit LQP nodes are ignored during
+ * the traversal.
  *
  *         input LQP   --- lqp_subplan_to_boolean_expression(Sort, Predicate A) --->   boolean expression
  *

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -59,7 +59,10 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
  * Create a boolean expression from an LQP by considering PredicateNodes and UnionNodes
  * @return      the expression, or nullptr if no expression could be created
  */
-std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(const std::shared_ptr<AbstractLQPNode>& lqp);
+std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(
+    const std::shared_ptr<AbstractLQPNode>& lqp,
+    const std::function<bool(const std::shared_ptr<AbstractLQPNode>& lqp)>& node_is_allowed =
+        [](const std::shared_ptr<AbstractLQPNode>& lqp) { return true; });
 
 enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
 

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -56,13 +56,11 @@ bool lqp_is_validated(const std::shared_ptr<AbstractLQPNode>& lqp);
 std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQPNode>& lqp);
 
 /**
- * Create a boolean expression from an LQP by considering PredicateNodes and UnionNodes
+ * Create a boolean expression from an LQP by considering PredicateNodes and UnionNodes until the base_node is reached.
  * @return      the expression, or nullptr if no expression could be created
  */
 std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(
-    const std::shared_ptr<AbstractLQPNode>& lqp,
-    const std::function<bool(const std::shared_ptr<AbstractLQPNode>& lqp)>& node_is_allowed =
-        [](const std::shared_ptr<AbstractLQPNode>& lqp) { return true; });
+    const std::shared_ptr<AbstractLQPNode>& lqp, const std::shared_ptr<AbstractLQPNode>& base_node);
 
 enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
 

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -89,7 +89,7 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
  */
 std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(
     const std::shared_ptr<AbstractLQPNode>& begin,
-    const std::optional<const std::shared_ptr<AbstractLQPNode>> end = std::nullopt);
+    const std::optional<const std::shared_ptr<AbstractLQPNode>>& end = std::nullopt);
 
 enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
 

--- a/src/lib/operators/jit_operator/jit_types.cpp
+++ b/src/lib/operators/jit_operator/jit_types.cpp
@@ -120,7 +120,6 @@ bool jit_expression_is_binary(const JitExpressionType expression_type) {
     case JitExpressionType::NotLike:
     case JitExpressionType::And:
     case JitExpressionType::Or:
-    case JitExpressionType::In:
       return true;
 
     case JitExpressionType::Column:

--- a/src/lib/operators/jit_operator/jit_types.hpp
+++ b/src/lib/operators/jit_operator/jit_types.hpp
@@ -271,8 +271,7 @@ enum class JitExpressionType {
   Or,
   Not,
   IsNull,
-  IsNotNull,
-  In
+  IsNotNull
 };
 
 bool jit_expression_is_binary(const JitExpressionType expression_type);

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -22,25 +22,37 @@ std::string JitReadTuples::description() const {
   return desc.str();
 }
 
-void JitReadTuples::before_query(const Table& in_table, JitRuntimeContext& context) const {
+void JitReadTuples::before_query(const Table& in_table, const std::vector<AllTypeVariant>& parameter_values,
+                                 JitRuntimeContext& context) const {
   // Create a runtime tuple of the appropriate size
   context.tuple.resize(_num_tuple_values);
 
-  // Copy all input literals to the runtime tuple
-  for (const auto& input_literal : _input_literals) {
-    auto data_type = input_literal.tuple_value.data_type();
+  const auto set_value_in_tuple = [&](const JitTupleValue& tuple_value, const AllTypeVariant& value) {
+    auto data_type = tuple_value.data_type();
     if (data_type == DataType::Null) {
-      input_literal.tuple_value.set_is_null(true, context);
+      tuple_value.set_is_null(true, context);
     } else {
       resolve_data_type(data_type, [&](auto type) {
         using LiteralDataType = typename decltype(type)::type;
-        input_literal.tuple_value.set<LiteralDataType>(boost::get<LiteralDataType>(input_literal.value), context);
+        tuple_value.set<LiteralDataType>(boost::get<LiteralDataType>(value), context);
         // Non-jit operators store bool values as int values
         if constexpr (std::is_same_v<LiteralDataType, Bool>) {
-          input_literal.tuple_value.set<bool>(boost::get<LiteralDataType>(input_literal.value), context);
+          tuple_value.set<bool>(boost::get<LiteralDataType>(value), context);
         }
       });
     }
+  };
+
+  // Copy all input literals to the runtime tuple
+  for (const auto& input_literal : _input_literals) {
+    set_value_in_tuple(input_literal.tuple_value, input_literal.value);
+  }
+
+  // Copy all parameter values to the runtime tuple
+  DebugAssert(_input_parameters.size() == parameter_values.size(), "Wrong number of parameters");
+  auto parameter_value_itr = parameter_values.cbegin();
+  for (const auto& input_parameter : _input_parameters) {
+    set_value_in_tuple(input_parameter.tuple_value, *parameter_value_itr++);
   }
 
   // Not related to reading tuples - evaluate the limit expression if JitLimit operator is used.
@@ -145,15 +157,30 @@ JitTupleValue JitReadTuples::add_literal_value(const AllTypeVariant& value) {
   return tuple_value;
 }
 
+JitTupleValue JitReadTuples::add_parameter_value(const DataType data_type, const ParameterID parameter_id) {
+  const auto it =
+      std::find_if(_input_parameters.begin(), _input_parameters.end(),
+                   [parameter_id](const auto& parameter) { return parameter.parameter_id == parameter_id; });
+  if (it != _input_parameters.end()) {
+    return it->tuple_value;
+  }
+
+  const auto tuple_value = JitTupleValue(data_type, true, _num_tuple_values++);
+  _input_parameters.push_back({parameter_id, tuple_value});
+  return tuple_value;
+}
+
 size_t JitReadTuples::add_temporary_value() {
   // Somebody wants to store a temporary value in the runtime tuple. We don't really care about the value itself,
   // but have to remember to make some space for it when we create the runtime tuple.
   return _num_tuple_values++;
 }
 
-std::vector<JitInputColumn> JitReadTuples::input_columns() const { return _input_columns; }
+const std::vector<JitInputColumn>& JitReadTuples::input_columns() const { return _input_columns; }
 
-std::vector<JitInputLiteral> JitReadTuples::input_literals() const { return _input_literals; }
+const std::vector<JitInputLiteral>& JitReadTuples::input_literals() const { return _input_literals; }
+
+const std::vector<JitInputParameter>& JitReadTuples::input_parameters() const { return _input_parameters; }
 
 std::optional<ColumnID> JitReadTuples::find_input_column(const JitTupleValue& tuple_value) const {
   const auto it = std::find_if(_input_columns.begin(), _input_columns.end(), [&tuple_value](const auto& input_column) {

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -49,7 +49,7 @@ void JitReadTuples::before_query(const Table& in_table, const std::vector<AllTyp
   }
 
   // Copy all parameter values to the runtime tuple
-  DebugAssert(_input_parameters.size() == parameter_values.size(), "Wrong number of parameters");
+  DebugAssert(_input_parameters.size() == parameter_values.size(), "Wrong number of parameter values");
   auto parameter_value_itr = parameter_values.cbegin();
   for (const auto& input_parameter : _input_parameters) {
     set_value_in_tuple(input_parameter.tuple_value, *parameter_value_itr++);
@@ -157,7 +157,7 @@ JitTupleValue JitReadTuples::add_literal_value(const AllTypeVariant& value) {
   return tuple_value;
 }
 
-JitTupleValue JitReadTuples::add_parameter_value(const DataType data_type, const ParameterID parameter_id) {
+JitTupleValue JitReadTuples::add_parameter(const DataType data_type, const ParameterID parameter_id) {
   const auto it =
       std::find_if(_input_parameters.begin(), _input_parameters.end(),
                    [parameter_id](const auto& parameter) { return parameter.parameter_id == parameter_id; });

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -19,6 +19,9 @@ std::string JitReadTuples::description() const {
   for (const auto& input_literal : _input_literals) {
     desc << "x" << input_literal.tuple_value.tuple_index() << " = " << input_literal.value << ", ";
   }
+  for (const auto& input_parameter : _input_parameters) {
+    desc << "x" << input_parameter.tuple_value.tuple_index() << " = Parameter#" << input_parameter.parameter_id << ", ";
+  }
   return desc.str();
 }
 
@@ -158,6 +161,9 @@ JitTupleValue JitReadTuples::add_literal_value(const AllTypeVariant& value) {
 }
 
 JitTupleValue JitReadTuples::add_parameter(const DataType data_type, const ParameterID parameter_id) {
+  // Check if parameter was already added. A subquery uses the same parameter_id for all references to the same column.
+  // The query "SELECT * FROM T1 WHERE EXISTS (SELECT * FROM T2 WHERE T1.a > T2.a AND T1.a < T2.b)" contains the
+  // following subquery "SELECT * FROM T2 WHERE Parameter#0 > a AND Parameter#0 < b".
   const auto it =
       std::find_if(_input_parameters.begin(), _input_parameters.end(),
                    [parameter_id](const auto& parameter) { return parameter.parameter_id == parameter_id; });

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -101,6 +101,11 @@ class JitReadTuples : public AbstractJittable {
                             JitRuntimeContext& context) const;
   virtual void before_chunk(const Table& in_table, const Chunk& in_chunk, JitRuntimeContext& context) const;
 
+  /*
+   * Methods create a place in the runtime tuple to hold a column, literal, parameter or temporary value which are used
+   * by the jittable operators and expressions.
+   * The returned JitTupleValue identifies the position of a value in the runtime tuple.
+   */
   JitTupleValue add_input_column(const DataType data_type, const bool is_nullable, const ColumnID column_id);
   JitTupleValue add_literal_value(const AllTypeVariant& value);
   JitTupleValue add_parameter(const DataType data_type, const ParameterID parameter_id);

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -27,6 +27,11 @@ struct JitInputLiteral {
   JitTupleValue tuple_value;
 };
 
+struct JitInputParameter {
+  ParameterID parameter_id;
+  JitTupleValue tuple_value;
+};
+
 /* JitReadTuples must be the first operator in any chain of jit operators.
  * It is responsible for:
  * 1) storing literal values to the runtime tuple before the query is executed
@@ -90,15 +95,18 @@ class JitReadTuples : public AbstractJittable {
 
   std::string description() const final;
 
-  virtual void before_query(const Table& in_table, JitRuntimeContext& context) const;
+  virtual void before_query(const Table& in_table, const std::vector<AllTypeVariant>& parameter_values,
+                            JitRuntimeContext& context) const;
   virtual void before_chunk(const Table& in_table, const Chunk& in_chunk, JitRuntimeContext& context) const;
 
   JitTupleValue add_input_column(const DataType data_type, const bool is_nullable, const ColumnID column_id);
   JitTupleValue add_literal_value(const AllTypeVariant& value);
+  JitTupleValue add_parameter_value(const DataType data_type, const ParameterID parameter_id);
   size_t add_temporary_value();
 
-  std::vector<JitInputColumn> input_columns() const;
-  std::vector<JitInputLiteral> input_literals() const;
+  const std::vector<JitInputColumn>& input_columns() const;
+  const std::vector<JitInputLiteral>& input_literals() const;
+  const std::vector<JitInputParameter>& input_parameters() const;
 
   std::optional<ColumnID> find_input_column(const JitTupleValue& tuple_value) const;
   std::optional<AllTypeVariant> find_literal_value(const JitTupleValue& tuple_value) const;
@@ -111,6 +119,7 @@ class JitReadTuples : public AbstractJittable {
   uint32_t _num_tuple_values{0};
   std::vector<JitInputColumn> _input_columns;
   std::vector<JitInputLiteral> _input_literals;
+  std::vector<JitInputParameter> _input_parameters;
 
  private:
   void _consume(JitRuntimeContext& context) const final {}

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -27,6 +27,8 @@ struct JitInputLiteral {
   JitTupleValue tuple_value;
 };
 
+// The JitReadTuples operator only stores the parameters without their actual values. This allows the same JitReadTuples
+// operator to be executed with different parameters simultaneously. The JitOperatorWrapper stores the actual values.
 struct JitInputParameter {
   ParameterID parameter_id;
   JitTupleValue tuple_value;
@@ -101,7 +103,7 @@ class JitReadTuples : public AbstractJittable {
 
   JitTupleValue add_input_column(const DataType data_type, const bool is_nullable, const ColumnID column_id);
   JitTupleValue add_literal_value(const AllTypeVariant& value);
-  JitTupleValue add_parameter_value(const DataType data_type, const ParameterID parameter_id);
+  JitTupleValue add_parameter(const DataType data_type, const ParameterID parameter_id);
   size_t add_temporary_value();
 
   const std::vector<JitInputColumn>& input_columns() const;

--- a/src/lib/operators/jit_operator_wrapper.cpp
+++ b/src/lib/operators/jit_operator_wrapper.cpp
@@ -33,6 +33,10 @@ const std::vector<std::shared_ptr<AbstractJittable>>& JitOperatorWrapper::jit_op
   return _specialized_function_wrapper->jit_operators;
 }
 
+const std::vector<AllTypeVariant>& JitOperatorWrapper::input_parameter_values() const {
+  return _input_parameter_values;
+}
+
 const std::shared_ptr<JitReadTuples> JitOperatorWrapper::_source() const {
   return std::dynamic_pointer_cast<JitReadTuples>(_specialized_function_wrapper->jit_operators.front());
 }

--- a/src/lib/operators/jit_operator_wrapper.cpp
+++ b/src/lib/operators/jit_operator_wrapper.cpp
@@ -8,10 +8,10 @@ namespace opossum {
 
 JitOperatorWrapper::JitOperatorWrapper(const std::shared_ptr<const AbstractOperator>& left,
                                        const JitExecutionMode execution_mode,
-                                       const std::vector<std::shared_ptr<AbstractJittable>>& jit_operators)
+                                       const std::shared_ptr<SpecializedFunctionWrapper>& specialized_function_wrapper)
     : AbstractReadOnlyOperator{OperatorType::JitOperatorWrapper, left},
       _execution_mode{execution_mode},
-      _jit_operators{jit_operators} {}
+      _specialized_function_wrapper{specialized_function_wrapper} {}
 
 const std::string JitOperatorWrapper::name() const { return "JitOperatorWrapper"; }
 
@@ -19,24 +19,26 @@ const std::string JitOperatorWrapper::description(DescriptionMode description_mo
   std::stringstream desc;
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
   desc << "[JitOperatorWrapper]" << separator;
-  for (const auto& op : _jit_operators) {
+  for (const auto& op : _specialized_function_wrapper->jit_operators) {
     desc << op->description() << separator;
   }
   return desc.str();
 }
 
-void JitOperatorWrapper::add_jit_operator(const std::shared_ptr<AbstractJittable>& op) { _jit_operators.push_back(op); }
+void JitOperatorWrapper::add_jit_operator(const std::shared_ptr<AbstractJittable>& op) {
+  _specialized_function_wrapper->jit_operators.push_back(op);
+}
 
 const std::vector<std::shared_ptr<AbstractJittable>>& JitOperatorWrapper::jit_operators() const {
-  return _jit_operators;
+  return _specialized_function_wrapper->jit_operators;
 }
 
 const std::shared_ptr<JitReadTuples> JitOperatorWrapper::_source() const {
-  return std::dynamic_pointer_cast<JitReadTuples>(_jit_operators.front());
+  return std::dynamic_pointer_cast<JitReadTuples>(_specialized_function_wrapper->jit_operators.front());
 }
 
 const std::shared_ptr<AbstractJittableSink> JitOperatorWrapper::_sink() const {
-  return std::dynamic_pointer_cast<AbstractJittableSink>(_jit_operators.back());
+  return std::dynamic_pointer_cast<AbstractJittableSink>(_specialized_function_wrapper->jit_operators.back());
 }
 
 std::shared_ptr<const Table> JitOperatorWrapper::_on_execute() {
@@ -56,37 +58,12 @@ std::shared_ptr<const Table> JitOperatorWrapper::_on_execute() {
   _source()->before_query(in_table, _input_parameter_values, context);
   _sink()->before_query(*out_table, context);
 
-  for (auto& jit_operator : _jit_operators) {
-    if (auto jit_validate = std::dynamic_pointer_cast<JitValidate>(jit_operator)) {
-      jit_validate->set_input_table_type(in_table.type());
-    }
-  }
-
-  // Connect operators to a chain
-  for (auto it = _jit_operators.begin(); it != _jit_operators.end() && it + 1 != _jit_operators.end(); ++it) {
-    (*it)->set_next_operator(*(it + 1));
-  }
-
-  std::function<void(const JitReadTuples*, JitRuntimeContext&)> execute_func;
-  // We want to perform two specialization passes if the operator chain contains a JitAggregate operator, since the
-  // JitAggregate operator contains multiple loops that need unrolling.
-  auto two_specialization_passes = static_cast<bool>(std::dynamic_pointer_cast<JitAggregate>(_sink()));
-  switch (_execution_mode) {
-    case JitExecutionMode::Compile:
-      // this corresponds to "opossum::JitReadTuples::execute(opossum::JitRuntimeContext&) const"
-      execute_func = _module.specialize_and_compile_function<void(const JitReadTuples*, JitRuntimeContext&)>(
-          "_ZNK7opossum13JitReadTuples7executeERNS_17JitRuntimeContextE",
-          std::make_shared<JitConstantRuntimePointer>(_source().get()), two_specialization_passes);
-      break;
-    case JitExecutionMode::Interpret:
-      execute_func = &JitReadTuples::execute;
-      break;
-  }
+  _prepare_and_specialize_operator_pipeline();
 
   for (opossum::ChunkID chunk_id{0}; chunk_id < in_table.chunk_count() && context.limit_rows; ++chunk_id) {
     const auto& in_chunk = *in_table.get_chunk(chunk_id);
     _source()->before_chunk(in_table, in_chunk, context);
-    execute_func(_source().get(), context);
+    _specialized_function_wrapper->execute_func(_source().get(), context);
     _sink()->after_chunk(*out_table, context);
   }
 
@@ -95,16 +72,53 @@ std::shared_ptr<const Table> JitOperatorWrapper::_on_execute() {
   return out_table;
 }
 
+void JitOperatorWrapper::_prepare_and_specialize_operator_pipeline() {
+  // Ensure that a jittable operartor pipeline is only specialized once.
+  std::lock_guard<std::mutex> guard(_specialized_function_wrapper->specialization_mutex);
+  if (_specialized_function_wrapper->execute_func) return;
+
+  const auto jit_operators = _specialized_function_wrapper->jit_operators;
+
+  for (auto& jit_operator : jit_operators) {
+    if (auto jit_validate = std::dynamic_pointer_cast<JitValidate>(jit_operator)) {
+      jit_validate->set_input_table_type(input_left()->get_output()->type());
+    }
+  }
+
+  // Connect operators to a chain
+  for (auto it = jit_operators.begin(); it != jit_operators.end() && it + 1 != jit_operators.end(); ++it) {
+    (*it)->set_next_operator(*(it + 1));
+  }
+
+  std::function<void(const JitReadTuples*, JitRuntimeContext&)> execute_func;
+  // We want to perform two specialization passes if the operator chain contains a JitAggregate operator, since the
+  // JitAggregate operator contains multiple loops that need unrolling.
+  auto two_specialization_passes = static_cast<bool>(std::dynamic_pointer_cast<JitAggregate>(_sink()));
+  switch (JitExecutionMode::Interpret) {
+    case JitExecutionMode::Compile:
+      // this corresponds to "opossum::JitReadTuples::execute(opossum::JitRuntimeContext&) const"
+      _specialized_function_wrapper->execute_func =
+          _specialized_function_wrapper->module
+              .specialize_and_compile_function<void(const JitReadTuples*, JitRuntimeContext&)>(
+                  "_ZNK7opossum13JitReadTuples7executeERNS_17JitRuntimeContextE",
+                  std::make_shared<JitConstantRuntimePointer>(_source().get()), two_specialization_passes);
+      break;
+    case JitExecutionMode::Interpret:
+      _specialized_function_wrapper->execute_func = &JitReadTuples::execute;
+      break;
+  }
+}
+
 void JitOperatorWrapper::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {
   const auto& input_parameters = _source()->input_parameters();
-  _input_parameter_values.reserve(input_parameters.size());
+  _input_parameter_values.resize(input_parameters.size());
+  auto itr = _input_parameter_values.begin();
   for (const auto& parameter : input_parameters) {
     auto search = parameters.find(parameter.parameter_id);
     if (search != parameters.end()) {
-      _input_parameter_values.push_back(search->second);
-    } else {
-      Fail("Required parameter not found.");
+      *itr = search->second;
     }
+    ++itr;
   }
 }
 
@@ -117,7 +131,7 @@ void JitOperatorWrapper::_on_set_transaction_context(const std::weak_ptr<Transac
 std::shared_ptr<AbstractOperator> JitOperatorWrapper::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_input_left,
     const std::shared_ptr<AbstractOperator>& copied_input_right) const {
-  return std::make_shared<JitOperatorWrapper>(copied_input_left, _execution_mode, _jit_operators);
+  return std::make_shared<JitOperatorWrapper>(copied_input_left, _execution_mode, _specialized_function_wrapper);
 }
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator_wrapper.cpp
+++ b/src/lib/operators/jit_operator_wrapper.cpp
@@ -98,7 +98,7 @@ void JitOperatorWrapper::_prepare_and_specialize_operator_pipeline() {
   // We want to perform two specialization passes if the operator chain contains a JitAggregate operator, since the
   // JitAggregate operator contains multiple loops that need unrolling.
   auto two_specialization_passes = static_cast<bool>(std::dynamic_pointer_cast<JitAggregate>(_sink()));
-  switch (JitExecutionMode::Interpret) {
+  switch (_execution_mode) {
     case JitExecutionMode::Compile:
       // this corresponds to "opossum::JitReadTuples::execute(opossum::JitRuntimeContext&) const"
       _specialized_function_wrapper->execute_func =
@@ -116,13 +116,12 @@ void JitOperatorWrapper::_prepare_and_specialize_operator_pipeline() {
 void JitOperatorWrapper::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {
   const auto& input_parameters = _source()->input_parameters();
   _input_parameter_values.resize(input_parameters.size());
-  auto itr = _input_parameter_values.begin();
-  for (const auto& parameter : input_parameters) {
-    auto search = parameters.find(parameter.parameter_id);
+
+  for (size_t index{0}; index < input_parameters.size(); ++index) {
+    const auto search = parameters.find(input_parameters[index].parameter_id);
     if (search != parameters.end()) {
-      *itr = search->second;
+      _input_parameter_values[index] = search->second;
     }
-    ++itr;
   }
 }
 

--- a/src/lib/operators/jit_operator_wrapper.hpp
+++ b/src/lib/operators/jit_operator_wrapper.hpp
@@ -20,8 +20,7 @@ enum class JitExecutionMode { Interpret, Compile };
  */
 class JitOperatorWrapper : public AbstractReadOnlyOperator {
  public:
-  /**
-   * The SpecializedFunctionWrapper allows the JitOperatorWrapper to share a jittable operator pipeline and the
+  /* The SpecializedFunctionWrapper allows the JitOperatorWrapper to share a jittable operator pipeline and the
    * specialized function from this pipeline between multiple JitOperatorWrapper instances. The mutex ensures that the
    * same pipeline within a correlated subquery is specialized only once when executed in parallel.
    *

--- a/src/lib/operators/jit_operator_wrapper.hpp
+++ b/src/lib/operators/jit_operator_wrapper.hpp
@@ -20,9 +20,12 @@ enum class JitExecutionMode { Interpret, Compile };
  */
 class JitOperatorWrapper : public AbstractReadOnlyOperator {
  public:
+  /**
+   * The SpecializedFunctionWrapper allows the JitOperatorWrapper to share a jittable operator pipeline and the
+   * specialized function from this pipeline between multiple JitOperatorWrapper instances. This ensures that the same
+   * pipeline is only specialized once.
+   */
   struct SpecializedFunctionWrapper {
-    // The SpecializedFunctionWrapper is required to share a jittable operator pipeline  and specialized function
-    // between multiple JitOperatorWrapper instances. It ensures that the same pipeline is only specialized once.
     std::vector<std::shared_ptr<AbstractJittable>> jit_operators;
     std::function<void(const JitReadTuples*, JitRuntimeContext&)> execute_func;
     std::mutex specialization_mutex;

--- a/src/lib/operators/jit_operator_wrapper.hpp
+++ b/src/lib/operators/jit_operator_wrapper.hpp
@@ -40,6 +40,7 @@ class JitOperatorWrapper : public AbstractReadOnlyOperator {
       const std::shared_ptr<AbstractOperator>& copied_input_left,
       const std::shared_ptr<AbstractOperator>& copied_input_right) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
+  void _on_set_transaction_context(const std::weak_ptr<TransactionContext>& transaction_context) override;
 
  private:
   const std::shared_ptr<JitReadTuples> _source() const;
@@ -48,6 +49,8 @@ class JitOperatorWrapper : public AbstractReadOnlyOperator {
   const JitExecutionMode _execution_mode;
   JitCodeSpecializer _module;
   std::vector<std::shared_ptr<AbstractJittable>> _jit_operators;
+
+  std::vector<AllTypeVariant> _input_parameter_values;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator_wrapper.hpp
+++ b/src/lib/operators/jit_operator_wrapper.hpp
@@ -21,8 +21,8 @@ enum class JitExecutionMode { Interpret, Compile };
 class JitOperatorWrapper : public AbstractReadOnlyOperator {
  public:
   struct SpecializedFunctionWrapper {
-    // Wrapper required to share jittable operators and specialized function between multiple JitOperatorWrapper
-    // instancces. This allows that the same jittable operator pipeline is only specialized once.
+    // The SpecializedFunctionWrapper is required to share a jittable operator pipeline  and specialized function
+    // between multiple JitOperatorWrapper instances. It ensures that the same pipeline is only specialized once.
     std::vector<std::shared_ptr<AbstractJittable>> jit_operators;
     std::function<void(const JitReadTuples*, JitRuntimeContext&)> execute_func;
     std::mutex specialization_mutex;
@@ -42,6 +42,7 @@ class JitOperatorWrapper : public AbstractReadOnlyOperator {
   void add_jit_operator(const std::shared_ptr<AbstractJittable>& op);
 
   const std::vector<std::shared_ptr<AbstractJittable>>& jit_operators() const;
+  const std::vector<AllTypeVariant>& input_parameter_values() const;
 
  protected:
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
@@ -472,7 +472,7 @@ TEST_F(JitAwareLQPTranslatorTest, AMoreComplexQuery) {
 
 TEST_F(JitAwareLQPTranslatorTest, AggregateOperator) {
   const auto jit_operator_wrapper =
-      translate_query("SELECT COUNT(a), SUM(b), AVG(a + b), MIN(a), MAX(b) FROM table_a GROUP BY a");
+      translate_query("SELECT COUNT(a), SUM(b), AVG(a + b), MIN(a), MAX(b), COUNT(*) FROM table_a GROUP BY a");
   ASSERT_NE(jit_operator_wrapper, nullptr);
 
   // Check the type of jit operators in the operator pipeline
@@ -501,7 +501,7 @@ TEST_F(JitAwareLQPTranslatorTest, AggregateOperator) {
   ASSERT_EQ(jit_read_tuples->find_input_column(groupby_columns[0].tuple_value), ColumnID{0});
 
   const auto aggregate_columns = jit_aggregate->aggregate_columns();
-  ASSERT_EQ(aggregate_columns.size(), 5u);
+  ASSERT_EQ(aggregate_columns.size(), 6u);
 
   ASSERT_EQ(aggregate_columns[0].column_name, "COUNT(a)");
   ASSERT_EQ(aggregate_columns[0].function, AggregateFunction::Count);
@@ -523,6 +523,10 @@ TEST_F(JitAwareLQPTranslatorTest, AggregateOperator) {
   ASSERT_EQ(aggregate_columns[4].column_name, "MAX(b)");
   ASSERT_EQ(aggregate_columns[4].function, AggregateFunction::Max);
   ASSERT_EQ(jit_read_tuples->find_input_column(aggregate_columns[4].tuple_value), ColumnID{1});
+
+  ASSERT_EQ(aggregate_columns[5].column_name, "COUNT(*)");
+  ASSERT_EQ(aggregate_columns[5].function, AggregateFunction::Count);
+  ASSERT_EQ(aggregate_columns[5].tuple_value.tuple_index(), 0u);
 }
 
 TEST_F(JitAwareLQPTranslatorTest, LimitOperator) {

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -44,7 +44,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_A) {
         SortNode::make(expression_vector(a_b), std::vector<OrderByMode>{OrderByMode::Ascending}, node_a))));
   // clang-format on
 
-  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
+  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp, nullptr);
   const auto expected_expression = and_(greater_than_(a_a, 5), less_than_(a_b, 4));
 
   EXPECT_EQ(*actual_expression, *expected_expression);
@@ -63,7 +63,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_B) {
         PredicateNode::make(less_than_(a_a, 500), node_a))));
   // clang-format on
 
-  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
+  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp, nullptr);
 
   // clang-format off
   const auto expected_expression = and_(greater_than_(a_a, 4),
@@ -86,7 +86,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_C) {
          node_b)));
   // clang-format on
 
-  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
+  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp, nullptr);
   const auto expected_expression = and_(greater_than_(a_a, 5), less_than_(b_x, 4));
 
   EXPECT_EQ(*actual_expression, *expected_expression);

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -44,7 +44,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_A) {
         SortNode::make(expression_vector(a_b), std::vector<OrderByMode>{OrderByMode::Ascending}, node_a))));
   // clang-format on
 
-  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp, nullptr);
+  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
   const auto expected_expression = and_(greater_than_(a_a, 5), less_than_(a_b, 4));
 
   EXPECT_EQ(*actual_expression, *expected_expression);
@@ -63,7 +63,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_B) {
         PredicateNode::make(less_than_(a_a, 500), node_a))));
   // clang-format on
 
-  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp, nullptr);
+  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
 
   // clang-format off
   const auto expected_expression = and_(greater_than_(a_a, 4),
@@ -86,8 +86,18 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_C) {
          node_b)));
   // clang-format on
 
-  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp, nullptr);
+  const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
   const auto expected_expression = and_(greater_than_(a_a, 5), less_than_(b_x, 4));
+
+  EXPECT_EQ(*actual_expression, *expected_expression);
+}
+
+TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpressionBeginEndNode) {
+  const auto end_node = PredicateNode::make(less_than_(a_b, 4), node_a);
+  const auto begin_node = PredicateNode::make(greater_than_(a_a, 5), end_node);
+
+  const auto actual_expression = lqp_subplan_to_boolean_expression(begin_node, end_node);
+  const auto expected_expression = greater_than_(a_a, 5);
 
   EXPECT_EQ(*actual_expression, *expected_expression);
 }

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -116,4 +116,25 @@ TEST_F(JitReadWriteTupleTest, LimitRowCountIsEvaluated) {
   ASSERT_EQ(context.limit_rows, limit_row_count);
 }
 
+TEST_F(JitReadWriteTupleTest, SetParameterValuesInContext) {
+  // Prepare JitReadTuples
+  JitReadTuples read_tuples;
+  auto tuple_1 = read_tuples.add_parameter_value(DataType::Long, ParameterID{1});
+  auto tuple_2 = read_tuples.add_parameter_value(DataType::Double, ParameterID{2});
+
+  // Prepare parameter values
+  int64_t value_1{1l};
+  double value_2{2.};
+  std::vector<AllTypeVariant> parameter_values{AllTypeVariant{value_1}, AllTypeVariant{value_2}};
+
+  JitRuntimeContext context;
+
+  // Since we only test parameter values here an empty input table is sufficient
+  Table input_table(TableColumnDefinitions{}, TableType::Data);
+  read_tuples.before_query(input_table, parameter_values, context);
+
+  ASSERT_EQ(tuple_1.get<int64_t>(context), value_1);
+  ASSERT_EQ(tuple_2.get<double>(context), value_2);
+}
+
 }  // namespace opossum

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -119,8 +119,8 @@ TEST_F(JitReadWriteTupleTest, LimitRowCountIsEvaluated) {
 TEST_F(JitReadWriteTupleTest, SetParameterValuesInContext) {
   // Prepare JitReadTuples
   JitReadTuples read_tuples;
-  auto tuple_1 = read_tuples.add_parameter_value(DataType::Long, ParameterID{1});
-  auto tuple_2 = read_tuples.add_parameter_value(DataType::Double, ParameterID{2});
+  auto tuple_1 = read_tuples.add_parameter(DataType::Long, ParameterID{1});
+  auto tuple_2 = read_tuples.add_parameter(DataType::Double, ParameterID{2});
 
   // Prepare parameter values
   int64_t value_1{1l};

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -59,7 +59,7 @@ TEST_F(JitReadWriteTupleTest, LiteralValuesAreInitialized) {
   // Since we only test literal values here an empty input table is sufficient
   JitRuntimeContext context;
   Table input_table(TableColumnDefinitions{}, TableType::Data);
-  read_tuples->before_query(input_table, context);
+  read_tuples->before_query(input_table, std::vector<AllTypeVariant>(), context);
 
   ASSERT_EQ(int_value.get<int32_t>(context), 1);
   ASSERT_EQ(float_value.get<float>(context), 1.23f);
@@ -84,7 +84,7 @@ TEST_F(JitReadWriteTupleTest, CopyTable) {
   // Initialize operators with actual input table
   auto input_table = load_table("resources/test_data/tbl/int_float_null_sorted_asc.tbl", 2);
   auto output_table = write_tuples->create_output_table(2);
-  read_tuples->before_query(*input_table, context);
+  read_tuples->before_query(*input_table, std::vector<AllTypeVariant>(), context);
   write_tuples->before_query(*output_table, context);
 
   // Pass each chunk through the pipeline
@@ -111,7 +111,7 @@ TEST_F(JitReadWriteTupleTest, LimitRowCountIsEvaluated) {
   JitRuntimeContext context;
   // Since we only test literal values here an empty input table is sufficient
   Table input_table(TableColumnDefinitions{}, TableType::Data);
-  read_tuples->before_query(input_table, context);
+  read_tuples->before_query(input_table, std::vector<AllTypeVariant>(), context);
 
   ASSERT_EQ(context.limit_rows, limit_row_count);
 }

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -161,6 +161,36 @@ TEST_F(JitOperatorWrapperTest, OperatorChecksLimitRowCount) {
   jit_operator_wrapper.execute();
 }
 
+TEST_F(JitOperatorWrapperTest, SetParameters) {
+  // Prepare parameters
+  AllTypeVariant value_1{1};
+  AllTypeVariant value_2{2};
+  AllTypeVariant value_3{3.f};
+  AllTypeVariant value_4{4.};
+  std::unordered_map<ParameterID, AllTypeVariant> parameters;
+  parameters[ParameterID{1}] = value_1;
+  parameters[ParameterID{2}] = value_2;
+  parameters[ParameterID{3}] = value_3;
+  parameters[ParameterID{4}] = value_4;
+
+  // Prepare JitReadTuples
+  const auto source = std::make_shared<JitReadTuples>();
+  source->add_parameter_value(DataType::Double, ParameterID{4});
+  source->add_parameter_value(DataType::Int, ParameterID{2});
+
+  // Prepare JitOperatorWrapper
+  JitOperatorWrapper jit_operator_wrapper(_empty_table_wrapper, JitExecutionMode::Interpret);
+  jit_operator_wrapper.add_jit_operator(source);
+
+  jit_operator_wrapper.set_parameters(parameters);
+
+  const auto input_parameter_values = jit_operator_wrapper.input_parameter_values();
+
+  EXPECT_EQ(input_parameter_values.size(), 2u);
+  EXPECT_EQ(input_parameter_values[0], value_4);
+  EXPECT_EQ(input_parameter_values[1], value_2);
+}
+
 TEST_F(JitOperatorWrapperTest, JitOperatorsSpecializedWithMultipleInliningOfSameFunction) {
   // During query specialization, the function calls of JitExpression::compute are inlined with two different objects:
   // First the compute function call with the object "expression" is inlined,

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -175,8 +175,8 @@ TEST_F(JitOperatorWrapperTest, SetParameters) {
 
   // Prepare JitReadTuples
   const auto source = std::make_shared<JitReadTuples>();
-  source->add_parameter_value(DataType::Double, ParameterID{4});
-  source->add_parameter_value(DataType::Int, ParameterID{2});
+  source->add_parameter(DataType::Double, ParameterID{4});
+  source->add_parameter(DataType::Int, ParameterID{2});
 
   // Prepare JitOperatorWrapper
   JitOperatorWrapper jit_operator_wrapper(_empty_table_wrapper, JitExecutionMode::Interpret);


### PR DESCRIPTION
This PR enables the jittable operators to use parameters.

The `JitReadTuples` operator keeps track of all used parameters within the jittable operator pipeline. The actual parameter values are stored within the `JitOperatorWrapper` and are passed to the `JitReadTuples` operator via the `JitReadTuples::before_query` function call.

The support for parameters enables JIT to be used within correlated subqueries. To prevent a new specialization of code for every execution of a correlated subquery, all `JitOperatorWrapper` instances with the same operator pipeline share the specialized function in a `SpecializedFunctionWrapper`. In case that multiple correlated subqueries are executed in parallel, a mutex within the wrapper ensures that the code is specialized only once.

This pr also enhances the identification of which operators are jittable in the `JitAwareLQPTranslator::_node_is_jittable` function by also checking whether the nested expressions within the operators are jittable.

Smaller enhancements include the replacement of the custom function `JitAwareLQPTranslator::_visit` with the utility function `visit_lqp` and the support for `COUNT(*)`.