### PR TITLE
[JIT] Fix bug #1741 - no support for COUNT(*) without group by

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -105,9 +105,9 @@ SELECT a AS x, SUM(b) FROM mixed GROUP BY x HAVING x > 10;
 SELECT a AS x, SUM(b) FROM mixed GROUP BY x HAVING x > 10;
 SELECT a AS a1, a AS a2 FROM mixed;
 SELECT a AS a1, b AS b2, b AS b3, a AS a3, b AS b1, a AS a2 FROM mixed;
-SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed GROUP BY a;
+SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed;
 SELECT a1, b2, a3 FROM (SELECT a AS a1, b AS b2, b AS b3, a AS a3, b AS b1, a AS a2 FROM mixed) AS R;
-SELECT * FROM (SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed GROUP BY a) AS R;
+SELECT * FROM (SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed) AS R;
 SELECT b AS b1, b AS b2 FROM id_int_int_int_100 WHERE a < (SELECT MAX(b) FROM mixed WHERE mixed.b > b1)
 
 -- ORDER BY
@@ -232,7 +232,6 @@ SELECT c_custkey, c_name, COUNT(a) FROM tpch_customer JOIN id_int_int_int_100 ON
 SELECT c_custkey, c_name, COUNT(a) FROM tpch_customer JOIN ( SELECT id_int_int_int_100.* FROM id_int_int_int_100 JOIN mixed ON id_int_int_int_100.a = mixed.id ) AS sub ON tpch_customer.c_custkey = sub.a GROUP BY c_custkey, c_name HAVING COUNT(sub.a) >= 2;
 
 -- COUNT(*)
--- SELECT COUNT(*) FROM mixed; (#1741)
 SELECT COUNT(*) FROM mixed
 SELECT COUNT(*) FROM mixed GROUP BY a;
 SELECT a, COUNT(*) FROM mixed GROUP BY a;

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -233,6 +233,7 @@ SELECT c_custkey, c_name, COUNT(a) FROM tpch_customer JOIN ( SELECT id_int_int_i
 
 -- COUNT(*)
 -- SELECT COUNT(*) FROM mixed; (#1741)
+SELECT COUNT(*) FROM mixed
 SELECT COUNT(*) FROM mixed GROUP BY a;
 SELECT a, COUNT(*) FROM mixed GROUP BY a;
 SELECT COUNT(*), SUM(a + b) FROM id_int_int_int_100;

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -106,6 +106,7 @@ SELECT a AS x, SUM(b) FROM mixed GROUP BY x HAVING x > 10;
 SELECT a AS a1, a AS a2 FROM mixed;
 SELECT a AS a1, b AS b2, b AS b3, a AS a3, b AS b1, a AS a2 FROM mixed;
 SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed;
+SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed GROUP BY a;
 SELECT a1, b2, a3 FROM (SELECT a AS a1, b AS b2, b AS b3, a AS a3, b AS b1, a AS a2 FROM mixed) AS R;
 SELECT * FROM (SELECT COUNT(*) AS cnt1, COUNT(*) AS cnt2, COUNT(*) AS cnt3 FROM mixed) AS R;
 SELECT b AS b1, b AS b2 FROM id_int_int_int_100 WHERE a < (SELECT MAX(b) FROM mixed WHERE mixed.b > b1)

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -232,7 +232,7 @@ SELECT c_custkey, c_name, COUNT(a) FROM tpch_customer JOIN id_int_int_int_100 ON
 SELECT c_custkey, c_name, COUNT(a) FROM tpch_customer JOIN ( SELECT id_int_int_int_100.* FROM id_int_int_int_100 JOIN mixed ON id_int_int_int_100.a = mixed.id ) AS sub ON tpch_customer.c_custkey = sub.a GROUP BY c_custkey, c_name HAVING COUNT(sub.a) >= 2;
 
 -- COUNT(*)
-SELECT COUNT(*) FROM mixed
+SELECT COUNT(*) FROM mixed;
 SELECT COUNT(*) FROM mixed GROUP BY a;
 SELECT a, COUNT(*) FROM mixed GROUP BY a;
 SELECT COUNT(*), SUM(a + b) FROM id_int_int_int_100;

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -235,10 +235,10 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
         // COUNT(*)
         DebugAssert(aggregate_expression->aggregate_function == AggregateFunction::Count,
                     "Only the aggregate function COUNT can have no arguments");
-        // JitAggregate requires one value for each aggregate function. This value is ignored for COUNT so that the
-        // first value in the tuple can be used.
-        const size_t tuple_index{0};
-        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), {DataType::Long, false, tuple_index},
+        // JitAggregate requires one value for each aggregate function. If no column is specified, a constant value is
+        // used.
+        auto constant_value = read_tuples->add_literal_value(AllTypeVariant{0});
+        aggregate->add_aggregate_column(aggregate_expression->as_column_name(), constant_value,
                                         aggregate_expression->aggregate_function);
       } else {
         const auto jit_expression =

--- a/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
+++ b/src/lib/logical_query_plan/jit_aware_lqp_translator.cpp
@@ -235,8 +235,8 @@ std::shared_ptr<JitOperatorWrapper> JitAwareLQPTranslator::_try_translate_sub_pl
         // COUNT(*)
         DebugAssert(aggregate_expression->aggregate_function == AggregateFunction::Count,
                     "Only the aggregate function COUNT can have no arguments");
-        // JitAggregate requires one value for each aggregate function. If no column is specified, a constant value is
-        // used.
+        // JitAggregate requires one value for each aggregate function. Since COUNT(*) does not specify a value, a
+        // constant value is used.
         auto constant_value = read_tuples->add_literal_value(AllTypeVariant{0});
         aggregate->add_aggregate_column(aggregate_expression->as_column_name(), constant_value,
                                         aggregate_expression->aggregate_function);

--- a/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/jit_aware_lqp_translator_test.cpp
@@ -543,7 +543,7 @@ TEST_F(JitAwareLQPTranslatorTest, AggregateOperator) {
 
   ASSERT_EQ(aggregate_columns[5].column_name, "COUNT(*)");
   ASSERT_EQ(aggregate_columns[5].function, AggregateFunction::Count);
-  ASSERT_EQ(aggregate_columns[5].tuple_entry.tuple_index, 0u);
+  ASSERT_EQ(aggregate_columns[5].tuple_entry.tuple_index, 3u);
 }
 
 TEST_F(JitAwareLQPTranslatorTest, LimitOperator) {


### PR DESCRIPTION
This pr fixes the issue that Aggregate in JIT could not handle COUNT(*) without a group by column.

`JitAggregate` always requires a value as a parameter for an aggregate function. Since COUNT(*) does not have a parameter, we just passed in the first value of the tuple as a dummy. This caused a problem if the tuple has no values and is now solved by adding a constant value to the tuple and using it as a parameter.

Closes #1741