### PR TITLE
TPC-C Preparation Part 2

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -103,7 +103,7 @@ for old, new in zip(old_data['benchmarks'], new_data['benchmarks']):
         old_unsuccessful_per_second = float(len(old['unsuccessful_runs'])) / (old['duration'] / 1e9)
         new_unsuccessful_per_second = float(len(new['unsuccessful_runs'])) / (new['duration'] / 1e9)
 
-        if len(old['unsuccessful_runs']) > 0.0:
+        if len(old['unsuccessful_runs']) > 0:
             diff_unsuccessful = float(new_unsuccessful_per_second / old_unsuccessful_per_second)
         else:
             diff_unsuccessful = float('nan')

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -11,14 +11,16 @@ p_value_significance_threshold = 0.001
 min_iterations = 10
 min_runtime_ns = 59 * 1000 * 1000 * 1000
 
-def format_diff(diff):
+def format_diff(diff, inverse_colors = False):
     select_color = lambda value, color: color if abs(value) > 0.05 else 'white'
 
     diff -= 1  # adapt to show change in percent
     if diff < 0.0:
-        return colored("{0:.0%}".format(diff), select_color(diff, 'red'))
+        color = 'green' if inverse_colors else 'red'
+        return colored("{0:.0%}".format(diff), select_color(diff, color))
     else:
-        return colored("+{0:.0%}".format(diff), select_color(diff, 'green'))
+        color = 'red' if inverse_colors else 'green'
+        return colored("+{0:.0%}".format(diff), select_color(diff, color))
 
 def geometric_mean(values):
     product = 1
@@ -41,8 +43,8 @@ def get_iteration_durations(iterations):
     return iteration_durations
 
 def calculate_and_format_p_value(old, new):
-    old_durations = [run["duration"] for run in old["runs"]]
-    new_durations = [run["duration"] for run in new["runs"]]
+    old_durations = [run["duration"] for run in old["successful_runs"]]
+    new_durations = [run["duration"] for run in new["successful_runs"]]
 
     p_value = ttest_ind(array('d', old_durations), array('d', new_durations))[1]
     is_significant = p_value < p_value_significance_threshold
@@ -95,7 +97,28 @@ for old, new in zip(old_data['benchmarks'], new_data['benchmarks']):
     diff_formatted = format_diff(diff)
     p_value_formatted = calculate_and_format_p_value(old, new)
 
-    table_data.append([name, str(old['items_per_second']), str(len(old['runs'])), str(new['items_per_second']), str(len(new['runs'])), diff_formatted, p_value_formatted])
+    table_data.append([name, str(old['items_per_second']), str(len(old['successful_runs'])), str(new['items_per_second']), str(len(new['successful_runs'])), diff_formatted, p_value_formatted])
+
+    if (len(old['unsuccessful_runs']) > 0 or len(new['unsuccessful_runs']) > 0):
+        old_unsuccessful_per_second = float(len(old['unsuccessful_runs'])) / (old['duration'] / 1e9)
+        new_unsuccessful_per_second = float(len(new['unsuccessful_runs'])) / (new['duration'] / 1e9)
+
+        if len(old['unsuccessful_runs']) > 0.0:
+            diff_unsuccessful = float(new_unsuccessful_per_second / old_unsuccessful_per_second)
+        else:
+            diff_unsuccessful = float('nan')
+
+        unsuccessful_info = [
+            '  unsucc.:',
+            ' ' + str(old_unsuccessful_per_second),
+            ' ' + str(len(old['unsuccessful_runs'])),
+            ' ' + str(new_unsuccessful_per_second),
+            ' ' + str(len(new['unsuccessful_runs'])),
+            ' ' + format_diff(diff_unsuccessful, True)
+        ]
+
+        unsuccessful_info_colored = [colored(text, attrs=['dark']) for text in unsuccessful_info]
+        table_data.append(unsuccessful_info_colored)
 
 table_data.append(['geometric mean', '', '', '', '', format_diff(geometric_mean(diffs)), ''])
 

--- a/src/benchmarklib/abstract_benchmark_item_runner.cpp
+++ b/src/benchmarklib/abstract_benchmark_item_runner.cpp
@@ -41,7 +41,7 @@ void AbstractBenchmarkItemRunner::load_dedicated_expected_results(
 
 void AbstractBenchmarkItemRunner::on_tables_loaded() {}
 
-std::pair<std::vector<SQLPipelineMetrics>, bool> AbstractBenchmarkItemRunner::execute_item(
+std::tuple<bool, std::vector<SQLPipelineMetrics>, bool> AbstractBenchmarkItemRunner::execute_item(
     const BenchmarkItemID item_id) {
   std::optional<std::string> visualize_prefix;
   if (_config->enable_visualization) {
@@ -51,8 +51,8 @@ std::pair<std::vector<SQLPipelineMetrics>, bool> AbstractBenchmarkItemRunner::ex
   }
 
   BenchmarkSQLExecutor sql_executor(_config->enable_jit, _sqlite_wrapper, visualize_prefix);
-  _on_execute_item(item_id, sql_executor);
-  return {std::move(sql_executor.metrics), sql_executor.any_verification_failed};
+  auto success = _on_execute_item(item_id, sql_executor);
+  return {success, std::move(sql_executor.metrics), sql_executor.any_verification_failed};
 }
 
 void AbstractBenchmarkItemRunner::set_sqlite_wrapper(const std::shared_ptr<SQLiteWrapper>& sqlite_wrapper) {

--- a/src/benchmarklib/abstract_benchmark_item_runner.hpp
+++ b/src/benchmarklib/abstract_benchmark_item_runner.hpp
@@ -27,7 +27,7 @@ class AbstractBenchmarkItemRunner {
 
   // Executes a benchmark item and returns
   // (1) a bool indicating whether the execution was successful (unsuccessful items may be caused, e.g., by
-  //.    transaction conflicts,
+  //     transaction conflicts,
   // (2) information about the SQL statements executed during the items execution,
   // (3) a bool indicating whether the verification failed.
   std::tuple<bool, std::vector<SQLPipelineMetrics>, bool> execute_item(const BenchmarkItemID item_id);

--- a/src/benchmarklib/abstract_benchmark_item_runner.hpp
+++ b/src/benchmarklib/abstract_benchmark_item_runner.hpp
@@ -25,9 +25,12 @@ class AbstractBenchmarkItemRunner {
   // Allows the benchmark to do whatever it needs to do once the tables have been loaded (e.g., PREPARE statements)
   virtual void on_tables_loaded();
 
-  // Executes a benchmark item and returns information about the SQL statements executed during its execution as well
-  // as a bool indicating whether the verification failed.
-  std::pair<std::vector<SQLPipelineMetrics>, bool> execute_item(const BenchmarkItemID item_id);
+  // Executes a benchmark item and returns
+  // (1) a bool indicating whether the execution was successful (unsuccessful items may be caused, e.g., by
+  //.    transaction conflicts,
+  // (2) information about the SQL statements executed during the items execution,
+  // (3) a bool indicating whether the verification failed.
+  std::tuple<bool, std::vector<SQLPipelineMetrics>, bool> execute_item(const BenchmarkItemID item_id);
 
   // Returns the names of the individual items (e.g., "TPC-H 1", "NewOrder")
   virtual std::string item_name(const BenchmarkItemID item_id) const = 0;
@@ -49,7 +52,8 @@ class AbstractBenchmarkItemRunner {
   // Executes the benchmark item with the given ID. BenchmarkItemRunners should not use the SQL pipeline directly,
   // but use the provided BenchmarkSQLExecutor. That class not only tracks the execution metrics and provides them
   // back to the benchmark runner, but it also implements SQLite verification and plan visualization.
-  virtual void _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) = 0;
+  // Returns true if the execution was successful (see execute_item)
+  virtual bool _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) = 0;
 
   std::shared_ptr<BenchmarkConfig> _config;
   std::vector<std::shared_ptr<const Table>> _dedicated_expected_results;

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -7,7 +7,8 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const Chunk
                                  const Duration& max_duration, const Duration& warmup_duration,
                                  const std::optional<std::string>& output_file_path, const bool enable_scheduler,
                                  const uint32_t cores, const uint32_t clients, const bool enable_visualization,
-                                 const bool verify, const bool cache_binary_tables, const bool enable_jit)
+                                 const bool verify, const bool cache_binary_tables, const bool enable_jit,
+                                 const bool sql_metrics)
     : benchmark_mode(benchmark_mode),
       chunk_size(chunk_size),
       encoding_config(encoding_config),
@@ -21,7 +22,8 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const Chunk
       enable_visualization(enable_visualization),
       verify(verify),
       cache_binary_tables(cache_binary_tables),
-      enable_jit(enable_jit) {}
+      enable_jit(enable_jit),
+      sql_metrics(sql_metrics) {}
 
 BenchmarkConfig BenchmarkConfig::get_default_config() { return BenchmarkConfig(); }
 

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -24,7 +24,7 @@ class BenchmarkConfig {
                   const Duration& warmup_duration, const std::optional<std::string>& output_file_path,
                   const bool enable_scheduler, const uint32_t cores, const uint32_t clients,
                   const bool enable_visualization, const bool verify, const bool cache_binary_tables,
-                  const bool enable_jit);
+                  const bool enable_jit, const bool sql_metrics);
 
   static BenchmarkConfig get_default_config();
 
@@ -42,6 +42,7 @@ class BenchmarkConfig {
   bool verify = false;
   bool cache_binary_tables = false;
   bool enable_jit = false;
+  bool sql_metrics = false;
 
   static const char* description;
 

--- a/src/benchmarklib/benchmark_item_result.cpp
+++ b/src/benchmarklib/benchmark_item_result.cpp
@@ -2,6 +2,9 @@
 
 namespace opossum {
 
-BenchmarkItemResult::BenchmarkItemResult() { runs.reserve(1'000'000); }
+BenchmarkItemResult::BenchmarkItemResult() {
+  successful_runs.reserve(1'000'000);
+  unsuccessful_runs.reserve(1'000);
+}
 
 }  // namespace opossum

--- a/src/benchmarklib/benchmark_item_result.hpp
+++ b/src/benchmarklib/benchmark_item_result.hpp
@@ -12,10 +12,12 @@ struct BenchmarkItemResult {
   BenchmarkItemResult();
 
   // Stores the detailed information about the runs executed.
-  tbb::concurrent_vector<BenchmarkItemRunResult> runs;
+  tbb::concurrent_vector<BenchmarkItemRunResult> successful_runs;
+  tbb::concurrent_vector<BenchmarkItemRunResult> unsuccessful_runs;
 
   // Stores the execution duration of the item if run in BenchmarkMode::Ordered. `runs/duration` is iterations/s, even
-  // if multiple clients executed the item in parallel. Undefined for BenchmarkMode::Shuffled.
+  // if multiple clients executed the item in parallel. For BenchmarkMode::Shuffled, this is the execution duration of
+  // the entire benchmark.
   Duration duration;
 
   // The *optional* is set if the verification was executed; the *bool* is true if the verification succeeded.

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -181,6 +181,7 @@ void BenchmarkRunner::_benchmark_shuffled() {
   _state.set_done();
 
   for (auto& result : _results) {
+    // As the execution of benchmark items is intermingled, we use the total duration for all items
     result.duration = _state.benchmark_duration;
   }
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -113,7 +113,10 @@ void BenchmarkRunner::run() {
   if (_config.benchmark_mode == BenchmarkMode::Shuffled && !_config.verify && !_config.enable_visualization) {
     for (const auto& item_id : items) {
       std::cout << "- Results for " << _benchmark_item_runner->item_name(item_id) << std::endl;
-      std::cout << "  -> Executed " << _results[item_id].runs.size() << " times" << std::endl;
+      std::cout << "  -> Executed " << _results[item_id].successful_runs.size() << " times" << std::endl;
+      if (!_results[item_id].unsuccessful_runs.empty()) {
+        std::cout << "  -> " << _results[item_id].unsuccessful_runs.size() << " additional runs failed" << std::endl;
+      }
     }
   }
 
@@ -177,6 +180,10 @@ void BenchmarkRunner::_benchmark_shuffled() {
   }
   _state.set_done();
 
+  for (auto& result : _results) {
+    result.duration = _state.benchmark_duration;
+  }
+
   // Wait for the rest of the tasks that didn't make it in time - they will not count towards the results
   CurrentScheduler::wait_for_all_tasks();
   Assert(_currently_running_clients == 0, "All runs must be finished at this point");
@@ -195,7 +202,8 @@ void BenchmarkRunner::_benchmark_ordered() {
 
     _state = BenchmarkState{_config.max_duration};
 
-    while (_state.keep_running() && result.runs.size() < _config.max_runs) {
+    while (_state.keep_running() &&
+           (result.successful_runs.size() + result.unsuccessful_runs.size()) < _config.max_runs) {
       // We want to only schedule as many items simultaneously as we have simulated clients
       if (_currently_running_clients.load(std::memory_order_relaxed) < _config.clients) {
         _schedule_item_run(item_id);
@@ -209,11 +217,14 @@ void BenchmarkRunner::_benchmark_ordered() {
     const auto duration_of_all_runs_ns =
         static_cast<float>(std::chrono::duration_cast<std::chrono::nanoseconds>(_state.benchmark_duration).count());
     const auto duration_seconds = duration_of_all_runs_ns / 1'000'000'000;
-    const auto items_per_second = static_cast<float>(result.runs.size()) / duration_seconds;
+    const auto items_per_second = static_cast<float>(result.successful_runs.size()) / duration_seconds;
 
     if (!_config.verify && !_config.enable_visualization) {
-      std::cout << "  -> Executed " << result.runs.size() << " times in " << duration_seconds << " seconds ("
+      std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds ("
                 << items_per_second << " iter/s)" << std::endl;
+      if (!result.unsuccessful_runs.empty()) {
+        std::cout << "  -> " << result.unsuccessful_runs.size() << " additional runs failed" << std::endl;
+      }
     }
 
     // Wait for the rest of the tasks that didn't make it in time - they will not count toward the results
@@ -229,7 +240,7 @@ void BenchmarkRunner::_schedule_item_run(const BenchmarkItemID item_id) {
   auto task = std::make_shared<JobTask>(
       [&, item_id]() {
         const auto run_start = std::chrono::steady_clock::now();
-        auto [metrics, any_run_verification_failed] = _benchmark_item_runner->execute_item(item_id);  // NOLINT
+        auto [success, metrics, any_run_verification_failed] = _benchmark_item_runner->execute_item(item_id);
         const auto run_end = std::chrono::steady_clock::now();
 
         --_currently_running_clients;
@@ -239,7 +250,14 @@ void BenchmarkRunner::_schedule_item_run(const BenchmarkItemID item_id) {
         result.verification_passed = result.verification_passed.value_or(true) && !any_run_verification_failed;
 
         if (!_state.is_done()) {  // To prevent items from adding their result after the time is up
-          result.runs.push_back({run_start - _benchmark_start, run_end - run_start, std::move(metrics)});
+          if (!_config.sql_metrics) metrics.clear();
+          const auto item_result =
+              BenchmarkItemRunResult{run_start - _benchmark_start, run_end - run_start, std::move(metrics)};
+          if (success) {
+            result.successful_runs.push_back(item_result);
+          } else {
+            result.unsuccessful_runs.push_back(item_result);
+          }
         }
       },
       SchedulePriority::High);
@@ -253,14 +271,13 @@ void BenchmarkRunner::_warmup(const BenchmarkItemID item_id) {
   if (_config.warmup_duration == Duration{0}) return;
 
   const auto& name = _benchmark_item_runner->item_name(item_id);
-  BenchmarkItemResult& result = _results[item_id];
   std::cout << "- Warming up for " << name << std::endl;
 
   Assert(_currently_running_clients == 0, "Did not expect any clients to run at this time");
 
   _state = BenchmarkState{_config.warmup_duration};
 
-  while (_state.keep_running() && result.runs.size() < _config.max_runs) {
+  while (_state.keep_running()) {
     // We want to only schedule as many items simultaneously as we have simulated clients
     if (_currently_running_clients.load(std::memory_order_relaxed) < _config.clients) {
       _schedule_item_run(item_id);
@@ -287,46 +304,55 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     const auto& name = _benchmark_item_runner->item_name(item_id);
     const auto& result = _results.at(item_id);
 
-    auto runs_json = nlohmann::json::array();
-    for (const auto& run_result : result.runs) {
+    const auto runs_to_json = [](auto runs) {
+      auto runs_json = nlohmann::json::array();
+      for (const auto& run_result : runs) {
+        // Convert the SQLPipelineMetrics for each run of the BenchmarkItem into JSON
+        auto all_pipeline_metrics_json = nlohmann::json::array();
+        // metrics can be empty if _config.sql_metrics is false
+        for (const auto& pipeline_metrics : run_result.metrics) {
+          auto pipeline_metrics_json = nlohmann::json{{"parse_duration", pipeline_metrics.parse_time_nanos.count()},
+                                                      {"statements", nlohmann::json::array()}};
 
-      // Convert the SQLPipelineMetrics for each run of the BenchmarkItem into JSON
-      auto all_pipeline_metrics_json = nlohmann::json::array();
-      for (const auto& pipeline_metrics : run_result.metrics) {
-        auto pipeline_metrics_json = nlohmann::json{{"parse_duration", pipeline_metrics.parse_time_nanos.count()},
-                                                    {"statements", nlohmann::json::array()}};
+          for (const auto& sql_statement_metrics : pipeline_metrics.statement_metrics) {
+            auto sql_statement_metrics_json =
+                nlohmann::json{{"sql_translation_duration", sql_statement_metrics->sql_translation_duration.count()},
+                               {"optimization_duration", sql_statement_metrics->optimization_duration.count()},
+                               {"lqp_translation_duration", sql_statement_metrics->lqp_translation_duration.count()},
+                               {"plan_execution_duration", sql_statement_metrics->plan_execution_duration.count()},
+                               {"query_plan_cache_hit", sql_statement_metrics->query_plan_cache_hit}};
 
-        for (const auto& sql_statement_metrics : pipeline_metrics.statement_metrics) {
-          auto sql_statement_metrics_json =
-              nlohmann::json{{"sql_translation_duration", sql_statement_metrics->sql_translation_duration.count()},
-                             {"optimization_duration", sql_statement_metrics->optimization_duration.count()},
-                             {"lqp_translation_duration", sql_statement_metrics->lqp_translation_duration.count()},
-                             {"plan_execution_duration", sql_statement_metrics->plan_execution_duration.count()},
-                             {"query_plan_cache_hit", sql_statement_metrics->query_plan_cache_hit}};
+            pipeline_metrics_json["statements"].push_back(sql_statement_metrics_json);
+          }
 
-          pipeline_metrics_json["statements"].push_back(sql_statement_metrics_json);
+          all_pipeline_metrics_json.push_back(pipeline_metrics_json);
         }
 
-        all_pipeline_metrics_json.push_back(pipeline_metrics_json);
+        runs_json.push_back(nlohmann::json{{"begin", run_result.begin.count()},
+                                           {"duration", run_result.duration.count()},
+                                           {"metrics", all_pipeline_metrics_json}});
       }
+      return runs_json;
+    };
 
-      runs_json.push_back(nlohmann::json{{"begin", run_result.begin.count()},
-                                         {"duration", run_result.duration.count()},
-                                         {"metrics", all_pipeline_metrics_json}});
-    }
-
-    nlohmann::json benchmark{{"name", name}, {"runs", runs_json}, {"iterations", result.runs.size()}};
+    nlohmann::json benchmark{{"name", name},
+                             {"duration", std::chrono::duration_cast<std::chrono::nanoseconds>(result.duration).count()},
+                             {"successful_runs", runs_to_json(result.successful_runs)},
+                             {"unsuccessful_runs", runs_to_json(result.unsuccessful_runs)},
+                             {"iterations", result.successful_runs.size()}};
 
     // For ordered benchmarks, report the time that this individual item ran. For shuffled benchmarks, return the
     // duration of the entire benchmark. This means that items_per_second of ordered and shuffled runs are not
     // comparable.
-    const auto reported_item_duration = _config.benchmark_mode == BenchmarkMode::Shuffled ? _total_run_duration : result.duration;
+    const auto reported_item_duration =
+        _config.benchmark_mode == BenchmarkMode::Shuffled ? _total_run_duration : result.duration;
     const auto reported_item_duration_ns =
         static_cast<float>(std::chrono::duration_cast<std::chrono::nanoseconds>(reported_item_duration).count());
     const auto duration_seconds = reported_item_duration_ns / 1'000'000'000;
-    const auto items_per_second = static_cast<float>(result.runs.size()) / duration_seconds;
+    const auto items_per_second = static_cast<float>(result.successful_runs.size()) / duration_seconds;
     benchmark["items_per_second"] = items_per_second;
-    const auto time_per_item = !result.runs.empty() ? reported_item_duration_ns / result.runs.size() : std::nanf("");
+    const auto time_per_item =
+        !result.successful_runs.empty() ? reported_item_duration_ns / result.successful_runs.size() : std::nanf("");
     benchmark["avg_real_time_per_iteration"] = time_per_item;
 
     benchmarks.push_back(benchmark);
@@ -378,7 +404,8 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint>()->default_value("1")) // NOLINT
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("cache_binary_tables", "Cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")); // NOLINT
+    ("cache_binary_tables", "Cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
+    ("sql_metrics", "Track SQL metrics (parse time etc.) for each SQL query", cxxopts::value<bool>()->default_value("false")); // NOLINT
 
   if constexpr (HYRISE_JIT_SUPPORT) {
     cli_options.add_options()

--- a/src/benchmarklib/benchmark_runner.hpp
+++ b/src/benchmarklib/benchmark_runner.hpp
@@ -87,7 +87,8 @@ class BenchmarkRunner {
   // let a simulated client schedule the next item, as well as the total number of finished items so far
   std::atomic_uint _currently_running_clients{0};
 
-  // For BenchmarkMode::Shuffled, we count the number of runs executed across all items.
+  // For BenchmarkMode::Shuffled, we count the number of runs executed across all items. This also includes items that
+  // were unsuccessful (e.g., because of transaction aborts).
   std::atomic_uint _total_finished_runs{0};
 
   BenchmarkState _state{Duration{0}};

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -133,15 +133,22 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
     std::cout << "- Not caching tables as binary files" << std::endl;
   }
 
+  const auto sql_metrics = json_config.value("sql_metrics", false);
+  if (sql_metrics) {
+    std::cout << "- Tracking SQL metrics" << std::endl;
+  } else {
+    std::cout << "- Not tracking SQL metrics" << std::endl;
+  }
+
   auto enable_jit = false;
   if constexpr (HYRISE_JIT_SUPPORT) {
     enable_jit = json_config.value("jit", default_config.enable_jit);
   }
   std::cout << "- JIT is " << (enable_jit ? "enabled" : "disabled") << std::endl;
 
-  return BenchmarkConfig{benchmark_mode,       chunk_size,       *encoding_config,    max_runs,  timeout_duration,
-                         warmup_duration,      output_file_path, enable_scheduler,    cores,     clients,
-                         enable_visualization, verify,           cache_binary_tables, enable_jit};
+  return BenchmarkConfig{benchmark_mode,       chunk_size,       *encoding_config,    max_runs,   timeout_duration,
+                         warmup_duration,      output_file_path, enable_scheduler,    cores,      clients,
+                         enable_visualization, verify,           cache_binary_tables, enable_jit, sql_metrics};
 }
 
 BenchmarkConfig CLIConfigParser::parse_basic_cli_options(const cxxopts::ParseResult& parse_result) {
@@ -165,6 +172,7 @@ nlohmann::json CLIConfigParser::basic_cli_options_to_json(const cxxopts::ParseRe
   json_config.emplace("output", parse_result["output"].as<std::string>());
   json_config.emplace("verify", parse_result["verify"].as<bool>());
   json_config.emplace("cache_binary_tables", parse_result["cache_binary_tables"].as<bool>());
+  json_config.emplace("sql_metrics", parse_result["sql_metrics"].as<bool>());
   if constexpr (HYRISE_JIT_SUPPORT) {
     json_config.emplace("jit", parse_result["jit"].as<bool>());
   }

--- a/src/benchmarklib/file_based_benchmark_item_runner.cpp
+++ b/src/benchmarklib/file_based_benchmark_item_runner.cpp
@@ -42,13 +42,14 @@ FileBasedBenchmarkItemRunner::FileBasedBenchmarkItemRunner(
   std::sort(_queries.begin(), _queries.end(), [](const Query& lhs, const Query& rhs) { return lhs.name < rhs.name; });
 }
 
-void FileBasedBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) {
+bool FileBasedBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) {
   std::shared_ptr<const Table> expected_result_table = nullptr;
   if (!_dedicated_expected_results.empty()) {
     expected_result_table = _dedicated_expected_results[item_id];
   }
 
-  sql_executor.execute(_queries[item_id].sql, expected_result_table);
+  const auto [status, table] = sql_executor.execute(_queries[item_id].sql, expected_result_table);
+  return status == SQLPipelineStatus::Success;
 }
 
 std::string FileBasedBenchmarkItemRunner::item_name(const BenchmarkItemID item_id) const {

--- a/src/benchmarklib/file_based_benchmark_item_runner.hpp
+++ b/src/benchmarklib/file_based_benchmark_item_runner.hpp
@@ -22,7 +22,7 @@ class FileBasedBenchmarkItemRunner : public AbstractBenchmarkItemRunner {
   const std::vector<BenchmarkItemID>& items() const override;
 
  protected:
-  void _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) override;
+  bool _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) override;
 
   struct Query {
     std::string name;

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -502,6 +502,8 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_new_order_table() {
 }
 
 std::unordered_map<std::string, BenchmarkTableInfo> TPCCTableGenerator::generate() {
+  Assert(!_benchmark_config->cache_binary_tables, "Caching binary tables is not yet supported for TPC-C");
+
   std::vector<std::thread> threads;
   auto item_table = std::async(std::launch::async, &TPCCTableGenerator::generate_items_table, this);
   auto warehouse_table = std::async(std::launch::async, &TPCCTableGenerator::generate_warehouse_table, this);

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
@@ -56,14 +56,16 @@ TPCHBenchmarkItemRunner::TPCHBenchmarkItemRunner(const std::shared_ptr<Benchmark
 
 const std::vector<BenchmarkItemID>& TPCHBenchmarkItemRunner::items() const { return _items; }
 
-void TPCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) {
+bool TPCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) {
   const auto sql = _build_query(item_id);
   std::shared_ptr<const Table> expected_result_table = nullptr;
   if (!_dedicated_expected_results.empty()) {
     expected_result_table = _dedicated_expected_results[item_id];
   }
 
-  sql_executor.execute(sql, expected_result_table);
+  const auto [status, table] = sql_executor.execute(sql, expected_result_table);
+  Assert(status == SQLPipelineStatus::Success, "TPC-H items should not fail");
+  return true;
 }
 
 void TPCHBenchmarkItemRunner::on_tables_loaded() {

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.hpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.hpp
@@ -25,7 +25,7 @@ class TPCHBenchmarkItemRunner : public AbstractBenchmarkItemRunner {
   const std::vector<BenchmarkItemID>& items() const override;
 
  protected:
-  void _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) override;
+  bool _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) override;
 
   // Runs the PREPARE queries if _use_prepared_statements is set, otherwise does nothing
   void _prepare_queries() const;

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -57,7 +57,7 @@ std::shared_ptr<AbstractExpression> expression_copy_and_adapt_to_different_lqp(c
                                                                                const LQPNodeMapping& node_mapping);
 
 /**
- * Makes all column references points to their equivalent in a copied LQP
+ * Makes all column references point to their equivalent in a copied LQP
  */
 void expression_adapt_to_different_lqp(std::shared_ptr<AbstractExpression>& expression,
                                        const LQPNodeMapping& node_mapping);


### PR DESCRIPTION
I realized that we will need support for unsuccessful transactions (i.e., transaction aborts). As #1759 will change the JSON result format and this will change it again, I'd rather have only a single master commit.

Also makes the inclusion of SQL metrics optional, greatly reducing the size of the resulting JSON.

To make the review easier, this is a PR into #1759.

Sorry for making this slightly confusing. Hopefully, this makes the final TPC-C PR a bit easier to read.