### PR TITLE
Compile time: More type erasure in ColumnVsColumnScan

### DIFF
--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -161,8 +161,6 @@ void Pagination::_print_help_screen() {
   delwin(help_screen);
 }
 
-void Pagination::push_ctrl_c() {
-  ungetch(CURSES_CTRL_C);
-}
+void Pagination::push_ctrl_c() { ungetch(CURSES_CTRL_C); }
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -145,8 +145,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
             Instead, we use the index in the ReferenceSegment itself. This way we can later correctly dereference
             values from different inputs (important for Multi Joins).
             */
-            if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> ||
-                          std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
+            if constexpr (is_reference_segment_iterable<IterableType>::value) {
               *(output_iterator++) = PartitionedElement<T>{RowID{chunk_id, reference_chunk_offset}, value.value()};
             } else {
               *(output_iterator++) = PartitionedElement<T>{RowID{chunk_id, value.chunk_offset()}, value.value()};
@@ -164,8 +163,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
             ++null_value_bitvector_iterator;
           }
           // reference_chunk_offset is only used for ReferenceSegments
-          if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> ||
-                        std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
+          if constexpr (is_reference_segment_iterable<IterableType>::value) {
             ++reference_chunk_offset;
           }
         }

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -145,7 +145,8 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
             Instead, we use the index in the ReferenceSegment itself. This way we can later correctly dereference
             values from different inputs (important for Multi Joins).
             */
-            if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> || std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
+            if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> ||
+                          std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
               *(output_iterator++) = PartitionedElement<T>{RowID{chunk_id, reference_chunk_offset}, value.value()};
             } else {
               *(output_iterator++) = PartitionedElement<T>{RowID{chunk_id, value.chunk_offset()}, value.value()};
@@ -163,7 +164,8 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
             ++null_value_bitvector_iterator;
           }
           // reference_chunk_offset is only used for ReferenceSegments
-          if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> || std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
+          if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> ||
+                        std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
             ++reference_chunk_offset;
           }
         }

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -145,7 +145,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
             Instead, we use the index in the ReferenceSegment itself. This way we can later correctly dereference
             values from different inputs (important for Multi Joins).
             */
-            if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T>>) {
+            if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> || std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
               *(output_iterator++) = PartitionedElement<T>{RowID{chunk_id, reference_chunk_offset}, value.value()};
             } else {
               *(output_iterator++) = PartitionedElement<T>{RowID{chunk_id, value.chunk_offset()}, value.value()};
@@ -163,7 +163,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
             ++null_value_bitvector_iterator;
           }
           // reference_chunk_offset is only used for ReferenceSegments
-          if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T>>) {
+          if constexpr (std::is_same_v<IterableType, ReferenceSegmentIterable<T, true>> || std::is_same_v<IterableType, ReferenceSegmentIterable<T, false>>) {
             ++reference_chunk_offset;
           }
         }

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -48,7 +48,10 @@ class AbstractTableScanImpl {
                        const ChunkID chunk_id, PosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     // The major part of the table is scanned using SIMD. Only the remainder is handled in this method.
     // For a description of the SIMD code, have a look at the comments in that method.
-    _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
+    // TODO Doc
+    if constexpr (!std::is_same_v<typename decltype(left_it)::ValueType, pmr_string>) {
+      _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
+    }
 
     // Do the remainder the easy way. If we did not use the optimization above, left_it was not yet touched, so we
     // iterate over the entire input data.

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -48,11 +48,7 @@ class AbstractTableScanImpl {
                        const ChunkID chunk_id, PosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     // The major part of the table is scanned using SIMD. Only the remainder is handled in this method.
     // For a description of the SIMD code, have a look at the comments in that method.
-    // To reduce the compile time, we do not use the SIMD scan for strings, as materializing the iterator values and
-    // performing the string comparisons dominates all performance gains made by the SIMD scan.
-    if constexpr (!std::is_same_v<typename decltype(left_it)::ValueType, pmr_string>) {
-      _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
-    }
+    _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
 
     // Do the remainder the easy way. If we did not use the optimization above, left_it was not yet touched, so we
     // iterate over the entire input data.

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -48,7 +48,8 @@ class AbstractTableScanImpl {
                        const ChunkID chunk_id, PosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     // The major part of the table is scanned using SIMD. Only the remainder is handled in this method.
     // For a description of the SIMD code, have a look at the comments in that method.
-    // TODO Doc
+    // To reduce the compile time, we do not use the SIMD scan for strings, as materializing the iterator values and
+    // performing the string comparisons dominates all performance gains made by the SIMD scan.
     if constexpr (!std::is_same_v<typename decltype(left_it)::ValueType, pmr_string>) {
       _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
     }

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -62,8 +62,8 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
       if (const auto right_typed_segment = std::dynamic_pointer_cast<SegmentType>(right_segment)) {
         if constexpr (std::is_same_v<SegmentType, ReferenceSegment>) {
           // For reference segments check if the iterables end up using the same type of iterator.
-          auto left_iterable = ReferenceSegmentIterable<ColumnDataType, false>{left_typed_segment};
-          auto right_iterable = ReferenceSegmentIterable<ColumnDataType, false>{*right_typed_segment};
+          auto left_iterable = ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{left_typed_segment};
+          auto right_iterable = ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{*right_typed_segment};
 
           left_iterable.with_iterators([&](auto left_it, const auto left_end) {
             right_iterable.with_iterators([&](auto right_it, const auto right_end) {

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -62,8 +62,10 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
       if (const auto right_typed_segment = std::dynamic_pointer_cast<SegmentType>(right_segment)) {
         if constexpr (std::is_same_v<SegmentType, ReferenceSegment>) {
           // For reference segments check if the iterables end up using the same type of iterator.
-          auto left_iterable = ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{left_typed_segment};
-          auto right_iterable = ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{*right_typed_segment};
+          auto left_iterable =
+              ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{left_typed_segment};
+          auto right_iterable =
+              ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{*right_typed_segment};
 
           left_iterable.with_iterators([&](auto left_it, const auto left_end) {
             right_iterable.with_iterators([&](auto right_it, const auto right_end) {

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -27,6 +27,9 @@ ColumnVsColumnTableScanImpl::ColumnVsColumnTableScanImpl(const std::shared_ptr<c
 
 std::string ColumnVsColumnTableScanImpl::description() const { return "ColumnVsColumn"; }
 
+template<typename... T>
+struct whatis;
+
 std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_id) const {
   const auto chunk = _in_table->get_chunk(chunk_id);
   const auto left_segment = chunk->get_segment(_left_column_id);
@@ -52,6 +55,7 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
   /**
    * FAST PATH
    * ...in which the SegmentType does not get erased in Release builds. DataTypes and SegmentTypes have to be the same.
+   * In the case of ReferenceSegments, the used ReferenceSegmentIterator has to be the same (see below).
    */
   if (left_segment->data_type() == right_segment->data_type()) {
     resolve_data_and_segment_type(*left_segment, [&](auto data_type_t, auto& left_typed_segment) {
@@ -59,10 +63,28 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
       using SegmentType = std::decay_t<decltype(left_typed_segment)>;
 
       if (const auto right_typed_segment = std::dynamic_pointer_cast<SegmentType>(right_segment)) {
-        // Same segment types - do not erase types in Release builds
-        result = _typed_scan_chunk<EraseTypes::OnlyInDebugBuild>(
-            chunk_id, create_iterable_from_segment<ColumnDataType>(left_typed_segment),
-            create_iterable_from_segment<ColumnDataType>(*right_typed_segment));
+        if constexpr (std::is_same_v<SegmentType, ReferenceSegment>) {
+          // For reference segments check if the iterables end up using the same type of iterator.
+          auto left_iterable = ReferenceSegmentIterable<ColumnDataType, false>{left_typed_segment};
+          auto right_iterable = ReferenceSegmentIterable<ColumnDataType, false>{*right_typed_segment};
+
+          left_iterable.with_iterators([&](auto left_it, const auto left_end) {
+            right_iterable.with_iterators([&](auto right_it, const auto right_end) {
+              if constexpr (std::is_same_v<std::decay_t<decltype(left_it)>, std::decay_t<decltype(right_it)>>) {
+                // Either both reference segments use the MultipleChunkIterator (which uses erased accessors anyway)
+                // or they use a SingleChunkIterator pointing to the same segment type (e.g., Dictionary and Dictionary)
+                result = _typed_scan_chunk_with_iterators<EraseTypes::OnlyInDebugBuild>(
+                chunk_id, left_it, left_end,
+                right_it, right_end);
+              }
+            });
+          });
+        } else {
+          // Same segment types - do not erase types in Release builds
+          result = _typed_scan_chunk_with_iterables<EraseTypes::OnlyInDebugBuild>(
+                chunk_id, create_iterable_from_segment<ColumnDataType>(left_typed_segment),
+                create_iterable_from_segment<ColumnDataType>(*right_typed_segment));
+        }
       }
     });
 
@@ -88,7 +110,7 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
       auto right_iterable = create_any_segment_iterable<RightColumnDataType>(*right_segment);
 
       PerformanceWarning("ColumnVsColumnTableScan using type-erased iterators");
-      result = _typed_scan_chunk<EraseTypes::Always>(chunk_id, left_iterable, right_iterable);
+      result = _typed_scan_chunk_with_iterables<EraseTypes::Always>(chunk_id, left_iterable, right_iterable);
     });
   });
 
@@ -96,15 +118,29 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
 }
 
 template <EraseTypes erase_comparator_type, typename LeftIterable, typename RightIterable>
-std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID chunk_id,
-                                                                        const LeftIterable& left_iterable,
-                                                                        const RightIterable& right_iterable) const {
+std::shared_ptr<PosList> __attribute__((noinline)) ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterables(ChunkID chunk_id,
+                                                                             const LeftIterable& left_iterable,
+                                                                             const RightIterable& right_iterable) const {
+  auto matches_out = std::shared_ptr<PosList>{};
+
+  left_iterable.with_iterators([&](auto left_it, const auto left_end) {
+    right_iterable.with_iterators([&](auto right_it, const auto right_end) {
+      matches_out = _typed_scan_chunk_with_iterators<erase_comparator_type>(chunk_id, left_it, left_end, right_it, right_end);
+    });
+  });
+
+  return matches_out;
+}
+
+template <EraseTypes erase_comparator_type, typename LeftIterator, typename RightIterator>
+std::shared_ptr<PosList> __attribute__((noinline)) ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterators(ChunkID chunk_id,
+                                                                             LeftIterator& left_it, const LeftIterator& left_end, RightIterator& right_it, const RightIterator& right_end) const {
   const auto chunk = _in_table->get_chunk(chunk_id);
 
   auto matches_out = std::make_shared<PosList>();
 
-  using LeftType = typename LeftIterable::ValueType;
-  using RightType = typename RightIterable::ValueType;
+  using LeftType = typename LeftIterator::ValueType;
+  using RightType = typename RightIterator::ValueType;
 
   // C++ cannot compare strings and non-strings out of the box:
   if constexpr (std::is_same_v<LeftType, pmr_string> == std::is_same_v<RightType, pmr_string>) {
@@ -129,24 +165,20 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::_typed_scan_chunk(ChunkID 
     const auto chunk_id_copy = chunk_id;
     const auto& matches_out_ref = matches_out;
 
-    left_iterable.with_iterators([&](auto left_it, const auto left_end) {
-      right_iterable.with_iterators([&](auto right_it, const auto right_end) {
-        with_comparator_light(maybe_flipped_condition, [&](auto predicate_comparator) {
-          const auto comparator = [predicate_comparator](const auto& left, const auto& right) {
-            return predicate_comparator(left.value(), right.value());
-          };
+    with_comparator_light(maybe_flipped_condition, [&](auto predicate_comparator) {
+      const auto comparator = [predicate_comparator](const auto& left, const auto& right) {
+        return predicate_comparator(left.value(), right.value());
+      };
 
-          if (condition_was_flipped) {
-            const auto erased_comparator = conditionally_erase_comparator_type(comparator, right_it, left_it);
-            AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id_copy,
-                                                              *matches_out_ref, left_it);
-          } else {
-            const auto erased_comparator = conditionally_erase_comparator_type(comparator, left_it, right_it);
-            AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it, left_end, chunk_id_copy,
-                                                              *matches_out_ref, right_it);
-          }
-        });
-      });
+      if (condition_was_flipped) {
+        const auto erased_comparator = conditionally_erase_comparator_type(comparator, right_it, left_it);
+        AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id_copy,
+                                                          *matches_out_ref, left_it);
+      } else {
+        const auto erased_comparator = conditionally_erase_comparator_type(comparator, left_it, right_it);
+        AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it, left_end, chunk_id_copy,
+                                                          *matches_out_ref, right_it);
+      }
     });
   } else {
     Fail("Trying to compare strings and non-strings");

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
@@ -38,8 +38,11 @@ class ColumnVsColumnTableScanImpl : public AbstractTableScanImpl {
   const ColumnID _right_column_id;
 
   template <EraseTypes erase_comparator_type, typename LeftIterable, typename RightIterable>
-  std::shared_ptr<PosList> _typed_scan_chunk(ChunkID chunk_id, const LeftIterable& left_iterable,
+  std::shared_ptr<PosList> _typed_scan_chunk_with_iterables(ChunkID chunk_id, const LeftIterable& left_iterable,
                                              const RightIterable& right_iterable) const;
+
+  template <EraseTypes erase_comparator_type, typename LeftIterator, typename RightIterator>
+  std::shared_ptr<PosList> _typed_scan_chunk_with_iterators(ChunkID chunk_id, LeftIterator& left_it, const LeftIterator& left_end, RightIterator& right_it, const RightIterator& right_end) const;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.hpp
@@ -39,10 +39,12 @@ class ColumnVsColumnTableScanImpl : public AbstractTableScanImpl {
 
   template <EraseTypes erase_comparator_type, typename LeftIterable, typename RightIterable>
   std::shared_ptr<PosList> _typed_scan_chunk_with_iterables(ChunkID chunk_id, const LeftIterable& left_iterable,
-                                             const RightIterable& right_iterable) const;
+                                                            const RightIterable& right_iterable) const;
 
   template <EraseTypes erase_comparator_type, typename LeftIterator, typename RightIterator>
-  std::shared_ptr<PosList> _typed_scan_chunk_with_iterators(ChunkID chunk_id, LeftIterator& left_it, const LeftIterator& left_end, RightIterator& right_it, const RightIterator& right_end) const;
+  std::shared_ptr<PosList> _typed_scan_chunk_with_iterators(ChunkID chunk_id, LeftIterator& left_it,
+                                                            const LeftIterator& left_end, RightIterator& right_it,
+                                                            const RightIterator& right_end) const;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -28,7 +28,7 @@ class ReferenceSegmentIterable;
  * @{
  */
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const ValueSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -37,7 +37,7 @@ auto create_iterable_from_segment(const ValueSegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -46,7 +46,7 @@ auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -55,7 +55,7 @@ auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -64,7 +64,7 @@ auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -73,7 +73,7 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = true, bool EraseReferencedSegmentType = false /*ignored*/>
+template <typename T, bool EraseSegmentType = true>
 auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
   // LZ4Segment always gets erased as its decoding is so slow, the virtual function calls won't make
   // a difference. If we'd allow it to not be erased we'd risk compile time increase creeping in for no benefit

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -10,7 +10,7 @@
 namespace opossum {
 
 class ReferenceSegment;
-template <typename T, bool>
+template <typename T, EraseReferencedSegmentType>
 class ReferenceSegmentIterable;
 
 /**
@@ -84,7 +84,9 @@ auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
  * This function must be forward-declared because ReferenceSegmentIterable
  * includes this file leading to a circular dependency
  */
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG,
+          EraseReferencedSegmentType = (HYRISE_DEBUG ? EraseReferencedSegmentType::Yes
+                                                     : EraseReferencedSegmentType::No)>
 auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 /**@}*/

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -10,7 +10,7 @@
 namespace opossum {
 
 class ReferenceSegment;
-template <typename T>
+template <typename T, bool>
 class ReferenceSegmentIterable;
 
 /**
@@ -28,7 +28,7 @@ class ReferenceSegmentIterable;
  * @{
  */
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
 auto create_iterable_from_segment(const ValueSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -37,7 +37,7 @@ auto create_iterable_from_segment(const ValueSegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
 auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -46,7 +46,7 @@ auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
 auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -55,7 +55,7 @@ auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
 auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -64,7 +64,7 @@ auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment
   }
 }
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = false /*ignored*/>
 auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
@@ -73,7 +73,7 @@ auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
   }
 }
 
-template <typename T, bool EraseSegmentType = true>
+template <typename T, bool EraseSegmentType = true, bool EraseReferencedSegmentType = false /*ignored*/>
 auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
   // LZ4Segment always gets erased as its decoding is so slow, the virtual function calls won't make
   // a difference. If we'd allow it to not be erased we'd risk compile time increase creeping in for no benefit
@@ -84,7 +84,7 @@ auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
  * This function must be forward-declared because ReferenceSegmentIterable
  * includes this file leading to a circular dependency
  */
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
+template <typename T, bool EraseSegmentType = HYRISE_DEBUG, bool EraseReferencedSegmentType = HYRISE_DEBUG>
 auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 /**@}*/

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -4,12 +4,12 @@
 
 namespace opossum {
 
-template <typename T, bool EraseSegmentType>
+template <typename T, bool EraseSegmentType, bool EraseReferencedSegmentType>
 auto create_iterable_from_segment(const ReferenceSegment& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
-    return ReferenceSegmentIterable<T>{segment};
+    return ReferenceSegmentIterable<T, EraseReferencedSegmentType>{segment};
   }
 }
 

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -4,12 +4,12 @@
 
 namespace opossum {
 
-template <typename T, bool EraseSegmentType, bool EraseReferencedSegmentType>
+template <typename T, bool EraseSegmentType, EraseReferencedSegmentType erase_referenced_segment_type>
 auto create_iterable_from_segment(const ReferenceSegment& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
-    return ReferenceSegmentIterable<T, EraseReferencedSegmentType>{segment};
+    return ReferenceSegmentIterable<T, erase_referenced_segment_type>{segment};
   }
 }
 

--- a/src/lib/storage/dictionary_segment/attribute_vector_iterable.hpp
+++ b/src/lib/storage/dictionary_segment/attribute_vector_iterable.hpp
@@ -50,6 +50,7 @@ class AttributeVectorIterable : public PointAccessibleSegmentIterable<AttributeV
   template <typename ZsIteratorType>
   class Iterator : public BaseSegmentIterator<Iterator<ZsIteratorType>, SegmentPosition<ValueID>> {
    public:
+    using ValueType = ValueID;
     explicit Iterator(const ValueID null_value_id, ZsIteratorType attribute_it, ChunkOffset chunk_offset)
         : _null_value_id{null_value_id}, _attribute_it{attribute_it}, _chunk_offset{chunk_offset} {}
 
@@ -92,6 +93,7 @@ class AttributeVectorIterable : public PointAccessibleSegmentIterable<AttributeV
   class PointAccessIterator
       : public BasePointAccessSegmentIterator<PointAccessIterator<ZsDecompressorType>, SegmentPosition<ValueID>> {
    public:
+    using ValueType = ValueID;
     PointAccessIterator(const ValueID null_value_id, const std::shared_ptr<ZsDecompressorType>& attribute_decompressor,
                         const PosList::const_iterator position_filter_begin, PosList::const_iterator position_filter_it)
         : BasePointAccessSegmentIterator<PointAccessIterator<ZsDecompressorType>,

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -205,7 +205,8 @@ struct is_reference_segment_iterable {
 
 template <template <typename, bool> typename Iterable, typename T, bool EraseReferencedSegmentType>
 struct is_reference_segment_iterable<Iterable<T, EraseReferencedSegmentType>> {
-  static constexpr auto value = std::is_same_v<ReferenceSegmentIterable<T, EraseReferencedSegmentType>, Iterable>;
+  static constexpr auto value =
+      std::is_same_v<ReferenceSegmentIterable<T, EraseReferencedSegmentType>, Iterable<T, EraseReferencedSegmentType>>;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -198,4 +198,14 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
   };
 };
 
+template <typename T>
+struct is_reference_segment_iterable {
+  static constexpr auto value = false;
+};
+
+template <template <typename, bool> typename Iterable, typename T, bool EraseReferencedSegmentType>
+struct is_reference_segment_iterable<Iterable<T, EraseReferencedSegmentType>> {
+  static constexpr auto value = std::is_same_v<ReferenceSegmentIterable<T, EraseReferencedSegmentType>, Iterable>;
+};
+
 }  // namespace opossum

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -52,7 +52,10 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
       } else {
         // As accessor is now an AbstractSegmentAccessor, functor only gets initialized only once, no matter how many
         // different accessors there might be.
-        auto accessor = std::shared_ptr<AbstractSegmentAccessor<T>>{std::move(create_segment_accessor<T>(referenced_segment))};
+        PerformanceWarning("Using type-erased accessor as the ReferenceSegmentIterable is type-erased itself");
+
+        auto accessor =
+            std::shared_ptr<AbstractSegmentAccessor<T>>{std::move(create_segment_accessor<T>(referenced_segment))};
 
         auto begin = SingleChunkIterator<AbstractSegmentAccessor<T>>{accessor, begin_it, begin_it};
         auto end = SingleChunkIterator<AbstractSegmentAccessor<T>>{accessor, begin_it, end_it};

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -12,7 +12,7 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
     if constexpr (std::is_same_v<std::decay_t<decltype(segment)>, ReferenceSegment>) {
-      const auto actual_iterable = create_iterable_from_segment<T, false, true>(segment);
+      const auto actual_iterable = create_iterable_from_segment<T, false, EraseReferencedSegmentType::Yes>(segment);
       any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
     } else {
       const auto actual_iterable = create_iterable_from_segment<T, false>(segment);

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -11,7 +11,7 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
   auto any_segment_iterable = std::optional<AnySegmentIterable<T>>{};
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
-    const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
+    const auto actual_iterable = create_iterable_from_segment<T, false, true>(segment);
     any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
   });
 

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -11,8 +11,13 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
   auto any_segment_iterable = std::optional<AnySegmentIterable<T>>{};
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
-    const auto actual_iterable = create_iterable_from_segment<T, false, true>(segment);
-    any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
+    if constexpr (std::is_same_v<std::decay_t<decltype(segment)>, ReferenceSegment>) {
+      const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
+      any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
+    } else {
+      const auto actual_iterable = create_iterable_from_segment<T, false, true>(segment);
+      any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
+    }
   });
 
   return std::move(*any_segment_iterable);

--- a/src/lib/storage/segment_iterables/any_segment_iterable.cpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.cpp
@@ -12,10 +12,10 @@ AnySegmentIterable<T> CreateAnySegmentIterable<T>::create(const BaseSegment& bas
 
   resolve_segment_type<T>(base_segment, [&](const auto& segment) {
     if constexpr (std::is_same_v<std::decay_t<decltype(segment)>, ReferenceSegment>) {
-      const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
+      const auto actual_iterable = create_iterable_from_segment<T, false, true>(segment);
       any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
     } else {
-      const auto actual_iterable = create_iterable_from_segment<T, false, true>(segment);
+      const auto actual_iterable = create_iterable_from_segment<T, false>(segment);
       any_segment_iterable.emplace(erase_type_from_iterable(actual_iterable));
     }
   });

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -615,4 +615,3 @@ TYPED_TEST(OperatorsAggregateTest, OuterJoinThenAggregate) {
 }
 
 }  // namespace opossum
-

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -280,7 +280,7 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunkTypeErased
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
 
-  auto iterable = ReferenceSegmentIterable<int, true>{*reference_segment};
+  auto iterable = ReferenceSegmentIterable<int, EraseReferencedSegmentType::Yes>{*reference_segment};
 
   auto nulls_found = uint32_t{0};
   auto accessed_offsets = std::vector<ChunkOffset>{};

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -245,7 +245,7 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
 
-  auto iterable = ReferenceSegmentIterable<int, false>{*reference_segment};
+  auto iterable = ReferenceSegmentIterable<int, EraseReferencedSegmentType::No>{*reference_segment};
 
   auto sum = uint32_t{0};
   auto accessed_offsets = std::vector<ChunkOffset>{};
@@ -263,7 +263,7 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunk) {
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
 
-  auto iterable = ReferenceSegmentIterable<int, false>{*reference_segment};
+  auto iterable = ReferenceSegmentIterable<int, EraseReferencedSegmentType::No>{*reference_segment};
 
   auto nulls_found = uint32_t{0};
   auto accessed_offsets = std::vector<ChunkOffset>{};

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -245,7 +245,7 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIterators) {
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
 
-  auto iterable = ReferenceSegmentIterable<int>{*reference_segment};
+  auto iterable = ReferenceSegmentIterable<int, false>{*reference_segment};
 
   auto sum = uint32_t{0};
   auto accessed_offsets = std::vector<ChunkOffset>{};
@@ -263,7 +263,24 @@ TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunk) {
   auto reference_segment =
       std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
 
-  auto iterable = ReferenceSegmentIterable<int>{*reference_segment};
+  auto iterable = ReferenceSegmentIterable<int, false>{*reference_segment};
+
+  auto nulls_found = uint32_t{0};
+  auto accessed_offsets = std::vector<ChunkOffset>{};
+  iterable.with_iterators(CountNullsWithIterator{nulls_found, accessed_offsets});
+
+  EXPECT_EQ(nulls_found, 2u);
+  EXPECT_EQ(accessed_offsets, (std::vector<ChunkOffset>{ChunkOffset{0}, ChunkOffset{1}}));
+}
+
+TEST_F(IterablesTest, ReferenceSegmentIteratorWithIteratorsSingleChunkTypeErased) {
+  auto pos_list = PosList{NULL_ROW_ID, NULL_ROW_ID};
+  pos_list.guarantee_single_chunk();
+
+  auto reference_segment =
+      std::make_unique<ReferenceSegment>(table, ColumnID{0u}, std::make_shared<PosList>(std::move(pos_list)));
+
+  auto iterable = ReferenceSegmentIterable<int, true>{*reference_segment};
 
   auto nulls_found = uint32_t{0};
   auto accessed_offsets = std::vector<ChunkOffset>{};

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -41,14 +41,14 @@ class SegmentIteratorsTest : public EncodingTest {
          */
         const auto reference_segment_single_chunk = ReferenceSegment{table, column_id, position_filter};
         const auto reference_segment_single_chunk_iterable =
-            ReferenceSegmentIterable<ColumnDataType, false>(reference_segment_single_chunk);
+            ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>(reference_segment_single_chunk);
         reference_segment_single_chunk_iterable.with_iterators(functor);
 
         /**
          * Test the ReferenceSegment iterators pointing to a single-chunk of the input column with types being erased
          */
         const auto reference_segment_single_chunk_iterable_erased =
-            ReferenceSegmentIterable<ColumnDataType, true>(reference_segment_single_chunk);
+            ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::Yes>(reference_segment_single_chunk);
         reference_segment_single_chunk_iterable_erased.with_iterators(functor);
 
         /**
@@ -56,7 +56,7 @@ class SegmentIteratorsTest : public EncodingTest {
          */
         const auto reference_segment_multi_chunk = ReferenceSegment{table, column_id, position_filter_multi_chunk};
         const auto reference_segment_multi_chunk_iterable =
-            ReferenceSegmentIterable<ColumnDataType, false>(reference_segment_multi_chunk);
+            ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>(reference_segment_multi_chunk);
         reference_segment_multi_chunk_iterable.with_iterators(functor);
       });
     }

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -41,15 +41,22 @@ class SegmentIteratorsTest : public EncodingTest {
          */
         const auto reference_segment_single_chunk = ReferenceSegment{table, column_id, position_filter};
         const auto reference_segment_single_chunk_iterable =
-            ReferenceSegmentIterable<ColumnDataType>(reference_segment_single_chunk);
+            ReferenceSegmentIterable<ColumnDataType, false>(reference_segment_single_chunk);
         reference_segment_single_chunk_iterable.with_iterators(functor);
+
+        /**
+         * Test the ReferenceSegment iterators pointing to a single-chunk of the input column with types being erased
+         */
+        const auto reference_segment_single_chunk_iterable_erased =
+            ReferenceSegmentIterable<ColumnDataType, true>(reference_segment_single_chunk);
+        reference_segment_single_chunk_iterable_erased.with_iterators(functor);
 
         /**
          * Test the ReferenceSegment iterators pointing to multiple chunks of the input column
          */
         const auto reference_segment_multi_chunk = ReferenceSegment{table, column_id, position_filter_multi_chunk};
         const auto reference_segment_multi_chunk_iterable =
-            ReferenceSegmentIterable<ColumnDataType>(reference_segment_multi_chunk);
+            ReferenceSegmentIterable<ColumnDataType, false>(reference_segment_multi_chunk);
         reference_segment_multi_chunk_iterable.with_iterators(functor);
       });
     }


### PR DESCRIPTION
In ColumnVsColumnScans, we previously generated code for comparing `ReferenceSegmentIterable::SingleChunkIterator<SegmentAccessor<int, FrameOfReferenceSegment<int>>>` with `ReferenceSegmentIterable::SingleChunkIterator<SegmentAccessor<int, LZ4Segment<int>>>`. No more.

The PerformanceWarning is never printed, and except for Q15 acting weird again, the TPC-H results remain the same, too.

```
8df96d5075443fde6dc98d41fce711e8cf02b969 (master)
real    10m22,591s
user    86m39,677s
sys     12m16,553s

d8a3a44920f4e61d9109aff50150cce97d050c01 (Type-erase the accessor in type-erased reference segments, erase more aggressively in ColumnVsColumnScan)
real    5m35,670s
user    82m8,795s
sys     12m35,370s
```