### PR TITLE
Upgrade to c++20

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # Global flags and include directories
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 # When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
 # Hence, the `-Wno-dollar-in-identifier-extension` flag is required.


### PR DESCRIPTION
After making some required changes in #1728, we can switch to c++20.

See the performance impact below.
Setup:
```
- Running in single-threaded mode
- 1 simulated clients are scheduling items in parallel
- Running benchmark in 'Ordered' mode
- Encoding is 'Dictionary'
- Chunk size is 100000
- Max runs per item is 10000
- Max duration per item is 60 seconds
- No warmup runs are performed
- Not caching tables as binary files
- JIT is disabled
- Benchmarking Queries: [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, ]
- TPCH scale factor is 1
- Using prepared statements: no
```
Comparison result c++17 vs c++20:
```c++
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 1        | 0.294453084469 | 18   | 0.295977264643 | 18   | +1%        |                          0.7770 |
| TPC-H 2        | 3.24868059158  | 195  | 3.25097417831  | 196  | +0%        |                          0.6825 |
| TPC-H 3        | 2.18753695488  | 132  | 2.1931874752   | 132  | +0%        |                          0.5135 |
| TPC-H 4        | 0.896624028683 | 54   | 0.91783452034  | 56   | +2%        |                          0.0004 |
| TPC-H 5        | 1.45599508286  | 88   | 1.46927642822  | 89   | +1%        |                          0.1067 |
| TPC-H 6        | 9.84528160095  | 591  | 9.83873653412  | 591  | -0%        |                          0.7182 |
| TPC-H 7        | 0.693615078926 | 42   | 0.696095108986 | 42   | +0%        |                          0.3187 |
| TPC-H 8        | 1.58406233788  | 96   | 1.67296612263  | 101  | +6%        |                          0.0000 |
| TPC-H 9        | 0.627240598202 | 38   | 0.632148325443 | 38   | +1%        |                          0.0023 |
| TPC-H 10       | 1.28844428062  | 78   | 1.29338145256  | 78   | +0%        |                          0.1631 |
| TPC-H 11       | 7.57236480713  | 455  | 7.60324048996  | 457  | +0%        |                          0.0320 |
| TPC-H 12       | 2.90828728676  | 175  | 2.9457025528   | 177  | +1%        |                          0.0000 |
| TPC-H 13       | 1.17731022835  | 71   | 1.17885899544  | 71   | +0%        |                          0.6092 |
| TPC-H 14       | 8.94148540497  | 537  | 9.03843784332  | 543  | +1%        |                          0.0000 |
| TPC-H 15       | 5.43796062469  | 327  | 5.44290065765  | 327  | +0%        |                          0.4617 |
| TPC-H 16       | 3.12594985962  | 188  | 3.11598968506  | 187  | -0%        |                          0.0461 |
| TPC-H 17       | 0.566211640835 | 34   | 0.565749943256 | 34   | -0%        |                          0.7258 |
| TPC-H 18       | 0.48985388875  | 30   | 0.48924484849  | 30   | -0%        |                          0.6487 |
| TPC-H 19       | 2.38220763206  | 143  | 2.40973043442  | 145  | +1%        |                          0.0000 |
| TPC-H 20       | 1.13224256039  | 68   | 1.13708198071  | 69   | +0%        |                          0.1613 |
| TPC-H 21       | 0.296012729406 | 18   | 0.29754036665  | 18   | +1%        |                          0.1205 |
| TPC-H 22       | 4.27338218689  | 257  | 4.29099369049  | 258  | +0%        |                          0.1389 |
| geometric mean |                |      |                |      | +1%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```