### PR TITLE
Proper libHyrise linking for hyriseTest & pausable_loop_thread fix

### DIFF
--- a/src/lib/utils/pausable_loop_thread.hpp
+++ b/src/lib/utils/pausable_loop_thread.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,3 +1,10 @@
+# -force_load/--whole-archive are necessary to include all symbols so that dynamically loaded plugins can use them
+if (APPLE)
+    set(HYRISE_LIBRARY_WITH_ALL_SYMBOLS -force_load hyrise)
+else()
+    set(HYRISE_LIBRARY_WITH_ALL_SYMBOLS -Wl,--whole-archive hyrise -Wl,--no-whole-archive)
+endif()
+
 set(
     SHARED_SOURCES
     base_test.hpp
@@ -298,10 +305,10 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # Configure hyriseTest
 add_executable(hyriseTest ${HYRISE_UNIT_TEST_SOURCES})
 add_dependencies(hyriseTest TestPlugin TestNonInstantiablePlugin)
-target_link_libraries(hyriseTest hyrise ${LIBRARIES})
+target_link_libraries(hyriseTest ${HYRISE_LIBRARY_WITH_ALL_SYMBOLS} ${LIBRARIES})
 
 # Configure hyriseSystemTest
 add_executable(hyriseSystemTest ${SYSTEM_TEST_SOURCES})
-target_link_libraries(hyriseSystemTest hyrise hyriseBenchmarkLib ${LIBRARIES})
+target_link_libraries(hyriseSystemTest ${HYRISE_LIBRARY_WITH_ALL_SYMBOLS} hyriseBenchmarkLib ${LIBRARIES})
 target_link_libraries_system(hyriseSystemTest pqxx)
 target_compile_options(hyriseSystemTest PRIVATE -DPQXX_HIDE_EXP_OPTIONAL)


### PR DESCRIPTION
Our DYOD18/19 group works on the MvccDeletePlugin. 
We experienced linking issues with the hyrisePlayground target, which now have been fixed (#1438).
Since we use our plugin in the hyriseTest target as well, we need the fix to be applied here as well.

Our plugin uses `utils/pausible_loop_thread.hpp`. The missing `#pragma once` led to compile issues on our front.