### PR TITLE
Make Assert() and DebugAssert() require semicolon

### DIFF
--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -13,7 +13,7 @@ void TransactionManager::reset() {
   manager._last_commit_id = INITIAL_COMMIT_ID;
   manager._last_commit_context = std::make_shared<CommitContext>(INITIAL_COMMIT_ID);
   Assert(manager._active_snapshot_commit_ids.empty(),
-         "Some transactions do not seem to have finished yet as they are still registered as active.")
+         "Some transactions do not seem to have finished yet as they are still registered as active.");
 }
 
 TransactionManager::TransactionManager()

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -716,8 +716,8 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_value_o
     value = value_expression.value;
   } else {
     const auto& correlated_parameter_expression = dynamic_cast<const CorrelatedParameterExpression*>(&expression);
-    Assert(correlated_parameter_expression, "ParameterExpression not a CorrelatedParameterExpression") Assert(
-        correlated_parameter_expression->value(), "CorrelatedParameterExpression: Value not set, cannot evaluate");
+    Assert(correlated_parameter_expression, "ParameterExpression not a CorrelatedParameterExpression");
+    Assert(correlated_parameter_expression->value(), "CorrelatedParameterExpression: Value not set, cannot evaluate");
     value = *correlated_parameter_expression->value();
   }
 

--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -215,8 +215,8 @@ void expression_set_transaction_context(const std::shared_ptr<AbstractExpression
     if (sub_expression->type != ExpressionType::PQPSubquery) return ExpressionVisitation::VisitArguments;
 
     const auto pqp_subquery_expression = std::dynamic_pointer_cast<PQPSubqueryExpression>(sub_expression);
-    Assert(pqp_subquery_expression, "Expected a PQPSubqueryExpression here")
-        pqp_subquery_expression->pqp->set_transaction_context_recursively(transaction_context);
+    Assert(pqp_subquery_expression, "Expected a PQPSubqueryExpression here");
+    pqp_subquery_expression->pqp->set_transaction_context_recursively(transaction_context);
 
     return ExpressionVisitation::DoNotVisitArguments;
   });

--- a/src/lib/expression/is_null_expression.cpp
+++ b/src/lib/expression/is_null_expression.cpp
@@ -10,7 +10,7 @@ IsNullExpression::IsNullExpression(const PredicateCondition predicate_condition,
                                    const std::shared_ptr<AbstractExpression>& operand)
     : AbstractPredicateExpression(predicate_condition, {operand}) {
   Assert(predicate_condition == PredicateCondition::IsNull || predicate_condition == PredicateCondition::IsNotNull,
-         "IsNullExpression only supports PredicateCondition::IsNull and PredicateCondition::IsNotNull")
+         "IsNullExpression only supports PredicateCondition::IsNull and PredicateCondition::IsNotNull");
 }
 
 const std::shared_ptr<AbstractExpression>& IsNullExpression::operand() const { return arguments[0]; }

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -227,7 +227,7 @@ class RadixClusterSortNUMA {
     CurrentScheduler::wait_for_tasks(cluster_jobs);
 
     DebugAssert(output_table.materialized_segments.size() == _cluster_count,
-                "Error in clustering: Number of output segments does not match the number of clusters.")
+                "Error in clustering: Number of output segments does not match the number of clusters.");
 
         return output_table;
   }

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -229,7 +229,7 @@ class RadixClusterSortNUMA {
     DebugAssert(output_table.materialized_segments.size() == _cluster_count,
                 "Error in clustering: Number of output segments does not match the number of clusters.");
 
-        return output_table;
+    return output_table;
   }
 
   /**

--- a/src/lib/statistics/chunk_statistics/histograms/equal_width_histogram.cpp
+++ b/src/lib/statistics/chunk_statistics/histograms/equal_width_histogram.cpp
@@ -26,7 +26,7 @@ EqualWidthHistogram<T>::EqualWidthHistogram(const T minimum, const T maximum,
          "Must have heights and distinct counts for each bin.");
   Assert(_bin_data.minimum <= _bin_data.maximum, "Cannot have upper bound of histogram smaller than lower bound.");
   if constexpr (std::is_floating_point_v<T>) {
-    Assert(_bin_data.bin_count_with_larger_range == 0, "Cannot have varying bin sizes in float histograms.")
+    Assert(_bin_data.bin_count_with_larger_range == 0, "Cannot have varying bin sizes in float histograms.");
   } else {
     Assert(_bin_data.bin_count_with_larger_range < _bin_data.bin_heights.size(),
            "Cannot have more or the same number of bins with a wider range than the number of bins itself.");

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -51,14 +51,14 @@ namespace opossum {
 }  // namespace opossum
 
 #define Assert(expr, msg)                                                                                 \
-  if (!static_cast<bool>(expr)) {                                                                         \
+  do { if (!static_cast<bool>(expr)) {                                                                         \
     opossum::Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
-  }
+  } } while(false)
 
 #define AssertInput(expr, msg)                                               \
-  if (!static_cast<bool>(expr)) {                                            \
+  do { if (!static_cast<bool>(expr)) {                                            \
     throw InvalidInputException(std::string("Invalid input error: ") + msg); \
-  }
+  } } while(false)
 
 #if HYRISE_DEBUG
 #define DebugAssert(expr, msg) Assert(expr, msg)

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -50,15 +50,19 @@ namespace opossum {
 
 }  // namespace opossum
 
-#define Assert(expr, msg)                                                                                 \
-  do { if (!static_cast<bool>(expr)) {                                                                         \
-    opossum::Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
-  } } while(false)
+#define Assert(expr, msg)                                                                                   \
+  do {                                                                                                      \
+    if (!static_cast<bool>(expr)) {                                                                         \
+      opossum::Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
+    }                                                                                                       \
+  } while (false)
 
-#define AssertInput(expr, msg)                                               \
-  do { if (!static_cast<bool>(expr)) {                                            \
-    throw InvalidInputException(std::string("Invalid input error: ") + msg); \
-  } } while(false)
+#define AssertInput(expr, msg)                                                 \
+  do {                                                                         \
+    if (!static_cast<bool>(expr)) {                                            \
+      throw InvalidInputException(std::string("Invalid input error: ") + msg); \
+    }                                                                          \
+  } while (false)
 
 #if HYRISE_DEBUG
 #define DebugAssert(expr, msg) Assert(expr, msg)

--- a/src/lib/utils/assert.hpp
+++ b/src/lib/utils/assert.hpp
@@ -50,19 +50,17 @@ namespace opossum {
 
 }  // namespace opossum
 
-#define Assert(expr, msg)                                                                                   \
-  do {                                                                                                      \
-    if (!static_cast<bool>(expr)) {                                                                         \
-      opossum::Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
-    }                                                                                                       \
-  } while (false)
+#define Assert(expr, msg)                                                                                 \
+  if (!static_cast<bool>(expr)) {                                                                         \
+    opossum::Fail(opossum::trim_source_file_path(__FILE__) + ":" BOOST_PP_STRINGIZE(__LINE__) " " + msg); \
+  }                                                                                                       \
+  static_assert(true, "End call of macro with a semicolon")
 
-#define AssertInput(expr, msg)                                                 \
-  do {                                                                         \
-    if (!static_cast<bool>(expr)) {                                            \
-      throw InvalidInputException(std::string("Invalid input error: ") + msg); \
-    }                                                                          \
-  } while (false)
+#define AssertInput(expr, msg)                                               \
+  if (!static_cast<bool>(expr)) {                                            \
+    throw InvalidInputException(std::string("Invalid input error: ") + msg); \
+  }                                                                          \
+  static_assert(true, "End call of macro with a semicolon")
 
 #if HYRISE_DEBUG
 #define DebugAssert(expr, msg) Assert(expr, msg)

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -92,8 +92,7 @@ TEST_P(TPCHTest, Test) {
   // TPC-H 15 needs special patching as it contains a DROP VIEW that doesn't return a table as last statement
   std::shared_ptr<const Table> result_table;
   if (tpch_idx == 15) {
-    Assert(sql_pipeline.statement_count() == 3u, "Expected 3 statements in TPC-H 15") sql_pipeline.get_result_table();
-
+    Assert(sql_pipeline.statement_count() == 3u, "Expected 3 statements in TPC-H 15");
     result_table = sql_pipeline.get_result_tables()[1];
   } else {
     result_table = sql_pipeline.get_result_table();


### PR DESCRIPTION
Before, this may have caused formatting/linting confusion.

The do-while(false) thing is the standard pattern for requiring macros to be concluded with a semicolon just like a normal function call. Pls don't question this. ;)