### PR TITLE
Create resources link only once

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -693,7 +693,7 @@ else()
 endif()
 
 # For convenience, to be able to launch, e.g., hyriseTest, directly from the build directory,
-# add a link to the resources/ directory at the root of the build directory)
+# add a link to the resources/ directory at the root of the build directory).
 add_custom_target(resourceLink
     COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/
 )

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -695,7 +695,7 @@ endif()
 # For convenience, to be able to launch, e.g., hyriseTest, directly from the build directory,
 # add a link to the resources/ directory at the root of the build directory)
 add_custom_target(resourceLink
-    COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/resources
+    COMMAND ln -fs ${CMAKE_BINARY_DIR}/../resources ${CMAKE_BINARY_DIR}/
 )
 
 # -rdynamic tells the linker to export the library's symbols so that plugins can use them.


### PR DESCRIPTION
fixes #1619, but you will have to delete the symlink inside the resources folder yourself.