### PR TITLE
Fix NULLable for aggregate, harden tests

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -358,6 +358,7 @@ SELECT * FROM id_int_int_int_100 t1 WHERE id < 9 AND (SELECT MIN(t2.id + 10) FRO
 SELECT CASE WHEN id < 50 THEN 'Hello' WHEN id < 70 THEN 'World' ELSE 'Ciao' END AS case_column FROM mixed;
 SELECT CASE WHEN id + 3.4 < 50 THEN 'Hello' WHEN id < 70 THEN 'World' ELSE 'Ciao' END AS case_column FROM mixed;
 SELECT CASE id + 10 WHEN 15 THEN a WHEN 26 THEN 'World' ELSE d END AS case_column FROM mixed;
+SELECT a, CASE WHEN a IS NULL THEN 1 ELSE 2 END FROM mixed_null GROUP BY a
 
 -- IN
 SELECT * FROM id_int_int_int_100 WHERE a IN (24, 55, 78)

--- a/resources/test_data/tbl/aggregateoperator/0gb_1agg/avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/0gb_1agg/avg.tbl
@@ -1,3 +1,3 @@
 AVG(b)
-double
+double_null
 430.95

--- a/resources/test_data/tbl/aggregateoperator/0gb_1agg/max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/0gb_1agg/max.tbl
@@ -1,3 +1,3 @@
 MAX(b)
-float
+float_null
 458.7

--- a/resources/test_data/tbl/aggregateoperator/0gb_1agg/min.tbl
+++ b/resources/test_data/tbl/aggregateoperator/0gb_1agg/min.tbl
@@ -1,3 +1,3 @@
 MIN(b)
-float
+float_null
 350.7

--- a/resources/test_data/tbl/aggregateoperator/0gb_1agg/stddev_samp.tbl
+++ b/resources/test_data/tbl/aggregateoperator/0gb_1agg/stddev_samp.tbl
@@ -1,3 +1,3 @@
 STDDEV_SAMP(b)
-double
+double_null
 53.50623

--- a/resources/test_data/tbl/aggregateoperator/0gb_1agg/sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/0gb_1agg/sum.tbl
@@ -1,3 +1,3 @@
 SUM(b)
-double
+double_null
 1723.8

--- a/resources/test_data/tbl/aggregateoperator/0gb_2agg/count_sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/0gb_2agg/count_sum.tbl
@@ -1,3 +1,3 @@
 COUNT(*)|SUM(a + b)
-long|long
+long|long_null
 8|115

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/avg.tbl
@@ -1,5 +1,5 @@
 a|AVG(b)
-int|double
+int|double_null
 12345|457.2
 123|458.7
 12|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/count_null.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/count_null.tbl
@@ -1,5 +1,5 @@
 a|COUNT(b)
-int_null|long_null
+int_null|long
 12345|2
 123|1
 12|1

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/max.tbl
@@ -1,5 +1,5 @@
 a|MAX(b)
-int|float
+int|float_null
 12345|457.7
 123|458.7
 12|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/max_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/max_filtered.tbl
@@ -1,3 +1,3 @@
 a|MAX(b)
-int|float
+int|float_null
 12|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/min.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/min.tbl
@@ -1,5 +1,5 @@
 a|MIN(b)
-int|float
+int|float_null
 12345|456.7
 123|458.7
 12|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/min_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/min_filtered.tbl
@@ -1,3 +1,3 @@
 a|MIN(b)
-int|float
+int|float_null
 12|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/sum.tbl
@@ -1,5 +1,5 @@
 a|SUM(b)
-int|double
+int|double_null
 12345|914.4
 123|458.7
 12|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/avg_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/avg_avg.tbl
@@ -1,5 +1,5 @@
 a|AVG(b)|AVG(c)
-int|double|double
+int|double_null|double_null
 12345|457.2|26.5
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/max_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/max_avg.tbl
@@ -1,5 +1,5 @@
 a|MAX(b)|AVG(c)
-int|float|double
+int|float_null|double_null
 12345|457.7|26.5
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/max_stddev_samp.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/max_stddev_samp.tbl
@@ -1,5 +1,5 @@
 a|MAX(b)|STDDEV_SAMP(c)
-int|float|double_null
+int|float_null|double_null
 12345|457.7|9.19238
 123|458.7|null
 12|350.7|null

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/min_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/min_avg.tbl
@@ -1,5 +1,5 @@
 a|MIN(b)|AVG(c)
-int|float|double
+int|float_null|double_null
 12345|456.7|26.5
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/min_max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/min_max.tbl
@@ -1,5 +1,5 @@
 a|MIN(b)|MAX(c)
-int|float|int
+int|float_null|int_null
 12345|456.7|33
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/min_stddev_samp.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/min_stddev_samp.tbl
@@ -1,5 +1,5 @@
 a|MIN(b)|STDDEV_SAMP(c)
-int|float|double_null
+int|float_null|double_null
 12345|456.7|9.19238
 123|458.7|null
 12|350.7|null

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/stddev_samp_avg_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/stddev_samp_avg_filtered.tbl
@@ -1,3 +1,3 @@
 a|STDDEV_SAMP(b)|AVG(c)
-int|double_null|double
+int|double_null|double_null
 12|null|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_avg.tbl
@@ -1,5 +1,5 @@
 a|SUM(b)|AVG(c)
-int|double|double
+int|double_null|double_null
 12345|914.4|26.5
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_avg_alias.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_avg_alias.tbl
@@ -1,5 +1,5 @@
 a|sum_b|AVG(c)
-int|double|double
+int|double_null|double_null
 12345|914.4|26.5
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_avg_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_avg_filtered.tbl
@@ -1,3 +1,3 @@
 a|SUM(b)|AVG(c)
-int|double|double
+int|double_null|double_null
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_count.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_count.tbl
@@ -1,5 +1,5 @@
 a|SUM(b)|COUNT(c)
-int|double|long
+int|double_null|long
 12345|914.4|2
 123|458.7|1
 12|350.7|1

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_2agg/sum_sum.tbl
@@ -1,5 +1,5 @@
 a|SUM(b)|SUM(c)
-int|double|long
+int|double_null|long_null
 12345|914.4|53
 123|458.7|20
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_3agg/max_count_count_empty.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_3agg/max_count_count_empty.tbl
@@ -1,2 +1,2 @@
 a|MAX(b)|COUNT(c)|COUNT(*)
-int|float|long|long
+int|float_null|long|long

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/avg.tbl
@@ -1,5 +1,5 @@
 a|b|AVG(c)
-int|float|double
+int|float|double_null
 12345|456.7|22
 12345|457.7|31.5
 123|458.7|20

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/max.tbl
@@ -1,5 +1,5 @@
 a|b|MAX(c)
-int|float|int
+int|float|int_null
 12345|456.7|24
 12345|457.7|33
 123|458.7|20

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/min.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/min.tbl
@@ -1,5 +1,5 @@
 a|b|MIN(c)
-int|float|int
+int|float|int_null
 12345|456.7|20
 12345|457.7|30
 123|458.7|20

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/sum.tbl
@@ -1,5 +1,5 @@
 a|b|SUM(c)
-int|float|long
+int|float|long_null
 12345|456.7|44
 12345|457.7|63
 123|458.7|40

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/sum_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_1agg/sum_filtered.tbl
@@ -1,3 +1,3 @@
 a|b|SUM(c)
-int|float|long
+int|float|long_null
 12|350.7|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/avg_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/avg_avg.tbl
@@ -1,5 +1,5 @@
 a|b|AVG(c)|AVG(d)
-int|float|double|double
+int|float|double_null|double_null
 12345|456.7|22|20.35
 12345|457.7|30|32.95
 123|458.7|20|3

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/having_on_gb.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/having_on_gb.tbl
@@ -1,3 +1,3 @@
 a|b|MAX(c)|AVG(d)
-int|float|int|double
+int|float|int_null|double_null
 12345|457.7|33|32.95

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_avg.tbl
@@ -1,5 +1,5 @@
 a|b|MAX(c)|AVG(d)
-int|float|int|double
+int|float|int_null|double_null
 12345|456.7|24|20.35
 12345|457.7|33|32.95
 123|458.7|20|3

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_avg_having.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_avg_having.tbl
@@ -1,4 +1,4 @@
 a|b|MAX(c)|AVG(d)
-int|float|int|double
+int|float|int_null|double_null
 12345|456.7|24|20.35
 123|458.7|20|3

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_min.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_min.tbl
@@ -1,5 +1,5 @@
 b|d|max_a|min_c
-int|int|float|float
+int|int|float_null|float_null
 12345|20|456.7|12.4
 12345|30|459.7|17.2
 123|20|958.7|1.1

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_min_filter_projection.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/max_min_filter_projection.tbl
@@ -1,4 +1,4 @@
 d|min_c|max_a
-int|float|float
+int|float_null|float_null
 30|17.2|459.7
 31|480.1|457.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/min_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/min_avg.tbl
@@ -1,5 +1,5 @@
 a|b|MIN(c)|AVG(d)
-int|float|int|double
+int|float|int_null|double_null
 12345|456.7|20|20.35
 12345|457.7|30|32.95
 123|458.7|20|3

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/min_avg_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/min_avg_filtered.tbl
@@ -1,3 +1,3 @@
 a|b|MIN(c)|AVG(d)
-int|float|int|double
+int|float|int_null|double_null
 12|350.7|10|5.4

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/min_max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/min_max.tbl
@@ -1,5 +1,5 @@
 a|b|MIN(c)|MAX(d)
-int|float|int|float
+int|float|int_null|float_null
 12345|456.7|20|28.3
 12345|457.7|30|48.7
 123|458.7|20|4.9

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/stddev_samp_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/stddev_samp_avg.tbl
@@ -1,5 +1,5 @@
 a|b|STDDEV_SAMP(c)|AVG(d)
-int|float|double_null|double
+int|float|double_null|double_null
 12345|456.7|2.82842|20.35
 12345|457.7|2.12132|32.95
 123|458.7|0.0|3

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/sum_avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/sum_avg.tbl
@@ -1,5 +1,5 @@
 a|b|SUM(c)|AVG(d)
-int|float|long|double
+int|float|long_null|double_null
 12345|456.7|44|20.35
 12345|457.7|63|32.95
 123|458.7|40|3

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/sum_count.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/sum_count.tbl
@@ -1,5 +1,5 @@
 a|b|SUM(c)|COUNT(d)
-int|float|long|long
+int|float|long_null|long
 12345|456.7|44|2
 12345|457.7|63|2
 123|458.7|40|2

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/sum_sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_2gb_2agg/sum_sum.tbl
@@ -1,5 +1,5 @@
 a|b|SUM(c)|SUM(d)
-int|float|long|double
+int|float|long_null|double_null
 12345|456.7|44|40.7
 12345|457.7|63|65.9
 123|458.7|40|6

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/avg.tbl
@@ -1,5 +1,5 @@
 a|b|d|AVG(c)
-int|float|int|double
+int|float|int|double_null
 12345|456.7|5|21
 12345|456.7|1|24
 12345|456.7|2|24

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/max.tbl
@@ -1,5 +1,5 @@
 a|b|d|MAX(c)
-int|float|int|int
+int|float|int|int_null
 12345|456.7|5|22
 12345|456.7|1|24
 12345|456.7|2|24

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/min.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/min.tbl
@@ -1,5 +1,5 @@
 a|b|d|MIN(c)
-int|float|int|int
+int|float|int|int_null
 12345|456.7|5|20
 12345|456.7|1|24
 12345|456.7|2|24

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/sum.tbl
@@ -1,5 +1,5 @@
 a|b|d|SUM(c)
-int|float|int|long
+int|float|int|long_null
 12345|456.7|5|42
 12345|456.7|1|24
 12345|456.7|2|24

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/sum_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_3gb_1agg/sum_filtered.tbl
@@ -1,4 +1,4 @@
 a|b|d|SUM(c)
-int|float|int|long
+int|float|int|long_null
 12|350.7|1|10
 12|350.7|4|10

--- a/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/avg.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/avg.tbl
@@ -1,5 +1,5 @@
 a|AVG(b)
-string|double
+string|double_null
 aaaaa|457.2
 aaa|458.7
 aa|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/max.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/max.tbl
@@ -1,5 +1,5 @@
 a|MAX(b)
-string|float
+string|float_null
 aaaaa|457.7
 aaa|458.7
 aa|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/max_str.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/max_str.tbl
@@ -1,3 +1,3 @@
 MAX(a)
-string
+string_null
 aaaaa

--- a/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/min.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/min.tbl
@@ -1,5 +1,5 @@
 a|MIN(b)
-string|float
+string|float_null
 aaaaa|456.7
 aaa|458.7
 aa|350.7

--- a/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/min_str.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/min_str.tbl
@@ -1,3 +1,3 @@
 MIN(a)
-string
+string_null
 aa

--- a/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/sum.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_string_1gb_1agg/sum.tbl
@@ -1,5 +1,5 @@
 a|SUM(b)
-string|double
+string|double_null
 aaaaa|914.4
 aaa|458.7
 aa|350.7

--- a/resources/test_data/tbl/int_string_like_containing.tbl
+++ b/resources/test_data/tbl/int_string_like_containing.tbl
@@ -1,5 +1,5 @@
 a|b
-int|string
+int|string_null
 1234|Dampfschifffahrtsgesellschaft
 123456|Dampfschifffahrtsgesellschaftskapitän
 1234567|Dampfschifffahrtsgesellschaftskapitänsdampf

--- a/resources/test_data/tbl/int_string_like_containing2.tbl
+++ b/resources/test_data/tbl/int_string_like_containing2.tbl
@@ -1,5 +1,5 @@
 a|b
-int|string
+int|string_null
 1234|dampfschifffahrtsgesellschaft
 123456|dampfschifffahrtsgesellschaftskapitaen
 1234567|dampfschifffahrtsgesellschaftskapitaensdampf

--- a/resources/test_data/tbl/int_string_like_containing_wildcard.tbl
+++ b/resources/test_data/tbl/int_string_like_containing_wildcard.tbl
@@ -1,3 +1,3 @@
 a|b
-int|string
+int|string_null
 123|Schifffahrtsgesellschaft

--- a/resources/test_data/tbl/int_string_like_ending.tbl
+++ b/resources/test_data/tbl/int_string_like_ending.tbl
@@ -1,4 +1,4 @@
 a|b
-int|string
+int|string_null
 123|Schifffahrtsgesellschaft
 1234|Dampfschifffahrtsgesellschaft

--- a/resources/test_data/tbl/int_string_like_equals.tbl
+++ b/resources/test_data/tbl/int_string_like_equals.tbl
@@ -1,3 +1,3 @@
 a|b
-int|string
+int|string_null
 12345|Reeperbahn

--- a/resources/test_data/tbl/int_string_like_less_than.tbl
+++ b/resources/test_data/tbl/int_string_like_less_than.tbl
@@ -1,5 +1,5 @@
 a|b
-int|string
+int|string_null
 1234|Dampfschifffahrtsgesellschaft
 12345|Reeperbahn
 123456|Dampfschifffahrtsgesellschaftskapitän

--- a/resources/test_data/tbl/int_string_like_not_equals.tbl
+++ b/resources/test_data/tbl/int_string_like_not_equals.tbl
@@ -1,5 +1,5 @@
 a|b
-int|string
+int|string_null
 123|Schifffahrtsgesellschaft
 1234|Dampfschifffahrtsgesellschaft
 123456|Dampfschifffahrtsgesellschaftskapitän

--- a/resources/test_data/tbl/int_string_like_not_starting.tbl
+++ b/resources/test_data/tbl/int_string_like_not_starting.tbl
@@ -1,5 +1,5 @@
 a|b
-int|string
+int|string_null
 123|Schifffahrtsgesellschaft
 12345|Reeperbahn
 1234567|1234

--- a/resources/test_data/tbl/int_string_like_starting.tbl
+++ b/resources/test_data/tbl/int_string_like_starting.tbl
@@ -1,5 +1,5 @@
 a|b
-int|string
+int|string_null
 1234|Dampfschifffahrtsgesellschaft
 123456|Dampfschifffahrtsgesellschaftskapitän
 1234567|Dampfschifffahrtsgesellschaftskapitänsdampf

--- a/resources/test_data/tbl/join_operators/int_inner_multijoin_val_val_val_leftouter.tbl
+++ b/resources/test_data/tbl/join_operators/int_inner_multijoin_val_val_val_leftouter.tbl
@@ -1,5 +1,5 @@
 a|b|a|b|a|b
-int|int|int|int|int|int
+int|int|int_null|int_null|int|int
 6|16|6|9|6|7
 7|0|7|1|7|1
 7|0|7|1|7|17

--- a/resources/test_data/tbl/tpch/test-validation/q1.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q1.tbl
@@ -1,5 +1,5 @@
 l_returnflag|l_linestatus|sum_qty|sum_base_price|sum_disc_price|sum_charge|avg_qty|avg_price|avg_disc|count_order
-string|string|double|double|double|double|double|double|double|long
+string|string|double_null|double_null|double_null|double_null|double_null|double_null|double_null|long
 A|F|380456|5.32348e+08|5.05822e+08|5.26166e+08|25.5752|35785.7|0.0500813|14876
 N|F|8971|1.23848e+07|1.17983e+07|1.22825e+07|25.7787|35588.5|0.0477586|348
 N|O|742802|1.0415e+09|9.89738e+08|1.02942e+09|25.455|35691.1|0.0499311|29181

--- a/resources/test_data/tbl/tpch/test-validation/q10.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q10.tbl
@@ -1,5 +1,5 @@
 c_custkey|c_name|revenue|c_acctbal|n_name|c_address|c_phone|c_comment
-int|string|double|float|string|string|string|string
+int|string|double_null|float|string|string|string|string
 394|Customer#000000394|481779|5200.96|UNITED KINGDOM|nxW1jt,MQvImdr z72gAt1bslnfEipCh,bKZN|33-422-600-6936| instructions. carefully special ideas after the fluffily unusual r
 529|Customer#000000529|459834|9647.58|MOROCCO|oGKgweC odpyORKPJ9oxTqzzdlYyFOwXm2F97C|25-383-240-7326| deposits after the fluffily special foxes integrate carefully blithely dogged dolphins. enticingly bold d
 2236|Customer#000002236|431506|-968.87|ROMANIA|x8 7D8xSxqIGoVOlqVCEBflsLXwKewpGMv,V|29-962-402-1321|totes. quickly even instructions boost blithely regular packages? carefully final foxes haggle slyly against the s

--- a/resources/test_data/tbl/tpch/test-validation/q11.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q11.tbl
@@ -1,5 +1,5 @@
 ps_partkey|value
-int|double
+int|double_null
 1376|1.32712e+07
 788|9.49865e+06
 1071|9.38826e+06

--- a/resources/test_data/tbl/tpch/test-validation/q12.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q12.tbl
@@ -1,4 +1,4 @@
 l_shipmode|high_line_count|low_line_count
-string|long|long
+string|long_null|long_null
 MAIL|64|86
 SHIP|61|96

--- a/resources/test_data/tbl/tpch/test-validation/q15.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q15.tbl
@@ -1,3 +1,3 @@
 s_suppkey|s_name|s_address|s_phone|total_revenue
-int|string|string|string|double
+int|string|string|string|double_null
 21|Supplier#000000021|81CavellcrJ0PQ3CPBID0Z0JwyJm0ka5igEs|12-253-590-5816|1.1611e+06

--- a/resources/test_data/tbl/tpch/test-validation/q18.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q18.tbl
@@ -1,4 +1,4 @@
 c_name|c_custkey|o_orderkey|o_orderdate|o_totalprice|SUM(l_quantity)
-string|int|int|string|float|double
+string|int|int|string|float|double_null
 Customer#000000334|334|29158|1995-10-21|441562|305
 Customer#000000089|89|6882|1997-04-09|389431|303

--- a/resources/test_data/tbl/tpch/test-validation/q19.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q19.tbl
@@ -1,3 +1,3 @@
 revenue
-double
+double_null
 22923

--- a/resources/test_data/tbl/tpch/test-validation/q22.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q22.tbl
@@ -1,5 +1,5 @@
 cntrycode|numcust|totacctbal
-string|long|double
+string_null|long|double_null
 13|10|75359.3
 17|8|62289
 18|14|111072

--- a/resources/test_data/tbl/tpch/test-validation/q3.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q3.tbl
@@ -1,5 +1,5 @@
 l_orderkey|revenue|o_orderdate|o_shippriority
-int|double|string|int
+int|double_null|string|int
 47714|267011|1995-03-11|0
 22276|266352|1995-01-29|0
 32965|263768|1995-02-25|0

--- a/resources/test_data/tbl/tpch/test-validation/q5.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q5.tbl
@@ -1,5 +1,5 @@
 n_name|revenue
-string|double
+string|double_null
 VIETNAM|1.00093e+06
 CHINA|740211
 JAPAN|660651

--- a/resources/test_data/tbl/tpch/test-validation/q6.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q6.tbl
@@ -1,3 +1,3 @@
 revenue
-double
+double_null
 1.19305e+06

--- a/resources/test_data/tbl/tpch/test-validation/q7.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q7.tbl
@@ -1,4 +1,4 @@
 supp_nation|cust_nation|l_year|revenue
-string|string|string|double
+string|string|string_null|double_null
 FRANCE|GERMANY|199|571931
 GERMANY|FRANCE|199|1.00026e+06

--- a/resources/test_data/tbl/tpch/test-validation/q8.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q8.tbl
@@ -1,3 +1,3 @@
 o_year|mkt_share
-string|double
+string_null|double
 199|0

--- a/resources/test_data/tbl/tpch/test-validation/q9.tbl
+++ b/resources/test_data/tbl/tpch/test-validation/q9.tbl
@@ -1,5 +1,5 @@
 nation|o_year|sum_profit
-string|string|double
+string|string_null|double_null
 ALGERIA|199|2.68951e+06
 ARGENTINA|199|1.02251e+06
 BRAZIL|199|1.10774e+06

--- a/src/benchmark/operators/union_positions_benchmark.cpp
+++ b/src/benchmark/operators/union_positions_benchmark.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<Table> create_reference_table(std::shared_ptr<Table> referenced_
 
   TableColumnDefinitions column_definitions;
   for (size_t column_idx = 0; column_idx < num_columns; ++column_idx) {
-    column_definitions.emplace_back("c" + std::to_string(column_idx), DataType::Int);
+    column_definitions.emplace_back("c" + std::to_string(column_idx), DataType::Int, false);
   }
   auto table = std::make_shared<Table>(column_definitions, TableType::References);
 
@@ -89,7 +89,7 @@ void BM_UnionPositions(::benchmark::State& state) {  // NOLINT
   TableColumnDefinitions column_definitions;
 
   for (auto column_idx = 0; column_idx < num_columns; ++column_idx) {
-    column_definitions.emplace_back("c" + std::to_string(column_idx), DataType::Int);
+    column_definitions.emplace_back("c" + std::to_string(column_idx), DataType::Int, false);
   }
   auto referenced_table = std::make_shared<Table>(column_definitions, TableType::Data);
 

--- a/src/benchmarklib/benchmark_sql_executor.cpp
+++ b/src/benchmarklib/benchmark_sql_executor.cpp
@@ -79,9 +79,9 @@ void BenchmarkSQLExecutor::_compare_tables(const std::shared_ptr<const Table>& e
       std::cout << "- Verification failed: Hyrise's actual result is not empty, but the expected result is ("
                 << timer.lap_formatted() << ")"
                 << "\n";
-    } else if (const auto table_difference_message =
-                   check_table_equal(actual_result_table, expected_result_table, OrderSensitivity::No,
-                                     TypeCmpMode::Lenient, FloatComparisonMode::RelativeDifference)) {
+    } else if (const auto table_difference_message = check_table_equal(
+                   actual_result_table, expected_result_table, OrderSensitivity::No, TypeCmpMode::Lenient,
+                   FloatComparisonMode::RelativeDifference, IgnoreNullable::Yes)) {
       any_verification_failed = true;
       if (description) {
         std::cout << *description << "\n";

--- a/src/benchmarklib/table_generator.cpp
+++ b/src/benchmarklib/table_generator.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<Table> TableGenerator::generate_table(const ChunkID chunk_size,
   TableColumnDefinitions column_definitions;
   for (size_t i = 0; i < _num_columns; i++) {
     auto column_name = std::string(1, static_cast<char>(static_cast<int>('a') + i));
-    column_definitions.emplace_back(column_name, DataType::Int);
+    column_definitions.emplace_back(column_name, DataType::Int, false);
     value_vectors.emplace_back(tbb::concurrent_vector<int>(vector_size));
   }
   const auto table = std::make_shared<Table>(column_definitions, TableType::Data, chunk_size);
@@ -94,7 +94,7 @@ std::shared_ptr<Table> TableGenerator::generate_table(
   TableColumnDefinitions column_definitions;
   for (size_t column = 1; column <= num_columns; ++column) {
     auto column_name = "column_" + std::to_string(column);
-    column_definitions.emplace_back(column_name, DataType::Int);
+    column_definitions.emplace_back(column_name, DataType::Int, false);
     value_vectors.emplace_back(tbb::concurrent_vector<int>(chunk_size));
   }
   std::shared_ptr<Table> table = std::make_shared<Table>(column_definitions, TableType::Data, chunk_size);

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -100,7 +100,8 @@ class TPCCTableGenerator : public AbstractTableGenerator {
     bool is_first_column = column_definitions.size() == 0;
 
     auto data_type = data_type_from_type<T>();
-    column_definitions.emplace_back(name, data_type);
+    // TODO(anyone): NULL values are still represented as -1, so the columns are marked as non-nullable.
+    column_definitions.emplace_back(name, data_type, false);
 
     /**
      * Calculate the total row count for this column based on the cardinalities of the influencing tables.

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -738,16 +738,22 @@ int Console::_visualize(const std::string& input) {
     } break;
   }
 
-  auto ret = system("./scripts/planviz/is_iterm2.sh");
+  auto scripts_dir = std::string{"./scripts/"};
+  auto ret = system((scripts_dir + "planviz/is_iterm2.sh 2>/dev/null").c_str());
   if (ret != 0) {
-    std::string msg{"Currently, only iTerm2 can print the visualization inline. You can find the plan at "};  // NOLINT
+    // Try in parent directory
+    scripts_dir = std::string{"."} + scripts_dir;
+    ret = system((scripts_dir + "planviz/is_iterm2.sh").c_str());
+  }
+  if (ret != 0) {
+    std::string msg{"Currently, only iTerm2 can print the visualization inline. You can find the plan at "};
     msg += img_filename + "\n";
     out(msg);
 
     return ReturnCode::Ok;
   }
 
-  auto cmd = std::string("./scripts/planviz/imgcat.sh ") + img_filename;
+  auto cmd = scripts_dir + "/planviz/imgcat.sh " + img_filename;
   ret = system(cmd.c_str());
   Assert(ret == 0, "Printing the image using ./scripts/imgcat.sh failed.");
 

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -614,7 +614,7 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_case_ex
           nulls.resize(result_size);
 
           for (auto chunk_offset = ChunkOffset{0}; chunk_offset < result_size; ++chunk_offset) {
-            if (when->value(chunk_offset) && !when->is_null(chunk_offset)) {
+            if (when->value(chunk_offset) /* && !when->is_null(chunk_offset)*/) {
               values[chunk_offset] = to_value<Result>(then_result.value(chunk_offset));
               nulls[chunk_offset] = then_result.is_null(chunk_offset);
             } else {
@@ -1362,6 +1362,7 @@ void ExpressionEvaluator::_materialize_segment_if_not_yet_materialized(const Col
 
     } else {
       segment_iterate<ColumnDataType>(segment, [&](const auto& position) {
+        DebugAssert(!position.is_null(), "Encountered NULL value in non-nullable column");
         values[chunk_offset] = position.value();
         ++chunk_offset;
       });

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -614,7 +614,7 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_case_ex
           nulls.resize(result_size);
 
           for (auto chunk_offset = ChunkOffset{0}; chunk_offset < result_size; ++chunk_offset) {
-            if (when->value(chunk_offset) /* && !when->is_null(chunk_offset)*/) {
+            if (when->value(chunk_offset) && !when->is_null(chunk_offset)) {
               values[chunk_offset] = to_value<Result>(then_result.value(chunk_offset));
               nulls[chunk_offset] = then_result.is_null(chunk_offset);
             } else {

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -623,7 +623,8 @@ void AggregateHash::_write_groupby_output(PosList& pos_list) {
   // For each GROUP BY column, resolve its type, iterate over its values, and add them to a new output ValueSegment
   for (const auto& column_id : _groupby_column_ids) {
     _output_column_definitions.emplace_back(input_table->column_name(column_id),
-                                            input_table->column_data_type(column_id));
+                                            input_table->column_data_type(column_id),
+                                            input_table->column_is_nullable(column_id));
 
     resolve_data_type(input_table->column_data_type(column_id), [&](const auto typed_value) {
       using ColumnDataType = typename decltype(typed_value)::type;

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -288,7 +288,8 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
   // Create group by column definitions
   for (const auto& column_id : _groupby_column_ids) {
     _output_column_definitions.emplace_back(input_table->column_name(column_id),
-                                            input_table->column_data_type(column_id), true);
+                                            input_table->column_data_type(column_id),
+                                            input_table->column_is_nullable(column_id));
   }
 
   // Create aggregate column definitions

--- a/src/lib/operators/maintenance/create_table.cpp
+++ b/src/lib/operators/maintenance/create_table.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<const Table> CreateTable::_on_execute(std::shared_ptr<Transactio
     _insert->set_transaction_context(context);
     _insert->execute();
   }
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int}}, TableType::Data);  // Dummy table
+  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
 }
 
 std::shared_ptr<AbstractOperator> CreateTable::_on_deep_copy(

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<const Table> CreateView::_on_execute() {
   if (!_if_not_exists || !StorageManager::get().has_view(_view_name)) {
     StorageManager::get().add_view(_view_name, _view);
   }
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int}}, TableType::Data);  // Dummy table
+  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
 }
 
 }  // namespace opossum

--- a/src/lib/operators/maintenance/drop_table.cpp
+++ b/src/lib/operators/maintenance/drop_table.cpp
@@ -19,7 +19,7 @@ std::shared_ptr<const Table> DropTable::_on_execute() {
     StorageManager::get().drop_table(table_name);
   }
 
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int}}, TableType::Data);  // Dummy table
+  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
 }
 
 std::shared_ptr<AbstractOperator> DropTable::_on_deep_copy(

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<const Table> DropView::_on_execute() {
     StorageManager::get().drop_view(view_name);
   }
 
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int}}, TableType::Data);  // Dummy table
+  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
 }
 
 }  // namespace opossum

--- a/src/lib/operators/maintenance/show_columns.cpp
+++ b/src/lib/operators/maintenance/show_columns.cpp
@@ -31,9 +31,9 @@ void ShowColumns::_on_set_parameters(const std::unordered_map<ParameterID, AllTy
 
 std::shared_ptr<const Table> ShowColumns::_on_execute() {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("column_name", DataType::String);
-  column_definitions.emplace_back("column_type", DataType::String);
-  column_definitions.emplace_back("is_nullable", DataType::Int);
+  column_definitions.emplace_back("column_name", DataType::String, false);
+  column_definitions.emplace_back("column_type", DataType::String, false);
+  column_definitions.emplace_back("is_nullable", DataType::Int, false);
   auto out_table = std::make_shared<Table>(column_definitions, TableType::Data);
 
   const auto table = StorageManager::get().get_table(_table_name);

--- a/src/lib/operators/maintenance/show_tables.cpp
+++ b/src/lib/operators/maintenance/show_tables.cpp
@@ -27,7 +27,8 @@ std::shared_ptr<AbstractOperator> ShowTables::_on_deep_copy(
 void ShowTables::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<const Table> ShowTables::_on_execute() {
-  auto table = std::make_shared<Table>(TableColumnDefinitions{{"table_name", DataType::String}}, TableType::Data);
+  auto table =
+      std::make_shared<Table>(TableColumnDefinitions{{"table_name", DataType::String, false}}, TableType::Data);
 
   const auto table_names = StorageManager::get().table_names();
   const auto segment = std::make_shared<ValueSegment<pmr_string>>(

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -36,7 +36,7 @@ class Projection : public AbstractReadOnlyOperator {
    */
   class DummyTable : public Table {
    public:
-    DummyTable() : Table(TableColumnDefinitions{{"dummy", DataType::Int}}, TableType::Data) {
+    DummyTable() : Table(TableColumnDefinitions{{"dummy", DataType::Int, false}}, TableType::Data) {
       append(std::vector<AllTypeVariant>{0});
     }
   };

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -27,15 +27,19 @@ class GroupKeyIndexTest;
  *    |(i)| Attribute | Dictionary |  Index  | Index Postings |
  *    |   |  Vector   |            | Offsets |                |
  *    +---+-----------+------------+---------+----------------+
- *    | 0 |         4 | apple    ------->  0 ------------>  4 |  ie "apple" can be found at i = 4 in the AV
- *    | 1 |         2 | charlie  ------->  1 ------------>  5 |
- *    | 2 |         3 | delta    ------->  3 ---------|     6 |
- *    | 3 |         2 | frank    ------->  5 -------| |-->  1 |
- *    | 4 |         0 | hotel    ------->  6 -----| |       3 |  ie "delta" can be found at i = 1 and 3
- *    | 5 |         1 | inbox    ------->  7 ---| | |---->  2 |
- *    | 6 |         1 |            |         |  | |------>  0 |
- *    | 7 |         5 |            |         |  |-------->  7 |  ie "inbox" can be found at i = 7 in the AV
+ *    | 0 |         4 | apple    ------->  0 -------------> 4 |  ie "apple" can be found at i = 4 in the AV
+ *    | 1 |         2 | charlie  ------->  1 -------------> 5 |
+ *    | 2 |         3 | delta    ------->  3 ----------|    6 |
+ *    | 3 |         2 | frank    ------->  5 --------| |--> 1 |
+ *    | 4 |         0 | hotel    ------->  6 ------| |      3 |  ie "delta" can be found at i = 1 and 3
+ *    | 5 |         1 | (NULL)   ------->  7 ----| | |----> 2 |
+ *    | 6 |         1 |            |       8 --| | |------> 0 |
+ *    | 7 |         5 |            |         | | |--------> 7 |  ie NULL can be found at i = 7 in the AV
+ *    | 8 |           |            |         | -----------> - |  marks the end
  *    +---+-----------+------------+---------+----------------+
+ *
+ * The attribute vector stores NULL values using the dictionary size as the value ID. I.e., the dictionary contains
+ * NULL as a virtual last value.
  *
  * Find more information about this in our Wiki: https://github.com/hyrise/hyrise/wiki/GroupKey-Index
  */

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -27,19 +27,15 @@ class GroupKeyIndexTest;
  *    |(i)| Attribute | Dictionary |  Index  | Index Postings |
  *    |   |  Vector   |            | Offsets |                |
  *    +---+-----------+------------+---------+----------------+
- *    | 0 |         4 | apple    ------->  0 -------------> 4 |  ie "apple" can be found at i = 4 in the AV
- *    | 1 |         2 | charlie  ------->  1 -------------> 5 |
- *    | 2 |         3 | delta    ------->  3 ----------|    6 |
- *    | 3 |         2 | frank    ------->  5 --------| |--> 1 |
- *    | 4 |         0 | hotel    ------->  6 ------| |      3 |  ie "delta" can be found at i = 1 and 3
- *    | 5 |         1 | (NULL)   ------->  7 ----| | |----> 2 |
- *    | 6 |         1 |            |       8 --| | |------> 0 |
- *    | 7 |         5 |            |         | | |--------> 7 |  ie NULL can be found at i = 7 in the AV
- *    | 8 |           |            |         | -----------> - |  marks the end
+ *    | 0 |         4 | apple    ------->  0 ------------>  4 |  ie "apple" can be found at i = 4 in the AV
+ *    | 1 |         2 | charlie  ------->  1 ------------>  5 |
+ *    | 2 |         3 | delta    ------->  3 ---------|     6 |
+ *    | 3 |         2 | frank    ------->  5 -------| |-->  1 |
+ *    | 4 |         0 | hotel    ------->  6 -----| |       3 |  ie "delta" can be found at i = 1 and 3
+ *    | 5 |         1 | inbox    ------->  7 ---| | |---->  2 |
+ *    | 6 |         1 |            |         |  | |------>  0 |
+ *    | 7 |         5 |            |         |  |-------->  7 |  ie "inbox" can be found at i = 7 in the AV
  *    +---+-----------+------------+---------+----------------+
- *
- * The attribute vector stores NULL values using the dictionary size as the value ID. I.e., the dictionary contains
- * NULL as a virtual last value.
  *
  * Find more information about this in our Wiki: https://github.com/hyrise/hyrise/wiki/GroupKey-Index
  */

--- a/src/lib/storage/table_column_definition.hpp
+++ b/src/lib/storage/table_column_definition.hpp
@@ -8,7 +8,7 @@ namespace opossum {
 
 struct TableColumnDefinition final {
   TableColumnDefinition() = default;
-  TableColumnDefinition(const std::string& name, const DataType data_type, const bool nullable = false);
+  TableColumnDefinition(const std::string& name, const DataType data_type, const bool nullable);
 
   bool operator==(const TableColumnDefinition& rhs) const;
 

--- a/src/lib/utils/check_table_equal.hpp
+++ b/src/lib/utils/check_table_equal.hpp
@@ -25,9 +25,16 @@ enum class TypeCmpMode { Strict, Lenient };
  */
 enum class FloatComparisonMode { RelativeDifference, AbsoluteDifference };
 
+/*
+ * As SQLite has a weird type concept, we ignore (NOT) NULL constraints for tables retrieved from SQLite.
+ */
+
+enum class IgnoreNullable { Yes, No };
+
 /**
- * Helper method to compare two segments for equality. Function
- * create temporary tables and uses the check_table_equals method.
+ * Helper method to compare two segments for equality. Function creates temporary tables and uses the
+ * check_table_equals method. As NULLable information is stored in the table, not in the segment,
+ * IgnoreNullable::Yes is implied.
  */
 bool check_segment_equal(const std::shared_ptr<BaseSegment>& actual_segment,
                          const std::shared_ptr<BaseSegment>& expected_segment, OrderSensitivity order_sensitivity,
@@ -39,6 +46,6 @@ bool check_segment_equal(const std::shared_ptr<BaseSegment>& actual_segment,
 std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>& opossum_table,
                                              const std::shared_ptr<const Table>& expected_table,
                                              OrderSensitivity order_sensitivity, TypeCmpMode type_cmp_mode,
-                                             FloatComparisonMode float_comparison_mode);
+                                             FloatComparisonMode float_comparison_mode, IgnoreNullable ignore_nullable);
 
 }  // namespace opossum

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -8,7 +8,7 @@ const std::string TestPlugin::description() const { return "This is the Hyrise T
 
 void TestPlugin::start() {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("col_1", DataType::Int);
+  column_definitions.emplace_back("col_1", DataType::Int, false);
   auto table = std::make_shared<Table>(column_definitions, TableType::Data);
 
   sm.add_table("DummyTable", table);

--- a/src/test/benchmarklib/sqlite_add_indices_test.cpp
+++ b/src/test/benchmarklib/sqlite_add_indices_test.cpp
@@ -16,8 +16,8 @@ class SQLiteAddIndicesTest : public BaseTest {
  protected:
   void SetUp() override {
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("column_1", DataType::Int);
-    column_definitions.emplace_back("column_2", DataType::String);
+    column_definitions.emplace_back("column_1", DataType::Int, false);
+    column_definitions.emplace_back("column_2", DataType::String, false);
     StorageManager::get().add_table("table_1", std::make_shared<Table>(column_definitions, TableType::Data, 2));
     stored_table = StorageManager::get().get_table("table_1");
     stored_table->append({13, "Hello,"});

--- a/src/test/benchmarklib/table_builder_test.cpp
+++ b/src/test/benchmarklib/table_builder_test.cpp
@@ -16,7 +16,8 @@ TEST(TableBuilderTest, CreateColumnsWithCorrectNamesAndTypesAndNullables) {
   const auto table = table_builder.finish_table();
 
   const auto expected_table = std::make_shared<Table>(
-      TableColumnDefinitions{{"a", DataType::Int}, {"b", DataType::Float}, {"c", DataType::String}}, TableType::Data);
+      TableColumnDefinitions{{"a", DataType::Int, false}, {"b", DataType::Float, true}, {"c", DataType::String, false}},
+      TableType::Data);
 
   EXPECT_TABLE_EQ_UNORDERED(table, expected_table);
   EXPECT_EQ(table->columns_are_nullable(), std::vector({false, true, false}));
@@ -29,7 +30,7 @@ TEST(TableBuilderTest, AppendsRows) {
   const auto table = table_builder.finish_table();
 
   auto expected_table = std::make_shared<Table>(
-      TableColumnDefinitions{{"a", DataType::Int}, {"b", DataType::Float, true}, {"c", DataType::String}},
+      TableColumnDefinitions{{"a", DataType::Int, false}, {"b", DataType::Float, true}, {"c", DataType::String, false}},
       TableType::Data);
   expected_table->append({42, 42.0f, "42"});
   expected_table->append({43, NULL_VALUE, "43"});

--- a/src/test/expression/expression_evaluator_to_pos_list_test.cpp
+++ b/src/test/expression/expression_evaluator_to_pos_list_test.cpp
@@ -180,7 +180,8 @@ TEST_F(ExpressionEvaluatorToPosListTest, ExistsUncorrelated) {
   const auto table_wrapper_all = std::make_shared<TableWrapper>(Projection::dummy_table());
   const auto subquery_returning_all = pqp_subquery_(table_wrapper_all, DataType::Int, false);
 
-  const auto empty_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
+  const auto empty_table =
+      std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
   const auto table_wrapper_empty = std::make_shared<TableWrapper>(empty_table);
   const auto subquery_returning_none = pqp_subquery_(table_wrapper_empty, DataType::Int, false);
 

--- a/src/test/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/expression/expression_evaluator_to_values_test.cpp
@@ -363,6 +363,7 @@ TEST_F(ExpressionEvaluatorToValuesTest, CaseSeries) {
   EXPECT_TRUE(test_expression<int32_t>(table_empty, *case_(greater_than_(empty_a, 3), 1, 2), {}));
   EXPECT_TRUE(test_expression<int32_t>(table_empty, *case_(1, empty_a, empty_a), {}));
   EXPECT_TRUE(test_expression<int32_t>(table_empty, *case_(greater_than_(empty_a, 3), empty_a, empty_a), {}));
+  EXPECT_TRUE(test_expression<int32_t>(table_empty, *case_(equals_(add_(NullValue{}, 1), 0), 1, 2), {2}));
   // clang-format on
 }
 

--- a/src/test/lib/import_export/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv_parser_test.cpp
@@ -11,8 +11,8 @@ class CsvParserTest : public BaseTest {};
 TEST_F(CsvParserTest, EmptyTableFromMetaFile) {
   CsvParser parser;
   const auto csv_meta_table = parser.create_table_from_meta_file("resources/test_data/csv/float_int.csv.json");
-  const auto expected_table =
-      std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float}, {"a", DataType::Int}}, TableType::Data);
+  const auto expected_table = std::make_shared<Table>(
+      TableColumnDefinitions{{"b", DataType::Float, false}, {"a", DataType::Int, false}}, TableType::Data);
 
   EXPECT_EQ(csv_meta_table->row_count(), 0);
   EXPECT_TABLE_EQ_UNORDERED(csv_meta_table, expected_table);

--- a/src/test/lib/utils/load_table_test.cpp
+++ b/src/test/lib/utils/load_table_test.cpp
@@ -10,8 +10,8 @@ class LoadTableTest : public BaseTest {};
 
 TEST_F(LoadTableTest, EmptyTableFromHeader) {
   const auto tbl_header_table = create_table_from_header("resources/test_data/tbl/float_int.tbl");
-  const auto expected_table =
-      std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Float}, {"a", DataType::Int}}, TableType::Data);
+  const auto expected_table = std::make_shared<Table>(
+      TableColumnDefinitions{{"b", DataType::Float, false}, {"a", DataType::Int, false}}, TableType::Data);
 
   EXPECT_EQ(tbl_header_table->row_count(), 0);
   EXPECT_TABLE_EQ_UNORDERED(tbl_header_table, expected_table);

--- a/src/test/lib/utils/verify_tables_test.cpp
+++ b/src/test/lib/utils/verify_tables_test.cpp
@@ -8,27 +8,44 @@ namespace opossum {
 class TableVerificationTest : public BaseTest {};
 
 TEST_F(TableVerificationTest, CaseInsensitiveColumns) {
-  const auto table_aa = std::make_shared<Table>(TableColumnDefinitions{{"aa", DataType::Float}}, TableType::Data);
-  const auto table_aa_1 = std::make_shared<Table>(TableColumnDefinitions{{"aa", DataType::Float}}, TableType::Data);
-  const auto table_aA = std::make_shared<Table>(TableColumnDefinitions{{"aA", DataType::Float}}, TableType::Data);
-  const auto table_Aa = std::make_shared<Table>(TableColumnDefinitions{{"Aa", DataType::Float}}, TableType::Data);
-  const auto table_AA = std::make_shared<Table>(TableColumnDefinitions{{"AA", DataType::Float}}, TableType::Data);
-  const auto table_ab = std::make_shared<Table>(TableColumnDefinitions{{"ab", DataType::Float}}, TableType::Data);
+  const auto table_aa =
+      std::make_shared<Table>(TableColumnDefinitions{{"aa", DataType::Float, false}}, TableType::Data);
+  const auto table_aa_1 =
+      std::make_shared<Table>(TableColumnDefinitions{{"aa", DataType::Float, false}}, TableType::Data);
+  const auto table_aA =
+      std::make_shared<Table>(TableColumnDefinitions{{"aA", DataType::Float, false}}, TableType::Data);
+  const auto table_Aa =
+      std::make_shared<Table>(TableColumnDefinitions{{"Aa", DataType::Float, false}}, TableType::Data);
+  const auto table_AA =
+      std::make_shared<Table>(TableColumnDefinitions{{"AA", DataType::Float, false}}, TableType::Data);
+  const auto table_ab =
+      std::make_shared<Table>(TableColumnDefinitions{{"ab", DataType::Float, false}}, TableType::Data);
 
   EXPECT_EQ(check_table_equal(table_aa, table_aa_1, OrderSensitivity::No, TypeCmpMode::Strict,
-                              FloatComparisonMode::AbsoluteDifference),
+                              FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No),
             std::nullopt);
   EXPECT_EQ(check_table_equal(table_aa, table_aA, OrderSensitivity::No, TypeCmpMode::Strict,
-                              FloatComparisonMode::AbsoluteDifference),
+                              FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No),
             std::nullopt);
   EXPECT_EQ(check_table_equal(table_aa, table_Aa, OrderSensitivity::No, TypeCmpMode::Strict,
-                              FloatComparisonMode::AbsoluteDifference),
+                              FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No),
             std::nullopt);
   EXPECT_EQ(check_table_equal(table_aa, table_AA, OrderSensitivity::No, TypeCmpMode::Strict,
-                              FloatComparisonMode::AbsoluteDifference),
+                              FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No),
             std::nullopt);
   EXPECT_NE(check_table_equal(table_aa, table_ab, OrderSensitivity::No, TypeCmpMode::Strict,
-                              FloatComparisonMode::AbsoluteDifference),
+                              FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No),
+            std::nullopt);
+}
+
+TEST_F(TableVerificationTest, NullableColumns) {
+  const auto table_nullable =
+      std::make_shared<Table>(TableColumnDefinitions{{"aa", DataType::Float, true}}, TableType::Data);
+  const auto table_not_nullable =
+      std::make_shared<Table>(TableColumnDefinitions{{"aa", DataType::Float, false}}, TableType::Data);
+
+  EXPECT_NE(check_table_equal(table_nullable, table_not_nullable, OrderSensitivity::No, TypeCmpMode::Strict,
+                              FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No),
             std::nullopt);
 }
 

--- a/src/test/operators/export_binary_test.cpp
+++ b/src/test/operators/export_binary_test.cpp
@@ -55,8 +55,8 @@ class OperatorsExportBinaryTest : public BaseTest {
 
 TEST_F(OperatorsExportBinaryTest, TwoColumnsNoValues) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("FirstColumn", DataType::Int);
-  column_definitions.emplace_back("SecondColumn", DataType::String);
+  column_definitions.emplace_back("FirstColumn", DataType::Int, false);
+  column_definitions.emplace_back("SecondColumn", DataType::String, false);
 
   table = std::make_shared<Table>(column_definitions, TableType::Data, 30000);
   auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
@@ -70,7 +70,7 @@ TEST_F(OperatorsExportBinaryTest, TwoColumnsNoValues) {
 
 TEST_F(OperatorsExportBinaryTest, SingleChunkSingleFloatColumn) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::Float);
+  column_definitions.emplace_back("a", DataType::Float, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
   table->append({5.5f});
@@ -88,7 +88,7 @@ TEST_F(OperatorsExportBinaryTest, SingleChunkSingleFloatColumn) {
 
 TEST_F(OperatorsExportBinaryTest, MultipleChunkSingleFloatColumn) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::Float);
+  column_definitions.emplace_back("a", DataType::Float, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   table->append({5.5f});
@@ -106,7 +106,7 @@ TEST_F(OperatorsExportBinaryTest, MultipleChunkSingleFloatColumn) {
 
 TEST_F(OperatorsExportBinaryTest, StringValueSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
   table->append({"This"});
@@ -125,7 +125,7 @@ TEST_F(OperatorsExportBinaryTest, StringValueSegment) {
 
 TEST_F(OperatorsExportBinaryTest, StringDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 10);
   table->append({"This"});
@@ -146,7 +146,7 @@ TEST_F(OperatorsExportBinaryTest, StringDictionarySegment) {
 
 TEST_F(OperatorsExportBinaryTest, FixedStringDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 10);
   table->append({"This"});
@@ -167,11 +167,11 @@ TEST_F(OperatorsExportBinaryTest, FixedStringDictionarySegment) {
 
 TEST_F(OperatorsExportBinaryTest, AllTypesValueSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
 
@@ -191,11 +191,11 @@ TEST_F(OperatorsExportBinaryTest, AllTypesValueSegment) {
 
 TEST_F(OperatorsExportBinaryTest, AllTypesDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
 
@@ -218,11 +218,11 @@ TEST_F(OperatorsExportBinaryTest, AllTypesDictionarySegment) {
 
 TEST_F(OperatorsExportBinaryTest, AllTypesMixColumn) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
 
@@ -247,11 +247,11 @@ TEST_F(OperatorsExportBinaryTest, AllTypesMixColumn) {
 // It assumes that the TableScan produces one output segment per input segment.
 TEST_F(OperatorsExportBinaryTest, AllTypesReferenceSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
 
@@ -275,7 +275,7 @@ TEST_F(OperatorsExportBinaryTest, AllTypesReferenceSegment) {
 
 TEST_F(OperatorsExportBinaryTest, EmptyStringsValueSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 10);
   table->append({""});
@@ -296,7 +296,7 @@ TEST_F(OperatorsExportBinaryTest, EmptyStringsValueSegment) {
 
 TEST_F(OperatorsExportBinaryTest, EmptyStringsDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, 10);
   table->append({""});

--- a/src/test/operators/export_csv_test.cpp
+++ b/src/test/operators/export_csv_test.cpp
@@ -22,9 +22,9 @@ class OperatorsExportCsvTest : public BaseTest {
  protected:
   void SetUp() override {
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("a", DataType::Int);
-    column_definitions.emplace_back("b", DataType::String);
-    column_definitions.emplace_back("c", DataType::Float);
+    column_definitions.emplace_back("a", DataType::Int, false);
+    column_definitions.emplace_back("b", DataType::String, false);
+    column_definitions.emplace_back("c", DataType::Float, false);
 
     table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   }
@@ -134,7 +134,7 @@ TEST_F(OperatorsExportCsvTest, FixedStringDictionarySegmentFixedSizeByteAligned)
   const auto meta_filename_string_table = filename_string_table + CsvMeta::META_FILE_EXTENSION;
 
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto string_table = std::make_shared<Table>(column_definitions, TableType::Data, 4);
   string_table->append({"a"});
@@ -191,11 +191,11 @@ TEST_F(OperatorsExportCsvTest, ReferenceSegment) {
 
 TEST_F(OperatorsExportCsvTest, ExportAllTypes) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::Int);
-  column_definitions.emplace_back("b", DataType::String);
-  column_definitions.emplace_back("c", DataType::Float);
-  column_definitions.emplace_back("d", DataType::Long);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::Int, false);
+  column_definitions.emplace_back("b", DataType::String, false);
+  column_definitions.emplace_back("c", DataType::Float, false);
+  column_definitions.emplace_back("d", DataType::Long, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   std::shared_ptr<Table> new_table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   new_table->append({1, "Hallo", 3.5f, static_cast<int64_t>(12), 2.333});

--- a/src/test/operators/import_binary_test.cpp
+++ b/src/test/operators/import_binary_test.cpp
@@ -14,7 +14,8 @@ namespace opossum {
 class OperatorsImportBinaryTest : public BaseTest {};
 
 TEST_F(OperatorsImportBinaryTest, SingleChunkSingleFloatColumn) {
-  auto expected_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Float}}, TableType::Data, 5);
+  auto expected_table =
+      std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Float, false}}, TableType::Data, 5);
   expected_table->append({5.5f});
   expected_table->append({13.0f});
   expected_table->append({16.2f});
@@ -27,7 +28,7 @@ TEST_F(OperatorsImportBinaryTest, SingleChunkSingleFloatColumn) {
 
 TEST_F(OperatorsImportBinaryTest, MultipleChunkSingleFloatColumn) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::Float);
+  column_definitions.emplace_back("a", DataType::Float, false);
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   expected_table->append({5.5f});
   expected_table->append({13.0f});
@@ -42,7 +43,7 @@ TEST_F(OperatorsImportBinaryTest, MultipleChunkSingleFloatColumn) {
 
 TEST_F(OperatorsImportBinaryTest, StringValueSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
   expected_table->append({"This"});
   expected_table->append({"is"});
@@ -57,7 +58,7 @@ TEST_F(OperatorsImportBinaryTest, StringValueSegment) {
 
 TEST_F(OperatorsImportBinaryTest, StringDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 10, UseMvcc::Yes);
   expected_table->append({"This"});
   expected_table->append({"is"});
@@ -76,11 +77,11 @@ TEST_F(OperatorsImportBinaryTest, StringDictionarySegment) {
 
 TEST_F(OperatorsImportBinaryTest, AllTypesValueSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
   expected_table->append({"AAAAA", 1, static_cast<int64_t>(100), 1.1f, 11.1});
@@ -96,11 +97,11 @@ TEST_F(OperatorsImportBinaryTest, AllTypesValueSegment) {
 
 TEST_F(OperatorsImportBinaryTest, AllTypesDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
   expected_table->append({"AAAAA", 1, static_cast<int64_t>(100), 1.1f, 11.1});
@@ -120,11 +121,11 @@ TEST_F(OperatorsImportBinaryTest, AllTypesDictionarySegment) {
 
 TEST_F(OperatorsImportBinaryTest, AllTypesMixColumn) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Long);
-  column_definitions.emplace_back("d", DataType::Float);
-  column_definitions.emplace_back("e", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Long, false);
+  column_definitions.emplace_back("d", DataType::Float, false);
+  column_definitions.emplace_back("e", DataType::Double, false);
 
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
   expected_table->append({"AAAAA", 1, static_cast<int64_t>(100), 1.1f, 11.1});
@@ -149,8 +150,8 @@ TEST_F(OperatorsImportBinaryTest, FileDoesNotExist) {
 
 TEST_F(OperatorsImportBinaryTest, TwoColumnsNoValues) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("FirstColumn", DataType::Int);
-  column_definitions.emplace_back("SecondColumn", DataType::String);
+  column_definitions.emplace_back("FirstColumn", DataType::Int, false);
+  column_definitions.emplace_back("SecondColumn", DataType::String, false);
 
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 30'000);
 
@@ -162,7 +163,7 @@ TEST_F(OperatorsImportBinaryTest, TwoColumnsNoValues) {
 
 TEST_F(OperatorsImportBinaryTest, EmptyStringsValueSegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 10);
 
@@ -180,7 +181,7 @@ TEST_F(OperatorsImportBinaryTest, EmptyStringsValueSegment) {
 
 TEST_F(OperatorsImportBinaryTest, EmptyStringsDictionarySegment) {
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
+  column_definitions.emplace_back("a", DataType::String, false);
 
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 10);
 

--- a/src/test/operators/import_csv_test.cpp
+++ b/src/test/operators/import_csv_test.cpp
@@ -49,7 +49,8 @@ TEST_F(OperatorsImportCsvTest, StringEscaping) {
   auto importer = std::make_shared<ImportCsv>("resources/test_data/csv/string_escaped.csv");
   importer->execute();
 
-  auto expected_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::String}}, TableType::Data, 5);
+  auto expected_table =
+      std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::String, false}}, TableType::Data, 5);
   expected_table->append({"aa\"\"aa"});
   expected_table->append({"xx\"x"});
   expected_table->append({"yy,y"});
@@ -109,7 +110,8 @@ TEST_F(OperatorsImportCsvTest, EmptyStrings) {
   auto importer = std::make_shared<ImportCsv>("resources/test_data/csv/empty_strings.csv");
   importer->execute();
 
-  TableColumnDefinitions column_definitions{{"a", DataType::String}, {"b", DataType::String}, {"c", DataType::String}};
+  TableColumnDefinitions column_definitions{
+      {"a", DataType::String, false}, {"b", DataType::String, false}, {"c", DataType::String, false}};
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
   for (int i = 0; i < 8; ++i) {
     expected_table->append({"", "", ""});
@@ -125,7 +127,7 @@ TEST_F(OperatorsImportCsvTest, Parallel) {
       std::make_shared<ImportCsv>("resources/test_data/csv/float_int_large.csv"), CleanupTemporaries::Yes);
   importer->schedule();
 
-  TableColumnDefinitions column_definitions{{"b", DataType::Float}, {"a", DataType::Int}};
+  TableColumnDefinitions column_definitions{{"b", DataType::Float, false}, {"a", DataType::Int, false}};
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 20);
 
   for (int i = 0; i < 100; ++i) {
@@ -144,7 +146,8 @@ TEST_F(OperatorsImportCsvTest, SemicolonSeparator) {
   auto importer = std::make_shared<ImportCsv>(csv_file, Chunk::DEFAULT_SIZE, std::nullopt, csv_meta);
   importer->execute();
 
-  TableColumnDefinitions column_definitions{{"a", DataType::Int}, {"b", DataType::Int}, {"c", DataType::Int}};
+  TableColumnDefinitions column_definitions{
+      {"a", DataType::Int, false}, {"b", DataType::Int, false}, {"c", DataType::Int, false}};
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
   for (int i = 0; i < 8; ++i) {
     expected_table->append({1, 2, 3});
@@ -177,7 +180,7 @@ TEST_F(OperatorsImportCsvTest, MaxChunkSize) {
   EXPECT_EQ(importer->get_output()->get_chunk(ChunkID{0})->size(), 100U);
   EXPECT_EQ(importer->get_output()->chunk_count(), ChunkID{1});
 
-  TableColumnDefinitions column_definitions{{"b", DataType::Float}, {"a", DataType::Int}};
+  TableColumnDefinitions column_definitions{{"b", DataType::Float, false}, {"a", DataType::Int, false}};
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 20);
 
   for (int i = 0; i < 100; ++i) {
@@ -194,7 +197,7 @@ TEST_F(OperatorsImportCsvTest, StringEscapingNonRfc) {
   auto importer = std::make_shared<ImportCsv>(csv_file, Chunk::DEFAULT_SIZE, std::nullopt, csv_meta);
   importer->execute();
 
-  TableColumnDefinitions column_definitions{{"a", DataType::String}};
+  TableColumnDefinitions column_definitions{{"a", DataType::String, false}};
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
   expected_table->append({"aa\"\"aa"});
   expected_table->append({"xx\"x"});
@@ -262,14 +265,14 @@ TEST_F(OperatorsImportCsvTest, WithAndWithoutQuotes) {
   importer->execute();
 
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::String);
-  column_definitions.emplace_back("b", DataType::Int);
-  column_definitions.emplace_back("c", DataType::Float);
-  column_definitions.emplace_back("d", DataType::Double);
-  column_definitions.emplace_back("e", DataType::String);
-  column_definitions.emplace_back("f", DataType::Int);
-  column_definitions.emplace_back("g", DataType::Float);
-  column_definitions.emplace_back("h", DataType::Double);
+  column_definitions.emplace_back("a", DataType::String, false);
+  column_definitions.emplace_back("b", DataType::Int, false);
+  column_definitions.emplace_back("c", DataType::Float, false);
+  column_definitions.emplace_back("d", DataType::Double, false);
+  column_definitions.emplace_back("e", DataType::String, false);
+  column_definitions.emplace_back("f", DataType::Int, false);
+  column_definitions.emplace_back("g", DataType::Float, false);
+  column_definitions.emplace_back("h", DataType::Double, false);
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
 
   expected_table->append({"xxx", 23, 0.5f, 24.23, "xxx", 23, 0.5f, 24.23});
@@ -285,7 +288,7 @@ TEST_F(OperatorsImportCsvTest, StringDoubleEscape) {
   auto importer = std::make_shared<ImportCsv>(csv_file, Chunk::DEFAULT_SIZE, std::nullopt, csv_meta);
   importer->execute();
 
-  TableColumnDefinitions column_definitions{{"a", DataType::String}};
+  TableColumnDefinitions column_definitions{{"a", DataType::String, false}};
   auto expected_table = std::make_shared<Table>(column_definitions, TableType::Data, 5);
 
   expected_table->append({"xxx\\\"xyz\\\""});

--- a/src/test/operators/jit_operator_wrapper_test.cpp
+++ b/src/test/operators/jit_operator_wrapper_test.cpp
@@ -18,7 +18,7 @@ namespace opossum {
 class JitOperatorWrapperTest : public BaseTest {
  protected:
   void SetUp() override {
-    _empty_table = Table::create_dummy_table({{"a", DataType::Int}});
+    _empty_table = Table::create_dummy_table({{"a", DataType::Int, false}});
     _empty_table_wrapper = std::make_shared<TableWrapper>(_empty_table);
     _empty_table_wrapper->execute();
     _int_table = load_table("resources/test_data/tbl/10_ints.tbl", 5);

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -16,7 +16,7 @@ class JoinHashStepsTest : public BaseTest {
     _table_size_zero_one = 1'000;
 
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("a", DataType::Int);
+    column_definitions.emplace_back("a", DataType::Int, false);
     _table_zero_one = std::make_shared<Table>(column_definitions, TableType::Data, _table_size_zero_one);
     for (auto i = size_t{0}; i < _table_size_zero_one; ++i) {
       _table_zero_one->append({static_cast<int>(i % 2)});

--- a/src/test/operators/join_hash_test.cpp
+++ b/src/test/operators/join_hash_test.cpp
@@ -34,7 +34,8 @@ class OperatorsJoinHashTest : public BaseTest {
   }
 
   void SetUp() override {
-    const auto dummy_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
+    const auto dummy_table =
+        std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
     dummy_input = std::make_shared<TableWrapper>(dummy_table);
   }
 

--- a/src/test/operators/join_mpsm_test.cpp
+++ b/src/test/operators/join_mpsm_test.cpp
@@ -9,7 +9,8 @@ namespace opossum {
 class OperatorsJoinMPSMTest : public ::testing::Test {
  public:
   void SetUp() override {
-    const auto dummy_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
+    const auto dummy_table =
+        std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
     dummy_input = std::make_shared<TableWrapper>(dummy_table);
   }
 

--- a/src/test/operators/join_nested_loop_test.cpp
+++ b/src/test/operators/join_nested_loop_test.cpp
@@ -9,7 +9,8 @@ namespace opossum {
 class OperatorsJoinNestedLoopTest : public ::testing::Test {
  public:
   void SetUp() override {
-    const auto dummy_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
+    const auto dummy_table =
+        std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
     dummy_input = std::make_shared<TableWrapper>(dummy_table);
   }
 

--- a/src/test/operators/join_sort_merge_test.cpp
+++ b/src/test/operators/join_sort_merge_test.cpp
@@ -9,7 +9,8 @@ namespace opossum {
 class OperatorsJoinSortMergeTest : public ::testing::Test {
  public:
   void SetUp() override {
-    const auto dummy_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
+    const auto dummy_table =
+        std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
     dummy_input = std::make_shared<TableWrapper>(dummy_table);
   }
 

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -580,7 +580,7 @@ TEST_P(JoinTestRunner, TestJoin) {
   expected_table = expected_output_table_iter->second;
 
   table_difference_message = check_table_equal(actual_table, expected_table, OrderSensitivity::No, TypeCmpMode::Strict,
-                                               FloatComparisonMode::AbsoluteDifference);
+                                               FloatComparisonMode::AbsoluteDifference, IgnoreNullable::No);
   if (table_difference_message) {
     print_configuration_info();
     FAIL();

--- a/src/test/operators/join_verification_test.cpp
+++ b/src/test/operators/join_verification_test.cpp
@@ -9,7 +9,8 @@ namespace opossum {
 class OperatorsJoinVerificationTest : public ::testing::Test {
  public:
   void SetUp() override {
-    const auto dummy_table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
+    const auto dummy_table =
+        std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
     dummy_input = std::make_shared<TableWrapper>(dummy_table);
   }
 

--- a/src/test/operators/operator_deep_copy_test.cpp
+++ b/src/test/operators/operator_deep_copy_test.cpp
@@ -189,7 +189,8 @@ TEST_F(OperatorDeepCopyTest, Subquery) {
   StorageManager::get().add_table("table_3int", table);
 
   const std::string subquery_query = "SELECT * FROM table_3int WHERE a = (SELECT MAX(b) FROM table_3int)";
-  const TableColumnDefinitions column_definitions = {{"a", DataType::Int}, {"b", DataType::Int}, {"c", DataType::Int}};
+  const TableColumnDefinitions column_definitions = {
+      {"a", DataType::Int, false}, {"b", DataType::Int, false}, {"c", DataType::Int, false}};
 
   auto sql_pipeline = SQLPipelineBuilder{subquery_query}.disable_mvcc().create_pipeline_statement();
   const auto [pipeline_status, first_result] = sql_pipeline.get_result_table();

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -18,8 +18,8 @@ class OperatorsPrintTest : public BaseTest {
  protected:
   void SetUp() override {
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("column_1", DataType::Int);
-    column_definitions.emplace_back("column_2", DataType::String);
+    column_definitions.emplace_back("column_1", DataType::Int, true);
+    column_definitions.emplace_back("column_2", DataType::String, false);
     _t = std::make_shared<Table>(column_definitions, TableType::Data, _chunk_size);
     StorageManager::get().add_table(_table_name, _t);
 
@@ -190,7 +190,7 @@ TEST_F(OperatorsPrintTest, MVCCFlag) {
       "=== Columns\n"
       "|column_1|column_2||        MVCC        |\n"
       "|     int|  string||_BEGIN|_END  |_TID  |\n"
-      "|not null|not null||      |      |      |\n";
+      "|    null|not null||      |      |      |\n";
 
   EXPECT_EQ(output.str(), expected_output);
   EXPECT_TRUE(print_wrap.is_printing_mvcc_information());
@@ -244,7 +244,7 @@ TEST_F(OperatorsPrintTest, DirectInstantiations) {
       "=== Columns\n"
       "|column_1|column_2|\n"
       "|     int|  string|\n"
-      "|not null|not null|\n";
+      "|    null|not null|\n";
 
   std::ostringstream output_ss_op_inst;
   Print::print(_gt, PrintFlags::None, output_ss_op_inst);
@@ -319,7 +319,7 @@ TEST_F(OperatorsPrintTest, EmptyTable) {
       "=== Columns\n"
       "|column_1|column_2|\n"
       "|     int|  string|\n"
-      "|not null|not null|\n"
+      "|    null|not null|\n"
       "=== Chunk 0 ===\n"
       "Empty chunk.\n";
 

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -103,8 +103,8 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
 
   std::shared_ptr<TableWrapper> get_table_op_filtered() {
     TableColumnDefinitions table_column_definitions;
-    table_column_definitions.emplace_back("a", DataType::Int);
-    table_column_definitions.emplace_back("b", DataType::Int);
+    table_column_definitions.emplace_back("a", DataType::Int, false);
+    table_column_definitions.emplace_back("b", DataType::Int, false);
 
     std::shared_ptr<Table> table = std::make_shared<Table>(table_column_definitions, TableType::References);
 
@@ -133,7 +133,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
   std::shared_ptr<TableWrapper> get_table_op_with_n_dict_entries(const int num_entries) {
     // Set up dictionary encoded table with a dictionary consisting of num_entries entries.
     TableColumnDefinitions table_column_definitions;
-    table_column_definitions.emplace_back("a", DataType::Int);
+    table_column_definitions.emplace_back("a", DataType::Int, false);
 
     std::shared_ptr<Table> table = std::make_shared<Table>(table_column_definitions, TableType::Data);
 

--- a/src/test/operators/union_positions_test.cpp
+++ b/src/test/operators/union_positions_test.cpp
@@ -284,9 +284,9 @@ TEST_F(UnionPositionsTest, MultipleShuffledPosList) {
   auto segment_right_1_2 = std::make_shared<ReferenceSegment>(_table_10_ints, ColumnID{0}, pos_list_right_1_1);
 
   TableColumnDefinitions column_definitions;
-  column_definitions.emplace_back("a", DataType::Int);
-  column_definitions.emplace_back("b", DataType::Float);
-  column_definitions.emplace_back("c", DataType::Int);
+  column_definitions.emplace_back("a", DataType::Int, false);
+  column_definitions.emplace_back("b", DataType::Float, false);
+  column_definitions.emplace_back("c", DataType::Int, false);
   auto table_left = std::make_shared<Table>(column_definitions, TableType::References);
 
   table_left->append_chunk(Segments({segment_left_0_0, segment_left_0_1, segment_left_0_2}));

--- a/src/test/operators/validate_visibility_test.cpp
+++ b/src/test/operators/validate_visibility_test.cpp
@@ -17,8 +17,8 @@ class OperatorsValidateVisibilityTest : public BaseTest {
  protected:
   void SetUp() override {
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("a", DataType::Int);
-    column_definitions.emplace_back("b", DataType::Int);
+    column_definitions.emplace_back("a", DataType::Int, false);
+    column_definitions.emplace_back("b", DataType::Int, false);
     t = std::make_shared<Table>(column_definitions, TableType::Data, chunk_size, UseMvcc::Yes);
     t->append({123, 456});
 

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -51,20 +51,20 @@ class SQLPipelineStatementTest : public BaseTest {
     StorageManager::get().add_table("table_int", _table_int);
 
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("a", DataType::Int);
-    column_definitions.emplace_back("b", DataType::Float);
-    column_definitions.emplace_back("bb", DataType::Float);
+    column_definitions.emplace_back("a", DataType::Int, false);
+    column_definitions.emplace_back("b", DataType::Float, false);
+    column_definitions.emplace_back("bb", DataType::Float, false);
     _join_result = std::make_shared<Table>(column_definitions, TableType::Data);
 
     _join_result->append({12345, 458.7f, 456.7f});
     _join_result->append({12345, 458.7f, 457.7f});
 
-    _int_float_column_definitions.emplace_back("a", DataType::Int);
-    _int_float_column_definitions.emplace_back("b", DataType::Float);
+    _int_float_column_definitions.emplace_back("a", DataType::Int, false);
+    _int_float_column_definitions.emplace_back("b", DataType::Float, false);
 
-    _int_int_int_column_definitions.emplace_back("a", DataType::Int);
-    _int_int_int_column_definitions.emplace_back("b", DataType::Int);
-    _int_int_int_column_definitions.emplace_back("c", DataType::Int);
+    _int_int_int_column_definitions.emplace_back("a", DataType::Int, false);
+    _int_int_int_column_definitions.emplace_back("b", DataType::Int, false);
+    _int_int_int_column_definitions.emplace_back("c", DataType::Int, false);
 
     _select_parse_result = std::make_shared<hsql::SQLParserResult>();
     hsql::SQLParser::parse(_select_query_a, _select_parse_result.get());

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -45,9 +45,9 @@ class SQLPipelineTest : public BaseTest {
     _table_b = load_table("resources/test_data/tbl/int_float2.tbl", 2);
 
     TableColumnDefinitions column_definitions;
-    column_definitions.emplace_back("a", DataType::Int);
-    column_definitions.emplace_back("b", DataType::Float);
-    column_definitions.emplace_back("bb", DataType::Float);
+    column_definitions.emplace_back("a", DataType::Int, false);
+    column_definitions.emplace_back("b", DataType::Float, false);
+    column_definitions.emplace_back("bb", DataType::Float, false);
     _join_result = std::make_shared<Table>(column_definitions, TableType::Data);
     _join_result->append({12345, 458.7f, 456.7f});
     _join_result->append({12345, 458.7f, 457.7f});

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -179,8 +179,9 @@ TEST_P(SQLiteTestRunner, CompareToSQLite) {
     }
   }
 
-  const auto table_comparison_msg = check_table_equal(result_table, sqlite_result_table, order_sensitivity,
-                                                      TypeCmpMode::Lenient, FloatComparisonMode::RelativeDifference);
+  const auto table_comparison_msg =
+      check_table_equal(result_table, sqlite_result_table, order_sensitivity, TypeCmpMode::Lenient,
+                        FloatComparisonMode::RelativeDifference, IgnoreNullable::Yes);
 
   if (table_comparison_msg) {
     FAIL() << "Query failed: " << *table_comparison_msg << std::endl;

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -25,7 +25,7 @@ class ChunkEncoderTest : public BaseTest {
     TableColumnDefinitions column_definitions;
     for (auto column_id = 0u; column_id < column_count; ++column_id) {
       const auto column_name = std::to_string(column_id);
-      column_definitions.emplace_back(column_name, DataType::Int);
+      column_definitions.emplace_back(column_name, DataType::Int, false);
     }
     _table = std::make_shared<Table>(column_definitions, TableType::Data, max_chunk_size);
 

--- a/src/test/storage/reference_segment_test.cpp
+++ b/src/test/storage/reference_segment_test.cpp
@@ -25,7 +25,7 @@ class ReferenceSegmentTest : public BaseTest {
   virtual void SetUp() {
     TableColumnDefinitions column_definitions;
     column_definitions.emplace_back("a", DataType::Int, true);
-    column_definitions.emplace_back("b", DataType::Float);
+    column_definitions.emplace_back("b", DataType::Float, false);
 
     _test_table = std::make_shared<opossum::Table>(column_definitions, TableType::Data, 3);
     _test_table->append({123, 456.7f});
@@ -35,8 +35,8 @@ class ReferenceSegmentTest : public BaseTest {
     _test_table->append({12345, 458.7f});
 
     TableColumnDefinitions column_definitions2;
-    column_definitions2.emplace_back("a", DataType::Int);
-    column_definitions2.emplace_back("b", DataType::Int);
+    column_definitions2.emplace_back("a", DataType::Int, false);
+    column_definitions2.emplace_back("b", DataType::Int, false);
     _test_table_dict = std::make_shared<opossum::Table>(column_definitions2, TableType::Data, 5, UseMvcc::Yes);
     for (int i = 0; i <= 24; i += 2) _test_table_dict->append({i, 100 + i});
 

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -30,8 +30,8 @@ class SegmentAccessorTest : public BaseTest {
     dc_int = encode_and_compress_segment(vc_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
     dc_str = encode_and_compress_segment(vc_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
 
-    tbl = std::make_shared<Table>(TableColumnDefinitions{TableColumnDefinition{"vc_int", DataType::Int},
-                                                         TableColumnDefinition{"dc_str", DataType::String}},
+    tbl = std::make_shared<Table>(TableColumnDefinitions{TableColumnDefinition{"vc_int", DataType::Int, false},
+                                                         TableColumnDefinition{"dc_str", DataType::String, false}},
                                   TableType::Data);
     tbl->append_chunk({vc_int, dc_str});
 

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -16,8 +16,8 @@ class StorageManagerTest : public BaseTest {
  protected:
   void SetUp() override {
     auto& sm = StorageManager::get();
-    auto t1 = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int}}, TableType::Data);
-    auto t2 = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Int}}, TableType::Data, 4);
+    auto t1 = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
+    auto t2 = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Int, false}}, TableType::Data, 4);
 
     sm.add_table("first_table", t1);
     sm.add_table("second_table", t2);

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -15,8 +15,8 @@ namespace opossum {
 class StorageTableTest : public BaseTest {
  protected:
   void SetUp() override {
-    column_definitions.emplace_back("column_1", DataType::Int);
-    column_definitions.emplace_back("column_2", DataType::String);
+    column_definitions.emplace_back("column_1", DataType::Int, false);
+    column_definitions.emplace_back("column_2", DataType::String, false);
     t = std::make_shared<Table>(column_definitions, TableType::Data, 2);
   }
 

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -41,13 +41,14 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
 /**
  * Compare two tables with respect to OrderSensitivity, TypeCmpMode and FloatComparisonMode
  */
-#define EXPECT_TABLE_EQ(opossum_table, expected_table, order_sensitivity, type_cmp_mode, float_comparison_mode)   \
-  {                                                                                                               \
-    if (const auto table_difference_message = check_table_equal(opossum_table, expected_table, order_sensitivity, \
-                                                                type_cmp_mode, float_comparison_mode)) {          \
-      FAIL() << *table_difference_message;                                                                        \
-    }                                                                                                             \
-  }                                                                                                               \
+#define EXPECT_TABLE_EQ(opossum_table, expected_table, order_sensitivity, type_cmp_mode, float_comparison_mode)       \
+  {                                                                                                                   \
+    if (const auto table_difference_message =                                                                         \
+            check_table_equal(opossum_table, expected_table, order_sensitivity, type_cmp_mode, float_comparison_mode, \
+                              IgnoreNullable::No)) {                                                                  \
+      FAIL() << *table_difference_message;                                                                            \
+    }                                                                                                                 \
+  }                                                                                                                   \
   static_assert(true, "End call of macro with a semicolon")
 
 /**


### PR DESCRIPTION
AggregateHash always returned non-nullable columns, causing #1769.

This PR:
1) Fixes the nullability information returned by aggregates
2) Hardens the expression evaluator to DebugAssert that NULL values do not occur in non-nullable columns
3) Hardens the test suite by enforcing matching nullability information for everything but SQLite tests
4) Sneaks in a fix in the console so that `visualize` works from both the root and the build directory

fixes #1769
fixes #1698