### PR TITLE
Strict EXPECT_LQP_EQ to avoid mistakes in Optimizer tests

### DIFF
--- a/src/test/optimizer/greedy_operator_ordering_test.cpp
+++ b/src/test/optimizer/greedy_operator_ordering_test.cpp
@@ -65,7 +65,7 @@ TEST_F(GreedyOperatorOrderingTest, NoEdges) {
       JoinGraph{std::vector<std::shared_ptr<AbstractLQPNode>>{node_a}, std::vector<JoinGraphEdge>{}};
 
   const auto actual_lqp = GreedyOperatorOrdering{cost_estimator}(join_graph);  // NOLINT
-  const auto expected_lqp = node_a;
+  const auto expected_lqp = node_a->deep_copy();
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }

--- a/src/test/optimizer/strategy/insert_limit_in_exists_rule_test.cpp
+++ b/src/test/optimizer/strategy/insert_limit_in_exists_rule_test.cpp
@@ -64,10 +64,11 @@ TEST_F(ExistsInsertLimitInExistsRuleTest, DoNotAddLimitIfLimitExists) {
   const auto lqp = PredicateNode::make(exists_(limit_subselect), node_table_a);
   // clang-format on
 
+  const auto expected_lqp = lqp->deep_copy();
   const auto actual_lqp = StrategyBaseTest::apply_rule(_rule, lqp);
 
   // If a limit node exists within the subselect of an exists expression, the lqp is not changed.
-  EXPECT_LQP_EQ(actual_lqp, lqp);
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 }  // namespace opossum

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -62,24 +62,24 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
 #define ASSERT_LQP_TIE(output, input_side, input) \
   if (!opossum::check_lqp_tie(output, input_side, input)) FAIL();
 
-#define EXPECT_LQP_EQ(lhs, rhs)                                             \
-  {                                                                         \
+#define EXPECT_LQP_EQ(lhs, rhs)                                                                           \
+  {                                                                                                       \
     Assert(lhs != rhs, "Comparing an LQP with itself is always true. Did you mean to take a deep copy?"); \
-    const auto mismatch = lqp_find_subplan_mismatch(lhs, rhs);              \
-    if (mismatch) {                                                         \
-      std::cout << "Differing subtrees" << std::endl;                       \
-      std::cout << "-------------- Actual LQP --------------" << std::endl; \
-      if (mismatch->first)                                                  \
-        mismatch->first->print();                                           \
-      else                                                                  \
-        std::cout << "NULL" << std::endl;                                   \
-      std::cout << std::endl;                                               \
-      std::cout << "------------- Expected LQP -------------" << std::endl; \
-      if (mismatch->second)                                                 \
-        mismatch->second->print();                                          \
-      else                                                                  \
-        std::cout << "NULL" << std::endl;                                   \
-      std::cout << "-------------..............-------------" << std::endl; \
-      GTEST_FAIL();                                                         \
-    }                                                                       \
+    const auto mismatch = lqp_find_subplan_mismatch(lhs, rhs);                                            \
+    if (mismatch) {                                                                                       \
+      std::cout << "Differing subtrees" << std::endl;                                                     \
+      std::cout << "-------------- Actual LQP --------------" << std::endl;                               \
+      if (mismatch->first)                                                                                \
+        mismatch->first->print();                                                                         \
+      else                                                                                                \
+        std::cout << "NULL" << std::endl;                                                                 \
+      std::cout << std::endl;                                                                             \
+      std::cout << "------------- Expected LQP -------------" << std::endl;                               \
+      if (mismatch->second)                                                                               \
+        mismatch->second->print();                                                                        \
+      else                                                                                                \
+        std::cout << "NULL" << std::endl;                                                                 \
+      std::cout << "-------------..............-------------" << std::endl;                               \
+      GTEST_FAIL();                                                                                       \
+    }                                                                                                     \
   }

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -64,6 +64,7 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
 
 #define EXPECT_LQP_EQ(lhs, rhs)                                             \
   {                                                                         \
+    Assert(lhs != rhs, "Comparing an LQP with itself is always true. Did you mean to take a deep copy?"); \
     const auto mismatch = lqp_find_subplan_mismatch(lhs, rhs);              \
     if (mismatch) {                                                         \
       std::cout << "Differing subtrees" << std::endl;                       \


### PR DESCRIPTION
Tests like this:

```c++
  // clang-format off
  const auto input_lqp =
  PredicateNode::make(greater_than_equals_(_column_a, 200),
    PredicateNode::make(less_than_equals_(_column_b, 300),
      _node));

  const auto expected_lqp = input_lqp;
  // clang-format on

  const auto result_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);

  EXPECT_LQP_EQ(result_lqp, expected_lqp);
```

should be encouraged to do `const auto expected_lqp = input_lqp->deep_copy()` to avoid false-positive tests. 