### PR TITLE
Small refactorings, mostly in the join

### DIFF
--- a/src/benchmarklib/encoding_config.hpp
+++ b/src/benchmarklib/encoding_config.hpp
@@ -26,9 +26,9 @@ class EncodingConfig {
 
   static EncodingConfig unencoded();
 
-  const SegmentEncodingSpec default_encoding_spec;
-  const DataTypeEncodingMapping type_encoding_mapping;
-  const TableSegmentEncodingMapping custom_encoding_mapping;
+  SegmentEncodingSpec default_encoding_spec;
+  DataTypeEncodingMapping type_encoding_mapping;
+  TableSegmentEncodingMapping custom_encoding_mapping;
 
   static SegmentEncodingSpec encoding_spec_from_strings(const std::string& encoding_str,
                                                         const std::string& compression_str);

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -1031,7 +1031,7 @@ PosList ExpressionEvaluator::evaluate_expression_to_pos_list(const AbstractExpre
                   auto matches = ExpressionEvaluator::Bool{0};
                   ExpressionFunctorType{}(matches, left_result.value(chunk_offset),  // NOLINT
                                           right_result.value(chunk_offset));
-                  if (matches != 0) result_pos_list.emplace_back(_chunk_id, chunk_offset);
+                  if (matches != 0) result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
                 }
               } else {
                 Fail("Argument types not compatible");
@@ -1053,11 +1053,11 @@ PosList ExpressionEvaluator::evaluate_expression_to_pos_list(const AbstractExpre
           _resolve_to_expression_result_view(*is_null_expression.operand(), [&](const auto& result) {
             if (is_null_expression.predicate_condition == PredicateCondition::IsNull) {
               for (auto chunk_offset = ChunkOffset{0}; chunk_offset < _output_row_count; ++chunk_offset) {
-                if (result.is_null(chunk_offset)) result_pos_list.emplace_back(_chunk_id, chunk_offset);
+                if (result.is_null(chunk_offset)) result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
               }
             } else {  // PredicateCondition::IsNotNull
               for (auto chunk_offset = ChunkOffset{0}; chunk_offset < _output_row_count; ++chunk_offset) {
-                if (!result.is_null(chunk_offset)) result_pos_list.emplace_back(_chunk_id, chunk_offset);
+                if (!result.is_null(chunk_offset)) result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
               }
             }
           });
@@ -1077,7 +1077,7 @@ PosList ExpressionEvaluator::evaluate_expression_to_pos_list(const AbstractExpre
           result->as_view([&](const auto& result_view) {
             for (auto chunk_offset = ChunkOffset{0}; chunk_offset < _output_row_count; ++chunk_offset) {
               if (result_view.value(chunk_offset) != 0 && !result_view.is_null(chunk_offset)) {
-                result_pos_list.emplace_back(_chunk_id, chunk_offset);
+                result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
               }
             }
           });
@@ -1115,13 +1115,13 @@ PosList ExpressionEvaluator::evaluate_expression_to_pos_list(const AbstractExpre
       if (subquery_expression->is_correlated()) {
         for (auto chunk_offset = ChunkOffset{0}; chunk_offset < _output_row_count; ++chunk_offset) {
           if ((subquery_result_tables[chunk_offset]->row_count() > 0) ^ invert) {
-            result_pos_list.emplace_back(_chunk_id, chunk_offset);
+            result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
           }
         }
       } else {
         if ((subquery_result_tables.front()->row_count() > 0) ^ invert) {
           for (auto chunk_offset = ChunkOffset{0}; chunk_offset < _output_row_count; ++chunk_offset) {
-            result_pos_list.emplace_back(_chunk_id, chunk_offset);
+            result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
           }
         }
       }

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -111,7 +111,7 @@ void AggregateHash::_aggregate_segment(ChunkID chunk_id, ColumnID column_index, 
 
   ChunkOffset chunk_offset{0};
   segment_iterate<ColumnDataType>(base_segment, [&](const auto& position) {
-    auto& result = get_or_add_result(result_ids, results, hash_keys[chunk_offset], RowID(chunk_id, chunk_offset));
+    auto& result = get_or_add_result(result_ids, results, hash_keys[chunk_offset], RowID{chunk_id, chunk_offset});
 
     /**
     * If the value is NULL, the current aggregate value does not change.

--- a/src/lib/operators/jit_operator/operators/jit_write_references.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_write_references.cpp
@@ -110,7 +110,7 @@ const std::vector<JitWriteReferences::OutputColumn>& JitWriteReferences::output_
 }
 
 void JitWriteReferences::_consume(JitRuntimeContext& context) const {
-  context.output_pos_list->emplace_back(context.chunk_id, context.chunk_offset);
+  context.output_pos_list->emplace_back(RowId{context.chunk_id, context.chunk_offset});
 }
 
 }  // namespace opossum

--- a/src/lib/operators/jit_operator/operators/jit_write_references.cpp
+++ b/src/lib/operators/jit_operator/operators/jit_write_references.cpp
@@ -110,7 +110,7 @@ const std::vector<JitWriteReferences::OutputColumn>& JitWriteReferences::output_
 }
 
 void JitWriteReferences::_consume(JitRuntimeContext& context) const {
-  context.output_pos_list->emplace_back(RowId{context.chunk_id, context.chunk_offset});
+  context.output_pos_list->emplace_back(RowID{context.chunk_id, context.chunk_offset});
 }
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -81,10 +81,11 @@ class PosHashTable {
         pos_list.emplace_back(row_id);
       }
     } else {
+      DebugAssert(_hash_table.size() < _pos_lists.size(), "Hash table too big for pre-allocated data structures");
       auto& pos_list = _pos_lists[_hash_table.size()];
       pos_list.push_back(row_id);
       _hash_table.emplace(casted_value, _hash_table.size());
-      Assert(_hash_table.size() < std::numeric_limits<Offset>::max(), "Hash table too big for offset");
+      DebugAssert(_hash_table.size() < std::numeric_limits<Offset>::max(), "Hash table too big for offset");
     }
   }
 

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -34,9 +34,6 @@ The original value is used to detect hash collisions.
 */
 template <typename T>
 struct PartitionedElement {
-  PartitionedElement() : row_id(NULL_ROW_ID), value(T()) {}
-  PartitionedElement(RowID row, T val) : row_id(row), value(val) {}
-
   RowID row_id;
   T value;
 };
@@ -68,8 +65,10 @@ class PosHashTable {
   using SmallPosList = boost::container::small_vector<RowID, 1>;
 
  public:
-  explicit PosHashTable(const JoinHashBuildMode mode, const size_t max_size)
-      : _hash_table(max_size), _pos_lists(max_size), _mode(mode) {}
+  explicit PosHashTable(const JoinHashBuildMode mode, const size_t max_size)  // TODO explicitly test this
+      : _hash_table(), _pos_lists(max_size), _mode(mode) {
+    _hash_table.reserve(max_size);
+  }
 
   // For a value seen on the build side, add its row_id to the table
   template <typename InputType>
@@ -77,8 +76,8 @@ class PosHashTable {
     const auto casted_value = static_cast<HashedType>(value);
     const auto it = _hash_table.find(casted_value);
     if (it != _hash_table.end()) {
-      auto& pos_list = _pos_lists[it->second];
       if (_mode == JoinHashBuildMode::AllPositions) {
+        auto& pos_list = _pos_lists[it->second];
         pos_list.emplace_back(row_id);
       }
     } else {
@@ -95,15 +94,48 @@ class PosHashTable {
     for (auto& pos_list : _pos_lists) {
       pos_list.shrink_to_fit();
     }
+
+    if (_hash_table.size() <= 10) {
+      _values = std::vector<std::pair<HashedType, Offset>>{};
+      _values->reserve(_hash_table.size());
+      for (const auto& [value, offset] : _hash_table) {
+        _values->emplace_back(std::pair<HashedType, Offset>{value, offset});
+      }
+      _hash_table.clear();
+    } else {
+      _hash_table.shrink_to_fit();
+    }
   }
 
-  // For a value seen on the probe side, return an iterator into the matching values
+  // For a value seen on the probe side, return an iterator into the matching positions on the build side
   template <typename InputType>
   const std::vector<SmallPosList>::const_iterator find(const InputType& value) const {
     const auto casted_value = static_cast<HashedType>(value);
-    const auto it = _hash_table.find(casted_value);
-    if (it == _hash_table.end()) return end();
-    return _pos_lists.begin() + it->second;
+
+    if (!_values) {
+      const auto hash_table_iter = _hash_table.find(casted_value);
+      if (hash_table_iter == _hash_table.end()) return end();
+      return _pos_lists.begin() + hash_table_iter->second;
+    } else {
+      const auto values_iter =
+          std::find_if(_values->begin(), _values->end(), [&](const auto& pair) { return pair.first == casted_value; });
+      if (values_iter == _values->end()) return end();
+      return _pos_lists.begin() + values_iter->second;
+    }
+  }
+
+  // For a value seen on the probe side, return whether it has been seen on the build side
+  template <typename InputType>
+  bool contains(const InputType& value) const {
+    const auto casted_value = static_cast<HashedType>(value);
+
+    if (!_values) {
+      return _hash_table.find(casted_value) != _hash_table.end();
+    } else {
+      const auto values_iter =
+          std::find_if(_values->begin(), _values->end(), [&](const auto& pair) { return pair.first == casted_value; });
+      return values_iter != _values->end();
+    }
   }
 
   const std::vector<SmallPosList>::const_iterator begin() const { return _pos_lists.begin(); }
@@ -114,6 +146,7 @@ class PosHashTable {
   HashTable _hash_table;
   std::vector<SmallPosList> _pos_lists;
   JoinHashBuildMode _mode;
+  std::optional<std::vector<std::pair<HashedType, Offset>>> _values{std::nullopt};
 };
 
 /*
@@ -213,16 +246,16 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
       segment_with_iterators<T>(*segment, [&](auto it, const auto end) {
         using IterableType = typename decltype(it)::IterableType;
 
+        if (radix_bits == 0) {
+          // If we do not use partitioning, we will not increment the histogram counter in the loop, so we do it here.
+          histogram[0] = std::distance(it, end);
+        }
+
         while (it != end) {
           const auto& value = *it;
           ++it;
 
           if (!value.is_null() || retain_null_values) {
-            // TODO(anyone): static_cast is almost always safe, since HashType is big enough. Only for double-vs-long
-            // joins an information loss is possible when joining with longs that cannot be losslessly converted to
-            // double
-            const Hash hashed_value = hash_function(static_cast<HashedType>(value.value()));
-
             /*
             For ReferenceSegments we do not use the RowIDs from the referenced tables.
             Instead, we use the index in the ReferenceSegment itself. This way we can later correctly dereference
@@ -239,11 +272,17 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
               if (value.is_null()) {
                 *null_value_bitvector_iterator = true;
               }
+              ++null_value_bitvector_iterator;
             }
 
-            const Hash radix = hashed_value & mask;
-            ++histogram[radix];
-            ++null_value_bitvector_iterator;
+            if (radix_bits > 0) {
+              // TODO(anyone): static_cast is almost always safe, since HashType is big enough. Only for double-vs-long
+              // joins an information loss is possible when joining with longs that cannot be losslessly converted to
+              // double
+              const Hash hashed_value = hash_function(static_cast<HashedType>(value.value()));
+              const Hash radix = hashed_value & mask;
+              ++histogram[radix];
+            }
           }
           // reference_chunk_offset is only used for ReferenceSegments
           if constexpr (is_reference_segment_iterable_v<IterableType>) {
@@ -253,7 +292,8 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
       });
 
       if constexpr (std::is_same_v<Partition<T>, uninitialized_vector<PartitionedElement<T>>>) {  // NOLINT
-        // Because the vector is uninitialized, we need to manually fill up all slots that we did not use
+        // Because the vector is uninitialized, we need to manually fill up all slots that we did not use because the
+        // input values were NULL.
         auto output_offset_end = chunk_id < chunk_offsets.size() - 1 ? chunk_offsets[chunk_id + 1] : elements->size();
         while (output_iterator != elements->begin() + output_offset_end) {
           *(output_iterator++) = PartitionedElement<T>{};
@@ -656,13 +696,14 @@ void probe_semi_anti(const RadixContainer<ProbeColumnType>& radix_probe_column,
 
       if (hash_tables[current_partition_id]) {
         // Valid hash table found, so there is at least one match in this partition
+        const auto& hash_table = hash_tables[current_partition_id].value();
 
         // Accessors are not thread-safe, so we create one evaluator per job
         MultiPredicateJoinEvaluator multi_predicate_join_evaluator(build_table, probe_table, mode,
                                                                    secondary_join_predicates);
 
         for (size_t partition_offset = partition_begin; partition_offset < partition_end; ++partition_offset) {
-          auto& probe_column_element = partition[partition_offset];
+          const auto& probe_column_element = partition[partition_offset];
 
           if constexpr (mode == JoinMode::Semi) {
             // NULLs on the probe side are never emitted
@@ -685,15 +726,19 @@ void probe_semi_anti(const RadixContainer<ProbeColumnType>& radix_probe_column,
           }
 
           auto any_build_column_value_matches = false;
-          const auto& hash_table = hash_tables[current_partition_id].value();
-          const auto& primary_predicate_matching_rows =
-              hash_table.find(static_cast<HashedType>(probe_column_element.value));
 
-          if (primary_predicate_matching_rows != hash_table.end()) {
-            for (const auto& row_id : *primary_predicate_matching_rows) {
-              if (multi_predicate_join_evaluator.satisfies_all_predicates(row_id, probe_column_element.row_id)) {
-                any_build_column_value_matches = true;
-                break;
+          if (secondary_join_predicates.empty()) {
+            any_build_column_value_matches = hash_table.contains(static_cast<HashedType>(probe_column_element.value));
+          } else {
+            const auto primary_predicate_matching_rows =
+                hash_table.find(static_cast<HashedType>(probe_column_element.value));
+
+            if (primary_predicate_matching_rows != hash_table.end()) {
+              for (const auto& row_id : *primary_predicate_matching_rows) {
+                if (multi_predicate_join_evaluator.satisfies_all_predicates(row_id, probe_column_element.row_id)) {
+                  any_build_column_value_matches = true;
+                  break;
+                }
               }
             }
           }

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -65,7 +65,7 @@ class PosHashTable {
   using SmallPosList = boost::container::small_vector<RowID, 1>;
 
  public:
-  explicit PosHashTable(const JoinHashBuildMode mode, const size_t max_size)  // TODO explicitly test this
+  explicit PosHashTable(const JoinHashBuildMode mode, const size_t max_size)
       : _hash_table(), _pos_lists(max_size), _mode(mode) {
     _hash_table.reserve(max_size);
   }

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -468,7 +468,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
       const auto chunk_size = chunk->size();
       for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (_probe_matches[chunk_id][chunk_offset] ^ invert) {
-          _probe_pos_list->emplace_back(chunk_id, chunk_offset);
+          _probe_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
         }
       }
     }

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -204,7 +204,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (!right_matches_by_chunk[chunk_id_right][chunk_offset]) {
           pos_list_left->emplace_back(NULL_ROW_ID);
-          pos_list_right->emplace_back(chunk_id_right, chunk_offset);
+          pos_list_right->emplace_back(RowID{chunk_id_right, chunk_offset});
         }
       }
     }
@@ -221,7 +221,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
       const auto chunk_size = chunk_left->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (left_matches_by_chunk[chunk_id][chunk_offset] ^ invert) {
-          pos_list_left->emplace_back(chunk_id, chunk_offset);
+          pos_list_left->emplace_back(RowID{chunk_id, chunk_offset});
         }
       }
     }

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -166,14 +166,14 @@ void ColumnVsValueTableScanImpl::_scan_sorted_segment(const BaseSegment& segment
            */
           if (position_filter || predicate_condition == PredicateCondition::NotEquals) {
             for (; begin != end; ++begin) {
-              matches[output_idx++] = RowID(chunk_id, begin->chunk_offset());
+              matches[output_idx++] = RowID{chunk_id, begin->chunk_offset()};
             }
           } else {
             const auto first_offset = begin->chunk_offset();
             const auto distance = std::distance(begin, end);
 
             for (auto chunk_offset = 0; chunk_offset < distance; ++chunk_offset) {
-              matches[output_idx++] = RowID(chunk_id, first_offset + chunk_offset);
+              matches[output_idx++] = RowID{chunk_id, first_offset + chunk_offset};
             }
           }
         });

--- a/src/lib/optimizer/strategy/abstract_rule.hpp
+++ b/src/lib/optimizer/strategy/abstract_rule.hpp
@@ -13,8 +13,6 @@ class AbstractRule {
  public:
   virtual ~AbstractRule() = default;
 
-  virtual std::string name() const = 0;
-
   /**
    * This function applies the concrete Optimizer Rule to an LQP.
    * apply_to() is intended to be called recursively by the concrete rule.

--- a/src/lib/optimizer/strategy/between_composition_rule.cpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.cpp
@@ -18,8 +18,6 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-std::string BetweenCompositionRule::name() const { return "Between Composition Rule"; }
-
 /**
  * _get_boundary takes a BinaryPredicateExpression and the corresponding PredicateNode
  * as its input and returns a standardized ColumnBoundary. This function checks where the

--- a/src/lib/optimizer/strategy/between_composition_rule.hpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.hpp
@@ -27,7 +27,6 @@ class PredicateNode;
 **/
 class BetweenCompositionRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
  private:

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -22,8 +22,6 @@
 
 namespace opossum {
 
-std::string ChunkPruningRule::name() const { return "Chunk Pruning Rule"; }
-
 void ChunkPruningRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   // we only want to follow chains of predicates
   if (node->type != LQPNodeType::Predicate) {

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -25,8 +25,6 @@ class Table;
  */
 class ChunkPruningRule : public AbstractRule {
  public:
-  std::string name() const override;
-
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
  protected:

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -22,8 +22,6 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-std::string ColumnPruningRule::name() const { return "Column Pruning Rule"; }
-
 void ColumnPruningRule::apply_to(const std::shared_ptr<AbstractLQPNode>& lqp) const {
   // Collect the columns that are used in expressions somewhere in the LQP.
   // This EXCLUDES columns that are merely forwarded by Projections throughout the LQP

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -21,7 +21,6 @@ class AbstractLQPNode;
  */
 class ColumnPruningRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& lqp) const override;
 
  private:

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -16,8 +16,6 @@ namespace opossum {
 
 using namespace opossum::expression_functional;  // NOLINT
 
-std::string ExpressionReductionRule::name() const { return "Expression Reduction Rule"; }
-
 void ExpressionReductionRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   Assert(node->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto");
 

--- a/src/lib/optimizer/strategy/expression_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.hpp
@@ -37,7 +37,6 @@ class AbstractLQPNode;
  */
 class ExpressionReductionRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
   /**

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -28,8 +28,6 @@ constexpr float INDEX_SCAN_SELECTIVITY_THRESHOLD = 0.01f;
 // The number is taken from: Fast Lookups for In-Memory Column Stores: Group-Key Indices, Lookup and Maintenance.
 constexpr float INDEX_SCAN_ROW_COUNT_THRESHOLD = 1000.0f;
 
-std::string IndexScanRule::name() const { return "Index Scan Rule"; }
-
 void IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   DebugAssert(cost_estimator, "IndexScanRule requires cost estimator to be set");
 

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -27,7 +27,6 @@ class PredicateNode;
 
 class IndexScanRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
  protected:

--- a/src/lib/optimizer/strategy/insert_limit_in_exists_rule.cpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists_rule.cpp
@@ -10,8 +10,6 @@
 
 namespace opossum {
 
-std::string InsertLimitInExistsRule::name() const { return "Insert Limit in Exists Expression Rule"; }
-
 void InsertLimitInExistsRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   visit_lqp(node, [&](const auto& sub_node) {
     // Iterate over all expressions of a lqp node

--- a/src/lib/optimizer/strategy/insert_limit_in_exists_rule.hpp
+++ b/src/lib/optimizer/strategy/insert_limit_in_exists_rule.hpp
@@ -19,7 +19,6 @@ class AbstractExpression;
  */
 class InsertLimitInExistsRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 };
 

--- a/src/lib/optimizer/strategy/join_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.cpp
@@ -13,8 +13,6 @@
 
 namespace opossum {
 
-std::string JoinOrderingRule::name() const { return "JoinOrderingRule"; }
-
 void JoinOrderingRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
   DebugAssert(cost_estimator, "JoinOrderingRule requires cost estimator to be set");
 

--- a/src/lib/optimizer/strategy/join_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.hpp
@@ -17,8 +17,6 @@ class AbstractCostEstimator;
  */
 class JoinOrderingRule : public AbstractRule {
  public:
-  std::string name() const override;
-
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
 
  private:

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -13,8 +13,6 @@
 
 namespace opossum {
 
-std::string PredicatePlacementRule::name() const { return "Predicate Placement Rule"; }
-
 void PredicatePlacementRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   // The traversal functions require the existence of a root of the LQP, so make sure we have that
   const auto root_node = node->type == LQPNodeType::Root ? node : LogicalPlanRootNode::make(node);

--- a/src/lib/optimizer/strategy/predicate_placement_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.hpp
@@ -19,7 +19,6 @@ class PredicateNode;
  */
 class PredicatePlacementRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
  private:

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -19,8 +19,6 @@
 
 namespace opossum {
 
-std::string PredicateReorderingRule::name() const { return "Predicate Reordering Rule"; }
-
 void PredicateReorderingRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   DebugAssert(cost_estimator, "PredicateReorderingRule requires cost estimator to be set");
 

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
@@ -25,7 +25,6 @@ class PredicateNode;
  */
 class PredicateReorderingRule : public AbstractRule {
  public:
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 
  private:

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -7,8 +7,6 @@
 
 namespace opossum {
 
-std::string PredicateSplitUpRule::name() const { return "PredicateSplitUp"; }
-
 void PredicateSplitUpRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
   Assert(root->type == LQPNodeType::Root, "PredicateSplitUpRule needs root to hold onto");
 

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
@@ -16,7 +16,6 @@ namespace opossum {
  *   `l_shipmode` and `l_shipinstruct` could not be pulled below the join.
  */
 class PredicateSplitUpRule : public AbstractRule {
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
 };
 

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -469,8 +469,6 @@ SubqueryToJoinRule::PredicatePullUpResult SubqueryToJoinRule::pull_up_correlated
   return pull_up_correlated_predicates_recursive(node, parameter_mapping, result_cache, false).first;
 }
 
-std::string SubqueryToJoinRule::name() const { return "Subquery to Join Rule"; }
-
 void SubqueryToJoinRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const {
   // Check if `node` is a PredicateNode with a subquery and try to turn it into an anti- or semi-join.
   // To do this, we

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
@@ -122,7 +122,6 @@ class SubqueryToJoinRule : public AbstractRule {
       const std::shared_ptr<AbstractLQPNode>& node,
       const std::map<ParameterID, std::shared_ptr<AbstractExpression>>& parameter_mapping);
 
-  std::string name() const override;
   void apply_to(const std::shared_ptr<AbstractLQPNode>& node) const override;
 };
 

--- a/src/lib/storage/segment_iterables/segment_positions.hpp
+++ b/src/lib/storage/segment_iterables/segment_positions.hpp
@@ -46,16 +46,16 @@ class AbstractSegmentPosition {
  * Used in most segment iterators.
  */
 template <typename T>
-class SegmentPosition : public AbstractSegmentPosition<T> {
+class SegmentPosition final : public AbstractSegmentPosition<T> {
  public:
   static constexpr bool Nullable = true;
 
   SegmentPosition(const T& value, const bool null_value, const ChunkOffset& chunk_offset)
       : _value{value}, _null_value{null_value}, _chunk_offset{chunk_offset} {}
 
-  const T& value() const final { return _value; }
-  bool is_null() const final { return _null_value; }
-  ChunkOffset chunk_offset() const final { return _chunk_offset; }
+  const T& value() const { return _value; }
+  bool is_null() const { return _null_value; }
+  ChunkOffset chunk_offset() const { return _chunk_offset; }
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization
@@ -70,16 +70,16 @@ class SegmentPosition : public AbstractSegmentPosition<T> {
  * Used when an underlying segment (or data structure) cannot be null.
  */
 template <typename T>
-class NonNullSegmentPosition : public AbstractSegmentPosition<T> {
+class NonNullSegmentPosition final : public AbstractSegmentPosition<T> {
  public:
   static constexpr bool Nullable = false;
 
   NonNullSegmentPosition(const T& value, const ChunkOffset& chunk_offset)
       : _value{value}, _chunk_offset{chunk_offset} {}
 
-  const T& value() const final { return _value; }
-  bool is_null() const final { return false; }
-  ChunkOffset chunk_offset() const final { return _chunk_offset; }
+  const T& value() const { return _value; }
+  bool is_null() const { return false; }
+  ChunkOffset chunk_offset() const { return _chunk_offset; }
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization
@@ -94,16 +94,16 @@ class NonNullSegmentPosition : public AbstractSegmentPosition<T> {
  *
  * @see NullValueVectorIterable
  */
-class IsNullSegmentPosition : public AbstractSegmentPosition<boost::blank> {
+class IsNullSegmentPosition final : public AbstractSegmentPosition<boost::blank> {
  public:
   static constexpr bool Nullable = true;
 
   IsNullSegmentPosition(const bool null_value, const ChunkOffset& chunk_offset)
       : _null_value{null_value}, _chunk_offset{chunk_offset} {}
 
-  const boost::blank& value() const final { return _blank; }
-  bool is_null() const final { return _null_value; }
-  ChunkOffset chunk_offset() const final { return _chunk_offset; }
+  const boost::blank& value() const { return _blank; }
+  bool is_null() const { return _null_value; }
+  ChunkOffset chunk_offset() const { return _chunk_offset; }
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization

--- a/src/lib/types.cpp
+++ b/src/lib/types.cpp
@@ -175,7 +175,7 @@ const boost::bimap<TableType, std::string> table_type_to_string =
     make_bimap<TableType, std::string>({{TableType::Data, "Data"}, {TableType::References, "References"}});
 
 const boost::bimap<UnionMode, std::string> union_mode_to_string =
-    make_bimap<UnionMode, std::string>({{UnionMode::Positions, "UnionPositions"}});
+    make_bimap<UnionMode, std::string>({{UnionMode::All, "UnionAll"}, {UnionMode::Positions, "UnionPositions"}});
 
 std::ostream& operator<<(std::ostream& stream, PredicateCondition predicate_condition) {
   return stream << predicate_condition_to_string.left.at(predicate_condition);

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -125,14 +125,6 @@ struct RowID {
   ChunkID chunk_id{INVALID_CHUNK_ID};
   ChunkOffset chunk_offset{INVALID_CHUNK_OFFSET};
 
-  RowID() = default;
-
-  RowID(const ChunkID chunk_id, const ChunkOffset chunk_offset) : chunk_id(chunk_id), chunk_offset(chunk_offset) {
-    DebugAssert((chunk_offset == INVALID_CHUNK_OFFSET) == (chunk_id == INVALID_CHUNK_ID),
-                "If you pass in one of the arguments as INVALID/NULL, the other has to be INVALID/NULL as well. This "
-                "makes sure there is just one value representing an invalid row id.");
-  }
-
   // Faster than row_id == ROW_ID_NULL, since we only compare the ChunkOffset
   bool is_null() const { return chunk_offset == INVALID_CHUNK_OFFSET; }
 

--- a/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_read_write_tuple_test.cpp
@@ -308,7 +308,7 @@ TEST_F(JitReadWriteTupleTest, UseValueIDsFromReferenceSegment) {
   // Create reference input table
   auto input_table = std::make_shared<Table>(encoded_table->column_definitions(), TableType::References);
   auto pos_list = std::make_shared<PosList>();
-  pos_list->emplace_back(ChunkID{0}, ChunkOffset{1});
+  pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
   pos_list->guarantee_single_chunk();
   Segments segments;
   segments.push_back(std::make_shared<ReferenceSegment>(encoded_table, ColumnID{0}, pos_list));

--- a/src/test/operators/jit_operator/operators/jit_validate_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_validate_test.cpp
@@ -183,10 +183,10 @@ TEST_F(JitValidateTest, ValidateOnReferenceTable) {
   context.pos_list = pos_list;
 
   // first chunk
-  (*pos_list)[0] = RowID(ChunkID(0), 0u);
-  (*pos_list)[1] = RowID(ChunkID(0), 1u);
-  (*pos_list)[2] = RowID(ChunkID(0), 2u);
-  (*pos_list)[3] = RowID(ChunkID(1), 0u);
+  (*pos_list)[0] = RowID{ChunkID(0), 0u};
+  (*pos_list)[1] = RowID{ChunkID(0), 1u};
+  (*pos_list)[2] = RowID{ChunkID(0), 2u};
+  (*pos_list)[3] = RowID{ChunkID(1), 0u};
 
   validate_row(ChunkID(0), ChunkOffset{0}, context, *expected_value_itr++, source, sink, TableType::References);
   validate_row(ChunkID(0), ChunkOffset{1}, context, *expected_value_itr++, source, sink, TableType::References);
@@ -194,10 +194,10 @@ TEST_F(JitValidateTest, ValidateOnReferenceTable) {
   validate_row(ChunkID(0), ChunkOffset{3}, context, *expected_value_itr++, source, sink, TableType::References);
 
   // second chunk
-  (*pos_list)[0] = RowID(ChunkID(1), 1u);
-  (*pos_list)[1] = RowID(ChunkID(1), 2u);
-  (*pos_list)[2] = RowID(ChunkID(2), 0u);
-  (*pos_list)[3] = RowID(ChunkID(2), 1u);
+  (*pos_list)[0] = RowID{ChunkID(1), 1u};
+  (*pos_list)[1] = RowID{ChunkID(1), 2u};
+  (*pos_list)[2] = RowID{ChunkID(2), 0u};
+  (*pos_list)[3] = RowID{ChunkID(2), 1u};
 
   validate_row(ChunkID(1), ChunkOffset{0}, context, *expected_value_itr++, source, sink, TableType::References);
   validate_row(ChunkID(1), ChunkOffset{1}, context, *expected_value_itr++, source, sink, TableType::References);

--- a/src/test/operators/jit_operator/operators/jit_write_reference_test.cpp
+++ b/src/test/operators/jit_operator/operators/jit_write_reference_test.cpp
@@ -10,12 +10,12 @@ class JitWriteReferenceTest : public BaseTest {
   Segments create_reference_segments(std::shared_ptr<Table> referenced_table, const bool same_pos_list,
                                      const bool guarantee_single_chunk, const ChunkID chunk_id) const {
     auto pos_list_1 = std::make_shared<PosList>();
-    pos_list_1->emplace_back(chunk_id, ChunkOffset{0});
+    pos_list_1->emplace_back(RowID{chunk_id, ChunkOffset{0}});
 
     auto pos_list_2 = pos_list_1;
     if (!same_pos_list) {
       pos_list_2 = std::make_shared<PosList>();
-      pos_list_2->emplace_back(chunk_id, ChunkOffset{0});
+      pos_list_2->emplace_back(RowID{chunk_id, ChunkOffset{0}});
     }
 
     if (guarantee_single_chunk) {
@@ -83,7 +83,7 @@ TEST_F(JitWriteReferenceTest, AfterChunkDataInputTable) {
   jit_write_references.before_query(*output_table, context);
 
   // Add row to output
-  context.output_pos_list->emplace_back(ChunkID{0}, ChunkOffset{0});
+  context.output_pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
 
   jit_write_references.after_chunk(input_table, *output_table, context);
 
@@ -122,7 +122,7 @@ TEST_F(JitWriteReferenceTest, AfterChunkReferenceTableInputSamePosList) {
   // No single chunk guarantee
   {
     // Add row to output
-    context.output_pos_list->emplace_back(ChunkID{0}, ChunkOffset{0});
+    context.output_pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
 
     context.chunk_id = 0;
     jit_write_references.after_chunk(input_table, *output_table, context);
@@ -143,7 +143,7 @@ TEST_F(JitWriteReferenceTest, AfterChunkReferenceTableInputSamePosList) {
   // Single chunk guarantee is set
   {
     // Add row to output
-    context.output_pos_list->emplace_back(ChunkID{1}, ChunkOffset{0});
+    context.output_pos_list->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
 
     context.chunk_id = 1;
     jit_write_references.after_chunk(input_table, *output_table, context);
@@ -180,7 +180,7 @@ TEST_F(JitWriteReferenceTest, AfterChunkReferenceTableInputDifferentPosLists) {
   // No single chunk guarantee
   {
     // Add row to output
-    context.output_pos_list->emplace_back(ChunkID{0}, ChunkOffset{0});
+    context.output_pos_list->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
 
     context.chunk_id = 0;
     jit_write_references.after_chunk(input_table, *output_table, context);
@@ -201,7 +201,7 @@ TEST_F(JitWriteReferenceTest, AfterChunkReferenceTableInputDifferentPosLists) {
   // Single chunk guarantee is set
   {
     // Add row to output
-    context.output_pos_list->emplace_back(ChunkID{1}, ChunkOffset{0});
+    context.output_pos_list->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
 
     context.chunk_id = 1;
     jit_write_references.after_chunk(input_table, *output_table, context);

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -57,11 +57,11 @@ class JoinHashStepsTest : public BaseTest {
 TEST_F(JoinHashStepsTest, SmallHashTableAllPositions) {
   auto table = PosHashTable<int>{JoinHashBuildMode::AllPositions, 50};
   for (auto i = 0; i < 10; ++i) {
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i});
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i + 1});
+    table.emplace(i, RowID{ChunkID{ChunkID::base_type{100} + i}, ChunkOffset{200} + i});
+    table.emplace(i, RowID{ChunkID{ChunkID::base_type{100} + i}, ChunkOffset{200} + i + 1});
   }
-  const auto expected_pos_list =
-      boost::container::small_vector<RowID, 1>{RowID{ChunkID{105}, ChunkOffset{205}}, RowID{ChunkID{105}, ChunkOffset{206}}};
+  const auto expected_pos_list = boost::container::small_vector<RowID, 1>{RowID{ChunkID{105}, ChunkOffset{205}},
+                                                                          RowID{ChunkID{105}, ChunkOffset{206}}};
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));
@@ -80,8 +80,8 @@ TEST_F(JoinHashStepsTest, SmallHashTableAllPositions) {
 TEST_F(JoinHashStepsTest, LargeHashTableSinglePositions) {
   auto table = PosHashTable<int>{JoinHashBuildMode::SinglePosition, 100};
   for (auto i = 0; i < 100; ++i) {
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i});
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i + 1});
+    table.emplace(i, RowID{ChunkID{ChunkID::base_type{100} + i}, ChunkOffset{200} + i});
+    table.emplace(i, RowID{ChunkID{ChunkID::base_type{100} + i}, ChunkOffset{200} + i + 1});
   }
   const auto expected_pos_list = boost::container::small_vector<RowID, 1>{RowID{ChunkID{150}, ChunkOffset{250}}};
   {

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -55,13 +55,13 @@ class JoinHashStepsTest : public BaseTest {
 };
 
 TEST_F(JoinHashStepsTest, SmallHashTableAllPositions) {
-  auto table = PosHashTable<int>{JoinHashBuildMode::AllPositions, 100};
+  auto table = PosHashTable<int>{JoinHashBuildMode::AllPositions, 50};
   for (auto i = 0; i < 10; ++i) {
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i}}});
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i + 1}}});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i + 1});
   }
   const auto expected_pos_list =
-      std::vector<RowID>{RowID{ChunkID{105}, ChunkOffset{205}}, RowID{ChunkID{105}, ChunkOffset{206}}};
+      boost::container::small_vector<RowID, 1>{RowID{ChunkID{105}, ChunkOffset{205}}, RowID{ChunkID{105}, ChunkOffset{206}}};
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));
@@ -78,12 +78,12 @@ TEST_F(JoinHashStepsTest, SmallHashTableAllPositions) {
 }
 
 TEST_F(JoinHashStepsTest, LargeHashTableSinglePositions) {
-  auto table = PosHashTable<int>{JoinHashBuildMode::AllPositions, 100};
+  auto table = PosHashTable<int>{JoinHashBuildMode::SinglePosition, 100};
   for (auto i = 0; i < 100; ++i) {
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i}}});
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i + 1}}});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200} + i + 1});
   }
-  const auto expected_pos_list = std::vector<RowID>{RowID{ChunkID{155}, ChunkOffset{255}}};
+  const auto expected_pos_list = boost::container::small_vector<RowID, 1>{RowID{ChunkID{150}, ChunkOffset{250}}};
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -57,42 +57,45 @@ class JoinHashStepsTest : public BaseTest {
 TEST_F(JoinHashStepsTest, SmallHashTableAllPositions) {
   auto table = PosHashTable<int>{JoinHashBuildMode::AllPositions, 100};
   for (auto i = 0; i < 10; ++i) {
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200 + i}});
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200 + i + 1}});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i}}});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i + 1}}});
   }
+  const auto expected_pos_list =
+      std::vector<RowID>{RowID{ChunkID{105}, ChunkOffset{205}}, RowID{ChunkID{105}, ChunkOffset{206}}};
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));
     const auto pos_list = *table.find(5);
-    EXPECT_EQ(pos_list, {RowID{ChunkID{105}, ChunkOffset{205}}, RowID{ChunkID{105}, ChunkOffset{206}}});
+    EXPECT_EQ(pos_list, expected_pos_list);
   }
   table.shrink_to_fit();
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));
     const auto pos_list = *table.find(5);
-    EXPECT_EQ(pos_list, {RowID{ChunkID{105}, ChunkOffset{205}}, RowID{ChunkID{105}, ChunkOffset{206}}});
+    EXPECT_EQ(pos_list, expected_pos_list);
   }
 }
 
 TEST_F(JoinHashStepsTest, LargeHashTableSinglePositions) {
   auto table = PosHashTable<int>{JoinHashBuildMode::AllPositions, 100};
   for (auto i = 0; i < 100; ++i) {
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200 + i}});
-    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{200 + i + 1}});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i}}});
+    table.emplace(i, RowID{ChunkID{100 + i}, ChunkOffset{uint{200 + i + 1}}});
   }
+  const auto expected_pos_list = std::vector<RowID>{RowID{ChunkID{155}, ChunkOffset{255}}};
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));
-    const auto pos_list = *table.find(5);
-    EXPECT_EQ(pos_list, {RowID{ChunkID{105}, ChunkOffset{205}}});
+    const auto pos_list = *table.find(50);
+    EXPECT_EQ(pos_list, expected_pos_list);
   }
   table.shrink_to_fit();
   {
     EXPECT_TRUE(table.contains(5));
     EXPECT_FALSE(table.contains(1000));
-    const auto pos_list = *table.find(5);
-    EXPECT_EQ(pos_list, {RowID{ChunkID{105}, ChunkOffset{205}}});
+    const auto pos_list = *table.find(50);
+    EXPECT_EQ(pos_list, expected_pos_list);
   }
 }
 

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -460,7 +460,7 @@ class JoinTestRunner : public BaseTestWithParam<JoinTestConfiguration> {
           if (input_table_type == InputTableType::SharedPosList) {
             const auto pos_list = std::make_shared<PosList>();
             for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk->size(); ++chunk_offset) {
-              pos_list->emplace_back(chunk_id, chunk_offset);
+              pos_list->emplace_back(RowID{chunk_id, chunk_offset});
             }
 
             for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {
@@ -471,7 +471,7 @@ class JoinTestRunner : public BaseTestWithParam<JoinTestConfiguration> {
             for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {
               const auto pos_list = std::make_shared<PosList>();
               for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk->size(); ++chunk_offset) {
-                pos_list->emplace_back(chunk_id, chunk_offset);
+                pos_list->emplace_back(RowID{chunk_id, chunk_offset});
               }
 
               reference_segments.emplace_back(std::make_shared<ReferenceSegment>(table, column_id, pos_list));

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -99,7 +99,7 @@ TEST_F(OperatorsValidateTest, ValidateReferenceSegmentWithMultipleChunks) {
   for (ChunkID chunk_id{0}; chunk_id < _test_table->chunk_count(); ++chunk_id) {
     const auto chunk_size = _test_table->get_chunk(chunk_id)->size();
     for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
-      pos_list->emplace_back(chunk_id, chunk_offset);
+      pos_list->emplace_back(RowID{chunk_id, chunk_offset});
     }
   }
 

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -54,7 +54,6 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
   class MockRule : public AbstractRule {
    public:
     explicit MockRule(std::unordered_set<std::shared_ptr<AbstractLQPNode>>& nodes) : nodes(nodes) {}
-    std::string name() const override { return "Mock"; }
 
     void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override {
       nodes.emplace(root);
@@ -132,7 +131,6 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
   class MockRule : public AbstractRule {
    public:
     explicit MockRule(size_t& counter) : counter(counter) {}
-    std::string name() const override { return "Mock"; }
 
     void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override { ++counter; }
 

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -76,17 +76,17 @@ TEST_P(SegmentIteratorsTest, LegacyForwardIteratorCompatible) {
   const auto table = load_table_with_encoding("resources/test_data/tbl/all_data_types_sorted.tbl", 5);
 
   const auto position_filter = std::make_shared<PosList>();
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{0});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{1});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{2});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{3});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{4});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{3}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{4}});
   position_filter->guarantee_single_chunk();
 
   const auto position_filter_multi_chunk = std::make_shared<PosList>(position_filter->begin(), position_filter->end());
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{0});
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{1});
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{2});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{2}});
 
   /**
    * Takes an iterator pair and verifies its LegacyForwardIterators compatibility by feeding it into STL algorithms that
@@ -129,14 +129,14 @@ TEST_P(SegmentIteratorsTest, LegacyBidirectionalIteratorCompatible) {
   const auto table = load_table_with_encoding("resources/test_data/tbl/all_data_types_sorted.tbl", 3);
 
   const auto position_filter = std::make_shared<PosList>();
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{0});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{1});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{2});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
   position_filter->guarantee_single_chunk();
 
   const auto position_filter_multi_chunk = std::make_shared<PosList>(position_filter->begin(), position_filter->end());
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{0});
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{1});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
 
   /**
    * Takes an iterator pair and verifies its LegacyBidirectionalIterators compatibility by both post and pre
@@ -173,25 +173,24 @@ TEST_P(SegmentIteratorsTest, LegacyRandomIteratorCompatible) {
   const auto table = load_table_with_encoding("resources/test_data/tbl/all_data_types_sorted.tbl", 3);
 
   const auto position_filter = std::make_shared<PosList>();
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{0});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{1});
-  position_filter->emplace_back(ChunkID{0}, ChunkOffset{2});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{0}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{1}});
+  position_filter->emplace_back(RowID{ChunkID{0}, ChunkOffset{2}});
   position_filter->guarantee_single_chunk();
 
   const auto position_filter_multi_chunk = std::make_shared<PosList>(position_filter->begin(), position_filter->end());
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{0});
-  position_filter_multi_chunk->emplace_back(ChunkID{1}, ChunkOffset{1});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{0}});
+  position_filter_multi_chunk->emplace_back(RowID{ChunkID{1}, ChunkOffset{1}});
 
   /**
    * Takes an iterator pair and verifies its LegacyRandomAccessIterator compatibility by feeding it into STL algorithms
    * that require LegacyRandomAccessIterator. Most of the testing is that this compiles.
    */
-  test_all_iterators(table, position_filter, position_filter_multi_chunk, [&](const auto begin, const auto end) {
-    (void) std::is_heap(begin, end);
-  });
+  test_all_iterators(table, position_filter, position_filter_multi_chunk,
+                     [&](const auto begin, const auto end) { (void)std::is_heap(begin, end); });
 }
 
-template<typename T>
+template <typename T>
 bool operator<(const AbstractSegmentPosition<T>&, const AbstractSegmentPosition<T>&) {
   // Fake comparator needed by is_heap
   return false;


### PR DESCRIPTION
* Made EncodingConfig assignable
* Made RowID trivially constructible
* JoinHash: Made PartitionedElement trivially constructible
* JoinHash: Added an optimization for very small hash tables (< 10 elements). For these, a linear search performs better than a hash lookup
* JoinHash: Moved some statements into more restrictive if clauses
* Added `final` to SegmentPosition so that the destructor is non-virtual
* Got rid of the names for optimizer rules - never have used them, never will

```
+---------------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark           | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+---------------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 1 -> TPC-H 01 | 0.617155075073 | 38   | 0.618902683258 | 38   | +0%        |                          0.6013 |
| TPC-H 2 -> TPC-H 02 | 7.49960327148  | 450  | 8.12754631042  | 488  | +8%        |                          0.0000 |
| TPC-H 3 -> TPC-H 03 | 6.31156110764  | 379  | 6.65233135223  | 400  | +5%        |                          0.0000 |
| TPC-H 4 -> TPC-H 04 | 2.21944689751  | 134  | 2.19491744041  | 132  | -1%        |                          0.0005 |
| TPC-H 5 -> TPC-H 05 | 4.03684329987  | 243  | 4.47283029556  | 269  | +11%       |                          0.0000 |
| TPC-H 6 -> TPC-H 06 | 41.9420509338  | 2517 | 42.7209510803  | 2564 | +2%        |                          0.0000 |
| TPC-H 7 -> TPC-H 07 | 1.6284481287   | 98   | 1.66860568523  | 101  | +2%        |                          0.0000 |
| TPC-H 8 -> TPC-H 08 | 4.88635730743  | 294  | 5.10390853882  | 307  | +4%        |                          0.0000 |
| TPC-H 9 -> TPC-H 09 | 1.62544131279  | 98   | 1.63231492043  | 98   | +0%        |                          0.2434 |
| TPC-H 10            | 3.01706027985  | 182  | 3.01270508766  | 181  | -0%        |                          0.5324 |
| TPC-H 11            | 24.3153686523  | 1459 | 25.4288425446  | 1526 | +5%        |                          0.0000 |
| TPC-H 12            | 7.34165716171  | 441  | 7.22060537338  | 434  | -2%        |                          0.0000 |
| TPC-H 13            | 2.2806186676   | 137  | 2.28460454941  | 138  | +0%        |                          0.5105 |
| TPC-H 14            | 23.7891483307  | 1428 | 24.7426815033  | 1485 | +4%        |                          0.0000 |
| TPC-H 15            | 14.7995157242  | 888  | 14.9751214981  | 899  | +1%        |                          0.0000 |
| TPC-H 16            | 6.90865135193  | 415  | 7.01547241211  | 421  | +2%        |                          0.0000 |
| TPC-H 17            | 1.3856202364   | 84   | 1.43691313267  | 87   | +4%        |                          0.0000 |
| TPC-H 18            | 1.28654658794  | 78   | 1.32715046406  | 80   | +3%        |                          0.0000 |
| TPC-H 19            | 5.55590867996  | 334  | 5.51016187668  | 331  | -1%        |                          0.0000 |
| TPC-H 20            | 2.2780623436   | 137  | 2.43080067635  | 146  | +7%        |                          0.0000 |
| TPC-H 21            | 0.728181242943 | 44   | 0.735364377499 | 45   | +1%        |                          0.0065 |
| TPC-H 22            | 12.9088258743  | 775  | 13.9496669769  | 837  | +8%        |                          0.0000 |
| geometric mean      |                |      |                |      | +3%        |                                 |
+---------------------+----------------+------+----------------+------+------------+---------------------------------+
```