### PR TITLE
JoinIndex support index on both sides

### DIFF
--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -232,8 +232,8 @@ void JoinIndex::_append_matches(const ChunkID& probe_chunk_id, const ChunkOffset
 
 // join loop that joins two segments of two columns using an iterator for the probe side,
 // and an index for the index side
-template <typename LeftIterator>
-void JoinIndex::_join_two_segments_using_index(LeftIterator probe_iter, LeftIterator probe_end,
+template <typename ProbeIterator>
+void JoinIndex::_join_two_segments_using_index(ProbeIterator probe_iter, ProbeIterator probe_end,
                                                const ChunkID probe_chunk_id, const ChunkID index_chunk_id,
                                                const std::shared_ptr<BaseIndex>& index) {
   for (; probe_iter != probe_end; ++probe_iter) {

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -21,7 +21,7 @@
 namespace opossum {
 
 /*
- * This is an index join implementation. It expects to find an index on the right column.
+ * This is an index join implementation. It expects to find an index on the index side column.
  * It can be used for all join modes except JoinMode::Cross.
  * For the remaining join types or if no index is found it falls back to a nested loop join.
  */
@@ -34,12 +34,12 @@ bool JoinIndex::supports(JoinMode join_mode, PredicateCondition predicate_condit
 JoinIndex::JoinIndex(const std::shared_ptr<const AbstractOperator>& left,
                      const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                      const OperatorJoinPredicate& primary_predicate,
-                     const std::vector<OperatorJoinPredicate>& secondary_predicates, const JoinInputSide index_side)
+                     const std::vector<OperatorJoinPredicate>& secondary_predicates, const IndexSide index_side)
     : AbstractJoinOperator(OperatorType::JoinIndex, left, right, mode, primary_predicate, secondary_predicates,
                            std::make_unique<JoinIndex::PerformanceData>()),
       _index_side(index_side),
       _adjusted_primary_predicate(primary_predicate) {
-  if (_index_side == JoinInputSide::Left) {
+  if (_index_side == IndexSide::Left) {
     _adjusted_primary_predicate.flip();
   }
 }
@@ -65,7 +65,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
   std::shared_ptr<const Table> probe_input_table;
   std::shared_ptr<const Table> index_input_table;
 
-  if (_index_side == JoinInputSide::Left) {
+  if (_index_side == IndexSide::Left) {
     probe_input_table = input_table_right();
     index_input_table = input_table_left();
   } else {
@@ -83,14 +83,14 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
   const auto track_index_matches = _mode == JoinMode::FullOuter || _mode == JoinMode::Right;
 
   if (track_probe_matches) {
-    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < probe_input_table->chunk_count(); ++chunk_id_left) {
-      _probe_matches[chunk_id_left].resize(probe_input_table->get_chunk(chunk_id_left)->size());
+    for (ChunkID probe_chunk_id = ChunkID{0}; probe_chunk_id < probe_input_table->chunk_count(); ++probe_chunk_id) {
+      _probe_matches[probe_chunk_id].resize(probe_input_table->get_chunk(probe_chunk_id)->size());
     }
   }
 
   if (track_index_matches) {
-    for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < index_input_table->chunk_count(); ++chunk_id_right) {
-      _index_matches[chunk_id_right].resize(index_input_table->get_chunk(chunk_id_right)->size());
+    for (ChunkID index_chunk_id = ChunkID{0}; index_chunk_id < index_input_table->chunk_count(); ++index_chunk_id) {
+      _index_matches[index_chunk_id].resize(index_input_table->get_chunk(index_chunk_id)->size());
     }
   }
 
@@ -107,10 +107,10 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
 
   auto secondary_predicate_evaluator = MultiPredicateJoinEvaluator{*probe_input_table, *index_input_table, _mode, {}};
 
-  // Scan all chunks for right input
-  for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < index_input_table->chunk_count(); ++chunk_id_right) {
-    const auto chunk_right = index_input_table->get_chunk(chunk_id_right);
-    const auto indices = chunk_right->get_indices(std::vector<ColumnID>{_adjusted_primary_predicate.column_ids.second});
+  // Scan all chunks for index input
+  for (ChunkID index_chunk_id = ChunkID{0}; index_chunk_id < index_input_table->chunk_count(); ++index_chunk_id) {
+    const auto index_chunk = index_input_table->get_chunk(index_chunk_id);
+    const auto indices = index_chunk->get_indices(std::vector<ColumnID>{_adjusted_primary_predicate.column_ids.second});
     std::shared_ptr<BaseIndex> index = nullptr;
 
     if (!indices.empty()) {
@@ -119,53 +119,53 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
       index = indices.front();
     }
 
-    // Scan all chunks from left input
+    // Scan all chunks from the pruning side input
     if (index) {
-      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < probe_input_table->chunk_count(); ++chunk_id_left) {
-        const auto segment_left =
-            probe_input_table->get_chunk(chunk_id_left)->get_segment(_adjusted_primary_predicate.column_ids.first);
-        segment_with_iterators(*segment_left, [&](auto it, const auto end) {
-          _join_two_segments_using_index(it, end, chunk_id_left, chunk_id_right, index);
+      for (ChunkID probe_chunk_id = ChunkID{0}; probe_chunk_id < probe_input_table->chunk_count(); ++probe_chunk_id) {
+        const auto probe_segment =
+            probe_input_table->get_chunk(probe_chunk_id)->get_segment(_adjusted_primary_predicate.column_ids.first);
+        segment_with_iterators(*probe_segment, [&](auto it, const auto end) {
+          _join_two_segments_using_index(it, end, probe_chunk_id, index_chunk_id, index);
         });
       }
       performance_data.chunks_scanned_with_index++;
     } else {
       // Fall back to NestedLoopJoin
-      const auto segment_right =
-          index_input_table->get_chunk(chunk_id_right)->get_segment(_adjusted_primary_predicate.column_ids.second);
-      for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < probe_input_table->chunk_count(); ++chunk_id_left) {
-        const auto segment_left =
-            probe_input_table->get_chunk(chunk_id_left)->get_segment(_adjusted_primary_predicate.column_ids.first);
+      const auto index_segment =
+          index_input_table->get_chunk(index_chunk_id)->get_segment(_adjusted_primary_predicate.column_ids.second);
+      for (ChunkID probe_chunk_id = ChunkID{0}; probe_chunk_id < probe_input_table->chunk_count(); ++probe_chunk_id) {
+        const auto probe_segment =
+            probe_input_table->get_chunk(probe_chunk_id)->get_segment(_adjusted_primary_predicate.column_ids.first);
         JoinNestedLoop::JoinParams params{*_probe_pos_list,
                                           *_index_pos_list,
-                                          _probe_matches[chunk_id_left],
-                                          _index_matches[chunk_id_right],
+                                          _probe_matches[probe_chunk_id],
+                                          _index_matches[index_chunk_id],
                                           track_probe_matches,
                                           track_index_matches,
                                           _mode,
                                           _adjusted_primary_predicate.predicate_condition,
                                           secondary_predicate_evaluator,
                                           !is_semi_or_anti_join};
-        JoinNestedLoop::_join_two_untyped_segments(*segment_left, *segment_right, chunk_id_left, chunk_id_right,
+        JoinNestedLoop::_join_two_untyped_segments(*probe_segment, *index_segment, probe_chunk_id, index_chunk_id,
                                                    params);
       }
       performance_data.chunks_scanned_without_index++;
     }
   }
 
-  // For Full Outer and Left Join we need to add all unmatched rows for the left side
+  // For Full Outer and Left Join we need to add all unmatched rows for the probe side
   if (_mode == JoinMode::Left || _mode == JoinMode::FullOuter) {
-    for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < probe_input_table->chunk_count(); ++chunk_id_left) {
-      for (ChunkOffset chunk_offset{0}; chunk_offset < _probe_matches[chunk_id_left].size(); ++chunk_offset) {
-        if (!_probe_matches[chunk_id_left][chunk_offset]) {
-          _probe_pos_list->emplace_back(RowID{chunk_id_left, chunk_offset});
+    for (ChunkID probe_chunk_id = ChunkID{0}; probe_chunk_id < probe_input_table->chunk_count(); ++probe_chunk_id) {
+      for (ChunkOffset chunk_offset{0}; chunk_offset < _probe_matches[probe_chunk_id].size(); ++chunk_offset) {
+        if (!_probe_matches[probe_chunk_id][chunk_offset]) {
+          _probe_pos_list->emplace_back(RowID{probe_chunk_id, chunk_offset});
           _index_pos_list->emplace_back(NULL_ROW_ID);
         }
       }
     }
   }
 
-  // For Full Outer and Right Join we need to add all unmatched rows for the right side.
+  // For Full Outer and Right Join we need to add all unmatched rows for the index side.
   if (_mode == JoinMode::FullOuter || _mode == JoinMode::Right) {
     for (ChunkID chunk_id{0}; chunk_id < _index_matches.size(); ++chunk_id) {
       for (ChunkOffset chunk_offset{0}; chunk_offset < _index_matches[chunk_id].size(); ++chunk_offset) {
@@ -181,7 +181,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
   _index_pos_list->shrink_to_fit();
 
   // Write PosLists for Semi/Anti Joins, which so far haven't written any results to the PosLists
-  // We use `left_matches_by_chunk` to determine whether a tuple from the left side found a match.
+  // We use `probe_matches_by_chunk` to determine whether a tuple from the probe side found a match.
   if (is_semi_or_anti_join) {
     const auto invert = _mode == JoinMode::AntiNullAsFalse || _mode == JoinMode::AntiNullAsTrue;
 
@@ -198,14 +198,14 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
   // write output chunks
   Segments output_segments;
 
-  if (_index_side == JoinInputSide::Left) {
+  if (_index_side == IndexSide::Left) {
     _write_output_segments(output_segments, index_input_table, _index_pos_list);
   } else {
     _write_output_segments(output_segments, probe_input_table, _probe_pos_list);
   }
 
   if (!is_semi_or_anti_join) {
-    if (_index_side == JoinInputSide::Left) {
+    if (_index_side == IndexSide::Left) {
       _write_output_segments(output_segments, probe_input_table, _probe_pos_list);
     } else {
       _write_output_segments(output_segments, index_input_table, _index_pos_list);
@@ -222,60 +222,62 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
   return _build_output_table({std::make_shared<Chunk>(output_segments)});
 }
 
-void JoinIndex::_append_matches(const ChunkID& left_chunk_id, const ChunkOffset& left_chunk_offset,
-                                const PosList& right_table_matches) {
-  for (const auto& right_row_id : right_table_matches) {
-    _probe_pos_list->emplace_back(RowID{left_chunk_id, left_chunk_offset});
-    _index_pos_list->emplace_back((right_row_id));
+void JoinIndex::_append_matches(const ChunkID& probe_chunk_id, const ChunkOffset& probe_chunk_offset,
+                                const PosList& index_table_matches) {
+  for (const auto& index_side_row_id : index_table_matches) {
+    _probe_pos_list->emplace_back(RowID{probe_chunk_id, probe_chunk_offset});
+    _index_pos_list->emplace_back((index_side_row_id));
   }
 }
 
-// join loop that joins two segments of two columns using an iterator for the left, and an index for the right
+// join loop that joins two segments of two columns using an iterator for the probe side,
+// and an index for the index side
 template <typename LeftIterator>
-void JoinIndex::_join_two_segments_using_index(LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id_left,
-                                               const ChunkID chunk_id_right, const std::shared_ptr<BaseIndex>& index) {
-  for (; left_it != left_end; ++left_it) {
-    const auto left_value = *left_it;
-    if (left_value.is_null()) continue;
+void JoinIndex::_join_two_segments_using_index(LeftIterator probe_iter, LeftIterator probe_end,
+                                               const ChunkID probe_chunk_id, const ChunkID index_chunk_id,
+                                               const std::shared_ptr<BaseIndex>& index) {
+  for (; probe_iter != probe_end; ++probe_iter) {
+    const auto probe_side_value = *probe_iter;
+    if (probe_side_value.is_null()) continue;
 
     auto range_begin = BaseIndex::Iterator{};
     auto range_end = BaseIndex::Iterator{};
 
     switch (_adjusted_primary_predicate.predicate_condition) {
       case PredicateCondition::Equals: {
-        range_begin = index->lower_bound({left_value.value()});
-        range_end = index->upper_bound({left_value.value()});
+        range_begin = index->lower_bound({probe_side_value.value()});
+        range_end = index->upper_bound({probe_side_value.value()});
         break;
       }
       case PredicateCondition::NotEquals: {
         // first, get all values less than the search value
         range_begin = index->cbegin();
-        range_end = index->lower_bound({left_value.value()});
+        range_end = index->lower_bound({probe_side_value.value()});
 
-        _append_matches(range_begin, range_end, left_value.chunk_offset(), chunk_id_left, chunk_id_right);
+        _append_matches(range_begin, range_end, probe_side_value.chunk_offset(), probe_chunk_id, index_chunk_id);
 
         // set range for second half to all values greater than the search value
-        range_begin = index->upper_bound({left_value.value()});
+        range_begin = index->upper_bound({probe_side_value.value()});
         range_end = index->cend();
         break;
       }
       case PredicateCondition::GreaterThan: {
         range_begin = index->cbegin();
-        range_end = index->lower_bound({left_value.value()});
+        range_end = index->lower_bound({probe_side_value.value()});
         break;
       }
       case PredicateCondition::GreaterThanEquals: {
         range_begin = index->cbegin();
-        range_end = index->upper_bound({left_value.value()});
+        range_end = index->upper_bound({probe_side_value.value()});
         break;
       }
       case PredicateCondition::LessThan: {
-        range_begin = index->upper_bound({left_value.value()});
+        range_begin = index->upper_bound({probe_side_value.value()});
         range_end = index->cend();
         break;
       }
       case PredicateCondition::LessThanEquals: {
-        range_begin = index->lower_bound({left_value.value()});
+        range_begin = index->lower_bound({probe_side_value.value()});
         range_end = index->cend();
         break;
       }
@@ -283,13 +285,13 @@ void JoinIndex::_join_two_segments_using_index(LeftIterator left_it, LeftIterato
         Fail("Unsupported comparison type encountered");
     }
 
-    _append_matches(range_begin, range_end, left_value.chunk_offset(), chunk_id_left, chunk_id_right);
+    _append_matches(range_begin, range_end, probe_side_value.chunk_offset(), probe_chunk_id, index_chunk_id);
   }
 }
 
 void JoinIndex::_append_matches(const BaseIndex::Iterator& range_begin, const BaseIndex::Iterator& range_end,
-                                const ChunkOffset chunk_offset_left, const ChunkID chunk_id_left,
-                                const ChunkID chunk_id_right) {
+                                const ChunkOffset probe_chunk_offset, const ChunkID probe_chunk_id,
+                                const ChunkID index_chunk_id) {
   const auto num_index_matches = std::distance(range_begin, range_end);
 
   if (num_index_matches == 0) {
@@ -298,20 +300,20 @@ void JoinIndex::_append_matches(const BaseIndex::Iterator& range_begin, const Ba
 
   // Remember the matches for outer joins
   if (_mode == JoinMode::Left || _mode == JoinMode::FullOuter) {
-    _probe_matches[chunk_id_left][chunk_offset_left] = true;
+    _probe_matches[probe_chunk_id][probe_chunk_offset] = true;
   }
 
-  // we replicate the left value for each right value
-  std::fill_n(std::back_inserter(*_probe_pos_list), num_index_matches, RowID{chunk_id_left, chunk_offset_left});
+  // we replicate the probe side value for each index side value
+  std::fill_n(std::back_inserter(*_probe_pos_list), num_index_matches, RowID{probe_chunk_id, probe_chunk_offset});
 
   std::transform(range_begin, range_end, std::back_inserter(*_index_pos_list),
-                 [chunk_id_right](ChunkOffset chunk_offset_right) {
-                   return RowID{chunk_id_right, chunk_offset_right};
+                 [index_chunk_id](ChunkOffset index_chunk_offset) {
+                   return RowID{index_chunk_id, index_chunk_offset};
                  });
 
   if (_mode == JoinMode::FullOuter || _mode == JoinMode::Right) {
-    std::for_each(range_begin, range_end, [this, chunk_id_right](ChunkOffset chunk_offset_right) {
-      _index_matches[chunk_id_right][chunk_offset_right] = true;
+    std::for_each(range_begin, range_end, [this, index_chunk_id](ChunkOffset index_chunk_offset) {
+      _index_matches[index_chunk_id][index_chunk_offset] = true;
     });
   }
 }

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -57,10 +57,6 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
                   !_secondary_predicates.empty()),
          "JoinHash doesn't support these parameters");
 
-  return _perform_join();
-}
-
-std::shared_ptr<Table> JoinIndex::_perform_join() {
   std::shared_ptr<const Table> left_input_table;
   std::shared_ptr<const Table> right_input_table;
   auto primary_predicate = _primary_predicate;
@@ -221,21 +217,6 @@ std::shared_ptr<Table> JoinIndex::_perform_join() {
   }
 
   return _build_output_table({std::make_shared<Chunk>(output_segments)});
-}
-
-std::shared_ptr<PosList> JoinIndex::_matches_of_reference_table(const std::shared_ptr<const Table>& table) {
-  auto matches = std::make_shared<PosList>();
-  matches->reserve(table->row_count());
-
-  if (!table->chunks().empty() && !table->get_chunk(ChunkID{0})->segments().empty()) {
-    for (const auto& chunk : table->chunks()) {
-      const auto& reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(chunk->get_segment(ColumnID{0}));
-      Assert(reference_segment != nullptr, "Segment is not a ReferenceSegment");
-      const auto& segment_matches = reference_segment->pos_list();
-      matches->insert(matches->end(), segment_matches->begin(), segment_matches->end());
-    }
-  }
-  return matches;
 }
 
 void JoinIndex::_append_matches(const ChunkID& left_chunk_id, const ChunkOffset& left_chunk_offset,

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -9,13 +9,11 @@
 #include <vector>
 
 #include "all_type_variant.hpp"
-#include "index_scan.hpp"
 #include "join_nested_loop.hpp"
 #include "multi_predicate_join/multi_predicate_join_evaluator.hpp"
 #include "resolve_type.hpp"
 #include "storage/index/base_index.hpp"
 #include "storage/segment_iterate.hpp"
-#include "table_wrapper.hpp"
 #include "type_comparison.hpp"
 #include "utils/assert.hpp"
 #include "utils/performance_warning.hpp"

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -124,7 +124,6 @@ std::shared_ptr<Table> JoinIndex::_perform_join() {
 
     // Scan all chunks from left input
     if (index) {
-      std::cout << "DATA" << "\n";
       for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < left_input_table->chunk_count(); ++chunk_id_left) {
         const auto segment_left =
             left_input_table->get_chunk(chunk_id_left)->get_segment(primary_predicate.column_ids.first);
@@ -135,8 +134,6 @@ std::shared_ptr<Table> JoinIndex::_perform_join() {
       performance_data.chunks_scanned_with_index++;
     } else {
       // Fall back to NestedLoopJoin
-      std::cout << "FALLBACK"
-                << "\n";
       const auto segment_right =
           right_input_table->get_chunk(chunk_id_right)->get_segment(primary_predicate.column_ids.second);
       for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < left_input_table->chunk_count(); ++chunk_id_left) {

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -124,6 +124,7 @@ std::shared_ptr<Table> JoinIndex::_perform_join() {
 
     // Scan all chunks from left input
     if (index) {
+      std::cout << "DATA" << "\n";
       for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < left_input_table->chunk_count(); ++chunk_id_left) {
         const auto segment_left =
             left_input_table->get_chunk(chunk_id_left)->get_segment(primary_predicate.column_ids.first);

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -70,13 +70,13 @@ class JoinIndex : public AbstractJoinOperator {
   OperatorJoinPredicate _adjusted_primary_predicate;
   std::shared_ptr<Table> _output_table;
 
-  std::shared_ptr<PosList> _pos_list_left;
-  std::shared_ptr<PosList> _pos_list_right;
+  std::shared_ptr<PosList> _probe_pos_list;
+  std::shared_ptr<PosList> _index_pos_list;
 
   // for left/right/outer joins
   // The outer vector enumerates chunks, the inner enumerates chunk_offsets
-  std::vector<std::vector<bool>> _left_matches;
-  std::vector<std::vector<bool>> _right_matches;
+  std::vector<std::vector<bool>> _probe_matches;
+  std::vector<std::vector<bool>> _index_matches;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -18,9 +18,9 @@ enum class IndexSide { Left, Right };
 /**
    * This operator joins two tables using one column of each table.
    * A speedup compared to the Nested Loop Join is achieved by avoiding the inner loop, and instead
-   * finding the right values utilizing the index.
+   * finding the index side values utilizing the index.
    *
-   * Note: An index needs to be present on the right table in order to execute an index join.
+   * Note: An index needs to be present on the index side table in order to execute an index join.
    */
 class JoinIndex : public AbstractJoinOperator {
  public:
@@ -49,20 +49,16 @@ class JoinIndex : public AbstractJoinOperator {
       const std::shared_ptr<AbstractOperator>& copied_input_right) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
-  void _append_matches(const ChunkID& left_chunk_id, const ChunkOffset& left_chunk_offset,
-                       const PosList& right_table_matches);
+  void _append_matches(const ChunkID& probe_chunk_id, const ChunkOffset& probe_chunk_offset,
+                       const PosList& index_table_matches);
 
-  template <typename LeftIterator>
-  void _join_two_segments_using_index(LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id_left,
-                                      const ChunkID chunk_id_right, const std::shared_ptr<BaseIndex>& index);
-
-  template <typename BinaryFunctor, typename LeftIterator, typename RightIterator>
-  void _join_two_segments_nested_loop(const BinaryFunctor& func, LeftIterator left_it, LeftIterator left_end,
-                                      RightIterator right_begin, RightIterator right_end, const ChunkID chunk_id_left,
-                                      const ChunkID chunk_id_right);
+  template <typename ProbeIterator>
+  void _join_two_segments_using_index(ProbeIterator probe_iter, ProbeIterator probe_end, const ChunkID probe_chunk_id,
+                                      const ChunkID index_chunk_id, const std::shared_ptr<BaseIndex>& index);
 
   void _append_matches(const BaseIndex::Iterator& range_begin, const BaseIndex::Iterator& range_end,
-                       const ChunkOffset chunk_offset_left, const ChunkID chunk_id_left, const ChunkID chunk_id_right);
+                       const ChunkOffset probe_chunk_offset, const ChunkID probe_chunk_id,
+                       const ChunkID index_chunk_id);
 
   void _write_output_segments(Segments& output_segments, const std::shared_ptr<const Table>& input_table,
                               std::shared_ptr<PosList> pos_list);

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -67,6 +67,7 @@ class JoinIndex : public AbstractJoinOperator {
   void _on_cleanup() override;
 
   const JoinInputSide _index_side;
+  OperatorJoinPredicate _adjusted_primary_predicate;
   std::shared_ptr<Table> _output_table;
 
   std::shared_ptr<PosList> _pos_list_left;

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -12,6 +12,9 @@
 #include "types.hpp"
 
 namespace opossum {
+
+enum class IndexSide { Left, Right };
+
 /**
    * This operator joins two tables using one column of each table.
    * A speedup compared to the Nested Loop Join is achieved by avoiding the inner loop, and instead
@@ -27,7 +30,7 @@ class JoinIndex : public AbstractJoinOperator {
   JoinIndex(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,
             const JoinMode mode, const OperatorJoinPredicate& primary_predicate,
             const std::vector<OperatorJoinPredicate>& secondary_predicates = {},
-            const JoinInputSide index_side = JoinInputSide::Right);
+            const IndexSide index_side = IndexSide::Right);
 
   const std::string name() const override;
 
@@ -66,7 +69,7 @@ class JoinIndex : public AbstractJoinOperator {
 
   void _on_cleanup() override;
 
-  const JoinInputSide _index_side;
+  const IndexSide _index_side;
   OperatorJoinPredicate _adjusted_primary_predicate;
   std::shared_ptr<Table> _output_table;
 

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -26,7 +26,8 @@ class JoinIndex : public AbstractJoinOperator {
 
   JoinIndex(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,
             const JoinMode mode, const OperatorJoinPredicate& primary_predicate,
-            const std::vector<OperatorJoinPredicate>& secondary_predicates = {});
+            const std::vector<OperatorJoinPredicate>& secondary_predicates = {},
+            const JoinInputSide index_side = JoinInputSide::Right);
 
   const std::string name() const override;
 
@@ -45,7 +46,11 @@ class JoinIndex : public AbstractJoinOperator {
       const std::shared_ptr<AbstractOperator>& copied_input_right) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
-  void _perform_join();
+  std::shared_ptr<Table> _perform_join();
+  std::shared_ptr<Table> _perform_join_right_reference_table();
+  void _append_matches(const ChunkID& left_chunk_id, const ChunkOffset& left_chunk_offset,
+                       const PosList& right_table_matches);
+  std::shared_ptr<PosList> _matches_of_reference_table(const std::shared_ptr<const Table>& table);
 
   template <typename LeftIterator>
   void _join_two_segments_using_index(LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id_left,
@@ -64,6 +69,7 @@ class JoinIndex : public AbstractJoinOperator {
 
   void _on_cleanup() override;
 
+  const JoinInputSide _index_side;
   std::shared_ptr<Table> _output_table;
 
   std::shared_ptr<PosList> _pos_list_left;

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -46,11 +46,8 @@ class JoinIndex : public AbstractJoinOperator {
       const std::shared_ptr<AbstractOperator>& copied_input_right) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
-  std::shared_ptr<Table> _perform_join();
-  std::shared_ptr<Table> _perform_join_right_reference_table();
   void _append_matches(const ChunkID& left_chunk_id, const ChunkOffset& left_chunk_offset,
                        const PosList& right_table_matches);
-  std::shared_ptr<PosList> _matches_of_reference_table(const std::shared_ptr<const Table>& table);
 
   template <typename LeftIterator>
   void _join_two_segments_using_index(LeftIterator left_it, LeftIterator left_end, const ChunkID chunk_id_left,

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -232,8 +232,6 @@ PredicateCondition inverse_predicate_condition(const PredicateCondition predicat
 //                      dropped. This behavior mirrors NOT EXISTS
 enum class JoinMode { Inner, Left, Right, FullOuter, Cross, Semi, AntiNullAsTrue, AntiNullAsFalse };
 
-enum class JoinInputSide { Left, Right };
-
 enum class UnionMode { Positions };
 
 enum class OrderByMode { Ascending, Descending, AscendingNullsLast, DescendingNullsLast };

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -232,6 +232,8 @@ PredicateCondition inverse_predicate_condition(const PredicateCondition predicat
 //                      dropped. This behavior mirrors NOT EXISTS
 enum class JoinMode { Inner, Left, Right, FullOuter, Cross, Semi, AntiNullAsTrue, AntiNullAsFalse };
 
+enum class JoinInputSide { Left, Right };
+
 enum class UnionMode { Positions };
 
 enum class OrderByMode { Ascending, Descending, AscendingNullsLast, DescendingNullsLast };

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -90,7 +90,7 @@ class JoinIndexTest : public BaseTest {
                                const std::shared_ptr<const AbstractOperator>& right,
                                const OperatorJoinPredicate& primary_predicate, const JoinMode mode,
                                const std::string& file_name, size_t chunk_size, bool using_index = true,
-                               const JoinInputSide index_side = JoinInputSide::Right) {
+                               const IndexSide index_side = IndexSide::Right) {
     // load expected results from file
     std::shared_ptr<Table> expected_result = load_table(file_name, chunk_size);
     EXPECT_NE(expected_result, nullptr) << "Could not load expected result table";
@@ -202,7 +202,7 @@ TYPED_TEST(JoinIndexTest, InnerDictJoin) {
 TYPED_TEST(JoinIndexTest, InnerDictJoinSwapTables) {
   this->test_join_output(this->_table_wrapper_a, this->_table_wrapper_b_no_index,
                          {{ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals}, JoinMode::Inner,
-                         "resources/test_data/tbl/join_operators/int_inner_join.tbl", 1, true, JoinInputSide::Left);
+                         "resources/test_data/tbl/join_operators/int_inner_join.tbl", 1, true, IndexSide::Left);
 }
 
 TYPED_TEST(JoinIndexTest, InnerRefDictJoin) {

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -89,13 +89,15 @@ class JoinIndexTest : public BaseTest {
   static void test_join_output(const std::shared_ptr<const AbstractOperator>& left,
                                const std::shared_ptr<const AbstractOperator>& right,
                                const OperatorJoinPredicate& primary_predicate, const JoinMode mode,
-                               const std::string& file_name, size_t chunk_size, bool using_index = true) {
+                               const std::string& file_name, size_t chunk_size, bool using_index = true,
+                               const JoinInputSide index_side = JoinInputSide::Right) {
     // load expected results from file
     std::shared_ptr<Table> expected_result = load_table(file_name, chunk_size);
     EXPECT_NE(expected_result, nullptr) << "Could not load expected result table";
 
     // build and execute join
-    auto join = std::make_shared<JoinIndex>(left, right, mode, primary_predicate);
+    auto join = std::make_shared<JoinIndex>(left, right, mode, primary_predicate,
+      std::vector<OperatorJoinPredicate>{}, index_side);
     EXPECT_NE(join, nullptr) << "Could not build Join";
     join->execute();
 
@@ -117,7 +119,7 @@ class JoinIndexTest : public BaseTest {
       _table_wrapper_m, _table_wrapper_n;
 };
 
-typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex /* , GroupKeyIndex */>
+typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex, GroupKeyIndex>
     DerivedIndices;
 
 TYPED_TEST_CASE(JoinIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)
@@ -195,6 +197,12 @@ TYPED_TEST(JoinIndexTest, InnerDictJoin) {
   this->test_join_output(this->_table_wrapper_a, this->_table_wrapper_b,
                          {{ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals}, JoinMode::Inner,
                          "resources/test_data/tbl/join_operators/int_inner_join.tbl", 1);
+}
+
+TYPED_TEST(JoinIndexTest, InnerDictJoinSwapTables) {
+  this->test_join_output(this->_table_wrapper_a, this->_table_wrapper_b_no_index,
+                         {{ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals}, JoinMode::Inner,
+                         "resources/test_data/tbl/join_operators/int_inner_join.tbl", 1, true, JoinInputSide::Left);
 }
 
 TYPED_TEST(JoinIndexTest, InnerRefDictJoin) {

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -119,7 +119,7 @@ class JoinIndexTest : public BaseTest {
       _table_wrapper_m, _table_wrapper_n;
 };
 
-typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex /* , GroupKeyIndex*/>
+typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex /* , GroupKeyIndex */>
     DerivedIndices;
 
 TYPED_TEST_CASE(JoinIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -119,7 +119,7 @@ class JoinIndexTest : public BaseTest {
       _table_wrapper_m, _table_wrapper_n;
 };
 
-typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex, GroupKeyIndex>
+typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex /* , GroupKeyIndex*/>
     DerivedIndices;
 
 TYPED_TEST_CASE(JoinIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -96,8 +96,8 @@ class JoinIndexTest : public BaseTest {
     EXPECT_NE(expected_result, nullptr) << "Could not load expected result table";
 
     // build and execute join
-    auto join = std::make_shared<JoinIndex>(left, right, mode, primary_predicate,
-      std::vector<OperatorJoinPredicate>{}, index_side);
+    auto join = std::make_shared<JoinIndex>(left, right, mode, primary_predicate, std::vector<OperatorJoinPredicate>{},
+                                            index_side);
     EXPECT_NE(join, nullptr) << "Could not build Join";
     join->execute();
 


### PR DESCRIPTION
This PR integrates the possibility to use the JoinIndex with the mandatory index structures in the output table of the left input operator. Previously the index structures had to be on the right side.
Now, the JoinIndex constructor expects the specification of the join input operator which output table contains the index structures (`const JoinInputSide index_side`). By default, the index_side is `JoinInputSide::Right`.