### PR TITLE
Remove obsolete docs for Join operators

### DIFF
--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -10,18 +10,13 @@
 
 namespace opossum {
 
-// operator to join two tables using one column of each table
-// output is a table with ReferenceSegments
-// to filter by multiple criteria, you can chain the operator
-
-// As with most operators, we do not guarantee a stable operation with regards
-// to positions - i.e., your sorting order might be disturbed
-
-// find more information about joins in our Wiki:
-// https://github.com/hyrise/hyrise/wiki/Operator-Join
-
-// We have decided against forwarding MVCC data in https://github.com/hyrise/hyrise/issues/409
-
+/**
+ * Base class for predicated (i.e., non-cross) join operator implementations. Cross Joins are performed by the Product
+ * operator.
+ *
+ * Find more information about joins in our Wiki: https://github.com/hyrise/hyrise/wiki/Operator-Join
+ * We have decided against forwarding MVCC data in https://github.com/hyrise/hyrise/issues/409
+ */
 class AbstractJoinOperator : public AbstractReadOnlyOperator {
  public:
   AbstractJoinOperator(

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -18,7 +18,6 @@ namespace opossum {
    * finding the right values utilizing the index.
    *
    * Note: An index needs to be present on the right table in order to execute an index join.
-   * Note: Cross joins are not supported. Use the product operator instead.
    */
 class JoinIndex : public AbstractJoinOperator {
  public:

--- a/src/lib/operators/join_mpsm.hpp
+++ b/src/lib/operators/join_mpsm.hpp
@@ -17,9 +17,6 @@ namespace opossum {
    *
    * As with most operators, we do not guarantee a stable operation with regards to positions -
    * i.e., your sorting order might be disturbed.
-   *
-   * Note: MPSMJoin does not support null values in the input at the moment.
-   * Note: Outer joins are only implemented for the equi-join case, i.e. the "=" operator.
 **/
 class JoinMPSM : public AbstractJoinOperator {
  public:

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -16,10 +16,6 @@ namespace opossum {
    *
    * As with most operators, we do not guarantee a stable operation with regards to positions -
    * i.e., your sorting order might be disturbed.
-   *
-   * Note: SortMergeJoin does not support null values in the input at the moment.
-   * Note: Cross joins are not supported. Use the product operator instead.
-   * Note: Outer joins are only implemented for the equi-join case, i.e. the "=" operator.
    */
 class JoinSortMerge : public AbstractJoinOperator {
  public:


### PR DESCRIPTION
Note, again, how comments do not compile and do not fail tests even if they become confusing gibberish.

* Both JSM and JMPSM are run through the join_null_test, so I'd assume they support null values.
* JSM supports outer joins for non-equal
