### PR TITLE
JoinHash for semi/anti: Insert values just once

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -258,8 +258,11 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
         radix_left = std::move(materialized_left);
       }
 
-      // build hash tables
-      if (_mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse) {
+      // Build hash tables. In the case of semi or anti joins, we do not need to track all rows on the hashed side,
+      // just one per value. However, if we have secondary predicates, those might fail on that single row. In that
+      // case, we DO need all rows.
+      if (_secondary_predicates.empty() &&
+          (_mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse)) {
         hashtables = build<LeftType, HashedType, true>(radix_left);
       } else {
         hashtables = build<LeftType, HashedType, false>(radix_left);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -263,9 +263,9 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       // case, we DO need all rows.
       if (_secondary_predicates.empty() &&
           (_mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse)) {
-        hashtables = build<LeftType, HashedType, true>(radix_left);
+        hashtables = build<LeftType, HashedType, JoinHashBuildPositions::OnePerValue>(radix_left);
       } else {
-        hashtables = build<LeftType, HashedType, false>(radix_left);
+        hashtables = build<LeftType, HashedType, JoinHashBuildPositions::All>(radix_left);
       }
     }));
     jobs.back()->schedule();

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -262,7 +262,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       if (_mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse) {
         hashtables = build<LeftType, HashedType, true>(radix_left);
       } else {
-        hashtables = build<LeftType, HashedType, falls>(radix_left);
+        hashtables = build<LeftType, HashedType, false>(radix_left);
       }
     }));
     jobs.back()->schedule();

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -105,7 +105,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
                const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                const ColumnIDPair& column_ids, const PredicateCondition predicate_condition, const bool inputs_swapped,
                const std::optional<size_t>& radix_bits = std::nullopt,
-               std::vector<OperatorJoinPredicate> secondary_join_predicates = {})
+               std::vector<OperatorJoinPredicate> secondary_predicates = {})
       : _join_hash(join_hash),
         _left(left),
         _right(right),
@@ -113,7 +113,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
         _column_ids(column_ids),
         _predicate_condition(predicate_condition),
         _inputs_swapped(inputs_swapped),
-        _secondary_join_predicates(std::move(secondary_join_predicates)) {
+        _secondary_predicates(std::move(secondary_predicates)) {
     if (radix_bits) {
       _radix_bits = radix_bits.value();
     } else {
@@ -128,7 +128,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
   const ColumnIDPair _column_ids;
   const PredicateCondition _predicate_condition;
   const bool _inputs_swapped;
-  const std::vector<OperatorJoinPredicate> _secondary_join_predicates;
+  const std::vector<OperatorJoinPredicate> _secondary_predicates;
 
   std::shared_ptr<Table> _output_table;
 
@@ -340,24 +340,24 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     switch (_mode) {
       case JoinMode::Inner:
         probe<RightType, HashedType, false>(radix_right, hashtables, left_pos_lists, right_pos_lists, _mode,
-                                            *left_in_table, *right_in_table, _secondary_join_predicates);
+                                            *left_in_table, *right_in_table, _secondary_predicates);
         break;
 
       case JoinMode::Left:
       case JoinMode::Right:
         probe<RightType, HashedType, true>(radix_right, hashtables, left_pos_lists, right_pos_lists, _mode,
-                                           *left_in_table, *right_in_table, _secondary_join_predicates);
+                                           *left_in_table, *right_in_table, _secondary_predicates);
         break;
 
       case JoinMode::Semi:
       case JoinMode::AntiNullAsTrue:
         probe_semi_anti<RightType, HashedType, false>(radix_right, hashtables, right_pos_lists, _mode, *left_in_table,
-                                                      *right_in_table, _secondary_join_predicates);
+                                                      *right_in_table, _secondary_predicates);
         break;
 
       case JoinMode::AntiNullAsFalse:
         probe_semi_anti<RightType, HashedType, true>(radix_right, hashtables, right_pos_lists, _mode, *left_in_table,
-                                                     *right_in_table, _secondary_join_predicates);
+                                                     *right_in_table, _secondary_predicates);
         break;
 
       default:

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -263,9 +263,9 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       // case, we DO need all rows.
       if (_secondary_predicates.empty() &&
           (_mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse)) {
-        hashtables = build<LeftType, HashedType, JoinHashBuildPositions::OnePerValue>(radix_left);
+        hashtables = build<LeftType, HashedType, JoinHashBuildMode::SinglePosition>(radix_left);
       } else {
-        hashtables = build<LeftType, HashedType, JoinHashBuildPositions::All>(radix_left);
+        hashtables = build<LeftType, HashedType, JoinHashBuildMode::AllPositions>(radix_left);
       }
     }));
     jobs.back()->schedule();

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -259,7 +259,11 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       }
 
       // build hash tables
-      hashtables = build<LeftType, HashedType>(radix_left);
+      if (_mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse) {
+        hashtables = build<LeftType, HashedType, true>(radix_left);
+      } else {
+        hashtables = build<LeftType, HashedType, falls>(radix_left);
+      }
     }));
     jobs.back()->schedule();
 

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -189,7 +189,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
 /*
 Build all the hash tables for the partitions of Left. We parallelize this process for all partitions of Left
 */
-template <typename LeftType, typename HashedType, bool SemiAnti>
+template <typename LeftType, typename HashedType, bool OneMatchPerValue>
 std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<LeftType>& radix_container) {
   /*
   NUMA notes:
@@ -231,8 +231,9 @@ std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<Lef
         auto casted_value = type_cast<HashedType>(std::move(element.value));
         auto it = hashtable.find(casted_value);
         if (it != hashtable.end()) {
-          if constexpr (!SemiAnti) {
+          if constexpr (!OneMatchPerValue) {
             // For semi and anti joins, we only care about existence, so there is no point in adding a second occurence
+            // unless we have secondary predicates
             it->second.emplace_back(element.row_id);
           }
         } else {

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -193,7 +193,7 @@ Build all the hash tables for the partitions of Left. We parallelize this proces
 // For semi and anti joins, we only care whether a value exists or not, so there is no point in tracking the position
 // in the input table of more than one occurrence of a value. However, if we have secondary predicates, we do need to
 // track all occurrences of a value as that first position might be disqualified later.
-enum class JoinHashBuildMode : { AllPositions, SinglePosition };
+enum class JoinHashBuildMode { AllPositions, SinglePosition };
 
 template <typename LeftType, typename HashedType, JoinHashBuildMode mode>
 std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<LeftType>& radix_container) {

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -189,7 +189,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
 /*
 Build all the hash tables for the partitions of Left. We parallelize this process for all partitions of Left
 */
-template <typename LeftType, typename HashedType>
+template <typename LeftType, typename HashedType, bool SemiAnti>
 std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<LeftType>& radix_container) {
   /*
   NUMA notes:
@@ -231,7 +231,10 @@ std::vector<std::optional<HashTable<HashedType>>> build(const RadixContainer<Lef
         auto casted_value = type_cast<HashedType>(std::move(element.value));
         auto it = hashtable.find(casted_value);
         if (it != hashtable.end()) {
-          it->second.emplace_back(element.row_id);
+          if constexpr (!SemiAnti) {
+            // For semi and anti joins, we only care about existence, so there is no point in adding a second occurence
+            it->second.emplace_back(element.row_id);
+          }
         } else {
           hashtable.emplace(casted_value, SmallPosList{element.row_id});
         }

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -108,8 +108,8 @@ TEST_F(JoinHashStepsTest, MaterializeAndBuildWithKeepNulls) {
   }
 
   // build phase: NULLs we be discarded
-  auto hash_map_with_nulls = build<int, int>(materialized_with_nulls);
-  auto hash_map_without_nulls = build<int, int>(materialized_without_nulls);
+  auto hash_map_with_nulls = build<int, int, false>(materialized_with_nulls);
+  auto hash_map_without_nulls = build<int, int, false>(materialized_without_nulls);
 
   // check for the expected number of hash maps
   EXPECT_EQ(hash_map_with_nulls.size(), pow(2, radix_bit_count));

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -108,8 +108,8 @@ TEST_F(JoinHashStepsTest, MaterializeAndBuildWithKeepNulls) {
   }
 
   // build phase: NULLs we be discarded
-  auto hash_map_with_nulls = build<int, int, JoinHashBuildPositions::All>(materialized_with_nulls);
-  auto hash_map_without_nulls = build<int, int, JoinHashBuildPositions::All>(materialized_without_nulls);
+  auto hash_map_with_nulls = build<int, int, JoinHashBuildMode::AllPositions>(materialized_with_nulls);
+  auto hash_map_without_nulls = build<int, int, JoinHashBuildMode::AllPositions>(materialized_without_nulls);
 
   // check for the expected number of hash maps
   EXPECT_EQ(hash_map_with_nulls.size(), pow(2, radix_bit_count));

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -108,8 +108,8 @@ TEST_F(JoinHashStepsTest, MaterializeAndBuildWithKeepNulls) {
   }
 
   // build phase: NULLs we be discarded
-  auto hash_map_with_nulls = build<int, int, false>(materialized_with_nulls);
-  auto hash_map_without_nulls = build<int, int, false>(materialized_without_nulls);
+  auto hash_map_with_nulls = build<int, int, JoinHashBuildPositions::All>(materialized_with_nulls);
+  auto hash_map_without_nulls = build<int, int, JoinHashBuildPositions::All>(materialized_without_nulls);
 
   // check for the expected number of hash maps
   EXPECT_EQ(hash_map_with_nulls.size(), pow(2, radix_bit_count));

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -21,7 +21,7 @@ void test_hash_map(const std::vector<T>& values) {
     elements.emplace_back(PartitionedElement<T>{row_id, static_cast<T>(values.at(i))});
   }
 
-  auto hash_map = build<T, HashType>(RadixContainer<T>{std::make_shared<Partition<T>>(elements),
+  auto hash_map = build<T, HashType, false>(RadixContainer<T>{std::make_shared<Partition<T>>(elements),
                                                        std::vector<size_t>{elements.size()},
                                                        std::make_shared<std::vector<bool>>()});
 

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -21,7 +21,7 @@ void test_hash_map(const std::vector<T>& values) {
     elements.emplace_back(PartitionedElement<T>{row_id, static_cast<T>(values.at(i))});
   }
 
-  auto hash_map = build<T, HashType, JoinHashBuildPositions::All>(
+  auto hash_map = build<T, HashType, JoinHashBuildMode::AllPositions>(
       RadixContainer<T>{std::make_shared<Partition<T>>(elements), std::vector<size_t>{elements.size()},
                         std::make_shared<std::vector<bool>>()});
 

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -22,8 +22,8 @@ void test_hash_map(const std::vector<T>& values) {
   }
 
   auto hash_map = build<T, HashType, false>(RadixContainer<T>{std::make_shared<Partition<T>>(elements),
-                                                       std::vector<size_t>{elements.size()},
-                                                       std::make_shared<std::vector<bool>>()});
+                                                              std::vector<size_t>{elements.size()},
+                                                              std::make_shared<std::vector<bool>>()});
 
   // With only one offset value passed, one hash map will be created
   EXPECT_EQ(hash_map.size(), 1);

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -21,9 +21,9 @@ void test_hash_map(const std::vector<T>& values) {
     elements.emplace_back(PartitionedElement<T>{row_id, static_cast<T>(values.at(i))});
   }
 
-  auto hash_map = build<T, HashType, false>(RadixContainer<T>{std::make_shared<Partition<T>>(elements),
-                                                              std::vector<size_t>{elements.size()},
-                                                              std::make_shared<std::vector<bool>>()});
+  auto hash_map = build<T, HashType, JoinHashBuildPositions::All>(
+      RadixContainer<T>{std::make_shared<Partition<T>>(elements), std::vector<size_t>{elements.size()},
+                        std::make_shared<std::vector<bool>>()});
 
   // With only one offset value passed, one hash map will be created
   EXPECT_EQ(hash_map.size(), 1);


### PR DESCRIPTION
In the case of semi or anti joins, we do not need to track all rows on the hashed side, just one per value. However, if we have secondary predicates, those might fail on that single row. In that case, we DO need all rows.

```
+-----------+----------------+------+----------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s   | runs | new iter/s     | runs | change | p-value (significant if <0.001) |
+-----------+----------------+------+----------------+------+--------+---------------------------------+
| TPC-H 1   | 0.524710536003 | 32   | 0.529083013535 | 32   | +1%    |                          0.3526 |
| TPC-H 2   | 8.37547397614  | 503  | 8.58118247986  | 515  | +2%    |                          0.0000 |
| TPC-H 3   | 6.53036642075  | 392  | 6.62790489197  | 398  | +1%    |                          0.0000 |
| TPC-H 4   | 1.87930011749  | 113  | 2.30043554306  | 139  | +22%   |                          0.0000 |
| TPC-H 5   | 4.33466625214  | 261  | 4.58093738556  | 275  | +6%    |                          0.0000 |
| TPC-H 6   | 29.5897426605  | 1776 | 30.1473503113  | 1809 | +2%    |                          0.0000 |
| TPC-H 7   | 1.33721923828  | 81   | 1.32540678978  | 80   | -1%    |                          0.0095 |
| TPC-H 8   | 5.67990541458  | 341  | 5.51186180115  | 331  | -3%    |                          0.0000 |
| TPC-H 9   | 1.66011428833  | 100  | 1.58242094517  | 95   | -5%    |                          0.0000 |
| TPC-H 10  | 2.75995373726  | 166  | 2.73807406425  | 165  | -1%    |                          0.0068 |
| TPC-H 11  | 33.8926773071  | 2034 | 33.3690032959  | 2003 | -2%    |                          0.0000 |
| TPC-H 12  | 8.26883602142  | 497  | 8.2902507782   | 498  | +0%    |                          0.2515 |
| TPC-H 13  | 2.2149503231   | 133  | 2.2219824791   | 134  | +0%    |                          0.6532 |
| TPC-H 14  | 24.5839805603  | 1476 | 25.1326675415  | 1508 | +2%    |                          0.0000 |
| TPC-H 15  | 19.8104991913  | 1189 | 19.8421077728  | 1191 | +0%    |                          0.0724 |
| TPC-H 16  | 7.7374048233   | 465  | 7.85144233704  | 472  | +1%    |                          0.0000 |
| TPC-H 17  | 1.42035341263  | 86   | 1.4392888546   | 87   | +1%    |                          0.1318 |
| TPC-H 18  | 1.99399292469  | 120  | 2.0535299778   | 124  | +3%    |                          0.0004 |
| TPC-H 19  | 5.36778068542  | 323  | 5.42425394058  | 326  | +1%    |                          0.0003 |
| TPC-H 20  | 2.0527536869   | 124  | 2.05536460876  | 124  | +0%    |                          0.8332 |
| TPC-H 21  | 0.418960034847 | 26   | 0.425139397383 | 26   | +1%    |                          0.0218 |
| TPC-H 22  | 10.1891183853  | 612  | 13.0220994949  | 782  | +28%   |                          0.0000 |
| average   |                |      |                |      | +3%    |                                 |
+-----------+----------------+------+----------------+------+--------+---------------------------------+
```