### PR TITLE
Fix MVCC performance regression, fix MVCC data for rows that are not inserted.

### DIFF
--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -130,7 +130,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       // new row count.
       {
         auto mvcc_data = target_chunk->get_scoped_mvcc_data_lock();
-        mvcc_data->grow_by(num_rows_for_target_chunk, false);
+        mvcc_data->grow_by(num_rows_for_target_chunk, MvccData::MAX_COMMIT_ID);
         for (auto chunk_offset = _target_chunk_ranges.back().begin_chunk_offset;
              chunk_offset < _target_chunk_ranges.back().end_chunk_offset; ++chunk_offset) {
           // This row is still invisible to everyone thanks to the begin set to infinity. We do this manually rather

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -130,7 +130,7 @@ std::shared_ptr<const Table> Insert::_on_execute(std::shared_ptr<TransactionCont
       // new row count.
       {
         auto mvcc_data = target_chunk->get_scoped_mvcc_data_lock();
-        mvcc_data->grow_by(num_rows_for_target_chunk);
+        mvcc_data->grow_by(num_rows_for_target_chunk, false);
         for (auto chunk_offset = _target_chunk_ranges.back().begin_chunk_offset;
              chunk_offset < _target_chunk_ranges.back().end_chunk_offset; ++chunk_offset) {
           // This row is still invisible to everyone thanks to the begin set to infinity. We do this manually rather

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 namespace {
 
-bool is_row_visible(CommitID our_tid, CommitID snapshot_commit_id, ChunkOffset chunk_offset,
+bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, ChunkOffset chunk_offset,
                     const MvccData& mvcc_data) {
   const auto row_tid = mvcc_data.tids[chunk_offset].load();
   const auto begin_cid = mvcc_data.begin_cids[chunk_offset];
@@ -23,7 +23,7 @@ bool is_row_visible(CommitID our_tid, CommitID snapshot_commit_id, ChunkOffset c
 
 }  // namespace
 
-bool Validate::is_row_visible(CommitID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
+bool Validate::is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                               const CommitID begin_cid, const CommitID end_cid) {
   // Taken from: https://github.com/hyrise/hyrise-v1/blob/master/docs/documentation/queryexecution/tx.rst
   // auto own_insert = (our_tid == row_tid) && !(snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -23,7 +23,7 @@ class Validate : public AbstractReadOnlyOperator {
   const std::string name() const override;
 
   // MVCC evaluation logic is exposed so that JitValidate can also use it
-  static bool is_row_visible(CommitID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
+  static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                              const CommitID begin_cid, const CommitID end_cid);
 
  protected:

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -43,7 +43,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row is the MVCC data.
-  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, TransactionID{0});
+  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u);
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_segments.size() == values.size()),

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -43,7 +43,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row is the MVCC data.
-  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, CommitID{0});
+  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, INVALID_TRANSACTION_ID, CommitID{0});
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_segments.size() == values.size()),

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -43,7 +43,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row is the MVCC data.
-  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, true);
+  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, CommitID{0});
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_segments.size() == values.size()),

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -43,7 +43,7 @@ void Chunk::append(const std::vector<AllTypeVariant>& values) {
   DebugAssert(is_mutable(), "Can't append to immutable Chunk");
 
   // Do this first to ensure that the first thing to exist in a row is the MVCC data.
-  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u);
+  if (has_mvcc_data()) get_scoped_mvcc_data_lock()->grow_by(1u, true);
 
   // The added values, i.e., a new row, must have the same number of attributes as the table.
   DebugAssert((_segments.size() == values.size()),

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -7,7 +7,7 @@
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size) { grow_by(size, INVALID_TRANSACTION_ID); }
+MvccData::MvccData(const size_t size) { grow_by(size); }
 
 size_t MvccData::size() const { return _size; }
 
@@ -26,9 +26,9 @@ void MvccData::shrink() {
   end_cids.shrink_to_fit();
 }
 
-void MvccData::grow_by(size_t delta, TransactionID transaction_id) {
+void MvccData::grow_by(size_t delta) {
   _size += delta;
-  tids.grow_to_at_least(_size, transaction_id);
+  tids.grow_to_at_least(_size);
   begin_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
   end_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
 }

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -7,7 +7,9 @@
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size, CommitID begin_commit_id) { grow_by(size, INVALID_TRANSACTION_ID, begin_commit_id); }
+MvccData::MvccData(const size_t size, CommitID begin_commit_id) {
+  grow_by(size, INVALID_TRANSACTION_ID, begin_commit_id);
+}
 
 size_t MvccData::size() const { return _size; }
 

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -7,7 +7,7 @@
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size, bool visible_for_all) { grow_by(size, visible_for_all); }
+MvccData::MvccData(const size_t size, CommitID begin_commit_id) { grow_by(size, begin_commit_id); }
 
 size_t MvccData::size() const { return _size; }
 
@@ -26,10 +26,10 @@ void MvccData::shrink() {
   end_cids.shrink_to_fit();
 }
 
-void MvccData::grow_by(size_t delta, bool visible_for_all) {
+void MvccData::grow_by(size_t delta, CommitID begin_commit_id) {
   _size += delta;
   tids.grow_to_at_least(_size);
-  begin_cids.grow_to_at_least(_size, visible_for_all ? CommitID{0} : MAX_COMMIT_ID);
+  begin_cids.grow_to_at_least(_size, begin_commit_id);
   end_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
 }
 

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -7,7 +7,7 @@
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size, CommitID begin_commit_id) { grow_by(size, begin_commit_id); }
+MvccData::MvccData(const size_t size, CommitID begin_commit_id) { grow_by(size, INVALID_TRANSACTION_ID, begin_commit_id); }
 
 size_t MvccData::size() const { return _size; }
 
@@ -26,9 +26,18 @@ void MvccData::shrink() {
   end_cids.shrink_to_fit();
 }
 
-void MvccData::grow_by(size_t delta, CommitID begin_commit_id) {
+void MvccData::grow_by(size_t delta, TransactionID transaction_id, CommitID begin_commit_id) {
   _size += delta;
   tids.grow_to_at_least(_size);
+
+  for (auto chunk_offset = _size - delta; chunk_offset < _size; ++chunk_offset) {
+    // We set the TIDs manually instead of passing them into grow_to_at_least, because this way we can do this
+    // without synchronization. As the rows are not visible to anyone yet (MVCC vectors are resized before the table
+    // is), there is no harm in using a relaxed model.
+    tids[chunk_offset].store(transaction_id, std::memory_order_relaxed);
+  }
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+
   begin_cids.grow_to_at_least(_size, begin_commit_id);
   end_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
 }

--- a/src/lib/storage/mvcc_data.cpp
+++ b/src/lib/storage/mvcc_data.cpp
@@ -7,7 +7,7 @@
 
 namespace opossum {
 
-MvccData::MvccData(const size_t size) { grow_by(size); }
+MvccData::MvccData(const size_t size, bool visible_for_all) { grow_by(size, visible_for_all); }
 
 size_t MvccData::size() const { return _size; }
 
@@ -26,10 +26,10 @@ void MvccData::shrink() {
   end_cids.shrink_to_fit();
 }
 
-void MvccData::grow_by(size_t delta) {
+void MvccData::grow_by(size_t delta, bool visible_for_all) {
   _size += delta;
   tids.grow_to_at_least(_size);
-  begin_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
+  begin_cids.grow_to_at_least(_size, visible_for_all ? CommitID{0} : MAX_COMMIT_ID);
   end_cids.grow_to_at_least(_size, MAX_COMMIT_ID);
 }
 

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -35,7 +35,7 @@ struct MvccData {
   /**
    * Grows mvcc data by the given delta
    */
-  void grow_by(size_t delta, CommitID begin_commit_id);
+  void grow_by(size_t delta, TransactionID transaction_id, CommitID begin_commit_id);
 
   void print(std::ostream& stream = std::cout) const;
 

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -34,10 +34,8 @@ struct MvccData {
 
   /**
    * Grows mvcc data by the given delta
-   *
-   * @param transaction_id    value all new tids will be set to
    */
-  void grow_by(size_t delta, TransactionID transaction_id);
+  void grow_by(size_t delta);
 
   void print(std::ostream& stream = std::cout) const;
 

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -22,7 +22,7 @@ struct MvccData {
   pmr_concurrent_vector<CommitID> begin_cids;                  ///< commit id when record was added
   pmr_concurrent_vector<CommitID> end_cids;                    ///< commit id when record was deleted
 
-  explicit MvccData(const size_t size, bool visible_for_all);
+  explicit MvccData(const size_t size, CommitID begin_commit_id);
 
   size_t size() const;
 
@@ -35,7 +35,7 @@ struct MvccData {
   /**
    * Grows mvcc data by the given delta
    */
-  void grow_by(size_t delta, bool visible_for_all);
+  void grow_by(size_t delta, CommitID begin_commit_id);
 
   void print(std::ostream& stream = std::cout) const;
 

--- a/src/lib/storage/mvcc_data.hpp
+++ b/src/lib/storage/mvcc_data.hpp
@@ -22,7 +22,7 @@ struct MvccData {
   pmr_concurrent_vector<CommitID> begin_cids;                  ///< commit id when record was added
   pmr_concurrent_vector<CommitID> end_cids;                    ///< commit id when record was deleted
 
-  explicit MvccData(const size_t size);
+  explicit MvccData(const size_t size, bool visible_for_all);
 
   size_t size() const;
 
@@ -35,7 +35,7 @@ struct MvccData {
   /**
    * Grows mvcc data by the given delta
    */
-  void grow_by(size_t delta);
+  void grow_by(size_t delta, bool visible_for_all);
 
   void print(std::ostream& stream = std::cout) const;
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -165,7 +165,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
   std::shared_ptr<MvccData> mvcc_data;
 
   if (_use_mvcc == UseMvcc::Yes) {
-    mvcc_data = std::make_shared<MvccData>(chunk_size, true);
+    mvcc_data = std::make_shared<MvccData>(chunk_size, CommitID{0});
   }
 
   _chunks.push_back(std::make_shared<Chunk>(segments, mvcc_data, alloc));

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -165,7 +165,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
   std::shared_ptr<MvccData> mvcc_data;
 
   if (_use_mvcc == UseMvcc::Yes) {
-    mvcc_data = std::make_shared<MvccData>(chunk_size);
+    mvcc_data = std::make_shared<MvccData>(chunk_size, true);
   }
 
   _chunks.push_back(std::make_shared<Chunk>(segments, mvcc_data, alloc));

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -165,6 +165,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
   std::shared_ptr<MvccData> mvcc_data;
 
   if (_use_mvcc == UseMvcc::Yes) {
+    // append_chunk is a helper method and rows are made visible immediately
     mvcc_data = std::make_shared<MvccData>(chunk_size, CommitID{0});
   }
 


### PR DESCRIPTION
#1585 changed the way MVCC vectors were extended. Resizing and writing a couple hundred atomics is quite expensive if we synchronize for each.

Also, the same PR changed new MVCC rows that they were not immediately visible. For the TPC-H with MVCC enabled, this meant that all tables were basically empty. This won't happen anymore with #1597, where we get rid of the option of running without MVCC altogether.

```
+-----------+----------------+------+----------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s   | runs | new iter/s     | runs | change | p-value (significant if <0.001) |
+-----------+----------------+------+----------------+------+--------+---------------------------------+
| TPC-H 1   | 0.533324956894 | 33   | 0.527172207832 | 32   | -1%    |                          0.1211 |
| TPC-H 2   | 7.16463375092  | 430  | 8.29684925079  | 498  | +16%   |                          0.0000 |
| TPC-H 3   | 6.57847356796  | 395  | 6.57278633118  | 395  | -0%    |                          0.6014 |
| TPC-H 4   | 1.90148293972  | 115  | 2.2281563282   | 134  | +17%   |                          0.0000 |
| TPC-H 5   | 3.23178911209  | 194  | 4.42444133759  | 266  | +37%   |                          0.0000 |
| TPC-H 6   | 29.7692642212  | 1787 | 29.3826828003  | 1763 | -1%    |                          0.0000 |
| TPC-H 7   | 1.2956045866   | 78   | 1.35758900642  | 82   | +5%    |                          0.0000 |
| TPC-H 8   | 4.04841804504  | 243  | 5.28122472763  | 317  | +30%   |                          0.0000 |
| TPC-H 9   | 1.37200808525  | 83   | 1.55264019966  | 94   | +13%   |                          0.0000 |
| TPC-H 10  | 2.75129842758  | 166  | 2.75398254395  | 166  | +0%    |                          0.7196 |
| TPC-H 11  | 20.1392726898  | 1209 | 31.9011650085  | 1915 | +58%   |                          0.0000 |
| TPC-H 12  | 7.31077384949  | 439  | 7.66930103302  | 461  | +5%    |                          0.0000 |
| TPC-H 13  | 2.22583818436  | 134  | 2.23531842232  | 135  | +0%    |                          0.5430 |
| TPC-H 14  | 23.4843826294  | 1410 | 24.4641456604  | 1468 | +4%    |                          0.0000 |
| TPC-H 15  | 19.5054988861  | 1171 | 19.4964313507  | 1170 | -0%    |                          0.4706 |
| TPC-H 16  | 7.12452030182  | 428  | 7.7613568306   | 466  | +9%    |                          0.0000 |
| TPC-H 17  | 1.17968988419  | 71   | 1.44373655319  | 87   | +22%   |                          0.0000 |
| TPC-H 18  | 1.50807476044  | 91   | 2.02401041985  | 122  | +34%   |                          0.0000 |
| TPC-H 19  | 5.29951524734  | 318  | 5.20063400269  | 313  | -2%    |                          0.0000 |
| TPC-H 20  | 2.00822305679  | 121  | 2.03985309601  | 123  | +2%    |                          0.0000 |
| TPC-H 21  | 0.425299465656 | 26   | 0.429752975702 | 26   | +1%    |                          0.1070 |
| TPC-H 22  | 10.0060491562  | 601  | 12.8247356415  | 770  | +28%   |                          0.0000 |
| average   |                |      |                |      | +13%   |                                 |
+-----------+----------------+------+----------------+------+--------+---------------------------------+
```