### PR TITLE
Fix ColumnPruningRule for Insert and Delete

### DIFF
--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -22,8 +22,8 @@ std::string DeleteNode::description() const {
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& DeleteNode::column_expressions() const {
-  static std::vector<std::shared_ptr<AbstractExpression>> dummy_column_expressions;
-  return dummy_column_expressions;
+  static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
+  return empty_vector;
 }
 
 std::shared_ptr<AbstractLQPNode> DeleteNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -21,6 +21,10 @@ std::string DeleteNode::description() const {
 
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 
+const std::vector<std::shared_ptr<AbstractExpression>>& DeleteNode::column_expressions() const {
+  return _dummy_column_expressions;
+}
+
 std::shared_ptr<AbstractLQPNode> DeleteNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return DeleteNode::make();
 }

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -22,7 +22,8 @@ std::string DeleteNode::description() const {
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& DeleteNode::column_expressions() const {
-  return _dummy_column_expressions;
+  static std::vector<std::shared_ptr<AbstractExpression>> dummy_column_expressions;
+  return dummy_column_expressions;
 }
 
 std::shared_ptr<AbstractLQPNode> DeleteNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -21,10 +21,6 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
-
- private:
-  // Always empty
-  std::vector<std::shared_ptr<AbstractExpression>> _dummy_column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -16,10 +16,15 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
 
   std::string description() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
+  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+
+ private:
+  // Always empty
+  std::vector<std::shared_ptr<AbstractExpression>> _dummy_column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -23,8 +23,8 @@ std::string InsertNode::description() const {
 bool InsertNode::is_column_nullable(const ColumnID column_id) const { Fail("Insert returns no columns"); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& InsertNode::column_expressions() const {
-  static std::vector<std::shared_ptr<AbstractExpression>> dummy_column_expressions;
-  return dummy_column_expressions;
+  static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
+  return empty_vector;
 }
 
 std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -23,7 +23,8 @@ std::string InsertNode::description() const {
 bool InsertNode::is_column_nullable(const ColumnID column_id) const { Fail("Insert returns no columns"); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& InsertNode::column_expressions() const {
-  return _dummy_column_expressions;
+  static std::vector<std::shared_ptr<AbstractExpression>> dummy_column_expressions;
+  return dummy_column_expressions;
 }
 
 std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -22,6 +22,10 @@ std::string InsertNode::description() const {
 
 bool InsertNode::is_column_nullable(const ColumnID column_id) const { Fail("Insert returns no columns"); }
 
+const std::vector<std::shared_ptr<AbstractExpression>>& InsertNode::column_expressions() const {
+  return _dummy_column_expressions;
+}
+
 std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return InsertNode::make(table_name);
 }

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -17,12 +17,17 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
 
   std::string description() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
+  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 
   const std::string table_name;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+
+ private:
+  // Always empty
+  std::vector<std::shared_ptr<AbstractExpression>> _dummy_column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -24,10 +24,6 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
-
- private:
-  // Always empty
-  std::vector<std::shared_ptr<AbstractExpression>> _dummy_column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -26,6 +26,10 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
+const std::vector<std::shared_ptr<AbstractExpression>>& UpdateNode::column_expressions() const {
+  return _dummy_column_expressions;
+}
+
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& update_node_rhs = static_cast<const UpdateNode&>(rhs);
   return table_name == update_node_rhs.table_name;

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -27,8 +27,8 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& UpdateNode::column_expressions() const {
-  static std::vector<std::shared_ptr<AbstractExpression>> dummy_column_expressions;
-  return dummy_column_expressions;
+  static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
+  return empty_vector;
 }
 
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -27,7 +27,8 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& UpdateNode::column_expressions() const {
-  return _dummy_column_expressions;
+  static std::vector<std::shared_ptr<AbstractExpression>> dummy_column_expressions;
+  return dummy_column_expressions;
 }
 
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -26,10 +26,6 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
-
- private:
-  // Always empty
-  std::vector<std::shared_ptr<AbstractExpression>> _dummy_column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,12 +19,17 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
 
   std::string description() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
+  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 
   const std::string table_name;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+
+ private:
+  // Always empty
+  std::vector<std::shared_ptr<AbstractExpression>> _dummy_column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -55,6 +55,8 @@ ExpressionUnorderedSet ColumnPruningRule::_collect_actually_used_columns(const s
   // the "functioning" of the LQP.
   visit_lqp(lqp, [&](const auto& node) {
     switch (node->type) {
+      // For the vast majority of node types, recursing through AbstractLQPNode::node_expression
+      // correctly yields all Columns used by this node.
       case LQPNodeType::Aggregate:
       case LQPNodeType::Alias:
       case LQPNodeType::CreateTable:
@@ -89,7 +91,7 @@ ExpressionUnorderedSet ColumnPruningRule::_collect_actually_used_columns(const s
         }
       } break;
 
-        // No pruning of the input columns to Delete, Update and Insert, they need them all.
+      // No pruning of the input columns to Delete, Update and Insert, they need them all.
       case LQPNodeType::Delete:
       case LQPNodeType::Insert:
       case LQPNodeType::Update: {

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -51,31 +51,56 @@ ExpressionUnorderedSet ColumnPruningRule::_collect_actually_used_columns(const s
     });
   };
 
-  // Search the entire LQP for columns used in the node expressions, i.e. columns that are necessary for
+  // Search the entire LQP for columns used in the node expressions, i.e. search for columns that are necessary for
   // the "functioning" of the LQP.
-  // For ProjectionNodes, ignore forwarded columns (since they would include all columns and we wouldn't be able to
-  // prune) by only searching the arguments of expression.
   visit_lqp(lqp, [&](const auto& node) {
-    for (const auto& expression : node->node_expressions) {
-      if (node->type == LQPNodeType::Projection) {
-        for (const auto& argument : expression->arguments) {
-          collect_consumed_columns_from_expression(argument);
+    switch (node->type) {
+      case LQPNodeType::Aggregate:
+      case LQPNodeType::Alias:
+      case LQPNodeType::CreateTable:
+      case LQPNodeType::CreatePreparedPlan:
+      case LQPNodeType::CreateView:
+      case LQPNodeType::DropView:
+      case LQPNodeType::DropTable:
+      case LQPNodeType::DummyTable:
+      case LQPNodeType::Join:
+      case LQPNodeType::Limit:
+      case LQPNodeType::Predicate:
+      case LQPNodeType::Root:
+      case LQPNodeType::ShowColumns:
+      case LQPNodeType::ShowTables:
+      case LQPNodeType::Sort:
+      case LQPNodeType::StoredTable:
+      case LQPNodeType::Union:
+      case LQPNodeType::Validate:
+      case LQPNodeType::Mock: {
+        for (const auto& expression : node->node_expressions) {
+          collect_consumed_columns_from_expression(expression);
         }
-      } else {
-        collect_consumed_columns_from_expression(expression);
-      }
-    }
+      } break;
 
-    // No pruning of the input columns to Update and Insert, they need them all.
-    if (const auto update_node = std::dynamic_pointer_cast<UpdateNode>(node)) {
-      const auto& left_input_expressions = update_node->left_input()->column_expressions();
-      consumed_columns.insert(left_input_expressions.begin(), left_input_expressions.end());
+      // For ProjectionNodes, ignore forwarded columns (since they would include all columns and we wouldn't be able to
+      // prune) by only searching the arguments of expression.
+      case LQPNodeType::Projection: {
+        for (const auto& expression : node->node_expressions) {
+          for (const auto& argument : expression->arguments) {
+            collect_consumed_columns_from_expression(argument);
+          }
+        }
+      } break;
 
-      const auto& right_input_expressions = update_node->right_input()->column_expressions();
-      consumed_columns.insert(right_input_expressions.begin(), right_input_expressions.end());
-    } else if (const auto insert_node = std::dynamic_pointer_cast<UpdateNode>(node)) {
-      const auto& expressions = insert_node->right_input()->column_expressions();
-      consumed_columns.insert(expressions.begin(), expressions.end());
+        // No pruning of the input columns to Delete, Update and Insert, they need them all.
+      case LQPNodeType::Delete:
+      case LQPNodeType::Insert:
+      case LQPNodeType::Update: {
+        const auto& left_input_expressions = node->left_input()->column_expressions();
+        consumed_columns.insert(left_input_expressions.begin(), left_input_expressions.end());
+
+        if (node->right_input()) {
+          const auto& right_input_expressions = node->right_input()->column_expressions();
+          consumed_columns.insert(right_input_expressions.begin(), right_input_expressions.end());
+        }
+      } break;
     }
 
     return LQPVisitation::VisitInputs;

--- a/src/test/logical_query_plan/delete_node_test.cpp
+++ b/src/test/logical_query_plan/delete_node_test.cpp
@@ -21,7 +21,9 @@ TEST_F(DeleteNodeTest, Equals) {
   EXPECT_EQ(*_delete_node, *another_delete_node);
 }
 
-TEST_F(DeleteNodeTest, NodeExpressions) { ASSERT_EQ(_delete_node->node_expressions.size(), 0u); }
+TEST_F(DeleteNodeTest, NodeExpressions) { EXPECT_TRUE(_delete_node->node_expressions.empty()); }
+
+TEST_F(DeleteNodeTest, ColumnExpressions) { EXPECT_TRUE(_delete_node->column_expressions().empty()); }
 
 TEST_F(DeleteNodeTest, Copy) { EXPECT_EQ(*_delete_node, *_delete_node->deep_copy()); }
 

--- a/src/test/logical_query_plan/insert_node_test.cpp
+++ b/src/test/logical_query_plan/insert_node_test.cpp
@@ -26,6 +26,8 @@ TEST_F(InsertNodeTest, Equals) {
   EXPECT_NE(*_insert_node, *InsertNode::make("table_b"));
 }
 
-TEST_F(InsertNodeTest, NodeExpressions) { ASSERT_EQ(_insert_node->node_expressions.size(), 0u); }
+TEST_F(InsertNodeTest, NodeExpressions) { EXPECT_TRUE(_insert_node->node_expressions.empty()); }
+
+TEST_F(InsertNodeTest, ColumnExpressions) { EXPECT_TRUE(_insert_node->column_expressions().empty()); }
 
 }  // namespace opossum

--- a/src/test/logical_query_plan/update_node_test.cpp
+++ b/src/test/logical_query_plan/update_node_test.cpp
@@ -43,4 +43,6 @@ TEST_F(UpdateNodeTest, Copy) { EXPECT_EQ(*_update_node->deep_copy(), *_update_no
 
 TEST_F(UpdateNodeTest, NodeExpressions) { ASSERT_TRUE(_update_node->node_expressions.empty()); }
 
+TEST_F(UpdateNodeTest, ColumnExpressions) { EXPECT_TRUE(_update_node->column_expressions().empty()); }
+
 }  // namespace opossum

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
+#include "logical_query_plan/delete_node.hpp"
 #include "logical_query_plan/insert_node.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -151,6 +152,22 @@ TEST_F(ColumnPruningRuleTest, DoNotPruneInsertInputs) {
   // clang-format off
   const auto lqp =
   InsertNode::make("dummy",
+   PredicateNode::make(greater_than_(a, 5),
+     node_a));
+  // clang-format on
+
+  const auto expected_lqp = lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(ColumnPruningRuleTest, DoNotPruneDeleteInputs) {
+  // Do not prune away input columns to Delete, Delete needs them all
+
+  // clang-format off
+  const auto lqp =
+  DeleteNode::make(
    PredicateNode::make(greater_than_(a, 5),
      node_a));
   // clang-format on

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -152,8 +152,8 @@ TEST_F(ColumnPruningRuleTest, DoNotPruneInsertInputs) {
   // clang-format off
   const auto lqp =
   InsertNode::make("dummy",
-   PredicateNode::make(greater_than_(a, 5),
-     node_a));
+    PredicateNode::make(greater_than_(a, 5),
+      node_a));
   // clang-format on
 
   const auto expected_lqp = lqp->deep_copy();
@@ -168,8 +168,8 @@ TEST_F(ColumnPruningRuleTest, DoNotPruneDeleteInputs) {
   // clang-format off
   const auto lqp =
   DeleteNode::make(
-   PredicateNode::make(greater_than_(a, 5),
-     node_a));
+    PredicateNode::make(greater_than_(a, 5),
+      node_a));
   // clang-format on
 
   const auto expected_lqp = lqp->deep_copy();


### PR DESCRIPTION
Fix #1440

There was already a ColumnPruningRule test for Insert, but it did not fail because, by coincidence, another bug fixed things: The Delete/Insert/UpdateNodes were assumed to output all their input columns, causing the ColumnPruningRule to not prune in LQPs with Insert/Update/DeleteNodes. Actually, the Delete/Insert/Update **operators** return a nullptr, which is now reflected in the LQP as well.