### PR TITLE
More performance optimizations

### DIFF
--- a/src/lib/cost_estimation/cost_estimator_logical.cpp
+++ b/src/lib/cost_estimation/cost_estimator_logical.cpp
@@ -54,7 +54,7 @@ Cost CostEstimatorLogical::estimate_node_cost(const std::shared_ptr<AbstractLQPN
 }
 
 float CostEstimatorLogical::_get_expression_cost_multiplier(const std::shared_ptr<AbstractExpression>& expression) {
-  // Number of operations +  number of different columns accessed to factor in expression complexity
+  // Number of operations + number of different columns accessed to factor in expression complexity
 
   auto multiplier = 0.0f;
 

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -15,6 +15,7 @@
 
 #include "abstract_aggregate_operator.hpp"
 #include "abstract_read_only_operator.hpp"
+#include "bytell_hash_map.hpp"
 #include "expression/aggregate_expression.hpp"
 #include "resolve_type.hpp"
 #include "storage/abstract_segment_visitor.hpp"
@@ -67,7 +68,7 @@ using AggregateResultIdMapAllocator = PolymorphicAllocator<std::pair<const Aggre
 
 template <typename AggregateKey>
 using AggregateResultIdMap =
-    std::unordered_map<AggregateKey, AggregateResultId, std::hash<AggregateKey>, std::equal_to<AggregateKey>,
+    ska::bytell_hash_map<AggregateKey, AggregateResultId, std::hash<AggregateKey>, std::equal_to<AggregateKey>,
                        AggregateResultIdMapAllocator<AggregateKey>>;
 
 /*

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -331,6 +331,8 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
           radix_build_column = partition_radix_parallel<BuildColumnType, HashedType, false>(
               materialized_build_column, build_chunk_offsets, histograms_build_column, _radix_bits);
         }
+        // After the data in materialized_build_column has been partitioned, it is not needed anymore.
+        materialized_build_column.clear();
       } else {
         // short cut: skip radix partitioning and use materialized data directly
         radix_build_column = std::move(materialized_build_column);
@@ -370,6 +372,8 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
           radix_probe_column = partition_radix_parallel<ProbeColumnType, HashedType, false>(
               materialized_probe_column, probe_chunk_offsets, histograms_probe_column, _radix_bits);
         }
+        // After the data in materialized_probe_column has been partitioned, it is not needed anymore.
+        materialized_probe_column.clear();
       } else {
         // short cut: skip radix partitioning and use materialized data directly
         radix_probe_column = std::move(materialized_probe_column);
@@ -450,6 +454,10 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       default:
         Fail("JoinMode not supported by JoinHash");
     }
+
+    // After probing, the partitioned columns are not needed anymore.
+    radix_build_column.clear();
+    radix_probe_column.clear();
 
     /**
      * 3. Write output Table

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -89,6 +89,14 @@ class PosHashTable {
     }
   }
 
+  void shrink_to_fit() {
+    _pos_lists.resize(_hash_table.size());
+    _pos_lists.shrink_to_fit();
+    for (auto& pos_list : _pos_lists) {
+      pos_list.shrink_to_fit();
+    }
+  }
+
   // For a value seen on the probe side, return an iterator into the matching values
   template <typename InputType>
   const std::vector<SmallPosList>::const_iterator find(const InputType& value) const {
@@ -291,6 +299,7 @@ std::vector<std::optional<PosHashTable<HashedType>>> build(const RadixContainer<
             hash_table.emplace(element.value, element.row_id);
           }
 
+          hash_table.shrink_to_fit();
           hash_tables[current_partition_id] = std::move(hash_table);
         }));
     jobs.back()->schedule();

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -136,6 +136,13 @@ struct RadixContainer {
 
   // bit vector to store NULL flags
   std::shared_ptr<std::vector<bool>> null_value_bitvector;
+
+  void clear() {
+    elements = nullptr;
+    partition_offsets.clear();
+    partition_offsets.shrink_to_fit();
+    null_value_bitvector = nullptr;
+  }
 };
 
 inline std::vector<size_t> determine_chunk_offsets(const std::shared_ptr<const Table>& table) {

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -101,13 +101,13 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   optimizer->add_rule(std::make_unique<BetweenCompositionRule>());
 
-  optimizer->add_rule(std::make_unique<SubqueryToJoinRule>());
-
-  optimizer->add_rule(std::make_unique<InsertLimitInExistsRule>());
-
   // Position the predicates after the JoinOrderingRule ran. The JOR manipulates predicate placement as well, but
   // for now we want the PredicateReorderingRule to have the final say on predicate positions
   optimizer->add_rule(std::make_unique<PredicatePlacementRule>());
+
+  optimizer->add_rule(std::make_unique<SubqueryToJoinRule>());
+
+  optimizer->add_rule(std::make_unique<InsertLimitInExistsRule>());
 
   // Bring predicates into the desired order once the PredicatePlacementRule has positioned them as desired
   optimizer->add_rule(std::make_unique<PredicateReorderingRule>());

--- a/src/lib/storage/reference_segment.cpp
+++ b/src/lib/storage/reference_segment.cpp
@@ -39,8 +39,8 @@ const AllTypeVariant ReferenceSegment::operator[](const ChunkOffset chunk_offset
   return (*chunk->get_segment(_referenced_column_id))[row_id.chunk_offset];
 }
 
-const std::shared_ptr<const PosList> ReferenceSegment::pos_list() const { return _pos_list; }
-const std::shared_ptr<const Table> ReferenceSegment::referenced_table() const { return _referenced_table; }
+const std::shared_ptr<const PosList>& ReferenceSegment::pos_list() const { return _pos_list; }
+const std::shared_ptr<const Table>& ReferenceSegment::referenced_table() const { return _referenced_table; }
 ColumnID ReferenceSegment::referenced_column_id() const { return _referenced_column_id; }
 
 size_t ReferenceSegment::size() const { return _pos_list->size(); }

--- a/src/lib/storage/reference_segment.hpp
+++ b/src/lib/storage/reference_segment.hpp
@@ -28,8 +28,8 @@ class ReferenceSegment : public BaseSegment {
 
   size_t size() const final;
 
-  const std::shared_ptr<const PosList> pos_list() const;
-  const std::shared_ptr<const Table> referenced_table() const;
+  const std::shared_ptr<const PosList>& pos_list() const;
+  const std::shared_ptr<const Table>& referenced_table() const;
 
   ColumnID referenced_column_id() const;
 

--- a/src/lib/storage/segment_accessor.cpp
+++ b/src/lib/storage/segment_accessor.cpp
@@ -12,8 +12,30 @@ std::unique_ptr<AbstractSegmentAccessor<T>> CreateSegmentAccessor<T>::create(
   resolve_segment_type<T>(*segment, [&](const auto& typed_segment) {
     using SegmentType = std::decay_t<decltype(typed_segment)>;
     if constexpr (std::is_same_v<SegmentType, ReferenceSegment>) {
-      if (typed_segment.pos_list()->references_single_chunk() && typed_segment.pos_list()->size() > 0) {
-        accessor = std::make_unique<SingleChunkReferenceSegmentAccessor<T>>(typed_segment);
+      const auto& pos_list = *typed_segment.pos_list();
+      if (pos_list.references_single_chunk() && pos_list.size() > 0) {
+        // If the first chunk_id references a non-existing chunk, the entry is NULL. Since all entries reference
+        // the same chunk_id, we can safely assume that all other entries are also NULL and always return std::nullopt.
+        if (pos_list[ChunkOffset{0}].is_null()) {
+          accessor = std::make_unique<NullAccessor<T>>();
+        } else {
+          auto chunk_id = pos_list[ChunkOffset{0}].chunk_id;
+          auto referenced_segment =
+              typed_segment.referenced_table()->get_chunk(chunk_id)->get_segment(typed_segment.referenced_column_id());
+
+          // If only a single segment is referenced, we can resolve it right here and now so that we can avoid some
+          // virtual method calls later.
+          resolve_segment_type<T>(*referenced_segment, [&](const auto& typed_referenced_segment) {
+            if constexpr (!std::is_same_v<std::decay_t<decltype(typed_referenced_segment)>, ReferenceSegment>) {
+              auto accessor_into_referenced =
+                  SegmentAccessor<T, decltype(typed_referenced_segment)>(typed_referenced_segment);
+              accessor = std::make_unique<SingleChunkReferenceSegmentAccessor<T, decltype(accessor_into_referenced)>>(
+                  pos_list, chunk_id, std::move(accessor_into_referenced));
+            } else {
+              Fail("Encountered nested ReferenceSegments");
+            }
+          });
+        }
       } else {
         accessor = std::make_unique<MultipleChunkReferenceSegmentAccessor<T>>(typed_segment);
       }

--- a/src/lib/storage/segment_accessor.cpp
+++ b/src/lib/storage/segment_accessor.cpp
@@ -14,8 +14,11 @@ std::unique_ptr<AbstractSegmentAccessor<T>> CreateSegmentAccessor<T>::create(
     if constexpr (std::is_same_v<SegmentType, ReferenceSegment>) {
       const auto& pos_list = *typed_segment.pos_list();
       if (pos_list.references_single_chunk() && pos_list.size() > 0) {
-        // If the first chunk_id references a non-existing chunk, the entry is NULL. Since all entries reference
-        // the same chunk_id, we can safely assume that all other entries are also NULL and always return std::nullopt.
+        // If the pos list stores a NULL value, its chunk_id references a non-existing chunk. If all entries reference
+        // the same chunk_id, we can safely assume that all other entries are also NULL. Instead of using an accessor
+        // that checks for the reference being NULL, we can simply use the NullAccessor, which always returns nullopt,
+        // i.e., the accessors representation of NULL values.
+        // Note that this is independent of the row being pointed to holding a NULL value.
         if (pos_list[ChunkOffset{0}].is_null()) {
           accessor = std::make_unique<NullAccessor<T>>();
         } else {
@@ -23,7 +26,7 @@ std::unique_ptr<AbstractSegmentAccessor<T>> CreateSegmentAccessor<T>::create(
           auto referenced_segment =
               typed_segment.referenced_table()->get_chunk(chunk_id)->get_segment(typed_segment.referenced_column_id());
 
-          // If only a single segment is referenced, we can resolve it right here and now so that we can avoid some
+          // If only a single segment is referenced, we can resolve it once and avoid some more expensive
           // virtual method calls later.
           resolve_segment_type<T>(*referenced_segment, [&](const auto& typed_referenced_segment) {
             using ReferencedSegment = std::decay_t<decltype(typed_referenced_segment)>;

--- a/src/lib/storage/segment_accessor.cpp
+++ b/src/lib/storage/segment_accessor.cpp
@@ -26,11 +26,10 @@ std::unique_ptr<AbstractSegmentAccessor<T>> CreateSegmentAccessor<T>::create(
           // If only a single segment is referenced, we can resolve it right here and now so that we can avoid some
           // virtual method calls later.
           resolve_segment_type<T>(*referenced_segment, [&](const auto& typed_referenced_segment) {
-            if constexpr (!std::is_same_v<std::decay_t<decltype(typed_referenced_segment)>, ReferenceSegment>) {
-              auto accessor_into_referenced =
-                  SegmentAccessor<T, decltype(typed_referenced_segment)>(typed_referenced_segment);
-              accessor = std::make_unique<SingleChunkReferenceSegmentAccessor<T, decltype(accessor_into_referenced)>>(
-                  pos_list, chunk_id, std::move(accessor_into_referenced));
+            using ReferencedSegment = std::decay_t<decltype(typed_referenced_segment)>;
+            if constexpr (!std::is_same_v<ReferencedSegment, ReferenceSegment>) {
+              accessor = std::make_unique<SingleChunkReferenceSegmentAccessor<T, ReferencedSegment>>(
+                  pos_list, chunk_id, typed_referenced_segment);
             } else {
               Fail("Encountered nested ReferenceSegments");
             }

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -41,7 +41,7 @@ std::unique_ptr<AbstractSegmentAccessor<T>> create_segment_accessor(const std::s
  * accessor each.
  */
 template <typename T, typename SegmentType>
-class SegmentAccessor : public AbstractSegmentAccessor<T> {
+class SegmentAccessor final : public AbstractSegmentAccessor<T> {
  public:
   explicit SegmentAccessor(const SegmentType& segment) : AbstractSegmentAccessor<T>{}, _segment{segment} {}
 
@@ -58,7 +58,7 @@ class SegmentAccessor : public AbstractSegmentAccessor<T> {
  * SingleChunkReferenceSegmentAccessor, we know that the same chunk is referenced, so we create the accessor only once.
  */
 template <typename T>
-class MultipleChunkReferenceSegmentAccessor : public AbstractSegmentAccessor<T> {
+class MultipleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor<T> {
  public:
   explicit MultipleChunkReferenceSegmentAccessor(const ReferenceSegment& segment)
       : _segment{segment}, _table{segment.referenced_table()}, _accessors{1} {}
@@ -92,33 +92,28 @@ class MultipleChunkReferenceSegmentAccessor : public AbstractSegmentAccessor<T> 
 };
 
 // Accessor for ReferenceSegments that reference single chunks - see comment above
-template <typename T>
-class SingleChunkReferenceSegmentAccessor : public AbstractSegmentAccessor<T> {
+template <typename T, typename AccessorIntoReferenced>
+class SingleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor<T> {
  public:
-  explicit SingleChunkReferenceSegmentAccessor(const ReferenceSegment& segment)
-      : _segment{segment},
-        _chunk_id((*_segment.pos_list())[ChunkOffset{0}].chunk_id),
-        // If *_segment.pos_list()[ChunkOffset{0}] is NULL, its chunk_id is INVALID_CHUNK_OFFSET. When the
-        // SingleChunkReferenceSegmentAccessor is used, all entries reference the same chunk_id (INVALID_CHUNK_OFFSET).
-        // Therefore, we can safely assume that all other entries are also NULL and always return std::nullopt.
-        _accessor((*_segment.pos_list())[ChunkOffset{0}].is_null()
-                      ? std::make_unique<NullAccessor>()
-                      : create_segment_accessor<T>(segment.referenced_table()->get_chunk(_chunk_id)->get_segment(
-                            _segment.referenced_column_id()))) {}
+  explicit SingleChunkReferenceSegmentAccessor(const PosList& pos_list, const ChunkID chunk_id,
+                                               AccessorIntoReferenced accessor)
+      : _pos_list{pos_list}, _chunk_id(chunk_id), _accessor(std::move(accessor)) {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
-    const auto referenced_chunk_offset = (*_segment.pos_list())[offset].chunk_offset;
-    return _accessor->access(referenced_chunk_offset);
+    const auto referenced_chunk_offset = _pos_list[offset].chunk_offset;
+    return _accessor.access(referenced_chunk_offset);
   }
 
  protected:
-  class NullAccessor : public AbstractSegmentAccessor<T> {
-    const std::optional<T> access(ChunkOffset offset) const final { return std::nullopt; }
-  };
-
-  const ReferenceSegment& _segment;
+  const PosList& _pos_list;
   const ChunkID _chunk_id;
-  const std::unique_ptr<AbstractSegmentAccessor<T>> _accessor;
+  const AccessorIntoReferenced _accessor;
+};
+
+// Accessor for ReferenceSegments that reference only NULL values
+template <typename T>
+class NullAccessor final : public AbstractSegmentAccessor<T> {
+  const std::optional<T> access(ChunkOffset offset) const final { return std::nullopt; }
 };
 
 }  // namespace opossum

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -92,22 +92,21 @@ class MultipleChunkReferenceSegmentAccessor final : public AbstractSegmentAccess
 };
 
 // Accessor for ReferenceSegments that reference single chunks - see comment above
-template <typename T, typename AccessorIntoReferenced>
+template <typename T, typename Segment>
 class SingleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor<T> {
  public:
-  explicit SingleChunkReferenceSegmentAccessor(const PosList& pos_list, const ChunkID chunk_id,
-                                               AccessorIntoReferenced accessor)
-      : _pos_list{pos_list}, _chunk_id(chunk_id), _accessor(std::move(accessor)) {}
+  explicit SingleChunkReferenceSegmentAccessor(const PosList& pos_list, const ChunkID chunk_id, const Segment& segment)
+      : _pos_list{pos_list}, _chunk_id(chunk_id), _segment(segment) {}
 
   const std::optional<T> access(ChunkOffset offset) const final {
     const auto referenced_chunk_offset = _pos_list[offset].chunk_offset;
-    return _accessor.access(referenced_chunk_offset);
+    return _segment.get_typed_value(referenced_chunk_offset);
   }
 
  protected:
   const PosList& _pos_list;
   const ChunkID _chunk_id;
-  const AccessorIntoReferenced _accessor;
+  const Segment& _segment;
 };
 
 // Accessor for ReferenceSegments that reference only NULL values


### PR DESCRIPTION
* Improved the SingleChunkReferenceSegmentAccessor, throwing away some indirections
* Return the pos_list of a ReferenceSegment by... reference
* Change the execution order of the optimizer rules to something more beneficial
* AggregateHash: Use bytell_hash_map for the hash table
* JoinHash: Shrink the hash tables before probing
* JoinHash: Clean up materialized data earlier

```
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 1        | 0.420189529657 | 26   | 0.613110005856 | 37   | +46%       |                          0.0000 |
| TPC-H 2        | 7.60741090775  | 457  | 7.54174852371  | 453  | -1%        |                          0.0000 |
| TPC-H 3        | 6.9376115799   | 417  | 6.45343065262  | 388  | -7%        |                          0.0000 |
| TPC-H 4        | 2.04814815521  | 123  | 2.16988158226  | 131  | +6%        |                          0.0000 |
| TPC-H 5        | 4.23463582993  | 255  | 4.26381397247  | 256  | +1%        |                          0.0334 |
| TPC-H 6        | 21.8125152588  | 1309 | 21.460723877   | 1288 | -2%        |                          0.0000 |
| TPC-H 7        | 1.63777244091  | 99   | 1.62447667122  | 98   | -1%        |                          0.0316 |
| TPC-H 8        | 4.97208786011  | 299  | 5.60109806061  | 337  | +13%       |                          0.0000 |
| TPC-H 9        | 1.64692366123  | 99   | 1.64427769184  | 99   | -0%        |                          0.6310 |
| TPC-H 10       | 3.00436234474  | 181  | 2.98310613632  | 179  | -1%        |                          0.0102 |
| TPC-H 11       | 24.2119445801  | 1453 | 24.1633701324  | 1450 | -0%        |                          0.0449 |
| TPC-H 12       | 7.19117450714  | 432  | 7.18651628494  | 432  | -0%        |                          0.5984 |
| TPC-H 13       | 2.34740757942  | 141  | 2.19545173645  | 132  | -6%        |                          0.0000 |
| TPC-H 14       | 23.9443721771  | 1437 | 23.8742237091  | 1433 | -0%        |                          0.0002 |
| TPC-H 15       | 14.5949516296  | 876  | 14.848238945   | 891  | +2%        |                          0.0000 |
| TPC-H 16       | 6.92039108276  | 416  | 6.92315769196  | 416  | +0%        |                          0.6517 |
| TPC-H 17       | 1.16022956371  | 70   | 1.37646317482  | 83   | +19%       |                          0.0000 |
| TPC-H 18       | 1.37468636036  | 83   | 1.29033589363  | 78   | -6%        |                          0.0000 |
| TPC-H 19       | 5.56122875214  | 334  | 5.5431189537   | 333  | -0%        |                          0.0228 |
| TPC-H 20       | 1.95489406586  | 118  | 2.43981266022  | 147  | +25%       |                          0.0000 |
| TPC-H 21       | 0.396816372871 | 24   | 0.72137928009  | 44   | +82%       |                          0.0000 |
| TPC-H 22       | 11.8611927032  | 712  | 12.3629369736  | 742  | +4%        |                          0.0000 |
| geometric mean |                |      |                |      | +6%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```