### PR TITLE
Cmake: add link to resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ node {
       }, gccDebug: {
         stage("gcc-debug") {
           sh "export CCACHE_BASEDIR=`pwd`; cd gcc-debug && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          # Test that running the binary from the build folder works
+          // Test that running the binary from the build folder works
           sh "cd gcc-debug && ./hyriseTest"
         }
       }, lint: {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,8 @@ node {
       }, gccDebug: {
         stage("gcc-debug") {
           sh "export CCACHE_BASEDIR=`pwd`; cd gcc-debug && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
-          sh "./gcc-debug/hyriseTest gcc-debug"
+          # Test that running the binary from the build folder works
+          sh "cd gcc-debug && ./hyriseTest"
         }
       }, lint: {
         stage("Linting") {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -692,6 +692,11 @@ else()
     set_property(TARGET hyrise PROPERTY INTERFACE_LINK_LIBRARIES -Wl,--whole-archive hyrise -Wl,--no-whole-archive)
 endif()
 
+# For convenience, to be able to launch, e.g., hyriseTest, directly from the build directory,
+# add a link to the resources/ directory at the root of the build directory)
+add_custom_target(resourceLink
+    COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/resources
+)
 
 # -rdynamic tells the linker to export the library's symbols so that plugins can use them.
 target_link_libraries(hyrise ${LIBRARIES} -rdynamic)
@@ -702,7 +707,7 @@ target_compile_options(hyrise PRIVATE -fPIC)
 
 # Dependency hyrise --> git_watcher needs to be added manually, apparently. Otherwise version.hpp, for reasons unknown
 # isn't updated when HEAD changes
-add_dependencies(hyrise AlwaysCheckGit)
+add_dependencies(hyrise AlwaysCheckGit resourceLink)
 
 if (${ENABLE_JIT_SUPPORT})
     # LLVM does not build with -Wshadow-all,-Werror. Overwrite the LLVM include so it is treated as a system library.

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -302,20 +302,13 @@ include_directories(../../third_party/googletest/googletest/)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-# For convenience, to be able to launch, e.g., hyriseTest, directly from the build directory,
-# add a link to the resources/ directory at the root of the build directory)
-add_custom_target(resourceLink
-    COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/resources
-)
-
 # Configure hyriseTest
 add_executable(hyriseTest ${HYRISE_UNIT_TEST_SOURCES})
-add_dependencies(hyriseTest resourceLink TestPlugin TestNonInstantiablePlugin)
+add_dependencies(hyriseTest TestPlugin TestNonInstantiablePlugin)
 target_link_libraries(hyriseTest hyrise ${LIBRARIES})
 
 # Configure hyriseSystemTest
 add_executable(hyriseSystemTest ${SYSTEM_TEST_SOURCES})
-add_dependencies(hyriseSystemTest resourceLink)
 target_link_libraries(hyriseSystemTest hyrise hyriseBenchmarkLib ${LIBRARIES})
 target_link_libraries_system(hyriseSystemTest pqxx)
 target_compile_options(hyriseSystemTest PRIVATE -DPQXX_HIDE_EXP_OPTIONAL)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -302,13 +302,18 @@ include_directories(../../third_party/googletest/googletest/)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+add_custom_target(resourceLink
+    COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/resources
+)
+
 # Configure hyriseTest
 add_executable(hyriseTest ${HYRISE_UNIT_TEST_SOURCES})
-add_dependencies(hyriseTest TestPlugin TestNonInstantiablePlugin)
+add_dependencies(hyriseTest resourceLink TestPlugin TestNonInstantiablePlugin)
 target_link_libraries(hyriseTest hyrise ${LIBRARIES})
 
 # Configure hyriseSystemTest
 add_executable(hyriseSystemTest ${SYSTEM_TEST_SOURCES})
+add_dependencies(hyriseSystemTest resourceLink)
 target_link_libraries(hyriseSystemTest hyrise hyriseBenchmarkLib ${LIBRARIES})
 target_link_libraries_system(hyriseSystemTest pqxx)
 target_compile_options(hyriseSystemTest PRIVATE -DPQXX_HIDE_EXP_OPTIONAL)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -302,6 +302,8 @@ include_directories(../../third_party/googletest/googletest/)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+# For convenience, to be able to launch, e.g., hyriseTest, directly from the build directory,
+# add a link to the resources/ directory at the root of the build directory)
 add_custom_target(resourceLink
     COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/resources
 )


### PR DESCRIPTION
fixes #1583, makes it possible to call `./hyriseTest` without changing the directory.

Tested with ninja and OS X as well as make+ninja and Ubuntu.