### PR TITLE
Update multi-predicate-join comment

### DIFF
--- a/src/lib/optimizer/join_ordering/abstract_join_ordering_algorithm.cpp
+++ b/src/lib/optimizer/join_ordering/abstract_join_ordering_algorithm.cpp
@@ -79,10 +79,10 @@ std::shared_ptr<AbstractLQPNode> AbstractJoinOrderingAlgorithm::_add_join_to_pla
             [&](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
 
   // Categorize join predicates into those that MUST be processed as part of a join operator (because they are required
-  // to see if an outer join emits a value or a NULL) and those that can also be processed as regular after the join
-  // predicates (post-join predicates, e.g., additional join predicates for inner joins). Since the multi-predicate
-  // join is currently slower than a regular predicate (i.e., a full table scan), we only use the multi-predicate join
-  // in cases where it is required for a correct result.
+  // to see if an outer join emits a value or a NULL) and those that can also be processed as regular predicates after
+  // the join predicates (post-join predicates, e.g., additional join predicates for inner joins). Since the
+  // multi-predicate join is currently slower than a regular predicate (i.e., a full table scan), we only use it in
+  // cases where it is required for a correct result.
   auto join_node_predicates = std::vector<std::shared_ptr<AbstractExpression>>{};
   auto post_join_node_predicates = std::vector<std::shared_ptr<AbstractExpression>>{};
 

--- a/src/lib/optimizer/join_ordering/abstract_join_ordering_algorithm.cpp
+++ b/src/lib/optimizer/join_ordering/abstract_join_ordering_algorithm.cpp
@@ -78,10 +78,11 @@ std::shared_ptr<AbstractLQPNode> AbstractJoinOrderingAlgorithm::_add_join_to_pla
   std::sort(join_predicates_and_cost.begin(), join_predicates_and_cost.end(),
             [&](const auto& lhs, const auto& rhs) { return lhs.second < rhs.second; });
 
-  // Categorize join predicates into those that can be processed as part of a join operator and those that need to be
-  // processed as normal predicates.
-  // NOTE: Since a multi-predicate join is currently slower than scanning the join output table, we do not emit multiple
-  //       predicates for the JoinNode, but use subsequent scans instead.
+  // Categorize join predicates into those that MUST be processed as part of a join operator (because they are required
+  // to see if an outer join emits a value or a NULL) and those that can also be processed as regular after the join
+  // predicates (post-join predicates, e.g., additional join predicates for inner joins). Since the multi-predicate
+  // join is currently slower than a regular predicate (i.e., a full table scan), we only use the multi-predicate join
+  // in cases where it is required for a correct result.
   auto join_node_predicates = std::vector<std::shared_ptr<AbstractExpression>>{};
   auto post_join_node_predicates = std::vector<std::shared_ptr<AbstractExpression>>{};
 


### PR DESCRIPTION
Adds to #1832. It is not that we have predicates that "need to be processed as normal predicates". We only have predicates that MUST be executed within the joins and predicates that NEED NOT.