### PR TITLE
Remove function Table::chunks()

### DIFF
--- a/src/benchmark/operators/table_scan_sorted_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_sorted_benchmark.cpp
@@ -84,7 +84,10 @@ std::shared_ptr<TableWrapper> create_table(const DataType data_type, const int t
   }
 
   if (mode == "Sorted") {
-    for (auto& chunk : table->chunks()) {
+    const auto chunk_count = table->chunk_count();
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      const auto chunk = table->get_chunk(chunk_id);
+
       chunk->set_ordered_by(std::make_pair(ColumnID(0), OrderByMode::Ascending));
     }
   }

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -80,8 +80,10 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
       } else {
         // Group is spread over multiple chunks
         uint64_t count = 0;
-        count += sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() - current_group_begin_pointer.chunk_offset;
-        for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < group_boundary.chunk_id; chunk_id++) {
+        count += sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() -
+                 current_group_begin_pointer.chunk_offset;
+        for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < group_boundary.chunk_id;
+             chunk_id++) {
           count += sorted_table->get_chunk(chunk_id)->size();
         }
         count += group_boundary.chunk_offset + 1;
@@ -94,8 +96,8 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
       aggregate_group_index++;
     }
     // Compute value count with null values for the last iteration
-    value_count_with_null =
-        sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() - current_group_begin_pointer.chunk_offset;
+    value_count_with_null = sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() -
+                            current_group_begin_pointer.chunk_offset;
     for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < chunk_count; chunk_id++) {
       value_count_with_null += sorted_table->get_chunk(chunk_id)->size();
     }

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -59,7 +59,7 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
   // The number of the current group-by-combination. Used as offset when storing values
   uint64_t aggregate_group_index = 0u;
 
-  const auto& chunks = sorted_table->chunks();
+  const auto chunk_count = sorted_table->chunk_count();
 
   std::optional<AggregateType> current_primary_aggregate;
   std::vector<AggregateType> current_secondary_aggregates{};
@@ -80,9 +80,9 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
       } else {
         // Group is spread over multiple chunks
         uint64_t count = 0;
-        count += chunks[current_group_begin_pointer.chunk_id]->size() - current_group_begin_pointer.chunk_offset;
-        for (auto chunk_id = current_group_begin_pointer.chunk_id + 1; chunk_id < group_boundary.chunk_id; chunk_id++) {
-          count += chunks[chunk_id]->size();
+        count += sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() - current_group_begin_pointer.chunk_offset;
+        for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < group_boundary.chunk_id; chunk_id++) {
+          count += sorted_table->get_chunk(chunk_id)->size();
         }
         count += group_boundary.chunk_offset + 1;
         value_count_with_null = count;
@@ -95,9 +95,9 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
     }
     // Compute value count with null values for the last iteration
     value_count_with_null =
-        chunks[current_group_begin_pointer.chunk_id]->size() - current_group_begin_pointer.chunk_offset;
-    for (size_t chunk_id = current_group_begin_pointer.chunk_id + 1; chunk_id < chunks.size(); chunk_id++) {
-      value_count_with_null += chunks[chunk_id]->size();
+        sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() - current_group_begin_pointer.chunk_offset;
+    for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < chunk_count; chunk_id++) {
+      value_count_with_null += sorted_table->get_chunk(chunk_id)->size();
     }
 
   } else {
@@ -119,8 +119,8 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
     auto group_boundary_iter = group_boundaries.cbegin();
     const auto column_id = _aggregates[aggregate_index];
     const auto column = column_id.column;
-    for (const auto& chunk : chunks) {
-      auto segment = chunk->get_segment(*column);
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      auto segment = sorted_table->get_chunk(chunk_id)->get_segment(*column);
       segment_iterate<ColumnType>(*segment, [&](const auto& position) {
         const auto row_id = RowID{current_chunk_id, position.chunk_offset()};
         const auto is_new_group = !group_boundaries.empty() && row_id == *group_boundary_iter;
@@ -392,13 +392,13 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
    *               So in total, group_boundaries will contain one element less than there are groups.
    */
   std::set<RowID> group_boundaries;
-  const auto& chunks = sorted_table->chunks();
+  const auto chunk_count = sorted_table->chunk_count();
   for (const auto& column_id : _groupby_column_ids) {
     auto data_type = input_table->column_data_type(column_id);
     resolve_data_type(data_type, [&](auto type) {
       using ColumnDataType = typename decltype(type)::type;
       std::optional<ColumnDataType> previous_value;
-      ChunkID chunk_id{0};
+      ChunkID chunk_id_outer{0};
 
       /*
        * Initialize previous_value to the first value in the table, so we avoid considering it a value change.
@@ -406,7 +406,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
        * For the reasoning behind it see above.
        * We are aware that operator[] is slow, however, for one value it should be faster than segment_iterate_filtered.
        */
-      const auto& first_segment = chunks[0]->get_segment(column_id);
+      const auto& first_segment = sorted_table->get_chunk(ChunkID{0})->get_segment(column_id);
       const auto& first_value = (*first_segment)[0];
       if (variant_is_null(first_value)) {
         previous_value.reset();
@@ -415,12 +415,12 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
       }
 
       // Iterate over all chunks and insert RowIDs when values change
-      for (const auto& chunk : chunks) {
-        const auto& segment = chunk->get_segment(column_id);
+      for (auto chunk_id_inner = ChunkID{0}; chunk_id_inner < chunk_count; ++chunk_id_inner) {
+        const auto& segment = sorted_table->get_chunk(chunk_id_inner)->get_segment(column_id);
         segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
           if (previous_value.has_value() == position.is_null() ||
               (previous_value.has_value() && !position.is_null() && position.value() != *previous_value)) {
-            group_boundaries.insert(RowID{chunk_id, position.chunk_offset()});
+            group_boundaries.insert(RowID{chunk_id_outer, position.chunk_offset()});
             if (position.is_null()) {
               previous_value.reset();
             } else {
@@ -428,7 +428,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
             }
           }
         });
-        chunk_id++;
+        chunk_id_outer++;
       }
     });
   }
@@ -458,7 +458,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
           group_boundary_iter++;
         }
 
-        const auto& chunk = chunks[group_start.chunk_id];
+        const auto chunk = sorted_table->get_chunk(group_start.chunk_id);
         const auto& segment = chunk->get_segment(column_id);
 
         /*

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -690,7 +690,7 @@ inline PosListsByChunk setup_pos_lists_by_chunk(const std::shared_ptr<const Tabl
     // Iterate over every chunk and add the chunks segment with column_id to pos_list_ptrs
     for (ChunkID chunk_id{0}; chunk_id < input_chunks_count; ++chunk_id) {
       const auto chunk = input_table->get_chunk(chunk_id);
-      if(!chunk) continue;
+      if (!chunk) continue;
 
       const auto& ref_segment_uncasted = chunk->segments()[column_id];
       const auto ref_segment = std::static_pointer_cast<const ReferenceSegment>(ref_segment_uncasted);

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -678,17 +678,21 @@ inline PosListsByChunk setup_pos_lists_by_chunk(const std::shared_ptr<const Tabl
   PosListsByChunk pos_lists_by_segment(input_table->column_count());
   auto pos_lists_by_segment_it = pos_lists_by_segment.begin();
 
-  const auto& input_chunks = input_table->chunks();
+  const auto input_chunks_count = input_table->chunk_count();
+  const auto input_columns_count = input_table->column_count();
 
   // For every column, for every chunk
-  for (ColumnID column_id{0}; column_id < input_table->column_count(); ++column_id) {
+  for (ColumnID column_id{0}; column_id < input_columns_count; ++column_id) {
     // Get all the input pos lists so that we only have to pointer cast the segments once
     auto pos_list_ptrs = std::make_shared<PosLists>(input_table->chunk_count());
     auto pos_lists_iter = pos_list_ptrs->begin();
 
     // Iterate over every chunk and add the chunks segment with column_id to pos_list_ptrs
-    for (ChunkID chunk_id{0}; chunk_id < input_table->chunk_count(); ++chunk_id) {
-      const auto& ref_segment_uncasted = input_chunks[chunk_id]->segments()[column_id];
+    for (ChunkID chunk_id{0}; chunk_id < input_chunks_count; ++chunk_id) {
+      const auto chunk = input_table->get_chunk(chunk_id);
+      if(!chunk) continue;
+
+      const auto& ref_segment_uncasted = chunk->segments()[column_id];
       const auto ref_segment = std::static_pointer_cast<const ReferenceSegment>(ref_segment_uncasted);
       *pos_lists_iter = ref_segment->pos_list();
       ++pos_lists_iter;

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -202,8 +202,11 @@ class Sort::SortImpl : public AbstractReadOnlyOperatorImpl {
     auto materialization = std::make_shared<SortImplMaterializeOutput<SortColumnType>>(_table_in, _row_id_value_vector,
                                                                                        _output_chunk_size);
     auto output = materialization->execute();
-    for (auto& chunk : output->chunks()) {
-      chunk->set_ordered_by(std::make_pair(_column_id, _order_by_mode));
+
+    auto output_table = std::const_pointer_cast<Table>(output); // cast away constness to call chunk->set_ordered_by
+    const auto chunk_count = output->chunk_count();
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      output_table->get_chunk(chunk_id)->set_ordered_by(std::make_pair(_column_id, _order_by_mode));
     }
 
     return output;

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -203,7 +203,7 @@ class Sort::SortImpl : public AbstractReadOnlyOperatorImpl {
                                                                                        _output_chunk_size);
     auto output = materialization->execute();
 
-    auto output_table = std::const_pointer_cast<Table>(output); // cast away constness to call chunk->set_ordered_by
+    auto output_table = std::const_pointer_cast<Table>(output);  // cast away constness to call chunk->set_ordered_by
     const auto chunk_count = output->chunk_count();
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
       output_table->get_chunk(chunk_id)->set_ordered_by(std::make_pair(_column_id, _order_by_mode));

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -54,7 +54,7 @@ class Sort::SortImplMaterializeOutput {
                             const size_t output_chunk_size)
       : _table_in(in), _output_chunk_size(output_chunk_size), _row_id_value_vector(id_value_map) {}
 
-  std::shared_ptr<const Table> execute() {
+  std::shared_ptr<Table> execute() {
     // First we create a new table as the output
     auto output = std::make_shared<Table>(_table_in->column_definitions(), TableType::Data, _output_chunk_size);
 
@@ -203,10 +203,9 @@ class Sort::SortImpl : public AbstractReadOnlyOperatorImpl {
                                                                                        _output_chunk_size);
     auto output = materialization->execute();
 
-    auto output_table = std::const_pointer_cast<Table>(output);  // cast away constness to call chunk->set_ordered_by
     const auto chunk_count = output->chunk_count();
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
-      output_table->get_chunk(chunk_id)->set_ordered_by(std::make_pair(_column_id, _order_by_mode));
+      output->get_chunk(chunk_id)->set_ordered_by(std::make_pair(_column_id, _order_by_mode));
     }
 
     return output;

--- a/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
@@ -46,7 +46,11 @@ std::vector<std::pair<T, HistogramCountType>> value_distribution_from_column(con
   //               resources.
   std::unordered_map<T, HistogramCountType> value_distribution_map;
 
-  for (const auto& chunk : table.chunks()) {
+  const auto chunk_count = table.chunk_count();
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+    const auto chunk = table.get_chunk(chunk_id);
+    if(!chunk) continue;
+
     value_distribution_map =
         add_segment_to_value_distribution<T>(*chunk->get_segment(column_id), std::move(value_distribution_map), domain);
   }

--- a/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
@@ -49,7 +49,7 @@ std::vector<std::pair<T, HistogramCountType>> value_distribution_from_column(con
   const auto chunk_count = table.chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table.get_chunk(chunk_id);
-    if(!chunk) continue;
+    if (!chunk) continue;
 
     value_distribution_map =
         add_segment_to_value_distribution<T>(*chunk->get_segment(column_id), std::move(value_distribution_map), domain);

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -147,8 +147,6 @@ bool Table::empty() const { return row_count() == 0u; }
 
 ChunkID Table::chunk_count() const { return ChunkID{static_cast<ChunkID::base_type>(_chunks.size())}; }
 
-const tbb::concurrent_vector<std::shared_ptr<Chunk>>& Table::chunks() const { return _chunks; }
-
 uint32_t Table::max_chunk_size() const { return _max_chunk_size; }
 
 std::shared_ptr<Chunk> Table::get_chunk(ChunkID chunk_id) {

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -9,7 +9,6 @@
 #include "base_segment.hpp"
 #include "boost/variant.hpp"
 #include "chunk.hpp"
-#include "gtest/gtest_prod.h"
 #include "storage/index/index_info.hpp"
 #include "storage/table_column_definition.hpp"
 #include "types.hpp"
@@ -24,6 +23,7 @@ class TableStatistics;
  * A Table is partitioned horizontally into a number of chunks.
  */
 class Table : private Noncopyable {
+  friend class StorageTableTest;
  public:
   static std::shared_ptr<Table> create_dummy_table(const TableColumnDefinitions& column_definitions);
 
@@ -186,6 +186,5 @@ class Table : private Noncopyable {
   std::vector<IndexInfo> _indexes;
   std::shared_ptr<TableStatistics> _table_statistics;
 
-  FRIEND_TEST(StorageTableTest, StableChunks);
 };
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
-#include <gtest/gtest_prod.h>
 
 #include "boost/variant.hpp"
 

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <gtest/gtest_prod.h>
 
 #include "boost/variant.hpp"
 
@@ -82,9 +83,6 @@ class Table : private Noncopyable {
    */
   // returns the number of chunks (cannot exceed ChunkID (uint32_t))
   ChunkID chunk_count() const;
-
-  // Returns all Chunks
-  const tbb::concurrent_vector<std::shared_ptr<Chunk>>& chunks() const;
 
   // returns the chunk with the given id
   std::shared_ptr<Chunk> get_chunk(ChunkID chunk_id);
@@ -188,5 +186,7 @@ class Table : private Noncopyable {
   std::unique_ptr<std::mutex> _append_mutex;
   std::vector<IndexInfo> _indexes;
   std::shared_ptr<TableStatistics> _table_statistics;
+
+  FRIEND_TEST(StorageTableTest, StableChunks);
 };
 }  // namespace opossum

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -1,16 +1,15 @@
 #pragma once
 
-#include <gtest/gtest_prod.h>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "boost/variant.hpp"
-
 #include "base_segment.hpp"
+#include "boost/variant.hpp"
 #include "chunk.hpp"
+#include "gtest/gtest_prod.h"
 #include "storage/index/index_info.hpp"
 #include "storage/table_column_definition.hpp"
 #include "types.hpp"

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -24,6 +24,7 @@ class TableStatistics;
  */
 class Table : private Noncopyable {
   friend class StorageTableTest;
+
  public:
   static std::shared_ptr<Table> create_dummy_table(const TableColumnDefinitions& column_definitions);
 
@@ -185,6 +186,5 @@ class Table : private Noncopyable {
   std::unique_ptr<std::mutex> _append_mutex;
   std::vector<IndexInfo> _indexes;
   std::shared_ptr<TableStatistics> _table_statistics;
-
 };
 }  // namespace opossum

--- a/src/test/operators/index_scan_test.cpp
+++ b/src/test/operators/index_scan_test.cpp
@@ -229,7 +229,10 @@ TYPED_TEST(OperatorsIndexScanTest, PosListGuarenteesSingleChunkReference) {
                                           PredicateCondition::Equals, right_values, right_values2);
   scan->execute();
 
-  for (const auto& chunk : scan->get_output()->chunks()) {
+  const auto chunk_count = scan->get_output()->chunk_count();
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+    const auto chunk = scan->get_output()->get_chunk(chunk_id);
+
     const auto segment = chunk->get_segment(this->_column_ids[0]);
     const auto reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment);
     const auto& pos_list = reference_segment->pos_list();

--- a/src/test/operators/table_scan_between_test.cpp
+++ b/src/test/operators/table_scan_between_test.cpp
@@ -105,9 +105,13 @@ class TableScanBetweenTest : public TypedOperatorBaseTest {
             create_between_table_scan(_data_table_wrapper, ColumnID{0}, left_casted, right_casted, predicate_condition);
         scan->execute();
 
-        const auto& result_table = *scan->get_output();
+        const auto result_table = scan->get_output();
         auto result_ints = std::vector<int>{};
-        for (const auto& chunk : result_table.chunks()) {
+
+        const auto chunk_count = result_table->chunk_count();
+        for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+          const auto chunk = result_table->get_chunk(chunk_id);
+
           const auto segment_b = chunk->get_segment(ColumnID{1});
           for (auto offset = ChunkOffset{0}; offset < segment_b->size(); ++offset) {
             result_ints.emplace_back(boost::get<int>((*segment_b)[offset]));

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -69,7 +69,11 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     ChunkEncoder::encode_all_chunks(table, chunk_encoding_spec);
 
     if (ordered_by) {
-      for (const auto& chunk : table->chunks()) {
+      const auto chunk_count = table->chunk_count();
+      for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+        const auto chunk = table->get_chunk(chunk_id);
+        if(!chunk) continue;
+
         chunk->set_ordered_by(ordered_by.value());
       }
     }

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -72,7 +72,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
       const auto chunk_count = table->chunk_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         const auto chunk = table->get_chunk(chunk_id);
-        if(!chunk) continue;
+        if (!chunk) continue;
 
         chunk->set_ordered_by(ordered_by.value());
       }

--- a/src/test/optimizer/strategy/chunk_pruning_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_test.cpp
@@ -43,8 +43,9 @@ class ChunkPruningTest : public StrategyBaseTest {
     storage_manager.add_table("fixed_string_compressed", load_table("resources/test_data/tbl/string.tbl", 3u));
 
     for (const auto& [name, table] : storage_manager.tables()) {
-      for (const auto& chunk : table->chunks()) {
-        chunk->mark_immutable();
+      const auto chunk_count = table->chunk_count();
+      for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+        table->get_chunk(chunk_id)->mark_immutable();
       }
       generate_chunk_pruning_statistics(table);
     }

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -168,8 +168,9 @@ TEST_F(ChunkEncoderTest, ReencodingTable) {
 
   for (auto const& chunk_encoding_spec : chunk_encoding_specs) {
     ChunkEncoder::encode_all_chunks(_table, chunk_encoding_spec);
-    for (auto const& chunk : _table->chunks()) {
-      verify_encoding(chunk, chunk_encoding_spec);
+    const auto chunk_count = _table->chunk_count();
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      verify_encoding(_table->get_chunk(chunk_id), chunk_encoding_spec);
     }
   }
 }

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -20,6 +20,10 @@ class StorageTableTest : public BaseTest {
     t = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   }
 
+  static tbb::concurrent_vector<std::shared_ptr<Chunk>> get_chunks(std::shared_ptr<Table>& table) {
+    return table->_chunks;
+  }
+
   std::shared_ptr<Table> t;
   TableColumnDefinitions column_definitions;
 };
@@ -215,7 +219,7 @@ TEST_F(StorageTableTest, StableChunks) {
   table->append({100, "Hello"});
 
   // The address of the first shared_ptr control object
-  const auto first_chunk = &table->_chunks[0];
+  const auto first_chunk = &get_chunks(table)[0];
 
   for (auto i = 1; i < 10; ++i) {
     table->append({i, "Hello"});
@@ -223,7 +227,7 @@ TEST_F(StorageTableTest, StableChunks) {
 
   // The vector should have been resized / expanded by now
 
-  EXPECT_EQ(first_chunk, &table->_chunks[0]);
+  EXPECT_EQ(first_chunk, &get_chunks(table)[0]);
   EXPECT_EQ((*(*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -215,7 +215,7 @@ TEST_F(StorageTableTest, StableChunks) {
   table->append({100, "Hello"});
 
   // The address of the first shared_ptr control object
-  const auto first_chunk = &table->chunks()[0];
+  const auto first_chunk = &table->_chunks[0];
 
   for (auto i = 1; i < 10; ++i) {
     table->append({i, "Hello"});
@@ -223,7 +223,7 @@ TEST_F(StorageTableTest, StableChunks) {
 
   // The vector should have been resized / expanded by now
 
-  EXPECT_EQ(first_chunk, &table->chunks()[0]);
+  EXPECT_EQ(first_chunk, &table->_chunks[0]);
   EXPECT_EQ((*(*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -20,7 +20,7 @@ class StorageTableTest : public BaseTest {
     t = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   }
 
-  static tbb::concurrent_vector<std::shared_ptr<Chunk>> get_chunks(std::shared_ptr<Table>& table) {
+  static tbb::concurrent_vector<std::shared_ptr<Chunk>>& get_chunks(std::shared_ptr<Table>& table) {
     return table->_chunks;
   }
 
@@ -219,7 +219,8 @@ TEST_F(StorageTableTest, StableChunks) {
   table->append({100, "Hello"});
 
   // The address of the first shared_ptr control object
-  const auto first_chunk = &get_chunks(table)[0];
+  const auto& chunks_vector = get_chunks(table);
+  const auto first_chunk = &chunks_vector[0];
 
   for (auto i = 1; i < 10; ++i) {
     table->append({i, "Hello"});
@@ -227,7 +228,7 @@ TEST_F(StorageTableTest, StableChunks) {
 
   // The vector should have been resized / expanded by now
 
-  EXPECT_EQ(first_chunk, &get_chunks(table)[0]);
+  EXPECT_EQ(first_chunk, &chunks_vector[0]);
   EXPECT_EQ((*(*first_chunk)->get_segment(ColumnID{0}))[0], AllTypeVariant{100});
 }
 


### PR DESCRIPTION
This PR has its root in #1686, which implements `std::atomic_load` and `std::atomic_store` for the vector `_chunks` in `Table`. Latter PR is in favor of the MvccDeletePlugin, which removes chunks from the `_chunks` vector.

Each read-/write-access on `_chunks` has to happen via atomics functions. People might forget about this and break thread-safety unwittingly.
Because of this, we remove the `chunks()` function from `Table`.  This limits all critical access to the `_chunks` vector to a single class (`Table`). 