### PR TITLE
Remove JitBaseSegmentIterator

### DIFF
--- a/src/lib/storage/segment_iterables/base_segment_iterators.hpp
+++ b/src/lib/storage/segment_iterables/base_segment_iterators.hpp
@@ -9,6 +9,14 @@
 namespace opossum {
 
 /**
+ * @brief template-free base class of all iterators used by iterables
+ *
+ * The class allows the JitOperatorWrapper to keep pointers to differently specialized versions
+ * of the iterators in a common data structure.
+ */
+class JitBaseSegmentIterator {};
+
+/**
  * @brief base class of all iterators used by iterables
  *
  * Instantiations of this template are part of the segment iterable
@@ -38,7 +46,8 @@ namespace opossum {
  * };
  */
 template <typename Derived, typename Value>
-class BaseSegmentIterator : public boost::iterator_facade<Derived, Value, boost::random_access_traversal_tag, Value> {};
+class BaseSegmentIterator : public boost::iterator_facade<Derived, Value, boost::random_access_traversal_tag, Value>,
+                            public JitBaseSegmentIterator {};
 
 /**
  * Mapping between chunk offset into a reference segment and

--- a/src/lib/storage/segment_iterables/base_segment_iterators.hpp
+++ b/src/lib/storage/segment_iterables/base_segment_iterators.hpp
@@ -9,14 +9,6 @@
 namespace opossum {
 
 /**
- * @brief template-free base class of all iterators used by iterables
- *
- * The class allows the JitOperatorWrapper to keep pointers to differently specialized versions
- * of the iterators in a common data structure.
- */
-class JitBaseSegmentIterator {};
-
-/**
  * @brief base class of all iterators used by iterables
  *
  * Instantiations of this template are part of the segment iterable
@@ -46,8 +38,7 @@ class JitBaseSegmentIterator {};
  * };
  */
 template <typename Derived, typename Value>
-class BaseSegmentIterator : public boost::iterator_facade<Derived, Value, boost::random_access_traversal_tag, Value>,
-                            public JitBaseSegmentIterator {};
+class BaseSegmentIterator : public boost::iterator_facade<Derived, Value, boost::random_access_traversal_tag, Value> {};
 
 /**
  * Mapping between chunk offset into a reference segment and


### PR DESCRIPTION
Code smell, imo, to have a special base class of a core class, dedicated to a particular component. Thankfully it wasn't used. 