### PR TITLE
Fix lossless tests on OS X

### DIFF
--- a/src/test/lossless_cast_test.cpp
+++ b/src/test/lossless_cast_test.cpp
@@ -113,9 +113,9 @@ TEST_F(LosslessCastTest, IntegralToIntegral) {
   EXPECT_EQ(lossless_cast<int32_t>(int64_t(3)), 3);
 
   EXPECT_EQ(lossless_cast<int32_t>(2'147'483'647), 2'147'483'647);
-  EXPECT_EQ(lossless_cast<int32_t>(2'147'483'648), std::nullopt);
-  EXPECT_EQ(lossless_cast<int32_t>(-2'147'483'648), -2'147'483'648);
-  EXPECT_EQ(lossless_cast<int32_t>(-2'147'483'649), std::nullopt);
+  EXPECT_EQ(lossless_cast<int32_t>(int64_t{2'147'483'648}), std::nullopt);
+  EXPECT_EQ(lossless_cast<int32_t>(int64_t{-2'147'483'648}), -2'147'483'648);
+  EXPECT_EQ(lossless_cast<int32_t>(int64_t{-2'147'483'649}), std::nullopt);
 }
 
 TEST_F(LosslessCastTest, NullToNonNull) {

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -875,7 +875,7 @@ TEST_P(OperatorsTableScanTest, GetImpl) {
   EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), and_(greater_than_(column_a, 5), less_than_(column_b, 6))}.create_impl().get()));  // NOLINT
   EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), greater_than_(column_a, 5.5f)}.create_impl().get()));  // NOLINT
   EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), greater_than_(column_b, 1e40)}.create_impl().get()));  // NOLINT
-  EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), greater_than_(column_a, 3'000'000'000)}.create_impl().get()));  // NOLINT
+  EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), greater_than_(column_a, int64_t{3'000'000'000})}.create_impl().get()));  // NOLINT
   EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), equals_(column_a, "hello")}.create_impl().get()));  // NOLINT
   EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), between_inclusive_(column_a, 0.1f, 5.5)}.create_impl().get()));  // NOLINT
   EXPECT_TRUE(dynamic_cast<ExpressionEvaluatorTableScanImpl*>(TableScan{get_int_float_op(), between_inclusive_(column_a, 0, null_())}.create_impl().get()));  // NOLINT

--- a/src/test/optimizer/strategy/chunk_pruning_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_test.cpp
@@ -309,7 +309,7 @@ TEST_F(ChunkPruningTest, ValueOutOfRange) {
 
   // clang-format off
   auto input_lqp =
-  PredicateNode::make(greater_than_equals_(LQPColumnReference(stored_table_node, ColumnID{0}), -3'000'000'000),
+  PredicateNode::make(greater_than_equals_(LQPColumnReference(stored_table_node, ColumnID{0}), int64_t{-3'000'000'000}),
     stored_table_node);
   // clang-format on
 


### PR DESCRIPTION
On OS X, `long` and `int64_t` are not the same type.

I'll ask for a Mac Mini to be used as a CI server tomorrow. -.-