### PR TITLE
Fix false call in jemalloc build

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -173,9 +173,9 @@ externalproject_add(
     # Executing autoconf and the configure script with suppressed output, only printing it in case of non-zero return
     CONFIGURE_COMMAND bash -c "cd <SOURCE_DIR> && if [ ! -f ./configure ] $<SEMICOLON> then autoconf $<SEMICOLON> fi && \
                                cd <BINARY_DIR> && output=$(<SOURCE_DIR>/configure --prefix=<BINARY_DIR> 2>&1) || \
-                               (printf \"$output\\n\" && /usr/bin/false)"
-    BUILD_COMMAND bash -c "output=$(make 2>&1) || (printf \"$output\\n\" && /usr/bin/false)"
-    INSTALL_COMMAND /usr/bin/false  # install should never be called, this is a safe guard that fails if it is
+                               (printf \"$output\\n\" && false)"
+    BUILD_COMMAND bash -c "output=$(make 2>&1) || (printf \"$output\\n\" && false)"
+    INSTALL_COMMAND false  # install should never be called, this is a safe guard that fails if it is
     STEP_TARGETS build
     BUILD_BYPRODUCTS ${JEMALLOC_LIB_PATH}
 )


### PR DESCRIPTION
references #1448 ([comment](https://github.com/hyrise/hyrise/issues/1448#issuecomment-460221250))

On Ubuntu (e.g., the build vms for the DYOD seminar) the following does not work:
`BUILD_COMMAND bash -c "output=$(make 2>&1) || (printf \"$output\\n\" && /usr/bin/false)"`

The false binary is located in `/usr/bin/false` on macOS while it is located in `/bin/false` on linux (or at least ubuntu).

This PR just uses `false` instead.