### PR TITLE
Unified handling of operator<<(std::ostream, ...), to_string() and print()

### DIFF
--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -39,8 +39,8 @@ class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
     // benchmark_config.encoding_config = EncodingConfig{SegmentEncodingSpec{default_encoding}};
 
     if (!sm.has_table("lineitem")) {
-      std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and "
-                << encoding_type_to_string.left.at(default_encoding) << " encoding:" << std::endl;
+      std::cout << "Generating TPC-H data set with scale factor " << scale_factor << " and " << default_encoding
+                << " encoding:" << std::endl;
       TpchTableGenerator(scale_factor, std::make_shared<BenchmarkConfig>(benchmark_config)).generate_and_store();
     }
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -40,7 +40,7 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig& config, std::unique_ptr<
 
     Topology::use_default_topology(config.cores);
     std::cout << "- Multi-threaded Topology:" << std::endl;
-    Topology::get().print(std::cout, 2);
+    std::cout << Topology::get();
 
     // Add NUMA topology information to the context, for processing in the benchmark_multithreaded.py script
     auto numa_cores_per_node = std::vector<size_t>();

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -271,7 +271,7 @@ void BenchmarkRunner::_benchmark_individual_queries() {
     const auto duration_seconds = static_cast<float>(result.duration_ns) / 1'000'000'000;
     const auto items_per_second = static_cast<float>(result.num_iterations) / duration_seconds;
 
-    std::cout << "  -> Executed " << result.num_iterations << " times in " << duration_seconds << " seconds ("
+    std::cout << "  -> Executed " << result.num_iterations.load() << " times in " << duration_seconds << " seconds ("
               << items_per_second << " iter/s)" << std::endl;
 
     // Wait for the rest of the tasks that didn't make it in time - they will not count toward the results

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -120,8 +120,8 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
       chunk_encoding_spec.push_back(encoding_config.default_encoding_spec);
     } else {
       std::cout << " - Column '" << table_name << "." << table->column_name(column_id) << "' of type ";
-      std::cout << data_type_to_string.left.at(column_data_type) << " cannot be encoded as ";
-      std::cout << encoding_type_to_string.left.at(encoding_config.default_encoding_spec.encoding_type) << " and is ";
+      std::cout << column_data_type << " cannot be encoded as ";
+      std::cout << encoding_config.default_encoding_spec.encoding_type << " and is ";
       std::cout << "left Unencoded." << std::endl;
       chunk_encoding_spec.push_back(EncodingType::Unencoded);
     }

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -285,7 +285,11 @@ int Console::_eval_sql(const std::string& sql) {
 
   out("===\n");
   out(std::to_string(row_count) + " rows total\n");
-  out(_sql_pipeline->metrics().to_string());
+
+  std::ostringstream stream;
+  stream << _sql_pipeline->metrics();
+
+  out(stream.str());
 
   return ReturnCode::Ok;
 }

--- a/src/lib/all_parameter_variant.cpp
+++ b/src/lib/all_parameter_variant.cpp
@@ -8,14 +8,17 @@
 #include "all_type_variant.hpp"
 
 namespace opossum {
-std::string to_string(const AllParameterVariant& x) {
-  if (is_parameter_id(x)) {
-    return std::string("Placeholder #") + std::to_string(boost::get<ParameterID>(x));
-  } else if (is_column_id(x)) {
-    return std::string("Column #") + std::to_string(boost::get<ColumnID>(x));
+
+std::ostream& operator<<(std::ostream& stream, const AllParameterVariant& variant) {
+  if (is_parameter_id(variant)) {
+    stream << "Placeholder #" << boost::get<ParameterID>(variant);
+  } else if (is_column_id(variant)) {
+    stream << "Column #" << boost::get<ColumnID>(variant);
   } else {
-    return boost::lexical_cast<std::string>(x);
+    stream << boost::lexical_cast<std::string>(variant);
   }
+
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/all_parameter_variant.cpp
+++ b/src/lib/all_parameter_variant.cpp
@@ -15,7 +15,7 @@ std::ostream& operator<<(std::ostream& stream, const AllParameterVariant& varian
   } else if (is_column_id(variant)) {
     stream << "Column #" << boost::get<ColumnID>(variant);
   } else {
-    stream << boost::lexical_cast<std::string>(variant);
+    stream << boost::get<AllTypeVariant>(variant);
   }
 
   return stream;

--- a/src/lib/all_parameter_variant.hpp
+++ b/src/lib/all_parameter_variant.hpp
@@ -42,6 +42,6 @@ inline bool is_column_id(const AllParameterVariant& variant) { return (variant.t
 // Function to check if AllParameterVariant is a ParameterID
 inline bool is_parameter_id(const AllParameterVariant& variant) { return (variant.type() == typeid(ParameterID)); }
 
-std::string to_string(const AllParameterVariant& x);
+std::ostream& operator<<(std::ostream& stream, const AllParameterVariant& variant);
 
 }  // namespace opossum

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -53,28 +53,23 @@ const boost::bimap<VectorCompressionType, std::string> vector_compression_type_t
     });
 
 std::ostream& operator<<(std::ostream& stream, AggregateFunction aggregate_function) {
-  stream << aggregate_function_to_string.left.at(aggregate_function);
-  return stream;
+  return stream << aggregate_function_to_string.left.at(aggregate_function);
 }
 
 std::ostream& operator<<(std::ostream& stream, FunctionType function_type) {
-  stream << function_type_to_string.left.at(function_type);
-  return stream;
+  return stream << function_type_to_string.left.at(function_type);
 }
 
 std::ostream& operator<<(std::ostream& stream, DataType data_type) {
-  stream << data_type_to_string.left.at(data_type);
-  return stream;
+  return stream << data_type_to_string.left.at(data_type);
 }
 
 std::ostream& operator<<(std::ostream& stream, EncodingType encoding_type) {
-  stream << encoding_type_to_string.left.at(encoding_type);
-  return stream;
+  return stream << encoding_type_to_string.left.at(encoding_type);
 }
 
 std::ostream& operator<<(std::ostream& stream, VectorCompressionType vector_compression_type) {
-  stream << vector_compression_type_to_string.left.at(vector_compression_type);
-  return stream;
+  return stream << vector_compression_type_to_string.left.at(vector_compression_type);
 }
 
 }  // namespace opossum

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -18,51 +18,6 @@
 
 namespace opossum {
 
-const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string =
-    make_bimap<PredicateCondition, std::string>({
-        {PredicateCondition::Equals, "="},
-        {PredicateCondition::NotEquals, "!="},
-        {PredicateCondition::LessThan, "<"},
-        {PredicateCondition::LessThanEquals, "<="},
-        {PredicateCondition::GreaterThan, ">"},
-        {PredicateCondition::GreaterThanEquals, ">="},
-        {PredicateCondition::BetweenInclusive, "BETWEEN INCLUSIVE"},
-        {PredicateCondition::BetweenLowerExclusive, "BETWEEN LOWER EXCLUSIVE"},
-        {PredicateCondition::BetweenUpperExclusive, "BETWEEN UPPER EXCLUSIVE"},
-        {PredicateCondition::BetweenExclusive, "BETWEEN EXCLUSIVE"},
-        {PredicateCondition::Like, "LIKE"},
-        {PredicateCondition::NotLike, "NOT LIKE"},
-        {PredicateCondition::In, "IN"},
-        {PredicateCondition::NotIn, "NOT IN"},
-        {PredicateCondition::IsNull, "IS NULL"},
-        {PredicateCondition::IsNotNull, "IS NOT NULL"},
-    });
-
-const std::unordered_map<OrderByMode, std::string> order_by_mode_to_string = {
-    {OrderByMode::Ascending, "AscendingNullsFirst"},
-    {OrderByMode::Descending, "DescendingNullsFirst"},
-    {OrderByMode::AscendingNullsLast, "AscendingNullsLast"},
-    {OrderByMode::DescendingNullsLast, "DescendingNullsLast"},
-};
-
-const std::unordered_map<hsql::OrderType, OrderByMode> order_type_to_order_by_mode = {
-    {hsql::kOrderAsc, OrderByMode::Ascending},
-    {hsql::kOrderDesc, OrderByMode::Descending},
-};
-
-const std::unordered_map<JoinMode, std::string> join_mode_to_string = {
-    {JoinMode::Cross, "Cross"},
-    {JoinMode::Inner, "Inner"},
-    {JoinMode::Left, "Left"},
-    {JoinMode::FullOuter, "FullOuter"},
-    {JoinMode::Right, "Right"},
-    {JoinMode::Semi, "Semi"},
-    {JoinMode::AntiNullAsTrue, "AntiNullAsTrue"},
-    {JoinMode::AntiNullAsFalse, "AntiNullAsFalse"},
-};
-
-const std::unordered_map<UnionMode, std::string> union_mode_to_string = {{UnionMode::Positions, "UnionPositions"}};
-
 const boost::bimap<AggregateFunction, std::string> aggregate_function_to_string =
     make_bimap<AggregateFunction, std::string>({
         {AggregateFunction::Min, "MIN"},
@@ -97,7 +52,29 @@ const boost::bimap<VectorCompressionType, std::string> vector_compression_type_t
         {VectorCompressionType::SimdBp128, "SIMD-BP128"},
     });
 
-const boost::bimap<TableType, std::string> table_type_to_string =
-    make_bimap<TableType, std::string>({{TableType::Data, "Data"}, {TableType::References, "References"}});
+std::ostream& operator<<(std::ostream& stream, AggregateFunction aggregate_function) {
+  stream << aggregate_function_to_string.left.at(aggregate_function);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, FunctionType function_type) {
+  stream << function_type_to_string.left.at(function_type);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, DataType data_type) {
+  stream << data_type_to_string.left.at(data_type);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, EncodingType encoding_type) {
+  stream << encoding_type_to_string.left.at(encoding_type);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, VectorCompressionType vector_compression_type) {
+  stream << vector_compression_type_to_string.left.at(vector_compression_type);
+  return stream;
+}
 
 }  // namespace opossum

--- a/src/lib/constant_mappings.hpp
+++ b/src/lib/constant_mappings.hpp
@@ -15,19 +15,17 @@ enum class EncodingType : uint8_t;
 enum class VectorCompressionType : uint8_t;
 enum class AggregateFunction;
 enum class ExpressionType;
-enum class TableType;
 
-extern const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string;
-extern const std::unordered_map<OrderByMode, std::string> order_by_mode_to_string;
-extern const std::unordered_map<hsql::OrderType, OrderByMode> order_type_to_order_by_mode;
-extern const std::unordered_map<ExpressionType, std::string> expression_type_to_operator_string;
-extern const std::unordered_map<JoinMode, std::string> join_mode_to_string;
-extern const std::unordered_map<UnionMode, std::string> union_mode_to_string;
 extern const boost::bimap<AggregateFunction, std::string> aggregate_function_to_string;
 extern const boost::bimap<FunctionType, std::string> function_type_to_string;
 extern const boost::bimap<DataType, std::string> data_type_to_string;
 extern const boost::bimap<EncodingType, std::string> encoding_type_to_string;
 extern const boost::bimap<VectorCompressionType, std::string> vector_compression_type_to_string;
-extern const boost::bimap<TableType, std::string> table_type_to_string;
+
+std::ostream& operator<<(std::ostream& stream, AggregateFunction aggregate_function);
+std::ostream& operator<<(std::ostream& stream, FunctionType function_type);
+std::ostream& operator<<(std::ostream& stream, DataType data_type);
+std::ostream& operator<<(std::ostream& stream, EncodingType encoding_type);
+std::ostream& operator<<(std::ostream& stream, VectorCompressionType vector_compression_type);
 
 }  // namespace opossum

--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -42,7 +42,7 @@ std::string AggregateExpression::as_column_name() const {
   } else if (aggregate_function == AggregateFunction::Count && !argument()) {
     stream << "COUNT(*)";
   } else {
-    stream << aggregate_function_to_string.left.at(aggregate_function) << "(";
+    stream << aggregate_function << "(";
     if (argument()) stream << argument()->as_column_name();
     stream << ")";
   }

--- a/src/lib/expression/between_expression.cpp
+++ b/src/lib/expression/between_expression.cpp
@@ -29,8 +29,7 @@ std::shared_ptr<AbstractExpression> BetweenExpression::deep_copy() const {
 
 std::string BetweenExpression::as_column_name() const {
   std::stringstream stream;
-  stream << _enclose_argument_as_column_name(*value()) << " "
-         << predicate_condition_to_string.left.at(predicate_condition) << " "
+  stream << _enclose_argument_as_column_name(*value()) << " " << predicate_condition << " "
          << _enclose_argument_as_column_name(*lower_bound()) << " AND "
          << _enclose_argument_as_column_name(*upper_bound());
   return stream.str();

--- a/src/lib/expression/binary_predicate_expression.cpp
+++ b/src/lib/expression/binary_predicate_expression.cpp
@@ -37,7 +37,7 @@ std::string BinaryPredicateExpression::as_column_name() const {
   std::stringstream stream;
 
   stream << _enclose_argument_as_column_name(*left_operand()) << " ";
-  stream << predicate_condition_to_string.left.at(predicate_condition) << " ";
+  stream << predicate_condition << " ";
   stream << _enclose_argument_as_column_name(*right_operand());
 
   return stream.str();

--- a/src/lib/expression/cast_expression.cpp
+++ b/src/lib/expression/cast_expression.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<AbstractExpression> CastExpression::deep_copy() const {
 
 std::string CastExpression::as_column_name() const {
   std::stringstream stream;
-  stream << "CAST(" << argument()->as_column_name() << " AS " << data_type_to_string.left.at(_data_type) << ")";
+  stream << "CAST(" << argument()->as_column_name() << " AS " << _data_type << ")";
   return stream.str();
 }
 

--- a/src/lib/expression/function_expression.cpp
+++ b/src/lib/expression/function_expression.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<AbstractExpression> FunctionExpression::deep_copy() const {
 std::string FunctionExpression::as_column_name() const {
   std::stringstream stream;
 
-  stream << function_type_to_string.left.at(function_type) << "(";
+  stream << function_type << "(";
   for (auto argument_idx = size_t{0}; argument_idx < arguments.size(); ++argument_idx) {
     stream << arguments[argument_idx]->as_column_name();
     if (argument_idx + 1 < arguments.size()) stream << ", ";

--- a/src/lib/expression/in_expression.cpp
+++ b/src/lib/expression/in_expression.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<AbstractExpression> InExpression::deep_copy() const {
 std::string InExpression::as_column_name() const {
   std::stringstream stream;
   stream << _enclose_argument_as_column_name(*value()) << " ";
-  stream << predicate_condition_to_string.left.at(predicate_condition) << " ";
+  stream << predicate_condition << " ";
   stream << set()->as_column_name();
   return stream.str();
 }

--- a/src/lib/expression/lqp_subquery_expression.cpp
+++ b/src/lib/expression/lqp_subquery_expression.cpp
@@ -7,6 +7,7 @@
 #include "expression_utils.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
+#include "types.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -159,11 +159,6 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pu
   // @}
 
   /**
-   * Prints this node and all its descendants (including all Subqueries) formatted as a tree
-   */
-  void print(std::ostream& out = std::cout) const;
-
-  /**
    * Perform a deep equality check
    */
   bool operator==(const AbstractLQPNode& rhs) const;
@@ -182,7 +177,6 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pu
   std::vector<std::shared_ptr<AbstractExpression>> node_expressions;
 
  protected:
-  void _print_impl(std::ostream& out) const;
   virtual std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const = 0;
   virtual bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const = 0;
 
@@ -202,5 +196,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode>, pu
   std::vector<std::weak_ptr<AbstractLQPNode>> _outputs;
   std::array<std::shared_ptr<AbstractLQPNode>, 2> _inputs;
 };
+
+std::ostream& operator<<(std::ostream& stream, const AbstractLQPNode& node);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/create_prepared_plan_node.cpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.cpp
@@ -13,7 +13,7 @@ CreatePreparedPlanNode::CreatePreparedPlanNode(const std::string& name,
 std::string CreatePreparedPlanNode::description() const {
   std::stringstream stream;
   stream << "[CreatePreparedPlan] '" << name << "' {\n";
-  prepared_plan->print(stream);
+  stream << *prepared_plan;
   stream << "}";
 
   return stream.str();

--- a/src/lib/logical_query_plan/create_table_node.cpp
+++ b/src/lib/logical_query_plan/create_table_node.cpp
@@ -16,7 +16,7 @@ std::string CreateTableNode::description() const {
   for (auto column_id = ColumnID{0}; column_id < column_definitions.size(); ++column_id) {
     const auto& column_definition = column_definitions[column_id];
 
-    stream << "'" << column_definition.name << "' " << data_type_to_string.left.at(column_definition.data_type) << " ";
+    stream << "'" << column_definition.name << "' " << column_definition.data_type << " ";
     if (column_definition.nullable) {
       stream << "NULL";
     } else {

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -16,7 +16,7 @@ std::shared_ptr<LQPView> CreateViewNode::view() const { return _view; }
 
 std::string CreateViewNode::description() const {
   std::stringstream stream;
-  _view->lqp->print(stream);
+  stream << *_view->lqp;
 
   return "[CreateView] Name: '" + _view_name + "' (\n" + stream.str() + ")";
 }

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -35,7 +35,7 @@ JoinNode::JoinNode(const JoinMode join_mode, const std::vector<std::shared_ptr<A
 
 std::string JoinNode::description() const {
   std::stringstream stream;
-  stream << "[Join] Mode: " << join_mode_to_string.at(join_mode);
+  stream << "[Join] Mode: " << join_mode;
 
   for (const auto& predicate : join_predicates()) {
     stream << " [" << predicate->as_column_name() << "]";

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -24,7 +24,7 @@ std::string SortNode::description() const {
 
   for (auto expression_idx = size_t{0}; expression_idx < node_expressions.size(); ++expression_idx) {
     stream << node_expressions[expression_idx]->as_column_name() << " ";
-    stream << "(" << order_by_mode_to_string.at(order_by_modes[expression_idx]) << ")";
+    stream << "(" << order_by_modes[expression_idx] << ")";
 
     if (expression_idx + 1 < node_expressions.size()) stream << ", ";
   }

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 UnionNode::UnionNode(const UnionMode union_mode) : AbstractLQPNode(LQPNodeType::Union), union_mode(union_mode) {}
 
-std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.at(union_mode); }
+std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.left.at(union_mode); }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& UnionNode::column_expressions() const {
   Assert(expressions_equal(left_input()->column_expressions(), right_input()->column_expressions()),

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -39,7 +39,7 @@ const std::string AbstractAggregateOperator::description(DescriptionMode descrip
   desc << " Aggregates: ";
   for (size_t expression_idx = 0; expression_idx < _aggregates.size(); ++expression_idx) {
     const auto& aggregate = _aggregates[expression_idx];
-    desc << aggregate_function_to_string.left.at(aggregate.function);
+    desc << aggregate.function;
 
     if (aggregate.column) {
       desc << "(Column #" << *aggregate.column << ")";

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -39,15 +39,15 @@ const std::string AbstractJoinOperator::description(DescriptionMode description_
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
 
   std::stringstream stream;
-  stream << name() << separator << "(" << join_mode_to_string.at(_mode) << " Join where "
+  stream << name() << separator << "(" << _mode << " Join where "
          << column_name(input_table_left(), _primary_predicate.column_ids.first) << " "
-         << predicate_condition_to_string.left.at(_primary_predicate.predicate_condition) << " "
+         << _primary_predicate.predicate_condition << " "
          << column_name(input_table_right(), _primary_predicate.column_ids.second);
 
   // add information about secondary join predicates
   for (const auto& secondary_predicate : _secondary_predicates) {
     stream << " AND " << column_name(input_table_left(), secondary_predicate.column_ids.first) << " "
-           << predicate_condition_to_string.left.at(secondary_predicate.predicate_condition) << " "
+           << secondary_predicate.predicate_condition << " "
            << column_name(input_table_right(), secondary_predicate.column_ids.second);
   }
 

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -124,8 +124,6 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
   // Return data about the operators performance (runtime, e.g.) AFTER it has been executed.
   const OperatorPerformanceData& performance_data() const;
 
-  void print(std::ostream& stream = std::cout) const;
-
   // Set parameters (AllParameterVariants or CorrelatedParameterExpressions) to their respective values
   void set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters);
 
@@ -171,5 +169,7 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
 
   const std::unique_ptr<OperatorPerformanceData> _performance_data;
 };
+
+std::ostream& operator<<(std::ostream& stream, const AbstractOperator& abstract_operator);
 
 }  // namespace opossum

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -655,7 +655,7 @@ void AggregateHash::write_aggregate_output(ColumnID column_index) {
   if (aggregate.function == AggregateFunction::CountDistinct) {
     column_name_stream << "COUNT(DISTINCT ";
   } else {
-    column_name_stream << aggregate_function_to_string.left.at(aggregate.function) << "(";
+    column_name_stream << aggregate.function << "(";
   }
 
   if (aggregate.column) {

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -613,7 +613,7 @@ void AggregateSort::create_aggregate_column_definitions(ColumnID column_index) {
   if (aggregate.function == AggregateFunction::CountDistinct) {
     column_name_stream << "COUNT(DISTINCT ";
   } else {
-    column_name_stream << aggregate_function_to_string.left.at(aggregate.function) << "(";
+    column_name_stream << aggregate.function << "(";
   }
 
   if (aggregate.column) {

--- a/src/lib/operators/jit_operator/operators/jit_aggregate.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_aggregate.cpp
@@ -15,8 +15,8 @@ std::string JitAggregate::description() const {
   }
   desc << " Aggregates: ";
   for (const auto& aggregate_column : _aggregate_columns) {
-    desc << aggregate_column.column_name << " = " << aggregate_function_to_string.left.at(aggregate_column.function)
-         << "(x" << aggregate_column.tuple_entry.tuple_index << "), ";
+    desc << aggregate_column.column_name << " = " << aggregate_column.function << "(x"
+         << aggregate_column.tuple_entry.tuple_index << "), ";
   }
   return desc.str();
 }

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -349,12 +349,12 @@ void JoinIndex::_on_cleanup() {
   _right_matches.clear();
 }
 
-std::string JoinIndex::PerformanceData::to_string(DescriptionMode description_mode) const {
-  std::string string = OperatorPerformanceData::to_string(description_mode);
-  string += (description_mode == DescriptionMode::SingleLine ? " / " : "\\n");
-  string += std::to_string(chunks_scanned_with_index) + " of " +
-            std::to_string(chunks_scanned_with_index + chunks_scanned_without_index) + " chunks used an index";
-  return string;
+void JoinIndex::PerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
+  OperatorPerformanceData::output_to_stream(stream, description_mode);
+
+  stream << (description_mode == DescriptionMode::SingleLine ? " / " : "\\n");
+  stream << std::to_string(chunks_scanned_with_index) << " of "
+         << std::to_string(chunks_scanned_with_index + chunks_scanned_without_index) << " chunks used an index";
 }
 
 }  // namespace opossum

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -30,7 +30,7 @@ class JoinIndex : public AbstractJoinOperator {
     size_t chunks_scanned_with_index{0};
     size_t chunks_scanned_without_index{0};
 
-    std::string to_string(DescriptionMode description_mode = DescriptionMode::SingleLine) const override;
+    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override;
   };
 
  protected:

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -105,7 +105,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   JoinSortMerge& _sort_merge_join;
 
   // Contains the materialized sorted input tables
-  std::unique_ptr<MaterializedSegmentList<T>> n;
+  std::unique_ptr<MaterializedSegmentList<T>> _sorted_left_table;
   std::unique_ptr<MaterializedSegmentList<T>> _sorted_right_table;
 
   // Contains the null value row ids if a join column is an outer join column

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -105,7 +105,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
   JoinSortMerge& _sort_merge_join;
 
   // Contains the materialized sorted input tables
-  std::unique_ptr<MaterializedSegmentList<T>> _sorted_left_table;
+  std::unique_ptr<MaterializedSegmentList<T>> n;
   std::unique_ptr<MaterializedSegmentList<T>> _sorted_right_table;
 
   // Contains the null value row ids if a join column is an outer join column

--- a/src/lib/operators/maintenance/create_prepared_plan.cpp
+++ b/src/lib/operators/maintenance/create_prepared_plan.cpp
@@ -16,7 +16,7 @@ const std::string CreatePreparedPlan::name() const { return "CreatePreparedPlan"
 const std::string CreatePreparedPlan::description(DescriptionMode description_mode) const {
   std::stringstream stream;
   stream << name() << " '" << _prepared_plan_name << "' {\n";
-  _prepared_plan->print(stream);
+  stream << *_prepared_plan;
   stream << "}";
 
   return stream.str();

--- a/src/lib/operators/maintenance/create_table.cpp
+++ b/src/lib/operators/maintenance/create_table.cpp
@@ -24,7 +24,7 @@ const std::string CreateTable::description(DescriptionMode description_mode) con
   for (auto column_id = ColumnID{0}; column_id < column_definitions.size(); ++column_id) {
     const auto& column_definition = column_definitions[column_id];
 
-    stream << "'" << column_definition.name << "' " << data_type_to_string.left.at(column_definition.data_type) << " ";
+    stream << "'" << column_definition.name << "' " << column_definition.data_type << " ";
     if (column_definition.nullable) {
       stream << "NULL";
     } else {

--- a/src/lib/operators/operator_performance_data.cpp
+++ b/src/lib/operators/operator_performance_data.cpp
@@ -10,4 +10,9 @@ void OperatorPerformanceData::output_to_stream(std::ostream& stream, Description
   stream << format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
 }
 
+std::ostream& operator<<(std::ostream& stream, const OperatorPerformanceData& performance_data) {
+  performance_data.output_to_stream(stream);
+  return stream;
+}
+
 }  // namespace opossum

--- a/src/lib/operators/operator_performance_data.cpp
+++ b/src/lib/operators/operator_performance_data.cpp
@@ -6,8 +6,8 @@
 
 namespace opossum {
 
-std::string OperatorPerformanceData::to_string(DescriptionMode description_mode) const {
-  return format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
+void OperatorPerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
+  stream << format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
 }
 
 }  // namespace opossum

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <chrono>
+#include <iostream>
 #include <string>
 
 #include "types.hpp"
@@ -14,7 +15,13 @@ struct OperatorPerformanceData : public Noncopyable {
 
   std::chrono::nanoseconds walltime{0};
 
-  virtual std::string to_string(DescriptionMode description_mode = DescriptionMode::SingleLine) const;
+  virtual void output_to_stream(std::ostream& stream,
+                                DescriptionMode description_mode = DescriptionMode::SingleLine) const;
 };
+
+std::ostream& operator<<(std::ostream& stream, const OperatorPerformanceData& performance_data) {
+  performance_data.output_to_stream(stream);
+  return stream;
+}
 
 }  // namespace opossum

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -19,9 +19,6 @@ struct OperatorPerformanceData : public Noncopyable {
                                 DescriptionMode description_mode = DescriptionMode::SingleLine) const;
 };
 
-std::ostream& operator<<(std::ostream& stream, const OperatorPerformanceData& performance_data) {
-  performance_data.output_to_stream(stream);
-  return stream;
-}
+std::ostream& operator<<(std::ostream& stream, const OperatorPerformanceData& performance_data);
 
 }  // namespace opossum

--- a/src/lib/operators/operator_scan_predicate.cpp
+++ b/src/lib/operators/operator_scan_predicate.cpp
@@ -34,25 +34,26 @@ std::optional<AllParameterVariant> resolve_all_parameter_variant(const AbstractE
 
 namespace opossum {
 
-std::string OperatorScanPredicate::to_string(const std::shared_ptr<const Table>& table) const {
+std::ostream& OperatorScanPredicate::output_to_stream(std::ostream& stream,
+                                                      const std::shared_ptr<const Table>& table) const {
   std::string column_name_left = std::string("Column #") + std::to_string(column_id);
   if (table) {
     column_name_left = table->column_name(column_id);
   }
 
-  std::string right = opossum::to_string(value);
-  if (table && is_column_id(value)) {
-    right = table->column_name(boost::get<ColumnID>(value));
-  }
+  stream << column_name_left << " " << predicate_condition;
 
-  std::stringstream stream;
-  stream << column_name_left << " " << predicate_condition_to_string.left.at(predicate_condition) << " " << right;
+  if (table && is_column_id(value)) {
+    stream << table->column_name(boost::get<ColumnID>(value));
+  } else {
+    stream << value;
+  }
 
   if (is_between_predicate_condition(predicate_condition)) {
     stream << " AND " << *value2;
   }
 
-  return stream.str();
+  return stream;
 }
 
 std::optional<std::vector<OperatorScanPredicate>> OperatorScanPredicate::from_expression(
@@ -153,7 +154,7 @@ bool operator==(const OperatorScanPredicate& lhs, const OperatorScanPredicate& r
 }
 
 std::ostream& operator<<(std::ostream& stream, const OperatorScanPredicate& predicate) {
-  stream << predicate.to_string();
+  predicate.output_to_stream(stream);
   return stream;
 }
 

--- a/src/lib/operators/operator_scan_predicate.hpp
+++ b/src/lib/operators/operator_scan_predicate.hpp
@@ -31,7 +31,7 @@ struct OperatorScanPredicate {
 
   // Returns a string representation of the predicate, using an optionally given table that is used to resolve column
   // ids to names.
-  std::string to_string(const std::shared_ptr<const Table>& table = nullptr) const;
+  std::ostream& output_to_stream(std::ostream& stream, const std::shared_ptr<const Table>& table = nullptr) const;
 
   ColumnID column_id{INVALID_COLUMN_ID};
   PredicateCondition predicate_condition{PredicateCondition::Equals};

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -56,8 +56,7 @@ std::shared_ptr<const Table> Print::_on_execute() {
   }
   _out << "|" << std::endl;
   for (ColumnID column_id{0}; column_id < input_table_left()->column_count(); ++column_id) {
-    const auto data_type = data_type_to_string.left.at(input_table_left()->column_data_type(column_id));
-    _out << "|" << std::setw(widths[column_id]) << data_type << std::setw(0);
+    _out << "|" << std::setw(widths[column_id]) << input_table_left()->column_data_type(column_id) << std::setw(0);
   }
   if (_flags & PrintMvcc) {
     _out << "||_BEGIN|_END  |_TID  ";
@@ -146,7 +145,9 @@ std::vector<uint16_t> Print::_column_string_widths(uint16_t min, uint16_t max,
 
     for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk->size(); ++chunk_offset) {
-        auto cell_length = static_cast<uint16_t>(to_string((*chunk->get_segment(column_id))[chunk_offset]).size());
+        std::ostringstream stream;
+        stream << (*chunk->get_segment(column_id))[chunk_offset];
+        auto cell_length = static_cast<uint16_t>(stream.str().size());
         widths[column_id] = std::max({min, widths[column_id], std::min(max, cell_length)});
       }
     }

--- a/src/lib/optimizer/join_ordering/join_graph.cpp
+++ b/src/lib/optimizer/join_ordering/join_graph.cpp
@@ -98,10 +98,9 @@ std::ostream& operator<<(std::ostream& stream, const JoinGraph& join_graph) {
     stream << "<none>" << std::endl;
   } else {
     for (const auto& edge : join_graph.edges) {
-      stream << edge << std::endl << std::endl;
+      stream << edge;
     }
   }
-  stream << std::endl;
 
   return stream;
 }

--- a/src/lib/optimizer/join_ordering/join_graph.cpp
+++ b/src/lib/optimizer/join_ordering/join_graph.cpp
@@ -84,24 +84,26 @@ std::vector<std::shared_ptr<AbstractExpression>> JoinGraph::find_join_predicates
   return predicates;
 }
 
-void JoinGraph::print(std::ostream& stream) const {
+std::ostream& operator<<(std::ostream& stream, const JoinGraph& join_graph) {
   stream << "==== Vertices ====" << std::endl;
-  if (vertices.empty()) {
+  if (join_graph.vertices.empty()) {
     stream << "<none>" << std::endl;
   } else {
-    for (const auto& vertex : vertices) {
+    for (const auto& vertex : join_graph.vertices) {
       stream << vertex->description() << std::endl;
     }
   }
   stream << "===== Edges ======" << std::endl;
-  if (edges.empty()) {
+  if (join_graph.edges.empty()) {
     stream << "<none>" << std::endl;
   } else {
-    for (const auto& edge : edges) {
-      edge.print(stream);
+    for (const auto& edge : join_graph.edges) {
+      stream << edge << std::endl << std::endl;
     }
   }
-  std::cout << std::endl;
+  stream << std::endl;
+
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/join_ordering/join_graph.hpp
+++ b/src/lib/optimizer/join_ordering/join_graph.hpp
@@ -51,10 +51,10 @@ class JoinGraph final {
   std::vector<std::shared_ptr<AbstractExpression>> find_join_predicates(const JoinGraphVertexSet& vertex_set_a,
                                                                         const JoinGraphVertexSet& vertex_set_b) const;
 
-  void print(std::ostream& stream = std::cout) const;
-
   const std::vector<std::shared_ptr<AbstractLQPNode>> vertices;
   const std::vector<JoinGraphEdge> edges;
 };
+
+std::ostream& operator<<(std::ostream& stream, const JoinGraph& join_graph);
 
 }  // namespace opossum

--- a/src/lib/optimizer/join_ordering/join_graph_edge.cpp
+++ b/src/lib/optimizer/join_ordering/join_graph_edge.cpp
@@ -8,11 +8,13 @@ JoinGraphEdge::JoinGraphEdge(const JoinGraphVertexSet& vertex_set,
                              const std::vector<std::shared_ptr<AbstractExpression>>& predicates)
     : vertex_set(vertex_set), predicates(predicates) {}
 
-void JoinGraphEdge::print(std::ostream& stream) const {
-  stream << "Vertices: " << vertex_set << "; " << predicates.size() << " predicates" << std::endl;
-  for (const auto& predicate : predicates) {
-    stream << predicate->as_column_name();
-    stream << std::endl;
+std::ostream& operator<<(std::ostream& stream, const JoinGraphEdge& join_graph_edge) {
+  stream << "Vertices: " << join_graph_edge.vertex_set << "; " << join_graph_edge.predicates.size() << " predicates"
+         << std::endl;
+  for (const auto& predicate : join_graph_edge.predicates) {
+    stream << predicate->as_column_name() << std::endl;
   }
+  return stream;
 }
+
 }  // namespace opossum

--- a/src/lib/optimizer/join_ordering/join_graph_edge.hpp
+++ b/src/lib/optimizer/join_ordering/join_graph_edge.hpp
@@ -34,10 +34,10 @@ struct JoinGraphEdge final {
   explicit JoinGraphEdge(const JoinGraphVertexSet& vertex_set,
                          const std::vector<std::shared_ptr<AbstractExpression>>& predicates = {});
 
-  void print(std::ostream& stream = std::cout) const;
-
   JoinGraphVertexSet vertex_set;
   std::vector<std::shared_ptr<AbstractExpression>> predicates;
 };
+
+std::ostream& operator<<(std::ostream& stream, const JoinGraphEdge& join_graph_edge);
 
 }  // namespace opossum

--- a/src/lib/scheduler/topology.hpp
+++ b/src/lib/scheduler/topology.hpp
@@ -28,10 +28,10 @@ struct TopologyCpu final {
 struct TopologyNode final {
   explicit TopologyNode(std::vector<TopologyCpu>&& cpus) : cpus(std::move(cpus)) {}
 
-  void print(std::ostream& stream = std::cout, size_t indent = 0) const;
-
   std::vector<TopologyCpu> cpus;
 };
+
+std::ostream& operator<<(std::ostream& stream, const TopologyNode& topology_node);
 
 /**
  * Topology is a singleton that encapsulates the Machine Architecture, i.e. how many Nodes/Cores there are.
@@ -79,13 +79,11 @@ class Topology final : public Singleton<Topology> {
    */
   static void use_fake_numa_topology(uint32_t max_num_workers = 0, uint32_t workers_per_node = 1);
 
-  const std::vector<TopologyNode>& nodes();
+  const std::vector<TopologyNode>& nodes() const;
 
   size_t num_cpus() const;
 
   boost::container::pmr::memory_resource* get_memory_resource(int node_id);
-
-  void print(std::ostream& stream = std::cout, size_t indent = 0) const;
 
  private:
   Topology();
@@ -108,4 +106,7 @@ class Topology final : public Singleton<Topology> {
 
   std::vector<NUMAMemoryResource> _memory_resources;
 };
+
+std::ostream& operator<<(std::ostream& stream, const Topology& topology);
+
 }  // namespace opossum

--- a/src/lib/server/query_response_builder.cpp
+++ b/src/lib/server/query_response_builder.cpp
@@ -73,7 +73,9 @@ std::string QueryResponseBuilder::build_command_complete_message(const AbstractO
 }
 
 std::string QueryResponseBuilder::build_execution_info_message(const std::shared_ptr<SQLPipeline>& sql_pipeline) {
-  return sql_pipeline->metrics().to_string();
+  std::stringstream stream;
+  stream << sql_pipeline->metrics();
+  return stream.str();
 }
 
 boost::future<uint64_t> QueryResponseBuilder::send_query_response(const send_row_t& send_row, const Table& table) {

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -235,14 +235,14 @@ const SQLPipelineMetrics& SQLPipeline::metrics() {
   return _metrics;
 }
 
-std::string SQLPipelineMetrics::to_string() const {
+std::ostream& operator<<(std::ostream& stream, const SQLPipelineMetrics& metrics) {
   auto total_sql_translate_nanos = std::chrono::nanoseconds::zero();
   auto total_optimize_nanos = std::chrono::nanoseconds::zero();
   auto total_lqp_translate_nanos = std::chrono::nanoseconds::zero();
   auto total_execute_nanos = std::chrono::nanoseconds::zero();
   std::vector<bool> query_plan_cache_hits;
 
-  for (const auto& statement_metric : statement_metrics) {
+  for (const auto& statement_metric : metrics.statement_metrics) {
     total_sql_translate_nanos += statement_metric->sql_translation_duration;
     total_optimize_nanos += statement_metric->optimization_duration;
     total_lqp_translate_nanos += statement_metric->lqp_translation_duration;
@@ -251,19 +251,19 @@ std::string SQLPipelineMetrics::to_string() const {
     query_plan_cache_hits.push_back(statement_metric->query_plan_cache_hit);
   }
 
-  const auto num_cache_hits = std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);
+  const auto num_cache_hits =
+      std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);
 
-  std::ostringstream info_string;
-  info_string << "Execution info: [";
-  info_string << "PARSE: " << format_duration(parse_time_nanos) << ", ";
-  info_string << "SQL TRANSLATE: " << format_duration(total_sql_translate_nanos) << ", ";
-  info_string << "OPTIMIZE: " << format_duration(total_optimize_nanos) << ", ";
-  info_string << "LQP TRANSLATE: " << format_duration(total_lqp_translate_nanos) << ", ";
-  info_string << "EXECUTE: " << format_duration(total_execute_nanos) << " (wall time) | ";
-  info_string << "QUERY PLAN CACHE HITS: " << num_cache_hits << "/" << query_plan_cache_hits.size() << " statement(s)";
-  info_string << "]\n";
+  stream << "Execution info: [";
+  stream << "PARSE: " << format_duration(metrics.parse_time_nanos) << ", ";
+  stream << "SQL TRANSLATE: " << format_duration(total_sql_translate_nanos) << ", ";
+  stream << "OPTIMIZE: " << format_duration(total_optimize_nanos) << ", ";
+  stream << "LQP TRANSLATE: " << format_duration(total_lqp_translate_nanos) << ", ";
+  stream << "EXECUTE: " << format_duration(total_execute_nanos) << " (wall time) | ";
+  stream << "QUERY PLAN CACHE HITS: " << num_cache_hits << "/" << query_plan_cache_hits.size() << " statement(s)";
+  stream << "]\n";
 
-  return info_string.str();
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -251,8 +251,7 @@ std::ostream& operator<<(std::ostream& stream, const SQLPipelineMetrics& metrics
     query_plan_cache_hits.push_back(statement_metric->query_plan_cache_hit);
   }
 
-  const auto num_cache_hits =
-      std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);
+  const auto num_cache_hits = std::count(query_plan_cache_hits.begin(), query_plan_cache_hits.end(), true);
 
   stream << "Execution info: [";
   stream << "PARSE: " << format_duration(metrics.parse_time_nanos) << ", ";

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -19,9 +19,9 @@ struct SQLPipelineMetrics {
 
   // This is different from the other measured times as we only get this for all statements at once
   std::chrono::nanoseconds parse_time_nanos{0};
-
-  std::string to_string() const;
 };
+
+std::ostream& operator<<(std::ostream& stream, const SQLPipelineMetrics& metrics);
 
 /**
  * The SQLPipeline represents the flow from the basic SQL string (containing one or more statements) to the result

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -91,6 +91,11 @@ const std::unordered_map<hsql::DatetimeField, DatetimeComponent> hsql_datetime_f
     {hsql::kDatetimeMinute, DatetimeComponent::Minute}, {hsql::kDatetimeSecond, DatetimeComponent::Second},
 };
 
+const std::unordered_map<hsql::OrderType, OrderByMode> order_type_to_order_by_mode = {
+    {hsql::kOrderAsc, OrderByMode::Ascending},
+    {hsql::kOrderDesc, OrderByMode::Descending},
+};
+
 JoinMode translate_join_mode(const hsql::JoinType join_type) {
   static const std::unordered_map<const hsql::JoinType, const JoinMode> join_type_to_mode = {
       {hsql::kJoinInner, JoinMode::Inner}, {hsql::kJoinFull, JoinMode::FullOuter}, {hsql::kJoinLeft, JoinMode::Left},

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -33,18 +33,20 @@ void MvccData::grow_by(size_t delta, TransactionID transaction_id) {
   end_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
 }
 
-void MvccData::print(std::ostream& stream) const {
+std::ostream& operator<<(std::ostream& stream, const MvccData& mvcc_data) {
   stream << "TIDs: ";
-  for (const auto& tid : tids) stream << tid << ", ";
+  for (const auto& tid : mvcc_data.tids) stream << tid << ", ";
   stream << std::endl;
 
   stream << "BeginCIDs: ";
-  for (const auto& begin_cid : begin_cids) stream << begin_cid << ", ";
+  for (const auto& begin_cid : mvcc_data.begin_cids) stream << begin_cid << ", ";
   stream << std::endl;
 
   stream << "EndCIDs: ";
-  for (const auto& end_cid : end_cids) stream << end_cid << ", ";
+  for (const auto& end_cid : mvcc_data.end_cids) stream << end_cid << ", ";
   stream << std::endl;
+
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -39,8 +39,6 @@ struct MvccData {
    */
   void grow_by(size_t delta, TransactionID transaction_id);
 
-  void print(std::ostream& stream = std::cout) const;
-
  private:
   /**
    * @brief Mutex used to manage access to MVCC data
@@ -53,5 +51,7 @@ struct MvccData {
 
   size_t _size{0};
 };
+
+std::ostream& operator<<(std::ostream& stream, const MvccData& mvcc_data);
 
 }  // namespace opossum

--- a/src/lib/storage/prepared_plan.cpp
+++ b/src/lib/storage/prepared_plan.cpp
@@ -60,16 +60,6 @@ std::shared_ptr<PreparedPlan> PreparedPlan::deep_copy() const {
   return std::make_shared<PreparedPlan>(lqp_copy, parameter_ids);
 }
 
-void PreparedPlan::print(std::ostream& stream) const {
-  stream << "ParameterIDs: [";
-  for (auto parameter_idx = size_t{0}; parameter_idx < parameter_ids.size(); ++parameter_idx) {
-    stream << parameter_ids[parameter_idx];
-    if (parameter_idx + 1 < parameter_ids.size()) stream << ", ";
-  }
-  stream << "]\n";
-  lqp->print(stream);
-}
-
 std::shared_ptr<AbstractLQPNode> PreparedPlan::instantiate(
     const std::vector<std::shared_ptr<AbstractExpression>>& parameters) const {
   Assert(parameters.size() == parameter_ids.size(), std::string("Incorrect number of parameters supplied - expected ") +
@@ -92,6 +82,17 @@ std::shared_ptr<AbstractLQPNode> PreparedPlan::instantiate(
 
 bool PreparedPlan::operator==(const PreparedPlan& rhs) const {
   return *lqp == *rhs.lqp && parameter_ids == rhs.parameter_ids;
+}
+
+std::ostream& operator<<(std::ostream& stream, const PreparedPlan& prepared_plan) {
+  stream << "ParameterIDs: [";
+  for (auto parameter_idx = size_t{0}; parameter_idx < prepared_plan.parameter_ids.size(); ++parameter_idx) {
+    stream << prepared_plan.parameter_ids[parameter_idx];
+    if (parameter_idx + 1 < prepared_plan.parameter_ids.size()) stream << ", ";
+  }
+  stream << "]\n";
+  stream << *prepared_plan.lqp;
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/storage/prepared_plan.hpp
+++ b/src/lib/storage/prepared_plan.hpp
@@ -26,12 +26,12 @@ class PreparedPlan final {
   std::shared_ptr<AbstractLQPNode> instantiate(
       const std::vector<std::shared_ptr<AbstractExpression>>& parameters) const;
 
-  void print(std::ostream& stream) const;
-
   bool operator==(const PreparedPlan& rhs) const;
 
   std::shared_ptr<AbstractLQPNode> lqp;
   std::vector<ParameterID> parameter_ids;
 };
+
+std::ostream& operator<<(std::ostream& stream, const PreparedPlan& prepared_plan);
 
 }  // namespace opossum

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -88,6 +88,8 @@ std::vector<std::string> StorageManager::view_names() const {
   return view_names;
 }
 
+const std::map<std::string, std::shared_ptr<LQPView>>& StorageManager::views() const { return _views; }
+
 void StorageManager::add_prepared_plan(const std::string& name, const std::shared_ptr<PreparedPlan>& prepared_plan) {
   Assert(_prepared_plans.find(name) == _prepared_plans.end(),
          "Cannot add prepared plan " + name + " - a prepared plan with the same name already exists");
@@ -113,32 +115,8 @@ void StorageManager::drop_prepared_plan(const std::string& name) {
   _prepared_plans.erase(iter);
 }
 
-void StorageManager::print(std::ostream& out) const {
-  out << "==================" << std::endl;
-  out << "===== Tables =====" << std::endl << std::endl;
-
-  for (auto const& table : _tables) {
-    out << "==== table >> " << table.first << " <<";
-    out << " (" << table.second->column_count() << " columns, " << table.second->row_count() << " rows in "
-        << table.second->chunk_count() << " chunks)";
-    out << std::endl;
-  }
-
-  out << "==================" << std::endl;
-  out << "===== Views ======" << std::endl << std::endl;
-
-  for (auto const& view : _views) {
-    out << "==== view >> " << view.first << " <<";
-    out << std::endl;
-  }
-
-  out << "==================" << std::endl;
-  out << "= PreparedPlans ==" << std::endl << std::endl;
-
-  for (auto const& prepared_plan : _prepared_plans) {
-    out << "==== prepared plan >> " << prepared_plan.first << " <<";
-    out << std::endl;
-  }
+const std::map<std::string, std::shared_ptr<PreparedPlan>>& StorageManager::prepared_plans() const {
+  return _prepared_plans;
 }
 
 void StorageManager::reset() { get() = StorageManager(); }
@@ -163,6 +141,36 @@ void StorageManager::export_all_tables_as_csv(const std::string& path) {
   }
 
   CurrentScheduler::wait_for_tasks(tasks);
+}
+
+std::ostream& operator<<(std::ostream& stream, const StorageManager& storage_manager) {
+  stream << "==================" << std::endl;
+  stream << "===== Tables =====" << std::endl << std::endl;
+
+  for (auto const& table : storage_manager.tables()) {
+    stream << "==== table >> " << table.first << " <<";
+    stream << " (" << table.second->column_count() << " columns, " << table.second->row_count() << " rows in "
+           << table.second->chunk_count() << " chunks)";
+    stream << std::endl;
+  }
+
+  stream << "==================" << std::endl;
+  stream << "===== Views ======" << std::endl << std::endl;
+
+  for (auto const& view : storage_manager.views()) {
+    stream << "==== view >> " << view.first << " <<";
+    stream << std::endl;
+  }
+
+  stream << "==================" << std::endl;
+  stream << "= PreparedPlans ==" << std::endl << std::endl;
+
+  for (auto const& prepared_plan : storage_manager.prepared_plans()) {
+    stream << "==== prepared plan >> " << prepared_plan.first << " <<";
+    stream << std::endl;
+  }
+
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -41,6 +41,7 @@ class StorageManager : public Singleton<StorageManager> {
   std::shared_ptr<LQPView> get_view(const std::string& name) const;
   bool has_view(const std::string& name) const;
   std::vector<std::string> view_names() const;
+  const std::map<std::string, std::shared_ptr<LQPView>>& views() const;
   /** @} */
 
   /**
@@ -51,10 +52,8 @@ class StorageManager : public Singleton<StorageManager> {
   std::shared_ptr<PreparedPlan> get_prepared_plan(const std::string& name) const;
   bool has_prepared_plan(const std::string& name) const;
   void drop_prepared_plan(const std::string& name);
+  const std::map<std::string, std::shared_ptr<PreparedPlan>>& prepared_plans() const;
   /** @} */
-
-  // prints information about all tables in the storage manager (name, #columns, #rows, #chunks)
-  void print(std::ostream& out = std::cout) const;
 
   // deletes the entire StorageManager and creates a new one, used especially in tests
   // This can lead to a lot of issues if there are still running tasks / threads that
@@ -79,4 +78,7 @@ class StorageManager : public Singleton<StorageManager> {
   std::map<std::string, std::shared_ptr<LQPView>> _views;
   std::map<std::string, std::shared_ptr<PreparedPlan>> _prepared_plans;
 };
+
+std::ostream& operator<<(std::ostream& stream, const StorageManager& storage_manager);
+
 }  // namespace opossum

--- a/src/lib/storage/table_column_definition.hpp
+++ b/src/lib/storage/table_column_definition.hpp
@@ -20,7 +20,7 @@ struct TableColumnDefinition final {
 // So that google test, e.g., prints readable error messages
 inline std::ostream& operator<<(std::ostream& stream, const TableColumnDefinition& definition) {
   stream << definition.name << " ";
-  stream << data_type_to_string.left.at(definition.data_type) << " ";
+  stream << definition.data_type << " ";
   stream << (definition.nullable ? "nullable" : "not nullable");
   return stream;
 }

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -35,7 +35,7 @@
     bool operator<(const D& other) const { return t < other.t; }                                                  \
   };                                                                                                              \
                                                                                                                   \
-  std::ostream& operator<<(std::ostream& stream, const D& value) {                                                \
+  inline std::ostream& operator<<(std::ostream& stream, const D& value) {                                         \
     stream << value.t;                                                                                            \
     return stream;                                                                                                \
   }                                                                                                               \

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -7,6 +7,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 
 #include <functional>
+#include <iostream>
 #include <limits>
 
 /*
@@ -33,6 +34,12 @@
     bool operator==(const D& other) const { return t == other.t; }                                                \
     bool operator<(const D& other) const { return t < other.t; }                                                  \
   };                                                                                                              \
+                                                                                                                  \
+  std::ostream& operator<<(std::ostream& stream, const D& value) {                                                \
+    stream << value.t;                                                                                            \
+    return stream;                                                                                                \
+  }                                                                                                               \
+                                                                                                                  \
   } /* NOLINT */                                                                                                  \
                                                                                                                   \
   namespace std {                                                                                                 \

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -35,10 +35,7 @@
     bool operator<(const D& other) const { return t < other.t; }                                                  \
   };                                                                                                              \
                                                                                                                   \
-  inline std::ostream& operator<<(std::ostream& stream, const D& value) {                                         \
-    stream << value.t;                                                                                            \
-    return stream;                                                                                                \
-  }                                                                                                               \
+  inline std::ostream& operator<<(std::ostream& stream, const D& value) { return stream << value.t; }             \
                                                                                                                   \
   } /* NOLINT */                                                                                                  \
                                                                                                                   \

--- a/src/lib/types.cpp
+++ b/src/lib/types.cpp
@@ -138,28 +138,23 @@ const boost::bimap<UnionMode, std::string> union_mode_to_string =
     make_bimap<UnionMode, std::string>({{UnionMode::Positions, "UnionPositions"}});
 
 std::ostream& operator<<(std::ostream& stream, PredicateCondition predicate_condition) {
-  stream << predicate_condition_to_string.left.at(predicate_condition);
-  return stream;
+  return stream << predicate_condition_to_string.left.at(predicate_condition);
 }
 
 std::ostream& operator<<(std::ostream& stream, OrderByMode order_by_mode) {
-  stream << order_by_mode_to_string.left.at(order_by_mode);
-  return stream;
+  return stream << order_by_mode_to_string.left.at(order_by_mode);
 }
 
 std::ostream& operator<<(std::ostream& stream, JoinMode join_mode) {
-  stream << join_mode_to_string.left.at(join_mode);
-  return stream;
+  return stream << join_mode_to_string.left.at(join_mode);
 }
 
 std::ostream& operator<<(std::ostream& stream, UnionMode union_mode) {
-  stream << union_mode_to_string.left.at(union_mode);
-  return stream;
+  return stream << union_mode_to_string.left.at(union_mode);
 }
 
 std::ostream& operator<<(std::ostream& stream, TableType table_type) {
-  stream << table_type_to_string.left.at(table_type);
-  return stream;
+  return stream << table_type_to_string.left.at(table_type);
 }
 
 }  // namespace opossum

--- a/src/lib/types.cpp
+++ b/src/lib/types.cpp
@@ -1,5 +1,7 @@
 #include "types.hpp"
 
+#include "utils/make_bimap.hpp"
+
 namespace opossum {
 
 bool is_binary_predicate_condition(const PredicateCondition predicate_condition) {
@@ -89,6 +91,75 @@ PredicateCondition inverse_predicate_condition(const PredicateCondition predicat
     default:
       Fail("Can't inverse the specified PredicateCondition");
   }
+}
+
+const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string =
+    make_bimap<PredicateCondition, std::string>({
+        {PredicateCondition::Equals, "="},
+        {PredicateCondition::NotEquals, "!="},
+        {PredicateCondition::LessThan, "<"},
+        {PredicateCondition::LessThanEquals, "<="},
+        {PredicateCondition::GreaterThan, ">"},
+        {PredicateCondition::GreaterThanEquals, ">="},
+        {PredicateCondition::BetweenInclusive, "BETWEEN INCLUSIVE"},
+        {PredicateCondition::BetweenLowerExclusive, "BETWEEN LOWER EXCLUSIVE"},
+        {PredicateCondition::BetweenUpperExclusive, "BETWEEN UPPER EXCLUSIVE"},
+        {PredicateCondition::BetweenExclusive, "BETWEEN EXCLUSIVE"},
+        {PredicateCondition::Like, "LIKE"},
+        {PredicateCondition::NotLike, "NOT LIKE"},
+        {PredicateCondition::In, "IN"},
+        {PredicateCondition::NotIn, "NOT IN"},
+        {PredicateCondition::IsNull, "IS NULL"},
+        {PredicateCondition::IsNotNull, "IS NOT NULL"},
+    });
+
+const boost::bimap<OrderByMode, std::string> order_by_mode_to_string = make_bimap<OrderByMode, std::string>({
+    {OrderByMode::Ascending, "AscendingNullsFirst"},
+    {OrderByMode::Descending, "DescendingNullsFirst"},
+    {OrderByMode::AscendingNullsLast, "AscendingNullsLast"},
+    {OrderByMode::DescendingNullsLast, "DescendingNullsLast"},
+});
+
+const boost::bimap<JoinMode, std::string> join_mode_to_string = make_bimap<JoinMode, std::string>({
+    {JoinMode::Cross, "Cross"},
+    {JoinMode::Inner, "Inner"},
+    {JoinMode::Left, "Left"},
+    {JoinMode::FullOuter, "FullOuter"},
+    {JoinMode::Right, "Right"},
+    {JoinMode::Semi, "Semi"},
+    {JoinMode::AntiNullAsTrue, "AntiNullAsTrue"},
+    {JoinMode::AntiNullAsFalse, "AntiNullAsFalse"},
+});
+
+const boost::bimap<TableType, std::string> table_type_to_string =
+    make_bimap<TableType, std::string>({{TableType::Data, "Data"}, {TableType::References, "References"}});
+
+const boost::bimap<UnionMode, std::string> union_mode_to_string =
+    make_bimap<UnionMode, std::string>({{UnionMode::Positions, "UnionPositions"}});
+
+std::ostream& operator<<(std::ostream& stream, PredicateCondition predicate_condition) {
+  stream << predicate_condition_to_string.left.at(predicate_condition);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, OrderByMode order_by_mode) {
+  stream << order_by_mode_to_string.left.at(order_by_mode);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, JoinMode join_mode) {
+  stream << join_mode_to_string.left.at(join_mode);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, UnionMode union_mode) {
+  stream << union_mode_to_string.left.at(union_mode);
+  return stream;
+}
+
+std::ostream& operator<<(std::ostream& stream, TableType table_type) {
+  stream << table_type_to_string.left.at(table_type);
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -8,12 +8,12 @@
 #include <tuple>
 #include <vector>
 
-#include <tbb/concurrent_vector.h>
+#include "tbb/concurrent_vector.h"
 
-#include <boost/bimap.hpp>
-#include <boost/circular_buffer.hpp>
-#include <boost/container/pmr/polymorphic_allocator.hpp>
-#include <boost/operators.hpp>
+#include "boost/bimap.hpp"
+#include "boost/circular_buffer.hpp"
+#include "boost/container/pmr/polymorphic_allocator.hpp"
+#include "boost/operators.hpp"
 
 #include "strong_typedef.hpp"
 #include "utils/assert.hpp"

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <tbb/concurrent_vector.h>
+#include <boost/bimap.hpp>
+#include <boost/circular_buffer.hpp>
+#include <boost/container/pmr/polymorphic_allocator.hpp>
+#include <boost/operators.hpp>
+
 #include <cstdint>
 #include <iostream>
 #include <limits>
@@ -7,13 +13,6 @@
 #include <string>
 #include <tuple>
 #include <vector>
-
-#include "tbb/concurrent_vector.h"
-
-#include "boost/bimap.hpp"
-#include "boost/circular_buffer.hpp"
-#include "boost/container/pmr/polymorphic_allocator.hpp"
-#include "boost/operators.hpp"
 
 #include "strong_typedef.hpp"
 #include "utils/assert.hpp"

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -1,10 +1,5 @@
 #pragma once
 
-#include <tbb/concurrent_vector.h>
-#include <boost/circular_buffer.hpp>
-#include <boost/container/pmr/polymorphic_allocator.hpp>
-#include <boost/operators.hpp>
-
 #include <cstdint>
 #include <iostream>
 #include <limits>
@@ -12,6 +7,13 @@
 #include <string>
 #include <tuple>
 #include <vector>
+
+#include <tbb/concurrent_vector.h>
+
+#include <boost/bimap.hpp>
+#include <boost/circular_buffer.hpp>
+#include <boost/container/pmr/polymorphic_allocator.hpp>
+#include <boost/operators.hpp>
 
 #include "strong_typedef.hpp"
 #include "utils/assert.hpp"
@@ -254,6 +256,18 @@ class Noncopyable {
 
 // Dummy type, can be used to overload functions with a variant accepting a Null value
 struct Null {};
+
+extern const boost::bimap<PredicateCondition, std::string> predicate_condition_to_string;
+extern const boost::bimap<OrderByMode, std::string> order_by_mode_to_string;
+extern const boost::bimap<JoinMode, std::string> join_mode_to_string;
+extern const boost::bimap<UnionMode, std::string> union_mode_to_string;
+extern const boost::bimap<TableType, std::string> table_type_to_string;
+
+std::ostream& operator<<(std::ostream& stream, PredicateCondition predicate_condition);
+std::ostream& operator<<(std::ostream& stream, OrderByMode order_by_mode);
+std::ostream& operator<<(std::ostream& stream, JoinMode join_mode);
+std::ostream& operator<<(std::ostream& stream, UnionMode union_mode);
+std::ostream& operator<<(std::ostream& stream, TableType table_type);
 
 }  // namespace opossum
 

--- a/src/lib/utils/print_directed_acyclic_graph.hpp
+++ b/src/lib/utils/print_directed_acyclic_graph.hpp
@@ -88,7 +88,7 @@ void print_directed_acyclic_graph_impl(const std::shared_ptr<Node>& node,
  * Results look comparable to this
  *
  * [0] [Cross Join]
- *  \_[1] [Cross Join]2
+ *  \_[1] [Cross Join]
  *  |  \_[2] [Predicate] a = 42
  *  |  |  \_[3] [Cross Join]
  *  |  |     \_[4] [MockTable]

--- a/src/test/lib/all_parameter_variant_test.cpp
+++ b/src/test/lib/all_parameter_variant_test.cpp
@@ -84,18 +84,24 @@ TEST_F(AllParameterVariantTest, GetCurrentValue) {
   }
 }
 
-TEST_F(AllParameterVariantTest, ToString) {
+TEST_F(AllParameterVariantTest, OutputToStream) {
   {
     const AllParameterVariant parameter(ParameterID{17});
-    EXPECT_EQ(to_string(parameter), "Placeholder #17");
+    std::ostringstream stream;
+    stream << parameter;
+    EXPECT_EQ(stream.str(), "Placeholder #17");
   }
   {
     const AllParameterVariant parameter(ColumnID{17});
-    EXPECT_EQ(to_string(parameter), "Column #17");
+    std::ostringstream stream;
+    stream << parameter;
+    EXPECT_EQ(stream.str(), "Column #17");
   }
   {
     const AllParameterVariant parameter("string");
-    EXPECT_EQ(to_string(parameter), "string");
+    std::ostringstream stream;
+    stream << parameter;
+    EXPECT_EQ(stream.str(), "string");
   }
 }
 

--- a/src/test/lib/fixed_string_test.cpp
+++ b/src/test/lib/fixed_string_test.cpp
@@ -96,7 +96,7 @@ TEST_F(FixedStringTest, Swap) {
   EXPECT_EQ(fixed_string, "foo");
 }
 
-TEST_F(FixedStringTest, Print) {
+TEST_F(FixedStringTest, OutputToStream) {
   std::stringstream sstream;
   sstream << fixed_string1;
   EXPECT_EQ(sstream.str().find("foo"), 0u);

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -335,7 +335,7 @@ TEST_F(LogicalQueryPlanTest, PrintWithoutSubquery) {
   // clang-format on
 
   std::stringstream stream;
-  lqp->print(stream);
+  stream << *lqp;
 
   EXPECT_EQ(stream.str(), R"([0] [Predicate] a > 5
  \_[1] [Join] Mode: Inner [a = a]
@@ -363,7 +363,7 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
   // clang-format on
 
   std::stringstream stream;
-  lqp->print(stream);
+  stream << *lqp;
 
   // Result is undeterministic, but should look something like (order and addresses may vary)
   // [0] [Predicate] a > SUBQUERY (LQP, 0x4e2bda0, Parameters: )

--- a/src/test/operators/table_scan_sorted_segment_search_test.cpp
+++ b/src/test/operators/table_scan_sorted_segment_search_test.cpp
@@ -15,7 +15,7 @@ struct TestData {
 using Params = std::tuple<TestData, opossum::OrderByMode, bool>;
 
 auto formatter = [](const ::testing::TestParamInfo<Params> info) {
-  return opossum::order_by_mode_to_string.at(std::get<1>(info.param)) +
+  return opossum::order_by_mode_to_string.left.at(std::get<1>(info.param)) +
          std::get<0>(info.param).predicate_condition_string + (std::get<2>(info.param) ? "WithNulls" : "WithoutNulls");
 };
 

--- a/src/test/optimizer/join_graph_test.cpp
+++ b/src/test/optimizer/join_graph_test.cpp
@@ -65,7 +65,7 @@ TEST_F(JoinGraphTest, Print) {
   const auto join_graph = JoinGraph{{node_a, node_b, node_c, node_d}, {edge_a_b, edge_b_c, edge_c_d, edge_b}};
 
   auto stream = std::stringstream{};
-  join_graph.print(stream);
+  stream << join_graph;
 
   EXPECT_EQ(stream.str(), R"(==== Vertices ====
 [MockNode 'a']

--- a/src/test/optimizer/join_graph_test.cpp
+++ b/src/test/optimizer/join_graph_test.cpp
@@ -56,7 +56,7 @@ TEST_F(JoinGraphTest, FindPredicates) {
   EXPECT_TRUE(join_graph.find_local_predicates(0).empty());
 }
 
-TEST_F(JoinGraphTest, Print) {
+TEST_F(JoinGraphTest, OutputToStream) {
   const auto edge_a_b = JoinGraphEdge{JoinGraphVertexSet{4u, 0b0011}, {equals_(a_a, b_a)}};
   const auto edge_b_c = JoinGraphEdge{JoinGraphVertexSet{4u, 0b0110}, {equals_(b_a, c_a), less_than_(b_a, c_a)}};
   const auto edge_b = JoinGraphEdge{JoinGraphVertexSet{4u, 0b0010}, {equals_(b_a, 3)}};

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -108,9 +108,9 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   const auto spec = info.param;
 
   auto stream = std::stringstream{};
-  stream << encoding_type_to_string.left.at(spec.encoding_type);
+  stream << spec.encoding_type;
   if (spec.vector_compression_type) {
-    stream << "-" << vector_compression_type_to_string.left.at(*spec.vector_compression_type);
+    stream << "-" << *spec.vector_compression_type;
   }
 
   auto string = stream.str();

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -116,9 +116,9 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   const auto spec = info.param;
 
   auto stream = std::stringstream{};
-  stream << encoding_type_to_string.left.at(spec.encoding_type);
+  stream << spec.encoding_type;
   if (spec.vector_compression_type) {
-    stream << "-" << vector_compression_type_to_string.left.at(*spec.vector_compression_type);
+    stream << "-" << *spec.vector_compression_type;
   }
 
   auto string = stream.str();

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -121,7 +121,7 @@ TEST_F(StorageManagerTest, Print) {
   sm.add_table("third_table", load_table("resources/test_data/tbl/int_int2.tbl", 2));
 
   std::ostringstream output;
-  sm.print(output);
+  output << sm;
   auto output_string = output.str();
 
   EXPECT_TRUE(output_string.find("===== Tables =====") != std::string::npos);

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -116,7 +116,7 @@ TEST_F(StorageManagerTest, ListViewNames) {
   EXPECT_EQ(view_names[1], "second_view");
 }
 
-TEST_F(StorageManagerTest, Print) {
+TEST_F(StorageManagerTest, OutputToStream) {
   auto& sm = StorageManager::get();
   sm.add_table("third_table", load_table("resources/test_data/tbl/int_int2.tbl", 2));
 

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -73,13 +73,13 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
       std::cout << "Differing subtrees" << std::endl;                                                     \
       std::cout << "-------------- Actual LQP --------------" << std::endl;                               \
       if (mismatch->first)                                                                                \
-        mismatch->first->print();                                                                         \
+        std::cout << *mismatch->first;                                                                    \
       else                                                                                                \
         std::cout << "NULL" << std::endl;                                                                 \
       std::cout << std::endl;                                                                             \
       std::cout << "------------- Expected LQP -------------" << std::endl;                               \
       if (mismatch->second)                                                                               \
-        mismatch->second->print();                                                                        \
+        std::cout << *mismatch->second;                                                                   \
       else                                                                                                \
         std::cout << "NULL" << std::endl;                                                                 \
       std::cout << "-------------..............-------------" << std::endl;                               \


### PR DESCRIPTION
Fix #716

Every relevant enum/class/struct is now print-able to streams like so: `std::cout << data_type << lqp_node;`. Previously this was different for each data type: `std::cout << data_type_to_string.left.at(data_type); lqp_node.print(std::cout);`