### PR TITLE
Benchmark: Warn about mismatching chunk sizes

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -46,6 +46,14 @@ void AbstractTableGenerator::generate_and_store() {
    * Write the Tables into binary files if required
    */
   if (_benchmark_config->cache_binary_tables) {
+    for (auto& [table_name, table_info] : table_info_by_name) {
+      const auto& table = table_info.table;
+      if (table->chunk_count() > 1 && table->get_chunk(ChunkID{0})->size() != _benchmark_config->chunk_size) {
+        std::cout << "- WARNING: " << table_name << " was loaded from binary, but has a mismatching chunk size of "
+                  << table->get_chunk(ChunkID{0})->size() << std::endl;
+      }
+    }
+
     std::cout << "- Writing tables into binary files if necessary" << std::endl;
 
     for (auto& [table_name, table_info] : table_info_by_name) {


### PR DESCRIPTION
When reusing .bin files but specifying a different chunk size, the latter is ignored. This PR adds a warning about this.