### PR TITLE
Change Lambda captures to be compatible with C++20

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,11 +67,11 @@ if (${ENABLE_COVERAGE})
 endif()
 
 # Global flags and include directories
-# When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
-# Hence, the `-Wno-dollar-in-identifier-extension` flag is required.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 
+# When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
+# Hence, the `-Wno-dollar-in-identifier-extension` flag is required.
 add_compile_options(-pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 # When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
 # Hence, the `-Wno-dollar-in-identifier-extension` flag is required.
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 17)
 
 add_compile_options(-pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 20)
 
-add_compile_options(-std=c++17 -pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas)
+add_compile_options(-pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-shadow-field-in-constructor -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,9 @@ endif()
 # Global flags and include directories
 # When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
 # Hence, the `-Wno-dollar-in-identifier-extension` flag is required.
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD 20)
+
 add_compile_options(-std=c++17 -pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<AbstractOperator> IndexScan::_on_deep_copy(
 void IndexScan::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<AbstractTask> IndexScan::_create_job_and_schedule(const ChunkID chunk_id, std::mutex& output_mutex) {
-  auto job_task = std::make_shared<JobTask>([=, &output_mutex]() {
+  auto job_task = std::make_shared<JobTask>([this, chunk_id, &output_mutex]() {
     const auto matches_out = std::make_shared<PosList>(_scan_chunk(chunk_id));
 
     // The output chunk is allocated on the same NUMA node as the input chunk.

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
   for (ChunkID chunk_id{0u}; chunk_id < in_table->chunk_count(); ++chunk_id) {
     if (excluded_chunk_set.count(chunk_id)) continue;
 
-    auto job_task = std::make_shared<JobTask>([this, in_table, chunk_id, &output_mutex, &output_chunks]() {
+    auto job_task = std::make_shared<JobTask>([this, chunk_id, &in_table, &output_mutex, &output_chunks]() {
       const auto chunk_guard = in_table->get_chunk(chunk_id);
       // The actual scan happens in the sub classes of BaseTableScanImpl
       const auto matches_out = _impl->scan_chunk(chunk_id);

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -94,7 +94,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
   for (ChunkID chunk_id{0u}; chunk_id < in_table->chunk_count(); ++chunk_id) {
     if (excluded_chunk_set.count(chunk_id)) continue;
 
-    auto job_task = std::make_shared<JobTask>([=, &output_mutex, &output_chunks]() {
+    auto job_task = std::make_shared<JobTask>([this, in_table, chunk_id, &output_mutex, &output_chunks]() {
       const auto chunk_guard = in_table->get_chunk(chunk_id);
       // The actual scan happens in the sub classes of BaseTableScanImpl
       const auto matches_out = _impl->scan_chunk(chunk_id);

--- a/src/lib/server/client_connection.cpp
+++ b/src/lib/server/client_connection.cpp
@@ -250,7 +250,7 @@ boost::future<uint64_t> ClientConnection::_send_bytes_async(const std::shared_pt
 
   if (_response_buffer.size() + packet_size > _max_response_size) {
     // We have to flush before we can actually process the data
-    return _flush_async() >> then >> [=](uint64_t) { return _send_bytes_async(packet, flush); };
+    return _flush_async() >> then >> [this, packet, flush](uint64_t) { return _send_bytes_async(packet, flush); };
   }
 
   _response_buffer.insert(_response_buffer.end(), packet->data.begin(), packet->data.end());
@@ -265,7 +265,7 @@ boost::future<uint64_t> ClientConnection::_send_bytes_async(const std::shared_pt
 
 boost::future<uint64_t> ClientConnection::_flush_async() {
   return _socket.async_send(boost::asio::buffer(_response_buffer), boost::asio::use_boost_future) >> then >>
-         [=](uint64_t sent_bytes) {
+         [this](uint64_t sent_bytes) {
            // If this fails, the connection may be closed but the server will keep running.
            Assert(sent_bytes == _response_buffer.size(), "Could not send all data");
            _response_buffer.clear();

--- a/src/lib/server/server_session.cpp
+++ b/src/lib/server/server_session.cpp
@@ -51,60 +51,60 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::start() {
 
 template <typename TConnection, typename TTaskRunner>
 boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_perform_session_startup() {
-  return _connection->receive_startup_packet_header() >> then >> [=](uint32_t startup_packet_length) {
+  return _connection->receive_startup_packet_header() >> then >> [this](uint32_t startup_packet_length) {
     if (startup_packet_length == 0) {
       // This is a request for SSL, deny it and wait for the next startup packet
-      return _connection->send_ssl_denied() >> then >> [=]() { return _perform_session_startup(); };
+      return _connection->send_ssl_denied() >> then >> [this]() { return _perform_session_startup(); };
     }
 
     return _connection->receive_startup_packet_body(startup_packet_length) >> then >>
-           [=]() { return _connection->send_auth(); } >> then >>
+           [this]() { return _connection->send_auth(); } >> then >>
            // We need to provide some random server version > 9 here, because some clients require it.
-           [=]() { return _connection->send_parameter_status("server_version", "9.5"); } >> then >>
-           [=]() { return _connection->send_parameter_status("client_encoding", "UTF8"); } >> then >>
-           [=]() { return _connection->send_ready_for_query(); };
+           [this]() { return _connection->send_parameter_status("server_version", "9.5"); } >> then >>
+           [this]() { return _connection->send_parameter_status("client_encoding", "UTF8"); } >> then >>
+           [this]() { return _connection->send_ready_for_query(); };
   };
 }
 
 template <typename TConnection, typename TTaskRunner>
 boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_client_requests() {
-  auto process_command = [=](RequestHeader request) {
+  auto process_command = [this](RequestHeader request) {
     switch (request.message_type) {
       case NetworkMessageType::SimpleQueryCommand: {
         return _connection->receive_simple_query_packet_body(request.payload_length) >> then >>
-               [=](std::string sql) { return _handle_simple_query_command(sql); } >> then >>
-               [=]() { return _connection->send_ready_for_query(); };
+               [this](std::string sql) { return _handle_simple_query_command(sql); } >> then >>
+               [this]() { return _connection->send_ready_for_query(); };
       }
 
       case NetworkMessageType::ParseCommand: {
         return _connection->receive_parse_packet_body(request.payload_length) >> then >>
-               [=](ParsePacket parse_packet) { return _handle_parse_command(parse_packet); };
+               [this](ParsePacket parse_packet) { return _handle_parse_command(parse_packet); };
       }
 
       case NetworkMessageType::BindCommand: {
         return _connection->receive_bind_packet_body(request.payload_length) >> then >>
-               [=](BindPacket bind_packet) { return _handle_bind_command(bind_packet); };
+               [this](BindPacket bind_packet) { return _handle_bind_command(bind_packet); };
       }
 
       case NetworkMessageType::DescribeCommand: {
         return _connection->receive_describe_packet_body(request.payload_length) >> then >>
-               [=](std::string portal) { return _handle_describe_command(portal); };
+               [this](std::string portal) { return _handle_describe_command(portal); };
       }
 
       case NetworkMessageType::SyncCommand: {
         return _connection->receive_sync_packet_body(request.payload_length) >> then >>
-               [=]() { return _handle_sync_command(); } >> then >>
-               [=]() { return _connection->send_ready_for_query(); };
+               [this]() { return _handle_sync_command(); } >> then >>
+               [this]() { return _connection->send_ready_for_query(); };
       }
 
       case NetworkMessageType::FlushCommand: {
         return _connection->receive_flush_packet_body(request.payload_length) >> then >>
-               [=]() { return _handle_flush_command(); };
+               [this]() { return _handle_flush_command(); };
       }
 
       case NetworkMessageType::ExecuteCommand: {
         return _connection->receive_execute_packet_body(request.payload_length) >> then >>
-               [=](std::string portal) { return _handle_execute_command(portal); };
+               [this](std::string portal) { return _handle_execute_command(portal); };
       }
 
       default:
@@ -152,25 +152,25 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_send_simple_qu
   Assert(result_table_pair.first == SQLPipelineStatus::Success, "Server cannot handle failed transactions yet");
   const auto result_table = result_table_pair.second;
 
-  auto send_row_data = [=]() {
+  auto send_row_data = [this, result_table]() {
     // If there is no result table, e.g. after an INSERT command, we cannot send row data
     if (!result_table) return boost::make_ready_future<uint64_t>(0);
 
     auto row_description = QueryResponseBuilder::build_row_description(result_table);
 
-    return _connection->send_row_description(row_description) >> then >> [=]() {
+    return _connection->send_row_description(row_description) >> then >> [this, result_table]() {
       return QueryResponseBuilder::send_query_response(
-          [=](const std::vector<std::string>& row) { return _connection->send_data_row(row); }, *result_table);
+          [this, result_table](const std::vector<std::string>& row) { return _connection->send_data_row(row); }, *result_table);
     };
   };
 
-  auto send_command_complete = [=](uint64_t row_count) {
+  auto send_command_complete = [this, sql_pipeline](uint64_t row_count) {
     auto root_op = sql_pipeline->get_physical_plans().front();
     auto complete_message = QueryResponseBuilder::build_command_complete_message(*root_op, row_count);
     return _connection->send_command_complete(complete_message);
   };
 
-  return send_row_data() >> then >> send_command_complete >> then >> [=]() {
+  return send_row_data() >> then >> send_command_complete >> then >> [this, sql_pipeline]() {
     auto execution_info = QueryResponseBuilder::build_execution_info_message(sql_pipeline);
     return _connection->send_notice(execution_info);
   };
@@ -178,17 +178,17 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_send_simple_qu
 
 template <typename TConnection, typename TTaskRunner>
 boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_simple_query_command(const std::string& sql) {
-  auto create_sql_pipeline = [=]() {
+  auto create_sql_pipeline = [this, sql]() {
     return _task_runner->dispatch_server_task(std::make_shared<CreatePipelineTask>(sql, true));
   };
 
-  auto load_table_file = [=](std::string& file_name, std::string& table_name) {
+  auto load_table_file = [this](std::string& file_name, std::string& table_name) {
     auto task = std::make_shared<LoadServerFileTask>(file_name, table_name);
     return _task_runner->dispatch_server_task(task) >> then >>
-           [=]() { return _connection->send_notice("Successfully loaded " + table_name); };
+           [this, table_name]() { return _connection->send_notice("Successfully loaded " + table_name); };
   };
 
-  auto execute_sql_pipeline = [=](std::shared_ptr<SQLPipeline> sql_pipeline) {
+  auto execute_sql_pipeline = [this](std::shared_ptr<SQLPipeline> sql_pipeline) {
     auto task = std::make_shared<ExecuteServerQueryTask>(sql_pipeline);
     return _task_runner->dispatch_server_task(task) >> then >> [=]() { return sql_pipeline; };
   };
@@ -197,12 +197,12 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_simple_
   if (StorageManager::get().has_prepared_plan("")) StorageManager::get().drop_prepared_plan("");
   _portals.erase("");
 
-  return create_sql_pipeline() >> then >> [=](std::unique_ptr<CreatePipelineResult> result) {
+  return create_sql_pipeline() >> then >> [this, load_table_file, execute_sql_pipeline](std::unique_ptr<CreatePipelineResult> result) {
     if (result->load_table) {
       return load_table_file(result->load_table->first, result->load_table->second);
     } else {
       return execute_sql_pipeline(result->sql_pipeline) >> then >>
-             [=](std::shared_ptr<SQLPipeline> sql_pipeline) { return _send_simple_query_response(sql_pipeline); };
+             [this](std::shared_ptr<SQLPipeline> sql_pipeline) { return _send_simple_query_response(sql_pipeline); };
     }
   };
 }
@@ -223,7 +223,7 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_parse_c
            // We know that SQLPipeline is set because the load table command is not allowed in this context
            StorageManager::get().add_prepared_plan(parse_info.statement_name, std::move(prepared_plan));
          } >>
-         then >> [=]() { return _connection->send_status_message(NetworkMessageType::ParseComplete); };
+         then >> [this]() { return _connection->send_status_message(NetworkMessageType::ParseComplete); };
 }
 
 template <typename TConnection, typename TTaskRunner>
@@ -250,8 +250,8 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_bind_co
 
   auto task = std::make_shared<BindServerPreparedStatementTask>(prepared_plan, packet.params);
   return _task_runner->dispatch_server_task(task) >> then >>
-         [=](std::shared_ptr<AbstractOperator> physical_plan) { _portals.emplace(portal_name, physical_plan); } >>
-         then >> [=]() { return _connection->send_status_message(NetworkMessageType::BindComplete); };
+         [this, portal_name](std::shared_ptr<AbstractOperator> physical_plan) { _portals.emplace(portal_name, physical_plan); } >>
+         then >> [this]() { return _connection->send_status_message(NetworkMessageType::BindComplete); };
 }
 
 template <typename TConnection, typename TTaskRunner>
@@ -293,7 +293,7 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_execute
 
   return _task_runner->dispatch_server_task(std::make_shared<ExecuteServerPreparedStatementTask>(physical_plan)) >>
          then >>
-         [=](std::shared_ptr<const Table> result_table) {
+         [this](std::shared_ptr<const Table> result_table) {
            // The behavior is a little different compared to SimpleQueryCommand: Send a 'No Data' response
            if (!result_table) {
              return _connection->send_status_message(NetworkMessageType::NoDataResponse) >> then >>
@@ -301,12 +301,12 @@ boost::future<void> ServerSessionImpl<TConnection, TTaskRunner>::_handle_execute
            }
 
            const auto row_description = QueryResponseBuilder::build_row_description(result_table);
-           return _connection->send_row_description(row_description) >> then >> [=]() {
+           return _connection->send_row_description(row_description) >> then >> [this, result_table]() {
              return QueryResponseBuilder::send_query_response(
-                 [=](const std::vector<std::string>& row) { return _connection->send_data_row(row); }, *result_table);
+                 [this](const std::vector<std::string>& row) { return _connection->send_data_row(row); }, *result_table);
            };
          } >>
-         then >> [=](uint64_t row_count) {
+         then >> [this, physical_plan](uint64_t row_count) {
            auto complete_message = QueryResponseBuilder::build_command_complete_message(*physical_plan, row_count);
            return _connection->send_command_complete(complete_message);
          };

--- a/src/lib/server/task_runner.hpp
+++ b/src/lib/server/task_runner.hpp
@@ -34,7 +34,7 @@ auto TaskRunner::dispatch_server_task(std::shared_ptr<TResult> task) -> decltype
 
   return task->get_future()
       .then(boost::launch::sync,
-            [=](auto result) {
+            [this](auto result) {
               // This result comes in on the scheduler thread, so we want to dispatch it back to the io_service
               return _io_service.post(boost::asio::use_boost_future)
                      // Make sure to be on the main thread before re-throwing the exceptions


### PR DESCRIPTION
With C++20 the implicit capture of `this` when the capture default is `=` [becomes deprecated](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0806r2.html). This PR adapts relevant Lambdas to be compatible with C++20.

* To capture `*this` by reference, explicit captures of `this` are added.
* `[=, this]` is an [extension of C++20](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0409r2.html) and not backward compatible with C++17. Therefore, some captures became more explicit.