### PR TITLE
LQP Utils: Correct order of expressions in the translation of an LQP to a boolean expression

### DIFF
--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -244,7 +244,7 @@ namespace {
  *       Stored Table                                                          returned expression
  *
  * An lqp is evaluated from bottom to top. However, this function traverses an lqp from top to bottom. In the given lqp,
- * Predicate B is reached first druing traversial, however, Predicate B can only be added to output expression once
+ * Predicate B is reached first during traversal, however, Predicate B can only be added to output expression once
  * Predicate A was added as Predicate A is evaluated before Predicate B.
  * The translated predicate expression from a visited predicate node is therefore not directly added to the output
  * expression. Instead it is added once the next Predicate or Union node are translated. To allow this, the translated

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -233,24 +233,11 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
 
 namespace {
 /**
- * Function creates a boolean expression from an lqp whilst preserving the same order of how expressions are evaluated.
- *
- *            LQP    --- lqp_subplan_to_boolean_expression(Predicate B) --->    boolean expression
- *
- *        Predicate B                                                    Predicate A       Predicate B
- *             |                                                                \             /
- *        Predicate A                                                             --- AND ---
- *             |                                                                       |
- *       Stored Table                                                          returned expression
- *
- * An lqp is evaluated from bottom to top. However, this function traverses an lqp from top to bottom. In the given lqp,
- * Predicate B is reached first during traversal, however, Predicate B can only be added to output expression once
- * Predicate A was added as Predicate A is evaluated before Predicate B.
- * The translated predicate expression from a visited predicate node is therefore not directly added to the output
- * expression. Instead it is added once the next Predicate or Union node are translated. To allow this, the translated
- * predicate expression is passed as the subsequent_expression parameter to the translation of its input nodes. If the
- * subsequent_expression parameter is set, an `and` expression is created to combine the translated expression of the
- * current node with the subsequent predicate expression.
+ * Function creates a boolean expression from an lqp. It traverses the passed lqp from top to bottom. However, an lqp is
+ * evaluated from bottom to top. This requires that the order in which the translated expressions are added to the
+ * output expression is the reverse order of how the nodes are traversed. The subsequent_expression parameter passes the
+ * translated expressions to the translation of its children nodes which enables to add the translated expression of
+ * child node before its parent node to the output expression.
  */
 std::shared_ptr<AbstractExpression> _lqp_subplan_to_boolean_expression(
     const std::shared_ptr<AbstractLQPNode>& begin, const std::optional<const std::shared_ptr<AbstractLQPNode>>& end,

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -66,24 +66,21 @@ std::set<std::string> lqp_find_modified_tables(const std::shared_ptr<AbstractLQP
  *
  *         input LQP   --- lqp_subplan_to_boolean_expression(Sort, Predicate A) --->   boolean expression
  *
- *       Sort (begin node)                                               Predicate D      Predicate C
- *             |                                                               \             /
- *           Union                                                               --- AND ---       Predicate E
- *         /       \                                                                   \              /
- *  Predicate D     |                                                                    ---  OR  ---     Predicate B
- *        |      Predicate E                                                                   \             /
- *  Predicate C  ´  |                                                                            --- AND ---
- *         \       /                                                                                  |
- *        Projection                                                                         returned expression
+ *       Sort (begin node)                                                  Predicate C       Predicate D
+ *             |                                                                   \             /
+ *           Union                                                                   --- AND ---       Predicate E
+ *         /       \                                                                       \              /
+ *  Predicate D     |                                                        Predicate B     ---  OR  ---
+ *        |      Predicate E                                                        \             /
+ *  Predicate C  ´  |                                                                 --- AND ---
+ *         \       /                                                                       |
+ *        Projection                                                               returned expression
  *             |
  *        Predicate B
  *             |
  *   Predicate A (end node)
  *             |
  *       Stored Table
- *
- * ToDo(Fabian) Current implementation creates nested expression in wrong order. Predicate B should be the first
- * predicate in the returned boolean expression.
  *
  * @return      the expression, or nullptr if no expression could be created
  */

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -45,7 +45,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_A) {
   // clang-format on
 
   const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
-  const auto expected_expression = and_(greater_than_(a_a, 5), less_than_(a_b, 4));
+  const auto expected_expression = and_(less_than_(a_b, 4), greater_than_(a_a, 5));
 
   EXPECT_EQ(*actual_expression, *expected_expression);
 }
@@ -66,11 +66,11 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_B) {
   const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
 
   // clang-format off
-  const auto expected_expression = and_(greater_than_(a_a, 4),
-                                        or_(and_(greater_than_(a_a, 5),
-                                                 less_than_(a_a, 50)),
+  const auto expected_expression = and_(or_(and_(less_than_(a_a, 50),
+                                                 greater_than_(a_a, 5)),
                                             or_(greater_than_(a_a, 450),
-                                                less_than_(a_a, 500))));
+                                                less_than_(a_a, 500))),
+                                        greater_than_(a_a, 4));
   // clang-format on
 
   EXPECT_EQ(*actual_expression, *expected_expression);
@@ -87,7 +87,7 @@ TEST_F(LQPUtilsTest, LQPSubplanToBooleanExpression_C) {
   // clang-format on
 
   const auto actual_expression = lqp_subplan_to_boolean_expression(lqp);
-  const auto expected_expression = and_(greater_than_(a_a, 5), less_than_(b_x, 4));
+  const auto expected_expression = and_(less_than_(b_x, 4), greater_than_(a_a, 5));
 
   EXPECT_EQ(*actual_expression, *expected_expression);
 }


### PR DESCRIPTION
This PR corrects the LQP helper function, `lqp_subplan_to_boolean_expression()`.
The function can combine multiple Predicate and Union nodes in an LQP to one boolean expression and is used by the jit-aware LQP translator.

The old implementation reversed the order of the predicates which results in the last predicate of an LQP being evaluated first. This was caused by the fact that an LQP is evaluated from first to last node but `lqp_subplan_to_boolean_expression` traverses the LQP from last to first node.
The new implementation traverses the LQP in the same way but reverses the order in which predicates are added to the result expression.