### PR TITLE
Projection performance: Don't allocate MvccData to then immediately overwrite it

### DIFF
--- a/resources/test_data/csv/no_columns.csv.json
+++ b/resources/test_data/csv/no_columns.csv.json
@@ -1,0 +1,7 @@
+{
+    "config": {
+      "reject_null_strings": false
+    },
+    "columns": [
+    ]
+}

--- a/src/benchmarklib/table_generator.cpp
+++ b/src/benchmarklib/table_generator.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<Table> TableGenerator::generate_table(
 
       // add full chunk to table
       if (column_index == num_columns - 1) {
-        table->append_chunk(segments, allocator_chunk);
+        table->append_chunk(segments, nullptr, allocator_chunk);
       }
     }
   }

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -61,7 +61,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_items_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("ITEM", table);
@@ -100,7 +101,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_warehouse_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("WAREHOUSE", table);
@@ -152,7 +154,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_stock_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("STOCK", table);
@@ -196,7 +199,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_district_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("DISTRICT", table);
@@ -265,7 +269,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_customer_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("CUSTOMER", table);
@@ -300,7 +305,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_history_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("HISTORY", table);
@@ -347,7 +353,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_table(
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("ORDER", table);
@@ -452,7 +459,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_line_table(
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("ORDER_LINE", table);
@@ -480,7 +488,8 @@ std::shared_ptr<Table> TpccTableGenerator::generate_new_order_table() {
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
   for (const auto& segments : segments_by_chunk) {
-    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   _encode_table("NEW_ORDER", table);

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -99,7 +99,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_warehouse_table() {
   });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("WAREHOUSE", table);
   return table;
@@ -149,7 +151,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_stock_table() {
       });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("STOCK", table);
   return table;
@@ -191,7 +195,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_district_table() {
                   [&](std::vector<size_t>) { return NUM_ORDERS + 1; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("DISTRICT", table);
   return table;
@@ -258,7 +264,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_customer_table() {
                          [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(300, 500)}; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("CUSTOMER", table);
   return table;
@@ -291,7 +299,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_history_table() {
                          [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(12, 24)}; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("HISTORY", table);
   return table;
@@ -336,7 +346,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_table(
                   [&](std::vector<size_t>) { return 1; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("ORDER", table);
   return table;
@@ -439,7 +451,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_line_table(
                                      [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(24, 24)}; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("ORDER_LINE", table);
   return table;
@@ -465,7 +479,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_new_order_table() {
                   [&](std::vector<size_t> indices) { return indices[0]; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("NEW_ORDER", table);
   return table;

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -60,7 +60,9 @@ std::shared_ptr<Table> TpccTableGenerator::generate_items_table() {
       });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) {
+    table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
+  }
 
   _encode_table("ITEM", table);
   return table;
@@ -97,7 +99,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_warehouse_table() {
   });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("WAREHOUSE", table);
   return table;
@@ -147,7 +149,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_stock_table() {
       });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("STOCK", table);
   return table;
@@ -189,7 +191,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_district_table() {
                   [&](std::vector<size_t>) { return NUM_ORDERS + 1; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("DISTRICT", table);
   return table;
@@ -256,7 +258,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_customer_table() {
                          [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(300, 500)}; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("CUSTOMER", table);
   return table;
@@ -289,7 +291,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_history_table() {
                          [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(12, 24)}; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("HISTORY", table);
   return table;
@@ -334,7 +336,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_table(
                   [&](std::vector<size_t>) { return 1; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("ORDER", table);
   return table;
@@ -437,7 +439,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_order_line_table(
                                      [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(24, 24)}; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("ORDER_LINE", table);
   return table;
@@ -463,7 +465,7 @@ std::shared_ptr<Table> TpccTableGenerator::generate_new_order_table() {
                   [&](std::vector<size_t> indices) { return indices[0]; });
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size, UseMvcc::Yes);
-  for (const auto& segment : segments_by_chunk) table->append_chunk(segment);
+  for (const auto& segments : segments_by_chunk) table->append_chunk(segments, std::make_shared<MvccData>(segments.front()->size(), CommitID{0}));
 
   _encode_table("NEW_ORDER", table);
   return table;

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -139,7 +139,14 @@ class TableBuilder {
       vector = std::decay_t<decltype(vector)>();
       vector.reserve(_estimated_rows_per_chunk);
     });
-    _table->append_chunk(segments);
+
+    // Create initial MvccData if MVCC is enabled
+    auto mvcc_data = std::shared_ptr<MvccData>{};
+    if (_use_mvcc == UseMvcc::Yes) {
+      mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    }
+
+    _table->append_chunk(segments, mvcc_data);
   }
 };
 

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,10 +1,21 @@
 #include <iostream>
 
 #include "types.hpp"
+#include "tpch/tpch_table_generator.hpp"
+#include "sql/sql_pipeline_builder.hpp"
+#include "visualization/pqp_visualizer.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-  std::cout << "Hello world!!" << std::endl;
+  TpchTableGenerator{0.02f, 500}.generate_and_store();
+
+  auto statement = SQLPipelineBuilder{"SELECT l_orderkey, l_quantity FROM lineitem;"}.dont_cleanup_temporaries().create_pipeline_statement();
+  statement.get_result_table();
+
+  const auto pqp = statement.get_physical_plan();
+
+  PQPVisualizer{}.visualize({pqp}, "test.dot", "test.png");
+
   return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,21 +1,10 @@
 #include <iostream>
 
 #include "types.hpp"
-#include "tpch/tpch_table_generator.hpp"
-#include "sql/sql_pipeline_builder.hpp"
-#include "visualization/pqp_visualizer.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-  TpchTableGenerator{0.02f, 500}.generate_and_store();
-
-  auto statement = SQLPipelineBuilder{"SELECT l_orderkey, l_quantity FROM lineitem;"}.dont_cleanup_temporaries().create_pipeline_statement();
-  statement.get_result_table();
-
-  const auto pqp = statement.get_physical_plan();
-
-  PQPVisualizer{}.visualize({pqp}, "test.dot", "test.png");
-
+  std::cout << "Hello world!!" << std::endl;
   return 0;
 }

--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -121,7 +121,7 @@ DataType expression_common_type(const DataType lhs, const DataType rhs) {
   Assert(lhs != DataType::Null || rhs != DataType::Null, "Can't deduce common type if both sides are NULL");
   Assert((lhs == DataType::String) == (rhs == DataType::String), "Strings only compatible with strings");
 
-  // Long+NULL -> Long; NULL+Long -> Long; NULL+NULL -> NULL
+  // Long+NULL -> Long; NULL+Long -> Long
   if (lhs == DataType::Null) return rhs;
   if (rhs == DataType::Null) return lhs;
 

--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -84,7 +84,9 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const std::
   CurrentScheduler::wait_for_tasks(tasks);
 
   for (auto& segments : segments_by_chunks) {
-    table->append_chunk(segments);
+    DebugAssert(!segments.empty(), "Empty chunks shouldn't occur when importing CSV");
+    const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+    table->append_chunk(segments, mvcc_data);
   }
 
   return table;

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -61,19 +61,6 @@ void AbstractOperator::execute() {
 
 // returns the result of the operator
 std::shared_ptr<const Table> AbstractOperator::get_output() const {
-  DebugAssert(
-      [&]() {
-        if (!_output) return true;
-        if (_output->chunk_count() <= ChunkID{1}) return true;
-        for (auto chunk_id = ChunkID{0}; chunk_id < _output->chunk_count(); ++chunk_id) {
-          if (_output->get_chunk(chunk_id)->size() < 1) return true;
-        }
-        return true;
-      }(),
-      "Empty chunk returned from operator " + description());
-
-  DebugAssert(!_output || _output->column_count() > 0, "Operator " + description() + " did not output any columns");
-
   return _output;
 }
 

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -71,8 +71,6 @@ std::shared_ptr<const Table> AbstractOperator::get_output() const {
       }(),
       "Empty chunk returned from operator " + description());
 
-  DebugAssert(!_output || _output->column_count() > 0, "Operator " + description() + " did not output any columns");
-
   return _output;
 }
 

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -60,9 +60,7 @@ void AbstractOperator::execute() {
 }
 
 // returns the result of the operator
-std::shared_ptr<const Table> AbstractOperator::get_output() const {
-  return _output;
-}
+std::shared_ptr<const Table> AbstractOperator::get_output() const { return _output; }
 
 void AbstractOperator::clear_output() { _output = nullptr; }
 

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -52,8 +52,8 @@ std::shared_ptr<const Table> AliasOperator::_on_execute() {
   /**
    * Generate the output table, forwarding segments from the input chunks and ordering them according to _column_ids
    */
-  const auto output_table = std::make_shared<Table>(output_column_definitions, input_table.type(), std::nullopt,
-                                                    input_table.has_mvcc());
+  const auto output_table =
+      std::make_shared<Table>(output_column_definitions, input_table.type(), std::nullopt, input_table.has_mvcc());
 
   for (auto chunk_id = ChunkID{0}; chunk_id < input_table.chunk_count(); ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -34,14 +34,16 @@ std::shared_ptr<AbstractOperator> AliasOperator::_on_deep_copy(
 void AliasOperator::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<const Table> AliasOperator::_on_execute() {
+  const auto& input_table = *input_table_left();
+
   /**
    * Generate the new TableColumnDefinitions, that is, setting the new names for the columns
    */
   auto output_column_definitions = std::vector<TableColumnDefinition>{};
-  output_column_definitions.reserve(input_table_left()->column_count());
+  output_column_definitions.reserve(input_table.column_count());
 
-  for (auto column_id = ColumnID{0}; column_id < input_table_left()->column_count(); ++column_id) {
-    const auto& input_column_definition = input_table_left()->column_definitions()[_column_ids[column_id]];
+  for (auto column_id = ColumnID{0}; column_id < input_table.column_count(); ++column_id) {
+    const auto& input_column_definition = input_table.column_definitions()[_column_ids[column_id]];
 
     output_column_definitions.emplace_back(_aliases[column_id], input_column_definition.data_type,
                                            input_column_definition.nullable);
@@ -50,20 +52,20 @@ std::shared_ptr<const Table> AliasOperator::_on_execute() {
   /**
    * Generate the output table, forwarding segments from the input chunks and ordering them according to _column_ids
    */
-  const auto output_table = std::make_shared<Table>(output_column_definitions, input_table_left()->type(), std::nullopt,
-                                                    input_table_left()->has_mvcc());
+  const auto output_table = std::make_shared<Table>(output_column_definitions, input_table.type(), std::nullopt,
+                                                    input_table.has_mvcc());
 
-  for (auto chunk_id = ChunkID{0}; chunk_id < input_table_left()->chunk_count(); ++chunk_id) {
-    const auto input_chunk = input_table_left()->get_chunk(chunk_id);
+  for (auto chunk_id = ChunkID{0}; chunk_id < input_table.chunk_count(); ++chunk_id) {
+    const auto input_chunk = input_table.get_chunk(chunk_id);
 
     auto output_segments = Segments{};
-    output_segments.reserve(input_table_left()->column_count());
+    output_segments.reserve(input_table.column_count());
 
     for (const auto& column_id : _column_ids) {
       output_segments.emplace_back(input_chunk->get_segment(column_id));
     }
 
-    output_table->append_chunk(output_segments, input_chunk->get_allocator());
+    output_table->append_chunk(output_segments, input_chunk->mvcc_data(), input_chunk->get_allocator());
   }
 
   return output_table;

--- a/src/lib/operators/import_binary.cpp
+++ b/src/lib/operators/import_binary.cpp
@@ -138,7 +138,9 @@ void ImportBinary::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& ta
     output_segments.push_back(
         _import_segment(file, row_count, table->column_data_type(column_id), table->column_is_nullable(column_id)));
   }
-  table->append_chunk(output_segments);
+
+  const auto mvcc_data = std::make_shared<MvccData>(row_count, CommitID{0});
+  table->append_chunk(output_segments, mvcc_data);
 }
 
 std::shared_ptr<BaseSegment> ImportBinary::_import_segment(std::ifstream& file, ChunkOffset row_count,

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<AbstractTask> IndexScan::_create_job_and_schedule(const ChunkID 
     }
 
     std::lock_guard<std::mutex> lock(output_mutex);
-    _out_table->append_chunk(segments, chunk->get_allocator());
+    _out_table->append_chunk(segments, nullptr, chunk->get_allocator());
   });
 
   job_task->schedule();

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
             column_is_nullable[column_id] || input_table.column_is_nullable(pqp_column_expression->column_id);
 
       } else {
-        const auto output_segment = evaluator.evaluate_expression_to_segment(*expression);
+        auto output_segment = evaluator.evaluate_expression_to_segment(*expression);
         column_is_nullable[column_id] = column_is_nullable[column_id] || output_segment->is_nullable();
         output_segments[column_id] = std::move(output_segment);
       }

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -13,6 +13,7 @@
 #include "expression/pqp_column_expression.hpp"
 #include "expression/value_expression.hpp"
 #include "utils/assert.hpp"
+#include "utils/timer.hpp"
 
 namespace opossum {
 
@@ -37,16 +38,18 @@ void Projection::_on_set_transaction_context(const std::weak_ptr<TransactionCont
 }
 
 std::shared_ptr<const Table> Projection::_on_execute() {
+  const auto& input_table = *input_table_left();
+
   /**
    * If an expression is a PQPColumnExpression then it might be possible to forward the input column, if the
-   * input TableType (References or Data) matches the output column type.
+   * input TableType (References or Data) matches the output column type (ReferenceSegment or not).
    */
   const auto only_projects_columns = std::all_of(expressions.begin(), expressions.end(), [&](const auto& expression) {
     return expression->type == ExpressionType::PQPColumn;
   });
 
-  const auto output_table_type = only_projects_columns ? input_table_left()->type() : TableType::Data;
-  const auto forward_columns = input_table_left()->type() == output_table_type;
+  const auto output_table_type = only_projects_columns ? input_table.type() : TableType::Data;
+  const auto forward_columns = input_table.type() == output_table_type;
 
   const auto uncorrelated_subquery_results =
       ExpressionEvaluator::populate_uncorrelated_subquery_results_cache(expressions);
@@ -56,27 +59,28 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   /**
    * Perform the projection
    */
-  auto output_chunk_segments = std::vector<Segments>(input_table_left()->chunk_count());
+  auto output_chunk_segments = std::vector<Segments>(input_table.chunk_count());
 
-  for (auto chunk_id = ChunkID{0}; chunk_id < input_table_left()->chunk_count(); ++chunk_id) {
-    Segments output_segments;
-    output_segments.reserve(expressions.size());
+  for (auto chunk_id = ChunkID{0}; chunk_id < input_table.chunk_count(); ++chunk_id) {
+    auto output_segments = Segments{expressions.size()};
 
-    const auto input_chunk = input_table_left()->get_chunk(chunk_id);
+    const auto input_chunk = input_table.get_chunk(chunk_id);
 
-    ExpressionEvaluator evaluator(input_table_left(), chunk_id, uncorrelated_subquery_results);
     for (auto column_id = ColumnID{0}; column_id < expressions.size(); ++column_id) {
       const auto& expression = expressions[column_id];
+
       // Forward input column if possible
       if (expression->type == ExpressionType::PQPColumn && forward_columns) {
-        const auto pqp_column_expression = std::dynamic_pointer_cast<PQPColumnExpression>(expression);
-        output_segments.emplace_back(input_chunk->get_segment(pqp_column_expression->column_id));
+        const auto pqp_column_expression = std::static_pointer_cast<PQPColumnExpression>(expression);
+        output_segments[column_id] = input_chunk->get_segment(pqp_column_expression->column_id);
         column_is_nullable[column_id] =
-            column_is_nullable[column_id] || input_table_left()->column_is_nullable(pqp_column_expression->column_id);
+            column_is_nullable[column_id] || input_table.column_is_nullable(pqp_column_expression->column_id);
+
       } else {
+        ExpressionEvaluator evaluator(input_table_left(), chunk_id, uncorrelated_subquery_results);
         const auto output_segment = evaluator.evaluate_expression_to_segment(*expression);
-        output_segments.emplace_back(output_segment);
         column_is_nullable[column_id] = column_is_nullable[column_id] || output_segment->is_nullable();
+        output_segments[column_id] = std::move(output_segment);
       }
     }
 
@@ -93,11 +97,10 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   }
 
   const auto output_table =
-      std::make_shared<Table>(column_definitions, output_table_type, std::nullopt, input_table_left()->has_mvcc());
+      std::make_shared<Table>(column_definitions, output_table_type, std::nullopt, input_table.has_mvcc());
 
-  for (auto chunk_id = ChunkID{0}; chunk_id < input_table_left()->chunk_count(); ++chunk_id) {
-    output_table->append_chunk(output_chunk_segments[chunk_id]);
-    output_table->get_chunk(chunk_id)->set_mvcc_data(input_table_left()->get_chunk(chunk_id)->mvcc_data());
+  for (auto chunk_id = ChunkID{0}; chunk_id < input_table.chunk_count(); ++chunk_id) {
+    output_table->append_chunk(output_chunk_segments[chunk_id], input_table.get_chunk(chunk_id)->mvcc_data());
   }
 
   return output_table;

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -13,7 +13,6 @@
 #include "expression/pqp_column_expression.hpp"
 #include "expression/value_expression.hpp"
 #include "utils/assert.hpp"
-#include "utils/timer.hpp"
 
 namespace opossum {
 
@@ -38,8 +37,6 @@ void Projection::_on_set_transaction_context(const std::weak_ptr<TransactionCont
 }
 
 std::shared_ptr<const Table> Projection::_on_execute() {
-  Timer t;
-
   const auto& input_table = *input_table_left();
 
   /**

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -155,7 +155,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
       }
 
       std::lock_guard<std::mutex> lock(output_mutex);
-      output_table->append_chunk(out_segments, chunk_guard->get_allocator());
+      output_table->append_chunk(out_segments, nullptr, chunk_guard->get_allocator());
     });
 
     jobs.push_back(job_task);

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -75,6 +75,8 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
     return early_result;
   }
 
+  const auto& left_input_table = *input_table_left();
+
   /**
    * For each input, create a ReferenceMatrix
    */
@@ -84,7 +86,7 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
   /**
    * Init the virtual pos lists
    */
-  VirtualPosList virtual_pos_list_left(input_table_left()->row_count(), 0u);
+  VirtualPosList virtual_pos_list_left(left_input_table.row_count(), 0u);
   std::iota(virtual_pos_list_left.begin(), virtual_pos_list_left.end(), 0u);
   VirtualPosList virtual_pos_list_right(input_table_right()->row_count(), 0u);
   std::iota(virtual_pos_list_right.begin(), virtual_pos_list_right.end(), 0u);
@@ -107,7 +109,7 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
   const auto num_rows_left = virtual_pos_list_left.size();
   const auto num_rows_right = virtual_pos_list_right.size();
 
-  auto out_table = std::make_shared<Table>(input_table_left()->column_definitions(), TableType::References);
+  auto out_table = std::make_shared<Table>(left_input_table.column_definitions(), TableType::References);
 
   std::vector<std::shared_ptr<PosList>> pos_lists(reference_matrix_left.size());
   std::generate(pos_lists.begin(), pos_lists.end(), [&] { return std::make_shared<PosList>(); });
@@ -126,7 +128,7 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
     for (size_t pos_lists_idx = 0; pos_lists_idx < pos_lists.size(); ++pos_lists_idx) {
       const auto cluster_column_id_begin = _column_cluster_offsets[pos_lists_idx];
       const auto cluster_column_id_end = pos_lists_idx >= _column_cluster_offsets.size() - 1
-                                             ? input_table_left()->column_count()
+                                             ? left_input_table.column_count()
                                              : _column_cluster_offsets[pos_lists_idx + 1];
       for (auto column_id = cluster_column_id_begin; column_id < cluster_column_id_end; ++column_id) {
         auto ref_segment = std::make_shared<ReferenceSegment>(
@@ -145,7 +147,7 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
    */
 
   // Somewhat random way to decide on a chunk size.
-  const auto out_chunk_size = std::max(input_table_left()->max_chunk_size(), input_table_right()->max_chunk_size());
+  const auto out_chunk_size = std::max(left_input_table.max_chunk_size(), input_table_right()->max_chunk_size());
 
   size_t chunk_row_idx = 0;
   for (; left_idx < num_rows_left || right_idx < num_rows_right;) {

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -83,8 +83,6 @@ SharedScopedLockingPtr<MvccData> Chunk::get_scoped_mvcc_data_lock() const {
 
 std::shared_ptr<MvccData> Chunk::mvcc_data() const { return _mvcc_data; }
 
-void Chunk::set_mvcc_data(const std::shared_ptr<MvccData>& mvcc_data) { _mvcc_data = mvcc_data; }
-
 std::vector<std::shared_ptr<BaseIndex>> Chunk::get_indices(
     const std::vector<std::shared_ptr<const BaseSegment>>& segments) const {
   auto result = std::vector<std::shared_ptr<BaseIndex>>();

--- a/src/lib/storage/chunk.hpp
+++ b/src/lib/storage/chunk.hpp
@@ -95,7 +95,6 @@ class Chunk : private Noncopyable {
   SharedScopedLockingPtr<MvccData> get_scoped_mvcc_data_lock() const;
 
   std::shared_ptr<MvccData> mvcc_data() const;
-  void set_mvcc_data(const std::shared_ptr<MvccData>& mvcc_data);
 
   std::vector<std::shared_ptr<BaseIndex>> get_indices(
       const std::vector<std::shared_ptr<const BaseSegment>>& segments) const;

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -12,7 +12,6 @@
 #include "statistics/table_statistics.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
-#include "utils/timer.hpp"
 #include "value_segment.hpp"
 
 namespace opossum {

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -13,6 +13,7 @@
 #include "types.hpp"
 #include "utils/assert.hpp"
 #include "value_segment.hpp"
+#include "utils/timer.hpp"
 
 namespace opossum {
 
@@ -144,7 +145,7 @@ void Table::remove_chunk(ChunkID chunk_id) {
   _chunks[chunk_id] = nullptr;
 }
 
-void Table::append_chunk(const Segments& segments, const std::optional<PolymorphicAllocator<Chunk>>& alloc) {
+void Table::append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data, const std::optional<PolymorphicAllocator<Chunk>>& alloc) {
   const auto chunk_size = segments.empty() ? 0u : segments[0]->size();
 
 #if HYRISE_DEBUG
@@ -162,10 +163,7 @@ void Table::append_chunk(const Segments& segments, const std::optional<Polymorph
   }
 #endif
 
-  std::shared_ptr<MvccData> mvcc_data;
-
-  if (_use_mvcc == UseMvcc::Yes) {
-    // append_chunk is a helper method and rows are made visible immediately
+  if (_use_mvcc == UseMvcc::Yes && !mvcc_data) {
     mvcc_data = std::make_shared<MvccData>(chunk_size, CommitID{0});
   }
 

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -100,7 +100,8 @@ class Table : private Noncopyable {
    * @param mvcc_data   If the Table uses MVCC, this can optionally be passed in. If the Table uses MVCC and no
    *                    mvcc_data is supplied, MvccData will be allocated.
    */
-  void append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data = {}, const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt);
+  void append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data = {},
+                    const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt);
 
   /**
    * Appends an existing chunk to this table.

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -95,11 +95,12 @@ class Table : private Noncopyable {
   /**
    * Creates a new Chunk and appends it to this table.
    * Makes sure the @param segments match with the TableType (only ReferenceSegments or only data containing segments)
-   * En/Disables MVCC for the Chunk depending on whether MVCC is enabled for the table (has_mvcc())
    * This is a convenience method to enable automatically creating a chunk with correct settings given a set of segments.
-   * @param alloc
+   *
+   * @param mvcc_data   If the Table uses MVCC, this can optionally be passed in. If the Table uses MVCC and no
+   *                    mvcc_data is supplied, MvccData will be allocated.
    */
-  void append_chunk(const Segments& segments, const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt);
+  void append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data = {}, const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt);
 
   /**
    * Appends an existing chunk to this table.

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -97,7 +97,7 @@ class Table : private Noncopyable {
    * Makes sure the @param segments match with the TableType (only ReferenceSegments or only data containing segments)
    * This is a convenience method to enable automatically creating a chunk with correct settings given a set of segments.
    *
-   * @param mvcc_data   Has to be passed in iff the Table is a data Table which uses MVCC
+   * @param mvcc_data   Has to be passed in iff the Table is a data Table that uses MVCC
    */
   void append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data = nullptr,
                     const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt);

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -97,10 +97,9 @@ class Table : private Noncopyable {
    * Makes sure the @param segments match with the TableType (only ReferenceSegments or only data containing segments)
    * This is a convenience method to enable automatically creating a chunk with correct settings given a set of segments.
    *
-   * @param mvcc_data   If the Table uses MVCC, this can optionally be passed in. If the Table uses MVCC and no
-   *                    mvcc_data is supplied, MvccData will be allocated.
+   * @param mvcc_data   Has to be passed in iff the Table is a data Table which uses MVCC
    */
-  void append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data = {},
+  void append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvcc_data = nullptr,
                     const std::optional<PolymorphicAllocator<Chunk>>& alloc = std::nullopt);
 
   /**

--- a/src/test/operators/import_csv_test.cpp
+++ b/src/test/operators/import_csv_test.cpp
@@ -58,10 +58,17 @@ TEST_F(OperatorsImportCsvTest, StringEscaping) {
   EXPECT_TABLE_EQ_ORDERED(importer->get_output(), expected_table);
 }
 
-TEST_F(OperatorsImportCsvTest, EmptyFile) {
+TEST_F(OperatorsImportCsvTest, NoRows) {
   auto importer = std::make_shared<ImportCsv>("resources/test_data/csv/float_int_empty.csv");
   importer->execute();
   std::shared_ptr<Table> expected_table = load_table("resources/test_data/tbl/float_int_empty.tbl", 2);
+  EXPECT_TABLE_EQ_ORDERED(importer->get_output(), expected_table);
+}
+
+TEST_F(OperatorsImportCsvTest, NoRowsNoColumns) {
+  auto importer = std::make_shared<ImportCsv>("resources/test_data/csv/no_columns.csv");
+  importer->execute();
+  std::shared_ptr<Table> expected_table = std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data);
   EXPECT_TABLE_EQ_ORDERED(importer->get_output(), expected_table);
 }
 


### PR DESCRIPTION
Fix #1645 

Also, avoid redundant calls to `input_table_left()` for each `Chunk` to save a shared_ptr copy.
Also, remove `Chunk::set_mvcc_data()` because it isn't needed anymore since `Table::append_chunk()` now takes the new Chunk's MvccData as well. One entry point less for potential concurrency problems.

TPC-H with sf=5 
```
+----------------+-----------------+------+-----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s    | runs | new iter/s      | runs | change [%] | p-value (significant if <0.001) |
+----------------+-----------------+------+-----------------+------+------------+---------------------------------+
| TPC-H 1        | 0.0490739420056 | 10   | 0.0489541068673 | 10   | -0%        |                          0.4264 |
| TPC-H 2        | 0.671977341175  | 60   | 0.730327427387  | 60   | +9%        |                          0.0000 |
| TPC-H 3        | 0.448871999979  | 60   | 0.448813527822  | 60   | -0%        |                          0.9500 |
| TPC-H 4        | 0.203322425485  | 41   | 0.208486706018  | 42   | +3%        |                          0.0162 |
| TPC-H 5        | 0.277782648802  | 56   | 0.319226652384  | 60   | +15%       |                          0.0000 |
| TPC-H 6        | 0.775415897369  | 60   | 0.792824447155  | 60   | +2%        |                          0.0666 |
| TPC-H 7        | 0.0973886549473 | 20   | 0.0974526852369 | 20   | +0%        |                          0.9659 |
| TPC-H 8        | 0.429121643305  | 60   | 0.514973104     | 60   | +20%       |                          0.0000 |
| TPC-H 9        | 0.113636538386  | 23   | 0.121970623732  | 25   | +7%        |                          0.0000 |
| TPC-H 10       | 0.216463521123  | 44   | 0.217899993062  | 44   | +1%        |                          0.0378 |
| TPC-H 11       | 2.28297924995   | 60   | 3.03103637695   | 60   | +33%       |     (run time too short) 0.0000 |
| TPC-H 12       | 0.699244916439  | 60   | 0.761795580387  | 60   | +9%        |                          0.0000 |
| TPC-H 13       | 0.157237693667  | 32   | 0.158344879746  | 32   | +1%        |                          0.3682 |
| TPC-H 14       | 1.7351616621    | 60   | 1.76626610756   | 60   | +2%        |     (run time too short) 0.0002 |
| TPC-H 15       | 1.3223618269    | 60   | 1.32369995117   | 60   | +0%        |     (run time too short) 0.6888 |
| TPC-H 16       | 0.699989378452  | 60   | 0.726635456085  | 60   | +4%        |                          0.0000 |
| TPC-H 17       | 0.071922019124  | 15   | 0.0755068510771 | 16   | +5%        |                          0.0000 |
| TPC-H 18       | 0.147115588188  | 30   | 0.171241939068  | 35   | +16%       |                          0.0000 |
| TPC-H 19       | 0.483642876148  | 60   | 0.48078635335   | 60   | -1%        |                          0.5958 |
| TPC-H 20       | 0.146263256669  | 30   | 0.147148549557  | 30   | +1%        |                          0.0003 |
| TPC-H 21       | 0.0334587022662 | 7    | 0.0333742797375 | 7    | -0%        |        (not enough runs) 0.5848 |
| TPC-H 22       | 0.900039494038  | 60   | 0.896938681602  | 60   | -0%        |                          0.2104 |
| geometric mean |                 |      |                 |      | +5%        |                                 |
+----------------+-----------------+------+-----------------+------+------------+---------------------------------+
```