### PR TITLE
Make iterators return references, small improvements to table generation

### DIFF
--- a/src/lib/statistics/generate_column_statistics.cpp
+++ b/src/lib/statistics/generate_column_statistics.cpp
@@ -13,15 +13,14 @@ namespace opossum {
 template <>
 std::shared_ptr<BaseColumnStatistics> generate_column_statistics<pmr_string>(const Table& table,
                                                                              const ColumnID column_id) {
-  // It would be nice to store string_views in the set, but the iterables hold copies of the values, not references.
-  // SegmentPosition would have to be changed to `T& _value` and this brings a whole bunch of problems in iterators
-  // that create stack copies of the accessed values (e.g., for ReferenceSegments)
-
   auto temp_buffer = boost::container::pmr::monotonic_buffer_resource(table.row_count() * 10);
   auto distinct_set =
-      std::unordered_set<pmr_string, std::hash<pmr_string>, std::equal_to<>, PolymorphicAllocator<pmr_string>>(
-          PolymorphicAllocator<pmr_string>{/*&temp_buffer*/});
+      std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>, PolymorphicAllocator<std::string_view>>(
+          PolymorphicAllocator<std::string_view>{&temp_buffer});
   distinct_set.reserve(table.row_count());
+
+  // For segments where the iterators do not return stable references, we temporarily copy the strings into temp_strings
+  auto temp_strings = std::list<pmr_string, PolymorphicAllocator<pmr_string>>{&temp_buffer};
 
   auto null_value_count = size_t{0};
 
@@ -33,26 +32,35 @@ std::shared_ptr<BaseColumnStatistics> generate_column_statistics<pmr_string>(con
   for (ChunkID chunk_id{0}; chunk_id < table.chunk_count(); ++chunk_id) {
     const auto base_segment = table.get_chunk(chunk_id)->get_segment(column_id);
 
-    segment_iterate<pmr_string>(*base_segment, [&](const auto& position) {
-      if (position.is_null()) {
-        ++null_value_count;
-      } else {
-        // One would expect distinct_set.emplace() to be the same as the code below. However, "The element may be
-        // constructed even if there already is an element with the key in the container, in which case the newly
-        // constructed element will be destroyed immediately."
-        // This is the case here, where simply using emplace takes ~50% longer.
-        auto it = distinct_set.find(position.value());
-        if (it != distinct_set.end()) return;
-
-        it = distinct_set.emplace_hint(it, std::move(position.value()));
-
-        if (distinct_set.size() == 1) {
-          min = *it;
-          max = *it;
+    segment_with_iterators<pmr_string>(*base_segment, [&](auto segment_it, const auto segment_end) {
+      while (segment_it != segment_end) {
+        if (segment_it->is_null()) {
+          ++null_value_count;
         } else {
-          if (*it < min) min = *it;
-          if (*it > max) max = *it;
+          // One would expect distinct_set.emplace() to be the same as the code below. However, "The element may be
+          // constructed even if there already is an element with the key in the container, in which case the newly
+          // constructed element will be destroyed immediately."
+          // This is the case here, where simply using emplace takes ~50% longer.
+          auto it = distinct_set.find(segment_it->value());
+          if (it != distinct_set.end()) return;
+
+          if constexpr(segment_it.ReferenceIsStable) {
+            it = distinct_set.emplace_hint(it, segment_it->value());
+          } else {
+            temp_strings.emplace_back(segment_it->value());
+            it = distinct_set.emplace_hint(it, temp_strings.back());
+          }
+
+          if (distinct_set.size() == 1) {
+            min = *it;
+            max = *it;
+          } else {
+            if (*it < min) min = *it;
+            if (*it > max) max = *it;
+          }
         }
+
+        ++segment_it;
       }
     });
   }

--- a/src/lib/statistics/generate_column_statistics.cpp
+++ b/src/lib/statistics/generate_column_statistics.cpp
@@ -15,8 +15,8 @@ std::shared_ptr<BaseColumnStatistics> generate_column_statistics<pmr_string>(con
                                                                              const ColumnID column_id) {
   auto temp_buffer = boost::container::pmr::monotonic_buffer_resource(table.row_count() * 10);
   auto distinct_set =
-      std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>, PolymorphicAllocator<std::string_view>>(
-          PolymorphicAllocator<std::string_view>{&temp_buffer});
+      std::unordered_set<std::string_view, std::hash<std::string_view>, std::equal_to<>,
+                         PolymorphicAllocator<std::string_view>>(PolymorphicAllocator<std::string_view>{&temp_buffer});
   distinct_set.reserve(table.row_count());
 
   // For segments where the iterators do not return stable references, we temporarily copy the strings into temp_strings
@@ -44,7 +44,7 @@ std::shared_ptr<BaseColumnStatistics> generate_column_statistics<pmr_string>(con
           auto it = distinct_set.find(segment_it->value());
           if (it != distinct_set.end()) return;
 
-          if constexpr(segment_it.ReferenceIsStable) {
+          if constexpr (segment_it.ReferenceIsStable) {
             it = distinct_set.emplace_hint(it, segment_it->value());
           } else {
             temp_strings.emplace_back(segment_it->value());

--- a/src/lib/storage/dictionary_segment/dictionary_encoder.hpp
+++ b/src/lib/storage/dictionary_segment/dictionary_encoder.hpp
@@ -79,6 +79,12 @@ class DictionaryEncoder : public SegmentEncoder<DictionaryEncoder<Encoding>> {
     dictionary.erase(std::unique(dictionary.begin(), dictionary.end()), dictionary.end());
     dictionary.shrink_to_fit();
 
+    if constexpr (std::is_same_v<T, pmr_string> && Encoding != EncodingType::FixedStringDictionary) {
+      // Somewhere before, pmr_string::operator= is called, which overallocates memory to enable amortized linear growth.
+      // As these strings won't change again, we return that overallocated memory.
+      for (auto& string : dictionary) string.shrink_to_fit();
+    }
+
     auto attribute_vector = pmr_vector<uint32_t>{values.get_allocator()};
     attribute_vector.reserve(values.size());
 

--- a/src/lib/storage/dictionary_segment/dictionary_encoder.hpp
+++ b/src/lib/storage/dictionary_segment/dictionary_encoder.hpp
@@ -80,8 +80,8 @@ class DictionaryEncoder : public SegmentEncoder<DictionaryEncoder<Encoding>> {
     dictionary.shrink_to_fit();
 
     if constexpr (std::is_same_v<T, pmr_string> && Encoding != EncodingType::FixedStringDictionary) {
-      // Somewhere before, pmr_string::operator= is called, which overallocates memory to enable amortized linear growth.
-      // As these strings won't change again, we return that overallocated memory.
+      // Somewhere before, pmr_string::operator= is called, which overallocates memory to enable amortized linear
+      // growth. As these strings won't change again, we return that overallocated memory.
       for (auto& string : dictionary) string.shrink_to_fit();
     }
 

--- a/src/lib/storage/dictionary_segment/dictionary_segment_iterable.hpp
+++ b/src/lib/storage/dictionary_segment/dictionary_segment_iterable.hpp
@@ -61,6 +61,7 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
    public:
     using ValueType = T;
     using IterableType = DictionarySegmentIterable<T, Dictionary>;
+    static constexpr bool ReferenceIsStable = std::is_same_v<Dictionary, pmr_vector<T>>;
 
     Iterator(DictionaryIteratorType dictionary_begin_it, ValueID null_value_id, ZsIteratorType attribute_it,
              ChunkOffset chunk_offset)
@@ -95,9 +96,16 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
       const auto value_id = static_cast<ValueID>(*_attribute_it);
       const auto is_null = (value_id == _null_value_id);
 
-      if (is_null) return SegmentPosition<T>{T{}, true, _chunk_offset};
+      if (is_null) {
+        return SegmentPosition<T>{_current_value, true, _chunk_offset};
+      }
 
-      return SegmentPosition<T>{T{*(_dictionary_begin_it + value_id)}, false, _chunk_offset};
+      if constexpr (std::is_same_v<Dictionary, FixedStringVector>) {
+        _current_value = *(_dictionary_begin_it + value_id);
+        return SegmentPosition<T>{_current_value, false, _chunk_offset};
+      } else {
+        return SegmentPosition<T>{*(_dictionary_begin_it + value_id), false, _chunk_offset};
+      }
     }
 
    private:
@@ -105,6 +113,9 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
     ValueID _null_value_id;
     ZsIteratorType _attribute_it;
     ChunkOffset _chunk_offset;
+
+    // Used only if we can't return a reference to an already existing object
+    mutable T _current_value = T{};
   };
 
   template <typename ZsDecompressorType, typename DictionaryIteratorType>
@@ -114,6 +125,7 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
    public:
     using ValueType = T;
     using IterableType = DictionarySegmentIterable<T, Dictionary>;
+    static constexpr bool ReferenceIsStable = std::is_same_v<Dictionary, pmr_vector<T>>;
 
     PointAccessIterator(DictionaryIteratorType dictionary_begin_it, const ValueID null_value_id,
                         const std::shared_ptr<ZsDecompressorType>& attribute_decompressor,
@@ -134,15 +146,25 @@ class DictionarySegmentIterable : public PointAccessibleSegmentIterable<Dictiona
       const auto value_id = _attribute_decompressor->get(chunk_offsets.offset_in_referenced_chunk);
       const auto is_null = (value_id == _null_value_id);
 
-      if (is_null) return SegmentPosition<T>{T{}, true, chunk_offsets.offset_in_poslist};
+      if (is_null) {
+        return SegmentPosition<T>{_current_value, true, chunk_offsets.offset_in_poslist};
+      }
 
-      return SegmentPosition<T>{T{*(_dictionary_begin_it + value_id)}, false, chunk_offsets.offset_in_poslist};
+      if constexpr (std::is_same_v<Dictionary, FixedStringVector>) {
+        _current_value = *(_dictionary_begin_it + value_id);
+        return SegmentPosition<T>{_current_value, false, chunk_offsets.offset_in_poslist};
+      } else {
+        return SegmentPosition<T>{*(_dictionary_begin_it + value_id), false, chunk_offsets.offset_in_poslist};
+      }
     }
 
    private:
     DictionaryIteratorType _dictionary_begin_it;
     ValueID _null_value_id;
     std::shared_ptr<ZsDecompressorType> _attribute_decompressor;
+
+    // Used only if we can't return a reference to an already existing object
+    mutable T _current_value = T{};
   };
 
  private:

--- a/src/lib/storage/lz4/lz4_iterable.hpp
+++ b/src/lib/storage/lz4/lz4_iterable.hpp
@@ -48,7 +48,8 @@ class LZ4Iterable : public PointAccessibleSegmentIterable<LZ4Iterable<T>> {
     auto cached_block_index = std::optional<size_t>{};
     for (auto index = size_t{0u}; index < position_filter->size(); ++index) {
       const auto& position = (*position_filter)[index];
-      auto [value, block_index] = _segment.decompress(position.chunk_offset, cached_block_index, cached_block);  // NOLINT
+      auto [value, block_index] =
+          _segment.decompress(position.chunk_offset, cached_block_index, cached_block);  // NOLINT
       decompressed_filtered_segment[index] = std::move(value);
       cached_block_index = block_index;
     }
@@ -73,6 +74,7 @@ class LZ4Iterable : public PointAccessibleSegmentIterable<LZ4Iterable<T>> {
     using ValueType = T;
     using IterableType = LZ4Iterable<T>;
     using NullValueIterator = typename pmr_vector<bool>::const_iterator;
+    static constexpr bool ReferenceIsStable = false;
 
    public:
     // Begin and End Iterator
@@ -127,6 +129,7 @@ class LZ4Iterable : public PointAccessibleSegmentIterable<LZ4Iterable<T>> {
    public:
     using ValueType = T;
     using IterableType = LZ4Iterable<T>;
+    static constexpr bool ReferenceIsStable = false;
 
     // Begin Iterator
     PointAccessIterator(const std::vector<T>& data, const std::optional<pmr_vector<bool>>* null_values,
@@ -142,7 +145,7 @@ class LZ4Iterable : public PointAccessibleSegmentIterable<LZ4Iterable<T>> {
 
     SegmentPosition<T> dereference() const {
       const auto& chunk_offsets = this->chunk_offsets();
-      const auto value = _data[chunk_offsets.offset_in_poslist];
+      const auto& value = _data[chunk_offsets.offset_in_poslist];
       const auto is_null = *_null_values && (**_null_values)[chunk_offsets.offset_in_referenced_chunk];
       return SegmentPosition<T>{value, is_null, chunk_offsets.offset_in_poslist};
     }

--- a/src/lib/storage/lz4/lz4_iterable.hpp
+++ b/src/lib/storage/lz4/lz4_iterable.hpp
@@ -48,8 +48,8 @@ class LZ4Iterable : public PointAccessibleSegmentIterable<LZ4Iterable<T>> {
     auto cached_block_index = std::optional<size_t>{};
     for (auto index = size_t{0u}; index < position_filter->size(); ++index) {
       const auto& position = (*position_filter)[index];
-      auto [value, block_index] =
-          _segment.decompress(position.chunk_offset, cached_block_index, cached_block);  // NOLINT
+      auto [value, block_index] =  // NOLINT
+          _segment.decompress(position.chunk_offset, cached_block_index, cached_block);
       decompressed_filtered_segment[index] = std::move(value);
       cached_block_index = block_index;
     }

--- a/src/lib/storage/run_length_segment/run_length_segment_iterable.hpp
+++ b/src/lib/storage/run_length_segment/run_length_segment_iterable.hpp
@@ -49,6 +49,7 @@ class RunLengthSegmentIterable : public PointAccessibleSegmentIterable<RunLength
     using ValueIterator = typename pmr_vector<T>::const_iterator;
     using NullValueIterator = typename pmr_vector<bool>::const_iterator;
     using EndPositionIterator = typename pmr_vector<ChunkOffset>::const_iterator;
+    static constexpr bool ReferenceIsStable = true;
 
    public:
     explicit Iterator(const ValueIterator& value_it, const NullValueIterator& null_value_it,
@@ -132,6 +133,7 @@ class RunLengthSegmentIterable : public PointAccessibleSegmentIterable<RunLength
    public:
     using ValueType = T;
     using IterableType = RunLengthSegmentIterable<T>;
+    static constexpr bool ReferenceIsStable = true;
 
     explicit PointAccessIterator(const pmr_vector<T>* values, const pmr_vector<bool>* null_values,
                                  const pmr_vector<ChunkOffset>* end_positions,
@@ -166,7 +168,7 @@ class RunLengthSegmentIterable : public PointAccessibleSegmentIterable<RunLength
 
       const auto current_index = std::distance(_end_positions->cbegin(), end_position_it);
 
-      const auto value = (*_values)[current_index];
+      const auto& value = (*_values)[current_index];
       const auto is_null = (*_null_values)[current_index];
 
       _prev_chunk_offset = current_chunk_offset;

--- a/src/lib/storage/segment_iterables/any_segment_iterator.hpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterator.hpp
@@ -102,6 +102,7 @@ class AnySegmentIterator : public BaseSegmentIterator<AnySegmentIterator<T>, Seg
  public:
   using ValueType = T;
   using IterableType = AnySegmentIterable<T>;
+  static constexpr bool ReferenceIsStable = false;
 
   /**
    * Prevents AnySegmentIterator from being created

--- a/src/lib/storage/segment_iterables/base_segment_iterators.hpp
+++ b/src/lib/storage/segment_iterables/base_segment_iterators.hpp
@@ -29,6 +29,11 @@ namespace opossum {
  * Example Usage
  *
  * class Iterator : public BaseSegmentIterator<Iterator, Value> {
+ *  public:
+ *   // Describes whether the reference returned when dereferencing the iterator is stable, i.e., remains
+ *   // valid for as long as the underlying segment is valid.
+ *   static constexpr bool ReferenceIsStable = false;
+ * 
  *  private:
  *   friend class boost::iterator_core_access;  // the following methods need to be accessible by the base class
  *

--- a/src/lib/storage/segment_iterables/segment_positions.hpp
+++ b/src/lib/storage/segment_iterables/segment_positions.hpp
@@ -28,6 +28,7 @@ class AbstractSegmentPosition {
   AbstractSegmentPosition(const AbstractSegmentPosition&) = default;
   virtual ~AbstractSegmentPosition() = default;
 
+  // This reference is only valid for as long as the iterator remains on the current position
   virtual const T& value() const = 0;
   virtual bool is_null() const = 0;
 
@@ -59,7 +60,7 @@ class SegmentPosition : public AbstractSegmentPosition<T> {
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization
-  alignas(8) const T _value;
+  alignas(8) const T& _value;
   alignas(8) const bool _null_value;
   alignas(8) const ChunkOffset _chunk_offset;
 };
@@ -83,7 +84,7 @@ class NonNullSegmentPosition : public AbstractSegmentPosition<T> {
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization
-  alignas(8) const T _value;
+  alignas(8) const T& _value;
   alignas(8) const ChunkOffset _chunk_offset;
 };
 

--- a/src/lib/storage/value_segment/value_segment_iterable.hpp
+++ b/src/lib/storage/value_segment/value_segment_iterable.hpp
@@ -56,6 +56,7 @@ class ValueSegmentIterable : public PointAccessibleSegmentIterable<ValueSegmentI
     using ValueType = T;
     using IterableType = ValueSegmentIterable<T>;
     using ValueIterator = typename pmr_concurrent_vector<T>::const_iterator;
+    static constexpr bool ReferenceIsStable = true;
 
    public:
     explicit NonNullIterator(const ValueIterator begin_value_it, const ValueIterator value_it)
@@ -96,6 +97,7 @@ class ValueSegmentIterable : public PointAccessibleSegmentIterable<ValueSegmentI
     using IterableType = ValueSegmentIterable<T>;
     using ValueIterator = typename pmr_concurrent_vector<T>::const_iterator;
     using NullValueIterator = pmr_concurrent_vector<bool>::const_iterator;
+    static constexpr bool ReferenceIsStable = true;
 
    public:
     explicit Iterator(const ValueIterator begin_value_it, const ValueIterator value_it,
@@ -143,6 +145,7 @@ class ValueSegmentIterable : public PointAccessibleSegmentIterable<ValueSegmentI
     using ValueType = T;
     using IterableType = ValueSegmentIterable<T>;
     using ValueVectorIterator = typename pmr_concurrent_vector<T>::const_iterator;
+    static constexpr bool ReferenceIsStable = true;
 
    public:
     explicit NonNullPointAccessIterator(ValueVectorIterator values_begin_it,
@@ -173,6 +176,7 @@ class ValueSegmentIterable : public PointAccessibleSegmentIterable<ValueSegmentI
     using IterableType = ValueSegmentIterable<T>;
     using ValueVectorIterator = typename pmr_concurrent_vector<T>::const_iterator;
     using NullValueVectorIterator = typename pmr_concurrent_vector<bool>::const_iterator;
+    static constexpr bool ReferenceIsStable = true;
 
    public:
     explicit PointAccessIterator(ValueVectorIterator values_begin_it, NullValueVectorIterator null_values_begin_it,


### PR DESCRIPTION
Currently, iterators copy the segment value into a `SegmentPosition`. For strings, this results in unnecessary copies. Sometimes, the compiler can optimize those away, sometimes not.  This PR changes this to a reference, either directly into the segment or, if this is not possible, into a temporary value stored in the iterator. In the latter case, this PR has no improvement.

Furthermore, it introduces the flag `ReferenceIsStable` to the iterator. A stable reference is one that is still valid once the iterator is moved forward. This is used in generate_column_statistics.cpp to reduce the time needed to add tables to the StorageManager.

Finally, it removes some memory waste in the DictionaryEncoder.

The changes to the generation of the TPC-H data sound almost too good. SF=1 was reduced from 1m50.607s to 0m24.258s. With cached binaries, SF=100 now loads in 7m42.147s instead of TODO.

hyriseTest now executes in 0m1.158s instead of 0m6.030s.

It's so fast, I feel like I have broken something. Let's see what asan/memcheck say.