### PR TITLE
[JIT] Remove unnecessary getters and setters from JIT operators

### DIFF
--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -173,11 +173,11 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
           _try_translate_expression_to_jit_expression(groupby_expression, *read_tuples, input_node);
       if (!jit_expression) return nullptr;
       // Create a JitCompute operator for each computed groupby column ...
-      if (jit_expression->expression_type() != JitExpressionType::Column) {
+      if (jit_expression->expression_type != JitExpressionType::Column) {
         jit_operator->add_jit_operator(std::make_shared<JitCompute>(jit_expression));
       }
       // ... and add the column to the JitAggregate operator.
-      aggregate->add_groupby_column(groupby_expression->as_column_name(), jit_expression->result_entry());
+      aggregate->add_groupby_column(groupby_expression->as_column_name(), jit_expression->result_entry);
     }
 
     for (auto expression_idx = aggregate_node->aggregate_expressions_begin_idx;
@@ -200,11 +200,11 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
             _try_translate_expression_to_jit_expression(aggregate_expression->arguments[0], *read_tuples, input_node);
         if (!jit_expression) return nullptr;
         // Create a JitCompute operator for each aggregate expression on a computed value ...
-        if (jit_expression->expression_type() != JitExpressionType::Column) {
+        if (jit_expression->expression_type != JitExpressionType::Column) {
           jit_operator->add_jit_operator(std::make_shared<JitCompute>(jit_expression));
         }
         // ... and add the aggregate expression to the JitAggregate operator.
-        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), jit_expression->result_entry(),
+        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), jit_expression->result_entry,
                                         aggregate_expression->aggregate_function);
       }
     }
@@ -229,11 +229,11 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
             _try_translate_expression_to_jit_expression(column_expression, *read_tuples, input_node);
         if (!jit_expression) return nullptr;
         // Add a compute operator for each computed output column (i.e., a column that is not from a stored table).
-        if (jit_expression->expression_type() != JitExpressionType::Column) {
+        if (jit_expression->expression_type != JitExpressionType::Column) {
           jit_operator->add_jit_operator(std::make_shared<JitCompute>(jit_expression));
         }
 
-        write_table->add_output_column_definition(column_expression->as_column_name(), jit_expression->result_entry());
+        write_table->add_output_column_definition(column_expression->as_column_name(), jit_expression->result_entry);
       }
 
       jit_operator->add_jit_operator(write_table);
@@ -300,8 +300,8 @@ std::shared_ptr<const JitExpression> JitAwareLQPTranslator::_try_translate_expre
                                                jit_source.add_temporary_value());
       } else if (jit_expression_arguments.size() == 2) {
         // An expression can handle strings only exclusively
-        if ((jit_expression_arguments[0]->result_entry().data_type() == DataType::String) !=
-            (jit_expression_arguments[1]->result_entry().data_type() == DataType::String)) {
+        if ((jit_expression_arguments[0]->result_entry.data_type == DataType::String) !=
+            (jit_expression_arguments[1]->result_entry.data_type == DataType::String)) {
           return nullptr;
         }
         return std::make_shared<JitExpression>(jit_expression_arguments[0], jit_expression_type,

--- a/src/lib/operators/jit_operator/jit_operations.cpp
+++ b/src/lib/operators/jit_operator/jit_operations.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 #define JIT_HASH_CASE(r, types)                      \
   case JIT_GET_ENUM_VALUE(0, types):                 \
     return std::hash<JIT_GET_DATA_TYPE(0, types)>()( \
-        context.tuple.get<JIT_GET_DATA_TYPE(0, types)>(tuple_entry.tuple_index()));
+        context.tuple.get<JIT_GET_DATA_TYPE(0, types)>(tuple_entry.tuple_index));
 
 #define JIT_AGGREGATE_EQUALS_CASE(r, types) \
   case JIT_GET_ENUM_VALUE(0, types):        \
@@ -15,10 +15,9 @@ namespace opossum {
   case JIT_GET_ENUM_VALUE(0, types): \
     return to.set<JIT_GET_DATA_TYPE(0, types)>(from.get<JIT_GET_DATA_TYPE(0, types)>(context), to_index, context);
 
-#define JIT_GROW_BY_ONE_CASE(r, types)                                                                     \
-  case JIT_GET_ENUM_VALUE(0, types):                                                                       \
-    return context.hashmap.columns[hashmap_entry.column_index()].grow_by_one<JIT_GET_DATA_TYPE(0, types)>( \
-        initial_value);
+#define JIT_GROW_BY_ONE_CASE(r, types) \
+  case JIT_GET_ENUM_VALUE(0, types):   \
+    return context.hashmap.columns[hashmap_entry.column_index].grow_by_one<JIT_GET_DATA_TYPE(0, types)>(initial_value);
 
 #define JIT_IS_NULL_CASE(r, types)                                               \
   case JIT_GET_ENUM_VALUE(0, types): {                                           \
@@ -34,11 +33,10 @@ namespace opossum {
 
 std::optional<bool> jit_not(const JitExpression& left_side, JitRuntimeContext& context) {
   // If the input value is computed by a non-jit operator, its data type is int but it can be read as a bool value.
-  DebugAssert(
-      (left_side.result_entry().data_type() == DataType::Bool || left_side.result_entry().data_type() == DataType::Int),
-      "invalid type for jit operation not");
+  DebugAssert((left_side.result_entry.data_type == DataType::Bool || left_side.result_entry.data_type == DataType::Int),
+              "invalid type for jit operation not");
   const auto value = left_side.compute<bool>(context);
-  if (left_side.result_entry().is_nullable() && !value) {
+  if (left_side.result_entry.is_nullable && !value) {
     return std::nullopt;
   } else {
     return !value.value();
@@ -52,27 +50,27 @@ std::optional<bool> jit_and(const JitExpression& left_side, const JitExpression&
   // and false.
 
   // Get left and right operand types, the actual operand values are computed later
-  const auto left_entry = left_side.result_entry();
-  const auto right_entry = right_side.result_entry();
+  const auto left_entry = left_side.result_entry;
+  const auto right_entry = right_side.result_entry;
 
   // If the input value is computed by a non-jit operator, its data type is int but it can be read as a bool value.
-  DebugAssert((left_entry.data_type() == DataType::Bool || left_entry.data_type() == DataType::Int) &&
-                  (right_entry.data_type() == DataType::Bool || right_entry.data_type() == DataType::Int),
+  DebugAssert((left_entry.data_type == DataType::Bool || left_entry.data_type == DataType::Int) &&
+                  (right_entry.data_type == DataType::Bool || right_entry.data_type == DataType::Int),
               "invalid type for jit operation and");
 
   const auto left_result = left_side.compute<bool>(context);
   // Computation of right hand side can be pruned if left result is false and not null
-  if (!left_entry.is_nullable() || left_result) {  // Left result is not null
-    if (!left_result.value()) {                    // Left result is false
+  if (!left_entry.is_nullable || left_result) {  // Left result is not null
+    if (!left_result.value()) {                  // Left result is false
       return false;
     }
   }
 
   // Left result is null or true
   const auto right_result = right_side.compute<bool>(context);
-  if (left_entry.is_nullable() && !left_result) {  // Left result is null
+  if (left_entry.is_nullable && !left_result) {  // Left result is null
     // Right result is null or true
-    if ((right_entry.is_nullable() && !right_result) || right_result.value()) {
+    if ((right_entry.is_nullable && !right_result) || right_result.value()) {
       return std::nullopt;
     } else {  // Right result is false
       return false;
@@ -80,7 +78,7 @@ std::optional<bool> jit_and(const JitExpression& left_side, const JitExpression&
   }
 
   // Left result is false and not null
-  if (right_entry.is_nullable() && !right_result) {
+  if (right_entry.is_nullable && !right_result) {
     return std::nullopt;
   } else {
     return right_result.value();
@@ -94,27 +92,27 @@ std::optional<bool> jit_or(const JitExpression& left_side, const JitExpression& 
   // and true.
 
   // Get left and right operand types, the actual operand values are computed later
-  const auto left_entry = left_side.result_entry();
-  const auto right_entry = right_side.result_entry();
+  const auto left_entry = left_side.result_entry;
+  const auto right_entry = right_side.result_entry;
 
   // If the input value is computed by a non-jit operator, its data type is int but it can be read as a bool value.
-  DebugAssert((left_entry.data_type() == DataType::Bool || left_entry.data_type() == DataType::Int) &&
-                  (right_entry.data_type() == DataType::Bool || right_entry.data_type() == DataType::Int),
+  DebugAssert((left_entry.data_type == DataType::Bool || left_entry.data_type == DataType::Int) &&
+                  (right_entry.data_type == DataType::Bool || right_entry.data_type == DataType::Int),
               "invalid type for jit operation or");
 
   const auto left_result = left_side.compute<bool>(context);
   // Computation of right hand side can be pruned if left result is true and not null
-  if (!left_entry.is_nullable() || left_result) {  // Left result is not null
-    if (left_result.value()) {                     // Left result is true
+  if (!left_entry.is_nullable || left_result) {  // Left result is not null
+    if (left_result.value()) {                   // Left result is true
       return true;
     }
   }
 
   // Left result is null or false
   const auto right_result = right_side.compute<bool>(context);
-  if (left_entry.is_nullable() && !left_result) {  // Left result is null
+  if (left_entry.is_nullable && !left_result) {  // Left result is null
     // Right result is null or false
-    if ((right_entry.is_nullable() && !right_result) || !right_result.value()) {
+    if ((right_entry.is_nullable && !right_result) || !right_result.value()) {
       return std::nullopt;
     } else {  // Right result is true
       return true;
@@ -122,7 +120,7 @@ std::optional<bool> jit_or(const JitExpression& left_side, const JitExpression& 
   }
 
   // Left result is false and not null
-  if (right_entry.is_nullable() && !right_result) {
+  if (right_entry.is_nullable && !right_result) {
     return std::nullopt;
   } else {
     return right_result.value();
@@ -146,7 +144,7 @@ bool jit_not_like(const pmr_string& a, const pmr_string& b) {
 std::optional<bool> jit_is_null(const JitExpression& left_side, JitRuntimeContext& context) {
   // switch and macros required to call compute<ResultValueType>() on left_side with the correct ResultValueType
   // template parameter for each data type.
-  switch (left_side.result_entry().data_type()) {
+  switch (left_side.result_entry.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_IS_NULL_CASE, (JIT_DATA_TYPE_INFO))
     case DataType::Null:
       return true;
@@ -156,7 +154,7 @@ std::optional<bool> jit_is_null(const JitExpression& left_side, JitRuntimeContex
 std::optional<bool> jit_is_not_null(const JitExpression& left_side, JitRuntimeContext& context) {
   // switch and macros required to call compute<ResultValueType>() on left_side with the correct ResultValueType
   // template parameter for each data type.
-  switch (left_side.result_entry().data_type()) {
+  switch (left_side.result_entry.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_IS_NOT_NULL_CASE, (JIT_DATA_TYPE_INFO))
     case DataType::Null:
       return false;
@@ -170,7 +168,7 @@ uint64_t jit_hash(const JitTupleEntry& tuple_entry, JitRuntimeContext& context) 
   }
 
   // For all other values the hash is computed by the corresponding std::hash function
-  switch (tuple_entry.data_type()) {
+  switch (tuple_entry.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_HASH_CASE, (JIT_DATA_TYPE_INFO))
     default:
       Fail("unreachable");
@@ -188,9 +186,9 @@ bool jit_aggregate_equals(const JitTupleEntry& lhs, const JitHashmapEntry& rhs, 
     return false;
   }
 
-  DebugAssert(lhs.data_type() == rhs.data_type(), "Data types don't match in jit_aggregate_equals.");
+  DebugAssert(lhs.data_type == rhs.data_type, "Data types don't match in jit_aggregate_equals.");
 
-  switch (lhs.data_type()) {
+  switch (lhs.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_AGGREGATE_EQUALS_CASE, (JIT_DATA_TYPE_INFO))
     default:
       Fail("unreachable");
@@ -202,9 +200,9 @@ void jit_assign(const JitTupleEntry& from, const JitHashmapEntry& to, const size
   // jit_assign only supports identical data types. This is sufficient for the current JitAggregate implementation.
   // However, this function could easily be extended to support cross-data type assignment in a fashion similar to the
   // jit_compute function.
-  DebugAssert(from.data_type() == to.data_type(), "Data types don't match in jit_assign.");
+  DebugAssert(from.data_type == to.data_type, "Data types don't match in jit_assign.");
 
-  if (to.is_nullable()) {
+  if (to.is_nullable) {
     const bool is_null = from.is_null(context);
     to.set_is_null(is_null, to_index, context);
     // The value is NULL - our work is done here.
@@ -213,7 +211,7 @@ void jit_assign(const JitTupleEntry& from, const JitHashmapEntry& to, const size
     }
   }
 
-  switch (from.data_type()) {
+  switch (from.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_ASSIGN_CASE, (JIT_DATA_TYPE_INFO))
     default:
       break;
@@ -222,7 +220,7 @@ void jit_assign(const JitTupleEntry& from, const JitHashmapEntry& to, const size
 
 size_t jit_grow_by_one(const JitHashmapEntry& hashmap_entry, const JitVariantVector::InitialValue initial_value,
                        JitRuntimeContext& context) {
-  switch (hashmap_entry.data_type()) {
+  switch (hashmap_entry.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_GROW_BY_ONE_CASE, (JIT_DATA_TYPE_INFO))
     default:
       return 0;

--- a/src/lib/operators/jit_operator/jit_operations.hpp
+++ b/src/lib/operators/jit_operator/jit_operations.hpp
@@ -174,15 +174,15 @@ struct InvalidTypeCatcher : Functor {
 template <typename ResultValueType, bool CheckRightSideForZero = false, typename T>
 std::optional<ResultValueType> jit_compute(const T& op_func, const JitExpression& left_side,
                                            const JitExpression& right_side, JitRuntimeContext& context) {
-  const auto left_entry = left_side.result_entry();
-  const auto right_entry = right_side.result_entry();
+  const auto left_entry = left_side.result_entry;
+  const auto right_entry = right_side.result_entry;
 
   // This lambda calls the op_func (a lambda that performs the actual computation) with typed arguments and stores
   // the result.
   const auto store_result_wrapper = [&](const auto& typed_lhs, const auto& typed_rhs)
       -> std::optional<decltype(op_func(typed_lhs.value(), typed_rhs.value()), ResultValueType{})> {
     // Handle NULL values and return NULL if either input is NULL.
-    if ((left_entry.is_nullable() && !typed_lhs) || (right_entry.is_nullable() && !typed_rhs)) {
+    if ((left_entry.is_nullable && !typed_lhs) || (right_entry.is_nullable && !typed_rhs)) {
       return std::nullopt;
     }
 
@@ -206,7 +206,7 @@ std::optional<ResultValueType> jit_compute(const T& op_func, const JitExpression
 
   // The type information from the lhs and rhs are combined into a single value for dispatching without nesting.
   const auto combined_types =
-      static_cast<uint8_t>(left_entry.data_type()) << 8 | static_cast<uint8_t>(right_entry.data_type());
+      static_cast<uint8_t>(left_entry.data_type) << 8 | static_cast<uint8_t>(right_entry.data_type);
   // catching_func is called in this switch:
   switch (combined_types) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_COMPUTE_CASE, (JIT_DATA_TYPE_INFO)(JIT_DATA_TYPE_INFO))
@@ -290,7 +290,7 @@ __attribute__((noinline)) void jit_aggregate_compute(const T& op_func, const Jit
   }
 
   // Since we are updating the aggregate with a valid value, the aggregate is no longer NULL
-  if (rhs.is_nullable()) {
+  if (rhs.is_nullable) {
     rhs.set_is_null(false, rhs_index, context);
   }
 
@@ -317,14 +317,14 @@ __attribute__((noinline)) void jit_aggregate_compute(const T& op_func, const Jit
   //    Double |  Double |  Double
   //    String |       - |  String
 
-  if (lhs.data_type() == DataType::Int && rhs.data_type() == DataType::Long) {
+  if (lhs.data_type == DataType::Int && rhs.data_type == DataType::Long) {
     return catching_func(static_cast<int64_t>(lhs.get<int32_t>(context)), rhs.get<int64_t>(rhs_index, context));
-  } else if (lhs.data_type() == DataType::Float && rhs.data_type() == DataType::Double) {
+  } else if (lhs.data_type == DataType::Float && rhs.data_type == DataType::Double) {
     return catching_func(static_cast<double>(lhs.get<float>(context)), rhs.get<double>(rhs_index, context));
   }
 
   // else, catching_func is called here:
-  switch (rhs.data_type()) {
+  switch (rhs.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_AGGREGATE_COMPUTE_CASE, (JIT_DATA_TYPE_INFO))
     default:
       break;

--- a/src/lib/operators/jit_operator/jit_types.cpp
+++ b/src/lib/operators/jit_operator/jit_types.cpp
@@ -61,45 +61,32 @@ BOOST_PP_SEQ_FOR_EACH(JIT_VARIANT_VECTOR_GROW_BY_ONE, _, JIT_DATA_TYPE_INFO)
 BOOST_PP_SEQ_FOR_EACH(JIT_VARIANT_VECTOR_GET_VECTOR, _, JIT_DATA_TYPE_INFO)
 
 JitTupleEntry::JitTupleEntry(const DataType data_type, const bool is_nullable, const size_t tuple_index)
-    : _data_type{data_type}, _is_nullable{is_nullable}, _tuple_index{tuple_index} {}
+    : data_type{data_type}, is_nullable{is_nullable}, tuple_index{tuple_index} {}
 
 JitTupleEntry::JitTupleEntry(const std::pair<const DataType, const bool> data_type, const size_t tuple_index)
-    : _data_type{data_type.first}, _is_nullable{data_type.second}, _tuple_index{tuple_index} {}
-
-DataType JitTupleEntry::data_type() const { return _data_type; }
-
-bool JitTupleEntry::is_nullable() const { return _is_nullable; }
-
-size_t JitTupleEntry::tuple_index() const { return _tuple_index; }
+    : data_type{data_type.first}, is_nullable{data_type.second}, tuple_index{tuple_index} {}
 
 bool JitTupleEntry::is_null(JitRuntimeContext& context) const {
-  return _is_nullable && context.tuple.is_null(_tuple_index);
+  return is_nullable && context.tuple.is_null(tuple_index);
 }
 
 void JitTupleEntry::set_is_null(const bool is_null, JitRuntimeContext& context) const {
-  context.tuple.set_is_null(_tuple_index, is_null);
+  context.tuple.set_is_null(tuple_index, is_null);
 }
 
 bool JitTupleEntry::operator==(const JitTupleEntry& other) const {
-  return data_type() == other.data_type() && is_nullable() == other.is_nullable() &&
-         tuple_index() == other.tuple_index();
+  return data_type == other.data_type && is_nullable == other.is_nullable && tuple_index == other.tuple_index;
 }
 
 JitHashmapEntry::JitHashmapEntry(const DataType data_type, const bool is_nullable, const size_t column_index)
-    : _data_type{data_type}, _is_nullable{is_nullable}, _column_index{column_index} {}
-
-DataType JitHashmapEntry::data_type() const { return _data_type; }
-
-bool JitHashmapEntry::is_nullable() const { return _is_nullable; }
-
-size_t JitHashmapEntry::column_index() const { return _column_index; }
+    : data_type{data_type}, is_nullable{is_nullable}, column_index{column_index} {}
 
 bool JitHashmapEntry::is_null(const size_t index, JitRuntimeContext& context) const {
-  return _is_nullable && context.hashmap.columns[_column_index].is_null(index);
+  return is_nullable && context.hashmap.columns[column_index].is_null(index);
 }
 
 void JitHashmapEntry::set_is_null(const bool is_null, const size_t index, JitRuntimeContext& context) const {
-  context.hashmap.columns[_column_index].set_is_null(index, is_null);
+  context.hashmap.columns[column_index].set_is_null(index, is_null);
 }
 
 bool jit_expression_is_binary(const JitExpressionType expression_type) {

--- a/src/lib/operators/jit_operator/jit_types.hpp
+++ b/src/lib/operators/jit_operator/jit_types.hpp
@@ -182,18 +182,14 @@ class JitTupleEntry {
   JitTupleEntry(const DataType data_type, const bool is_nullable, const size_t tuple_index);
   JitTupleEntry(const std::pair<const DataType, const bool> data_type, const size_t tuple_index);
 
-  DataType data_type() const;
-  bool is_nullable() const;
-  size_t tuple_index() const;
-
   template <typename T>
   T get(JitRuntimeContext& context) const {
-    return context.tuple.get<T>(_tuple_index);
+    return context.tuple.get<T>(tuple_index);
   }
 
   template <typename T>
   void set(const T value, JitRuntimeContext& context) const {
-    context.tuple.set<T>(_tuple_index, value);
+    context.tuple.set<T>(tuple_index, value);
   }
 
   bool is_null(JitRuntimeContext& context) const;
@@ -204,10 +200,9 @@ class JitTupleEntry {
   // the same value in a given JitRuntimeContext.
   bool operator==(const JitTupleEntry& other) const;
 
- private:
-  const DataType _data_type;
-  const bool _is_nullable;
-  const size_t _tuple_index;
+  const DataType data_type;
+  const bool is_nullable;
+  const size_t tuple_index;
 };
 
 // The JitHashmapEntry represents a value in the runtime hashmap.
@@ -230,34 +225,29 @@ class JitHashmapEntry {
  public:
   JitHashmapEntry(const DataType data_type, const bool is_nullable, const size_t column_index);
 
-  DataType data_type() const;
-  bool is_nullable() const;
-  size_t column_index() const;
-
   template <typename T, typename = typename std::enable_if_t<!std::is_scalar_v<T>>>
   __attribute__((optnone)) pmr_string get(const size_t index, JitRuntimeContext& context) const {
-    return context.hashmap.columns[_column_index].get<pmr_string>(index);
+    return context.hashmap.columns[column_index].get<pmr_string>(index);
   }
   template <typename T, typename = typename std::enable_if_t<std::is_scalar_v<T>>>
   T get(const size_t index, JitRuntimeContext& context) const {
-    return context.hashmap.columns[_column_index].get<T>(index);
+    return context.hashmap.columns[column_index].get<T>(index);
   }
   template <typename T, typename = typename std::enable_if_t<!std::is_scalar_v<T>>>
   __attribute__((optnone)) void set(const pmr_string& value, const size_t index, JitRuntimeContext& context) const {
-    context.hashmap.columns[_column_index].set<pmr_string>(index, value);
+    context.hashmap.columns[column_index].set<pmr_string>(index, value);
   }
   template <typename T, typename = typename std::enable_if_t<std::is_scalar_v<T>>>
   void set(const T value, const size_t index, JitRuntimeContext& context) const {
-    context.hashmap.columns[_column_index].set<T>(index, value);
+    context.hashmap.columns[column_index].set<T>(index, value);
   }
 
   bool is_null(const size_t index, JitRuntimeContext& context) const;
   void set_is_null(const bool is_null, const size_t index, JitRuntimeContext& context) const;
 
- private:
-  const DataType _data_type;
-  const bool _is_nullable;
-  const size_t _column_index;
+  const DataType data_type;
+  const bool is_nullable;
+  const size_t column_index;
 };
 
 enum class JitExpressionType {

--- a/src/lib/operators/jit_operator/operators/jit_compute.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_compute.cpp
@@ -4,16 +4,14 @@
 
 namespace opossum {
 
-JitCompute::JitCompute(const std::shared_ptr<const JitExpression>& expression) : _expression{expression} {}
+JitCompute::JitCompute(const std::shared_ptr<const JitExpression>& expression) : expression{expression} {}
 
 std::string JitCompute::description() const {
-  return "[Compute] x" + std::to_string(_expression->result_entry().tuple_index()) + " = " + _expression->to_string();
+  return "[Compute] x" + std::to_string(expression->result_entry.tuple_index) + " = " + expression->to_string();
 }
 
-std::shared_ptr<const JitExpression> JitCompute::expression() { return _expression; }
-
 void JitCompute::_consume(JitRuntimeContext& context) const {
-  _expression->compute_and_store(context);
+  expression->compute_and_store(context);
   _emit(context);
 }
 

--- a/src/lib/operators/jit_operator/operators/jit_compute.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_compute.hpp
@@ -15,12 +15,10 @@ class JitCompute : public AbstractJittable {
 
   std::string description() const final;
 
-  std::shared_ptr<const JitExpression> expression();
+  const std::shared_ptr<const JitExpression> expression;
 
  private:
   void _consume(JitRuntimeContext& context) const final;
-
-  const std::shared_ptr<const JitExpression> _expression;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_expression.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_expression.cpp
@@ -10,16 +10,16 @@ namespace opossum {
 
 // Call the compute function with the correct template parameter if compute is called without a template parameter and
 // store the result in the runtime tuple.
-#define JIT_EXPRESSION_COMPUTE_CASE(r, types)                                  \
-  case JIT_GET_ENUM_VALUE(0, types): {                                         \
-    const auto result = compute<JIT_GET_DATA_TYPE(0, types)>(context);         \
-    if (!_result_entry.is_nullable() || result) {                              \
-      _result_entry.set<JIT_GET_DATA_TYPE(0, types)>(result.value(), context); \
-    }                                                                          \
-    if (_result_entry.is_nullable()) {                                         \
-      _result_entry.set_is_null(!result, context);                             \
-    }                                                                          \
-    break;                                                                     \
+#define JIT_EXPRESSION_COMPUTE_CASE(r, types)                                 \
+  case JIT_GET_ENUM_VALUE(0, types): {                                        \
+    const auto result = compute<JIT_GET_DATA_TYPE(0, types)>(context);        \
+    if (!result_entry.is_nullable || result) {                                \
+      result_entry.set<JIT_GET_DATA_TYPE(0, types)>(result.value(), context); \
+    }                                                                         \
+    if (result_entry.is_nullable) {                                           \
+      result_entry.set_is_null(!result, context);                             \
+    }                                                                         \
+    break;                                                                    \
   }
 
 #define JIT_VARIANT_GET(r, d, type)                          \
@@ -59,33 +59,33 @@ JitVariant::JitVariant(const AllTypeVariant& variant) : is_null{variant_is_null(
 }
 
 JitExpression::JitExpression(const JitTupleEntry& tuple_entry)
-    : _expression_type{JitExpressionType::Column}, _result_entry{tuple_entry} {}
+    : expression_type{JitExpressionType::Column}, result_entry{tuple_entry} {}
 
 JitExpression::JitExpression(const JitTupleEntry& tuple_entry, const AllTypeVariant& variant)
-    : _expression_type{JitExpressionType::Value}, _result_entry{tuple_entry}, _variant{variant} {}
+    : expression_type{JitExpressionType::Value}, result_entry{tuple_entry}, _variant{variant} {}
 
 JitExpression::JitExpression(const std::shared_ptr<const JitExpression>& child, const JitExpressionType expression_type,
                              const size_t result_tuple_index)
-    : _left_child{child},
-      _expression_type{expression_type},
-      _result_entry{JitTupleEntry(_compute_result_type(), result_tuple_index)} {}
+    : left_child{child},
+      expression_type{expression_type},
+      result_entry{JitTupleEntry(_compute_result_type(), result_tuple_index)} {}
 
 JitExpression::JitExpression(const std::shared_ptr<const JitExpression>& left_child,
                              const JitExpressionType expression_type,
                              const std::shared_ptr<const JitExpression>& right_child, const size_t result_tuple_index)
-    : _left_child{left_child},
-      _right_child{right_child},
-      _expression_type{expression_type},
-      _result_entry{JitTupleEntry(_compute_result_type(), result_tuple_index)} {}
+    : left_child{left_child},
+      right_child{right_child},
+      expression_type{expression_type},
+      result_entry{JitTupleEntry(_compute_result_type(), result_tuple_index)} {}
 
 std::string JitExpression::to_string() const {
-  if (_expression_type == JitExpressionType::Column) {
-    return "x" + std::to_string(_result_entry.tuple_index());
-  } else if (_expression_type == JitExpressionType::Value) {
-    if (_result_entry.data_type() != DataType::Null) {
+  if (expression_type == JitExpressionType::Column) {
+    return "x" + std::to_string(result_entry.tuple_index);
+  } else if (expression_type == JitExpressionType::Value) {
+    if (result_entry.data_type != DataType::Null) {
       // JitVariant does not have a operator<<() function.
       std::stringstream str;
-      resolve_data_type(_result_entry.data_type(), [&](const auto current_data_type_t) {
+      resolve_data_type(result_entry.data_type, [&](const auto current_data_type_t) {
         using CurrentType = typename decltype(current_data_type_t)::type;
         str << _variant.get<CurrentType>();
       });
@@ -95,19 +95,19 @@ std::string JitExpression::to_string() const {
     }
   }
 
-  const auto left = _left_child->to_string() + " ";
-  const auto right = _right_child ? _right_child->to_string() + " " : "";
-  return "(" + left + jit_expression_type_to_string.left.at(_expression_type) + " " + right + ")";
+  const auto left = left_child->to_string() + " ";
+  const auto right = right_child ? right_child->to_string() + " " : "";
+  return "(" + left + jit_expression_type_to_string.left.at(expression_type) + " " + right + ")";
 }
 
 void JitExpression::compute_and_store(JitRuntimeContext& context) const {
   // We are dealing with an already computed value here, so there is nothing to do.
-  if (_expression_type == JitExpressionType::Column || _expression_type == JitExpressionType::Value) {
+  if (expression_type == JitExpressionType::Column || expression_type == JitExpressionType::Value) {
     return;
   }
 
   // Compute result value using compute<ResultValueType>() function and store it in the runtime tuple
-  switch (_result_entry.data_type()) {
+  switch (result_entry.data_type) {
     BOOST_PP_SEQ_FOR_EACH_PRODUCT(JIT_EXPRESSION_COMPUTE_CASE, (JIT_DATA_TYPE_INFO))
     case DataType::Null:
       break;
@@ -115,12 +115,12 @@ void JitExpression::compute_and_store(JitRuntimeContext& context) const {
 }
 
 std::pair<const DataType, const bool> JitExpression::_compute_result_type() {
-  const auto& left_tuple_entry = _left_child->result_entry();
+  const auto& left_tuple_entry = left_child->result_entry;
 
-  if (!jit_expression_is_binary(_expression_type)) {
-    switch (_expression_type) {
+  if (!jit_expression_is_binary(expression_type)) {
+    switch (expression_type) {
       case JitExpressionType::Not:
-        return std::make_pair(DataType::Bool, left_tuple_entry.is_nullable());
+        return std::make_pair(DataType::Bool, left_tuple_entry.is_nullable);
       case JitExpressionType::IsNull:
       case JitExpressionType::IsNotNull:
         return std::make_pair(DataType::Bool, false);
@@ -129,28 +129,27 @@ std::pair<const DataType, const bool> JitExpression::_compute_result_type() {
     }
   }
 
-  const auto& right_tuple_entry = _right_child->result_entry();
+  const auto& right_tuple_entry = right_child->result_entry;
 
   DataType result_data_type;
-  switch (_expression_type) {
+  switch (expression_type) {
     case JitExpressionType::Addition:
-      result_data_type = jit_compute_type(jit_addition, left_tuple_entry.data_type(), right_tuple_entry.data_type());
+      result_data_type = jit_compute_type(jit_addition, left_tuple_entry.data_type, right_tuple_entry.data_type);
       break;
     case JitExpressionType::Subtraction:
-      result_data_type = jit_compute_type(jit_subtraction, left_tuple_entry.data_type(), right_tuple_entry.data_type());
+      result_data_type = jit_compute_type(jit_subtraction, left_tuple_entry.data_type, right_tuple_entry.data_type);
       break;
     case JitExpressionType::Multiplication:
-      result_data_type =
-          jit_compute_type(jit_multiplication, left_tuple_entry.data_type(), right_tuple_entry.data_type());
+      result_data_type = jit_compute_type(jit_multiplication, left_tuple_entry.data_type, right_tuple_entry.data_type);
       break;
     case JitExpressionType::Division:
-      result_data_type = jit_compute_type(jit_division, left_tuple_entry.data_type(), right_tuple_entry.data_type());
+      result_data_type = jit_compute_type(jit_division, left_tuple_entry.data_type, right_tuple_entry.data_type);
       break;
     case JitExpressionType::Modulo:
-      result_data_type = jit_compute_type(jit_modulo, left_tuple_entry.data_type(), right_tuple_entry.data_type());
+      result_data_type = jit_compute_type(jit_modulo, left_tuple_entry.data_type, right_tuple_entry.data_type);
       break;
     case JitExpressionType::Power:
-      result_data_type = jit_compute_type(jit_power, left_tuple_entry.data_type(), right_tuple_entry.data_type());
+      result_data_type = jit_compute_type(jit_power, left_tuple_entry.data_type, right_tuple_entry.data_type);
       break;
     case JitExpressionType::Equals:
     case JitExpressionType::NotEquals:
@@ -168,23 +167,21 @@ std::pair<const DataType, const bool> JitExpression::_compute_result_type() {
       Fail("This binary expression type is not supported.");
   }
 
-  const bool nullable = left_tuple_entry.is_nullable() || right_tuple_entry.is_nullable() ||
-                        _expression_type == JitExpressionType::Division ||
-                        _expression_type == JitExpressionType::Modulo;
+  const bool nullable = left_tuple_entry.is_nullable || right_tuple_entry.is_nullable ||
+                        expression_type == JitExpressionType::Division || expression_type == JitExpressionType::Modulo;
   return std::make_pair(result_data_type, nullable);
 }
 
 template <typename ResultValueType>
 std::optional<ResultValueType> JitExpression::compute(JitRuntimeContext& context) const {
-  if (_expression_type == JitExpressionType::Column) {
-    if (_result_entry.data_type() == DataType::Null ||
-        (_result_entry.is_nullable() && _result_entry.is_null(context))) {
+  if (expression_type == JitExpressionType::Column) {
+    if (result_entry.data_type == DataType::Null || (result_entry.is_nullable && result_entry.is_null(context))) {
       return std::nullopt;
     }
-    return _result_entry.get<ResultValueType>(context);
+    return result_entry.get<ResultValueType>(context);
 
-  } else if (_expression_type == JitExpressionType::Value) {
-    if (_result_entry.is_nullable() && _variant.is_null) {
+  } else if (expression_type == JitExpressionType::Value) {
+    if (result_entry.is_nullable && _variant.is_null) {
       return std::nullopt;
     }
     return _variant.get<ResultValueType>();
@@ -192,77 +189,77 @@ std::optional<ResultValueType> JitExpression::compute(JitRuntimeContext& context
 
   // We check for the result type here to reduce the size of the instantiated templated functions.
   if constexpr (std::is_same_v<ResultValueType, bool>) {
-    if (!jit_expression_is_binary(_expression_type)) {
-      switch (_expression_type) {
+    if (!jit_expression_is_binary(expression_type)) {
+      switch (expression_type) {
         case JitExpressionType::Not:
-          return jit_not(*_left_child, context);
+          return jit_not(*left_child, context);
         case JitExpressionType::IsNull:
-          return jit_is_null(*_left_child, context);
+          return jit_is_null(*left_child, context);
         case JitExpressionType::IsNotNull:
-          return jit_is_not_null(*_left_child, context);
+          return jit_is_not_null(*left_child, context);
         default:
           Fail("This non-binary expression type is not supported.");
       }
     }
 
-    if (_left_child->result_entry().data_type() == DataType::String) {
-      switch (_expression_type) {
+    if (left_child->result_entry.data_type == DataType::String) {
+      switch (expression_type) {
         case JitExpressionType::Equals:
-          return jit_compute<ResultValueType>(jit_string_equals, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_string_equals, *left_child, *right_child, context);
         case JitExpressionType::NotEquals:
-          return jit_compute<ResultValueType>(jit_string_not_equals, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_string_not_equals, *left_child, *right_child, context);
         case JitExpressionType::GreaterThan:
-          return jit_compute<ResultValueType>(jit_string_greater_than, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_string_greater_than, *left_child, *right_child, context);
         case JitExpressionType::GreaterThanEquals:
-          return jit_compute<ResultValueType>(jit_string_greater_than_equals, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_string_greater_than_equals, *left_child, *right_child, context);
         case JitExpressionType::LessThan:
-          return jit_compute<ResultValueType>(jit_string_less_than, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_string_less_than, *left_child, *right_child, context);
         case JitExpressionType::LessThanEquals:
-          return jit_compute<ResultValueType>(jit_string_less_than_equals, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_string_less_than_equals, *left_child, *right_child, context);
         case JitExpressionType::Like:
-          return jit_compute<ResultValueType>(jit_like, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_like, *left_child, *right_child, context);
         case JitExpressionType::NotLike:
-          return jit_compute<ResultValueType>(jit_not_like, *_left_child, *_right_child, context);
+          return jit_compute<ResultValueType>(jit_not_like, *left_child, *right_child, context);
         default:
           Fail("This expression type is not supported for left operand type string.");
       }
     }
 
-    switch (_expression_type) {
+    switch (expression_type) {
       case JitExpressionType::Equals:
-        return jit_compute<ResultValueType>(jit_equals, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_equals, *left_child, *right_child, context);
       case JitExpressionType::NotEquals:
-        return jit_compute<ResultValueType>(jit_not_equals, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_not_equals, *left_child, *right_child, context);
       case JitExpressionType::GreaterThan:
-        return jit_compute<ResultValueType>(jit_greater_than, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_greater_than, *left_child, *right_child, context);
       case JitExpressionType::GreaterThanEquals:
-        return jit_compute<ResultValueType>(jit_greater_than_equals, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_greater_than_equals, *left_child, *right_child, context);
       case JitExpressionType::LessThan:
-        return jit_compute<ResultValueType>(jit_less_than, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_less_than, *left_child, *right_child, context);
       case JitExpressionType::LessThanEquals:
-        return jit_compute<ResultValueType>(jit_less_than_equals, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_less_than_equals, *left_child, *right_child, context);
 
       case JitExpressionType::And:
-        return jit_and(*_left_child, *_right_child, context);
+        return jit_and(*left_child, *right_child, context);
       case JitExpressionType::Or:
-        return jit_or(*_left_child, *_right_child, context);
+        return jit_or(*left_child, *right_child, context);
       default:
         Fail("This expression type is not supported for result type bool.");
     }
   } else if constexpr (std::is_arithmetic_v<ResultValueType>) {  // NOLINT(readability/braces)
-    switch (_expression_type) {
+    switch (expression_type) {
       case JitExpressionType::Addition:
-        return jit_compute<ResultValueType>(jit_addition, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_addition, *left_child, *right_child, context);
       case JitExpressionType::Subtraction:
-        return jit_compute<ResultValueType>(jit_subtraction, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_subtraction, *left_child, *right_child, context);
       case JitExpressionType::Multiplication:
-        return jit_compute<ResultValueType>(jit_multiplication, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_multiplication, *left_child, *right_child, context);
       case JitExpressionType::Division:
-        return jit_compute<ResultValueType, true>(jit_division, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType, true>(jit_division, *left_child, *right_child, context);
       case JitExpressionType::Modulo:
-        return jit_compute<ResultValueType, true>(jit_modulo, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType, true>(jit_modulo, *left_child, *right_child, context);
       case JitExpressionType::Power:
-        return jit_compute<ResultValueType>(jit_power, *_left_child, *_right_child, context);
+        return jit_compute<ResultValueType>(jit_power, *left_child, *right_child, context);
       default:
         Fail("This expression type is not supported for an arithmetic result type.");
     }

--- a/src/lib/operators/jit_operator/operators/jit_expression.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_expression.hpp
@@ -54,11 +54,6 @@ class JitExpression {
 
   std::string to_string() const;
 
-  JitExpressionType expression_type() const { return _expression_type; }
-  std::shared_ptr<const JitExpression> left_child() const { return _left_child; }
-  std::shared_ptr<const JitExpression> right_child() const { return _right_child; }
-  const JitTupleEntry& result_entry() const { return _result_entry; }
-
   // The compute_and_store() and compute<ResultValueType>() functions trigger the (recursive) computation of the value
   // represented by this expression.
 
@@ -78,13 +73,13 @@ class JitExpression {
   template <typename ResultValueType>
   std::optional<ResultValueType> compute(JitRuntimeContext& context) const;
 
+  const std::shared_ptr<const JitExpression> left_child;
+  const std::shared_ptr<const JitExpression> right_child;
+  const JitExpressionType expression_type;
+  const JitTupleEntry result_entry;
+
  private:
   std::pair<const DataType, const bool> _compute_result_type();
-
-  const std::shared_ptr<const JitExpression> _left_child;
-  const std::shared_ptr<const JitExpression> _right_child;
-  const JitExpressionType _expression_type;
-  const JitTupleEntry _result_entry;
 
   JitVariant _variant;
 };

--- a/src/lib/operators/jit_operator/operators/jit_filter.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_filter.cpp
@@ -4,17 +4,15 @@
 
 namespace opossum {
 
-JitFilter::JitFilter(const std::shared_ptr<const JitExpression>& expression) : _expression{expression} {
-  DebugAssert(_expression->result_entry().data_type() == DataType::Bool, "Filter condition must be a boolean");
+JitFilter::JitFilter(const std::shared_ptr<const JitExpression>& expression) : expression{expression} {
+  DebugAssert(expression->result_entry.data_type == DataType::Bool, "Filter condition must be a boolean");
 }
 
-std::string JitFilter::description() const { return "[Filter] on x = " + _expression->to_string(); }
-
-std::shared_ptr<const JitExpression> JitFilter::expression() { return _expression; }
+std::string JitFilter::description() const { return "[Filter] on x = " + expression->to_string(); }
 
 void JitFilter::_consume(JitRuntimeContext& context) const {
-  const auto result = _expression->compute<bool>(context);
-  if ((!_expression->result_entry().is_nullable() || result) && result.value()) {
+  const auto result = expression->compute<bool>(context);
+  if ((!expression->result_entry.is_nullable || result) && result.value()) {
     _emit(context);
   }
 }

--- a/src/lib/operators/jit_operator/operators/jit_filter.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_filter.hpp
@@ -15,12 +15,10 @@ class JitFilter : public AbstractJittable {
 
   std::string description() const final;
 
-  std::shared_ptr<const JitExpression> expression();
+  const std::shared_ptr<const JitExpression> expression;
 
  private:
   void _consume(JitRuntimeContext& context) const final;
-
-  const std::shared_ptr<const JitExpression> _expression;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.hpp
@@ -76,12 +76,12 @@ class JitReadTuples : public AbstractJittable {
       ++_iterator;
       // clang-format off
       if constexpr (Nullable) {
-        context.tuple.set_is_null(_tuple_entry.tuple_index(), value.is_null());
+        context.tuple.set_is_null(_tuple_entry.tuple_index, value.is_null());
         if (!value.is_null()) {
-          context.tuple.set<DataType>(_tuple_entry.tuple_index(), value.value());
+          context.tuple.set<DataType>(_tuple_entry.tuple_index, value.value());
         }
       } else {
-        context.tuple.set<DataType>(_tuple_entry.tuple_index(), value.value());
+        context.tuple.set<DataType>(_tuple_entry.tuple_index, value.value());
       }
       // clang-format on
     }
@@ -118,9 +118,9 @@ class JitReadTuples : public AbstractJittable {
   std::optional<ColumnID> find_input_column(const JitTupleEntry& tuple_entry) const;
   std::optional<AllTypeVariant> find_literal_value(const JitTupleEntry& tuple_entry) const;
 
-  std::shared_ptr<AbstractExpression> row_count_expression() const;
-
   void execute(JitRuntimeContext& context) const;
+
+  const std::shared_ptr<AbstractExpression> row_count_expression;
 
  protected:
   uint32_t _num_tuple_values{0};
@@ -132,7 +132,6 @@ class JitReadTuples : public AbstractJittable {
   void _consume(JitRuntimeContext& context) const final {}
 
   const bool _has_validate;
-  const std::shared_ptr<AbstractExpression> _row_count_expression;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_validate.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_validate.cpp
@@ -16,14 +16,12 @@ bool is_row_visible(const CommitID our_tid, const TransactionID row_tid, const C
 
 }  // namespace
 
-JitValidate::JitValidate(const TableType input_table_type) : _input_table_type(input_table_type) {}
+JitValidate::JitValidate(const TableType input_table_type) : input_table_type(input_table_type) {}
 
 std::string JitValidate::description() const { return "[Validate]"; }
 
-void JitValidate::set_input_table_type(const TableType input_table_type) { _input_table_type = input_table_type; }
-
 void JitValidate::_consume(JitRuntimeContext& context) const {
-  if (_input_table_type == TableType::References) {
+  if (input_table_type == TableType::References) {
     const auto row_id = (*context.pos_list)[context.chunk_offset];
     const auto& referenced_chunk = context.referenced_table->get_chunk(row_id.chunk_id);
     const auto mvcc_data = referenced_chunk->get_scoped_mvcc_data_lock();

--- a/src/lib/operators/jit_operator/operators/jit_validate.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_validate.hpp
@@ -15,7 +15,7 @@ class JitValidate : public AbstractJittable {
 
   std::string description() const final;
 
-  void set_input_table_type(const TableType input_table_type);
+  TableType input_table_type;
 
  protected:
   void _consume(JitRuntimeContext& context) const final;
@@ -24,8 +24,6 @@ class JitValidate : public AbstractJittable {
   // Function not optimized due to specialization issues with atomic
   __attribute__((optnone)) static TransactionID _load_atomic_value(
       const copyable_atomic<TransactionID>& transaction_id);
-
-  TableType _input_table_type;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_write_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_write_tuples.cpp
@@ -12,7 +12,7 @@ std::string JitWriteTuples::description() const {
   std::stringstream desc;
   desc << "[WriteTuple] ";
   for (const auto& output_column : _output_columns) {
-    desc << output_column.column_name << " = x" << output_column.tuple_entry.tuple_index() << ", ";
+    desc << output_column.column_name << " = x" << output_column.tuple_entry.tuple_index << ", ";
   }
   return desc.str();
 }
@@ -22,9 +22,9 @@ std::shared_ptr<Table> JitWriteTuples::create_output_table(const Table& in_table
 
   for (const auto& output_column : _output_columns) {
     // Add a column definition for each output column
-    const auto data_type = output_column.tuple_entry.data_type();
+    const auto data_type = output_column.tuple_entry.data_type;
     const auto output_column_type = data_type == DataType::Bool ? DataTypeBool : data_type;
-    const auto is_nullable = output_column.tuple_entry.is_nullable();
+    const auto is_nullable = output_column.tuple_entry.is_nullable;
     column_definitions.emplace_back(output_column.column_name, output_column_type, is_nullable);
   }
 
@@ -59,37 +59,38 @@ void JitWriteTuples::_create_output_chunk(JitRuntimeContext& context) const {
 
   // Create new value segments and add them to the runtime context to make them accessible by the segment writers
   for (const auto& output_column : _output_columns) {
-    const auto data_type = output_column.tuple_entry.data_type();
-    const auto is_nullable = output_column.tuple_entry.is_nullable();
+    const auto data_type = output_column.tuple_entry.data_type;
+    const auto is_nullable = output_column.tuple_entry.is_nullable;
+    const auto tuple_index = output_column.tuple_entry.tuple_index;
 
     // Create the appropriate segment writer for the output segment
     if (data_type == DataType::Bool) {
       // Data type bool is a special jit data type and not an opossum data type
       // Therefore, bools needs to be handled separately as they are transformed to opossum int types
-      auto segment = std::make_shared<ValueSegment<Bool>>(output_column.tuple_entry.is_nullable());
+      auto segment = std::make_shared<ValueSegment<Bool>>(is_nullable);
       context.out_chunk.push_back(segment);
       if (is_nullable) {
         context.outputs.push_back(
-            std::make_shared<JitSegmentWriter<ValueSegment<Bool>, bool, true>>(segment, output_column.tuple_entry));
+            std::make_shared<JitSegmentWriter<ValueSegment<Bool>, bool, true>>(segment, tuple_index));
       } else {
         context.outputs.push_back(
-            std::make_shared<JitSegmentWriter<ValueSegment<Bool>, bool, false>>(segment, output_column.tuple_entry));
+            std::make_shared<JitSegmentWriter<ValueSegment<Bool>, bool, false>>(segment, tuple_index));
       }
     } else {
       // Opossum data types
       resolve_data_type(data_type, [&](auto type) {
         using ColumnDataType = typename decltype(type)::type;
-        auto segment = std::make_shared<ValueSegment<ColumnDataType>>(output_column.tuple_entry.is_nullable());
+        auto segment = std::make_shared<ValueSegment<ColumnDataType>>(is_nullable);
         context.out_chunk.push_back(segment);
 
         if (is_nullable) {
           context.outputs.push_back(
-              std::make_shared<JitSegmentWriter<ValueSegment<ColumnDataType>, ColumnDataType, true>>(
-                  segment, output_column.tuple_entry));
+              std::make_shared<JitSegmentWriter<ValueSegment<ColumnDataType>, ColumnDataType, true>>(segment,
+                                                                                                     tuple_index));
         } else {
           context.outputs.push_back(
-              std::make_shared<JitSegmentWriter<ValueSegment<ColumnDataType>, ColumnDataType, false>>(
-                  segment, output_column.tuple_entry));
+              std::make_shared<JitSegmentWriter<ValueSegment<ColumnDataType>, ColumnDataType, false>>(segment,
+                                                                                                      tuple_index));
         }
       });
     }

--- a/src/lib/operators/jit_operator/operators/jit_write_tuples.hpp
+++ b/src/lib/operators/jit_operator/operators/jit_write_tuples.hpp
@@ -41,22 +41,22 @@ class JitWriteTuples : public AbstractJittableSink {
   template <typename ValueSegment, typename DataType, bool Nullable>
   class JitSegmentWriter : public BaseJitSegmentWriter {
    public:
-    JitSegmentWriter(const std::shared_ptr<ValueSegment>& segment, const JitTupleEntry& tuple_entry)
-        : _segment{segment}, _tuple_entry{tuple_entry} {}
+    JitSegmentWriter(const std::shared_ptr<ValueSegment>& segment, const size_t tuple_index)
+        : _segment{segment}, _tuple_index{tuple_index} {}
 
     // Reads the value from the _tuple_entry and appends it to the output ValueSegment.
     void write_value(JitRuntimeContext& context) const {
-      _segment->values().push_back(context.tuple.get<DataType>(_tuple_entry.tuple_index()));
+      _segment->values().push_back(context.tuple.get<DataType>(_tuple_index));
       // clang-format off
       if constexpr (Nullable) {
-        _segment->null_values().push_back(context.tuple.is_null(_tuple_entry.tuple_index()));
+        _segment->null_values().push_back(context.tuple.is_null(_tuple_index));
       }
       // clang-format on
     }
 
    private:
-    std::shared_ptr<ValueSegment> _segment;
-    const JitTupleEntry _tuple_entry;
+    const std::shared_ptr<ValueSegment> _segment;
+    const size_t _tuple_index;
   };
 
  public:

--- a/src/lib/operators/jit_operator_wrapper.cpp
+++ b/src/lib/operators/jit_operator_wrapper.cpp
@@ -85,7 +85,7 @@ void JitOperatorWrapper::_prepare_and_specialize_operator_pipeline() {
 
   for (auto& jit_operator : jit_operators) {
     if (auto jit_validate = std::dynamic_pointer_cast<JitValidate>(jit_operator)) {
-      jit_validate->set_input_table_type(input_left()->get_output()->type());
+      jit_validate->input_table_type = input_left()->get_output()->type();
     }
   }
 
@@ -125,14 +125,14 @@ void JitOperatorWrapper::_on_set_parameters(const std::unordered_map<ParameterID
   }
 
   // Set any parameter values used within in the row count expression.
-  if (const auto row_count_expression = _source()->row_count_expression()) {
+  if (const auto row_count_expression = _source()->row_count_expression) {
     expression_set_parameters(row_count_expression, parameters);
   }
 }
 
 void JitOperatorWrapper::_on_set_transaction_context(const std::weak_ptr<TransactionContext>& transaction_context) {
   // Set the MVCC data in the row count expression required by possible subqueries within the expression.
-  if (const auto row_count_expression = _source()->row_count_expression()) {
+  if (const auto row_count_expression = _source()->row_count_expression) {
     expression_set_transaction_context(row_count_expression, transaction_context);
   }
 }

--- a/src/test/operators/jit_operator/jit_hashmap_entry_test.cpp
+++ b/src/test/operators/jit_operator/jit_hashmap_entry_test.cpp
@@ -8,21 +8,21 @@ class JitHashmapEntryTest : public BaseTest {};
 TEST_F(JitHashmapEntryTest, Accessors) {
   {
     JitHashmapEntry hashmap_entry{DataType::String, false, 123u};
-    ASSERT_EQ(hashmap_entry.data_type(), DataType::String);
-    ASSERT_EQ(hashmap_entry.is_nullable(), false);
-    ASSERT_EQ(hashmap_entry.column_index(), 123u);
+    ASSERT_EQ(hashmap_entry.data_type, DataType::String);
+    ASSERT_FALSE(hashmap_entry.is_nullable);
+    ASSERT_EQ(hashmap_entry.column_index, 123u);
   }
   {
     JitHashmapEntry hashmap_entry{DataType::Int, true, 456u};
-    ASSERT_EQ(hashmap_entry.data_type(), DataType::Int);
-    ASSERT_EQ(hashmap_entry.is_nullable(), true);
-    ASSERT_EQ(hashmap_entry.column_index(), 456u);
+    ASSERT_EQ(hashmap_entry.data_type, DataType::Int);
+    ASSERT_TRUE(hashmap_entry.is_nullable);
+    ASSERT_EQ(hashmap_entry.column_index, 456u);
   }
   {
     JitHashmapEntry hashmap_entry{DataType::Double, true, 789u};
-    ASSERT_EQ(hashmap_entry.data_type(), DataType::Double);
-    ASSERT_EQ(hashmap_entry.is_nullable(), true);
-    ASSERT_EQ(hashmap_entry.column_index(), 789u);
+    ASSERT_EQ(hashmap_entry.data_type, DataType::Double);
+    ASSERT_TRUE(hashmap_entry.is_nullable);
+    ASSERT_EQ(hashmap_entry.column_index, 789u);
   }
 }
 

--- a/src/test/operators/jit_operator/operators/jit_expression_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_expression_test.cpp
@@ -15,12 +15,12 @@ TEST_F(JitExpressionTest, Is_Not_Null) {
 
   {
     JitExpression expression(std::make_shared<JitExpression>(tuple_entry), JitExpressionType::IsNull, result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Bool);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Bool);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
 
     tuple_entry.set_is_null(true, context);
     expression.compute_and_store(context);
-    ASSERT_TRUE(expression.result_entry().get<bool>(context));
+    ASSERT_TRUE(expression.result_entry.get<bool>(context));
 
     tuple_entry.set_is_null(false, context);
     expression.compute_and_store(context);
@@ -28,8 +28,8 @@ TEST_F(JitExpressionTest, Is_Not_Null) {
   }
   {
     JitExpression expression(std::make_shared<JitExpression>(tuple_entry), JitExpressionType::IsNotNull, result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Bool);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Bool);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
 
     tuple_entry.set_is_null(true, context);
     expression.compute_and_store(context);
@@ -49,12 +49,12 @@ TEST_F(JitExpressionTest, Not) {
   {
     auto tuple_entry = JitTupleEntry{DataType::Bool, false, 0};
     JitExpression expression(std::make_shared<JitExpression>(tuple_entry), JitExpressionType::Not, result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Bool);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Bool);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
 
     tuple_entry.set<bool>(true, context);
     expression.compute_and_store(context);
-    ASSERT_FALSE(expression.result_entry().get<bool>(context));
+    ASSERT_FALSE(expression.result_entry.get<bool>(context));
 
     tuple_entry.set<bool>(false, context);
     expression.compute_and_store(context);
@@ -63,8 +63,8 @@ TEST_F(JitExpressionTest, Not) {
   {
     auto tuple_entry = JitTupleEntry{DataType::Bool, true, 0};
     JitExpression expression(std::make_shared<JitExpression>(tuple_entry), JitExpressionType::Not, result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Bool);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Bool);
+    ASSERT_TRUE(expression.result_entry.is_nullable);
 
     tuple_entry.set_is_null(true, context);
     expression.compute_and_store(context);
@@ -116,50 +116,50 @@ TEST_F(JitExpressionTest, ArithmeticOperations) {
   {
     JitExpression expression(std::make_shared<JitExpression>(int_tuple_entry), JitExpressionType::Addition,
                              std::make_shared<JitExpression>(float_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Float);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Float);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_EQ(expression.result_entry().get<float>(context), int_value + float_value);
+    ASSERT_EQ(expression.result_entry.get<float>(context), int_value + float_value);
   }
   {
     JitExpression expression(std::make_shared<JitExpression>(int_tuple_entry), JitExpressionType::Subtraction,
                              std::make_shared<JitExpression>(double_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Double);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Double);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_EQ(expression.result_entry().get<double>(context), int_value - double_value);
+    ASSERT_EQ(expression.result_entry.get<double>(context), int_value - double_value);
   }
   {
     JitExpression expression(std::make_shared<JitExpression>(long_tuple_entry), JitExpressionType::Multiplication,
                              std::make_shared<JitExpression>(int_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Long);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Long);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_EQ(expression.result_entry().get<int64_t>(context), long_value * int_value);
+    ASSERT_EQ(expression.result_entry.get<int64_t>(context), long_value * int_value);
   }
   {
     JitExpression expression(std::make_shared<JitExpression>(float_tuple_entry), JitExpressionType::Division,
                              std::make_shared<JitExpression>(double_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Double);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Double);
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_EQ(expression.result_entry().get<double>(context), float_value / double_value);
+    ASSERT_EQ(expression.result_entry.get<double>(context), float_value / double_value);
   }
   {
     JitExpression expression(std::make_shared<JitExpression>(long_tuple_entry), JitExpressionType::Modulo,
                              std::make_shared<JitExpression>(int_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Long);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Long);
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_EQ(expression.result_entry().get<int64_t>(context), long_value % int_value);
+    ASSERT_EQ(expression.result_entry.get<int64_t>(context), long_value % int_value);
   }
   {
     JitExpression expression(std::make_shared<JitExpression>(long_tuple_entry), JitExpressionType::Power,
                              std::make_shared<JitExpression>(double_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Double);
-    ASSERT_FALSE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Double);
+    ASSERT_FALSE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_EQ(expression.result_entry().get<double>(context), std::pow(long_value, double_value));
+    ASSERT_EQ(expression.result_entry.get<double>(context), std::pow(long_value, double_value));
   }
 
   // Check NULL semantics
@@ -167,25 +167,25 @@ TEST_F(JitExpressionTest, ArithmeticOperations) {
   {
     JitExpression expression(std::make_shared<JitExpression>(null_tuple_entry), JitExpressionType::Addition,
                              std::make_shared<JitExpression>(null_tuple_entry), result_index);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_TRUE(expression.result_entry().is_null(context));
+    ASSERT_TRUE(expression.result_entry.is_null(context));
   }
   context.tuple.set_is_null(result_index, false);
   {
     JitExpression expression(std::make_shared<JitExpression>(int_tuple_entry), JitExpressionType::Multiplication,
                              std::make_shared<JitExpression>(null_tuple_entry), result_index);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_TRUE(expression.result_entry().is_null(context));
+    ASSERT_TRUE(expression.result_entry.is_null(context));
   }
   context.tuple.set_is_null(result_index, false);
   {
     JitExpression expression(std::make_shared<JitExpression>(null_tuple_entry), JitExpressionType::Power,
                              std::make_shared<JitExpression>(int_tuple_entry), result_index);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_TRUE(expression.result_entry().is_null(context));
+    ASSERT_TRUE(expression.result_entry.is_null(context));
   }
 
   // Check for division/modulo by zero
@@ -193,19 +193,19 @@ TEST_F(JitExpressionTest, ArithmeticOperations) {
   {
     JitExpression expression(std::make_shared<JitExpression>(float_tuple_entry), JitExpressionType::Division,
                              std::make_shared<JitExpression>(zero_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Float);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Float);
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_TRUE(expression.result_entry().is_null(context));
+    ASSERT_TRUE(expression.result_entry.is_null(context));
   }
   context.tuple.set_is_null(result_index, false);
   {
     JitExpression expression(std::make_shared<JitExpression>(int_tuple_entry), JitExpressionType::Modulo,
                              std::make_shared<JitExpression>(zero_tuple_entry), result_index);
-    ASSERT_EQ(expression.result_entry().data_type(), DataType::Int);
-    ASSERT_TRUE(expression.result_entry().is_nullable());
+    ASSERT_EQ(expression.result_entry.data_type, DataType::Int);
+    ASSERT_TRUE(expression.result_entry.is_nullable);
     expression.compute_and_store(context);
-    ASSERT_TRUE(expression.result_entry().is_null(context));
+    ASSERT_TRUE(expression.result_entry.is_null(context));
   }
 }
 
@@ -230,12 +230,12 @@ TEST_F(JitExpressionTest, PredicateOperations) {
   JitExpression ne_expression(std::make_shared<JitExpression>(left_tuple_entry), JitExpressionType::NotEquals,
                               std::make_shared<JitExpression>(right_tuple_entry), result_index);
 
-  ASSERT_EQ(gt_expression.result_entry().data_type(), DataType::Bool);
-  ASSERT_EQ(gte_expression.result_entry().data_type(), DataType::Bool);
-  ASSERT_EQ(lt_expression.result_entry().data_type(), DataType::Bool);
-  ASSERT_EQ(lte_expression.result_entry().data_type(), DataType::Bool);
-  ASSERT_EQ(e_expression.result_entry().data_type(), DataType::Bool);
-  ASSERT_EQ(ne_expression.result_entry().data_type(), DataType::Bool);
+  ASSERT_EQ(gt_expression.result_entry.data_type, DataType::Bool);
+  ASSERT_EQ(gte_expression.result_entry.data_type, DataType::Bool);
+  ASSERT_EQ(lt_expression.result_entry.data_type, DataType::Bool);
+  ASSERT_EQ(lte_expression.result_entry.data_type, DataType::Bool);
+  ASSERT_EQ(e_expression.result_entry.data_type, DataType::Bool);
+  ASSERT_EQ(ne_expression.result_entry.data_type, DataType::Bool);
 
   for (auto i = 0; i < 10; ++i) {
     auto left_value = static_cast<int32_t>(std::rand()) % 5;
@@ -245,22 +245,22 @@ TEST_F(JitExpressionTest, PredicateOperations) {
     right_tuple_entry.set(right_value, context);
 
     gt_expression.compute_and_store(context);
-    ASSERT_EQ(gt_expression.result_entry().get<bool>(context), left_value > right_value);
+    ASSERT_EQ(gt_expression.result_entry.get<bool>(context), left_value > right_value);
 
     gte_expression.compute_and_store(context);
-    ASSERT_EQ(gt_expression.result_entry().get<bool>(context), left_value >= right_value);
+    ASSERT_EQ(gt_expression.result_entry.get<bool>(context), left_value >= right_value);
 
     lt_expression.compute_and_store(context);
-    ASSERT_EQ(gt_expression.result_entry().get<bool>(context), left_value < right_value);
+    ASSERT_EQ(gt_expression.result_entry.get<bool>(context), left_value < right_value);
 
     lte_expression.compute_and_store(context);
-    ASSERT_EQ(gt_expression.result_entry().get<bool>(context), left_value <= right_value);
+    ASSERT_EQ(gt_expression.result_entry.get<bool>(context), left_value <= right_value);
 
     e_expression.compute_and_store(context);
-    ASSERT_EQ(gt_expression.result_entry().get<bool>(context), left_value == right_value);
+    ASSERT_EQ(gt_expression.result_entry.get<bool>(context), left_value == right_value);
 
     ne_expression.compute_and_store(context);
-    ASSERT_EQ(gt_expression.result_entry().get<bool>(context), left_value != right_value);
+    ASSERT_EQ(gt_expression.result_entry.get<bool>(context), left_value != right_value);
   }
 
   // Check that invalid data type combinations throw an exception
@@ -283,8 +283,8 @@ TEST_F(JitExpressionTest, StringComparison) {
   JitExpression not_like_expression(std::make_shared<JitExpression>(left_tuple_entry), JitExpressionType::NotLike,
                                     std::make_shared<JitExpression>(right_tuple_entry), result_index);
 
-  ASSERT_EQ(like_expression.result_entry().data_type(), DataType::Bool);
-  ASSERT_EQ(not_like_expression.result_entry().data_type(), DataType::Bool);
+  ASSERT_EQ(like_expression.result_entry.data_type, DataType::Bool);
+  ASSERT_EQ(not_like_expression.result_entry.data_type, DataType::Bool);
 
   for (auto i = 0; i < 10; ++i) {
     auto left_value = pmr_string(1, 'a' + abs(static_cast<signed char>(std::rand())) % 5);
@@ -294,12 +294,12 @@ TEST_F(JitExpressionTest, StringComparison) {
     right_tuple_entry.set(right_value, context);
 
     like_expression.compute_and_store(context);
-    auto a = like_expression.result_entry().get<bool>(context);
+    auto a = like_expression.result_entry.get<bool>(context);
     auto b = left_value == right_value;
     ASSERT_EQ(a, b);
 
     not_like_expression.compute_and_store(context);
-    ASSERT_EQ(not_like_expression.result_entry().get<bool>(context), left_value != right_value);
+    ASSERT_EQ(not_like_expression.result_entry.get<bool>(context), left_value != right_value);
   }
 }
 
@@ -335,10 +335,10 @@ TEST_F(JitExpressionTest, NestedExpressions) {
       c_tuple_entry.set<float>(c_value, context);
       d_tuple_entry.set<double>(d_value, context);
 
-      ASSERT_EQ(expression.result_entry().data_type(), DataType::Double);
-      ASSERT_TRUE(expression.result_entry().is_nullable());
+      ASSERT_EQ(expression.result_entry.data_type, DataType::Double);
+      ASSERT_TRUE(expression.result_entry.is_nullable);
       expression.compute_and_store(context);
-      ASSERT_EQ(expression.result_entry().get<double>(context), (a_value - (b_value * c_value)) / (d_value + b_value));
+      ASSERT_EQ(expression.result_entry.get<double>(context), (a_value - (b_value * c_value)) / (d_value + b_value));
     }
   }
 
@@ -370,10 +370,10 @@ TEST_F(JitExpressionTest, NestedExpressions) {
       c_tuple_entry.set<float>(c_value, context);
       d_tuple_entry.set<double>(d_value, context);
 
-      ASSERT_EQ(expression.result_entry().data_type(), DataType::Bool);
-      ASSERT_FALSE(expression.result_entry().is_nullable());
+      ASSERT_EQ(expression.result_entry.data_type, DataType::Bool);
+      ASSERT_FALSE(expression.result_entry.is_nullable);
       expression.compute_and_store(context);
-      ASSERT_EQ(expression.result_entry().get<bool>(context),
+      ASSERT_EQ(expression.result_entry.get<bool>(context),
                 (a_value > b_value && c_value >= d_value) || a_value + b_value < c_value);
     }
   }

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -29,11 +29,11 @@ TEST_F(JitReadWriteTupleTest, TupleIndicesAreIncremented) {
   auto read_tuples = std::make_shared<JitReadTuples>();
 
   // Add different kinds of values (input columns, literals, temporary values) to the runtime tuple
-  auto tuple_index_1 = read_tuples->add_input_column(DataType::Int, false, ColumnID{0}).tuple_index();
-  auto tuple_index_2 = read_tuples->add_literal_value(1).tuple_index();
+  auto tuple_index_1 = read_tuples->add_input_column(DataType::Int, false, ColumnID{0}).tuple_index;
+  auto tuple_index_2 = read_tuples->add_literal_value(1).tuple_index;
   auto tuple_index_3 = read_tuples->add_temporary_value();
-  auto tuple_index_4 = read_tuples->add_input_column(DataType::Int, false, ColumnID{1}).tuple_index();
-  auto tuple_index_5 = read_tuples->add_literal_value("some string").tuple_index();
+  auto tuple_index_4 = read_tuples->add_input_column(DataType::Int, false, ColumnID{1}).tuple_index;
+  auto tuple_index_5 = read_tuples->add_literal_value("some string").tuple_index;
   auto tuple_index_6 = read_tuples->add_temporary_value();
 
   // All values should have their own position in the tuple with tuple indices increasing
@@ -44,7 +44,7 @@ TEST_F(JitReadWriteTupleTest, TupleIndicesAreIncremented) {
   ASSERT_LT(tuple_index_5, tuple_index_6);
 
   // Adding the same input column twice should not create a new value in the tuple
-  auto tuple_index_1_b = read_tuples->add_input_column(DataType::Int, false, ColumnID{0}).tuple_index();
+  auto tuple_index_1_b = read_tuples->add_input_column(DataType::Int, false, ColumnID{0}).tuple_index;
   ASSERT_EQ(tuple_index_1, tuple_index_1_b);
 }
 

--- a/src/test/operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp
+++ b/src/test/operators/jit_operator/specialization/get_runtime_pointer_for_value_test.cpp
@@ -55,7 +55,7 @@ class GetRuntimePointerForValueTest : public BaseTest {
   void assert_address_eq(const std::shared_ptr<const JitRuntimePointer>& runtime_pointer,
                          const uint64_t expected_address) const {
     auto known_runtime_pointer = std::dynamic_pointer_cast<const JitKnownRuntimePointer>(runtime_pointer);
-    ASSERT_NE(known_runtime_pointer, nullptr);
+    ASSERT_TRUE(known_runtime_pointer);
     ASSERT_TRUE(known_runtime_pointer->is_valid());
     ASSERT_EQ(known_runtime_pointer->address(), expected_address);
   }

--- a/src/test/operators/jit_operator/specialization/jit_repository_test.cpp
+++ b/src/test/operators/jit_operator/specialization/jit_repository_test.cpp
@@ -26,16 +26,16 @@ TEST_F(JitRepositoryTest, ProvidesAccessToDefinedFunctions) {
   // Check that all defined methods in the class hierarchy are present in the bitcode repository.
   // Virtual methods that are not implemented should cause a nullptr.
   // See "src/test/llvm/virtual_methods.cpp" for the class hierarchy.
-  ASSERT_EQ(repository.get_function("_ZN4Base3fooEv"), nullptr);
-  ASSERT_NE(repository.get_function("_ZN4Base3barEv"), nullptr);
-  ASSERT_NE(repository.get_function("_ZN8DerivedA3fooEv"), nullptr);
-  ASSERT_EQ(repository.get_function("_ZN8DerivedA3barEv"), nullptr);
-  ASSERT_NE(repository.get_function("_ZN8DerivedB3fooEv"), nullptr);
-  ASSERT_NE(repository.get_function("_ZN8DerivedB3barEv"), nullptr);
-  ASSERT_EQ(repository.get_function("_ZN8DerivedC3fooEv"), nullptr);
-  ASSERT_NE(repository.get_function("_ZN8DerivedC3barEv"), nullptr);
-  ASSERT_NE(repository.get_function("_ZN8DerivedD3fooEv"), nullptr);
-  ASSERT_EQ(repository.get_function("_ZN8DerivedD3barEv"), nullptr);
+  ASSERT_FALSE(repository.get_function("_ZN4Base3fooEv"));
+  ASSERT_TRUE(repository.get_function("_ZN4Base3barEv"));
+  ASSERT_TRUE(repository.get_function("_ZN8DerivedA3fooEv"));
+  ASSERT_FALSE(repository.get_function("_ZN8DerivedA3barEv"));
+  ASSERT_TRUE(repository.get_function("_ZN8DerivedB3fooEv"));
+  ASSERT_TRUE(repository.get_function("_ZN8DerivedB3barEv"));
+  ASSERT_FALSE(repository.get_function("_ZN8DerivedC3fooEv"));
+  ASSERT_TRUE(repository.get_function("_ZN8DerivedC3barEv"));
+  ASSERT_TRUE(repository.get_function("_ZN8DerivedD3fooEv"));
+  ASSERT_FALSE(repository.get_function("_ZN8DerivedD3barEv"));
 }
 
 TEST_F(JitRepositoryTest, CorrectlyParsesVTablesAcrossClassHierarchy) {
@@ -52,7 +52,7 @@ TEST_F(JitRepositoryTest, CorrectlyParsesVTablesAcrossClassHierarchy) {
   // and that the correct implementation is returned for each class / index combination.
   // See "src/test/llvm/virtual_methods.cpp" for the class hierarchy.
 
-  ASSERT_EQ(repository.get_vtable_entry("4Base", 0), nullptr);
+  ASSERT_FALSE(repository.get_vtable_entry("4Base", 0));
   ASSERT_EQ(repository.get_vtable_entry("4Base", 1), base_bar);
 
   ASSERT_EQ(repository.get_vtable_entry("8DerivedA", 0), derived_a_foo);
@@ -61,7 +61,7 @@ TEST_F(JitRepositoryTest, CorrectlyParsesVTablesAcrossClassHierarchy) {
   ASSERT_EQ(repository.get_vtable_entry("8DerivedB", 0), derived_b_foo);
   ASSERT_EQ(repository.get_vtable_entry("8DerivedB", 1), derived_b_bar);
 
-  ASSERT_EQ(repository.get_vtable_entry("8DerivedC", 0), nullptr);
+  ASSERT_FALSE(repository.get_vtable_entry("8DerivedC", 0));
   ASSERT_EQ(repository.get_vtable_entry("8DerivedC", 1), derived_c_bar);
 
   ASSERT_EQ(repository.get_vtable_entry("8DerivedD", 0), derived_d_foo);

--- a/src/test/operators/jit_operator/specialization/resolve_condition_test.cpp
+++ b/src/test/operators/jit_operator/specialization/resolve_condition_test.cpp
@@ -67,7 +67,7 @@ TEST_F(ResolveConditionTest, BranchConditionsAreResolved) {
   {
     // No runtime information is set in the specialization context. Thus the resolution of the condition must fail.
     const auto resolved_condition = ResolveCondition(_branch_instruction->getCondition(), _specialization_context);
-    ASSERT_EQ(resolved_condition, nullptr);
+    ASSERT_FALSE(resolved_condition);
   }
   {
     // Create runtime information (i.e., an instance of the SomeStruct parameter).
@@ -82,7 +82,7 @@ TEST_F(ResolveConditionTest, BranchConditionsAreResolved) {
 
     // The condition should now be replaced by a "false" constant (which is represented as a 1-bit integer in LLVM),
     // since the resolved expression "s.a + s.b > 5" = "1 + 2 > 5" is false.
-    ASSERT_NE(resolved_condition, nullptr);
+    ASSERT_TRUE(resolved_condition);
     ASSERT_EQ(resolved_condition->getType(), llvm::Type::getInt1Ty(*_repository->llvm_context()));
     const auto resolved_int_condition = llvm::dyn_cast<llvm::ConstantInt>(resolved_condition);
     ASSERT_TRUE(resolved_int_condition->isZero());
@@ -95,7 +95,7 @@ TEST_F(ResolveConditionTest, BranchConditionsAreResolved) {
         std::make_shared<JitConstantRuntimePointer>(&runtime_parameter);
 
     const auto resolved_condition = ResolveCondition(_branch_instruction->getCondition(), _specialization_context);
-    ASSERT_NE(resolved_condition, nullptr);
+    ASSERT_TRUE(resolved_condition);
     ASSERT_EQ(resolved_condition->getType(), llvm::Type::getInt1Ty(*_repository->llvm_context()));
     const auto resolved_int_condition = llvm::dyn_cast<llvm::ConstantInt>(resolved_condition);
     ASSERT_TRUE(resolved_int_condition->isOne());
@@ -112,14 +112,14 @@ TEST_F(ResolveConditionTest, UnresolvableBranchConditionsAreNotResolved) {
 
   const auto resolved_condition =
       ResolveCondition(_branch_instruction_failing->getCondition(), _specialization_context);
-  ASSERT_EQ(resolved_condition, nullptr);
+  ASSERT_FALSE(resolved_condition);
 }
 
 TEST_F(ResolveConditionTest, SwitchConditionsAreResolved) {
   {
     // No runtime information is set in the specialization context. Thus the resolution of the condition must fail.
     const auto resolved_condition = ResolveCondition(_switch_instruction->getCondition(), _specialization_context);
-    ASSERT_EQ(resolved_condition, nullptr);
+    ASSERT_FALSE(resolved_condition);
   }
   {
     // Create runtime information (i.e., an instance of the SomeStruct parameter).
@@ -134,7 +134,7 @@ TEST_F(ResolveConditionTest, SwitchConditionsAreResolved) {
     const auto resolved_condition = ResolveCondition(_switch_instruction->getCondition(), _specialization_context);
 
     // The condition should now be replaced by an integer constant with the correct value from the runtime parameter.
-    ASSERT_NE(resolved_condition, nullptr);
+    ASSERT_TRUE(resolved_condition);
     ASSERT_EQ(resolved_condition->getType(), llvm::Type::getInt32Ty(*_repository->llvm_context()));
     const auto resolved_int_condition = llvm::dyn_cast<llvm::ConstantInt>(resolved_condition);
     const auto resolved_condition_value =

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -264,7 +264,7 @@ TEST_F(JitOperatorWrapperTest, JitOperatorsSpecializedWithMultipleInliningOfSame
 
   // copy computed value from jit tuple at index 1 to output table for non-jit operators
   auto write_operator = std::make_shared<JitWriteTuples>();
-  write_operator->add_output_column_definition("a+a", expression->result_entry());
+  write_operator->add_output_column_definition("a+a", expression->result_entry);
 
   JitOperatorWrapper jit_operator_wrapper(_int_table_wrapper, JitExecutionMode::Compile);
   jit_operator_wrapper.add_jit_operator(read_operator);


### PR DESCRIPTION
This pr removes unnecessary getter and setter functions from JIT operators.

If a class member has a getter, the class member is now `public const`.
If the member has a setter, it has no `const` attribute.

This pr also incorporates the new rule to use automatic pointer conversion to bool.
Updated JIT tests according to the following rules:
`ASSERT_EQ(x, nullptr); -> ASSERT_FALSE(x);`
`ASSERT_NE(x, nullptr); -> ASSERT_TRUE(x);`
`ASSERT_EQ(x, false); -> ASSERT_FALSE(x);`
`ASSERT_EQ(x, true); -> ASSERT_TRUE(x);`