### PR TITLE
New plot script: Run duration over time

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
+matplotlib>=2.1.1
+numpy==1.16.4
+pandas==0.24.2
+pexpect>=4.7.0
 scipy>=1.0
 termcolor>=1.0
 terminaltables>=3.0
-matplotlib>=2.1.1
-pexpect>=4.7.0

--- a/scripts/plot_run_duration_over_time.json
+++ b/scripts/plot_run_duration_over_time.json
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Takes a single benchmark output JSON and plots the duration of item executions over time
+
+# TODO add to requirements.txt
+import json
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import sys
+
+if(len(sys.argv) != 2):
+    print('Usage: ' + sys.argv[0] + ' benchmark.json')
+    exit()
+
+with open(sys.argv[1]) as json_file:
+    data_json = json.load(json_file)['benchmarks']
+
+# Build flat list of {name, begin, duration} entries for every benchmark item run
+data = []
+for benchmark_json in data_json:
+	name = benchmark_json['name']
+	for run_json in benchmark_json['runs']:
+		begin = run_json['begin']
+		duration = run_json['duration']
+		data.append({'name': name, 'begin': begin, 'duration': duration})
+
+fig, ax = plt.subplots()
+
+df = pd.DataFrame(data)
+colors = np.where(df['name'] == 'Delivery','r','-')
+colors[df['name'] == 'New-Order'] = 'g'
+colors[df['name'] == 'Order-Status'] = 'b'
+colors[df['name'] == 'Payment'] = 'c'
+colors[df['name'] == 'Stock-Level'] = 'm'
+df.reset_index().plot(kind='scatter', x='begin', y='duration', c=colors)
+
+handles = [
+	mpatches.Patch(color='r', label='Delivery'),
+	mpatches.Patch(color='g', label='NewOrder'),
+	mpatches.Patch(color='b', label='OrderStatus'),
+	mpatches.Patch(color='c', label='Payment'),
+	mpatches.Patch(color='m', label='StockLevel')
+]
+plt.legend(handles=handles)
+
+ax.grid(True)
+
+basename = sys.argv[1].replace('.json', '')
+plt.savefig(basename + '.pdf')
+plt.savefig(basename + '.png')

--- a/scripts/plot_run_duration_over_time.py
+++ b/scripts/plot_run_duration_over_time.py
@@ -22,12 +22,13 @@ benchmark_names = []
 for benchmark_json in data_json:
 	name = benchmark_json['name']
 	benchmark_names.append(name)
-	for run_json in benchmark_json['runs']:
-		begin = run_json['begin']
-		duration = run_json['duration']
-		data.append({'name': name, 'begin': begin / 1e9, 'duration': duration})
+	for run_json in benchmark_json['successful_runs']:
+		data.append({'name': name, 'begin': run_json['begin'] / 1e9, 'duration': run_json['duration'], 'success': True})
+	for run_json in benchmark_json['unsuccessful_runs']:
+		data.append({'name': name, 'begin': run_json['begin'] / 1e9, 'duration': run_json['duration'], 'success': False})
 
-df = pd.DataFrame(data)
+
+df = pd.DataFrame(data).reset_index()
 
 # Set the colors
 benchmark_names.sort()  # Sort the benchmarks for a deterministic color mapping
@@ -35,15 +36,20 @@ name_to_color = {}
 prop_cycle = plt.rcParams['axes.prop_cycle']
 default_colors = prop_cycle.by_key()['color']
 
-name_to_color[benchmark_names[0]] = default_colors[0]
-colors = np.where(df['name'] == benchmark_names[0], default_colors[0], '-')
-for i in range(1, len(benchmark_names)):
+fig, ax = plt.subplots()
+for i in range(0, len(benchmark_names)):
+	benchmark_name = benchmark_names[i]
 	color = default_colors[i % len(default_colors)]
-	name_to_color[benchmark_names[i]] = color
-	colors[df['name'] == benchmark_names[i]] = color
+	name_to_color[benchmark_name] = color
 
-# Plot combined graph
-ax = df.reset_index().plot(kind='scatter', x='begin', y='duration', c=colors, s=.3, figsize=(12, 9))
+	filtered_df = df[df['name'] == benchmark_name]
+
+	# Plot into combined graph
+	for success in [True, False]:
+		if not filtered_df[filtered_df['success']==success].empty:
+			filtered_df[filtered_df['success']==success].plot(ax=ax, kind='scatter', x='begin', y='duration', c=color, figsize=(12, 9), s=5, marker=('o' if success else 'x'), linewidth=1)
+
+# Finish combined graph
 ax.set_xlabel('Seconds since start')
 ax.set_ylabel('Execution duration [ns]')
 ax.grid(True, alpha=.3)
@@ -63,7 +69,10 @@ plt.savefig(basename + '.png')
 grouped_df = df.reset_index().groupby('name')
 fig, axes = plt.subplots(nrows=len(benchmark_names), ncols=1, figsize=(12, 3*len(benchmark_names)), sharex=True)
 for (key, ax) in zip(grouped_df.groups.keys(), axes.flatten()):
-	grouped_df.get_group(key).plot(ax=ax, kind='scatter', x='begin', y='duration', s=.6, c=name_to_color[key])
+	filtered_df = grouped_df.get_group(key)
+	for success in [True, False]:
+		if not filtered_df[filtered_df['success']==success].empty:
+			filtered_df[filtered_df['success']==success].plot(ax=ax, kind='scatter', x='begin', y='duration', c=name_to_color[key], s=5, marker=('o' if success else 'x'), linewidth=1)
 	ax.set_title(key)
 	ax.set_xlabel('Seconds since start')
 	ax.set_ylabel('Execution duration [ns]')

--- a/scripts/plot_run_duration_over_time.py
+++ b/scripts/plot_run_duration_over_time.py
@@ -32,6 +32,7 @@ fig, ax = plt.subplots()
 df = pd.DataFrame(data)
 
 # Set the colors
+benchmark_names.sort()  # Sort the benchmarks for a deterministic color mapping
 name_to_color = {}
 prop_cycle = plt.rcParams['axes.prop_cycle']
 default_colors = prop_cycle.by_key()['color']

--- a/scripts/plot_run_duration_over_time.py
+++ b/scripts/plot_run_duration_over_time.py
@@ -2,7 +2,6 @@
 
 # Takes a single benchmark output JSON and plots the duration of item executions over time
 
-# TODO add to requirements.txt
 import json
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt

--- a/scripts/plot_run_duration_over_time.py
+++ b/scripts/plot_run_duration_over_time.py
@@ -26,9 +26,8 @@ for benchmark_json in data_json:
 	for run_json in benchmark_json['runs']:
 		begin = run_json['begin']
 		duration = run_json['duration']
-		data.append({'name': name, 'begin': begin, 'duration': duration})
+		data.append({'name': name, 'begin': begin / 1e9, 'duration': duration})
 
-fig, ax = plt.subplots()
 df = pd.DataFrame(data)
 
 # Set the colors
@@ -44,17 +43,35 @@ for i in range(1, len(benchmark_names)):
 	name_to_color[benchmark_names[i]] = color
 	colors[df['name'] == benchmark_names[i]] = color
 
-# Plot
-df.reset_index().plot(kind='scatter', x='begin', y='duration', c=colors, s=.3)
-ax.grid(True)
+# Plot combined graph
+ax = df.reset_index().plot(kind='scatter', x='begin', y='duration', c=colors, s=.3, figsize=(12, 9))
+ax.set_xlabel('Seconds since start')
+ax.set_ylabel('Execution duration [ns]')
+ax.grid(True, alpha=.3)
 
-# Add legend
+# Add legend to combined graph
 handles = []
 for name, color in name_to_color.items():
 	handles.append(mpatches.Patch(label=name, color=color))
 plt.legend(handles=handles)
 
-# Write to file
+# Write combined graph to file
 basename = sys.argv[1].replace('.json', '')
 plt.savefig(basename + '.pdf')
 plt.savefig(basename + '.png')
+
+# Plot detailed graph
+grouped_df = df.reset_index().groupby('name')
+fig, axes = plt.subplots(nrows=len(benchmark_names), ncols=1, figsize=(12, 3*len(benchmark_names)), sharex=True)
+for (key, ax) in zip(grouped_df.groups.keys(), axes.flatten()):
+	grouped_df.get_group(key).plot(ax=ax, kind='scatter', x='begin', y='duration', s=.6, c=name_to_color[key])
+	ax.set_title(key)
+	ax.set_xlabel('Seconds since start')
+	ax.set_ylabel('Execution duration [ns]')
+	ax.yaxis.set_label_coords(-.08, 0.5)
+	ax.grid(True, alpha=.3)
+fig.tight_layout()
+
+# Write detailed graph to file
+plt.savefig(basename + '_detailed.pdf')
+plt.savefig(basename + '_detailed.png')


### PR DESCRIPTION
Adds a script that plots the duration of individual benchmark runs over time. Example:

![tpcc](https://user-images.githubusercontent.com/575106/61712787-6634b100-ad57-11e9-8bdc-fe672b943350.png)

Detailed version:

![tpcc_detailed](https://user-images.githubusercontent.com/575106/61712793-6af96500-ad57-11e9-9045-dd0c611b76a2.png)

