### PR TITLE
compare_benchmarks.py: fix "runtime too short"

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -32,7 +32,7 @@ def calculate_and_format_p_value(old, new):
 		is_significant = False
 		notes += "(not enough runs) "
 
-	color = 'green' if is_significant else 'grey'
+	color = 'green' if is_significant else 'white'
 	return colored(notes + "{0:.4f}".format(p_value), color)
 
 

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -9,7 +9,7 @@ from array import array
 
 p_value_significance_threshold = 0.001
 min_iterations = 10
-min_runtime_ns = 60 * 1000 * 1000 * 1000
+min_runtime_ns = 59 * 1000 * 1000 * 1000
 
 def format_diff(diff):
 	if diff >= 0:


### PR DESCRIPTION
For some reason, the reported runtime sometimes ends up just short of 60 seconds. This leads to the compare_benchmarks.py script to report results as "runtime too short".

Also changes the grey color for insignificant results to white. Grey doesn't seem to be supported by OS X.