### PR TITLE
Update ExpressionReductionRule docs for NOT LIKE rewrite

### DIFF
--- a/src/lib/optimizer/strategy/expression_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.hpp
@@ -30,8 +30,9 @@ class AbstractLQPNode;
  *   literal.
  *   E.g. `a LIKE 'abc%'` becomes `a BetweenUpperExclusive 'abc' AND 'abd'`
  *
+ * NOT LIKE to LessThan-Or-GreaterThanEquals
  *   `<expression> NOT LIKE <pattern>` can be rewritten to a LessThan-Or-GreaterThanEquals scan if `<pattern>` is a
- *   prefix wildcard literal.  *
+ *   prefix wildcard literal.
  *   E.g. `a NOT LIKE 'abc%'` becomes `a < 'abc' OR a >= 'abcd'`
  */
 class ExpressionReductionRule : public AbstractRule {

--- a/src/lib/optimizer/strategy/expression_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.hpp
@@ -28,12 +28,12 @@ class AbstractLQPNode;
  * LIKE to BetweenUpperExclusive
  *   `<expression> LIKE <pattern>` can be rewritten to BetweenUpperExclusive if `<pattern>` is a prefix wildcard
  *   literal.
- *   E.g. `a LIKE 'abc%'` becomes `a BetweenUpperExclusive 'abc' AND 'abd'`
+ *   E.g., `a LIKE 'abc%'` becomes `a BetweenUpperExclusive 'abc' AND 'abd'`
  *
  * NOT LIKE to LessThan-Or-GreaterThanEquals
  *   `<expression> NOT LIKE <pattern>` can be rewritten to a LessThan-Or-GreaterThanEquals scan if `<pattern>` is a
  *   prefix wildcard literal.
- *   E.g. `a NOT LIKE 'abc%'` becomes `a < 'abc' OR a >= 'abcd'`
+ *   E.g., `a NOT LIKE 'abc%'` becomes `a < 'abc' OR a >= 'abcd'`
  */
 class ExpressionReductionRule : public AbstractRule {
  public:


### PR DESCRIPTION
Sorry to create another PR for this, but previously the NOT LIKE rewrite was doc'ed under the headline "LIKE to BetweenUpperExclusive" , which just didn't fit.