### PR TITLE
Show hash join's radix bits in PQP

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -140,14 +140,14 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
           !std::is_same_v<pmr_string, BuildColumnDataType> && !std::is_same_v<pmr_string, ProbeColumnDataType>;
 
       if constexpr (BOTH_ARE_STRING || NEITHER_IS_STRING) {
-        auto join_impl = JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>(
+        auto join_impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(
             *this, build_input_table, probe_input_table, _mode, adjusted_column_ids,
             _primary_predicate.predicate_condition, output_column_order, _radix_bits,
             std::move(adjusted_secondary_predicates));
         if (!_radix_bits) {
-          _radix_bits = join_impl._radix_bits;
+          _radix_bits = join_impl->_radix_bits;
         }
-        _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(std::move(join_impl));
+        _impl = std::move(join_impl);
       } else {
         Fail("Cannot join String with non-String column");
       }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -66,7 +66,7 @@ void JoinHash::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeV
 
 template <typename T>
 size_t JoinHash::_calculate_radix_bits(const std::shared_ptr<const Table> build_table,
-    const std::shared_ptr<const Table> probe_table) {
+                                       const std::shared_ptr<const Table> probe_table) {
   /*
     Setting number of bits for radix clustering:
     The number of bits is used to create probe partitions with a size that can

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -184,8 +184,8 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
 
       if constexpr (BOTH_ARE_STRING || NEITHER_IS_STRING) {
         if (!_radix_bits) {
-          _radix_bits = calculate_radix_bits<BuildColumnDataType>(build_input_table->row_count(),
-                                                                   probe_input_table->row_count());
+          _radix_bits =
+              calculate_radix_bits<BuildColumnDataType>(build_input_table->row_count(), probe_input_table->row_count());
         }
 
         _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -145,10 +145,10 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
             *this, build_input_table, probe_input_table, _mode, adjusted_column_ids,
             _primary_predicate.predicate_condition, output_column_order, _radix_bits,
             std::move(adjusted_secondary_predicates));
-        _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(join_impl);
         if (!_radix_bits) {
           _radix_bits = join_impl._radix_bits;
         }
+        _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(std::move(join_impl));
       } else {
         Fail("Cannot join String with non-String column");
       }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -49,10 +49,9 @@ JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator>& left,
 const std::string JoinHash::name() const { return "JoinHash"; }
 
 const std::string JoinHash::description(DescriptionMode description_mode) const {
-  const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
   std::ostringstream stream;
   stream << AbstractJoinOperator::description(description_mode);
-  stream << separator << "Radix bits: " << (_radix_bits ? std::to_string(*_radix_bits) : "Unspecified");
+  stream << " Radix bits: " << (_radix_bits ? std::to_string(*_radix_bits) : "Unspecified");
   return stream.str();
 }
 

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -40,6 +40,9 @@ class JoinHash : public AbstractJoinOperator {
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
   void _on_cleanup() override;
 
+  template <typename T>
+  static size_t _calculate_radix_bits(const std::shared_ptr<const Table> build_table, const std::shared_ptr<const Table> probe_table);
+
   std::unique_ptr<AbstractReadOnlyOperatorImpl> _impl;
   std::optional<size_t> _radix_bits;
 

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -32,6 +32,9 @@ class JoinHash : public AbstractJoinOperator {
   const std::string name() const override;
   const std::string description(DescriptionMode description_mode) const override;
 
+  template <typename T>
+  static size_t calculate_radix_bits(const size_t build_relation_size, const size_t probe_relation_size);
+
  protected:
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
@@ -39,10 +42,6 @@ class JoinHash : public AbstractJoinOperator {
       const std::shared_ptr<AbstractOperator>& copied_input_right) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
   void _on_cleanup() override;
-
-  template <typename T>
-  static size_t _calculate_radix_bits(const std::shared_ptr<const Table> build_table,
-                                      const std::shared_ptr<const Table> probe_table);
 
   std::unique_ptr<AbstractReadOnlyOperatorImpl> _impl;
   std::optional<size_t> _radix_bits;

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -41,7 +41,8 @@ class JoinHash : public AbstractJoinOperator {
   void _on_cleanup() override;
 
   template <typename T>
-  static size_t _calculate_radix_bits(const std::shared_ptr<const Table> build_table, const std::shared_ptr<const Table> probe_table);
+  static size_t _calculate_radix_bits(const std::shared_ptr<const Table> build_table,
+                                      const std::shared_ptr<const Table> probe_table);
 
   std::unique_ptr<AbstractReadOnlyOperatorImpl> _impl;
   std::optional<size_t> _radix_bits;

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -41,7 +41,7 @@ class JoinHash : public AbstractJoinOperator {
   void _on_cleanup() override;
 
   std::unique_ptr<AbstractReadOnlyOperatorImpl> _impl;
-  const std::optional<size_t> _radix_bits;
+  std::optional<size_t> _radix_bits;
 
   template <typename LeftType, typename RightType>
   class JoinHashImpl;

--- a/src/test/operators/join_hash_test.cpp
+++ b/src/test/operators/join_hash_test.cpp
@@ -108,17 +108,18 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 }
 
 // TODO(Bouncner): enable with merge of #1714
-TEST(OperatorsJoinHashTestStatic, DISABLED_RadixBitCalculation) {
+TEST(OperatorsJoinHashTestStatic, DISABLED_RadixBitCalculation /* #1714 */) {
   // simple cases
   EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 1), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int>(0, 1), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 0), 0ul);
-  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()) > 0ul);
+  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(std::numeric_limits<size_t>::max(),
+                                                  std::numeric_limits<size_t>::max()) > 0ul);
 
   // Check that clusters are not larger than uint32_t (potential overflow in hash map offsets).
   // Such large inputs should be clustered into multiple partitions, even when the build side is small.
-  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(1, static_cast<size_t>(std::numeric_limits<uint32_t>::max() * 1.1)) > 1ul);
+  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(1, static_cast<size_t>(std::numeric_limits<uint32_t>::max() * 1.1)) >
+              1ul);
 }
-
 
 }  // namespace opossum

--- a/src/test/operators/join_hash_test.cpp
+++ b/src/test/operators/join_hash_test.cpp
@@ -60,7 +60,7 @@ TEST_F(OperatorsJoinHashTest, DISABLED_ChunkCount /* #698 */) {
                                          std::vector<OperatorJoinPredicate>{}, 10);
   join->execute();
 
-  // While radix clustering is well-suited for very large tables, it also yield many output tables.
+  // While radix clustering is well-suited for very large tables, it also yields many output tables.
   // This test checks whether we create more chunks that existing in the input (which should not be the case).
   EXPECT_TRUE(join->get_output()->chunk_count() <=
               std::max(_table_tpch_orders_scanned->get_output()->chunk_count(),
@@ -106,5 +106,19 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
   EXPECT_NE(join_operator_copy->input_left(), nullptr);
   EXPECT_NE(join_operator_copy->input_right(), nullptr);
 }
+
+// TODO(Bouncner): enable with merge of #1714
+TEST(OperatorsJoinHashTestStatic, DISABLED_RadixBitCalculation) {
+  // simple cases
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 1), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int>(0, 1), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 0), 0ul);
+  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()) > 0ul);
+
+  // Check that clusters are not larger than uint32_t (potential overflow in hash map offsets).
+  // Such large inputs should be clustered into multiple partitions, even when the build side is small.
+  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(1, static_cast<size_t>(std::numeric_limits<uint32_t>::max() * 1.1)) > 1ul);
+}
+
 
 }  // namespace opossum


### PR DESCRIPTION
This PR prints the number of radix bits (used in the hash join operator) in the PQP visualization. Before, it has only been printed, when it was set with the creation of the hash join operator.

When somebody is not happy with public mutable members, I am happy to take suggestions.

![image](https://user-images.githubusercontent.com/1745857/60022135-878c7980-9693-11e9-9dc5-376e81e0fa78.png)
