### PR TITLE
Use JoinOperator::supports() to find a matching Join implementation for a JoinNode

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -121,10 +121,11 @@ SELECT * FROM (SELECT "right".a a, "left".b b FROM mixed AS "left" LEFT JOIN mix
 SELECT * FROM mixed AS m1 JOIN mixed AS m2 ON m1.id * 3 = m2.id - 5;
 SELECT l.id, r.id + 10 AS a FROM (SELECT id + 5 AS id FROM mixed WHERE id > 90) AS l LEFT JOIN mixed AS r ON l.id = r.id
 SELECT (SELECT r.id AS a FROM (SELECT id + 5 AS id FROM mixed) AS l LEFT JOIN mixed AS r ON l.id = r.id WHERE l.id >= 100 LIMIT 1) + 5 AS a
--- #1527 SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a < t2.a;
--- #1527 SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a > t2.a;
+SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a < t2.a;
+SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a > t2.a;
 SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a <= t2.a;
 SELECT * FROM id_int_int_int_100 AS t1 LEFT JOIN id_int_int_int_100 AS t2 ON t1.a >= t2.a;
+SELECT * FROM mixed AS t1 LEFT JOIN mixed AS t2 ON t1.id >= t2.b WHERE t1.id > 90;
 
 -- Join multiple predicates
 SELECT * FROM mixed AS t1 JOIN mixed_null AS t2 ON t1.a = t2.a AND t1.b = t2.b;

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -319,6 +319,8 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_join_node(
   const auto left_data_type = join_node->join_predicates().front()->arguments[0]->data_type();
   const auto right_data_type = join_node->join_predicates().front()->arguments[1]->data_type();
 
+  // Lacking a proper cost model, we assume JoinHash is always faster than JoinSortMerge, which is faster than
+  // JoinNestedLoop and thus check for an operator compatible with the JoinNode in that order
   boost::hana::for_each(
       hana::to_tuple(hana::tuple_t<JoinHash, JoinSortMerge, JoinNestedLoop>), [&](const auto join_operator_t) {
         using JoinOperator = typename decltype(join_operator_t)::type;

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -321,19 +321,20 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_join_node(
 
   // Lacking a proper cost model, we assume JoinHash is always faster than JoinSortMerge, which is faster than
   // JoinNestedLoop and thus check for an operator compatible with the JoinNode in that order
-  boost::hana::for_each(
-      hana::to_tuple(hana::tuple_t<JoinHash, JoinSortMerge, JoinNestedLoop>), [&](const auto join_operator_t) {
-        using JoinOperator = typename decltype(join_operator_t)::type;
+  constexpr auto join_operator_preference_order =
+      hana::to_tuple(hana::tuple_t<JoinHash, JoinSortMerge, JoinNestedLoop>);
 
-        if (join_operator) return;
+  boost::hana::for_each(join_operator_preference_order, [&](const auto join_operator_t) {
+    using JoinOperator = typename decltype(join_operator_t)::type;
 
-        if (JoinOperator::supports(join_node->join_mode, primary_join_predicate.predicate_condition, left_data_type,
-                                   right_data_type, !secondary_join_predicates.empty())) {
-          join_operator =
-              std::make_shared<JoinOperator>(input_left_operator, input_right_operator, join_node->join_mode,
-                                             primary_join_predicate, std::move(secondary_join_predicates));
-        }
-      });
+    if (join_operator) return;
+
+    if (JoinOperator::supports(join_node->join_mode, primary_join_predicate.predicate_condition, left_data_type,
+                               right_data_type, !secondary_join_predicates.empty())) {
+      join_operator = std::make_shared<JoinOperator>(input_left_operator, input_right_operator, join_node->join_mode,
+                                                     primary_join_predicate, std::move(secondary_join_predicates));
+    }
+  });
 
   Assert(join_operator, "No operator implementation available for join '"s + join_node->description() + "'");
 

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -5,6 +5,9 @@
 #include <string>
 #include <vector>
 
+#include <boost/hana/for_each.hpp>
+#include <boost/hana/tuple.hpp>
+
 #include "abstract_lqp_node.hpp"
 #include "aggregate_node.hpp"
 #include "alias_node.hpp"
@@ -37,6 +40,7 @@
 #include "operators/index_scan.hpp"
 #include "operators/insert.hpp"
 #include "operators/join_hash.hpp"
+#include "operators/join_nested_loop.hpp"
 #include "operators/join_sort_merge.hpp"
 #include "operators/limit.hpp"
 #include "operators/maintenance/create_prepared_plan.hpp"
@@ -310,14 +314,25 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_join_node(
   const auto& primary_join_predicate = join_predicates.front();
   std::vector<OperatorJoinPredicate> secondary_join_predicates(join_predicates.cbegin() + 1, join_predicates.cend());
 
-  if (primary_join_predicate.predicate_condition == PredicateCondition::Equals &&
-      join_node->join_mode != JoinMode::FullOuter) {
-    return std::make_shared<JoinHash>(input_left_operator, input_right_operator, join_node->join_mode,
-                                      primary_join_predicate, std::move(secondary_join_predicates));
-  } else {
-    return std::make_shared<JoinSortMerge>(input_left_operator, input_right_operator, join_node->join_mode,
-                                           primary_join_predicate, std::move(secondary_join_predicates));
-  }
+  auto join_operator = std::shared_ptr<AbstractOperator>{};
+
+  const auto left_data_type = join_node->join_predicates().front()->arguments[0]->data_type();
+  const auto right_data_type = join_node->join_predicates().front()->arguments[1]->data_type();
+
+  boost::hana::for_each(hana::to_tuple(hana::tuple_t<JoinHash, JoinSortMerge, JoinNestedLoop>), [&](const auto join_operator_t) {
+    using JoinOperator = typename decltype(join_operator_t)::type;
+
+    if (join_operator) return;
+
+    if (JoinOperator::supports(join_node->join_mode, primary_join_predicate.predicate_condition, left_data_type, right_data_type, !secondary_join_predicates.empty())) {
+      join_operator = std::make_shared<JoinOperator>(input_left_operator, input_right_operator, join_node->join_mode,
+                                                     primary_join_predicate, std::move(secondary_join_predicates));
+    }
+  });
+
+  Assert(join_operator, "No operator implementation available for join '"s + join_node->description() + "'");
+
+  return join_operator;
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_aggregate_node(

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -321,10 +321,10 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_join_node(
 
   // Lacking a proper cost model, we assume JoinHash is always faster than JoinSortMerge, which is faster than
   // JoinNestedLoop and thus check for an operator compatible with the JoinNode in that order
-  constexpr auto join_operator_preference_order =
+  constexpr auto JOIN_OPERATOR_PREFERENCE_ORDER =
       hana::to_tuple(hana::tuple_t<JoinHash, JoinSortMerge, JoinNestedLoop>);
 
-  boost::hana::for_each(join_operator_preference_order, [&](const auto join_operator_t) {
+  boost::hana::for_each(JOIN_OPERATOR_PREFERENCE_ORDER, [&](const auto join_operator_t) {
     using JoinOperator = typename decltype(join_operator_t)::type;
 
     if (join_operator) return;

--- a/src/test/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/lqp_translator_test.cpp
@@ -523,7 +523,7 @@ TEST_F(LQPTranslatorTest, JoinNodeToJoinHash) {
   const auto op = LQPTranslator{}.translate_node(join_node);
 
   /**
-   * Check PQP
+   * Check PQP - for a inner-equi join, JoinHash should be used.
    */
   const auto join_op = std::dynamic_pointer_cast<JoinHash>(op);
   ASSERT_TRUE(join_op);
@@ -541,7 +541,7 @@ TEST_F(LQPTranslatorTest, JoinNodeToJoinSortMerge) {
   const auto op = LQPTranslator{}.translate_node(join_node);
 
   /**
-   * Check PQP
+   * Check PQP - JoinHash doesn't support non-equi joins, thus we fall back to JoinSortMerge
    */
   const auto join_op = std::dynamic_pointer_cast<JoinSortMerge>(op);
   ASSERT_TRUE(join_op);
@@ -559,7 +559,8 @@ TEST_F(LQPTranslatorTest, JoinNodeToJoinNestedLoop) {
   const auto op = LQPTranslator{}.translate_node(join_node);
 
   /**
-   * Check PQP
+   * Check PQP - Neither JoinHash nor JoinSortMerge support non-equi joins on different column types. So we fall back to
+   * JoinNestedLoop.
    */
   const auto join_op = std::dynamic_pointer_cast<JoinNestedLoop>(op);
   ASSERT_TRUE(join_op);

--- a/src/test/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/lqp_translator_test.cpp
@@ -32,6 +32,7 @@
 #include "operators/index_scan.hpp"
 #include "operators/join_hash.hpp"
 #include "operators/join_sort_merge.hpp"
+#include "operators/join_nested_loop.hpp"
 #include "operators/limit.hpp"
 #include "operators/maintenance/create_prepared_plan.hpp"
 #include "operators/maintenance/create_table.hpp"
@@ -348,38 +349,6 @@ TEST_F(LQPTranslatorTest, Sort) {
   ASSERT_TRUE(get_table);
 }
 
-TEST_F(LQPTranslatorTest, JoinNonEqui) {
-  /**
-   * Build LQP and translate to PQP
-   *
-   * LQP resembles:
-   *   SELECT * FROM int_float2 JOIN int_float ON int_float.a < int_float2.b
-   */
-  // clang-format off
-  const auto lqp =
-  JoinNode::make(JoinMode::Inner, less_than_(int_float_a, int_float2_b),
-    int_float2_node, int_float_node);
-  // clang-format on
-  const auto pqp = LQPTranslator{}.translate_node(lqp);
-
-  /**
-   * Check PQP
-   */
-  const auto join_sort_merge = std::dynamic_pointer_cast<JoinSortMerge>(pqp);
-  ASSERT_TRUE(join_sort_merge);
-  EXPECT_EQ(join_sort_merge->primary_predicate().column_ids.first, ColumnID{1});
-  EXPECT_EQ(join_sort_merge->primary_predicate().column_ids.second, ColumnID{0});
-  EXPECT_EQ(join_sort_merge->primary_predicate().predicate_condition, PredicateCondition::GreaterThan);
-
-  const auto get_table_int_float2 = std::dynamic_pointer_cast<const GetTable>(join_sort_merge->input_left());
-  ASSERT_TRUE(get_table_int_float2);
-  EXPECT_EQ(get_table_int_float2->table_name(), "table_int_float2");
-
-  const auto get_table_int_float = std::dynamic_pointer_cast<const GetTable>(join_sort_merge->input_right());
-  ASSERT_TRUE(get_table_int_float);
-  EXPECT_EQ(get_table_int_float->table_name(), "table_int_float");
-}
-
 TEST_F(LQPTranslatorTest, LimitLiteral) {
   /**
    * Build LQP and translate to PQP
@@ -546,12 +515,30 @@ TEST_F(LQPTranslatorTest, ProjectionNode) {
   EXPECT_EQ(*projection_op->expressions[0], *PQPColumnExpression::from_table(*table_int_float, "a"));
 }
 
-TEST_F(LQPTranslatorTest, JoinNode) {
+TEST_F(LQPTranslatorTest, JoinNodeToJoinHash) {
   /**
    * Build LQP and translate to PQP
    */
   auto join_node =
-      JoinNode::make(JoinMode::FullOuter, equals_(int_float_b, int_float2_a), int_float_node, int_float2_node);
+      JoinNode::make(JoinMode::Inner, equals_(int_float2_b, int_float_b), int_float_node, int_float2_node);
+  const auto op = LQPTranslator{}.translate_node(join_node);
+
+  /**
+   * Check PQP
+   */
+  const auto join_op = std::dynamic_pointer_cast<JoinHash>(op);
+  ASSERT_TRUE(join_op);
+  EXPECT_EQ(join_op->primary_predicate().column_ids, ColumnIDPair(ColumnID{1}, ColumnID{0}));
+  EXPECT_EQ(join_op->primary_predicate().predicate_condition, PredicateCondition::Equals);
+  EXPECT_EQ(join_op->mode(), JoinMode::Inner);
+}
+
+TEST_F(LQPTranslatorTest, JoinNodeToJoinSortMerge) {
+  /**
+   * Build LQP and translate to PQP
+   */
+  auto join_node =
+      JoinNode::make(JoinMode::Inner, less_than_(int_float_b, int_float2_b), int_float_node, int_float2_node);
   const auto op = LQPTranslator{}.translate_node(join_node);
 
   /**
@@ -559,9 +546,27 @@ TEST_F(LQPTranslatorTest, JoinNode) {
    */
   const auto join_op = std::dynamic_pointer_cast<JoinSortMerge>(op);
   ASSERT_TRUE(join_op);
-  EXPECT_EQ(join_op->primary_predicate().column_ids, ColumnIDPair(ColumnID{1}, ColumnID{0}));
-  EXPECT_EQ(join_op->primary_predicate().predicate_condition, PredicateCondition::Equals);
-  EXPECT_EQ(join_op->mode(), JoinMode::FullOuter);
+  EXPECT_EQ(join_op->primary_predicate().column_ids, ColumnIDPair(ColumnID{1}, ColumnID{1}));
+  EXPECT_EQ(join_op->primary_predicate().predicate_condition, PredicateCondition::LessThan);
+  EXPECT_EQ(join_op->mode(), JoinMode::Inner);
+}
+
+TEST_F(LQPTranslatorTest, JoinNodeToJoinNestedLoop) {
+  /**
+   * Build LQP and translate to PQP
+   */
+  auto join_node =
+      JoinNode::make(JoinMode::Inner, less_than_(int_float_a, int_float2_b), int_float_node, int_float2_node);
+  const auto op = LQPTranslator{}.translate_node(join_node);
+
+  /**
+   * Check PQP
+   */
+  const auto join_op = std::dynamic_pointer_cast<JoinNestedLoop>(op);
+  ASSERT_TRUE(join_op);
+  EXPECT_EQ(join_op->primary_predicate().column_ids, ColumnIDPair(ColumnID{0}, ColumnID{1}));
+  EXPECT_EQ(join_op->primary_predicate().predicate_condition, PredicateCondition::LessThan);
+  EXPECT_EQ(join_op->mode(), JoinMode::Inner);
 }
 
 TEST_F(LQPTranslatorTest, ShowTablesNode) {

--- a/src/test/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/lqp_translator_test.cpp
@@ -31,8 +31,8 @@
 #include "operators/get_table.hpp"
 #include "operators/index_scan.hpp"
 #include "operators/join_hash.hpp"
-#include "operators/join_sort_merge.hpp"
 #include "operators/join_nested_loop.hpp"
+#include "operators/join_sort_merge.hpp"
 #include "operators/limit.hpp"
 #include "operators/maintenance/create_prepared_plan.hpp"
 #include "operators/maintenance/create_table.hpp"
@@ -519,8 +519,7 @@ TEST_F(LQPTranslatorTest, JoinNodeToJoinHash) {
   /**
    * Build LQP and translate to PQP
    */
-  auto join_node =
-      JoinNode::make(JoinMode::Inner, equals_(int_float2_b, int_float_b), int_float_node, int_float2_node);
+  auto join_node = JoinNode::make(JoinMode::Inner, equals_(int_float2_b, int_float_b), int_float_node, int_float2_node);
   const auto op = LQPTranslator{}.translate_node(join_node);
 
   /**
@@ -528,7 +527,7 @@ TEST_F(LQPTranslatorTest, JoinNodeToJoinHash) {
    */
   const auto join_op = std::dynamic_pointer_cast<JoinHash>(op);
   ASSERT_TRUE(join_op);
-  EXPECT_EQ(join_op->primary_predicate().column_ids, ColumnIDPair(ColumnID{1}, ColumnID{0}));
+  EXPECT_EQ(join_op->primary_predicate().column_ids, ColumnIDPair(ColumnID{1}, ColumnID{1}));
   EXPECT_EQ(join_op->primary_predicate().predicate_condition, PredicateCondition::Equals);
   EXPECT_EQ(join_op->mode(), JoinMode::Inner);
 }


### PR DESCRIPTION
Fix #1529 

Fall back from JoinHash to JoinSortMerge to JoinNestedLoop to find a matching Join operator for JoinNode.