### PR TITLE
Fix sqlite comparison

### DIFF
--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -15,7 +15,7 @@ def initialize():
 		sys.exit(1)
 
 	build_dir = sys.argv[1]
-	console = pexpect.spawn(build_dir + "/hyriseConsole", timeout=15, dimensions=(200, 64))
+	console = pexpect.spawn(build_dir + "/hyriseConsole", timeout=60, dimensions=(200, 64))
 	return console
 
 def close_console(console):

--- a/src/lib/utils/check_table_equal.cpp
+++ b/src/lib/utils/check_table_equal.cpp
@@ -196,16 +196,14 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
         expected_column_type = DataType::Int;
       }
 
-      if (expected_column_type == DataType::Int) {
-        bool all_null = true;
-        for (auto row_id = size_t{HEADER_SIZE}; row_id < expected_matrix.size(); row_id++) {
-          if (!variant_is_null(expected_matrix[row_id][column_id])) {
-            all_null = false;
-            break;
-          }
+      bool all_null = true;
+      for (auto row_id = size_t{HEADER_SIZE}; row_id < expected_matrix.size(); row_id++) {
+        if (!variant_is_null(expected_matrix[row_id][column_id])) {
+          all_null = false;
+          break;
         }
-        if (all_null) expected_column_type = actual_column_type;
       }
+      if (all_null) expected_column_type = actual_column_type;
     }
 
     if (!boost::iequals(actual_table->column_name(column_id), expected_table->column_name(column_id))) {

--- a/src/lib/utils/check_table_equal.cpp
+++ b/src/lib/utils/check_table_equal.cpp
@@ -127,24 +127,24 @@ bool check_segment_equal(const std::shared_ptr<BaseSegment>& actual_segment,
                             IgnoreNullable::Yes);
 }
 
-std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>& opossum_table,
+std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>& actual_table,
                                              const std::shared_ptr<const Table>& expected_table,
                                              OrderSensitivity order_sensitivity, TypeCmpMode type_cmp_mode,
                                              FloatComparisonMode float_comparison_mode,
                                              IgnoreNullable ignore_nullable) {
-  if (!opossum_table && expected_table) return "No 'actual' table given";
-  if (opossum_table && !expected_table) return "No 'expected' table given";
-  if (!opossum_table && !expected_table) return "No 'expected' table and no 'actual' table given";
+  if (!actual_table && expected_table) return "No 'actual' table given";
+  if (actual_table && !expected_table) return "No 'expected' table given";
+  if (!actual_table && !expected_table) return "No 'expected' table and no 'actual' table given";
 
   auto stream = std::stringstream{};
 
-  auto opossum_matrix = table_to_matrix(opossum_table);
+  auto actual_matrix = table_to_matrix(actual_table);
   auto expected_matrix = table_to_matrix(expected_table);
 
   // sort if order does not matter
   if (order_sensitivity == OrderSensitivity::No) {
     // skip header when sorting
-    std::sort(opossum_matrix.begin() + HEADER_SIZE, opossum_matrix.end());
+    std::sort(actual_matrix.begin() + HEADER_SIZE, actual_matrix.end());
     std::sort(expected_matrix.begin() + HEADER_SIZE, expected_matrix.end());
   }
 
@@ -152,7 +152,7 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
                                           const std::vector<std::pair<uint64_t, uint16_t>>& highlighted_cells = {}) {
     stream << "===================== Tables are not equal =====================" << std::endl;
     stream << "------------------------- Actual Result ------------------------" << std::endl;
-    stream << matrix_to_string(opossum_matrix, highlighted_cells, ANSI_COLOR_RED, ANSI_COLOR_BG_RED);
+    stream << matrix_to_string(actual_matrix, highlighted_cells, ANSI_COLOR_RED, ANSI_COLOR_BG_RED);
     stream << "----------------------------------------------------------------" << std::endl << std::endl;
     stream << "------------------------ Expected Result -----------------------" << std::endl;
     stream << matrix_to_string(expected_matrix, highlighted_cells, ANSI_COLOR_GREEN, ANSI_COLOR_BG_GREEN);
@@ -164,9 +164,9 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
 
   // compare schema of tables
   //  - column count
-  if (opossum_table->column_count() != expected_table->column_count()) {
+  if (actual_table->column_count() != expected_table->column_count()) {
     const std::string error_type = "Column count mismatch";
-    const std::string error_msg = "Actual number of columns: " + std::to_string(opossum_table->column_count()) + "\n" +
+    const std::string error_msg = "Actual number of columns: " + std::to_string(actual_table->column_count()) + "\n" +
                                   "Expected number of columns: " + std::to_string(expected_table->column_count());
 
     print_table_comparison(error_type, error_msg);
@@ -174,52 +174,64 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
   }
 
   //  - column names and types
-  DataType left_column_type, right_column_type;
-  bool left_column_is_nullable, right_column_is_nullable;
+  DataType actual_column_type, expected_column_type;
+  bool actual_column_is_nullable, expected_column_is_nullable;
   for (auto column_id = ColumnID{0}; column_id < expected_table->column_count(); ++column_id) {
-    left_column_type = opossum_table->column_data_type(column_id);
-    left_column_is_nullable = opossum_table->column_is_nullable(column_id);
-    right_column_type = expected_table->column_data_type(column_id);
-    right_column_is_nullable = expected_table->column_is_nullable(column_id);
+    actual_column_type = actual_table->column_data_type(column_id);
+    actual_column_is_nullable = actual_table->column_is_nullable(column_id);
+    expected_column_type = expected_table->column_data_type(column_id);
+    expected_column_is_nullable = expected_table->column_is_nullable(column_id);
     // This is needed for the SQLiteTestrunner, since SQLite does not differentiate between float/double, and int/long.
+    // Also, as sqlite returns a generic type for all-NULL columns, we need to adapt those columns to our type.
     if (type_cmp_mode == TypeCmpMode::Lenient) {
-      if (left_column_type == DataType::Double) {
-        left_column_type = DataType::Float;
-      } else if (left_column_type == DataType::Long) {
-        left_column_type = DataType::Int;
+      if (actual_column_type == DataType::Double) {
+        actual_column_type = DataType::Float;
+      } else if (actual_column_type == DataType::Long) {
+        actual_column_type = DataType::Int;
       }
 
-      if (right_column_type == DataType::Double) {
-        right_column_type = DataType::Float;
-      } else if (right_column_type == DataType::Long) {
-        right_column_type = DataType::Int;
+      if (expected_column_type == DataType::Double) {
+        expected_column_type = DataType::Float;
+      } else if (expected_column_type == DataType::Long) {
+        expected_column_type = DataType::Int;
+      }
+
+      if (expected_column_type == DataType::Int) {
+        bool all_null = true;
+        for (auto row_id = size_t{HEADER_SIZE}; row_id < expected_matrix.size(); row_id++) {
+          if (!variant_is_null(expected_matrix[row_id][column_id])) {
+            all_null = false;
+            break;
+          }
+        }
+        if (all_null) expected_column_type = actual_column_type;
       }
     }
 
-    if (!boost::iequals(opossum_table->column_name(column_id), expected_table->column_name(column_id))) {
+    if (!boost::iequals(actual_table->column_name(column_id), expected_table->column_name(column_id))) {
       const std::string error_type = "Column name mismatch (column " + std::to_string(column_id) + ")";
-      const std::string error_msg = "Actual column name: " + opossum_table->column_name(column_id) + "\n" +
+      const std::string error_msg = "Actual column name: " + actual_table->column_name(column_id) + "\n" +
                                     "Expected column name: " + expected_table->column_name(column_id);
 
       print_table_comparison(error_type, error_msg, {{0, column_id}});
       return stream.str();
     }
 
-    if (left_column_type != right_column_type) {
+    if (actual_column_type != expected_column_type) {
       const std::string error_type = "Column type mismatch (column " + std::to_string(column_id) + ")";
       const std::string error_msg =
-          "Actual column type: " + data_type_to_string.left.at(opossum_table->column_data_type(column_id)) + "\n" +
+          "Actual column type: " + data_type_to_string.left.at(actual_table->column_data_type(column_id)) + "\n" +
           "Expected column type: " + data_type_to_string.left.at(expected_table->column_data_type(column_id));
 
       print_table_comparison(error_type, error_msg, {{1, column_id}});
       return stream.str();
     }
 
-    if (ignore_nullable == IgnoreNullable::No && left_column_is_nullable != right_column_is_nullable) {
+    if (ignore_nullable == IgnoreNullable::No && actual_column_is_nullable != expected_column_is_nullable) {
       const std::string error_type = "Column NULLable mismatch (column " + std::to_string(column_id) + ")";
-      const std::string error_msg = std::string{"Actual column is "} + (left_column_is_nullable ? "" : "NOT ") +
+      const std::string error_msg = std::string{"Actual column is "} + (actual_column_is_nullable ? "" : "NOT ") +
                                     "NULL\n" + std::string{"Expected column is "} +
-                                    (right_column_is_nullable ? "" : "NOT ") + "NULL";
+                                    (expected_column_is_nullable ? "" : "NOT ") + "NULL";
 
       print_table_comparison(error_type, error_msg, {{2, column_id}});
       return stream.str();
@@ -228,9 +240,9 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
 
   // compare content of tables
   //  - row count for fast failure
-  if (opossum_table->row_count() != expected_table->row_count()) {
+  if (actual_table->row_count() != expected_table->row_count()) {
     const std::string error_type = "Row count mismatch";
-    const std::string error_msg = "Actual number of rows: " + std::to_string(opossum_table->row_count()) + "\n" +
+    const std::string error_msg = "Actual number of rows: " + std::to_string(actual_table->row_count()) + "\n" +
                                   "Expected number of rows: " + std::to_string(expected_table->row_count());
 
     print_table_comparison(error_type, error_msg);
@@ -240,7 +252,7 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
   // sort if order does not matter
   if (order_sensitivity == OrderSensitivity::No) {
     // skip header when sorting
-    std::sort(opossum_matrix.begin() + HEADER_SIZE, opossum_matrix.end());
+    std::sort(actual_matrix.begin() + HEADER_SIZE, actual_matrix.end());
     std::sort(expected_matrix.begin() + HEADER_SIZE, expected_matrix.end());
   }
 
@@ -255,37 +267,38 @@ std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>&
   };
 
   // Compare each cell, skipping header
-  for (auto row_id = size_t{HEADER_SIZE}; row_id < opossum_matrix.size(); row_id++)
-    for (auto column_id = ColumnID{0}; column_id < opossum_matrix[row_id].size(); column_id++) {
-      if (variant_is_null(opossum_matrix[row_id][column_id]) || variant_is_null(expected_matrix[row_id][column_id])) {
-        highlight_if(!(variant_is_null(opossum_matrix[row_id][column_id]) &&
-                       variant_is_null(expected_matrix[row_id][column_id])),
-                     row_id, column_id);
-      } else if (opossum_table->column_data_type(column_id) == DataType::Float) {
-        auto left_val = static_cast<double>(boost::get<float>(opossum_matrix[row_id][column_id]));
+  for (auto row_id = size_t{HEADER_SIZE}; row_id < actual_matrix.size(); row_id++) {
+    for (auto column_id = ColumnID{0}; column_id < actual_matrix[row_id].size(); column_id++) {
+      if (variant_is_null(actual_matrix[row_id][column_id]) || variant_is_null(expected_matrix[row_id][column_id])) {
+        highlight_if(
+            !(variant_is_null(actual_matrix[row_id][column_id]) && variant_is_null(expected_matrix[row_id][column_id])),
+            row_id, column_id);
+      } else if (actual_table->column_data_type(column_id) == DataType::Float) {
+        auto left_val = static_cast<double>(boost::get<float>(actual_matrix[row_id][column_id]));
         auto right_val = lossless_variant_cast<double>(expected_matrix[row_id][column_id]);
         Assert(right_val, "Expected double or float in expected_matrix");
 
         highlight_if(!almost_equals(left_val, *right_val, float_comparison_mode), row_id, column_id);
-      } else if (opossum_table->column_data_type(column_id) == DataType::Double) {
-        auto left_val = boost::get<double>(opossum_matrix[row_id][column_id]);
+      } else if (actual_table->column_data_type(column_id) == DataType::Double) {
+        auto left_val = boost::get<double>(actual_matrix[row_id][column_id]);
         auto right_val = lossless_variant_cast<double>(expected_matrix[row_id][column_id]);
         Assert(right_val, "Expected double or float in expected_matrix");
 
         highlight_if(!almost_equals(left_val, *right_val, float_comparison_mode), row_id, column_id);
       } else {
-        if (type_cmp_mode == TypeCmpMode::Lenient && (opossum_table->column_data_type(column_id) == DataType::Int ||
-                                                      opossum_table->column_data_type(column_id) == DataType::Long)) {
-          auto left_val = lossless_variant_cast<int64_t>(opossum_matrix[row_id][column_id]);
+        if (type_cmp_mode == TypeCmpMode::Lenient && (actual_table->column_data_type(column_id) == DataType::Int ||
+                                                      actual_table->column_data_type(column_id) == DataType::Long)) {
+          auto left_val = lossless_variant_cast<int64_t>(actual_matrix[row_id][column_id]);
           auto right_val = lossless_variant_cast<int64_t>(expected_matrix[row_id][column_id]);
-          Assert(left_val && right_val, "Expected int or long in opossum_matrix and expected_matrix");
+          Assert(left_val && right_val, "Expected int or long in actual_matrix and expected_matrix");
 
           highlight_if(*left_val != *right_val, row_id, column_id);
         } else {
-          highlight_if(opossum_matrix[row_id][column_id] != expected_matrix[row_id][column_id], row_id, column_id);
+          highlight_if(actual_matrix[row_id][column_id] != expected_matrix[row_id][column_id], row_id, column_id);
         }
       }
     }
+  }
 
   if (has_error) {
     const std::string error_type = "Cell data mismatch";

--- a/src/lib/utils/check_table_equal.hpp
+++ b/src/lib/utils/check_table_equal.hpp
@@ -43,7 +43,7 @@ bool check_segment_equal(const std::shared_ptr<BaseSegment>& actual_segment,
 // Compares two tables for equality
 // @return  A human-readable description of the table-mismatch, if any
 //          std::nullopt if the Tables are the same
-std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>& opossum_table,
+std::optional<std::string> check_table_equal(const std::shared_ptr<const Table>& actual_table,
                                              const std::shared_ptr<const Table>& expected_table,
                                              OrderSensitivity order_sensitivity, TypeCmpMode type_cmp_mode,
                                              FloatComparisonMode float_comparison_mode, IgnoreNullable ignore_nullable);

--- a/src/lib/utils/sqlite_wrapper.cpp
+++ b/src/lib/utils/sqlite_wrapper.cpp
@@ -30,6 +30,9 @@ SQLiteWrapper::SQLiteWrapper() {
     sqlite3_close(_db);
     Fail("Cannot open database: " + std::string(sqlite3_errmsg(_db)));
   }
+
+  // Make LIKE case sensitive, just like in Hyrise
+  raw_execute_query("PRAGMA case_sensitive_like = true");
 }
 
 SQLiteWrapper::~SQLiteWrapper() { sqlite3_close(_db); }


### PR DESCRIPTION
By default, LIKE is case-insensitive in sqlite. This PR changes that behavior to match Hyrise's.

Also, it fixes the comparison of all-NULL columns.

There is still a mismatch in the table sizes between the imdb_data set that we are using and the one linked in the benchmark. That leads to some results being NULL as described in #1409. I don't see this as a big issue, as we are only using the JOB for internal comparisons. As a result, I suggest that this closes #1409.