### PR TITLE
Force erasure of LZ4Segment

### DIFF
--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -75,11 +75,10 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
 
 template <typename T, bool EraseSegmentType = true>
 auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
-  // We always erase the type here because LZ4 is too slow to notice a difference anyway.
-  static_assert(EraseSegmentType,
-                "LZ4Segment should always get erased as its decoding is so slow, the virtual function calls won't make "
-                "a difference. If we'd allow it to not be erased we'd risk compile time increase, so we opt for a "
-                "static_assert to make sure this never happens.");
+  // LZ4Segment should always get erased as its decoding is so slow, the virtual function calls won't make
+  // a difference. If we'd allow it to not be erased we'd risk compile time increase, so we opt for a
+  // static_assert to make sure this never happens.
+  static_assert(EraseSegmentType, "Creating a non-type-erased Iterable for the LZ4Segment is forbidden.");
   return create_any_segment_iterable<T>(segment);
 }
 

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -75,10 +75,8 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
 
 template <typename T, bool EraseSegmentType = true>
 auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
-  // LZ4Segment should always get erased as its decoding is so slow, the virtual function calls won't make
-  // a difference. If we'd allow it to not be erased we'd risk compile time increase, so we opt for a
-  // static_assert to make sure this never happens.
-  static_assert(EraseSegmentType, "Creating a non-type-erased Iterable for the LZ4Segment is forbidden.");
+  // LZ4Segment always gets erased as its decoding is so slow, the virtual function calls won't make
+  // a difference. If we'd allow it to not be erased we'd risk compile time increase creeping in for no benefit
   return create_any_segment_iterable<T>(segment);
 }
 

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -77,7 +77,7 @@ template <typename T, bool EraseSegmentType = true>
 auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
   // LZ4Segment always gets erased as its decoding is so slow, the virtual function calls won't make
   // a difference. If we'd allow it to not be erased we'd risk compile time increase creeping in for no benefit
-  return create_any_segment_iterable<T>(segment);
+  return AnySegmentIterable<T>(LZ4Iterable<T>(segment));
 }
 
 /**

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -76,11 +76,11 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
 template <typename T, bool EraseSegmentType = true>
 auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
   // We always erase the type here because LZ4 is too slow to notice a difference anyway.
-  if constexpr (EraseSegmentType) {
-    return create_any_segment_iterable<T>(segment);
-  } else {
-    return LZ4Iterable<T>{segment};
-  }
+  static_assert(EraseSegmentType,
+                "LZ4Segment should always get erased as its decoding is so slow, the virtual function calls won't make "
+                "a difference. If we'd allow it to not be erased we'd risk compile time increase, so we opt for a "
+                "static_assert to make sure this never happens.");
+  return create_any_segment_iterable<T>(segment);
 }
 
 /**

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -11,8 +11,7 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
   auto any_segment_iterable = std::optional<AnySegmentIterable<T>>{};
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
-    const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
-    any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
+    any_segment_iterable.emplace(create_iterable_from_segment<T, true>(segment));
   });
 
   return std::move(*any_segment_iterable);

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -11,7 +11,6 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
   auto any_segment_iterable = std::optional<AnySegmentIterable<T>>{};
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
-
     const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
     any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
   });

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -11,7 +11,9 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
   auto any_segment_iterable = std::optional<AnySegmentIterable<T>>{};
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
-    any_segment_iterable.emplace(create_iterable_from_segment<T, true>(segment));
+
+    const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
+    any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
   });
 
   return std::move(*any_segment_iterable);


### PR DESCRIPTION
I was a bit uneasy that it might still happen that code gets instantiated for the LZ4Iterable and higher compile times might be creeping in. This PR makes sure the compiler will tell us if someone attempts to do this and only allows type-erased iteration of the LZ4Segment