### PR TITLE
Enabled TPC-H table caching

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -61,7 +61,7 @@ void AbstractTableGenerator::generate_and_store() {
         binary_file_path.replace_extension(".bin");
       }
 
-      std::cout << "- Writing '" << table_name << "' into binary file '" << binary_file_path << "' " << std::flush;
+      std::cout << "- Writing '" << table_name << "' into binary file " << binary_file_path << " " << std::flush;
       Timer per_table_timer;
       ExportBinary::write_binary(*table_info.table, binary_file_path);
       std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -51,6 +51,12 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig& config, std::unique_ptr<
 
     const auto scheduler = std::make_shared<NodeQueueScheduler>();
     CurrentScheduler::set(scheduler);
+
+    if (config.clients == 1) {
+      std::cout << "\n\n- WARNING: You are running in multi-threaded (MT) mode but have set --clients=1.";
+      std::cout << "           You will achieve better MT performance by executing multiple queries in parallel.\n";
+      std::cout << std::endl;
+    }
   }
 }
 

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -219,7 +219,7 @@ TpchTableGenerator::TpchTableGenerator(float scale_factor, const std::shared_ptr
     : AbstractTableGenerator(benchmark_config), _scale_factor(scale_factor) {}
 
 std::unordered_map<std::string, BenchmarkTableInfo> TpchTableGenerator::generate() {
-  const auto cache_directory = std::string{"tpch_cached_tables/sf-"} + std::to_string(_scale_factor) + "/";
+  const auto cache_directory = std::string{"tpch_cached_tables/sf-"} + std::to_string(_scale_factor) + "/"; // NOLINT
   if (_benchmark_config->cache_binary_tables && std::filesystem::is_directory(cache_directory)) {
     std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
 

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -219,7 +219,7 @@ TpchTableGenerator::TpchTableGenerator(float scale_factor, const std::shared_ptr
     : AbstractTableGenerator(benchmark_config), _scale_factor(scale_factor) {}
 
 std::unordered_map<std::string, BenchmarkTableInfo> TpchTableGenerator::generate() {
-  const auto cache_directory = std::string{"tpch_cached_tables/sf-"} + std::to_string(_scale_factor) + "/"; // NOLINT
+  const auto cache_directory = std::string{"tpch_cached_tables/sf-"} + std::to_string(_scale_factor); // NOLINT
   if (_benchmark_config->cache_binary_tables && std::filesystem::is_directory(cache_directory)) {
     std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
 
@@ -365,7 +365,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> TpchTableGenerator::generate
   if (_benchmark_config->cache_binary_tables) {
     std::filesystem::create_directories(cache_directory);
     for (auto& [table_name, table_info] : table_info_by_name) {
-      table_info.binary_file_path = cache_directory + table_name + ".tbl";
+      table_info.binary_file_path = cache_directory + "/" + table_name + ".tbl";
     }
   }
 

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -6,15 +6,16 @@ extern "C" {
 #include <rnd.h>
 }
 
+#include <boost/hana/for_each.hpp>
+#include <boost/hana/integral_constant.hpp>
+#include <boost/hana/zip_with.hpp>
 #include <utility>
 
-#include "boost/hana/for_each.hpp"
-#include "boost/hana/integral_constant.hpp"
-#include "boost/hana/zip_with.hpp"
-
 #include "benchmark_config.hpp"
+#include "operators/import_binary.hpp"
 #include "storage/chunk.hpp"
 #include "storage/storage_manager.hpp"
+#include "utils/timer.hpp"
 
 extern char** asc_date;
 extern seed_t seed[];
@@ -218,7 +219,25 @@ TpchTableGenerator::TpchTableGenerator(float scale_factor, const std::shared_ptr
     : AbstractTableGenerator(benchmark_config), _scale_factor(scale_factor) {}
 
 std::unordered_map<std::string, BenchmarkTableInfo> TpchTableGenerator::generate() {
-  Assert(!_benchmark_config->cache_binary_tables, "Caching binary Tables not supported by TpchTableGenerator, yet");
+  const auto cache_directory = std::string{"tpch_cached_tables/sf-"} + std::to_string(_scale_factor) + "/";
+  if (_benchmark_config->cache_binary_tables && std::filesystem::is_directory(cache_directory)) {
+    std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
+
+    for (const auto& table_file : filesystem::recursive_directory_iterator(cache_directory)) {
+      const auto table_name = table_file.path().stem();
+      Timer timer;
+      std::cout << "-  Loading table '" << table_name << "' from cached binary " << table_file.path().relative_path();
+
+      BenchmarkTableInfo table_info;
+      table_info.table = ImportBinary::read_binary(table_file.path());
+      table_info.loaded_from_binary = true;
+      table_info_by_name[table_name] = table_info;
+
+      std::cout << " (" << timer.lap_formatted() << ")" << std::endl;
+    }
+
+    return table_info_by_name;
+  }
 
   const auto customer_count = static_cast<size_t>(tdefs[CUST].base * _scale_factor);
   const auto order_count = static_cast<size_t>(tdefs[ORDER].base * _scale_factor);
@@ -342,6 +361,13 @@ std::unordered_map<std::string, BenchmarkTableInfo> TpchTableGenerator::generate
   table_info_by_name["supplier"].table = supplier_builder.finish_table();
   table_info_by_name["nation"].table = nation_builder.finish_table();
   table_info_by_name["region"].table = region_builder.finish_table();
+
+  if (_benchmark_config->cache_binary_tables) {
+    std::filesystem::create_directories(cache_directory);
+    for (auto& [table_name, table_info] : table_info_by_name) {
+      table_info.binary_file_path = cache_directory + table_name + ".tbl";
+    }
+  }
 
   return table_info_by_name;
 }


### PR DESCRIPTION
On my macbook, this reduces the TPC-H startup time for SF 10 from 8m14.176s to 3m41.794s.