### PR TITLE
Fix console crashing on exit

### DIFF
--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -1081,6 +1081,10 @@ bool Console::_handle_rollback() {
 }  // namespace opossum
 
 int main(int argc, char** argv) {
+  // Make sure the TransactionManager is initialized before the console so that we don't run into destruction order
+  // problems (#1635)
+  opossum::TransactionManager::get();
+
   using Return = opossum::Console::ReturnCode;
   auto& console = opossum::Console::get();
 


### PR DESCRIPTION
fixes #1635

> Static destruction order... -.-

> The console is static so that the signal handler can find it. The console gets initialized first. The SQL pipeline needs a transaction context, so it calls `TransactionManager::get().new_transaction_context()`, which initializes the static transaction manager. On destruction, the transaction manager was created last and gets destructed first. Next, the console, and with it, the last SQL pipeline is destructed. The pipeline has a context which cannot be deregistered in the now defunct transaction manager.