### PR TITLE
[DYOD18/19] MvccDeletePlugin prep. (TransactionManager & -Context)

### DIFF
--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -15,7 +15,7 @@ TransactionContext::TransactionContext(const TransactionID transaction_id, const
       _snapshot_commit_id{snapshot_commit_id},
       _phase{TransactionPhase::Active},
       _num_active_operators{0} {
-  TransactionManager::get().register_transaction(snapshot_commit_id);
+  TransactionManager::get()._register_transaction(snapshot_commit_id);
 }
 
 TransactionContext::~TransactionContext() {
@@ -46,7 +46,7 @@ TransactionContext::~TransactionContext() {
    * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
    * that this transaction has finished.
    */
-  TransactionManager::get().deregister_transaction(_snapshot_commit_id);
+  TransactionManager::get()._deregister_transaction(_snapshot_commit_id);
 }
 
 TransactionID TransactionContext::transaction_id() const { return _transaction_id; }

--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -10,11 +10,9 @@
 
 namespace opossum {
 
-TransactionContext::TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id,
-                                       const bool created_by_transaction_manager)
+TransactionContext::TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id)
     : _transaction_id{transaction_id},
       _snapshot_commit_id{snapshot_commit_id},
-      _created_by_transaction_manager{created_by_transaction_manager},
       _phase{TransactionPhase::Active},
       _num_active_operators{0} {}
 
@@ -42,13 +40,11 @@ TransactionContext::~TransactionContext() {
               }()),
               "Has registered operators but has neither been committed nor rolled back.");
 
-  if (_created_by_transaction_manager) {
-    /**
+  /**
      * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
      * that this transaction has finished.
      */
-    TransactionManager::get().remove_active_snapshot_commit_id(_snapshot_commit_id);
-  }
+  TransactionManager::get().deregister_transaction(_snapshot_commit_id);
 }
 
 TransactionID TransactionContext::transaction_id() const { return _transaction_id; }

--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -10,9 +10,11 @@
 
 namespace opossum {
 
-TransactionContext::TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id)
+TransactionContext::TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id,
+                                       const bool created_by_transaction_manager)
     : _transaction_id{transaction_id},
       _snapshot_commit_id{snapshot_commit_id},
+      _created_by_transaction_manager{created_by_transaction_manager},
       _phase{TransactionPhase::Active},
       _num_active_operators{0} {}
 
@@ -40,11 +42,13 @@ TransactionContext::~TransactionContext() {
               }()),
               "Has registered operators but has neither been committed nor rolled back.");
 
-  /**
-   * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
-   * that this transaction has finished.
-   */
-  TransactionManager::get().remove_active_snapshot_commit_id(_snapshot_commit_id);
+  if (_created_by_transaction_manager) {
+    /**
+     * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
+     * that this transaction has finished.
+     */
+    TransactionManager::get().remove_active_snapshot_commit_id(_snapshot_commit_id);
+  }
 }
 
 TransactionID TransactionContext::transaction_id() const { return _transaction_id; }

--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -14,7 +14,9 @@ TransactionContext::TransactionContext(const TransactionID transaction_id, const
     : _transaction_id{transaction_id},
       _snapshot_commit_id{snapshot_commit_id},
       _phase{TransactionPhase::Active},
-      _num_active_operators{0} {}
+      _num_active_operators{0} {
+  TransactionManager::get().register_transaction(snapshot_commit_id);
+}
 
 TransactionContext::~TransactionContext() {
   DebugAssert(([this]() {
@@ -41,9 +43,9 @@ TransactionContext::~TransactionContext() {
               "Has registered operators but has neither been committed nor rolled back.");
 
   /**
-     * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
-     * that this transaction has finished.
-     */
+   * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
+   * that this transaction has finished.
+   */
   TransactionManager::get().deregister_transaction(_snapshot_commit_id);
 }
 

--- a/src/lib/concurrency/transaction_context.cpp
+++ b/src/lib/concurrency/transaction_context.cpp
@@ -39,6 +39,12 @@ TransactionContext::~TransactionContext() {
                 return !has_registered_operators || committed_or_rolled_back;
               }()),
               "Has registered operators but has neither been committed nor rolled back.");
+
+  /**
+   * Tell the TransactionManager, which keeps track of active snapshot-commit-ids,
+   * that this transaction has finished.
+   */
+  TransactionManager::get().remove_active_snapshot_commit_id(_snapshot_commit_id);
 }
 
 TransactionID TransactionContext::transaction_id() const { return _transaction_id; }
@@ -67,7 +73,6 @@ bool TransactionContext::rollback() {
   }
 
   _mark_as_rolled_back();
-
   return true;
 }
 

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -51,7 +51,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
   friend class TransactionManager;
 
  public:
-  TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id);
+  TransactionContext(TransactionID transaction_id, CommitID snapshot_commit_id);
   ~TransactionContext();
 
   /**

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -51,7 +51,8 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
   friend class TransactionManager;
 
  public:
-  TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id);
+  TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id,
+                     const bool created_by_transaction_manager = false);
   ~TransactionContext();
 
   /**
@@ -174,6 +175,8 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
  private:
   const TransactionID _transaction_id;
   const CommitID _snapshot_commit_id;
+  const bool _created_by_transaction_manager;
+
   std::vector<std::shared_ptr<AbstractReadWriteOperator>> _rw_operators;
 
   std::atomic<TransactionPhase> _phase;

--- a/src/lib/concurrency/transaction_context.hpp
+++ b/src/lib/concurrency/transaction_context.hpp
@@ -51,8 +51,7 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
   friend class TransactionManager;
 
  public:
-  TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id,
-                     const bool created_by_transaction_manager = false);
+  TransactionContext(const TransactionID transaction_id, const CommitID snapshot_commit_id);
   ~TransactionContext();
 
   /**
@@ -175,7 +174,6 @@ class TransactionContext : public std::enable_shared_from_this<TransactionContex
  private:
   const TransactionID _transaction_id;
   const CommitID _snapshot_commit_id;
-  const bool _created_by_transaction_manager;
 
   std::vector<std::shared_ptr<AbstractReadWriteOperator>> _rw_operators;
 

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -28,12 +28,12 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
   return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id);
 }
 
-void TransactionManager::register_transaction(const CommitID snapshot_commit_id) {
+void TransactionManager::_register_transaction(const CommitID snapshot_commit_id) {
   std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
   _active_snapshot_commit_ids.insert(snapshot_commit_id);
 }
 
-void TransactionManager::deregister_transaction(const CommitID snapshot_commit_id) {
+void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_id) {
   std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
 
   auto it = std::find(_active_snapshot_commit_ids.begin(), _active_snapshot_commit_ids.end(), snapshot_commit_id);

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -12,7 +12,8 @@ void TransactionManager::reset() {
   manager._next_transaction_id = INITIAL_TRANSACTION_ID;
   manager._last_commit_id = INITIAL_COMMIT_ID;
   manager._last_commit_context = std::make_shared<CommitContext>(INITIAL_COMMIT_ID);
-  manager._active_snapshot_commit_ids.clear();
+  DebugAssert(manager._active_snapshot_commit_ids.empty(),
+              "Some transactions do not seem to have finished yet as they are still registered as active.")
 }
 
 TransactionManager::TransactionManager()
@@ -23,13 +24,16 @@ TransactionManager::TransactionManager()
 CommitID TransactionManager::last_commit_id() const { return _last_commit_id; }
 
 std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context() {
-  std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
   const TransactionID snapshot_commit_id = _last_commit_id;
-  _active_snapshot_commit_ids.insert(snapshot_commit_id);
   return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id);
 }
 
-void TransactionManager::deregister_transaction(CommitID snapshot_commit_id) {
+void TransactionManager::register_transaction(const CommitID snapshot_commit_id) {
+  std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
+  _active_snapshot_commit_ids.insert(snapshot_commit_id);
+}
+
+void TransactionManager::deregister_transaction(const CommitID snapshot_commit_id) {
   std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
 
   auto it =
@@ -40,13 +44,9 @@ void TransactionManager::deregister_transaction(CommitID snapshot_commit_id) {
     return;
   }
 
-  /**
-   * TODO(all) Change Google tests like get_table_test.cpp to always use the TransactionManager for creating
-   * TransactionContexts. After dong that, enable the following check:
-   */
-  //  Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) +
-  //       " Could not find snapshot_commit_id in TransactionManager's _active_snapshot_commit_ids. Therefore," +
-  //       " the removal failed and the function should not have been called.");
+  Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) +
+       " Could not find snapshot_commit_id in TransactionManager's _active_snapshot_commit_ids. Therefore," +
+       " the removal failed and the function should not have been called.");
 }
 
 CommitID TransactionManager::get_lowest_active_snapshot_commit_id() const {

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -26,10 +26,10 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
   std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
   const TransactionID snapshot_commit_id = _last_commit_id;
   _active_snapshot_commit_ids.insert(snapshot_commit_id);
-  return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id, true);
+  return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id);
 }
 
-void TransactionManager::remove_active_snapshot_commit_id(CommitID snapshot_commit_id) {
+void TransactionManager::deregister_transaction(CommitID snapshot_commit_id) {
   std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
 
   auto it =
@@ -39,10 +39,14 @@ void TransactionManager::remove_active_snapshot_commit_id(CommitID snapshot_comm
     _active_snapshot_commit_ids.erase(it);
     return;
   }
-  DebugAssert(false,
-              "Could not find snapshot_commit_id in TransactionManager's "
-              "_active_snapshot_commit_ids. Therefore, the removal failed and "
-              "the function should not have been called.");
+
+  /**
+   * TODO(all) Change Google tests like get_table_test.cpp to always use the TransactionManager for creating
+   * TransactionContexts. After dong that, enable the following check:
+   */
+  //  Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) +
+  //       " Could not find snapshot_commit_id in TransactionManager's _active_snapshot_commit_ids. Therefore," +
+  //       " the removal failed and the function should not have been called.");
 }
 
 CommitID TransactionManager::get_lowest_active_snapshot_commit_id() const {

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -1,6 +1,7 @@
 #include "transaction_manager.hpp"
 
 #include <memory>
+#include <storage/mvcc_data.hpp>
 
 #include "commit_context.hpp"
 #include "transaction_context.hpp"
@@ -13,6 +14,7 @@ void TransactionManager::reset() {
   manager._next_transaction_id = INITIAL_TRANSACTION_ID;
   manager._last_commit_id = INITIAL_COMMIT_ID;
   manager._last_commit_context = std::make_shared<CommitContext>(INITIAL_COMMIT_ID);
+  manager._active_snapshot_commit_ids.clear();
 }
 
 TransactionManager::TransactionManager()
@@ -23,7 +25,32 @@ TransactionManager::TransactionManager()
 CommitID TransactionManager::last_commit_id() const { return _last_commit_id; }
 
 std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context() {
-  return std::make_shared<TransactionContext>(_next_transaction_id++, _last_commit_id);
+  std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
+  TransactionID snapshot_commit_id = _last_commit_id;
+  _active_snapshot_commit_ids.insert(snapshot_commit_id);
+  return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id);
+}
+
+void TransactionManager::remove_active_snapshot_commit_id(CommitID snapshot_commit_id) {
+  std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
+  for (auto it = _active_snapshot_commit_ids.begin(); it != _active_snapshot_commit_ids.end(); ++it) {
+    if (*it == snapshot_commit_id) {
+      it = _active_snapshot_commit_ids.erase(it);
+      return;
+    }
+  }
+  DebugAssert(false,
+              "Could not find snapshot_commit_id in TransactionManager's "
+              "_active_snapshot_commit_ids. Therefore, the removal failed and "
+              "the function should not have been called.")
+}
+
+CommitID TransactionManager::get_lowest_active_snapshot_commit_id() const {
+  std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
+  CommitID lowest_id = MvccData::MAX_COMMIT_ID;
+  for (auto it = _active_snapshot_commit_ids.begin(); it != _active_snapshot_commit_ids.end(); it++)
+    if (*it < lowest_id) lowest_id = *it;
+  return lowest_id;
 }
 
 /**

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -1,9 +1,7 @@
 #include "transaction_manager.hpp"
 
-#include <memory>
-#include <storage/mvcc_data.hpp>
-
 #include "commit_context.hpp"
+#include "storage/mvcc_data.hpp"
 #include "transaction_context.hpp"
 #include "utils/assert.hpp"
 
@@ -28,7 +26,7 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
   std::unique_lock<std::mutex> lock(_mutex_active_snapshot_commit_ids);
   TransactionID snapshot_commit_id = _last_commit_id;
   _active_snapshot_commit_ids.insert(snapshot_commit_id);
-  return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id);
+  return std::make_shared<TransactionContext>(_next_transaction_id++, snapshot_commit_id, true);
 }
 
 void TransactionManager::remove_active_snapshot_commit_id(CommitID snapshot_commit_id) {

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -84,11 +84,11 @@ class TransactionManager : public Singleton<TransactionManager> {
   /**
    * The TransactionManager keeps track of issued snapshot-commit-ids,
    * which are in use by unfinished transactions.
-   * This function adds a snapshot-commit-id to the multiset of active
-   * snapshot commit ids (resp. transactions).
+   * The following two functions are used to keep the multiset of active
+   * snapshot-commit-ids up to date.
    */
-  void register_transaction(CommitID snapshot_commit_id);
-  void deregister_transaction(CommitID snapshot_commit_id);
+  void _register_transaction(CommitID snapshot_commit_id);
+  void _deregister_transaction(CommitID snapshot_commit_id);
 
   std::atomic<TransactionID> _next_transaction_id;
 

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -62,7 +62,7 @@ class TransactionManager : public Singleton<TransactionManager> {
   /**
    * The TransactionManager keeps track of issued snapshot-commit-ids,
    * which are in use by unfinished transactions.
-   * Transactions have to call this function with their snapshot-commit-id
+   * Transactions call this function with their snapshot-commit-id
    * once they have finished (committed or rolled back).
    */
   void remove_active_snapshot_commit_id(CommitID snapshot_commit_id);

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -65,7 +65,7 @@ class TransactionManager : public Singleton<TransactionManager> {
    * Transactions call this function with their snapshot-commit-id
    * once they have finished (committed or rolled back).
    */
-  void remove_active_snapshot_commit_id(CommitID snapshot_commit_id);
+  void deregister_transaction(CommitID snapshot_commit_id);
 
   /**
    * Returns the lowest snapshot-commit-id currently used by a transaction.

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -60,14 +60,6 @@ class TransactionManager : public Singleton<TransactionManager> {
   std::shared_ptr<TransactionContext> new_transaction_context();
 
   /**
-   * The TransactionManager keeps track of issued snapshot-commit-ids,
-   * which are in use by unfinished transactions.
-   * Transactions call this function with their snapshot-commit-id
-   * once they have finished (committed or rolled back).
-   */
-  void deregister_transaction(CommitID snapshot_commit_id);
-
-  /**
    * Returns the lowest snapshot-commit-id currently used by a transaction.
    */
   CommitID get_lowest_active_snapshot_commit_id() const;
@@ -86,6 +78,15 @@ class TransactionManager : public Singleton<TransactionManager> {
 
   std::shared_ptr<CommitContext> _new_commit_context();
   void _try_increment_last_commit_id(const std::shared_ptr<CommitContext>& context);
+
+  /**
+   * The TransactionManager keeps track of issued snapshot-commit-ids,
+   * which are in use by unfinished transactions.
+   * This function adds a snapshot-commit-id to the multiset of active
+   * snapshot commit ids (resp. transactions).
+   */
+  void register_transaction(CommitID snapshot_commit_id);
+  void deregister_transaction(CommitID snapshot_commit_id);
 
   std::atomic<TransactionID> _next_transaction_id;
 

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -49,6 +49,10 @@ class TransactionContext;
  * The TransactionManager is thread-safe.
  */
 class TransactionManager : public Singleton<TransactionManager> {
+  friend class Singleton;
+  friend class TransactionContext;
+  friend class TransactionManagerTest;
+
  public:
   static void reset();
 
@@ -72,9 +76,6 @@ class TransactionManager : public Singleton<TransactionManager> {
 
  private:
   TransactionManager();
-
-  friend class Singleton;
-  friend class TransactionContext;
 
   std::shared_ptr<CommitContext> _new_commit_context();
   void _try_increment_last_commit_id(const std::shared_ptr<CommitContext>& context);

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -49,8 +49,6 @@ class TransactionContext;
  * The TransactionManager is thread-safe.
  */
 class TransactionManager : public Singleton<TransactionManager> {
-  friend class Singleton;
-  friend class TransactionContext;
   friend class TransactionManagerTest;
 
  public:
@@ -66,7 +64,7 @@ class TransactionManager : public Singleton<TransactionManager> {
   /**
    * Returns the lowest snapshot-commit-id currently used by a transaction.
    */
-  CommitID get_lowest_active_snapshot_commit_id() const;
+  std::optional<CommitID> get_lowest_active_snapshot_commit_id() const;
 
   // TransactionID = 0 means "not set" in the MVCC data. This is the case if the row has (a) just been reserved, but
   // not yet filled with content, (b) been inserted, committed and not marked for deletion, or (c) inserted but
@@ -76,6 +74,9 @@ class TransactionManager : public Singleton<TransactionManager> {
 
  private:
   TransactionManager();
+
+  friend class Singleton;
+  friend class TransactionContext;
 
   std::shared_ptr<CommitContext> _new_commit_context();
   void _try_increment_last_commit_id(const std::shared_ptr<CommitContext>& context);

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <unordered_set>
 
 #include "types.hpp"

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <unordered_set>
 
 #include "types.hpp"
 #include "utils/singleton.hpp"
@@ -57,6 +58,19 @@ class TransactionManager : public Singleton<TransactionManager> {
    */
   std::shared_ptr<TransactionContext> new_transaction_context();
 
+  /**
+   * The TransactionManager keeps track of issued snapshot-commit-ids,
+   * which are in use by unfinished transactions.
+   * Transactions have to call this function with their snapshot-commit-id
+   * once they have finished (committed or rolled back).
+   */
+  void remove_active_snapshot_commit_id(CommitID snapshot_commit_id);
+
+  /**
+   * Returns the lowest snapshot-commit-id currently used by a transaction.
+   */
+  CommitID get_lowest_active_snapshot_commit_id() const;
+
   // TransactionID = 0 means "not set" in the MVCC data. This is the case if the row has (a) just been reserved, but
   // not yet filled with content, (b) been inserted, committed and not marked for deletion, or (c) inserted but
   // deleted in the same transaction (which has not yet committed)
@@ -80,5 +94,8 @@ class TransactionManager : public Singleton<TransactionManager> {
   static constexpr auto INITIAL_COMMIT_ID = CommitID{1};
 
   std::shared_ptr<CommitContext> _last_commit_context;
+
+  mutable std::mutex _mutex_active_snapshot_commit_ids;
+  std::unordered_multiset<CommitID> _active_snapshot_commit_ids;
 };
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(
     cache/cache_test.cpp
     concurrency/commit_context_test.cpp
     concurrency/transaction_context_test.cpp
+    concurrency/transaction_manager_test.cpp
     cost_model/cost_estimator_test.cpp
     expression/expression_evaluator_to_pos_list_test.cpp
     expression/expression_evaluator_to_values_test.cpp

--- a/src/test/concurrency/transaction_manager_test.cpp
+++ b/src/test/concurrency/transaction_manager_test.cpp
@@ -35,7 +35,7 @@ TEST_F(TransactionManagerTest, TrackActiveCommitIDs) {
   auto& manager = TransactionManager::get();
 
   EXPECT_EQ(get_active_snapshot_commit_ids().size(), 0);
-  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), std::nullopt);
 
   const auto t1_context = manager.new_transaction_context();
   const auto t2_context = manager.new_transaction_context();
@@ -77,7 +77,7 @@ TEST_F(TransactionManagerTest, TrackActiveCommitIDs) {
   deregister_transaction(t2_context->snapshot_commit_id());
 
   EXPECT_EQ(get_active_snapshot_commit_ids().size(), 0);
-  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), MvccData::MAX_COMMIT_ID);
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), std::nullopt);
 
   // To prevent exceptions in TransactionContext destructor
   register_transaction(t1_snapshot_commit_id);

--- a/src/test/concurrency/transaction_manager_test.cpp
+++ b/src/test/concurrency/transaction_manager_test.cpp
@@ -18,10 +18,10 @@ class TransactionManagerTest : public BaseTest {
   }
 
   static void register_transaction(CommitID snapshot_commit_id) {
-    TransactionManager::get().register_transaction(snapshot_commit_id);
+    TransactionManager::get()._register_transaction(snapshot_commit_id);
   }
   static void deregister_transaction(CommitID snapshot_commit_id) {
-    TransactionManager::get().deregister_transaction(snapshot_commit_id);
+    TransactionManager::get()._deregister_transaction(snapshot_commit_id);
   }
 };
 

--- a/src/test/concurrency/transaction_manager_test.cpp
+++ b/src/test/concurrency/transaction_manager_test.cpp
@@ -1,0 +1,88 @@
+#include <algorithm>
+#include <vector>
+
+#include "base_test.hpp"
+#include "gtest/gtest.h"
+
+#include "concurrency/transaction_context.hpp"
+#include "concurrency/transaction_manager.hpp"
+
+namespace opossum {
+
+class TransactionManagerTest : public BaseTest {
+ protected:
+  void SetUp() override {}
+
+  static std::unordered_multiset<CommitID>& get_active_snapshot_commit_ids() {
+    return TransactionManager::get()._active_snapshot_commit_ids;
+  }
+
+  static void register_transaction(CommitID snapshot_commit_id) {
+    TransactionManager::get().register_transaction(snapshot_commit_id);
+  }
+  static void deregister_transaction(CommitID snapshot_commit_id) {
+    TransactionManager::get().deregister_transaction(snapshot_commit_id);
+  }
+};
+
+/** Check if all active snapshot commit ids of uncommitted
+ * transaction contexts are tracked correctly.
+ * Normally, deregister_transaction() is called in the
+ * destructor of the transaction context but is called
+ * manually for this test.
+ */
+TEST_F(TransactionManagerTest, TrackActiveCommitIDs) {
+  auto& manager = TransactionManager::get();
+
+  EXPECT_EQ(get_active_snapshot_commit_ids().size(), 0);
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), MvccData::MAX_COMMIT_ID);
+
+  const auto t1_context = manager.new_transaction_context();
+  const auto t2_context = manager.new_transaction_context();
+  const auto t3_context = manager.new_transaction_context();
+
+  const CommitID t1_snapshot_commit_id = t1_context->snapshot_commit_id();
+  const CommitID t2_snapshot_commit_id = t2_context->snapshot_commit_id();
+  const CommitID t3_snapshot_commit_id = t3_context->snapshot_commit_id();
+  const auto vec = std::vector<CommitID>{t1_snapshot_commit_id, t2_snapshot_commit_id, t3_snapshot_commit_id};
+
+  EXPECT_EQ(get_active_snapshot_commit_ids().size(), 3);
+  EXPECT_TRUE(std::find(get_active_snapshot_commit_ids().cbegin(), get_active_snapshot_commit_ids().cend(),
+                        t1_snapshot_commit_id) != get_active_snapshot_commit_ids().cend());
+  EXPECT_TRUE(std::find(get_active_snapshot_commit_ids().cbegin(), get_active_snapshot_commit_ids().cend(),
+                        t2_snapshot_commit_id) != get_active_snapshot_commit_ids().cend());
+  EXPECT_TRUE(std::find(get_active_snapshot_commit_ids().cbegin(), get_active_snapshot_commit_ids().cend(),
+                        t3_snapshot_commit_id) != get_active_snapshot_commit_ids().cend());
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), *std::min_element(vec.cbegin(), vec.cend()));
+
+  t1_context->commit();
+  deregister_transaction(t1_context->snapshot_commit_id());
+
+  EXPECT_EQ(get_active_snapshot_commit_ids().size(), 2);
+  EXPECT_TRUE(std::find(get_active_snapshot_commit_ids().cbegin(), get_active_snapshot_commit_ids().cend(),
+                        t1_context->snapshot_commit_id()) != get_active_snapshot_commit_ids().cend());
+  EXPECT_TRUE(std::find(get_active_snapshot_commit_ids().cbegin(), get_active_snapshot_commit_ids().cend(),
+                        t3_context->snapshot_commit_id()) != get_active_snapshot_commit_ids().cend());
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), t2_context->snapshot_commit_id());
+
+  t3_context->commit();
+  deregister_transaction(t3_context->snapshot_commit_id());
+
+  EXPECT_EQ(get_active_snapshot_commit_ids().size(), 1);
+  EXPECT_TRUE(std::find(get_active_snapshot_commit_ids().cbegin(), get_active_snapshot_commit_ids().cend(),
+                        t2_context->snapshot_commit_id()) != get_active_snapshot_commit_ids().cend());
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), t2_context->snapshot_commit_id());
+
+  t2_context->commit();
+  deregister_transaction(t2_context->snapshot_commit_id());
+
+  EXPECT_EQ(get_active_snapshot_commit_ids().size(), 0);
+  EXPECT_EQ(manager.get_lowest_active_snapshot_commit_id(), MvccData::MAX_COMMIT_ID);
+
+  // To prevent exceptions in TransactionContext destructor
+  register_transaction(t1_snapshot_commit_id);
+  register_transaction(t2_snapshot_commit_id);
+  register_transaction(t3_snapshot_commit_id);
+}
+
+}  // namespace opossum


### PR DESCRIPTION
Our upcoming MvccDeletePlugin (DYOD18/19 project) requires some changes within hyrise.

- `TransactionManager` needs to keep track of running transactions resp. the snapshot-commit-ids being in use. 
This allows our MvccDeletePlugin to make sure that an already logically deleted chunk (fully invalidated) can be deleted physically (from memory) as well – without interfering with ongoing transactions.
- `TransactionContext` notifies `TransactionManager` that the transaction has finished. So the `TransactionManager` can "release" the snapshot-commit-id

 