### PR TITLE
Fix LZ4 and RunLength encoding for empty Segments

### DIFF
--- a/src/lib/storage/run_length_segment/run_length_encoder.hpp
+++ b/src/lib/storage/run_length_segment/run_length_encoder.hpp
@@ -28,6 +28,11 @@ class RunLengthEncoder : public SegmentEncoder<RunLengthEncoder> {
     auto iterable = ValueSegmentIterable<T>{*value_segment};
 
     iterable.with_iterators([&](auto it, auto end) {
+      // Early out for empty segments, code below assumes it to be non-empty
+      if (it == end) {
+        return;
+      }
+
       // Init is_current_null such that it does not equal the first entry
       auto current_value = T{};
       auto is_current_null = !it->is_null();

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.cpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_iterator.cpp
@@ -9,7 +9,7 @@ SimdBp128Iterator::SimdBp128Iterator(const pmr_vector<uint128_t>* data, size_t s
       _absolute_index{absolute_index},
       _current_meta_block{std::make_unique<std::array<uint32_t, Packing::meta_block_size>>()},
       _current_meta_block_index{0u} {
-  if (data) {
+  if (data && !data->empty()) {
     _unpack_next_meta_block();
   }
 }

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -233,19 +233,14 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithShuffledChunkOf
   });
 }
 
-TEST_P(EncodedSegmentTest, EmptySegment) {
-  auto value_segment = std::make_shared<ValueSegment<int32_t>>();
-  auto base_encoded_segment = this->encode_value_segment(DataType::Int, value_segment);
-
-  EXPECT_EQ(base_encoded_segment->size(), 0u);
-}
-
 TEST_P(EncodedSegmentTest, SequentiallyReadEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_concurrent_vector<int32_t>{});
   auto base_encoded_segment = this->encode_value_segment(DataType::Int, value_segment);
 
   EXPECT_EQ(value_segment->size(), base_encoded_segment->size());
 
+  // Even if no actual reading happens here, iterators are created and we can test that they do not crash on empty
+  // segments
   resolve_encoded_segment_type<int32_t>(*base_encoded_segment, [&](const auto& encoded_segment) {
     auto encoded_segment_iterable = create_iterable_from_segment(encoded_segment);
 

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -233,4 +233,11 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithShuffledChunkOf
   });
 }
 
+TEST_P(EncodedSegmentTest, EmptySegment) {
+  auto value_segment = std::make_shared<ValueSegment<int32_t>>();
+  auto base_encoded_segment = this->encode_value_segment(DataType::Int, value_segment);
+
+  EXPECT_EQ(base_encoded_segment->size(), 0u);
+}
+
 }  // namespace opossum

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -240,4 +240,19 @@ TEST_P(EncodedSegmentTest, EmptySegment) {
   EXPECT_EQ(base_encoded_segment->size(), 0u);
 }
 
+TEST_P(EncodedSegmentTest, SequentiallyReadEmptyIntSegment) {
+  auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_concurrent_vector<int32_t>{});
+  auto base_encoded_segment = this->encode_value_segment(DataType::Int, value_segment);
+
+  EXPECT_EQ(value_segment->size(), base_encoded_segment->size());
+
+  resolve_encoded_segment_type<int32_t>(*base_encoded_segment, [&](const auto& encoded_segment) {
+    auto encoded_segment_iterable = create_iterable_from_segment(encoded_segment);
+
+    encoded_segment_iterable.with_iterators([&](auto encoded_segment_it, auto encoded_segment_end) {
+      // Nothing happens here since the segments are empty
+    });
+  });
+}
+
 }  // namespace opossum

--- a/src/test/storage/simd_bp128_test.cpp
+++ b/src/test/storage/simd_bp128_test.cpp
@@ -77,7 +77,6 @@ INSTANTIATE_TEST_CASE_P(BitSizes, SimdBp128Test, ::testing::Range(uint8_t{1}, ui
 TEST_P(SimdBp128Test, DecompressSequenceUsingIterators) {
   const auto sequence = generate_sequence(420);
   const auto compressed_sequence_base = compress(sequence);
-
   auto compressed_sequence = dynamic_cast<const SimdBp128Vector*>(compressed_sequence_base.get());
   EXPECT_NE(compressed_sequence, nullptr);
 
@@ -101,6 +100,20 @@ TEST_P(SimdBp128Test, DecompressSequenceUsingDecompressor) {
   for (; seq_it != seq_end; seq_it++, index++) {
     EXPECT_EQ(*seq_it, decompressor->get(index));
   }
+}
+
+TEST_P(SimdBp128Test, CompressEmptySequence) {
+  const auto sequence = generate_sequence(0);
+  const auto compressed_sequence_base = compress(sequence);
+
+  ASSERT_EQ(compressed_sequence_base->size(), 0u);
+  ASSERT_EQ(compressed_sequence_base->data_size(), 0u);
+
+  auto compressed_sequence = dynamic_cast<const SimdBp128Vector*>(compressed_sequence_base.get());
+  EXPECT_NE(compressed_sequence, nullptr);
+
+  auto decompressor = compressed_sequence->create_base_decompressor();
+  ASSERT_EQ(decompressor->size(), 0u);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
Fix #1522

~@janehmueller I was able to reproduce a bug in the RunLengthEncoder as well as LZ4 - the SIMDBP128 doesn't crash for me when compressing an empty Segment. Can you provide a compilable, crashing test/playground for this problem?~
