### PR TITLE
Reduce hyriseTest runtime

### DIFF
--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -27,7 +27,7 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
 
  protected:
   size_t row_count() {
-    static constexpr auto default_row_count = size_t{1u} << 14;
+    static constexpr auto default_row_count = size_t{1u} << 10;
 
     const auto encoding_spec = GetParam();
 

--- a/src/test/storage/simd_bp128_test.cpp
+++ b/src/test/storage/simd_bp128_test.cpp
@@ -75,7 +75,7 @@ auto formatter = [](const ::testing::TestParamInfo<uint8_t> info) {
 INSTANTIATE_TEST_CASE_P(BitSizes, SimdBp128Test, ::testing::Range(uint8_t{1}, uint8_t{33}), formatter);
 
 TEST_P(SimdBp128Test, DecompressSequenceUsingIterators) {
-  const auto sequence = generate_sequence(4'200);
+  const auto sequence = generate_sequence(420);
   const auto compressed_sequence_base = compress(sequence);
 
   auto compressed_sequence = dynamic_cast<const SimdBp128Vector*>(compressed_sequence_base.get());
@@ -90,7 +90,7 @@ TEST_P(SimdBp128Test, DecompressSequenceUsingIterators) {
 }
 
 TEST_P(SimdBp128Test, DecompressSequenceUsingDecompressor) {
-  const auto sequence = generate_sequence(4'200);
+  const auto sequence = generate_sequence(420);
   const auto compressed_sequence = compress(sequence);
 
   auto decompressor = compressed_sequence->create_base_decompressor();


### PR DESCRIPTION
Decreased some magic numbers and got the test runtime (debug) from >5s down to 4.5s on my machine. For none of these magic numbers was a justification given, so I suppose they are fair game :man_shrugging: 