### PR TITLE
[JIT] Correct div/mod by zero (issue #1450)

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -49,8 +49,8 @@ SELECT a, b, a+b AS e, a+b+NULL AS f FROM id_int_int_int_100;
 SELECT a, b, b+b AS e, b+b+NULL AS f FROM mixed;
 SELECT a, b, b+b AS e, b+b+NULL AS f FROM mixed_null;
 SELECT 1 + 5.6 > 7 OR 2 > 1 AS i FROM mixed;
-SELECT 2 / 0, b / 0, 50 % id FROM mixed;
-SELECT 2 % 0, b % 0, 50 / id FROM mixed;
+SELECT 2 / 0, b / 0, 50 / id FROM mixed;
+SELECT 2 % 0, b % 0, 50 % id FROM mixed;
 
 -- ORDER BY
 SELECT * FROM mixed ORDER BY a;

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -49,6 +49,8 @@ SELECT a, b, a+b AS e, a+b+NULL AS f FROM id_int_int_int_100;
 SELECT a, b, b+b AS e, b+b+NULL AS f FROM mixed;
 SELECT a, b, b+b AS e, b+b+NULL AS f FROM mixed_null;
 SELECT 1 + 5.6 > 7 OR 2 > 1 AS i FROM mixed;
+SELECT 2 / 0, b / 0, 50 % id FROM mixed;
+SELECT 2 % 0, b % 0, 50 / id FROM mixed;
 
 -- ORDER BY
 SELECT * FROM mixed ORDER BY a;

--- a/src/lib/operators/jit_operator/jit_operations.hpp
+++ b/src/lib/operators/jit_operator/jit_operations.hpp
@@ -171,7 +171,7 @@ struct InvalidTypeCatcher : Functor {
   }
 };
 
-template <typename ResultValueType, typename T>
+template <typename ResultValueType, bool CheckRightSideForZero = false, typename T>
 std::optional<ResultValueType> jit_compute(const T& op_func, const JitExpression& left_side,
                                            const JitExpression& right_side, JitRuntimeContext& context) {
   const auto left_entry = left_side.result_entry();
@@ -185,6 +185,14 @@ std::optional<ResultValueType> jit_compute(const T& op_func, const JitExpression
     if ((left_entry.is_nullable() && !typed_lhs.has_value()) || (right_entry.is_nullable() && !typed_rhs.has_value())) {
       return std::nullopt;
     }
+
+    // Return null for modulo or division by zero
+    if constexpr (CheckRightSideForZero) {
+      if (typed_rhs.value() == 0) {
+        return std::nullopt;
+      }
+    }
+
     using ResultType = decltype(op_func(typed_lhs.value(), typed_rhs.value()));
     if constexpr (std::is_same_v<ResultValueType, ResultType>) {
       return op_func(typed_lhs.value(), typed_rhs.value());

--- a/src/lib/operators/jit_operator/operators/jit_expression.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_expression.cpp
@@ -168,7 +168,10 @@ std::pair<const DataType, const bool> JitExpression::_compute_result_type() {
       Fail("This binary expression type is not supported.");
   }
 
-  return std::make_pair(result_data_type, left_tuple_entry.is_nullable() || right_tuple_entry.is_nullable());
+  const bool nullable = left_tuple_entry.is_nullable() || right_tuple_entry.is_nullable() ||
+                        _expression_type == JitExpressionType::Division ||
+                        _expression_type == JitExpressionType::Modulo;
+  return std::make_pair(result_data_type, nullable);
 }
 
 template <typename ResultValueType>
@@ -255,9 +258,9 @@ std::optional<ResultValueType> JitExpression::compute(JitRuntimeContext& context
       case JitExpressionType::Multiplication:
         return jit_compute<ResultValueType>(jit_multiplication, *_left_child, *_right_child, context);
       case JitExpressionType::Division:
-        return jit_compute<ResultValueType>(jit_division, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType, true>(jit_division, *_left_child, *_right_child, context);
       case JitExpressionType::Modulo:
-        return jit_compute<ResultValueType>(jit_modulo, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType, true>(jit_modulo, *_left_child, *_right_child, context);
       case JitExpressionType::Power:
         return jit_compute<ResultValueType>(jit_power, *_left_child, *_right_child, context);
       default:

--- a/src/test/operators/jit_operator/jit_operations_test.cpp
+++ b/src/test/operators/jit_operator/jit_operations_test.cpp
@@ -57,16 +57,19 @@ TEST_F(JitOperationsTest, ArithmeticComputations) {
   const JitTupleEntry long_tuple_entry{DataType::Long, false, 1};
   const JitTupleEntry float_tuple_entry{DataType::Float, false, 2};
   const JitTupleEntry double_tuple_entry{DataType::Double, false, 3};
+  const JitTupleEntry zero_tuple_entry{DataType::Int, false, 4};
 
   int_tuple_entry.set<int32_t>(2, context);
   long_tuple_entry.set<int64_t>(5l, context);
   float_tuple_entry.set<float>(3.14f, context);
   double_tuple_entry.set<double>(1.23, context);
+  zero_tuple_entry.set<int32_t>(0, context);
 
   const JitExpression int_value_expression{int_tuple_entry};
   const JitExpression long_value_expression{long_tuple_entry};
   const JitExpression float_value_expression{float_tuple_entry};
   const JitExpression double_value_expression{double_tuple_entry};
+  const JitExpression zero_value_expression{zero_tuple_entry};
 
   auto result_value_1 = jit_compute<int64_t>(jit_addition, int_value_expression, long_value_expression, context);
   ASSERT_EQ(2 + 5l, result_value_1.value());
@@ -77,14 +80,20 @@ TEST_F(JitOperationsTest, ArithmeticComputations) {
   auto result_value_3 = jit_compute<double>(jit_multiplication, double_value_expression, int_value_expression, context);
   ASSERT_EQ(1.23 * 2, result_value_3.value());
 
-  auto result_value_4 = jit_compute<float>(jit_division, int_value_expression, float_value_expression, context);
+  auto result_value_4 = jit_compute<float, true>(jit_division, int_value_expression, float_value_expression, context);
   ASSERT_EQ(2 / 3.14f, result_value_4.value());
 
-  auto result_value_5 = jit_compute<int64_t>(jit_modulo, long_value_expression, int_value_expression, context);
-  ASSERT_EQ(5l % 2, result_value_5.value());
+  auto result_value_5 = jit_compute<float, true>(jit_division, float_value_expression, zero_value_expression, context);
+  ASSERT_FALSE(result_value_5.has_value());
 
-  auto result_value_6 = jit_compute<double>(jit_power, double_value_expression, float_value_expression, context);
-  ASSERT_EQ(std::pow(1.23, 3.14f), result_value_6.value());
+  auto result_value_6 = jit_compute<int64_t, true>(jit_modulo, long_value_expression, int_value_expression, context);
+  ASSERT_EQ(5l % 2, result_value_6.value());
+
+  auto result_value_7 = jit_compute<int64_t, true>(jit_modulo, long_value_expression, zero_value_expression, context);
+  ASSERT_FALSE(result_value_7.has_value());
+
+  auto result_value_8 = jit_compute<double>(jit_power, double_value_expression, float_value_expression, context);
+  ASSERT_EQ(std::pow(1.23, 3.14f), result_value_8.value());
 }
 
 TEST_F(JitOperationsTest, Predicates) {


### PR DESCRIPTION
This pr adds a check for division and modulo operations if the right operand is zero.
The tests have been extended to cover these edge cases including two new queries for the sqlite test.

Fixes #1450