### PR TITLE
Replace boost::variant with std::variant in LikeMatcher

### DIFF
--- a/scripts/cpplint.py
+++ b/scripts/cpplint.py
@@ -384,6 +384,7 @@ _CPP_HEADERS = frozenset([
     'unordered_set',
     'utility',
     'valarray',
+    'variant',
     'vector',
     # 17.6.1.2 C++ headers for C library facilities
     'cassert',

--- a/src/lib/expression/evaluation/like_matcher.cpp
+++ b/src/lib/expression/evaluation/like_matcher.cpp
@@ -42,19 +42,20 @@ LikeMatcher::PatternTokens LikeMatcher::pattern_string_to_tokens(const pmr_strin
 LikeMatcher::AllPatternVariant LikeMatcher::pattern_string_to_pattern_variant(const pmr_string& pattern) {
   const auto tokens = pattern_string_to_tokens(pattern);
 
-  if (tokens.size() == 2 && tokens[0].type() == typeid(pmr_string) && tokens[1] == PatternToken{Wildcard::AnyChars}) {
+  if (tokens.size() == 2 && std::holds_alternative<pmr_string>(tokens[0]) &&
+      tokens[1] == PatternToken{Wildcard::AnyChars}) {
     // Pattern has the form 'hello%'
-    return StartsWithPattern{boost::get<pmr_string>(tokens[0])};
+    return StartsWithPattern{std::get<pmr_string>(tokens[0])};
 
   } else if (tokens.size() == 2 && tokens[0] == PatternToken{Wildcard::AnyChars} &&  // NOLINT
-             tokens[1].type() == typeid(pmr_string)) {
+             std::holds_alternative<pmr_string>(tokens[1])) {
     // Pattern has the form '%hello'
-    return EndsWithPattern{boost::get<pmr_string>(tokens[1])};
+    return EndsWithPattern{std::get<pmr_string>(tokens[1])};
 
   } else if (tokens.size() == 3 && tokens[0] == PatternToken{Wildcard::AnyChars} &&  // NOLINT
-             tokens[1].type() == typeid(pmr_string) && tokens[2] == PatternToken{Wildcard::AnyChars}) {
+             std::holds_alternative<pmr_string>(tokens[1]) && tokens[2] == PatternToken{Wildcard::AnyChars}) {
     // Pattern has the form '%hello%'
-    return ContainsPattern{boost::get<pmr_string>(tokens[1])};
+    return ContainsPattern{std::get<pmr_string>(tokens[1])};
 
   } else {
     /**
@@ -76,12 +77,12 @@ LikeMatcher::AllPatternVariant LikeMatcher::pattern_string_to_pattern_variant(co
         pattern_is_contains_multiple = false;
         break;
       }
-      if (!expect_any_chars && token.type() != typeid(pmr_string)) {
+      if (!expect_any_chars && !std::holds_alternative<pmr_string>(token)) {
         pattern_is_contains_multiple = false;
         break;
       }
       if (!expect_any_chars) {
-        strings.emplace_back(boost::get<pmr_string>(token));
+        strings.emplace_back(std::get<pmr_string>(token));
       }
 
       expect_any_chars = !expect_any_chars;

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -2,9 +2,9 @@
 
 #include <regex>
 #include <string>
+#include <variant>  // NOLINT(build/include_order) Linter assumes variant is a c library
 #include <vector>
 
-#include "boost/variant.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
 
@@ -29,7 +29,7 @@ class LikeMatcher {
   explicit LikeMatcher(const pmr_string& pattern);
 
   enum class Wildcard { SingleChar /* '_' */, AnyChars /* '%' */ };
-  using PatternToken = boost::variant<pmr_string, Wildcard>;  // Keep type order, users rely on which()
+  using PatternToken = std::variant<pmr_string, Wildcard>;  // Keep type order, users rely on which()
   using PatternTokens = std::vector<PatternToken>;
 
   /**
@@ -64,7 +64,7 @@ class LikeMatcher {
    * general pattern.
    */
   using AllPatternVariant =
-      boost::variant<std::regex, StartsWithPattern, EndsWithPattern, ContainsPattern, MultipleContainsPattern>;
+      std::variant<std::regex, StartsWithPattern, EndsWithPattern, ContainsPattern, MultipleContainsPattern>;
 
   static AllPatternVariant pattern_string_to_pattern_variant(const pmr_string& pattern);
 
@@ -77,28 +77,28 @@ class LikeMatcher {
    */
   template <typename Functor>
   void resolve(const bool invert_results, const Functor& functor) const {
-    if (_pattern_variant.type() == typeid(StartsWithPattern)) {
-      const auto& prefix = boost::get<StartsWithPattern>(_pattern_variant).string;
+    if (std::holds_alternative<StartsWithPattern>(_pattern_variant)) {
+      const auto& prefix = std::get<StartsWithPattern>(_pattern_variant).string;
       functor([&](const pmr_string& string) -> bool {
         if (string.size() < prefix.size()) return invert_results;
         return (string.compare(0, prefix.size(), prefix) == 0) ^ invert_results;
       });
 
-    } else if (_pattern_variant.type() == typeid(EndsWithPattern)) {
-      const auto& suffix = boost::get<EndsWithPattern>(_pattern_variant).string;
+    } else if (std::holds_alternative<EndsWithPattern>(_pattern_variant)) {
+      const auto& suffix = std::get<EndsWithPattern>(_pattern_variant).string;
       functor([&](const pmr_string& string) -> bool {
         if (string.size() < suffix.size()) return invert_results;
         return (string.compare(string.size() - suffix.size(), suffix.size(), suffix) == 0) ^ invert_results;
       });
 
-    } else if (_pattern_variant.type() == typeid(ContainsPattern)) {
-      const auto& contains_str = boost::get<ContainsPattern>(_pattern_variant).string;
+    } else if (std::holds_alternative<ContainsPattern>(_pattern_variant)) {
+      const auto& contains_str = std::get<ContainsPattern>(_pattern_variant).string;
       functor([&](const pmr_string& string) -> bool {
         return (string.find(contains_str) != pmr_string::npos) ^ invert_results;
       });
 
-    } else if (_pattern_variant.type() == typeid(MultipleContainsPattern)) {
-      const auto& contains_strs = boost::get<MultipleContainsPattern>(_pattern_variant).strings;
+    } else if (std::holds_alternative<MultipleContainsPattern>(_pattern_variant)) {
+      const auto& contains_strs = std::get<MultipleContainsPattern>(_pattern_variant).strings;
 
       functor([&](const pmr_string& string) -> bool {
         auto current_position = size_t{0};
@@ -110,8 +110,8 @@ class LikeMatcher {
         return !invert_results;
       });
 
-    } else if (_pattern_variant.type() == typeid(std::regex)) {
-      const auto& regex = boost::get<std::regex>(_pattern_variant);
+    } else if (std::holds_alternative<std::regex>(_pattern_variant)) {
+      const auto& regex = std::get<std::regex>(_pattern_variant);
 
       functor([&](const pmr_string& string) -> bool { return std::regex_match(string, regex) ^ invert_results; });
 

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -2,7 +2,7 @@
 
 #include <regex>
 #include <string>
-#include <variant>  // NOLINT(build/include_order) Linter assumes variant is a c library
+#include <variant>
 #include <vector>
 
 #include "types.hpp"


### PR DESCRIPTION
This pr replaces `boost::variant` with `std::variant` in `LikeMatcher` class.

It is a preparation for a future JIT pr improving the evaluation of like queries.
JIT cannot handle `boost::variant` code during specialization but it can handle `std::variant` code.