### PR TITLE
[JIT] Correct default value of ENABLE_JIT_SUPPORT and handling of LIMIT expressions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,11 @@ add_definitions(-DHYRISE_DEBUG=${HYRISE_DEBUG})
 # Provide ENABLE_JIT_SUPPORT option and automatically disable JIT if compiler is not Clang 6.*
 # ENABLE_JIT_SUPPORT is OFF on MacOS by default as JIT compilation currently fails on MacOS because the specialized code
 # contains asm code on MacOS which the JIT compiler cannot handle
-option(ENABLE_JIT_SUPPORT "Build with JIT support" "NOT APPLE")
+if (APPLE)
+    option(ENABLE_JIT_SUPPORT "Build with JIT support" OFF)
+else()
+    option(ENABLE_JIT_SUPPORT "Build with JIT support" ON)
+endif()
 if (NOT ${LLVM_FOUND} OR NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6 OR NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
     set(ENABLE_JIT_SUPPORT OFF)
 elseif (APPLE AND ENABLE_JIT_SUPPORT)

--- a/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_read_tuples.cpp
@@ -163,7 +163,7 @@ void JitReadTuples::before_query(const Table& in_table, const std::vector<AllTyp
 
       if constexpr (std::is_integral_v<LimitDataType>) {
         const auto num_rows_expression_result =
-                ExpressionEvaluator{}.evaluate_expression_to_result<LimitDataType>(*row_count_expression);
+            ExpressionEvaluator{}.evaluate_expression_to_result<LimitDataType>(*row_count_expression);
         Assert(num_rows_expression_result->size() == 1, "Expected exactly one row for Limit");
         Assert(!num_rows_expression_result->is_null(0), "Expected non-null for Limit");
 


### PR DESCRIPTION
This pr corrects the default value of `ENABLE_JIT_SUPPORT` which was changed in pr #1566 caused the value to be always set to `OFF`.

As a result, Jenkins did not build and test the JIT code anymore so that the changes concerning the evaluation of limit expressions in pr #1581  could pass by not running the not working JIT tests.
The limit expression evaluation in the JIT code has now been adjusted.