### PR TITLE
Optimizer: store rules as unique_ptr

### DIFF
--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -490,7 +490,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("w,warmup", "Number of seconds that each query is run for warm up", cxxopts::value<size_t>()->default_value("0")) // NOLINT
     ("o,output", "File to output results to, don't specify for stdout", cxxopts::value<std::string>()->default_value("")) // NOLINT
     ("m,mode", "IndividualQueries or PermutedQuerySet, default is IndividualQueries", cxxopts::value<std::string>()->default_value("IndividualQueries")) // NOLINT
-    ("e,encoding", "Specify Chunk encoding as a string or as a JSON config file (for more detailed configuration, see below). String options: " + encoding_strings_option, cxxopts::value<std::string>()->default_value("Dictionary"))  // NOLINT
+    ("e,encoding", "Specify Chunk encoding as a string or as a JSON config file (for more detailed configuration, see --full_help). String options: " + encoding_strings_option, cxxopts::value<std::string>()->default_value("Dictionary"))  // NOLINT
     ("compression", "Specify vector compression as a string. Options: " + compression_strings_option, cxxopts::value<std::string>()->default_value(""))  // NOLINT
     ("scheduler", "Enable or disable the scheduler", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("cores", "Specify the number of cores used by the scheduler (if active). 0 means all available cores", cxxopts::value<uint>()->default_value("0")) // NOLINT

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -87,33 +87,33 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   auto optimizer = std::make_shared<Optimizer>();
 
   // Run pruning just once since the rule would otherwise insert the pruning ProjectionNodes multiple times.
-  optimizer->add_rule(std::make_shared<ConstantCalculationRule>());
+  optimizer->add_rule(std::make_unique<ConstantCalculationRule>());
 
-  optimizer->add_rule(std::make_shared<LogicalReductionRule>());
+  optimizer->add_rule(std::make_unique<LogicalReductionRule>());
 
-  optimizer->add_rule(std::make_shared<ColumnPruningRule>());
+  optimizer->add_rule(std::make_unique<ColumnPruningRule>());
 
-  optimizer->add_rule(std::make_shared<ExistsReformulationRule>());
+  optimizer->add_rule(std::make_unique<ExistsReformulationRule>());
 
-  optimizer->add_rule(std::make_shared<InsertLimitInExistsRule>());
+  optimizer->add_rule(std::make_unique<InsertLimitInExistsRule>());
 
-  optimizer->add_rule(std::make_shared<ChunkPruningRule>());
+  optimizer->add_rule(std::make_unique<ChunkPruningRule>());
 
-  optimizer->add_rule(std::make_shared<JoinOrderingRule>(std::make_shared<CostModelLogical>()));
+  optimizer->add_rule(std::make_unique<JoinOrderingRule>(std::make_unique<CostModelLogical>()));
 
   // Position the predicates after the JoinOrderingRule ran. The JOR manipulates predicate placement as well, but
   // for now we want the PredicateReorderingRule to have the final say on predicate positions
-  optimizer->add_rule(std::make_shared<PredicatePlacementRule>());
+  optimizer->add_rule(std::make_unique<PredicatePlacementRule>());
 
   // Bring predicates into the desired order once the PredicateReorderingRule has positioned them as desired
-  optimizer->add_rule(std::make_shared<PredicateReorderingRule>());
+  optimizer->add_rule(std::make_unique<PredicateReorderingRule>());
 
-  optimizer->add_rule(std::make_shared<IndexScanRule>());
+  optimizer->add_rule(std::make_unique<IndexScanRule>());
 
   return optimizer;
 }
 
-void Optimizer::add_rule(const std::shared_ptr<AbstractRule>& rule) { _rules.emplace_back(rule); }
+void Optimizer::add_rule(std::unique_ptr<AbstractRule> rule) { _rules.emplace_back(std::move(rule)); }
 
 std::shared_ptr<AbstractLQPNode> Optimizer::optimize(const std::shared_ptr<AbstractLQPNode>& input) const {
   // Add explicit root node, so the rules can freely change the tree below it without having to maintain a root node

--- a/src/lib/optimizer/optimizer.hpp
+++ b/src/lib/optimizer/optimizer.hpp
@@ -19,12 +19,12 @@ class Optimizer final {
  public:
   static std::shared_ptr<Optimizer> create_default_optimizer();
 
-  void add_rule(const std::shared_ptr<AbstractRule>& rule);
+  void add_rule(std::unique_ptr<AbstractRule> rule);
 
   std::shared_ptr<AbstractLQPNode> optimize(const std::shared_ptr<AbstractLQPNode>& input) const;
 
  private:
-  std::vector<std::shared_ptr<AbstractRule>> _rules;
+  std::vector<std::unique_ptr<AbstractRule>> _rules;
 
   void _apply_rule(const AbstractRule& rule, const std::shared_ptr<AbstractLQPNode>& root_node) const;
 };

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -48,7 +48,7 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
   // A "rule" that just collects the nodes it was applied to
   class MockRule : public AbstractRule {
    public:
-    MockRule(std::unordered_set<std::shared_ptr<AbstractLQPNode>>& nodes) : nodes(nodes) {}
+    explicit MockRule(std::unordered_set<std::shared_ptr<AbstractLQPNode>>& nodes) : nodes(nodes) {}
     std::string name() const override { return "Mock"; }
 
     void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override {
@@ -126,7 +126,7 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
   size_t counter{0};
   class MockRule : public AbstractRule {
    public:
-    MockRule(size_t& counter) : counter(counter) {}
+    explicit MockRule(size_t& counter) : counter(counter) {}
     std::string name() const override { return "Mock"; }
 
     void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override { ++counter; }

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -43,9 +43,12 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
    * Test that the Optimizer's rules reach subqueries
    */
 
+  std::unordered_set<std::shared_ptr<AbstractLQPNode>> nodes;
+
   // A "rule" that just collects the nodes it was applied to
   class MockRule : public AbstractRule {
    public:
+    MockRule(std::unordered_set<std::shared_ptr<AbstractLQPNode>>& nodes) : nodes(nodes) {}
     std::string name() const override { return "Mock"; }
 
     void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override {
@@ -53,7 +56,7 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
       _apply_to_inputs(root);
     }
 
-    mutable std::unordered_set<std::shared_ptr<AbstractLQPNode>> nodes;
+    std::unordered_set<std::shared_ptr<AbstractLQPNode>>& nodes;
   };
 
   // clang-format off
@@ -63,16 +66,16 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
       node_a));
   // clang-format on
 
-  const auto rule = std::make_shared<MockRule>();
+  auto rule = std::make_unique<MockRule>(nodes);
 
   Optimizer optimizer{};
-  optimizer.add_rule(rule);
+  optimizer.add_rule(std::move(rule));
 
   optimizer.optimize(lqp);
 
   // Test that the optimizer has reached all nodes (the number includes all nodes created above and the root nodes
   // created by the optimizer for the lqp and each subquery)
-  EXPECT_EQ(rule->nodes.size(), 10u);
+  EXPECT_EQ(nodes.size(), 10u);
 }
 
 TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
@@ -120,26 +123,28 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
   // A "rule" that counts how often it was `apply_to()`ed. We use this
   // to check whether SubqueryExpressions pointing to the same LQP before optimization still point to the same (though
   // deep_copy()ed) LQP afterwards
+  size_t counter{0};
   class MockRule : public AbstractRule {
    public:
+    MockRule(size_t& counter) : counter(counter) {}
     std::string name() const override { return "Mock"; }
 
     void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override { ++counter; }
 
-    mutable size_t counter{0};
+    size_t& counter;
   };
 
-  const auto rule = std::make_shared<MockRule>();
+  auto rule = std::make_unique<MockRule>(counter);
 
   Optimizer optimizer{};
-  optimizer.add_rule(rule);
+  optimizer.add_rule(std::move(rule));
 
   optimizer.optimize(lqp);
 
   /**
    * 3. Check that the rule was invoked 3 times. Once for the main LQP, once for subquery_a and once for subquery_b
    */
-  EXPECT_EQ(rule->counter, 3u);
+  EXPECT_EQ(counter, 3u);
 
   /**
    * 4. Check that now - after optimizing - both SubqueryExpressions using subquery_lqp_a point to the same LQP object


### PR DESCRIPTION
> The optimizer stores the rules as shared_ptr. Is this necessary? Could these be unique_ptr?

No. Yes.

Fixes #1476.