### PR TITLE
Fail if config or build step of jemalloc fails.

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -172,8 +172,9 @@ externalproject_add(
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/jemalloc
     # Executing autoconf and the configure script with suppressed output, only printing it in case of non-zero return
     CONFIGURE_COMMAND bash -c "cd <SOURCE_DIR> && if [ ! -f ./configure ] $<SEMICOLON> then autoconf $<SEMICOLON> fi && \
-                               cd <BINARY_DIR> && output=$(<SOURCE_DIR>/configure --prefix=<BINARY_DIR> 2>&1) || printf \"$output\\n\""
-    BUILD_COMMAND bash -c "output=$(make 2>&1) || printf \"$output\\n\""
+                               cd <BINARY_DIR> && output=$(<SOURCE_DIR>/configure --prefix=<BINARY_DIR> 2>&1) || \
+                               (printf \"$output\\n\" && /usr/bin/false)"
+    BUILD_COMMAND bash -c "output=$(make 2>&1) || (printf \"$output\\n\" && /usr/bin/false)"
     INSTALL_COMMAND /usr/bin/false  # install should never be called, this is a safe guard that fails if it is
     STEP_TARGETS build
     BUILD_BYPRODUCTS ${JEMALLOC_LIB_PATH}


### PR DESCRIPTION
fixes #1448.

The problem was that the jemalloc build step did not fail our build if it fails to config/build jemalloc. This is because of the `||` case in the config and build command. We use that to print the output in case of failure, but it also prevents the failure to propagate to the next step:
```
BUILD_COMMAND bash -c "output=$(make 2>&1) || printf \"$output\\n\""
```
This PR makes it that, if either the config or build step of jemalloc fails, we manually fail (which is what's supposed to happen anyway).