### PR TITLE
FileBasedBenchmark, JOB: Support -q

### DIFF
--- a/src/benchmark/file_based_benchmark.cpp
+++ b/src/benchmark/file_based_benchmark.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
   cli_options.add_options()
       ("table_path", "Directory containing the Tables", cxxopts::value<std::string>()->default_value("")) // NOLINT
       ("query_path", "Directory/file containing the queries", cxxopts::value<std::string>()->default_value("")) // NOLINT
-      ("queries", "Subset of queries to run as a comma separated list", cxxopts::value<std::string>()->default_value("all")); // NOLINT
+      ("q,queries", "Subset of queries to run as a comma separated list", cxxopts::value<std::string>()->default_value("all")); // NOLINT
   // clang-format on
 
   std::shared_ptr<BenchmarkConfig> benchmark_config;

--- a/src/benchmark/join_order_benchmark.cpp
+++ b/src/benchmark/join_order_benchmark.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]) {
   cli_options.add_options()
   ("table_path", "Directory containing the Tables", cxxopts::value<std::string>()->default_value(DEFAULT_TABLE_PATH)) // NOLINT
   ("query_path", "Directory/file containing the queries", cxxopts::value<std::string>()->default_value(DEFAULT_QUERY_PATH)) // NOLINT
-  ("queries", "Subset of queries to run as a comma separated list", cxxopts::value<std::string>()->default_value("all")); // NOLINT
+  ("q,queries", "Subset of queries to run as a comma separated list", cxxopts::value<std::string>()->default_value("all")); // NOLINT
   // clang-format on
 
   std::shared_ptr<BenchmarkConfig> benchmark_config;


### PR DESCRIPTION
Right now, only TPC-H supports `-q 1` for selecting a single query. This PR adds that to the other benchmarks.