### PR TITLE
Index join: change pos list size initially reserved

### DIFF
--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -69,7 +69,7 @@ void JoinIndex::_perform_join() {
   _pos_list_right = std::make_shared<PosList>();
 
   size_t pos_list_size_to_reserve =
-      std::max(100ull, std::min(input_table_left()->row_count(), input_table_right()->row_count()));
+      std::max(size_t{100}, std::min(input_table_left()->row_count(), input_table_right()->row_count()));
 
   _pos_list_left->reserve(pos_list_size_to_reserve);
   _pos_list_right->reserve(pos_list_size_to_reserve);

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -68,10 +68,11 @@ void JoinIndex::_perform_join() {
   _pos_list_left = std::make_shared<PosList>();
   _pos_list_right = std::make_shared<PosList>();
 
-  size_t worst_case = input_table_left()->row_count() * input_table_right()->row_count();
+  size_t pos_list_size_to_reserve =
+      std::max(100ull, std::min(input_table_left()->row_count(), input_table_right()->row_count()));
 
-  _pos_list_left->reserve(worst_case);
-  _pos_list_right->reserve(worst_case);
+  _pos_list_left->reserve(pos_list_size_to_reserve);
+  _pos_list_right->reserve(pos_list_size_to_reserve);
 
   auto& performance_data = static_cast<PerformanceData&>(*_performance_data);
 

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -68,8 +68,8 @@ void JoinIndex::_perform_join() {
   _pos_list_left = std::make_shared<PosList>();
   _pos_list_right = std::make_shared<PosList>();
 
-  size_t pos_list_size_to_reserve =
-      std::max(size_t{100}, std::min(input_table_left()->row_count(), input_table_right()->row_count()));
+  auto pos_list_size_to_reserve =
+      std::max(uint64_t{100}, std::min(input_table_left()->row_count(), input_table_right()->row_count()));
 
   _pos_list_left->reserve(pos_list_size_to_reserve);
   _pos_list_right->reserve(pos_list_size_to_reserve);


### PR DESCRIPTION
The index join preallocated the result pos list, assuming the worst case output size of a join (n*m tuples). For large tables with hundreds of thousands of rows, the join easily allocated TBs.

This PR changes the size to reserve. It expects that each tuple of the smaller relation will have exactly one match. For very small tables, 100 RowIDs are reserved to avoid frequent resizes while not wasting memory.

Fixes #1390.