### PR TITLE
Fix Multi-threading support for Insert

### DIFF
--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,43 +1,10 @@
-#include <atomic>
 #include <iostream>
-#include <thread>
 
-#include "operators/print.hpp"
-#include "sql/sql_pipeline_builder.hpp"
-#include "storage/storage_manager.hpp"
-#include "storage/table.hpp"
 #include "types.hpp"
 
-using namespace opossum;               // NOLINT
-using namespace std::string_literals;  // NOLINT
+using namespace opossum;  // NOLINT
 
 int main() {
-  const auto table =
-      std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data, 5, UseMvcc::Yes);
-  //table->add_unique_constraint({ColumnID{0}}, false);
-
-  StorageManager::get().add_table("T0", table);
-
-  std::atomic<int32_t> global_variable{0};
-
-  std::vector<std::thread> threads;
-
-  for (size_t t{0}; t < 10; ++t) {
-    threads.emplace_back([&global_variable, t]() {
-      while (global_variable.load() < 50) {
-        const auto query = "INSERT INTO T0 VALUES("s + std::to_string(global_variable.load()) + ")";
-
-        auto statement = SQLPipelineBuilder{query}.dont_cleanup_temporaries().create_pipeline_statement();
-        statement.get_result_table();
-
-        if (t == 0) global_variable++;
-      }
-    });
-  }
-
-  for (auto& thread : threads) thread.join();
-
-  Print::print(table);
-
+  std::cout << "Hello world!!" << std::endl;
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,10 +1,43 @@
+#include <atomic>
 #include <iostream>
+#include <thread>
 
+#include "operators/print.hpp"
+#include "sql/sql_pipeline_builder.hpp"
+#include "storage/storage_manager.hpp"
+#include "storage/table.hpp"
 #include "types.hpp"
 
-using namespace opossum;  // NOLINT
+using namespace opossum;               // NOLINT
+using namespace std::string_literals;  // NOLINT
 
 int main() {
-  std::cout << "Hello world!!" << std::endl;
+  const auto table =
+      std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data, 5, UseMvcc::Yes);
+  //table->add_unique_constraint({ColumnID{0}}, false);
+
+  StorageManager::get().add_table("T0", table);
+
+  std::atomic<int32_t> global_variable{0};
+
+  std::vector<std::thread> threads;
+
+  for (size_t t{0}; t < 10; ++t) {
+    threads.emplace_back([&global_variable, t]() {
+      while (global_variable.load() < 50) {
+        const auto query = "INSERT INTO T0 VALUES("s + std::to_string(global_variable.load()) + ")";
+
+        auto statement = SQLPipelineBuilder{query}.dont_cleanup_temporaries().create_pipeline_statement();
+        statement.get_result_table();
+
+        if (t == 0) global_variable++;
+      }
+    });
+  }
+
+  for (auto& thread : threads) thread.join();
+
+  Print::print(table);
+
   return 0;
 }

--- a/src/lib/concurrency/transaction_manager.hpp
+++ b/src/lib/concurrency/transaction_manager.hpp
@@ -66,12 +66,6 @@ class TransactionManager : public Singleton<TransactionManager> {
    */
   std::optional<CommitID> get_lowest_active_snapshot_commit_id() const;
 
-  // TransactionID = 0 means "not set" in the MVCC data. This is the case if the row has (a) just been reserved, but
-  // not yet filled with content, (b) been inserted, committed and not marked for deletion, or (c) inserted but
-  // deleted in the same transaction (which has not yet committed)
-  static constexpr auto INVALID_TRANSACTION_ID = TransactionID{0};
-  static constexpr auto INITIAL_TRANSACTION_ID = TransactionID{1};
-
  private:
   TransactionManager();
 

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<const Table> Delete::_on_execute(std::shared_ptr<TransactionCont
 
           if (mvcc_data->tids[row_id.chunk_offset] == _transaction_id) {
             // Make sure that even we don't see it anymore
-            mvcc_data->tids[row_id.chunk_offset] = TransactionManager::INVALID_TRANSACTION_ID;
+            mvcc_data->tids[row_id.chunk_offset] = INVALID_TRANSACTION_ID;
           } else {
             // the row is already locked by someone else and the transaction needs to be rolled back
             _mark_as_failed();

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -97,10 +97,6 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
    *    Do so while locking the table to prevent multiple threads modifying the table's size simultaneously.
    *    Since allocation is expected to be faster than writing to the memory, allocating under lock and then writing -
    *    in a second step - without lock will minimize the time that the Table's append_mutex is locked.
-   *
-   *    In the rare case where the input table is the table that we write to (OperatorsInsertTest.SelfInsert), this
-   *    modifies input_table_left(), so calling row_count() on it or size() on its segment is no longer a valid way
-   *    to retrieve the number of rows that are to be inserted.
    */
   {
     const auto append_lock = _target_table->acquire_append_mutex();

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -109,8 +109,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
   // Create ColumnTypeWrappers
   auto column_type_wrappers = std::vector<std::unique_ptr<BaseColumnTypeWrapper>>();
   for (const auto& column_type : _target_table->column_data_types()) {
-    column_type_wrappers.emplace_back(
-        make_unique_by_data_type<BaseColumnTypeWrapper, ColumnTypeWrapper>(column_type));
+    column_type_wrappers.emplace_back(make_unique_by_data_type<BaseColumnTypeWrapper, ColumnTypeWrapper>(column_type));
   }
 
   /**
@@ -153,7 +152,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       auto old_size = target_chunk->size();
       for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
         column_type_wrappers[column_id]->resize_value_segment(target_chunk->get_segment(column_id),
-                                                                  old_size + target_chunk_num_inserted_rows);
+                                                              old_size + target_chunk_num_inserted_rows);
       }
 
       remaining_rows -= target_chunk_num_inserted_rows;
@@ -184,8 +183,8 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
         const auto source_segment = source_chunk->get_segment(column_id);
         column_type_wrappers[column_id]->copy(source_segment, source_row_id.chunk_offset,
-                                                  target_chunk->get_segment(column_id), target_chunk_offset,
-                                                  source_chunk_num_rows);
+                                              target_chunk->get_segment(column_id), target_chunk_offset,
+                                              source_chunk_num_rows);
       }
 
       if (source_chunk_num_rows == source_chunk_remaining_rows) {

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -85,6 +85,12 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
   _target_table = StorageManager::get().get_table(_target_table_name);
 
   Assert(_target_table->max_chunk_size() > 0, "Expected max chunk size of target table to be greater than zero");
+  for (ColumnID column_id{0}; column_id < _target_table->column_count(); ++column_id) {
+    // This is not really a strong limitation, we just did not want the compile time of all type combinations.
+    // If you really want this, it should be only a couple of lines to implement.
+    Assert(input_table_left()->column_data_type(column_id) == _target_table->column_data_type(column_id),
+           "Cannot handle inserts into column of different type");
+  }
 
   /**
    * 1. Allocate the required rows in the target Table, without actually copying data to them.

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -8,235 +8,242 @@
 #include "concurrency/transaction_context.hpp"
 #include "resolve_type.hpp"
 #include "storage/base_encoded_segment.hpp"
+#include "storage/segment_iterate.hpp"
 #include "storage/storage_manager.hpp"
 #include "storage/value_segment.hpp"
 #include "type_cast.hpp"
 #include "utils/assert.hpp"
 
-namespace opossum {
+namespace {
 
-// We need these classes to perform the dynamic cast into a templated ValueSegment
-class AbstractTypedSegmentProcessor : public Noncopyable {
+using namespace opossum;  // NOLINT
+
+class BaseColumnTypeWrapper : public Noncopyable {
  public:
-  AbstractTypedSegmentProcessor() = default;
-  AbstractTypedSegmentProcessor(const AbstractTypedSegmentProcessor&) = delete;
-  AbstractTypedSegmentProcessor& operator=(const AbstractTypedSegmentProcessor&) = delete;
-  AbstractTypedSegmentProcessor(AbstractTypedSegmentProcessor&&) = default;
-  AbstractTypedSegmentProcessor& operator=(AbstractTypedSegmentProcessor&&) = default;
-  virtual ~AbstractTypedSegmentProcessor() = default;
-  virtual void resize_vector(std::shared_ptr<BaseSegment> segment, size_t new_size) = 0;
-  virtual void copy_data(std::shared_ptr<const BaseSegment> source, ChunkOffset source_start_index,
-                         std::shared_ptr<BaseSegment> target, ChunkOffset target_start_index, ChunkOffset length) = 0;
+  virtual ~BaseColumnTypeWrapper() = default;
+
+  virtual void resize_value_segment(std::shared_ptr<BaseSegment> segment, size_t new_size) = 0;
+  virtual void copy(const std::shared_ptr<const BaseSegment>& source, ChunkOffset source_start_index,
+                    const std::shared_ptr<BaseSegment>& target, ChunkOffset target_start_index, ChunkOffset length) = 0;
 };
 
 template <typename T>
-class TypedSegmentProcessor : public AbstractTypedSegmentProcessor {
+class ColumnTypeWrapper : public BaseColumnTypeWrapper {
  public:
-  void resize_vector(std::shared_ptr<BaseSegment> segment, size_t new_size) override {
-    auto value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(segment);
-    DebugAssert(value_segment, "Cannot insert into non-ValueColumns");
-    auto& values = value_segment->values();
+  void resize_value_segment(std::shared_ptr<BaseSegment> segment, size_t new_size) override {
+    const auto value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(segment);
+    Assert(value_segment, "Cannot insert into non-ValueColumns");
 
-    values.resize(new_size);
+    value_segment->values().resize(new_size);
 
     if (value_segment->is_nullable()) {
       value_segment->null_values().resize(new_size);
     }
   }
 
-  // this copies
-  void copy_data(std::shared_ptr<const BaseSegment> source, ChunkOffset source_start_index,
-                 std::shared_ptr<BaseSegment> target, ChunkOffset target_start_index, ChunkOffset length) override {
-    auto casted_target = std::dynamic_pointer_cast<ValueSegment<T>>(target);
-    DebugAssert(casted_target, "Cannot insert into non-ValueColumns");
-    auto& values = casted_target->values();
+  void copy(const std::shared_ptr<const BaseSegment>& source_base_segment, ChunkOffset source_start_index,
+            const std::shared_ptr<BaseSegment>& target_base_segment, ChunkOffset target_start_index,
+            ChunkOffset length) override {
+    const auto target_value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(target_base_segment);
+    Assert(target_value_segment, "Cannot insert into non-ValueColumns");
 
-    auto target_is_nullable = casted_target->is_nullable();
+    auto& target_values = target_value_segment->values();
+    const auto target_is_nullable = target_value_segment->is_nullable();
 
-    if (auto casted_source = std::dynamic_pointer_cast<const ValueSegment<T>>(source)) {
-      std::copy_n(casted_source->values().begin() + source_start_index, length, values.begin() + target_start_index);
+    /**
+     * If the source Segment is a ValueSegment, take a fast path to copy the data.
+     * Otherwise, take a (potentially slower) fallback path.
+     */
+    if (const auto source_value_segment = std::dynamic_pointer_cast<const ValueSegment<T>>(source_base_segment)) {
+      std::copy_n(source_value_segment->values().begin() + source_start_index, length,
+                  target_values.begin() + target_start_index);
 
-      if (casted_source->is_nullable()) {
-        const auto nulls_begin_iter = casted_source->null_values().begin() + source_start_index;
+      if (source_value_segment->is_nullable()) {
+        const auto nulls_begin_iter = source_value_segment->null_values().begin() + source_start_index;
         const auto nulls_end_iter = nulls_begin_iter + length;
 
         Assert(
             target_is_nullable || std::none_of(nulls_begin_iter, nulls_end_iter, [](const auto& null) { return null; }),
             "Trying to insert NULL into non-NULL segment");
-        std::copy(nulls_begin_iter, nulls_end_iter, casted_target->null_values().begin() + target_start_index);
+        std::copy(nulls_begin_iter, nulls_end_iter, target_value_segment->null_values().begin() + target_start_index);
       }
-    } else if (auto casted_dummy_source = std::dynamic_pointer_cast<const ValueSegment<int32_t>>(source)) {
-      // We use the segment type of the Dummy table used to insert a single null value.
-      // A few asserts are needed to guarantee correct behaviour.
-
-      // You may also end up here if the data types of the input and the target column mismatch. Usually, this gets
-      // caught way earlier, but if you build your own tests, this might happen.
-      Assert(length == 1, "Cannot insert multiple unknown null values at once.");
-      Assert(casted_dummy_source->size() == 1, "Source segment is of wrong type.");
-      Assert(casted_dummy_source->null_values().front() == true, "Only value in dummy table must be NULL!");
-      Assert(target_is_nullable, "Cannot insert NULL into NOT NULL target.");
-
-      // Ignore source value and only set null to true
-      casted_target->null_values()[target_start_index] = true;
     } else {
-      // } else if(auto casted_source = std::dynamic_pointer_cast<ReferenceSegment>(source)){
-      // since we have no guarantee that a ReferenceSegment references only a single other segment,
-      // this would require us to find out the referenced segment's type for each single row.
-      // instead, we just use the slow path below.
-      for (auto i = 0u; i < length; i++) {
-        auto ref_value = (*source)[source_start_index + i];
-        if (variant_is_null(ref_value)) {
-          Assert(target_is_nullable, "Cannot insert NULL into NOT NULL target");
-          values[target_start_index + i] = T{};
-          casted_target->null_values()[target_start_index + i] = true;
-        } else {
-          values[target_start_index + i] = type_cast_variant<T>(ref_value);
+      segment_with_iterators<T>(*source_base_segment, [&](auto source_begin, const auto source_end) {
+        auto source_iter = source_begin + source_start_index;
+        auto target_iter = target_values.begin() + target_start_index;
+
+        // Copy values and null values
+        for (auto i = 0u; i < length; i++) {
+          *target_iter = source_iter->value();
+
+          if (target_is_nullable) {
+            target_value_segment->null_values()[target_start_index + i] = source_iter->is_null();
+          } else {
+            Assert(!source_iter->is_null(), "Cannot insert NULL into NOT NULL target");
+          }
+
+          ++source_iter;
+          ++target_iter;
         }
-      }
+      });
     }
   }
 };
+
+}  // namespace
+
+namespace opossum {
 
 Insert::Insert(const std::string& target_table_name, const std::shared_ptr<const AbstractOperator>& values_to_insert)
     : AbstractReadWriteOperator(OperatorType::Insert, values_to_insert), _target_table_name(target_table_name) {}
 
 const std::string Insert::name() const { return "Insert"; }
 
+std::string Insert::target_table_name() const { return _target_table_name; }
+
 std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionContext> context) {
   context->register_read_write_operator(std::static_pointer_cast<AbstractReadWriteOperator>(shared_from_this()));
 
   _target_table = StorageManager::get().get_table(_target_table_name);
 
-  // These TypedSegmentProcessors kind of retrieve the template parameter of the segments.
-  auto typed_segment_processors = std::vector<std::unique_ptr<AbstractTypedSegmentProcessor>>();
+  Assert(_target_table->max_chunk_size() > 0, "Expected max chunk size of target table to be greater than zero");
+
+  // Create TypedSegmentProcessors
+  auto typed_segment_processors = std::vector<std::unique_ptr<BaseColumnTypeWrapper>>();
   for (const auto& column_type : _target_table->column_data_types()) {
     typed_segment_processors.emplace_back(
-        make_unique_by_data_type<AbstractTypedSegmentProcessor, TypedSegmentProcessor>(column_type));
+        make_unique_by_data_type<BaseColumnTypeWrapper, ColumnTypeWrapper>(column_type));
   }
 
-  auto total_rows_to_insert = static_cast<uint32_t>(input_table_left()->row_count());
-
-  // First, allocate space for all the rows to insert. Do so while locking the table to prevent multiple threads
-  // modifying the table's size simultaneously.
-  auto start_index = 0u;
-  auto start_chunk_id = ChunkID{0};
-  auto end_chunk_id = 0u;
+  /**
+   * 1. Allocate the required rows before actually writing to them. Do so while locking the table to prevent multiple
+   *    threads modifying the table's size simultaneously.
+   *    Since allocation is expected to be faster than writing to the memory, this will minimize the time that the 
+   *    Table's append_mutex is locked.
+   */
   {
-    auto scoped_lock = _target_table->acquire_append_mutex();
+    const auto append_lock = _target_table->acquire_append_mutex();
+
+    auto remaining_rows = input_table_left()->row_count();
 
     if (_target_table->chunk_count() == 0) {
       _target_table->append_mutable_chunk();
     }
 
-    start_chunk_id = _target_table->chunk_count() - 1;
-    end_chunk_id = start_chunk_id + 1;
-    auto last_chunk = _target_table->get_chunk(start_chunk_id);
-    start_index = last_chunk->size();
-
-    // If last chunk is compressed, add a new uncompressed chunk
-    if (!last_chunk->is_mutable()) {
-      _target_table->append_mutable_chunk();
-      end_chunk_id++;
-    }
-
-    auto remaining_rows = total_rows_to_insert;
     while (remaining_rows > 0) {
-      auto current_chunk = _target_table->get_chunk(static_cast<ChunkID>(_target_table->chunk_count() - 1));
-      auto rows_to_insert_this_loop = std::min(_target_table->max_chunk_size() - current_chunk->size(), remaining_rows);
+      auto target_chunk_id = ChunkID{_target_table->chunk_count() - 1};
+      auto target_chunk = _target_table->get_chunk(target_chunk_id);
 
-      // Resize MVCC vectors.
-      current_chunk->get_scoped_mvcc_data_lock()->grow_by(rows_to_insert_this_loop, MvccData::MAX_COMMIT_ID);
-
-      // Resize current chunk to full size.
-      auto old_size = current_chunk->size();
-      for (ColumnID column_id{0}; column_id < current_chunk->column_count(); ++column_id) {
-        typed_segment_processors[column_id]->resize_vector(current_chunk->get_segment(column_id),
-                                                           old_size + rows_to_insert_this_loop);
-      }
-
-      remaining_rows -= rows_to_insert_this_loop;
-
-      // Create new chunk if necessary.
-      if (remaining_rows > 0) {
+      // If the last Chunk of the target Table is either immutable or full, append a new mutable Chunk
+      if (!target_chunk->is_mutable() || target_chunk->size() == _target_table->max_chunk_size()) {
         _target_table->append_mutable_chunk();
-        end_chunk_id++;
+        ++target_chunk_id;
+        target_chunk = _target_table->get_chunk(target_chunk_id);
       }
+
+      const auto target_chunk_num_inserted_rows =
+          std::min<size_t>(_target_table->max_chunk_size() - target_chunk->size(), remaining_rows);
+
+      _target_chunk_ranges.emplace_back(
+          ChunkRange{target_chunk_id, target_chunk->size(),
+                     static_cast<ChunkOffset>(target_chunk->size() + target_chunk_num_inserted_rows)});
+
+      // Grow MVCC columns.
+      target_chunk->get_scoped_mvcc_data_lock()->grow_by(target_chunk_num_inserted_rows, MvccData::MAX_COMMIT_ID);
+
+      // Grow data Segments.
+      auto old_size = target_chunk->size();
+      for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
+        typed_segment_processors[column_id]->resize_value_segment(target_chunk->get_segment(column_id),
+                                                                  old_size + target_chunk_num_inserted_rows);
+      }
+
+      remaining_rows -= target_chunk_num_inserted_rows;
     }
   }
+
   // TODO(all): make compress chunk thread-safe; if it gets called here by another thread, things will likely break.
 
-  // Then, actually insert the data.
-  auto input_offset = 0u;
-  auto source_chunk_id = ChunkID{0};
-  auto source_chunk_start_index = 0u;
+  /**
+   * 2. Insert the Data into the memory allocated in the first step. Write the transaction_context's transaction_id into
+   *    all allocated rows.
+   */
+  auto input_row_id = RowID{ChunkID{0}, ChunkOffset{0}};
 
-  for (auto target_chunk_id = start_chunk_id; target_chunk_id < end_chunk_id; target_chunk_id++) {
-    auto target_chunk = _target_table->get_chunk(target_chunk_id);
+  for (const auto& target_chunk_range : _target_chunk_ranges) {
+    const auto target_chunk = _target_table->get_chunk(target_chunk_range.chunk_id);
 
-    const auto current_num_rows_to_insert =
-        std::min(target_chunk->size() - start_index, total_rows_to_insert - input_offset);
+    auto target_chunk_offset = target_chunk_range.begin_chunk_offset;
+    auto target_chunk_range_remaining_rows =
+        target_chunk_range.end_chunk_offset - target_chunk_range.begin_chunk_offset;
 
-    auto target_start_index = start_index;
-    auto still_to_insert = current_num_rows_to_insert;
+    while (target_chunk_range_remaining_rows > 0) {
+      const auto input_chunk = input_table_left()->get_chunk(input_row_id.chunk_id);
+      const auto input_chunk_remaining_rows = input_chunk->size() - input_row_id.chunk_offset;
+      const auto input_chunk_num_rows = std::min(input_chunk_remaining_rows, target_chunk_range_remaining_rows);
 
-    // while target chunk is not full
-    while (target_start_index != target_chunk->size()) {
-      const auto source_chunk = input_table_left()->get_chunk(source_chunk_id);
-      auto num_to_insert = std::min(source_chunk->size() - source_chunk_start_index, still_to_insert);
+      // Copy from the input into the target Segments
       for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
-        const auto& source_segment = source_chunk->get_segment(column_id);
-        typed_segment_processors[column_id]->copy_data(source_segment, source_chunk_start_index,
-                                                       target_chunk->get_segment(column_id), target_start_index,
-                                                       num_to_insert);
+        const auto input_segment = input_chunk->get_segment(column_id);
+        typed_segment_processors[column_id]->copy(input_segment, input_row_id.chunk_offset,
+                                                  target_chunk->get_segment(column_id), target_chunk_offset,
+                                                  input_chunk_num_rows);
       }
-      still_to_insert -= num_to_insert;
-      target_start_index += num_to_insert;
-      source_chunk_start_index += num_to_insert;
 
-      bool source_chunk_depleted = source_chunk_start_index == source_chunk->size();
-      if (source_chunk_depleted) {
-        source_chunk_id++;
-        source_chunk_start_index = 0u;
+      if (input_chunk_num_rows == input_chunk_remaining_rows) {
+        // Proceed to next input Chunk
+        ++input_row_id.chunk_id;
+        input_row_id.chunk_offset = 0;
+      } else {
+        input_row_id.chunk_offset += input_chunk_num_rows;
       }
+
+      target_chunk_offset += input_chunk_num_rows;
+      target_chunk_range_remaining_rows -= input_chunk_num_rows;
     }
 
-    for (auto i = start_index; i < start_index + current_num_rows_to_insert; i++) {
+    // Write the transaction_context's transaction_id into all new rows
+    for (auto chunk_offset = target_chunk_range.begin_chunk_offset; chunk_offset < target_chunk_range.end_chunk_offset;
+         ++chunk_offset) {
       // we do not need to check whether other operators have locked the rows, we have just created them
       // and they are not visible for other operators.
       // the transaction IDs are set here and not during the resize, because
       // tbb::concurrent_vector::grow_to_at_least(n, t)" does not work with atomics, since their copy constructor is
       // deleted.
-      target_chunk->get_scoped_mvcc_data_lock()->tids[i] = context->transaction_id();
-      _inserted_rows.emplace_back(RowID{target_chunk_id, i});
+      target_chunk->get_scoped_mvcc_data_lock()->tids[chunk_offset] = context->transaction_id();
     }
-
-    input_offset += current_num_rows_to_insert;
-    start_index = 0u;
   }
 
   return nullptr;
 }
 
 void Insert::_on_commit_records(const CommitID cid) {
-  for (auto row_id : _inserted_rows) {
-    auto chunk = _target_table->get_chunk(row_id.chunk_id);
+  for (const auto& target_chunk_range : _target_chunk_ranges) {
+    const auto target_chunk = _target_table->get_chunk(target_chunk_range.chunk_id);
+    auto mvcc_data = target_chunk->get_scoped_mvcc_data_lock();
 
-    auto mvcc_data = chunk->get_scoped_mvcc_data_lock();
-    mvcc_data->begin_cids[row_id.chunk_offset] = cid;
-    mvcc_data->tids[row_id.chunk_offset] = 0u;
+    for (auto chunk_offset = target_chunk_range.begin_chunk_offset; chunk_offset < target_chunk_range.end_chunk_offset;
+         ++chunk_offset) {
+      mvcc_data->begin_cids[chunk_offset] = cid;
+      mvcc_data->tids[chunk_offset] = 0u;
+    }
   }
 }
 
 void Insert::_on_rollback_records() {
-  for (auto row_id : _inserted_rows) {
-    auto chunk = _target_table->get_chunk(row_id.chunk_id);
-    // We set the begin and end cids to 0 (effectively making it invisible for everyone) so that the ChunkCompression
-    // does not think that this row is still incomplete. We need to make sure that the end is written before the begin.
-    chunk->get_scoped_mvcc_data_lock()->end_cids[row_id.chunk_offset] = 0u;
-    std::atomic_thread_fence(std::memory_order_release);
-    chunk->get_scoped_mvcc_data_lock()->begin_cids[row_id.chunk_offset] = 0u;
+  for (const auto& target_chunk_range : _target_chunk_ranges) {
+    const auto target_chunk = _target_table->get_chunk(target_chunk_range.chunk_id);
+    auto mvcc_data = target_chunk->get_scoped_mvcc_data_lock();
 
-    chunk->get_scoped_mvcc_data_lock()->tids[row_id.chunk_offset] = 0u;
+    for (auto chunk_offset = target_chunk_range.begin_chunk_offset; chunk_offset < target_chunk_range.end_chunk_offset;
+         ++chunk_offset) {
+      // Set the begin and end cids to 0 (effectively making it invisible for everyone).
+      // Make sure that the end is written before the begin.
+      mvcc_data->end_cids[chunk_offset] = 0u;
+      std::atomic_thread_fence(std::memory_order_release);
+      mvcc_data->begin_cids[chunk_offset] = 0u;
+      mvcc_data->tids[chunk_offset] = 0u;
+    }
   }
 }
 

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -41,8 +41,8 @@ class ColumnTypeWrapper : public BaseColumnTypeWrapper {
     }
   }
 
-  void copy(const std::shared_ptr<const BaseSegment>& source_base_segment, ChunkOffset source_start_index,
-            const std::shared_ptr<BaseSegment>& target_base_segment, ChunkOffset target_start_index,
+  void copy(const std::shared_ptr<const BaseSegment>& source_base_segment, ChunkOffset source_begin_offset,
+            const std::shared_ptr<BaseSegment>& target_base_segment, ChunkOffset target_begin_offset,
             ChunkOffset length) override {
     const auto target_value_segment = std::dynamic_pointer_cast<ValueSegment<T>>(target_base_segment);
     Assert(target_value_segment, "Cannot insert into non-ValueColumns");
@@ -55,29 +55,29 @@ class ColumnTypeWrapper : public BaseColumnTypeWrapper {
      * Otherwise, take a (potentially slower) fallback path.
      */
     if (const auto source_value_segment = std::dynamic_pointer_cast<const ValueSegment<T>>(source_base_segment)) {
-      std::copy_n(source_value_segment->values().begin() + source_start_index, length,
-                  target_values.begin() + target_start_index);
+      std::copy_n(source_value_segment->values().begin() + source_begin_offset, length,
+                  target_values.begin() + target_begin_offset);
 
       if (source_value_segment->is_nullable()) {
-        const auto nulls_begin_iter = source_value_segment->null_values().begin() + source_start_index;
+        const auto nulls_begin_iter = source_value_segment->null_values().begin() + source_begin_offset;
         const auto nulls_end_iter = nulls_begin_iter + length;
 
         Assert(
             target_is_nullable || std::none_of(nulls_begin_iter, nulls_end_iter, [](const auto& null) { return null; }),
             "Trying to insert NULL into non-NULL segment");
-        std::copy(nulls_begin_iter, nulls_end_iter, target_value_segment->null_values().begin() + target_start_index);
+        std::copy(nulls_begin_iter, nulls_end_iter, target_value_segment->null_values().begin() + target_begin_offset);
       }
     } else {
       segment_with_iterators<T>(*source_base_segment, [&](auto source_begin, const auto source_end) {
-        auto source_iter = source_begin + source_start_index;
-        auto target_iter = target_values.begin() + target_start_index;
+        auto source_iter = source_begin + source_begin_offset;
+        auto target_iter = target_values.begin() + target_begin_offset;
 
         // Copy values and null values
-        for (auto i = 0u; i < length; i++) {
+        for (auto index = ChunkOffset(0); index < length; index++) {
           *target_iter = source_iter->value();
 
           if (target_is_nullable) {
-            target_value_segment->null_values()[target_start_index + i] = source_iter->is_null();
+            target_value_segment->null_values()[target_begin_offset + index] = source_iter->is_null();
           } else {
             Assert(!source_iter->is_null(), "Cannot insert NULL into NOT NULL target");
           }
@@ -99,8 +99,6 @@ Insert::Insert(const std::string& target_table_name, const std::shared_ptr<const
 
 const std::string Insert::name() const { return "Insert"; }
 
-std::string Insert::target_table_name() const { return _target_table_name; }
-
 std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionContext> context) {
   context->register_read_write_operator(std::static_pointer_cast<AbstractReadWriteOperator>(shared_from_this()));
 
@@ -108,18 +106,18 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
 
   Assert(_target_table->max_chunk_size() > 0, "Expected max chunk size of target table to be greater than zero");
 
-  // Create TypedSegmentProcessors
-  auto typed_segment_processors = std::vector<std::unique_ptr<BaseColumnTypeWrapper>>();
+  // Create ColumnTypeWrappers
+  auto column_type_wrappers = std::vector<std::unique_ptr<BaseColumnTypeWrapper>>();
   for (const auto& column_type : _target_table->column_data_types()) {
-    typed_segment_processors.emplace_back(
+    column_type_wrappers.emplace_back(
         make_unique_by_data_type<BaseColumnTypeWrapper, ColumnTypeWrapper>(column_type));
   }
 
   /**
-   * 1. Allocate the required rows before actually writing to them. Do so while locking the table to prevent multiple
-   *    threads modifying the table's size simultaneously.
-   *    Since allocation is expected to be faster than writing to the memory, this will minimize the time that the 
-   *    Table's append_mutex is locked.
+   * 1. Allocate the required rows in the target Table, without actually copying data to them.
+   *    Do so while locking the table to prevent multiple threads modifying the table's size simultaneously.
+   *    Since allocation is expected to be faster than writing to the memory, allocating under lock and then writing -
+   *    in a second step - without lock will minimize the time that the Table's append_mutex is locked.
    */
   {
     const auto append_lock = _target_table->acquire_append_mutex();
@@ -149,12 +147,12 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
                      static_cast<ChunkOffset>(target_chunk->size() + target_chunk_num_inserted_rows)});
 
       // Grow MVCC columns.
-      target_chunk->get_scoped_mvcc_data_lock()->grow_by(target_chunk_num_inserted_rows, MvccData::MAX_COMMIT_ID);
+      target_chunk->get_scoped_mvcc_data_lock()->grow_by(target_chunk_num_inserted_rows, context->transaction_id());
 
       // Grow data Segments.
       auto old_size = target_chunk->size();
       for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
-        typed_segment_processors[column_id]->resize_value_segment(target_chunk->get_segment(column_id),
+        column_type_wrappers[column_id]->resize_value_segment(target_chunk->get_segment(column_id),
                                                                   old_size + target_chunk_num_inserted_rows);
       }
 
@@ -168,7 +166,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
    * 2. Insert the Data into the memory allocated in the first step. Write the transaction_context's transaction_id into
    *    all allocated rows.
    */
-  auto input_row_id = RowID{ChunkID{0}, ChunkOffset{0}};
+  auto source_row_id = RowID{ChunkID{0}, ChunkOffset{0}};
 
   for (const auto& target_chunk_range : _target_chunk_ranges) {
     const auto target_chunk = _target_table->get_chunk(target_chunk_range.chunk_id);
@@ -178,39 +176,28 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
         target_chunk_range.end_chunk_offset - target_chunk_range.begin_chunk_offset;
 
     while (target_chunk_range_remaining_rows > 0) {
-      const auto input_chunk = input_table_left()->get_chunk(input_row_id.chunk_id);
-      const auto input_chunk_remaining_rows = input_chunk->size() - input_row_id.chunk_offset;
-      const auto input_chunk_num_rows = std::min(input_chunk_remaining_rows, target_chunk_range_remaining_rows);
+      const auto source_chunk = input_table_left()->get_chunk(source_row_id.chunk_id);
+      const auto source_chunk_remaining_rows = source_chunk->size() - source_row_id.chunk_offset;
+      const auto source_chunk_num_rows = std::min(source_chunk_remaining_rows, target_chunk_range_remaining_rows);
 
-      // Copy from the input into the target Segments
+      // Copy from the source into the target Segments
       for (ColumnID column_id{0}; column_id < target_chunk->column_count(); ++column_id) {
-        const auto input_segment = input_chunk->get_segment(column_id);
-        typed_segment_processors[column_id]->copy(input_segment, input_row_id.chunk_offset,
+        const auto source_segment = source_chunk->get_segment(column_id);
+        column_type_wrappers[column_id]->copy(source_segment, source_row_id.chunk_offset,
                                                   target_chunk->get_segment(column_id), target_chunk_offset,
-                                                  input_chunk_num_rows);
+                                                  source_chunk_num_rows);
       }
 
-      if (input_chunk_num_rows == input_chunk_remaining_rows) {
-        // Proceed to next input Chunk
-        ++input_row_id.chunk_id;
-        input_row_id.chunk_offset = 0;
+      if (source_chunk_num_rows == source_chunk_remaining_rows) {
+        // Proceed to next source Chunk
+        ++source_row_id.chunk_id;
+        source_row_id.chunk_offset = 0;
       } else {
-        input_row_id.chunk_offset += input_chunk_num_rows;
+        source_row_id.chunk_offset += source_chunk_num_rows;
       }
 
-      target_chunk_offset += input_chunk_num_rows;
-      target_chunk_range_remaining_rows -= input_chunk_num_rows;
-    }
-
-    // Write the transaction_context's transaction_id into all new rows
-    for (auto chunk_offset = target_chunk_range.begin_chunk_offset; chunk_offset < target_chunk_range.end_chunk_offset;
-         ++chunk_offset) {
-      // we do not need to check whether other operators have locked the rows, we have just created them
-      // and they are not visible for other operators.
-      // the transaction IDs are set here and not during the resize, because
-      // tbb::concurrent_vector::grow_to_at_least(n, t)" does not work with atomics, since their copy constructor is
-      // deleted.
-      target_chunk->get_scoped_mvcc_data_lock()->tids[chunk_offset] = context->transaction_id();
+      target_chunk_offset += source_chunk_num_rows;
+      target_chunk_range_remaining_rows -= source_chunk_num_rows;
     }
   }
 

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -97,6 +97,10 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
    *    Do so while locking the table to prevent multiple threads modifying the table's size simultaneously.
    *    Since allocation is expected to be faster than writing to the memory, allocating under lock and then writing -
    *    in a second step - without lock will minimize the time that the Table's append_mutex is locked.
+   *
+   *    In the rare case where the input table is the table that we write to (OperatorsInsertTest.SelfInsert), this
+   *    modifies input_table_left(), so calling row_count() on it or size() on its segment is no longer a valid way
+   *    to retrieve the number of rows that are to be inserted.
    */
   {
     const auto append_lock = _target_table->acquire_append_mutex();

--- a/src/lib/operators/insert.hpp
+++ b/src/lib/operators/insert.hpp
@@ -26,16 +26,6 @@ class Insert : public AbstractReadWriteOperator {
 
   const std::string name() const override;
 
-  /**
-   * ID of first chunk that contained a ValueSegment when the unique constraints for
-   * inserting values have been checked. When the constraints are checked again during
-   * the commit in the transaction context, all chunks before this chunk can be
-   * skipped as they are compressed and won't be changed.
-   */
-  ChunkID first_chunk_to_check() const;
-
-  std::string target_table_name() const;
-
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -43,7 +43,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row are the MVCC data.
-  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, MvccData::MAX_COMMIT_ID);
+  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, TransactionID{0});
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_segments.size() == values.size()),

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -42,7 +42,7 @@ void Chunk::replace_segment(size_t column_id, const std::shared_ptr<BaseSegment>
 void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
-  // Do this first to ensure that the first thing to exist in a row are the MVCC data.
+  // Do this first to ensure that the first thing to exist in a row is the MVCC data.
   if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, TransactionID{0});
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -47,7 +47,8 @@ void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::
   chunk->set_statistics(std::make_shared<ChunkStatistics>(column_statistics));
 
   if (chunk->has_mvcc_data()) {
-    chunk->get_scoped_mvcc_data_lock()->shrink();
+    // MvccData::shrink() will acquire a write lock itself
+    chunk->mvcc_data()->shrink();
   }
 }
 

--- a/src/lib/storage/chunk_encoder.hpp
+++ b/src/lib/storage/chunk_encoder.hpp
@@ -32,6 +32,9 @@ using ChunkEncodingSpec = std::vector<SegmentEncodingSpec>;
 /**
  * @brief Interface for encoding chunks
  *
+ * TODO(all): make compress chunk thread-safe; if it gets called while another thread is inserting, things will likely
+ *            break.
+ *
  * The methods provided are not thread-safe and might lead to race conditions
  * if there are other operations manipulating the chunks at the same time.
  */

--- a/src/lib/storage/chunk_encoder.hpp
+++ b/src/lib/storage/chunk_encoder.hpp
@@ -32,8 +32,7 @@ using ChunkEncodingSpec = std::vector<SegmentEncodingSpec>;
 /**
  * @brief Interface for encoding chunks
  *
- * TODO(all): make compress chunk thread-safe; if it gets called while another thread is inserting, things will likely
- *            break.
+ * NOT thread-safe. In a multi-threaded context, the ChunkCompressionTask should invoke the ChunkEncoder.
  *
  * The methods provided are not thread-safe and might lead to race conditions
  * if there are other operations manipulating the chunks at the same time.

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -6,7 +6,7 @@
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size) { grow_by(size, 0); }
+MvccData::MvccData(const size_t size) { grow_by(size, TransactionID{0}); }
 
 size_t MvccData::size() const { return _size; }
 
@@ -16,10 +16,10 @@ void MvccData::shrink() {
   end_cids.shrink_to_fit();
 }
 
-void MvccData::grow_by(size_t delta, CommitID begin_cid) {
+void MvccData::grow_by(size_t delta, TransactionID transaction_id) {
   _size += delta;
-  tids.grow_to_at_least(_size);
-  begin_cids.grow_to_at_least(_size, begin_cid);
+  tids.grow_to_at_least(_size, transaction_id);
+  begin_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
   end_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
 }
 

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -2,11 +2,12 @@
 
 #include <shared_mutex>
 
+#include "concurrency/transaction_manager.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size) { grow_by(size, TransactionID{0}); }
+MvccData::MvccData(const size_t size) { grow_by(size, INVALID_TRANSACTION_ID); }
 
 size_t MvccData::size() const { return _size; }
 

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -27,9 +27,8 @@ struct MvccData {
   size_t size() const;
 
   /**
-   * Compacts the internal representation of
-   * the mvcc data in order to reduce fragmentation
-   * Locks mvcc data exclusively in order to do so
+   * Compacts the internal representation of the mvcc data in order to reduce fragmentation.
+   * Locks mvcc data exclusively in order to do so.
    */
   void shrink();
 

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -36,9 +36,9 @@ struct MvccData {
   /**
    * Grows mvcc data by the given delta
    *
-   * @param begin_cid value all new begin_cids will be set to
+   * @param transaction_id    value all new tids will be set to
    */
-  void grow_by(size_t delta, CommitID begin_cid);
+  void grow_by(size_t delta, TransactionID transaction_id);
 
   void print(std::ostream& stream = std::cout) const;
 

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -42,6 +42,9 @@ bool ChunkCompressionTask::_chunk_is_completed(const std::shared_ptr<Chunk>& chu
   auto mvcc_data = chunk->get_scoped_mvcc_data_lock();
 
   for (const auto begin_cid : mvcc_data->begin_cids) {
+    // TODO(anybody) Reading the non-atomic begin_cid (which is written to in Insert without a write lock) is likely UB
+    //               When activating the ChunkCompressionTask, please look for a different means of determining whether
+    //               All Inserts to a Chunk finished.
     if (begin_cid == MvccData::MAX_COMMIT_ID) return false;
   }
 

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -161,6 +161,12 @@ constexpr CpuID INVALID_CPU_ID{std::numeric_limits<CpuID::base_type>::max()};
 constexpr WorkerID INVALID_WORKER_ID{std::numeric_limits<WorkerID>::max()};
 constexpr ColumnID INVALID_COLUMN_ID{std::numeric_limits<ColumnID::base_type>::max()};
 
+// TransactionID = 0 means "not set" in the MVCC data. This is the case if the row has (a) just been reserved, but
+// not yet filled with content, (b) been inserted, committed and not marked for deletion, or (c) inserted but
+// deleted in the same transaction (which has not yet committed)
+constexpr auto INVALID_TRANSACTION_ID = TransactionID{0};
+constexpr auto INITIAL_TRANSACTION_ID = TransactionID{1};
+
 constexpr NodeID CURRENT_NODE_ID{std::numeric_limits<NodeID::base_type>::max() - 1};
 
 // Declaring one part of a RowID as invalid would suffice to represent NULL values. However, this way we add an extra

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -107,7 +107,7 @@ TEST_F(StorageTableTest, ShrinkingMvccDataHasNoSideEffects) {
 
   const auto previous_size = chunk->size();
 
-  chunk->get_scoped_mvcc_data_lock()->shrink();
+  chunk->mvcc_data()->shrink();
 
   ASSERT_EQ(previous_size, chunk->size());
   ASSERT_TRUE(chunk->has_mvcc_data());


### PR DESCRIPTION
...and general cleanup. The Insert code is now much more pleasant to read.

Also, fix #1086 


Here is the playground that I used to "test" whether multi-threaded insert works:

```c++
#include <atomic>
#include <iostream>
#include <thread>

#include "operators/print.hpp"
#include "sql/sql_pipeline_builder.hpp"
#include "storage/storage_manager.hpp"
#include "storage/table.hpp"
#include "types.hpp"

using namespace opossum;               // NOLINT
using namespace std::string_literals;  // NOLINT

int main() {
  const auto table =
      std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data, 5, UseMvcc::Yes);
  //table->add_unique_constraint({ColumnID{0}}, false);

  StorageManager::get().add_table("T0", table);

  std::atomic<int32_t> global_variable{0};

  std::vector<std::thread> threads;

  for (size_t t{0}; t < 10; ++t) {
    threads.emplace_back([&global_variable, t]() {
      while (global_variable.load() < 50) {
        const auto query = "INSERT INTO T0 VALUES("s + std::to_string(global_variable.load()) + ")";

        auto statement = SQLPipelineBuilder{query}.dont_cleanup_temporaries().create_pipeline_statement();
        statement.get_result_table();

        if (t == 0) global_variable++;
      }
    });
  }

  for (auto& thread : threads) thread.join();

  Print::print(table);

  return 0;
}
```