### PR TITLE
Remove scan alignment

### DIFF
--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -41,9 +41,9 @@ class AbstractTableScanImpl {
 
   template <bool CheckForNull, typename BinaryFunctor, typename LeftIterator, typename RightIterator>
   // This is a function that is critical for our performance. We want the compiler to try its best in optimizing it.
-  // Also, we want all functions called inside to be inlined (flattened) and the function itself being always aligned
-  // at a page boundary. Finally, it should not be inlined because that might break the alignment.
-  static void __attribute__((hot, flatten, aligned(256), noinline))
+  // Also, we want all functions called inside to be inlined (flattened). GCC seems to like for this to not be inlined
+  // itself.
+  static void __attribute__((hot, flatten, noinline))
   _scan_with_iterators(const BinaryFunctor func, LeftIterator left_it, const LeftIterator left_end,
                        const ChunkID chunk_id, PosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     // The major part of the table is scanned using SIMD. Only the remainder is handled in this method.


### PR DESCRIPTION
fixes #1505 

As seen there, `aligned` now seems to hurt the performance, while it was good a while ago. Since it causes issues on OSX, it should go.

I also checked if `noinline` had a reason to stay, but GCC likes it:

```
+-----------+----------------+------+----------------+------+--------+---------------------------------+
| Benchmark | prev. iter/s   | runs | new iter/s     | runs | change | p-value (significant if <0.001) |
+-----------+----------------+------+----------------+------+--------+---------------------------------+
| TPC-H 1   | 0.514372348785 | 31   | 0.505956292152 | 31   | -2%    |                          0.0337 |
| TPC-H 2   | 6.7894821167   | 408  | 7.1751203537   | 431  | +6%    |                          0.0000 |
| TPC-H 3   | 6.35070705414  | 382  | 5.90168619156  | 355  | -7%    |                          0.0000 |
| TPC-H 4   | 2.26171517372  | 136  | 2.24217391014  | 135  | -1%    |                          0.0054 |
| TPC-H 5   | 3.17908143997  | 191  | 3.16070127487  | 190  | -1%    |                          0.2544 |
| TPC-H 6   | 25.801864624   | 1549 | 23.7456016541  | 1425 | -8%    |                          0.0000 |
| TPC-H 7   | 1.25577676296  | 76   | 1.26308000088  | 76   | +1%    |                          0.0865 |
| TPC-H 8   | 3.69552755356  | 222  | 3.691167593    | 222  | -0%    |                          0.8162 |
| TPC-H 9   | 1.2770383358   | 77   | 1.15462553501  | 70   | -10%   |                          0.0000 |
| TPC-H 10  | 2.69823265076  | 162  | 2.23694133759  | 135  | -17%   |                          0.0000 |
| TPC-H 11  | 19.1244335175  | 1148 | 19.5469303131  | 1173 | +2%    |                          0.0000 |
| TPC-H 12  | 6.6251168251   | 398  | 6.40213775635  | 385  | -3%    |                          0.0000 |
| TPC-H 13  | 2.13980698586  | 129  | 1.79239189625  | 108  | -16%   |                          0.0000 |
| TPC-H 14  | 19.7114009857  | 1183 | 18.2267341614  | 1094 | -8%    |                          0.0000 |
| TPC-H 15  | 15.9331235886  | 956  | 14.8630247116  | 892  | -7%    |                          0.0000 |
| TPC-H 16  | 6.91763973236  | 416  | 6.99602937698  | 420  | +1%    |                          0.0000 |
| TPC-H 17  | 1.15024495125  | 70   | 1.12114942074  | 68   | -3%    |                          0.0000 |
| TPC-H 18  | 1.49797916412  | 90   | 1.45974433422  | 88   | -3%    |                          0.0018 |
| TPC-H 19  | 5.11680650711  | 308  | 4.82436704636  | 290  | -6%    |                          0.0000 |
| TPC-H 20  | 1.89963114262  | 114  | 1.79275870323  | 108  | -6%    |                          0.0000 |
| TPC-H 21  | 0.422179222107 | 26   | 0.393474400043 | 24   | -7%    |                          0.0000 |
| TPC-H 22  | 12.8088855743  | 769  | 11.2290849686  | 674  | -12%   |                          0.0000 |
| average   |                |      |                |      | -5%    |                                 |
+-----------+----------------+------+----------------+------+--------+---------------------------------+
```