### PR TITLE
Optimize Validate operator to validate chunks in parallel

### DIFF
--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -103,7 +103,8 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
         output_chunks.emplace_back(chunk);
       }
     }
-  } else {
+  } else if(job_results.size() > 0) {
+    Assert(job_results.size() == 1, "Direct execution should not produce multiple result vectors.");
     output_chunks = *job_results.front();
   }
 

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <scheduler/job_task.hpp>
+#include <scheduler/current_scheduler.hpp>
 
 #include "concurrency/transaction_context.hpp"
 #include "storage/reference_segment.hpp"
@@ -55,17 +57,51 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
   DebugAssert(transaction_context, "Validate requires a valid TransactionContext.");
   DebugAssert(transaction_context->phase() == TransactionPhase::Active, "Transaction is not active anymore.");
 
-  const auto in_table = input_table_left();
-
-  auto output_chunks = std::vector<std::shared_ptr<Chunk>>{};
-  output_chunks.reserve(in_table->chunk_count());
+  const auto chunk_count = input_table_left()->chunk_count();
 
   const auto our_tid = transaction_context->transaction_id();
   const auto snapshot_commit_id = transaction_context->snapshot_commit_id();
 
-  const auto chunk_count = in_table->chunk_count();
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
-    const auto chunk_in = in_table->get_chunk(chunk_id);
+  std::vector<std::shared_ptr<JobTask>> jobs;
+  std::vector<std::vector<std::shared_ptr<Chunk>>> job_results;
+  auto job_chunk_id_start = ChunkID{0};
+  auto job_row_count = uint32_t{0};
+  for (auto chunk_id = job_chunk_id_start; chunk_id < chunk_count; ++chunk_id) {
+    const auto chunk = input_table_left()->get_chunk(chunk_id);
+    job_row_count += chunk->size();
+
+    if(job_row_count >= Chunk::DEFAULT_SIZE || chunk_id == (chunk_count - 1)) {
+      auto output_chunks = std::vector<std::shared_ptr<Chunk>>{};
+      output_chunks.reserve(chunk_id - job_chunk_id_start);
+      job_results.emplace_back(output_chunks);
+
+      jobs.push_back(std::make_shared<JobTask>([=, this, &output_chunks] {
+        _process_chunks(job_chunk_id_start, chunk_id, our_tid, snapshot_commit_id, output_chunks);
+      }));
+      jobs.back()->schedule();
+
+      job_chunk_id_start = chunk_id + 1;
+      job_row_count = uint32_t{0};
+    }
+  }
+
+  // Merge results
+  CurrentScheduler::wait_for_tasks(jobs);
+  auto output_chunks = std::vector<std::shared_ptr<Chunk>>{};
+  output_chunks.reserve(chunk_count);
+  for(const auto& chunk_vector : job_results) {
+    for(const auto& chunk : chunk_vector) {
+      output_chunks.emplace_back(chunk);
+    }
+  }
+
+  return std::make_shared<Table>(input_table_left()->column_definitions(), TableType::References, std::move(output_chunks));
+}
+
+void Validate::_process_chunks(const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::vector<std::shared_ptr<Chunk>>& output_chunks) {
+
+  for (auto chunk_id = chunk_id_start; chunk_id <= chunk_id_end; ++chunk_id) {
+    const auto chunk_in = input_table_left()->get_chunk(chunk_id);
     Assert(chunk_in, "Did not expect deleted chunk here.");  // see #1686
 
     Segments output_segments;
@@ -122,7 +158,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
 
       // Otherwise we have a Value- or DictionarySegment and simply iterate over all rows to build a poslist.
     } else {
-      referenced_table = in_table;
+      referenced_table = input_table_left();
       DebugAssert(chunk_in->has_mvcc_data(), "Trying to use Validate on a table that has no MVCC data");
       const auto mvcc_data = chunk_in->get_scoped_mvcc_data_lock();
       pos_list_out->guarantee_single_chunk();
@@ -146,8 +182,6 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
       output_chunks.emplace_back(std::make_shared<Chunk>(output_segments));
     }
   }
-
-  return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }
 
 }  // namespace opossum

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -95,14 +95,14 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
     }
   }
 
-  if (jobs.size() > 0) {
+  if (!jobs.empty()) {
     CurrentScheduler::wait_for_tasks(jobs);
   }
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }
 
-void Validate::_validate_chunks(const std::shared_ptr<const Table> in_table, const ChunkID chunk_id_start,
+void Validate::_validate_chunks(const std::shared_ptr<const Table> &in_table, const ChunkID chunk_id_start,
                                 const ChunkID chunk_id_end, const TransactionID our_tid,
                                 const TransactionID snapshot_commit_id,
                                 std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex) {

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -15,7 +15,7 @@ namespace opossum {
 
 namespace {
 
-bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, ChunkOffset chunk_offset,
+static bool inline is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, ChunkOffset chunk_offset,
                     const MvccData& mvcc_data) {
   const auto row_tid = mvcc_data.tids[chunk_offset].load();
   const auto begin_cid = mvcc_data.begin_cids[chunk_offset];
@@ -24,17 +24,6 @@ bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, ChunkOff
 }
 
 }  // namespace
-
-bool Validate::is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
-                              const CommitID begin_cid, const CommitID end_cid) {
-  // Taken from: https://github.com/hyrise/hyrise-v1/blob/master/docs/documentation/queryexecution/tx.rst
-  // auto own_insert = (our_tid == row_tid) && !(snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);
-  // auto past_insert = (our_tid != row_tid) && (snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);
-  // return own_insert || past_insert;
-
-  // since gcc and clang are surprisingly bad at optimizing the above boolean expression, lets do that ourselves
-  return snapshot_commit_id < end_cid && ((snapshot_commit_id >= begin_cid) != (row_tid == our_tid));
-}
 
 Validate::Validate(const std::shared_ptr<AbstractOperator>& in)
     : AbstractReadOnlyOperator(OperatorType::Validate, in) {}

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -26,7 +26,7 @@ class Validate : public AbstractReadOnlyOperator {
   static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                              const CommitID begin_cid, const CommitID end_cid);
 
-  void _process_chunks(const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::vector<std::shared_ptr<Chunk>>& output_chunks);
+  void _process_chunks(const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::shared_ptr<std::vector<std::shared_ptr<Chunk>>> output_chunks);
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> transaction_context) override;

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -23,18 +23,11 @@ class Validate : public AbstractReadOnlyOperator {
   const std::string name() const override;
 
   // MVCC evaluation logic is exposed so that JitValidate can also use it
-  static bool inline is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
-                                    const CommitID begin_cid, const CommitID end_cid) {
-    // Taken from: https://github.com/hyrise/hyrise-v1/blob/master/docs/documentation/queryexecution/tx.rst
-    // auto own_insert = (our_tid == row_tid) && !(snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);
-    // auto past_insert = (our_tid != row_tid) && (snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);
-    // return own_insert || past_insert;
-    // since gcc and clang are surprisingly bad at optimizing the above boolean expression, lets do that ourselves
-    return snapshot_commit_id < end_cid && ((snapshot_commit_id >= begin_cid) != (row_tid == our_tid));
-  }
+  static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
+                             const CommitID begin_cid, const CommitID end_cid);
 
  private:
-  void _validate_chunks(const std::shared_ptr<const Table>& in_table, const ChunkID chunk_id_start,
+  void _validate_chunks(const std::shared_ptr<const Table> &in_table, const ChunkID chunk_id_start,
                         const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id,
                         std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex);
 

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -26,7 +26,9 @@ class Validate : public AbstractReadOnlyOperator {
   static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                              const CommitID begin_cid, const CommitID end_cid);
 
-  void _validate_chunks(const std::shared_ptr<const Table> in_table, const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::vector<std::shared_ptr<Chunk>> &output_chunks, std::mutex &output_mutex);
+  void _validate_chunks(const std::shared_ptr<const Table> in_table, const ChunkID chunk_id_start,
+                        const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id,
+                        std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex);
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> transaction_context) override;

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -26,6 +26,7 @@ class Validate : public AbstractReadOnlyOperator {
   static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                              const CommitID begin_cid, const CommitID end_cid);
 
+ private:
   void _validate_chunks(const std::shared_ptr<const Table> in_table, const ChunkID chunk_id_start,
                         const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id,
                         std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex);

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -27,7 +27,7 @@ class Validate : public AbstractReadOnlyOperator {
                              const CommitID begin_cid, const CommitID end_cid);
 
  private:
-  void _validate_chunks(const std::shared_ptr<const Table> in_table, const ChunkID chunk_id_start,
+  void _validate_chunks(const std::shared_ptr<const Table> &in_table, const ChunkID chunk_id_start,
                         const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id,
                         std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex);
 

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -26,7 +26,7 @@ class Validate : public AbstractReadOnlyOperator {
   static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                              const CommitID begin_cid, const CommitID end_cid);
 
-  void _process_chunks(const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::shared_ptr<std::vector<std::shared_ptr<Chunk>>> output_chunks);
+  void _validate_chunks(const std::shared_ptr<const Table> in_table, const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::vector<std::shared_ptr<Chunk>> &output_chunks, std::mutex &output_mutex);
 
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> transaction_context) override;

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -26,6 +26,8 @@ class Validate : public AbstractReadOnlyOperator {
   static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
                              const CommitID begin_cid, const CommitID end_cid);
 
+  void _process_chunks(const ChunkID chunk_id_start, const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id, std::vector<std::shared_ptr<Chunk>>& output_chunks);
+
  protected:
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> transaction_context) override;
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -27,7 +27,7 @@ class Validate : public AbstractReadOnlyOperator {
                              const CommitID begin_cid, const CommitID end_cid);
 
  private:
-  void _validate_chunks(const std::shared_ptr<const Table> &in_table, const ChunkID chunk_id_start,
+  void _validate_chunks(const std::shared_ptr<const Table>& in_table, const ChunkID chunk_id_start,
                         const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id,
                         std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex);
 

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -23,11 +23,18 @@ class Validate : public AbstractReadOnlyOperator {
   const std::string name() const override;
 
   // MVCC evaluation logic is exposed so that JitValidate can also use it
-  static bool is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
-                             const CommitID begin_cid, const CommitID end_cid);
+  static bool inline is_row_visible(TransactionID our_tid, CommitID snapshot_commit_id, const TransactionID row_tid,
+                                    const CommitID begin_cid, const CommitID end_cid) {
+    // Taken from: https://github.com/hyrise/hyrise-v1/blob/master/docs/documentation/queryexecution/tx.rst
+    // auto own_insert = (our_tid == row_tid) && !(snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);
+    // auto past_insert = (our_tid != row_tid) && (snapshot_commit_id >= begin_cid) && !(snapshot_commit_id >= end_cid);
+    // return own_insert || past_insert;
+    // since gcc and clang are surprisingly bad at optimizing the above boolean expression, lets do that ourselves
+    return snapshot_commit_id < end_cid && ((snapshot_commit_id >= begin_cid) != (row_tid == our_tid));
+  }
 
  private:
-  void _validate_chunks(const std::shared_ptr<const Table> &in_table, const ChunkID chunk_id_start,
+  void _validate_chunks(const std::shared_ptr<const Table>& in_table, const ChunkID chunk_id_start,
                         const ChunkID chunk_id_end, const TransactionID our_tid, const TransactionID snapshot_commit_id,
                         std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex);
 


### PR DESCRIPTION
Currently, the `Validate` operator processes all chunks sequentially. Especially for large input tables this can be time-consuming.

This PR parallelizes the validation process on a chunk-level. Chunks of `100.000` rows and more are handled by individual`JobTask`s. 

Running the TPC-DS benchmark, we get the following results:

```
+----------------+-----------------+------+-----------------+------+------------+-----------------------------------------------+
| Benchmark      | prev. iter/s    | runs | new iter/s      | runs | change [%] |               p-value (significant if <0.001) |
+----------------+-----------------+------+-----------------+------+------------+-----------------------------------------------+
| 01             | 1.23315536976   | 74   | 1.33324241638   | 80   | +8%        |                                        0.0000 |
| 07             | 0.349959135056  | 21   | 0.533293247223  | 32   | +52%       |                   (run time too short) 0.0000 |
| 09             | 0.149977818131  | 9    | 0.233311876655  | 14   | +56%       | (run time too short) (not enough runs) 0.0000 |
| 10             | 0.0166652090847 | 1    | 0.0166653320193 | 1    | +0%        |    (run time too short) (not enough runs) nan |
| 13             | 0.149983122945  | 9    | 0.18331451714   | 11   | +22%       | (run time too short) (not enough runs) 0.0000 |
| 15             | 0.933237314224  | 56   | 1.59984433651   | 96   | +71%       |                                        0.0000 |
| 17             | 0.383291661739  | 23   | 0.633280575275  | 38   | +65%       |                   (run time too short) 0.0000 |
| 25             | 0.533257484436  | 32   | 1.11652958393   | 67   | +109%      |                   (run time too short) 0.0000 |
| 26             | 0.666588366032  | 40   | 0.96658462286   | 58   | +45%       |                   (run time too short) 0.0000 |
| 28             | 3.09959936142   | 186  | 3.19959402084   | 192  | +3%        |                   (run time too short) 0.0000 |
| 29             | 0.466603755951  | 28   | 0.849895179272  | 51   | +82%       |                   (run time too short) 0.0000 |
| 31             | 0.0666584670544 | 4    | 0.0833244845271 | 5    | +25%       | (run time too short) (not enough runs) 0.0176 |
| 34             | 0.399941444397  | 24   | 0.633297622204  | 38   | +58%       |                   (run time too short) 0.0000 |
| 39a            | 0.0333290807903 | 2    | 0.0333317145705 | 2    | +0%        | (run time too short) (not enough runs) 0.0054 |
| 39b            | 0.0333289951086 | 2    | 0.033331759274  | 2    | +0%        | (run time too short) (not enough runs) 0.0223 |
| 41             | 0.749932944775  | 45   | 0.74994623661   | 45   | +0%        |                                        0.9887 |
| 42             | 0.599925875664  | 36   | 1.39983057976   | 84   | +133%      |                                        0.0000 |
| 43             | 0.11665546149   | 7    | 0.133323639631  | 8    | +14%       | (run time too short) (not enough runs) 0.0000 |
| 45             | 1.5164488554    | 91   | 2.18314504623   | 131  | +44%       |                                        0.0000 |
| 48             | 0.166645333171  | 10   | 0.199988186359  | 12   | +20%       |                   (run time too short) 0.0000 |
| 50             | 0.566587567329  | 34   | 1.11655521393   | 67   | +97%       |                   (run time too short) 0.0000 |
| 62             | 0.399958074093  | 24   | 0.433306783438  | 26   | +8%        |                                        0.0000 |
| 65             | 0.349954247475  | 21   | 0.516615152359  | 31   | +48%       |                   (run time too short) 0.0000 |
| 69             | 0.566586494446  | 34   | 1.04996812344   | 63   | +85%       |                   (run time too short) 0.0000 |
| 73             | 0.533263146877  | 32   | 1.06656324863   | 64   | +100%      |                                        0.0000 |
| 79             | 0.199974954128  | 12   | 0.249988943338  | 15   | +25%       |                   (run time too short) 0.0000 |
| 81             | 2.13304376602   | 128  | 2.19980335236   | 132  | +3%        |                   (run time too short) 0.0000 |
| 83             | 2.38330936432   | 143  | 2.36641764641   | 142  | -1%        |                   (run time too short) 0.8066 |
| 88             | 0.349989384413  | 21   | 0.49996316433   | 30   | +43%       |                   (run time too short) 0.0000 |
| 93             | 0.0833239108324 | 5    | 0.0833271816373 | 5    | +0%        | (run time too short) (not enough runs) 0.0026 |
| 96             | 0.466610074043  | 28   | 0.849919676781  | 51   | +82%       |                   (run time too short) 0.0000 |
| 97             | 0.133318185806  | 8    | 0.149990394711  | 9    | +13%       | (run time too short) (not enough runs) 0.0000 |
| 99             | 0.199980735779  | 12   | 0.216657459736  | 13   | +8%        |                   (run time too short) 0.0000 |
| geometric mean |                 |      |                 |      | +35%       |                                               |
+----------------+-----------------+------+-----------------+------+------------+-----------------------------------------------+
```

**Options**:  `numactl -m0 -N0 ./hyriseBenchmarkTPCDS --scheduler --cache_binary_tables` 

In TPC-H the results are similar:

```
+----------------+-----------------+------+-----------------+------+------------+-----------------------------------------------+
| Benchmark      | prev. iter/s    | runs | new iter/s      | runs | change [%] |               p-value (significant if <0.001) |
+----------------+-----------------+------+-----------------+------+------------+-----------------------------------------------+
| TPC-H 01       | 0.0166658777744 | 1    | 0.016664981842  | 1    | -0%        |    (run time too short) (not enough runs) nan |
| TPC-H 02       | 0.349946945906  | 21   | 0.383284211159  | 23   | +10%       |                   (run time too short) 0.0000 |
| TPC-H 03       | 0.399943590164  | 24   | 0.649976074696  | 39   | +63%       |                   (run time too short) 0.0000 |
| TPC-H 04       | 0.333330184221  | 20   | 1.09989619255   | 66   | +230%      |                   (run time too short) 0.0000 |
| TPC-H 05       | 0.18330784142   | 11   | 0.333324968815  | 20   | +82%       |                   (run time too short) 0.0000 |
| TPC-H 06       | 4.24990701675   | 255  | 4.24992418289   | 255  | +0%        |                   (run time too short) 0.6056 |
| TPC-H 07       | 0.0999894589186 | 6    | 0.099983394146  | 6    | -0%        | (run time too short) (not enough runs) 0.0000 |
| TPC-H 08       | 0.266634732485  | 16   | 0.566645503044  | 34   | +113%      |                                        0.0000 |
| TPC-H 09       | 0.116653516889  | 7    | 0.149976223707  | 9    | +29%       | (run time too short) (not enough runs) 0.0000 |
| TPC-H 10       | 0.316632598639  | 19   | 0.383274137974  | 23   | +21%       |                   (run time too short) 0.0000 |
| TPC-H 11       | 0.84989386797   | 51   | 1.4164390564    | 85   | +67%       |                                        0.0000 |
| TPC-H 12       | 0.849866449833  | 51   | 1.13333070278   | 68   | +33%       |                   (run time too short) 0.0000 |
| TPC-H 13       | 0.316624581814  | 19   | 0.366608709097  | 22   | +16%       |                   (run time too short) 0.0000 |
| TPC-H 14       | 2.19999527931   | 132  | 2.24963259697   | 135  | +2%        |                                        0.0000 |
| TPC-H 15       | 1.68309319019   | 101  | 1.7833224535    | 107  | +6%        |                                        0.0000 |
| TPC-H 16       | 0.466603517532  | 28   | 0.516592085361  | 31   | +11%       |                   (run time too short) 0.0000 |
| TPC-H 17       | 0.0999837145209 | 6    | 0.133333101869  | 8    | +33%       | (run time too short) (not enough runs) 0.0000 |
| TPC-H 18       | 0.0666573271155 | 4    | 0.0666561573744 | 4    | -0%        | (run time too short) (not enough runs) 0.0000 |
| TPC-H 19       | 0.366655439138  | 22   | 0.466636151075  | 28   | +27%       |                   (run time too short) 0.0000 |
| TPC-H 20       | 0.283302009106  | 17   | 0.316615492105  | 19   | +12%       |                   (run time too short) 0.0000 |
| TPC-H 21       | 0.183303102851  | 11   | 0.283294171095  | 17   | +55%       |                   (run time too short) 0.0000 |
| TPC-H 22       | 1.43309664726   | 86   | 1.61663269997   | 97   | +13%       |                   (run time too short) 0.0000 |
| geometric mean |                 |      |                 |      | +31%       |                                               |
+----------------+-----------------+------+-----------------+------+------------+-----------------------------------------------+
```
**Options**: `numactl -m0 -N0 ./hyriseBenchmarkTPCH --scheduler --cache_binary_tables`