### PR TITLE
View columns can have only single names

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -306,7 +306,7 @@ INSERT INTO mixed_null (b, c, a, d) SELECT b, c, a, d FROM mixed WHERE id < 13; 
 CREATE VIEW count_view1 AS SELECT a, COUNT(DISTINCT b) AS cd FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view1;
 CREATE VIEW count_view2 AS SELECT a, COUNT(DISTINCT b) AS cd FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view2 WHERE a > 10;
 CREATE VIEW count_view3 (foo, bar) AS SELECT a, COUNT(DISTINCT b) AS cd FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view3 WHERE foo > 10;
-CREATE VIEW alias_view AS SELECT a AS a1, a AS a2 FROM id_int_int_int_100 WHERE a > 10; SELECT a1 FROM alias_view;
+CREATE VIEW alias_view AS SELECT a AS a1, a AS a2 FROM id_int_int_int_100 WHERE a > 10; SELECT a1, a2 FROM alias_view;
 
 -- NULL Semantics
 SELECT * FROM mixed WHERE b IS NOT NULL;

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -306,7 +306,7 @@ INSERT INTO mixed_null (b, c, a, d) SELECT b, c, a, d FROM mixed WHERE id < 13; 
 CREATE VIEW count_view1 AS SELECT a, COUNT(DISTINCT b) AS cd FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view1;
 CREATE VIEW count_view2 AS SELECT a, COUNT(DISTINCT b) AS cd FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view2 WHERE a > 10;
 CREATE VIEW count_view3 (foo, bar) AS SELECT a, COUNT(DISTINCT b) AS cd FROM id_int_int_int_100 GROUP BY a; SELECT * FROM count_view3 WHERE foo > 10;
-CREATE VIEW alias_view AS SELECT a AS a1, a AS a2 FROM id_int_int_int_100 WHERE a > 10; SELECT a1, a2 FROM alias_view;
+CREATE VIEW alias_view AS SELECT a AS a1, a AS a2 FROM id_int_int_int_100 WHERE a > 10; SELECT a1 FROM alias_view;
 
 -- NULL Semantics
 SELECT * FROM mixed WHERE b IS NOT NULL;

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -16,8 +16,8 @@ std::string CreateViewNode::description() const {
   stream << "[CreateView] " << (if_not_exists ? "IfNotExists " : "");
   stream << "Name: " << view_name << ", Columns: ";
 
-  for (const auto& [column_id, column_names] : view->column_names) {
-    stream << column_names[0] << " ";
+  for (const auto& [column_id, column_name] : view->column_names) {
+    stream << column_name << " ";
   }
 
   stream << "FROM (\n" << *view->lqp << ")";

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -17,8 +17,6 @@ std::string CreateViewNode::description() const {
   stream << "Name: " << view_name << ", Columns: ";
 
   for (const auto& [column_id, column_names] : view->column_names) {
-    // Hotfix to make the master green:
-    Assert(column_names.size() == 1, "Using multiple names for a view column has unclear semantics (#1748)");
     stream << column_names[0] << " ";
   }
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -482,9 +482,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_table_origin(const hsq
 
           const auto column_name_iter = view->column_names.find(column_id);
           if (column_name_iter != view->column_names.end()) {
-            for (const auto& column_name : column_name_iter->second) {
-              sql_identifier_resolver->add_column_name(column_expression, column_name);
-            }
+            sql_identifier_resolver->add_column_name(column_expression, column_name_iter->second);
           }
           sql_identifier_resolver->set_table_name(column_expression, hsql_table_ref.name);
         }
@@ -1029,11 +1027,11 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create(const hsql::Cr
 std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsql::CreateStatement& create_statement) {
   auto lqp = _translate_select_statement(static_cast<const hsql::SelectStatement&>(*create_statement.select));
 
-  std::unordered_map<ColumnID, std::vector<std::string>> column_names;
+  std::unordered_map<ColumnID, std::string> column_names;
 
   for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
     for (const auto& identifier : _inflated_select_list_elements[column_id].identifiers) {
-      column_names[column_id].emplace_back(identifier.column_name);
+      column_names.emplace(column_id, identifier.column_name);
     }
   }
 
@@ -1043,7 +1041,15 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsq
                 "Number of Columns in CREATE VIEW does not match SELECT statement");
 
     for (auto column_id = ColumnID{0}; column_id < create_statement.viewColumns->size(); ++column_id) {
-      column_names[column_id].emplace_back((*create_statement.viewColumns)[column_id]);
+      column_names.emplace(column_id, (*create_statement.viewColumns)[column_id]);
+    }
+  } else {
+    for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
+      const auto identifiers =
+          _sql_identifier_resolver->get_expression_identifiers(lqp->column_expressions()[column_id]);
+      for (const auto& identifier : identifiers) {
+        column_names.emplace(column_id, identifier.column_name);
+      }
     }
   }
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1043,14 +1043,6 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsq
     for (auto column_id = ColumnID{0}; column_id < create_statement.viewColumns->size(); ++column_id) {
       column_names.insert_or_assign(column_id, (*create_statement.viewColumns)[column_id]);
     }
-  } else {
-    for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
-      const auto identifiers =
-          _sql_identifier_resolver->get_expression_identifiers(lqp->column_expressions()[column_id]);
-      for (const auto& identifier : identifiers) {
-        column_names.insert_or_assign(column_id, identifier.column_name);
-      }
-    }
   }
 
   return CreateViewNode::make(create_statement.tableName, std::make_shared<LQPView>(lqp, column_names),

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1029,12 +1029,6 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsq
 
   std::unordered_map<ColumnID, std::string> column_names;
 
-  for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
-    for (const auto& identifier : _inflated_select_list_elements[column_id].identifiers) {
-      column_names.insert_or_assign(column_id, identifier.column_name);
-    }
-  }
-
   if (create_statement.viewColumns) {
     // The CREATE VIEW statement has renamed the columns: CREATE VIEW myview (foo, bar) AS SELECT ...
     AssertInput(create_statement.viewColumns->size() == lqp->column_expressions().size(),
@@ -1042,6 +1036,12 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsq
 
     for (auto column_id = ColumnID{0}; column_id < create_statement.viewColumns->size(); ++column_id) {
       column_names.insert_or_assign(column_id, (*create_statement.viewColumns)[column_id]);
+    }
+  } else {
+    for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
+      for (const auto& identifier : _inflated_select_list_elements[column_id].identifiers) {
+        column_names.insert_or_assign(column_id, identifier.column_name);
+      }
     }
   }
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1031,7 +1031,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsq
 
   for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
     for (const auto& identifier : _inflated_select_list_elements[column_id].identifiers) {
-      column_names.emplace(column_id, identifier.column_name);
+      column_names.insert_or_assign(column_id, identifier.column_name);
     }
   }
 
@@ -1041,14 +1041,14 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_create_view(const hsq
                 "Number of Columns in CREATE VIEW does not match SELECT statement");
 
     for (auto column_id = ColumnID{0}; column_id < create_statement.viewColumns->size(); ++column_id) {
-      column_names.emplace(column_id, (*create_statement.viewColumns)[column_id]);
+      column_names.insert_or_assign(column_id, (*create_statement.viewColumns)[column_id]);
     }
   } else {
     for (auto column_id = ColumnID{0}; column_id < lqp->column_expressions().size(); ++column_id) {
       const auto identifiers =
           _sql_identifier_resolver->get_expression_identifiers(lqp->column_expressions()[column_id]);
       for (const auto& identifier : identifiers) {
-        column_names.emplace(column_id, identifier.column_name);
+        column_names.insert_or_assign(column_id, identifier.column_name);
       }
     }
   }

--- a/src/lib/storage/lqp_view.cpp
+++ b/src/lib/storage/lqp_view.cpp
@@ -6,8 +6,8 @@
 namespace opossum {
 
 LQPView::LQPView(const std::shared_ptr<AbstractLQPNode>& lqp,
-                 const std::unordered_map<ColumnID, std::string>& column_names)
-    : lqp(lqp), column_names(column_names) {}
+                 std::unordered_map<ColumnID, std::string> column_names = {})
+    : lqp(lqp), column_names(std::move(column_names)) {}
 
 std::shared_ptr<LQPView> LQPView::deep_copy() const {
   return std::make_shared<LQPView>(lqp->deep_copy(), column_names);

--- a/src/lib/storage/lqp_view.cpp
+++ b/src/lib/storage/lqp_view.cpp
@@ -6,7 +6,7 @@
 namespace opossum {
 
 LQPView::LQPView(const std::shared_ptr<AbstractLQPNode>& lqp,
-                 const std::unordered_map<ColumnID, std::vector<std::string>>& column_names)
+                 const std::unordered_map<ColumnID, std::string>& column_names)
     : lqp(lqp), column_names(column_names) {}
 
 std::shared_ptr<LQPView> LQPView::deep_copy() const {

--- a/src/lib/storage/lqp_view.hpp
+++ b/src/lib/storage/lqp_view.hpp
@@ -15,7 +15,7 @@ class AbstractLQPNode;
  */
 class LQPView {
  public:
-  LQPView(const std::shared_ptr<AbstractLQPNode>& lqp, const std::unordered_map<ColumnID, std::string>& column_names);
+  LQPView(const std::shared_ptr<AbstractLQPNode>& lqp, std::unordered_map<ColumnID, std::string> column_names);
 
   std::shared_ptr<LQPView> deep_copy() const;
   bool deep_equals(const LQPView& other) const;

--- a/src/lib/storage/lqp_view.hpp
+++ b/src/lib/storage/lqp_view.hpp
@@ -15,16 +15,13 @@ class AbstractLQPNode;
  */
 class LQPView {
  public:
-  LQPView(const std::shared_ptr<AbstractLQPNode>& lqp,
-          const std::unordered_map<ColumnID, std::vector<std::string>>& column_names);
+  LQPView(const std::shared_ptr<AbstractLQPNode>& lqp, const std::unordered_map<ColumnID, std::string>& column_names);
 
   std::shared_ptr<LQPView> deep_copy() const;
   bool deep_equals(const LQPView& other) const;
 
   const std::shared_ptr<AbstractLQPNode> lqp;
-
-  // Each ColumnID maps to n strings because a column can have multiple aliases.
-  const std::unordered_map<ColumnID, std::vector<std::string>> column_names;
+  const std::unordered_map<ColumnID, std::string> column_names;
 };
 
 }  // namespace opossum

--- a/src/test/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/logical_query_plan/create_view_node_test.cpp
@@ -11,8 +11,7 @@ class CreateViewNodeTest : public ::testing::Test {
  public:
   void SetUp() override {
     _view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
-    _view = std::make_shared<LQPView>(_view_node,
-                                      std::unordered_map<ColumnID, std::vector<std::string>>{{ColumnID{0}, {"a"}}});
+    _view = std::make_shared<LQPView>(_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, {"a"}}});
     _create_view_node = CreateViewNode::make("some_view", _view, false);
   }
 
@@ -41,8 +40,8 @@ TEST_F(CreateViewNodeTest, Equals) {
   const auto different_create_view_node_a = CreateViewNode::make("some_view2", _view, false);
 
   const auto different_view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "b"}}));
-  const auto different_view = std::make_shared<LQPView>(
-      different_view_node, std::unordered_map<ColumnID, std::vector<std::string>>{{ColumnID{0}, {"b"}}});
+  const auto different_view =
+      std::make_shared<LQPView>(different_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, {"b"}}});
   const auto different_create_view_node_b = CreateViewNode::make("some_view", different_view, false);
   const auto different_create_view_node_c = CreateViewNode::make("some_view", _view, true);
 
@@ -53,8 +52,8 @@ TEST_F(CreateViewNodeTest, Equals) {
 
 TEST_F(CreateViewNodeTest, Copy) {
   const auto same_view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
-  const auto same_view = std::make_shared<LQPView>(
-      _view_node, std::unordered_map<ColumnID, std::vector<std::string>>{{ColumnID{0}, {"a"}}});
+  const auto same_view =
+      std::make_shared<LQPView>(_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, {"a"}}});
   const auto same_create_view_node = CreateViewNode::make("some_view", _view, false);
 
   EXPECT_EQ(*same_create_view_node, *_create_view_node->deep_copy());

--- a/src/test/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/logical_query_plan/create_view_node_test.cpp
@@ -53,7 +53,7 @@ TEST_F(CreateViewNodeTest, Equals) {
 TEST_F(CreateViewNodeTest, Copy) {
   const auto same_view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
   const auto same_view =
-      std::make_shared<LQPView>(_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, {"a"}}});
+      std::make_shared<LQPView>(_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, "a"}});
   const auto same_create_view_node = CreateViewNode::make("some_view", _view, false);
 
   EXPECT_EQ(*same_create_view_node, *_create_view_node->deep_copy());

--- a/src/test/operators/maintenance/create_view_test.cpp
+++ b/src/test/operators/maintenance/create_view_test.cpp
@@ -26,7 +26,7 @@ class CreateViewTest : public BaseTest {
 
 TEST_F(CreateViewTest, OperatorName) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
-  const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+  const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
   auto cv = std::make_shared<CreateView>("view_name", view, false);
 
@@ -35,7 +35,7 @@ TEST_F(CreateViewTest, OperatorName) {
 
 TEST_F(CreateViewTest, DeepCopy) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
-  const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+  const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
   auto cv = std::make_shared<CreateView>("view_name", view, false);
 
@@ -48,7 +48,7 @@ TEST_F(CreateViewTest, DeepCopy) {
 
 TEST_F(CreateViewTest, Execute) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
-  const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+  const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
   auto cv = std::make_shared<CreateView>("view_name", view_in, false);
   cv->execute();
@@ -66,7 +66,7 @@ TEST_F(CreateViewTest, Execute) {
 
 TEST_F(CreateViewTest, ExecuteWithIfNotExists) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
-  const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+  const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
   auto cv = std::make_shared<CreateView>("view_name", view_in, true);
   cv->execute();

--- a/src/test/operators/maintenance/drop_view_test.cpp
+++ b/src/test/operators/maintenance/drop_view_test.cpp
@@ -22,7 +22,7 @@ class DropViewTest : public BaseTest {
     sm.add_table("first_table", t1);
 
     const auto view_lqp = StoredTableNode::make("first_table");
-    const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+    const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
     sm.add_view("view_name", view);
   }

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -565,9 +565,9 @@ TEST_F(SQLTranslatorTest, SelectListAliasesUsedInView) {
     PredicateNode::make(greater_than_(int_float_a, value_(10)),
       stored_table_node_int_float));
 
-  const auto view_columns = std::unordered_map<ColumnID, std::vector<std::string>>({
-                                                                      {ColumnID{0}, {"a", "x"}},
-                                                                      {ColumnID{1}, {"b", "y"}}
+  const auto view_columns = std::unordered_map<ColumnID, std::string>({
+                                                                      {ColumnID{0}, "a"},
+                                                                      {ColumnID{1}, "b"}
                                                                       });
   // clang-format on
 
@@ -591,10 +591,10 @@ TEST_F(SQLTranslatorTest, SelectListAliasesDifferentForSimilarColumnsUsedInView)
       PredicateNode::make(greater_than_(int_float_a, value_(10)),
         stored_table_node_int_float)));
 
-  const auto view_columns = std::unordered_map<ColumnID, std::vector<std::string>>({
-                                                                                   {ColumnID{0}, {"a", "a1"}},
-                                                                                   {ColumnID{1}, {"a", "a2"}}
-                                                                                   });
+  const auto view_columns = std::unordered_map<ColumnID, std::string>({
+                                                                      {ColumnID{0}, "a"},
+                                                                      {ColumnID{1}, "a"}
+                                                                      });
   // clang-format on
 
   const auto view = std::make_shared<LQPView>(view_lqp, view_columns);
@@ -617,10 +617,7 @@ TEST_F(SQLTranslatorTest, SelectListManyAliasesDifferentForSimilarColumnsUsedInV
       PredicateNode::make(greater_than_(int_float_a, value_(10)),
         stored_table_node_int_float)));
 
-  const auto view_columns = std::unordered_map<ColumnID, std::vector<std::string>>({
-                                                                                   {ColumnID{0}, {"a", "a1", "a3"}},
-                                                                                   {ColumnID{1}, {"a", "a2", "a4"}}
-                                                                                   });
+  const auto view_columns = std::unordered_map<ColumnID, std::string>({{ColumnID{0}, "a3"}, {ColumnID{1}, "a4"}});
   // clang-format on
 
   const auto view = std::make_shared<LQPView>(view_lqp, view_columns);
@@ -1960,11 +1957,11 @@ TEST_F(SQLTranslatorTest, CreateView) {
       PredicateNode::make(equals_(int_float_a, "b"),
          stored_table_node_int_float)));
 
-  const auto view_columns = std::unordered_map<ColumnID, std::vector<std::string>>({
-                                                                                   {ColumnID{0}, {"a"}},
-                                                                                   {ColumnID{1}, {"b"}},
-                                                                                   {ColumnID{3}, {"t"}},
-                                                                                   });
+  const auto view_columns = std::unordered_map<ColumnID, std::string>({
+                                                                      {ColumnID{0}, "a"},
+                                                                      {ColumnID{1}, "b"},
+                                                                      {ColumnID{3}, "t"},
+                                                                      });
   // clang-format on
 
   const auto view = std::make_shared<LQPView>(view_lqp, view_columns);
@@ -1978,10 +1975,10 @@ TEST_F(SQLTranslatorTest, CreateAliasView) {
   const auto actual_lqp = compile_query("CREATE VIEW my_second_view (c, d) AS SELECT * FROM int_float WHERE a = 'b';");
 
   // clang-format off
-  const auto view_columns = std::unordered_map<ColumnID, std::vector<std::string>>({
-                                                                                   {ColumnID{0}, {"a", "c"}},
-                                                                                   {ColumnID{1}, {"b", "d"}}
-                                                                                   });
+  const auto view_columns = std::unordered_map<ColumnID, std::string>({
+                                                                      {ColumnID{0}, "c"},
+                                                                      {ColumnID{1}, "d"}
+                                                                      });
 
   const auto view_lqp = PredicateNode::make(equals_(int_float_a, "b"), stored_table_node_int_float);
   // clang-format on
@@ -2006,8 +2003,7 @@ TEST_F(SQLTranslatorTest, CreateViewIfNotExists) {
       stored_table_node_int_float));
   // clang-format on
 
-  const auto view_columns =
-      std::unordered_map<ColumnID, std::vector<std::string>>({{ColumnID{0}, {"b"}}, {ColumnID{1}, {"a"}}});
+  const auto view_columns = std::unordered_map<ColumnID, std::string>({{ColumnID{0}, "b"}, {ColumnID{1}, "a"}});
 
   const auto view = std::make_shared<LQPView>(view_lqp, view_columns);
 

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -566,8 +566,8 @@ TEST_F(SQLTranslatorTest, SelectListAliasesUsedInView) {
       stored_table_node_int_float));
 
   const auto view_columns = std::unordered_map<ColumnID, std::string>({
-                                                                      {ColumnID{0}, "a"},
-                                                                      {ColumnID{1}, "b"}
+                                                                      {ColumnID{0}, "x"},
+                                                                      {ColumnID{1}, "y"}
                                                                       });
   // clang-format on
 
@@ -592,8 +592,8 @@ TEST_F(SQLTranslatorTest, SelectListAliasesDifferentForSimilarColumnsUsedInView)
         stored_table_node_int_float)));
 
   const auto view_columns = std::unordered_map<ColumnID, std::string>({
-                                                                      {ColumnID{0}, "a"},
-                                                                      {ColumnID{1}, "a"}
+                                                                      {ColumnID{0}, "a1"},
+                                                                      {ColumnID{1}, "a2"}
                                                                       });
   // clang-format on
 

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -789,7 +789,7 @@ TEST_F(CardinalityEstimatorTest, NonQueryNodes) {
   EXPECT_EQ(estimator.estimate_cardinality(create_prepared_plan_lqp), 0.0f);
 
   const auto lqp_view = std::make_shared<LQPView>(
-      node_a, std::unordered_map<ColumnID, std::vector<std::string>>{{ColumnID{0}, {"x"}}, {ColumnID{1}, {"y"}}});
+      node_a, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, "x"}, {ColumnID{1}, "y"}});
   const auto create_view_lqp = CreateViewNode::make("v", lqp_view, false);
   EXPECT_EQ(estimator.estimate_cardinality(create_view_lqp), 0.0f);
 

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -23,10 +23,10 @@ class StorageManagerTest : public BaseTest {
     sm.add_table("second_table", t2);
 
     const auto v1_lqp = StoredTableNode::make("first_table");
-    const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+    const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::string>{});
 
     const auto v2_lqp = StoredTableNode::make("second_table");
-    const auto v2 = std::make_shared<LQPView>(v2_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+    const auto v2 = std::make_shared<LQPView>(v2_lqp, std::unordered_map<ColumnID, std::string>{});
 
     sm.add_view("first_view", std::move(v1));
     sm.add_view("second_view", std::move(v2));
@@ -69,7 +69,7 @@ TEST_F(StorageManagerTest, HasTable) {
 
 TEST_F(StorageManagerTest, AddViewTwice) {
   const auto v1_lqp = StoredTableNode::make("first_table");
-  const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::vector<std::string>>{});
+  const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::string>{});
 
   auto& sm = StorageManager::get();
   EXPECT_THROW(sm.add_view("first_table", v1), std::exception);


### PR DESCRIPTION
- Close #1748 
- This partially reverts changes from #1692.
- The WITH feature (#1715) should use a similar solution.