### PR TITLE
Fix concurrent access to _chunks

### DIFF
--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -167,7 +167,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
     mvcc_data = std::make_shared<MvccData>(chunk_size);
   }
 
-  _chunks.emplace_back(std::make_shared<Chunk>(segments, mvcc_data, alloc, access_counter));
+  _chunks.push_back(std::make_shared<Chunk>(segments, mvcc_data, alloc, access_counter));
 }
 
 void Table::append_chunk(const std::shared_ptr<Chunk>& chunk) {
@@ -188,7 +188,7 @@ void Table::append_chunk(const std::shared_ptr<Chunk>& chunk) {
   DebugAssert(chunk->has_mvcc_data() == (_use_mvcc == UseMvcc::Yes),
               "Chunk does not have the same MVCC setting as the table.");
 
-  _chunks.emplace_back(chunk);
+  _chunks.push_back(chunk);
 }
 
 std::unique_lock<std::mutex> Table::acquire_append_mutex() { return std::unique_lock<std::mutex>(*_append_mutex); }

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -118,7 +118,7 @@ bool Table::empty() const { return row_count() == 0u; }
 
 ChunkID Table::chunk_count() const { return ChunkID{static_cast<ChunkID::base_type>(_chunks.size())}; }
 
-const std::vector<std::shared_ptr<Chunk>>& Table::chunks() const { return _chunks; }
+const tbb::concurrent_vector<std::shared_ptr<Chunk>>& Table::chunks() const { return _chunks; }
 
 uint32_t Table::max_chunk_size() const { return _max_chunk_size; }
 

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -80,7 +80,7 @@ class Table : private Noncopyable {
   ChunkID chunk_count() const;
 
   // Returns all Chunks
-  const std::vector<std::shared_ptr<Chunk>>& chunks() const;
+  const tbb::concurrent_vector<std::shared_ptr<Chunk>>& chunks() const;
 
   // returns the chunk with the given id
   std::shared_ptr<Chunk> get_chunk(ChunkID chunk_id);
@@ -171,7 +171,7 @@ class Table : private Noncopyable {
   const TableType _type;
   const UseMvcc _use_mvcc;
   const uint32_t _max_chunk_size;
-  std::vector<std::shared_ptr<Chunk>> _chunks;
+  tbb::concurrent_vector<std::shared_ptr<Chunk>> _chunks;
   std::shared_ptr<TableStatistics> _table_statistics;
   std::unique_ptr<std::mutex> _append_mutex;
   std::vector<IndexInfo> _indexes;

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -193,8 +193,8 @@ TEST_F(StorageTableTest, StableChunks) {
 
   // The vector should have been resized / expanded by now
 
-  (*first_chunk->get_segment(ColumnID{0}))[0];
-
+  // first_chunk is a reference to a shared_ptr in the vector. If the vector's contents have moved, the reference
+  // would no longer be valid and the following will fail:
   EXPECT_EQ(first_chunk, table->chunks()[0]);
   EXPECT_EQ((*first_chunk->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -185,7 +185,8 @@ TEST_F(StorageTableTest, StableChunks) {
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 1);
   table->append({100, "Hello"});
 
-  const auto& first_chunk = table->chunks()[0];
+  // The address of the first shared_ptr control object
+  const auto first_chunk = &table->chunks()[0];
 
   for (auto i = 1; i < 10; ++i) {
     table->append({i, "Hello"});
@@ -193,10 +194,8 @@ TEST_F(StorageTableTest, StableChunks) {
 
   // The vector should have been resized / expanded by now
 
-  // first_chunk is a reference to a shared_ptr in the vector. If the vector's contents have moved, the reference
-  // would no longer be valid and the following will fail:
-  EXPECT_EQ(first_chunk, table->chunks()[0]);
-  EXPECT_EQ((*first_chunk->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
+  EXPECT_EQ(first_chunk, &table->chunks()[0]);
+  EXPECT_EQ(((*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }
 
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -195,7 +195,7 @@ TEST_F(StorageTableTest, StableChunks) {
   // The vector should have been resized / expanded by now
 
   EXPECT_EQ(first_chunk, &table->chunks()[0]);
-  EXPECT_EQ(*((*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
+  EXPECT_EQ((*(*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }
 
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -180,4 +180,24 @@ TEST_F(StorageTableTest, MemoryUsageEstimation) {
                                                      sizeof(TransactionID) + 2 * sizeof(CommitID));
 }
 
+TEST_F(StorageTableTest, StableChunks) {
+  // Tests that pointers to a chunk remain valid even if the table grows (#1463)
+  auto table = std::make_shared<Table>(column_definitions, TableType::Data, 1);
+  table->append({100, "Hello"});
+
+  const auto& first_chunk = table->chunks()[0];
+
+  for (auto i = 1; i < 10; ++i) {
+    table->append({i, "Hello"});
+  }
+
+  // The vector should have been resized / expanded by now
+
+  (*first_chunk->get_segment(ColumnID{0}))[0];
+
+  EXPECT_EQ(first_chunk, table->chunks()[0]);
+  EXPECT_EQ((*first_chunk->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
+}
+
+
 }  // namespace opossum

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -195,7 +195,7 @@ TEST_F(StorageTableTest, StableChunks) {
   // The vector should have been resized / expanded by now
 
   EXPECT_EQ(first_chunk, &table->chunks()[0]);
-  EXPECT_EQ(((*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
+  EXPECT_EQ(*((*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }
 
 


### PR DESCRIPTION
fixes #1463 

Not optimal and we might want to revisit this, but at least it doesn't break anymore.

```
+-----------+-----------------+------+-----------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s    | runs | new iter/s      | runs | change | p-value (significant if <0.001) |
+-----------+-----------------+------+-----------------+------+--------+---------------------------------+
| TPC-H 1   | 0.6128718853    | 37   | 0.579127073288  | 35   | -6%    |                          0.0000 |
| TPC-H 2   | 8.59151172638   | 516  | 8.31142425537   | 499  | -3%    |                          0.0000 |
| TPC-H 3   | 6.95756530762   | 418  | 6.60669755936   | 397  | -5%    |                          0.0000 |
| TPC-H 4   | 2.13772106171   | 129  | 2.14647006989   | 129  | +0%    |                          0.1393 |
| TPC-H 5   | 4.4478187561    | 267  | 4.22858667374   | 254  | -5%    |                          0.0000 |
| TPC-H 6   | 15.8865213394   | 954  | 15.4344005585   | 927  | -3%    |                          0.0000 |
| TPC-H 7   | 1.42654454708   | 86   | 1.40942430496   | 85   | -1%    |                          0.0014 |
| TPC-H 8   | 5.90418624878   | 355  | 5.48630237579   | 330  | -7%    |                          0.0000 |
| TPC-H 9   | 1.63775336742   | 99   | 1.50495541096   | 91   | -8%    |                          0.0000 |
| TPC-H 10  | 2.80638980865   | 169  | 2.68618774414   | 162  | -4%    |                          0.0000 |
| TPC-H 11  | 34.190486908    | 2052 | 32.7052688599   | 1963 | -4%    |                          0.0000 |
| TPC-H 12  | 7.83901643753   | 471  | 7.57066488266   | 455  | -3%    |                          0.0000 |
| TPC-H 13  | 2.09237933159   | 126  | 2.06458282471   | 124  | -1%    |                          0.0886 |
| TPC-H 14  | 17.5334644318   | 1053 | 16.0108528137   | 961  | -9%    |                          0.0000 |
| TPC-H 15  | 10.7580623627   | 646  | 12.2548885345   | 736  | +14%   |                          0.0000 |
| TPC-H 16  | 7.5523648262    | 454  | 7.37716007233   | 443  | -2%    |                          0.0000 |
| TPC-H 17  | 0.12925042212   | 8    | 0.128209486604  | 8    | -1%    |        (not enough runs) 0.8309 |
| TPC-H 18  | 1.89410257339   | 114  | 1.84474253654   | 111  | -3%    |                          0.0059 |
| TPC-H 19  | 5.57891225815   | 335  | 5.50950908661   | 331  | -1%    |                          0.0000 |
| TPC-H 20  | 0.0698382630944 | 5    | 0.0679370760918 | 5    | -3%    |        (not enough runs) 0.2858 |
| TPC-H 21  | 0.127069339156  | 8    | 0.11686129868   | 8    | -8%    |        (not enough runs) 0.0016 |
| TPC-H 22  | 16.5995578766   | 996  | 16.6294517517   | 998  | +0%    |                          0.1882 |
| average   |                 |      |                 |      | -3%    |                                 |
+-----------+-----------------+------+-----------------+------+--------+---------------------------------+
```