### PR TITLE
Add optional indexes (currently unused) and sorting to TPC-H, fix StoredTableNode

### DIFF
--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -21,6 +21,7 @@ def main():
   arguments["--mode"] = "'Shuffled'"
   arguments["--encoding"] = "'Dictionary'"
   arguments["--compression"] = "'Fixed-size byte-aligned'"
+  arguments["--indexes"] = "true"
   arguments["--scheduler"] = "false"
   arguments["--clients"] = "1"
   arguments["--cache_binary_tables"] = "false"
@@ -40,6 +41,7 @@ def main():
   benchmark.expect("Benchmarking Queries: \[ 1, 13, 19, \]")
   benchmark.expect("TPCH scale factor is 0.01")
   benchmark.expect("Using prepared statements: yes")
+  benchmark.expect("Creating index on customer [ c_custkey ]")
   benchmark.expect("Preparing queries")
 
   close_benchmark(benchmark)

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -78,6 +78,7 @@ def main():
   arguments["--warmup"] = "10"
   arguments["--encoding"] = "'LZ4'"
   arguments["--compression"] = "'SIMD-BP128'"
+  arguments["--indexes"] = "false"
   arguments["--scheduler"] = "true"
   arguments["--clients"] = "4"
   arguments["--visualize"] = "true"

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -3,6 +3,8 @@
 #include "benchmark_config.hpp"
 #include "benchmark_table_encoder.hpp"
 #include "hyrise.hpp"
+#include "storage/index/group_key/composite_group_key_index.hpp"
+#include "storage/index/group_key/group_key_index.hpp"
 #include "operators/export_binary.hpp"
 #include "utils/format_duration.hpp"
 #include "utils/timer.hpp"
@@ -13,7 +15,8 @@ void to_json(nlohmann::json& json, const TableGenerationMetrics& metrics) {
   json = {{"generation_duration", metrics.generation_duration.count()},
           {"encoding_duration", metrics.encoding_duration.count()},
           {"binary_caching_duration", metrics.binary_caching_duration.count()},
-          {"store_duration", metrics.store_duration.count()}};
+          {"store_duration", metrics.store_duration.count()},
+          {"index_duration", metrics.index_duration.count()}};
 }
 
 BenchmarkTableInfo::BenchmarkTableInfo(const std::shared_ptr<Table>& table) : table(table) {}
@@ -84,7 +87,7 @@ void AbstractTableGenerator::generate_and_store() {
   /**
    * Add the Tables to the StorageManager
    */
-  std::cout << "- Adding tables to StorageManager and generating statistics " << std::endl;
+  std::cout << "- Adding tables to StorageManager and generating statistics" << std::endl;
   auto& storage_manager = Hyrise::get().storage_manager;
   for (auto& [table_name, table_info] : table_info_by_name) {
     std::cout << "-  Adding '" << table_name << "' " << std::flush;
@@ -98,6 +101,37 @@ void AbstractTableGenerator::generate_and_store() {
 
   std::cout << "- Adding tables to StorageManager and generating statistics done ("
             << format_duration(metrics.store_duration) << ")" << std::endl;
+
+  std::cout << "- Creating indexes" << std::endl;
+  for (const auto& [table_name, indexes] : _indexes_by_table()) {
+    const auto& table = table_info_by_name[table_name].table;
+
+    for (const auto& index_columns : indexes) {
+      auto column_ids = std::vector<ColumnID>{};
+
+      for (const auto& index_column : index_columns) {
+        column_ids.emplace_back(table->column_id_by_name(index_column));
+      }
+
+      std::cout << "-  Creating index on " << table_name << " [ ";
+      for (const auto& index_column : index_columns) {
+        std::cout << index_column << " ";
+      }
+      std::cout << "] " << std::flush;
+      Timer per_index_timer;
+
+      if (column_ids.size() == 1) {
+        table->create_index<GroupKeyIndex>(column_ids);
+      } else {
+        table->create_index<CompositeGroupKeyIndex>(column_ids);
+      }
+
+      std::cout << "(" << per_index_timer.lap_formatted() << ")" << std::endl;
+    }
+  }
+  metrics.index_duration = timer.lap();
+  std::cout << "- Creating indexes done ("
+            << format_duration(metrics.index_duration) << ")" << std::endl;
 }
 
 std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(
@@ -106,5 +140,7 @@ std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config
   config.chunk_size = chunk_size;
   return std::make_shared<BenchmarkConfig>(config);
 }
+
+AbstractTableGenerator::IndexesByTable AbstractTableGenerator::_indexes_by_table() const {return {};};
 
 }  // namespace opossum

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -103,7 +103,11 @@ void AbstractTableGenerator::generate_and_store() {
             << format_duration(metrics.store_duration) << ")" << std::endl;
 
   std::cout << "- Creating indexes" << std::endl;
-  for (const auto& [table_name, indexes] : _indexes_by_table()) {
+  const auto& indexes_by_table = _indexes_by_table();
+  if (indexes_by_table.empty()) {
+    std::cout << "-  No indexes defined by benchmark" << std::endl;
+  }
+  for (const auto& [table_name, indexes] : indexes_by_table) {
     const auto& table = table_info_by_name[table_name].table;
 
     for (const auto& index_columns : indexes) {

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -140,6 +140,6 @@ std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config
   return std::make_shared<BenchmarkConfig>(config);
 }
 
-AbstractTableGenerator::IndexesByTable AbstractTableGenerator::_indexes_by_table() const { return {}; };
+AbstractTableGenerator::IndexesByTable AbstractTableGenerator::_indexes_by_table() const { return {}; }
 
 }  // namespace opossum

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -4,6 +4,8 @@
 #include "benchmark_table_encoder.hpp"
 #include "hyrise.hpp"
 #include "operators/export_binary.hpp"
+#include "operators/sort.hpp"
+#include "operators/table_wrapper.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
 #include "utils/format_duration.hpp"
@@ -15,6 +17,7 @@ void to_json(nlohmann::json& json, const TableGenerationMetrics& metrics) {
   json = {{"generation_duration", metrics.generation_duration.count()},
           {"encoding_duration", metrics.encoding_duration.count()},
           {"binary_caching_duration", metrics.binary_caching_duration.count()},
+          {"sort_duration", metrics.sort_duration.count()},
           {"store_duration", metrics.store_duration.count()},
           {"index_duration", metrics.index_duration.count()}};
 }
@@ -31,6 +34,41 @@ void AbstractTableGenerator::generate_and_store() {
   auto table_info_by_name = generate();
   metrics.generation_duration = timer.lap();
   std::cout << "- Loading/Generating tables done (" << format_duration(metrics.generation_duration) << ")" << std::endl;
+
+  /**
+   * Sort tables if a sort order was defined by the benchmark
+   */
+
+  const auto& sort_order_by_table = _sort_order_by_table();
+  if (!sort_order_by_table.empty()) {
+    std::cout << "- Sorting tables" << std::endl;
+
+    for (const auto& [table_name, column_name] : sort_order_by_table) {
+      std::cout << "-  Sorting '" << table_name << "' by '" << column_name << "' " << std::flush;
+      Timer per_table_timer;
+
+      // We sort the tables after their creation so that we are independent of the order in which they are filled.
+      // For this, we use the sort operator. Because it returns a `const Table`, we need to recreate the table and
+      // migrate the sorted chunks to that table.
+
+      auto& table = table_info_by_name[table_name].table;
+      auto table_wrapper = std::make_shared<TableWrapper>(table);
+      table_wrapper->execute();
+      auto sort = std::make_shared<Sort>(table_wrapper, table->column_id_by_name(column_name));
+      sort->execute();
+      const auto immutable_sorted_table = sort->get_output();
+      table = std::make_shared<Table>(immutable_sorted_table->column_definitions(), TableType::Data,
+                                      Chunk::DEFAULT_SIZE, UseMvcc::Yes);
+      for (auto chunk_id = ChunkID{0}; chunk_id < immutable_sorted_table->chunk_count(); ++chunk_id) {
+        auto mvcc_data = std::make_shared<MvccData>(immutable_sorted_table->get_chunk(chunk_id)->size(), CommitID{0});
+        table->append_chunk(immutable_sorted_table->get_chunk(chunk_id)->segments(), mvcc_data);
+      }
+
+      std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;
+    }
+    metrics.sort_duration = timer.lap();
+    std::cout << "- Sorting tables done (" << format_duration(metrics.sort_duration) << ")" << std::endl;
+  }
 
   /**
    * Encode the Tables
@@ -102,39 +140,46 @@ void AbstractTableGenerator::generate_and_store() {
   std::cout << "- Adding tables to StorageManager and generating statistics done ("
             << format_duration(metrics.store_duration) << ")" << std::endl;
 
-  std::cout << "- Creating indexes" << std::endl;
-  const auto& indexes_by_table = _indexes_by_table();
-  if (indexes_by_table.empty()) {
-    std::cout << "-  No indexes defined by benchmark" << std::endl;
-  }
-  for (const auto& [table_name, indexes] : indexes_by_table) {
-    const auto& table = table_info_by_name[table_name].table;
-
-    for (const auto& index_columns : indexes) {
-      auto column_ids = std::vector<ColumnID>{};
-
-      for (const auto& index_column : index_columns) {
-        column_ids.emplace_back(table->column_id_by_name(index_column));
-      }
-
-      std::cout << "-  Creating index on " << table_name << " [ ";
-      for (const auto& index_column : index_columns) {
-        std::cout << index_column << " ";
-      }
-      std::cout << "] " << std::flush;
-      Timer per_index_timer;
-
-      if (column_ids.size() == 1) {
-        table->create_index<GroupKeyIndex>(column_ids);
-      } else {
-        table->create_index<CompositeGroupKeyIndex>(column_ids);
-      }
-
-      std::cout << "(" << per_index_timer.lap_formatted() << ")" << std::endl;
+  /**
+   * Create indexes if requested by the user
+   */
+  if (_benchmark_config->indexes) {
+    std::cout << "- Creating indexes" << std::endl;
+    const auto& indexes_by_table = _indexes_by_table();
+    if (indexes_by_table.empty()) {
+      std::cout << "-  No indexes defined by benchmark" << std::endl;
     }
+    for (const auto& [table_name, indexes] : indexes_by_table) {
+      const auto& table = table_info_by_name[table_name].table;
+
+      for (const auto& index_columns : indexes) {
+        auto column_ids = std::vector<ColumnID>{};
+
+        for (const auto& index_column : index_columns) {
+          column_ids.emplace_back(table->column_id_by_name(index_column));
+        }
+
+        std::cout << "-  Creating index on " << table_name << " [ ";
+        for (const auto& index_column : index_columns) {
+          std::cout << index_column << " ";
+        }
+        std::cout << "] " << std::flush;
+        Timer per_index_timer;
+
+        if (column_ids.size() == 1) {
+          table->create_index<GroupKeyIndex>(column_ids);
+        } else {
+          table->create_index<CompositeGroupKeyIndex>(column_ids);
+        }
+
+        std::cout << "(" << per_index_timer.lap_formatted() << ")" << std::endl;
+      }
+    }
+    metrics.index_duration = timer.lap();
+    std::cout << "- Creating indexes done (" << format_duration(metrics.index_duration) << ")" << std::endl;
+  } else {
+    std::cout << "- No indexes created as --indexes was not specified" << std::endl;
   }
-  metrics.index_duration = timer.lap();
-  std::cout << "- Creating indexes done (" << format_duration(metrics.index_duration) << ")" << std::endl;
 }
 
 std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(
@@ -145,5 +190,7 @@ std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config
 }
 
 AbstractTableGenerator::IndexesByTable AbstractTableGenerator::_indexes_by_table() const { return {}; }
+
+AbstractTableGenerator::SortOrderByTable AbstractTableGenerator::_sort_order_by_table() const { return {}; }
 
 }  // namespace opossum

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -3,9 +3,9 @@
 #include "benchmark_config.hpp"
 #include "benchmark_table_encoder.hpp"
 #include "hyrise.hpp"
+#include "operators/export_binary.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
-#include "operators/export_binary.hpp"
 #include "utils/format_duration.hpp"
 #include "utils/timer.hpp"
 
@@ -130,8 +130,7 @@ void AbstractTableGenerator::generate_and_store() {
     }
   }
   metrics.index_duration = timer.lap();
-  std::cout << "- Creating indexes done ("
-            << format_duration(metrics.index_duration) << ")" << std::endl;
+  std::cout << "- Creating indexes done (" << format_duration(metrics.index_duration) << ")" << std::endl;
 }
 
 std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(
@@ -141,6 +140,6 @@ std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config
   return std::make_shared<BenchmarkConfig>(config);
 }
 
-AbstractTableGenerator::IndexesByTable AbstractTableGenerator::_indexes_by_table() const {return {};};
+AbstractTableGenerator::IndexesByTable AbstractTableGenerator::_indexes_by_table() const { return {}; };
 
 }  // namespace opossum

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -39,6 +39,7 @@ struct TableGenerationMetrics {
   std::chrono::nanoseconds generation_duration{};
   std::chrono::nanoseconds encoding_duration{};
   std::chrono::nanoseconds binary_caching_duration{};
+  std::chrono::nanoseconds sort_duration{};
   std::chrono::nanoseconds store_duration{};
   std::chrono::nanoseconds index_duration{};
 };
@@ -47,8 +48,6 @@ void to_json(nlohmann::json& json, const TableGenerationMetrics& metrics);
 
 class AbstractTableGenerator {
  public:
-  using IndexesByTable = std::map<std::string, std::vector<std::vector<std::string>>>;
-
   explicit AbstractTableGenerator(const std::shared_ptr<BenchmarkConfig>& benchmark_config);
   virtual ~AbstractTableGenerator() = default;
 
@@ -65,7 +64,13 @@ class AbstractTableGenerator {
 
  protected:
   // Creates indexes, expects the table to have been added to the StorageManager and, if requested, encoded
+  using IndexesByTable = std::map<std::string, std::vector<std::vector<std::string>>>;
   virtual IndexesByTable _indexes_by_table() const;
+
+  // Optionally, the benchmark may define tables (left side) that are ordered (aka. clustered) by one of their columns
+  // (right side).
+  using SortOrderByTable = std::map<std::string, std::string>;
+  virtual SortOrderByTable _sort_order_by_table() const;
 
   const std::shared_ptr<BenchmarkConfig> _benchmark_config;
 };

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -40,12 +40,15 @@ struct TableGenerationMetrics {
   std::chrono::nanoseconds encoding_duration{};
   std::chrono::nanoseconds binary_caching_duration{};
   std::chrono::nanoseconds store_duration{};
+  std::chrono::nanoseconds index_duration{};
 };
 
 void to_json(nlohmann::json& json, const TableGenerationMetrics& metrics);
 
 class AbstractTableGenerator {
  public:
+  using IndexesByTable = std::map<std::string, std::vector<std::vector<std::string>>>;
+
   explicit AbstractTableGenerator(const std::shared_ptr<BenchmarkConfig>& benchmark_config);
   virtual ~AbstractTableGenerator() = default;
 
@@ -61,6 +64,9 @@ class AbstractTableGenerator {
   static std::shared_ptr<BenchmarkConfig> create_benchmark_config_with_chunk_size(uint32_t chunk_size);
 
  protected:
+  // Creates indexes, expects the table to have been added to the StorageManager and, if requested, encoded
+  virtual IndexesByTable _indexes_by_table() const;
+
   const std::shared_ptr<BenchmarkConfig> _benchmark_config;
 };
 

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -3,7 +3,7 @@
 namespace opossum {
 
 BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const ChunkOffset chunk_size,
-                                 const EncodingConfig& encoding_config, const size_t max_runs,
+                                 const EncodingConfig& encoding_config, const bool indexes, const size_t max_runs,
                                  const Duration& max_duration, const Duration& warmup_duration,
                                  const std::optional<std::string>& output_file_path, const bool enable_scheduler,
                                  const uint32_t cores, const uint32_t clients, const bool enable_visualization,
@@ -12,6 +12,7 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const Chunk
     : benchmark_mode(benchmark_mode),
       chunk_size(chunk_size),
       encoding_config(encoding_config),
+      indexes(indexes),
       max_runs(max_runs),
       max_duration(max_duration),
       warmup_duration(warmup_duration),

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -20,17 +20,18 @@ using TimePoint = std::chrono::high_resolution_clock::time_point;
 class BenchmarkConfig {
  public:
   BenchmarkConfig(const BenchmarkMode benchmark_mode, const ChunkOffset chunk_size,
-                  const EncodingConfig& encoding_config, const size_t max_runs, const Duration& max_duration,
-                  const Duration& warmup_duration, const std::optional<std::string>& output_file_path,
-                  const bool enable_scheduler, const uint32_t cores, const uint32_t clients,
-                  const bool enable_visualization, const bool verify, const bool cache_binary_tables,
-                  const bool enable_jit, const bool sql_metrics);
+                  const EncodingConfig& encoding_config, const bool indexes, const size_t max_runs,
+                  const Duration& max_duration, const Duration& warmup_duration,
+                  const std::optional<std::string>& output_file_path, const bool enable_scheduler, const uint32_t cores,
+                  const uint32_t clients, const bool enable_visualization, const bool verify,
+                  const bool cache_binary_tables, const bool enable_jit, const bool sql_metrics);
 
   static BenchmarkConfig get_default_config();
 
   BenchmarkMode benchmark_mode = BenchmarkMode::Ordered;
   ChunkOffset chunk_size = 100'000;
   EncodingConfig encoding_config = EncodingConfig{};
+  bool indexes = false;
   size_t max_runs = 1000;
   Duration max_duration = std::chrono::seconds(60);
   Duration warmup_duration = std::chrono::seconds(0);

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -401,6 +401,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("m,mode", "Ordered or Shuffled, default is Ordered", cxxopts::value<std::string>()->default_value("Ordered")) // NOLINT
     ("e,encoding", "Specify Chunk encoding as a string or as a JSON config file (for more detailed configuration, see --full_help). String options: " + encoding_strings_option, cxxopts::value<std::string>()->default_value("Dictionary"))  // NOLINT
     ("compression", "Specify vector compression as a string. Options: " + compression_strings_option, cxxopts::value<std::string>()->default_value(""))  // NOLINT
+    ("indexes", "Create indexes (where defined by benchmark)", cxxopts::value<bool>()->default_value("false"))  // NOLINT
     ("scheduler", "Enable or disable the scheduler", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("cores", "Specify the number of cores used by the scheduler (if active). 0 means all available cores", cxxopts::value<uint>()->default_value("0")) // NOLINT
     ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint>()->default_value("1")) // NOLINT
@@ -442,6 +443,7 @@ nlohmann::json BenchmarkRunner::create_context(const BenchmarkConfig& config) {
       {"compiler", compiler.str()},
       {"build_type", HYRISE_DEBUG ? "debug" : "release"},
       {"encoding", config.encoding_config.to_json()},
+      {"indexes", config.indexes},
       {"benchmark_mode", config.benchmark_mode == BenchmarkMode::Ordered ? "Ordered" : "Shuffled"},
       {"max_runs", config.max_runs},
       {"max_duration", std::chrono::duration_cast<std::chrono::nanoseconds>(config.max_duration).count()},

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -99,6 +99,11 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
     std::cout << "- Encoding is '" << encoding_type_str << "'" << std::endl;
   }
 
+  const auto indexes = json_config.value("indexes", default_config.indexes);
+  if (indexes) {
+    std::cout << "- Creating indexes (as defined by the benchmark)" << std::endl;
+  }
+
   // Get all other variables
   const auto chunk_size = json_config.value("chunk_size", default_config.chunk_size);
   std::cout << "- Chunk size is " << chunk_size << std::endl;
@@ -146,9 +151,10 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
   }
   std::cout << "- JIT is " << (enable_jit ? "enabled" : "disabled") << std::endl;
 
-  return BenchmarkConfig{benchmark_mode,       chunk_size,       *encoding_config,    max_runs,   timeout_duration,
-                         warmup_duration,      output_file_path, enable_scheduler,    cores,      clients,
-                         enable_visualization, verify,           cache_binary_tables, enable_jit, sql_metrics};
+  return BenchmarkConfig{
+      benchmark_mode,  chunk_size,          *encoding_config, indexes,    max_runs, timeout_duration,
+      warmup_duration, output_file_path,    enable_scheduler, cores,      clients,  enable_visualization,
+      verify,          cache_binary_tables, enable_jit,       sql_metrics};
 }
 
 BenchmarkConfig CLIConfigParser::parse_basic_cli_options(const cxxopts::ParseResult& parse_result) {
@@ -165,6 +171,7 @@ nlohmann::json CLIConfigParser::basic_cli_options_to_json(const cxxopts::ParseRe
   json_config.emplace("mode", parse_result["mode"].as<std::string>());
   json_config.emplace("encoding", parse_result["encoding"].as<std::string>());
   json_config.emplace("compression", parse_result["compression"].as<std::string>());
+  json_config.emplace("indexes", parse_result["indexes"].as<bool>());
   json_config.emplace("scheduler", parse_result["scheduler"].as<bool>());
   json_config.emplace("cores", parse_result["cores"].as<uint>());
   json_config.emplace("clients", parse_result["clients"].as<uint>());

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -288,4 +288,9 @@ AbstractTableGenerator::IndexesByTable TPCHTableGenerator::_indexes_by_table() c
   };
 }
 
+AbstractTableGenerator::SortOrderByTable TPCHTableGenerator::_sort_order_by_table() const {
+  // Allowed as per TPC-H Specification, paragraph 1.5.2
+  return {{"lineitem", "l_shipdate"}, {"orders", "o_orderdate"}};
+}
+
 }  // namespace opossum

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -278,7 +278,7 @@ AbstractTableGenerator::IndexesByTable TPCHTableGenerator::_indexes_by_table() c
   return {
       {"part", {{"p_partkey"}}},
       {"supplier", {{"s_suppkey"}, {"s_nationkey"}}},
-      // TODO multi-column indexes are currently not used by the index scan rule and the translator
+      // TODO(anyone): multi-column indexes are currently not used by the index scan rule and the translator
       {"partsupp", {{"ps_partkey", "ps_suppkey"}, {"ps_suppkey"}}},  // ps_partkey is subset of {ps_partkey, ps_suppkey}
       {"customer", {{"c_custkey"}, {"c_nationkey"}}},
       {"orders", {{"o_orderkey"}, {"o_custkey"}}},

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -274,4 +274,18 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCHTableGenerator::generate
   return table_info_by_name;
 }
 
+AbstractTableGenerator::IndexesByTable TPCHTableGenerator::_indexes_by_table() const {
+  return {
+    {"part", {{"p_partkey"}}},
+    {"supplier", {{"s_suppkey"}, {"s_nationkey"}}},
+    // TODO multi-column indexes are currently not used by the index scan rule and the translator
+    {"partsupp", {{"ps_partkey", "ps_suppkey"}, {"ps_suppkey"}}},  // ps_partkey is subset of {ps_partkey, ps_suppkey}
+    {"customer", {{"c_custkey"}, {"c_nationkey"}}},
+    {"orders", {{"o_orderkey"}, {"o_custkey"}}},
+    {"lineitem", {{"l_orderkey", "l_linenumber"}, {"l_partkey", "l_suppkey"}}},
+    {"nation", {{"n_nationkey"}, {"n_regionkey"}}},
+    {"region", {{"r_regionkey"}}},
+  };
+}
+
 }  // namespace opossum

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -276,15 +276,15 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCHTableGenerator::generate
 
 AbstractTableGenerator::IndexesByTable TPCHTableGenerator::_indexes_by_table() const {
   return {
-    {"part", {{"p_partkey"}}},
-    {"supplier", {{"s_suppkey"}, {"s_nationkey"}}},
-    // TODO multi-column indexes are currently not used by the index scan rule and the translator
-    {"partsupp", {{"ps_partkey", "ps_suppkey"}, {"ps_suppkey"}}},  // ps_partkey is subset of {ps_partkey, ps_suppkey}
-    {"customer", {{"c_custkey"}, {"c_nationkey"}}},
-    {"orders", {{"o_orderkey"}, {"o_custkey"}}},
-    {"lineitem", {{"l_orderkey", "l_linenumber"}, {"l_partkey", "l_suppkey"}}},
-    {"nation", {{"n_nationkey"}, {"n_regionkey"}}},
-    {"region", {{"r_regionkey"}}},
+      {"part", {{"p_partkey"}}},
+      {"supplier", {{"s_suppkey"}, {"s_nationkey"}}},
+      // TODO multi-column indexes are currently not used by the index scan rule and the translator
+      {"partsupp", {{"ps_partkey", "ps_suppkey"}, {"ps_suppkey"}}},  // ps_partkey is subset of {ps_partkey, ps_suppkey}
+      {"customer", {{"c_custkey"}, {"c_nationkey"}}},
+      {"orders", {{"o_orderkey"}, {"o_custkey"}}},
+      {"lineitem", {{"l_orderkey", "l_linenumber"}, {"l_partkey", "l_suppkey"}}},
+      {"nation", {{"n_nationkey"}, {"n_regionkey"}}},
+      {"region", {{"r_regionkey"}}},
   };
 }
 

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -39,6 +39,7 @@ class TPCHTableGenerator final : public AbstractTableGenerator {
 
  protected:
   IndexesByTable _indexes_by_table() const override;
+  SortOrderByTable _sort_order_by_table() const override;
 
  private:
   float _scale_factor;

--- a/src/benchmarklib/tpch/tpch_table_generator.hpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.hpp
@@ -37,6 +37,9 @@ class TPCHTableGenerator final : public AbstractTableGenerator {
 
   std::unordered_map<std::string, BenchmarkTableInfo> generate() override;
 
+ protected:
+  IndexesByTable _indexes_by_table() const override;
+
  private:
   float _scale_factor;
 };

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -107,7 +107,7 @@ std::vector<IndexStatistics> StoredTableNode::indexes_statistics() const {
   // Update index statistics
   // Note: The lambda also modifies statistics.column_ids. This is done because a regular for loop runs into issues
   // when remove(iterator) invalidates the iterator.
-  // TODO test fix
+  // TODO(anyone): Theoretically, we could keep multi-column indexes where only the last column was pruned
   pruned_indexes_statistics.erase(std::remove_if(pruned_indexes_statistics.begin(), pruned_indexes_statistics.end(),
                                                  [&](auto& statistics) {
                                                    for (auto& original_column_id : statistics.column_ids) {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -96,30 +96,33 @@ std::vector<IndexStatistics> StoredTableNode::indexes_statistics() const {
   DebugAssert(!left_input() && !right_input(), "StoredTableNode must be a leaf");
 
   const auto table = Hyrise::get().storage_manager.get_table(table_name);
-  auto stored_indexes_statistics = table->indexes_statistics();
+  auto pruned_indexes_statistics = table->indexes_statistics();
 
   if (_pruned_column_ids.empty()) {
-    return stored_indexes_statistics;
+    return pruned_indexes_statistics;
   }
 
   const auto column_id_mapping = column_ids_after_pruning(table->column_count(), _pruned_column_ids);
 
-  // update index statistics
-  for (auto stored_index_stats_iter = stored_indexes_statistics.begin();
-       stored_index_stats_iter != stored_indexes_statistics.end();) {
-    for (auto& original_column_id : (*stored_index_stats_iter).column_ids) {
+  // Update index statistics
+  // Note: The lambda also modifies statistics.column_ids. This is done because a regular for loop runs into issues
+  // when remove(iterator) invalidates the iterator.
+  // TODO test fix
+  pruned_indexes_statistics.erase(std::remove_if(pruned_indexes_statistics.begin(), pruned_indexes_statistics.end(), [&](auto& statistics) {
+    for (auto& original_column_id : statistics.column_ids) {
       const auto& updated_column_id = column_id_mapping[original_column_id];
       if (!updated_column_id) {
-        // column was pruned, we cannot use the index anymore.
-        stored_indexes_statistics.erase(stored_index_stats_iter);
-        break;
+        // Indexed column was pruned - remove index from statistics
+        return true;
       } else {
+        // Update column id
         original_column_id = *updated_column_id;
-        ++stored_index_stats_iter;
       }
     }
-  }
-  return stored_indexes_statistics;
+    return false;
+  }), pruned_indexes_statistics.end());
+
+  return pruned_indexes_statistics;
 }
 
 std::shared_ptr<AbstractLQPNode> StoredTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -108,19 +108,22 @@ std::vector<IndexStatistics> StoredTableNode::indexes_statistics() const {
   // Note: The lambda also modifies statistics.column_ids. This is done because a regular for loop runs into issues
   // when remove(iterator) invalidates the iterator.
   // TODO test fix
-  pruned_indexes_statistics.erase(std::remove_if(pruned_indexes_statistics.begin(), pruned_indexes_statistics.end(), [&](auto& statistics) {
-    for (auto& original_column_id : statistics.column_ids) {
-      const auto& updated_column_id = column_id_mapping[original_column_id];
-      if (!updated_column_id) {
-        // Indexed column was pruned - remove index from statistics
-        return true;
-      } else {
-        // Update column id
-        original_column_id = *updated_column_id;
-      }
-    }
-    return false;
-  }), pruned_indexes_statistics.end());
+  pruned_indexes_statistics.erase(std::remove_if(pruned_indexes_statistics.begin(), pruned_indexes_statistics.end(),
+                                                 [&](auto& statistics) {
+                                                   for (auto& original_column_id : statistics.column_ids) {
+                                                     const auto& updated_column_id =
+                                                         column_id_mapping[original_column_id];
+                                                     if (!updated_column_id) {
+                                                       // Indexed column was pruned - remove index from statistics
+                                                       return true;
+                                                     } else {
+                                                       // Update column id
+                                                       original_column_id = *updated_column_id;
+                                                     }
+                                                   }
+                                                   return false;
+                                                 }),
+                                  pruned_indexes_statistics.end());
 
   return pruned_indexes_statistics;
 }

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -52,25 +52,25 @@ void IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const
 
 bool IndexScanRule::_is_index_scan_applicable(const IndexStatistics& index_statistics,
                                               const std::shared_ptr<PredicateNode>& predicate_node) const {
-  if (!_is_single_segment_index(index_statistics)) return false;
+  if (!_is_single_segment_index(index_statistics)) {std::cout << "false: " << __LINE__ << std::endl; return false;}
 
-  if (index_statistics.type != SegmentIndexType::GroupKey) return false;
+  if (index_statistics.type != SegmentIndexType::GroupKey) {std::cout << "false: " << __LINE__ << std::endl; return false;}
 
   const auto operator_predicates =
       OperatorScanPredicate::from_expression(*predicate_node->predicate(), *predicate_node);
-  if (!operator_predicates) return false;
-  if (operator_predicates->size() != 1) return false;
+  if (!operator_predicates) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (operator_predicates->size() != 1) {std::cout << "false: " << __LINE__ << std::endl; return false;}
 
   const auto& operator_predicate = (*operator_predicates)[0];
 
   // Currently, we do not support two-column predicates
-  if (is_column_id(operator_predicate.value)) return false;
+  if (is_column_id(operator_predicate.value)) {std::cout << "false: " << __LINE__ << std::endl; return false;}
 
-  if (index_statistics.column_ids[0] != operator_predicate.column_id) return false;
+  if (index_statistics.column_ids[0] != operator_predicate.column_id) {std::cout << "false: " << __LINE__ << std::endl; return false;}
 
   const auto row_count_table =
       cost_estimator->cardinality_estimator->estimate_cardinality(predicate_node->left_input());
-  if (row_count_table < INDEX_SCAN_ROW_COUNT_THRESHOLD) return false;
+  if (row_count_table < INDEX_SCAN_ROW_COUNT_THRESHOLD) {std::cout << "false: " << __LINE__ << std::endl; return false;}
 
   const auto row_count_predicate = cost_estimator->cardinality_estimator->estimate_cardinality(predicate_node);
   const float selectivity = row_count_predicate / row_count_table;

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -52,25 +52,25 @@ void IndexScanRule::apply_to(const std::shared_ptr<AbstractLQPNode>& node) const
 
 bool IndexScanRule::_is_index_scan_applicable(const IndexStatistics& index_statistics,
                                               const std::shared_ptr<PredicateNode>& predicate_node) const {
-  if (!_is_single_segment_index(index_statistics)) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (!_is_single_segment_index(index_statistics)) return false;
 
-  if (index_statistics.type != SegmentIndexType::GroupKey) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (index_statistics.type != SegmentIndexType::GroupKey) return false;
 
   const auto operator_predicates =
       OperatorScanPredicate::from_expression(*predicate_node->predicate(), *predicate_node);
-  if (!operator_predicates) {std::cout << "false: " << __LINE__ << std::endl; return false;}
-  if (operator_predicates->size() != 1) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (!operator_predicates) return false;
+  if (operator_predicates->size() != 1) return false;
 
   const auto& operator_predicate = (*operator_predicates)[0];
 
   // Currently, we do not support two-column predicates
-  if (is_column_id(operator_predicate.value)) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (is_column_id(operator_predicate.value)) return false;
 
-  if (index_statistics.column_ids[0] != operator_predicate.column_id) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (index_statistics.column_ids[0] != operator_predicate.column_id) return false;
 
   const auto row_count_table =
       cost_estimator->cardinality_estimator->estimate_cardinality(predicate_node->left_input());
-  if (row_count_table < INDEX_SCAN_ROW_COUNT_THRESHOLD) {std::cout << "false: " << __LINE__ << std::endl; return false;}
+  if (row_count_table < INDEX_SCAN_ROW_COUNT_THRESHOLD) return false;
 
   const auto row_count_predicate = cost_estimator->cardinality_estimator->estimate_cardinality(predicate_node);
   const float selectivity = row_count_predicate / row_count_table;

--- a/src/test/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/logical_query_plan/stored_table_node_test.cpp
@@ -11,6 +11,7 @@
 #include "logical_query_plan/stored_table_node.hpp"
 #include "statistics/table_statistics.hpp"
 #include "storage/chunk_encoder.hpp"
+#include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
@@ -20,34 +21,36 @@ namespace opossum {
 class StoredTableNodeTest : public BaseTest {
  protected:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("t_a", load_table("resources/test_data/tbl/int_float.tbl", 1));
-    Hyrise::get().storage_manager.add_table("t_b", load_table("resources/test_data/tbl/int_float.tbl", 1));
+    Hyrise::get().storage_manager.add_table("t_a", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
+    Hyrise::get().storage_manager.add_table("t_b", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
 
     const auto& table_t_a = Hyrise::get().storage_manager.get_table("t_a");
     ChunkEncoder::encode_all_chunks(table_t_a);
     table_t_a->create_index<GroupKeyIndex>({ColumnID{0}}, "i_a1");
-    table_t_a->create_index<GroupKeyIndex>({ColumnID{0}}, "i_a2");
     table_t_a->create_index<GroupKeyIndex>({ColumnID{1}}, "i_b");
+    table_t_a->create_index<CompositeGroupKeyIndex>({ColumnID{0}, ColumnID{1}}, "i_a2");
+    table_t_a->create_index<CompositeGroupKeyIndex>({ColumnID{1}, ColumnID{0}}, "i_a3");
 
     _stored_table_node = StoredTableNode::make("t_a");
     _a = LQPColumnReference(_stored_table_node, ColumnID{0});
     _b = LQPColumnReference(_stored_table_node, ColumnID{1});
+    _c = LQPColumnReference(_stored_table_node, ColumnID{2});
 
     _stored_table_node->set_pruned_chunk_ids({ChunkID{2}});
   }
 
   std::shared_ptr<StoredTableNode> _stored_table_node;
-  LQPColumnReference _a, _b;
+  LQPColumnReference _a, _b, _c;
 };
 
 TEST_F(StoredTableNodeTest, Description) {
   const auto stored_table_node_a = StoredTableNode::make("t_a");
-  EXPECT_EQ(stored_table_node_a->description(), "[StoredTable] Name: 't_a' pruned: 0/3 chunk(s), 0/2 column(s)");
+  EXPECT_EQ(stored_table_node_a->description(), "[StoredTable] Name: 't_a' pruned: 0/4 chunk(s), 0/3 column(s)");
 
   const auto stored_table_node_b = StoredTableNode::make("t_a");
   stored_table_node_b->set_pruned_chunk_ids({ChunkID{2}});
   stored_table_node_b->set_pruned_column_ids({ColumnID{1}});
-  EXPECT_EQ(stored_table_node_b->description(), "[StoredTable] Name: 't_a' pruned: 1/3 chunk(s), 1/2 column(s)");
+  EXPECT_EQ(stored_table_node_b->description(), "[StoredTable] Name: 't_a' pruned: 1/4 chunk(s), 1/3 column(s)");
 }
 
 TEST_F(StoredTableNodeTest, GetColumn) {
@@ -61,14 +64,16 @@ TEST_F(StoredTableNodeTest, GetColumn) {
 }
 
 TEST_F(StoredTableNodeTest, ColumnExpressions) {
-  EXPECT_EQ(_stored_table_node->column_expressions().size(), 2u);
+  EXPECT_EQ(_stored_table_node->column_expressions().size(), 3u);
   EXPECT_EQ(*_stored_table_node->column_expressions().at(0u), *lqp_column_(_a));
   EXPECT_EQ(*_stored_table_node->column_expressions().at(1u), *lqp_column_(_b));
+  EXPECT_EQ(*_stored_table_node->column_expressions().at(2u), *lqp_column_(_c));
 
   // Column pruning does not interfere with get_column()
   _stored_table_node->set_pruned_column_ids({ColumnID{0}});
-  EXPECT_EQ(_stored_table_node->column_expressions().size(), 1u);
+  EXPECT_EQ(_stored_table_node->column_expressions().size(), 2u);
   EXPECT_EQ(*_stored_table_node->column_expressions().at(0u), *lqp_column_(_b));
+  EXPECT_EQ(*_stored_table_node->column_expressions().at(1u), *lqp_column_(_c));
 }
 
 TEST_F(StoredTableNodeTest, Equals) {
@@ -100,10 +105,10 @@ TEST_F(StoredTableNodeTest, Copy) {
 
 TEST_F(StoredTableNodeTest, NodeExpressions) { ASSERT_EQ(_stored_table_node->node_expressions.size(), 0u); }
 
-TEST_F(StoredTableNodeTest, GetStatistics) {
-  EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 3u);
+TEST_F(StoredTableNodeTest, GetStatisticsPruneFirstColumn) {
+  EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 4u);
 
-  auto expected_statistics = _stored_table_node->indexes_statistics().at(2u);
+  auto expected_statistics = _stored_table_node->indexes_statistics().at(1u);
 
   _stored_table_node->set_pruned_column_ids({ColumnID{0}});
 
@@ -112,6 +117,28 @@ TEST_F(StoredTableNodeTest, GetStatistics) {
 
   EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 1u);
   EXPECT_EQ(_stored_table_node->indexes_statistics().at(0u), expected_statistics);
+}
+
+TEST_F(StoredTableNodeTest, GetStatisticsPruneSecondColumn) {
+  EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 4u);
+
+  auto expected_statistics = _stored_table_node->indexes_statistics().at(0u);
+
+  _stored_table_node->set_pruned_column_ids({ColumnID{1}});
+
+  // column with ColumnID{1} was pruned, so ColumnID{0} should be untouched
+
+  EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 1u);
+  EXPECT_EQ(_stored_table_node->indexes_statistics().at(0u), expected_statistics);
+}
+
+TEST_F(StoredTableNodeTest, GetStatisticsPruneBothColumns) {
+  EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 4u);
+
+  _stored_table_node->set_pruned_column_ids({ColumnID{0}, ColumnID{1}});
+
+  // All indexed columns were pruned, therefore the index statistics should be empty
+  EXPECT_EQ(_stored_table_node->indexes_statistics().size(), 0u);
 }
 
 }  // namespace opossum


### PR DESCRIPTION
* Sort two TPC-H tables (see the benchmark results below)
* Enabled `./hyriseBenchmarkTPCH --indexes` (even if the indexes don't help yet)
* Fixes the column pruning of index statistics in StoredTableNode

```
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 01       | 0.615062177181 | 37   | 0.539779722691 | 33   | -12%       |                          0.0000 |
| TPC-H 02       | 7.99957561493  | 480  | 8.06976127625  | 485  | +1%        |                          0.0000 |
| TPC-H 03       | 6.49863004684  | 390  | 6.33193445206  | 380  | -3%        |                          0.0000 |
| TPC-H 04       | 2.17022633553  | 131  | 2.25641059875  | 136  | +4%        |                          0.0000 |
| TPC-H 05       | 4.41364431381  | 265  | 4.20719718933  | 253  | -5%        |                          0.0000 |
| TPC-H 06       | 42.2867660522  | 2538 | 104.216506958  | 6253 | +146%      |                          0.0000 |
| TPC-H 07       | 1.66296219826  | 100  | 1.57539618015  | 95   | -5%        |                          0.0000 |
| TPC-H 08       | 5.24449110031  | 315  | 5.91493940353  | 355  | +13%       |                          0.0000 |
| TPC-H 09       | 1.64935135841  | 99   | 1.56764471531  | 95   | -5%        |                          0.0000 |
| TPC-H 10       | 2.99691796303  | 180  | 3.01092982292  | 181  | +0%        |                          0.2278 |
| TPC-H 11       | 25.0198612213  | 1502 | 25.2651672363  | 1516 | +1%        |                          0.0000 |
| TPC-H 12       | 7.09069490433  | 426  | 7.91925477982  | 476  | +12%       |                          0.0000 |
| TPC-H 13       | 2.25348448753  | 136  | 2.26658129692  | 136  | +1%        |                          0.0068 |
| TPC-H 14       | 24.591255188   | 1476 | 45.2207527161  | 2714 | +84%       |                          0.0000 |
| TPC-H 15       | 14.7617921829  | 886  | 38.5287780762  | 2312 | +161%      |                          0.0000 |
| TPC-H 16       | 7.01512289047  | 421  | 6.92506694794  | 416  | -1%        |                          0.0000 |
| TPC-H 17       | 1.35287034512  | 82   | 1.40179693699  | 85   | +4%        |                          0.0000 |
| TPC-H 18       | 1.33346748352  | 81   | 0.76583480835  | 46   | -43%       |                          0.0000 |
| TPC-H 19       | 5.5188703537   | 332  | 5.43943595886  | 327  | -1%        |                          0.0000 |
| TPC-H 20       | 2.40476560593  | 145  | 2.65809130669  | 160  | +11%       |                          0.0000 |
| TPC-H 21       | 0.724993526936 | 44   | 0.663121402264 | 40   | -9%        |                          0.0000 |
| TPC-H 22       | 13.4100723267  | 805  | 13.7682619095  | 827  | +3%        |                          0.0000 |
| geometric mean |                |      |                |      | +9%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```