### PR TITLE
[JIT] Add option to use JIT in console and benchmark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,11 +8,11 @@ add_definitions(-DHYRISE_DEBUG=${HYRISE_DEBUG})
 
 # Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang
 # ENABLE_JIT_SUPPORT is OFF on MacOS by default as JIT does not work with -O2 and -O3 on MacOS
-CMAKE_DEPENDENT_OPTION(ENABLE_JIT_SUPPORT "Build with JIT support" OFF APPLE ON)
+option(ENABLE_JIT_SUPPORT "Build with JIT support" "NOT APPLE")
 if (NOT ${LLVM_FOUND} OR NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
     set(ENABLE_JIT_SUPPORT OFF)
 elseif (APPLE AND NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    message(FATAL_ERROR "Jit only works on MacOS with CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}.")
+    message(FATAL_WARNING "Jit only works on MacOS with CMAKE_BUILD_TYPE=Debug.")
 endif()
 
 if (${ENABLE_JIT_SUPPORT})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,13 +6,13 @@ endif()
 
 add_definitions(-DHYRISE_DEBUG=${HYRISE_DEBUG})
 
-# Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang
-# ENABLE_JIT_SUPPORT is OFF on MacOS by default as JIT does not work with -O2 and -O3 on MacOS
+# Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang 6.*
+# ENABLE_JIT_SUPPORT is OFF on MacOS by default as it currently does not work on MacOS
 option(ENABLE_JIT_SUPPORT "Build with JIT support" "NOT APPLE")
-if (NOT ${LLVM_FOUND} OR NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
+if (NOT ${LLVM_FOUND} OR NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6 OR NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
     set(ENABLE_JIT_SUPPORT OFF)
-elseif (APPLE AND NOT ${CMAKE_BUILD_TYPE} STREQUAL "Debug")
-    message(FATAL_WARNING "Jit only works on MacOS with CMAKE_BUILD_TYPE=Debug.")
+elseif (APPLE AND ENABLE_JIT_SUPPORT)
+    message(WARNING "Jit does not work on MacOS.")
 endif()
 
 if (${ENABLE_JIT_SUPPORT})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,12 +7,13 @@ endif()
 add_definitions(-DHYRISE_DEBUG=${HYRISE_DEBUG})
 
 # Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang 6.*
-# ENABLE_JIT_SUPPORT is OFF on MacOS by default as it currently does not work on MacOS
+# ENABLE_JIT_SUPPORT is OFF on MacOS by default as JIT compilation currently fails on MacOS because the specialized code
+# contains asm code on MacOS which the JIT compiler cannot handle
 option(ENABLE_JIT_SUPPORT "Build with JIT support" "NOT APPLE")
 if (NOT ${LLVM_FOUND} OR NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6 OR NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
     set(ENABLE_JIT_SUPPORT OFF)
 elseif (APPLE AND ENABLE_JIT_SUPPORT)
-    message(WARNING "Jit does not work on MacOS.")
+    message(WARNING "Jit does not work on MacOS (see https://github.com/hyrise/hyrise/issues/1569 for details).")
 endif()
 
 if (${ENABLE_JIT_SUPPORT})

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -7,7 +7,7 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const Chunk
                                  const Duration& max_duration, const Duration& warmup_duration, const UseMvcc use_mvcc,
                                  const std::optional<std::string>& output_file_path, const bool enable_scheduler,
                                  const uint32_t cores, const uint32_t clients, const bool enable_visualization,
-                                 const bool verify, const bool cache_binary_tables)
+                                 const bool verify, const bool cache_binary_tables, const bool enable_jit)
     : benchmark_mode(benchmark_mode),
       chunk_size(chunk_size),
       encoding_config(encoding_config),
@@ -21,7 +21,8 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const Chunk
       clients(clients),
       enable_visualization(enable_visualization),
       verify(verify),
-      cache_binary_tables(cache_binary_tables) {}
+      cache_binary_tables(cache_binary_tables),
+      enable_jit(enable_jit) {}
 
 BenchmarkConfig BenchmarkConfig::get_default_config() { return BenchmarkConfig(); }
 

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -24,7 +24,7 @@ class BenchmarkConfig {
                   const Duration& warmup_duration, const UseMvcc use_mvcc,
                   const std::optional<std::string>& output_file_path, const bool enable_scheduler, const uint32_t cores,
                   const uint32_t clients, const bool enable_visualization, const bool verify,
-                  const bool cache_binary_tables);
+                  const bool cache_binary_tables, const bool enable_jit);
 
   static BenchmarkConfig get_default_config();
 
@@ -42,6 +42,7 @@ class BenchmarkConfig {
   bool enable_visualization = false;
   bool verify = false;
   bool cache_binary_tables = false;
+  bool enable_jit = false;
 
   static const char* description;
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -523,8 +523,12 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("mvcc", "Enable MVCC", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("visualize", "Create a visualization image of one LQP and PQP for each query", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("cache_binary_tables", "Cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("jit", "Enable just-in-time query compilation", cxxopts::value<bool>()->default_value("false")); // NOLINT
+    ("cache_binary_tables", "Cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")); // NOLINT
+
+  if constexpr (HYRISE_JIT_SUPPORT) {
+    cli_options.add_options()
+      ("jit", "Enable just-in-time query compilation", cxxopts::value<bool>()->default_value("false")); // NOLINT
+  }
   // clang-format on
 
   return cli_options;

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -130,10 +130,13 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
     std::cout << "- Not caching tables as binary files" << std::endl;
   }
 
+  const auto enable_jit = json_config.value("jit", default_config.enable_jit);
+  std::cout << "- JIT is " << (enable_jit ? "enabled" : "disabled") << std::endl;
+
   return BenchmarkConfig{
-      benchmark_mode, chunk_size,         *encoding_config, max_runs, timeout_duration, warmup_duration,
-      use_mvcc,       output_file_path,   enable_scheduler, cores,    clients,          enable_visualization,
-      verify,         cache_binary_tables};
+      benchmark_mode, chunk_size,          *encoding_config, max_runs, timeout_duration, warmup_duration,
+      use_mvcc,       output_file_path,    enable_scheduler, cores,    clients,          enable_visualization,
+      verify,         cache_binary_tables, enable_jit};
 }
 
 BenchmarkConfig CLIConfigParser::parse_basic_cli_options(const cxxopts::ParseResult& parse_result) {
@@ -158,6 +161,7 @@ nlohmann::json CLIConfigParser::basic_cli_options_to_json(const cxxopts::ParseRe
   json_config.emplace("output", parse_result["output"].as<std::string>());
   json_config.emplace("verify", parse_result["verify"].as<bool>());
   json_config.emplace("cache_binary_tables", parse_result["cache_binary_tables"].as<bool>());
+  json_config.emplace("jit", parse_result["jit"].as<bool>());
 
   return json_config;
 }

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -130,7 +130,10 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
     std::cout << "- Not caching tables as binary files" << std::endl;
   }
 
-  const auto enable_jit = json_config.value("jit", default_config.enable_jit);
+  auto enable_jit = false;
+  if constexpr (HYRISE_JIT_SUPPORT) {
+    enable_jit = json_config.value("jit", default_config.enable_jit);
+  }
   std::cout << "- JIT is " << (enable_jit ? "enabled" : "disabled") << std::endl;
 
   return BenchmarkConfig{
@@ -161,7 +164,9 @@ nlohmann::json CLIConfigParser::basic_cli_options_to_json(const cxxopts::ParseRe
   json_config.emplace("output", parse_result["output"].as<std::string>());
   json_config.emplace("verify", parse_result["verify"].as<bool>());
   json_config.emplace("cache_binary_tables", parse_result["cache_binary_tables"].as<bool>());
-  json_config.emplace("jit", parse_result["jit"].as<bool>());
+  if constexpr (HYRISE_JIT_SUPPORT) {
+    json_config.emplace("jit", parse_result["jit"].as<bool>());
+  }
 
   return json_config;
 }

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -11,7 +11,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <ctime>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -491,7 +491,7 @@ int Console::_load_table(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  const auto filepath = std::experimental::filesystem::path{arguments[0]};
+  const auto filepath = std::filesystem::path{arguments[0]};
   const auto extension = std::string{filepath.extension()};
 
   const auto tablename = arguments.size() >= 2 ? arguments[1] : std::string{filepath.stem()};

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -152,6 +152,7 @@ class Console : public Singleton<Console> {
   std::ofstream _log;
   bool _verbose;
   bool _pagination_active;
+  bool _use_jit;
 
   std::unique_ptr<SQLPipeline> _sql_pipeline;
   std::shared_ptr<TransactionContext> _explicitly_created_transaction_context;


### PR DESCRIPTION
This pr introduces the option to enable JIT in console and benchmark.

JIT can be enabled in the benchmark with `--jit ` and in the console with `setting jit on`.
If Hyrise is build without JIT support (`-DENABLE_JIT_SUPPORT=OFF`), these options are not available.

This pr also corrects the functionality in the CMake file to en- or disable JIT.

Fixes #970