### PR TITLE
Rename querys to queries

### DIFF
--- a/src/lib/expression/exists_expression.cpp
+++ b/src/lib/expression/exists_expression.cpp
@@ -22,7 +22,8 @@ std::shared_ptr<AbstractExpression> ExistsExpression::subquery() const {
 
 std::string ExistsExpression::as_column_name() const {
   std::stringstream stream;
-  stream << "EXISTS(" << subquery()->as_column_name() << ")";
+  stream << (exists_expression_type == ExistsExpressionType : Exists ? "EXISTS" : "NOT EXISTS");
+  stream << "(" << subquery()->as_column_name() << ")";
   return stream.str();
 }
 

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -134,7 +134,7 @@ void expressions_set_parameters(const std::vector<std::shared_ptr<AbstractExpres
                                 const std::unordered_map<ParameterID, AllTypeVariant>& parameters);
 
 /**
- * Traverse the expression(s) for subquerys and set the transaction context in them
+ * Traverse the expression(s) for subqueries and set the transaction context in them
  */
 void expression_set_transaction_context(const std::shared_ptr<AbstractExpression>& expression,
                                         const std::weak_ptr<TransactionContext>& transaction_context);

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -64,7 +64,7 @@ std::shared_ptr<AbstractExpression> lqp_subplan_to_boolean_expression(const std:
 enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
 
 /**
- * Calls the passed @param visitor on each node of the @param lqp. This will NOT visit subquerys.
+ * Calls the passed @param visitor on each node of the @param lqp. This will NOT visit subqueries.
  * The visitor returns `ExpressionVisitation`, indicating whether the current nodes's input should be visited
  * as well.
  * Each node is visited exactly once.
@@ -93,8 +93,8 @@ void visit_lqp(const std::shared_ptr<AbstractLQPNode>& lqp, Visitor visitor) {
 }
 
 /**
- * @return The node @param lqp as well as the root nodes of all LQPs in subquerys and, recursively, LQPs in their
- *         subquerys
+ * @return The node @param lqp as well as the root nodes of all LQPs in subqueries and, recursively, LQPs in their
+ *         subqueries
  */
 std::vector<std::shared_ptr<AbstractLQPNode>> lqp_find_subplan_roots(const std::shared_ptr<AbstractLQPNode>& lqp);
 

--- a/src/lib/optimizer/strategy/exists_reformulation_rule.cpp
+++ b/src/lib/optimizer/strategy/exists_reformulation_rule.cpp
@@ -33,7 +33,7 @@ void ExistsReformulationRule::apply_to(const std::shared_ptr<AbstractLQPNode>& n
   const auto exists_expression = std::static_pointer_cast<ExistsExpression>(predicate_node->predicate());
   const auto subquery_expression = std::static_pointer_cast<LQPSubqueryExpression>(exists_expression->subquery());
 
-  // We don't care about uncorrelated subquerys, nor subquerys with more than one parameter
+  // We don't care about uncorrelated subqueries, nor subqueries with more than one parameter
   if (subquery_expression->arguments.size() != 1) {
     _apply_to_inputs(node);
     return;

--- a/src/lib/optimizer/strategy/exists_reformulation_rule.hpp
+++ b/src/lib/optimizer/strategy/exists_reformulation_rule.hpp
@@ -15,7 +15,7 @@ class AbstractLQPNode;
 //                - cases where multiple predicates exists (because our joins can only handle single predicates)
 //                - cases where the subquery uses multiple external parameters, or uses one twice
 //                    (because that makes things more complicated; it is sometimes possible though)
-//                - other complex subquerys (because we have not thought about all eventualities yet)
+//                - other complex subqueries (because we have not thought about all eventualities yet)
 
 class ExistsReformulationRule : public AbstractRule {
  public:

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -53,7 +53,7 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
     _build_dataflow(right_input, node);
   }
 
-  // Visualize subquerys
+  // Visualize subqueries
   for (const auto& expression : node->node_expressions) {
     visit_expression(expression, [&](const auto& sub_expression) {
       const auto subquery_expression = std::dynamic_pointer_cast<LQPSubqueryExpression>(sub_expression);

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -52,25 +52,25 @@ void PQPVisualizer::_build_subtree(const std::shared_ptr<const AbstractOperator>
     case OperatorType::Projection: {
       const auto projection = std::dynamic_pointer_cast<const Projection>(op);
       for (const auto& column_expression : projection->expressions) {
-        _visualize_subquerys(op, column_expression, visualized_ops);
+        _visualize_subqueries(op, column_expression, visualized_ops);
       }
     } break;
 
     case OperatorType::TableScan: {
       const auto table_scan = std::dynamic_pointer_cast<const TableScan>(op);
-      _visualize_subquerys(op, table_scan->predicate(), visualized_ops);
+      _visualize_subqueries(op, table_scan->predicate(), visualized_ops);
     } break;
 
     case OperatorType::Limit: {
       const auto limit = std::dynamic_pointer_cast<const Limit>(op);
-      _visualize_subquerys(op, limit->row_count_expression(), visualized_ops);
+      _visualize_subqueries(op, limit->row_count_expression(), visualized_ops);
     } break;
 
     default: {}  // OperatorType has no expressions
   }
 }
 
-void PQPVisualizer::_visualize_subquerys(const std::shared_ptr<const AbstractOperator>& op,
+void PQPVisualizer::_visualize_subqueries(const std::shared_ptr<const AbstractOperator>& op,
                                          const std::shared_ptr<AbstractExpression>& expression,
                                          std::unordered_set<std::shared_ptr<const AbstractOperator>>& visualized_ops) {
   visit_expression(expression, [&](const auto& sub_expression) {

--- a/src/lib/visualization/pqp_visualizer.hpp
+++ b/src/lib/visualization/pqp_visualizer.hpp
@@ -23,7 +23,7 @@ class PQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
   void _build_subtree(const std::shared_ptr<const AbstractOperator>& op,
                       std::unordered_set<std::shared_ptr<const AbstractOperator>>& visualized_ops);
 
-  void _visualize_subquerys(const std::shared_ptr<const AbstractOperator>& op,
+  void _visualize_subqueries(const std::shared_ptr<const AbstractOperator>& op,
                             const std::shared_ptr<AbstractExpression>& expression,
                             std::unordered_set<std::shared_ptr<const AbstractOperator>>& visualized_ops);
 

--- a/src/test/expression/lqp_subquery_expression_test.cpp
+++ b/src/test/expression/lqp_subquery_expression_test.cpp
@@ -133,7 +133,7 @@ TEST_F(LQPSubqueryExpressionTest, AsColumnName) {
   EXPECT_TRUE(std::regex_search(subquery_a->as_column_name(), std::regex{"SUBQUERY \\(LQP, 0x[0-9a-f]+\\)"}));
   EXPECT_TRUE(std::regex_search(subquery_c->as_column_name(), std::regex{"SUBQUERY \\(LQP, 0x[0-9a-f]+, Parameters: \\[a, id=0\\]\\)"}));  // NOLINT
 
-  // Test IN and EXISTS here as well, since they need subquerys to function
+  // Test IN and EXISTS here as well, since they need subqueries to function
   EXPECT_TRUE(std::regex_search(exists_(subquery_c)->as_column_name(), std::regex{"EXISTS\\(SUBQUERY \\(LQP, 0x[0-9a-f]+, Parameters: \\[a, id=0\\]\\)\\)"}));  // NOLINT
   EXPECT_TRUE(std::regex_search(in_(5, subquery_c)->as_column_name(), std::regex{"\\(5\\) IN SUBQUERY \\(LQP, 0x[0-9a-f]+, Parameters: \\[a, id=0\\]\\)"}));  // NOLINT
 }

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -385,7 +385,7 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
   EXPECT_TRUE(std::regex_search(stream.str().c_str(), std::regex{R"(\[0\] \[Predicate\] a = 5)"}));
 }
 
-TEST_F(LogicalQueryPlanTest, DeepCopySubquerys) {
+TEST_F(LogicalQueryPlanTest, DeepCopySubqueries) {
   const auto parameter_a = correlated_parameter_(ParameterID{0}, b1);
 
   // clang-format off

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -1690,7 +1690,7 @@ TEST_F(SQLTranslatorTest, PrepareWithParameters) {
 }
 
 TEST_F(SQLTranslatorTest, PrepareWithParametersAndCorrelatedSubquery) {
-  // Correlated subquerys and prepared statement's parameters both use the ParameterID system, so let's test that they
+  // Correlated subqueries and prepared statement's parameters both use the ParameterID system, so let's test that they
   // cooperate
 
   const auto actual_lqp = compile_query(


### PR DESCRIPTION
Fix find-replace issue from #1435, fixes #1455.
Also sneaks in a fix for the exists expression where the description was lacking the "not".