### PR TITLE
Adapt supported encodings of FoR

### DIFF
--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -37,7 +37,7 @@ constexpr auto supported_data_types_for_encoding_type = hana::make_map(
     hana::make_pair(enum_c<EncodingType, EncodingType::Dictionary>, data_types),
     hana::make_pair(enum_c<EncodingType, EncodingType::RunLength>, data_types),
     hana::make_pair(enum_c<EncodingType, EncodingType::FixedStringDictionary>, hana::tuple_t<pmr_string>),
-    hana::make_pair(enum_c<EncodingType, EncodingType::FrameOfReference>, hana::tuple_t<int32_t, int64_t>),
+    hana::make_pair(enum_c<EncodingType, EncodingType::FrameOfReference>, hana::tuple_t<int32_t>),
     hana::make_pair(enum_c<EncodingType, EncodingType::LZ4>, data_types));
 
 /**

--- a/src/lib/storage/frame_of_reference_segment.cpp
+++ b/src/lib/storage/frame_of_reference_segment.cpp
@@ -88,6 +88,7 @@ std::optional<CompressedVectorType> FrameOfReferenceSegment<T, U>::compressed_ve
 }
 
 template class FrameOfReferenceSegment<int32_t>;
-template class FrameOfReferenceSegment<int64_t>;
+// int64_t disabled for now, as vector compression cannot handle 64 bit values
+// template class FrameOfReferenceSegment<int64_t>;
 
 }  // namespace opossum

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -167,10 +167,9 @@ class JoinTestRunner : public BaseTestWithParam<JoinTestConfiguration> {
     const auto all_input_table_types =
         std::vector{InputTableType::Data, InputTableType::IndividualPosLists, InputTableType::SharedPosList};
 
-    // TODO(anybody) include FrameOfReferenceEncoding once #1662 is resolved
     const auto all_encoding_types =
-        std::vector{EncodingType::Unencoded, EncodingType::RunLength, EncodingType::Dictionary,
-                    EncodingType::FixedStringDictionary, EncodingType::LZ4};
+        std::vector{EncodingType::Unencoded, EncodingType::Dictionary, EncodingType::FrameOfReference,
+                    EncodingType::FixedStringDictionary, EncodingType::RunLength, EncodingType::LZ4};
 
     // clang-format off
     JoinTestConfiguration default_configuration{


### PR DESCRIPTION
This PR disables the support of `int64_t` for FrameOfReverence segments.

During table generation for the calibration framework, I stumbled over the issue that Moritz found during the work on the join test runner as well. FrameOfReference segments do not support `uint64_t` values since the underlying vector compression only handles `uint32t` values (see discussion in #1662).

I would vote for extending the vector compression to default to `uint64_t` values, but that has several disadvantages (one of them compile time). And since SIMDBP adaptions do not appear to be too easy, I don't think it will be fixed within the next couple of weeks.

This change simply limits the usage of FrameOfReference segments. No benchmark I know of uses anything larger int and most users won't use FoR at all. So I think this limitation of FoR does not hurt.

Fix #1662.