### PR TITLE
Fix query_analyzer.stp and remove TaskQueue::_num_tasks

### DIFF
--- a/resources/tracer_scripts/query_analyzer.stp
+++ b/resources/tracer_scripts/query_analyzer.stp
@@ -33,7 +33,7 @@ probe begin
 // Creation of a new SQL pipeline has started
 probe process(@1).provider("HYRISE").mark("CREATE_PIPELINE")
 {
-    pipeline_creation_time[$arg1] = gettimeofday_us()
+    pipeline_creation_time[$arg1] = gettimeofday_ns()
 }
 
 // SQL string parsing
@@ -45,10 +45,10 @@ probe process(@1).provider("HYRISE").mark("SQL_PARSING")
 // Pipeline creation done
 probe process(@1).provider("HYRISE").mark("PIPELINE_CREATION_DONE")
 {
-    creation_time = gettimeofday_us() - pipeline_creation_time[$arg3]
-    printf("\nSQL parsed within %i μs\n"
+    creation_time = gettimeofday_ns() - pipeline_creation_time[$arg3]
+    printf("\nSQL parsed within %i ns\n"
            "Statement contains %i statement(s)\n"
-           "Overall pipeline creation time: %i μs\n\n", parsing_time[user_string($arg2)], $arg1, creation_time);
+           "Overall pipeline creation time: %i ns\n\n", parsing_time[user_string($arg2)], $arg1, creation_time);
 }
 
 // This probe gets executed as soon as a query fully executed
@@ -58,12 +58,12 @@ probe process(@1).provider("HYRISE").mark("SUMMARY")
         printf("\n================================================================\n"
                "SUMMARY:\nQuery: %s\n"
                "----------------------------------------------------------------\n"
-               "\tTranslation time: %i μs\n"
-               "\tOptimization time: %i μs\n"
-               "\tLQP translation time: %i μs\n"
+               "\tTranslation time: %i ns\n"
+               "\tOptimization time: %i ns\n"
+               "\tLQP translation time: %i ns\n"
                "\tQuery plan cached: %s\n"
                "\tAmount of tasks initially scheduled: %i\n"
-               "\tQuery execution time: %i μs\n"
+               "\tQuery execution time: %i ns\n"
                "\tOperator execution times (preserved order):\n"
                , user_string($arg1), $arg2, $arg3, $arg4, $arg6 ? "yes" : "no", $arg7, $arg5
             )
@@ -72,7 +72,7 @@ probe process(@1).provider("HYRISE").mark("SUMMARY")
         foreach (task_id = [tid, counter+] in task_list) {
             if (tasks_for_specific_id == tid) {
                 operator_id = operator_task_list[task_id]
-                printf("\t\t%s: %i μs        Fetched %i row(s) / %i chunk(s)\n", 
+                printf("\t\t%s: %i ns        Fetched %i row(s) / %i chunk(s)\n",
                     operator_name[operator_id],
                     operator_statistics[operator_id, "runtime"],
                     operator_statistics[operator_id, "rows"],
@@ -116,7 +116,7 @@ probe process(@1).provider("HYRISE").mark("OPERATOR_EXECUTED")
     operator_statistics[$arg5, "runtime"] = $arg2
     operator_statistics[$arg5, "rows"] = $arg3
     operator_statistics[$arg5, "chunks"] = $arg4
-    if (debug) printf("(debug) Operator %s executed : %i μs\n", user_string($arg1), $arg2)
+    if (debug) printf("(debug) Operator %s executed : %i ns\n", user_string($arg1), $arg2)
 }
 
 probe process(@1).provider("HYRISE").mark("OPERATOR_STARTED")

--- a/src/lib/scheduler/task_queue.cpp
+++ b/src/lib/scheduler/task_queue.cpp
@@ -10,7 +10,12 @@ namespace opossum {
 
 TaskQueue::TaskQueue(NodeID node_id) : _node_id(node_id) {}
 
-bool TaskQueue::empty() const { return _num_tasks == 0; }
+bool TaskQueue::empty() const {
+  for (const auto& queue : _queues) {
+    if (!queue.empty()) return false;
+  }
+  return true;
+}
 
 NodeID TaskQueue::node_id() const { return _node_id; }
 
@@ -23,14 +28,12 @@ void TaskQueue::push(const std::shared_ptr<AbstractTask>& task, uint32_t priorit
   task->set_node_id(_node_id);
   _queues[priority].push(task);
 
-  _num_tasks++;
 }
 
 std::shared_ptr<AbstractTask> TaskQueue::pull() {
   std::shared_ptr<AbstractTask> task;
   for (auto& queue : _queues) {
     if (queue.try_pop(task)) {
-      _num_tasks--;
       return task;
     }
   }
@@ -42,7 +45,6 @@ std::shared_ptr<AbstractTask> TaskQueue::steal() {
   for (auto& queue : _queues) {
     if (queue.try_pop(task)) {
       if (task->is_stealable()) {
-        _num_tasks--;
         return task;
       } else {
         queue.push(task);

--- a/src/lib/scheduler/task_queue.cpp
+++ b/src/lib/scheduler/task_queue.cpp
@@ -27,7 +27,6 @@ void TaskQueue::push(const std::shared_ptr<AbstractTask>& task, uint32_t priorit
 
   task->set_node_id(_node_id);
   _queues[priority].push(task);
-
 }
 
 std::shared_ptr<AbstractTask> TaskQueue::pull() {

--- a/src/lib/scheduler/task_queue.hpp
+++ b/src/lib/scheduler/task_queue.hpp
@@ -40,7 +40,6 @@ class TaskQueue {
  private:
   NodeID _node_id;
   std::array<tbb::concurrent_queue<std::shared_ptr<AbstractTask>>, NUM_PRIORITY_LEVELS> _queues;
-  std::atomic_uint _num_tasks{0};
 };
 
 }  // namespace opossum


### PR DESCRIPTION
This issue addresses two small things I found during my work on hyrise.

1) Since PR #1419 operator performance is measured in nanoseconds. The SystemTap script `query_analyzer.stp` uses this information but has not been updated from microseconds to nanoseconds. (Other scripts are not effected)

2) In `TaskQueue` class we currently count the amount of tasks present in the node's queues. We increment/decrement `std::atomic_uint _num_tasks` whenever a task is pushed to/pulled from the queue. However, this variable is only accessed in `TaskQueue::empty()`. Indeed, this method is only called once - in a DebugAssert (node_queue_scheduler.cpp:72).