### PR TITLE
Fix handling of diamonds in placement rule

### DIFF
--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -37,8 +37,17 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
 
       if (!_is_expensive_predicate(predicate_node->predicate())) {
         push_down_nodes.emplace_back(predicate_node);
+
+        // As predicate_node might be the input to multiple nodes, remember those nodes before we untie predicate_node
+        const auto output_relations = predicate_node->output_relations();
+
         lqp_remove_node(predicate_node);
         _push_down_traversal(current_node, input_side, push_down_nodes);
+
+        // Restore the output relationships
+        for (const auto& [output_node, output_side] : output_relations) {
+          output_node->set_input(output_side, current_node->input(input_side));
+        }
       } else {
         _push_down_traversal(input_node, input_side, push_down_nodes);
       }

--- a/src/test/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -12,6 +12,7 @@
 #include "logical_query_plan/sort_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "logical_query_plan/union_node.hpp"
+#include "logical_query_plan/validate_node.hpp"
 #include "optimizer/strategy/predicate_placement_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
 #include "testing_assert.hpp"
@@ -123,9 +124,7 @@ TEST_F(PredicatePlacementRuleTest, SimpleSortPushdownTest) {
   PredicateNode::make(greater_than_(_a_a, _a_b),
     SortNode::make(expression_vector(_a_a), std::vector<OrderByMode>{OrderByMode::Ascending},
       _table_a));
-  // clang-format on
 
-  // clang-format off
   const auto expected_lqp =
   SortNode::make(expression_vector(_a_a), std::vector<OrderByMode>{OrderByMode::Ascending},
     PredicateNode::make(greater_than_(_a_a, _a_b),
@@ -136,6 +135,39 @@ TEST_F(PredicatePlacementRuleTest, SimpleSortPushdownTest) {
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
+
+TEST_F(PredicatePlacementRuleTest, DiamondPushdownTest) {
+  // Regression test: If the predicate cannot be pushed down and is effectively re-inserted at the same position, make
+  // sure that its outputs are correctly restored.
+  // clang-format off
+  const auto input_sub_lqp =
+  PredicateNode::make(greater_than_(_a_a, 1),
+    ValidateNode::make(
+      _table_a));
+
+  const auto input_lqp =
+  UpdateNode::make("int_float",
+    input_sub_lqp,
+    ProjectionNode::make(expression_vector(_a_a, cast_(3.2, DataType::Float)),
+      input_sub_lqp));
+
+  const auto expected_sub_lqp =
+  PredicateNode::make(greater_than_(_a_a, 1),
+    ValidateNode::make(
+      _table_a));
+
+  const auto expected_lqp =
+  UpdateNode::make("int_float",
+    expected_sub_lqp,
+    ProjectionNode::make(expression_vector(_a_a, cast_(3.2, DataType::Float)),
+      expected_sub_lqp));
+  // clang-format on
+
+  auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
 
 TEST_F(PredicatePlacementRuleTest, ComplexBlockingPredicatesPushdownTest) {
   // clang-format off


### PR DESCRIPTION
fixes #1776 

In "full" Hyrise, this bug is only exposed if the PredicatePlacementRule is running alone. Otherwise, it is hidden by the JoinOrderingRule.

@mweisgut - since you are looking into diamonds anyway, could you have a look at this and see if you can come up with any additional edge cases?