### PR TITLE
Add const LQP support to visit_lqp() and clean up LQP hashing

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -72,19 +72,13 @@ AbstractLQPNode::~AbstractLQPNode() {
 size_t AbstractLQPNode::hash() const {
   size_t hash{0};
 
-  visit_lqp(std::const_pointer_cast<AbstractLQPNode>(shared_from_this()), [&hash](const auto& node) {
+  visit_lqp(shared_from_this(), [&hash](const auto& node) {
     if (node) {
       for (const auto& expression : node->node_expressions) {
         boost::hash_combine(hash, expression->hash());
       }
       boost::hash_combine(hash, node->type);
       boost::hash_combine(hash, node->_shallow_hash());
-      // since visit_lqp is used, the hash for an already visited node is not combined with
-      // the overall hash again, even if the same node is used as left and right input node (diamond structure).
-      // Therefore, a node that has only one (left) input node could have the same hash as a node with two
-      // (left and right) inputs which are in a diamond structure (same node pointer).
-      // To differentiate these, the boolean value (left input == right input) is combined with the overall hash.
-      boost::hash_combine(hash, node->left_input() == node->right_input());
       return LQPVisitation::VisitInputs;
     } else {
       return LQPVisitation::DoNotVisitInputs;

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -145,10 +145,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   bool operator!=(const AbstractLQPNode& rhs) const;
 
   /**
-   *  Builds a hash code by hashing the node type combined with specific member variables of
-   *  derived classes (see _shallow_hash()) and the hash codes of non-empty input nodes recursively.
-   *  Node expressions are not taken into account since combining the hashes of the expressions
-   *  can lead to unequal hash codes, even if lqp nodes are sementically equal.
+   * @return a hash for the (sub)plan whose root this node is
    */
   size_t hash() const;
 

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -99,12 +99,14 @@ enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
  * @tparam Visitor      Functor called with every node as a param.
  *                      Returns `LQPVisitation`
  */
-template <typename Visitor>
-void visit_lqp(const std::shared_ptr<AbstractLQPNode>& lqp, Visitor visitor) {
-  std::queue<std::shared_ptr<AbstractLQPNode>> node_queue;
+template <typename Node, typename Visitor>
+void visit_lqp(const std::shared_ptr<Node>& lqp, Visitor visitor) {
+  using AbstractNodeType = std::conditional_t<std::is_const_v<Node>, const AbstractLQPNode, AbstractLQPNode>;
+
+  std::queue<std::shared_ptr<AbstractNodeType>> node_queue;
   node_queue.push(lqp);
 
-  std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
+  std::unordered_set<std::shared_ptr<AbstractNodeType>> visited_nodes;
 
   while (!node_queue.empty()) {
     auto node = node_queue.front();

--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -57,7 +57,7 @@ TEST_F(AggregateNodeTest, Description) {
   EXPECT_EQ(description, "[Aggregate] GroupBy: [a, c] Aggregates: [SUM(a + b), SUM(a + c)]");
 }
 
-TEST_F(AggregateNodeTest, HashEquals) {
+TEST_F(AggregateNodeTest, HashingAndEqualityCheck) {
   const auto same_aggregate_node = AggregateNode::make(
       expression_vector(_a, _c), expression_vector(sum_(add_(_a, _b)), sum_(add_(_a, _c))), _mock_node);
 

--- a/src/test/logical_query_plan/alias_node_test.cpp
+++ b/src/test/logical_query_plan/alias_node_test.cpp
@@ -47,7 +47,7 @@ TEST_F(AliasNodeTest, ShallowEqualsAndCopy) {
   EXPECT_TRUE(alias_node->shallow_equals(*alias_node_copy, node_mapping));
 }
 
-TEST_F(AliasNodeTest, HashEquals) {
+TEST_F(AliasNodeTest, HashingAndEqualityCheck) {
   const auto alias_node_copy = alias_node->deep_copy();
   EXPECT_EQ(*alias_node, *alias_node_copy);
 

--- a/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
+++ b/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
@@ -28,7 +28,7 @@ ParameterIDs: []
 })");
 }
 
-TEST_F(CreatePreparedPlanNodeTest, HashEquals) {
+TEST_F(CreatePreparedPlanNodeTest, HashingAndEqualityCheck) {
   const auto deep_copied_node = create_prepared_plan_node->deep_copy();
   EXPECT_EQ(*create_prepared_plan_node, *deep_copied_node);
 

--- a/src/test/logical_query_plan/create_table_node_test.cpp
+++ b/src/test/logical_query_plan/create_table_node_test.cpp
@@ -31,7 +31,7 @@ TEST_F(CreateTableNodeTest, Description) {
 
 TEST_F(CreateTableNodeTest, NodeExpressions) { ASSERT_EQ(create_table_node->node_expressions.size(), 0u); }
 
-TEST_F(CreateTableNodeTest, HashEquals) {
+TEST_F(CreateTableNodeTest, HashingAndEqualityCheck) {
   const auto deep_copy_node = create_table_node->deep_copy();
   EXPECT_EQ(*create_table_node, *deep_copy_node);
 

--- a/src/test/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/logical_query_plan/create_view_node_test.cpp
@@ -33,7 +33,7 @@ TEST_F(CreateViewNodeTest, Description) {
             ")");
 }
 
-TEST_F(CreateViewNodeTest, HashEquals) {
+TEST_F(CreateViewNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_create_view_node, *_create_view_node);
   EXPECT_EQ(*_create_view_node, *_create_view_node->deep_copy());
 

--- a/src/test/logical_query_plan/delete_node_test.cpp
+++ b/src/test/logical_query_plan/delete_node_test.cpp
@@ -16,7 +16,7 @@ class DeleteNodeTest : public BaseTest {
 
 TEST_F(DeleteNodeTest, Description) { EXPECT_EQ(_delete_node->description(), "[Delete]"); }
 
-TEST_F(DeleteNodeTest, HashEquals) {
+TEST_F(DeleteNodeTest, HashingAndEqualityCheck) {
   const auto another_delete_node = DeleteNode::make();
   EXPECT_EQ(*_delete_node, *another_delete_node);
 

--- a/src/test/logical_query_plan/drop_table_node_test.cpp
+++ b/src/test/logical_query_plan/drop_table_node_test.cpp
@@ -13,7 +13,7 @@ class DropTableNodeTest : public ::testing::Test {
 
 TEST_F(DropTableNodeTest, Description) { EXPECT_EQ(drop_table_node->description(), "[DropTable] Name: 'some_table'"); }
 
-TEST_F(DropTableNodeTest, HashEquals) {
+TEST_F(DropTableNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*drop_table_node, *drop_table_node);
 
   const auto different_drop_table_node = DropTableNode::make("some_table2", false);

--- a/src/test/logical_query_plan/drop_view_node_test.cpp
+++ b/src/test/logical_query_plan/drop_view_node_test.cpp
@@ -15,7 +15,7 @@ class DropViewNodeTest : public ::testing::Test {
 
 TEST_F(DropViewNodeTest, Description) { EXPECT_EQ(_drop_view_node->description(), "[Drop] View: 'some_view'"); }
 
-TEST_F(DropViewNodeTest, HashEquals) {
+TEST_F(DropViewNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_drop_view_node, *_drop_view_node);
 
   const auto same_drop_view_node = DropViewNode::make("some_view", false);

--- a/src/test/logical_query_plan/dummy_table_node_test.cpp
+++ b/src/test/logical_query_plan/dummy_table_node_test.cpp
@@ -18,7 +18,7 @@ TEST_F(DummyTableNodeTest, Description) { EXPECT_EQ(_dummy_table_node->descripti
 
 TEST_F(DummyTableNodeTest, OutputColumnExpressions) { EXPECT_EQ(_dummy_table_node->column_expressions().size(), 0u); }
 
-TEST_F(DummyTableNodeTest, HashEquals) {
+TEST_F(DummyTableNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_dummy_table_node, *_dummy_table_node);
   EXPECT_EQ(*_dummy_table_node, *DummyTableNode::make());
 

--- a/src/test/logical_query_plan/insert_node_test.cpp
+++ b/src/test/logical_query_plan/insert_node_test.cpp
@@ -20,7 +20,7 @@ TEST_F(InsertNodeTest, Description) { EXPECT_EQ(_insert_node->description(), "[I
 
 TEST_F(InsertNodeTest, TableName) { EXPECT_EQ(_insert_node->table_name, "table_a"); }
 
-TEST_F(InsertNodeTest, HashEquals) {
+TEST_F(InsertNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_insert_node, *_insert_node);
   EXPECT_EQ(*_insert_node, *InsertNode::make("table_a"));
   EXPECT_NE(*_insert_node, *InsertNode::make("table_b"));

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -69,7 +69,7 @@ TEST_F(JoinNodeTest, OutputColumnExpressions) {
   EXPECT_EQ(*_join_node->column_expressions().at(4), *lqp_column_(_t_b_y));
 }
 
-TEST_F(JoinNodeTest, HashEquals) {
+TEST_F(JoinNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_join_node, *_join_node);
   EXPECT_EQ(*_inner_join_node, *_inner_join_node);
   EXPECT_EQ(*_semi_join_node, *_semi_join_node);

--- a/src/test/logical_query_plan/limit_node_test.cpp
+++ b/src/test/logical_query_plan/limit_node_test.cpp
@@ -21,7 +21,7 @@ class LimitNodeTest : public ::testing::Test {
 
 TEST_F(LimitNodeTest, Description) { EXPECT_EQ(_limit_node->description(), "[Limit] 10"); }
 
-TEST_F(LimitNodeTest, HashEquals) {
+TEST_F(LimitNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_limit_node, *_limit_node);
   EXPECT_EQ(*LimitNode::make(value_(10)), *_limit_node);
   EXPECT_NE(*LimitNode::make(value_(11)), *_limit_node);

--- a/src/test/logical_query_plan/mock_node_test.cpp
+++ b/src/test/logical_query_plan/mock_node_test.cpp
@@ -52,7 +52,7 @@ TEST_F(MockNodeTest, OutputColumnExpression) {
   EXPECT_EQ(*_mock_node_a->column_expressions().at(1), *lqp_column_({_mock_node_a, ColumnID{2}}));
 }
 
-TEST_F(MockNodeTest, HashEquals) {
+TEST_F(MockNodeTest, HashingAndEqualityCheck) {
   const auto same_mock_node_b =
       MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}}, "mock_name");
   const auto different_mock_node_1 =

--- a/src/test/logical_query_plan/predicate_node_test.cpp
+++ b/src/test/logical_query_plan/predicate_node_test.cpp
@@ -30,7 +30,7 @@ class PredicateNodeTest : public BaseTest {
 
 TEST_F(PredicateNodeTest, Descriptions) { EXPECT_EQ(_predicate_node->description(), "[Predicate] i = 5"); }
 
-TEST_F(PredicateNodeTest, HashEquals) {
+TEST_F(PredicateNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_predicate_node, *_predicate_node);
   const auto equal_table_node = StoredTableNode::make("table_a");
   LQPColumnReference equal_i{equal_table_node, ColumnID{0}};

--- a/src/test/logical_query_plan/projection_node_test.cpp
+++ b/src/test/logical_query_plan/projection_node_test.cpp
@@ -39,7 +39,7 @@ TEST_F(ProjectionNodeTest, Description) {
   EXPECT_EQ(_projection_node->description(), "[Projection] c, a, b, b + c, a + c");
 }
 
-TEST_F(ProjectionNodeTest, HashEquals) {
+TEST_F(ProjectionNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_projection_node, *_projection_node);
 
   const auto different_projection_node_a =

--- a/src/test/logical_query_plan/sort_node_test.cpp
+++ b/src/test/logical_query_plan/sort_node_test.cpp
@@ -44,7 +44,7 @@ TEST_F(SortNodeTest, Descriptions) {
   EXPECT_EQ(sort_c->description(), "[Sort] d (DescendingNullsFirst), f (AscendingNullsLast), i (DescendingNullsLast)");
 }
 
-TEST_F(SortNodeTest, HashEquals) {
+TEST_F(SortNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_sort_node, *_sort_node);
 
   const auto sort_a =

--- a/src/test/logical_query_plan/static_table_node_test.cpp
+++ b/src/test/logical_query_plan/static_table_node_test.cpp
@@ -25,7 +25,7 @@ TEST_F(StaticTableNodeTest, Description) {
 
 TEST_F(StaticTableNodeTest, NodeExpressions) { ASSERT_EQ(static_table_node->node_expressions.size(), 0u); }
 
-TEST_F(StaticTableNodeTest, HashEquals) {
+TEST_F(StaticTableNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*static_table_node, *static_table_node);
 
   const auto same_static_table_node = StaticTableNode::make(Table::create_dummy_table(column_definitions));

--- a/src/test/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/logical_query_plan/stored_table_node_test.cpp
@@ -76,7 +76,7 @@ TEST_F(StoredTableNodeTest, ColumnExpressions) {
   EXPECT_EQ(*_stored_table_node->column_expressions().at(1u), *lqp_column_(_c));
 }
 
-TEST_F(StoredTableNodeTest, HashEquals) {
+TEST_F(StoredTableNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_stored_table_node, *_stored_table_node);
 
   const auto different_node_a = StoredTableNode::make("t_b");

--- a/src/test/logical_query_plan/union_node_test.cpp
+++ b/src/test/logical_query_plan/union_node_test.cpp
@@ -42,7 +42,7 @@ TEST_F(UnionNodeTest, OutputColumnExpressions) {
   EXPECT_EQ(*_union_node->column_expressions().at(2), *_mock_node1->column_expressions().at(2));
 }
 
-TEST_F(UnionNodeTest, HashEquals) {
+TEST_F(UnionNodeTest, HashingAndEqualityCheck) {
   auto same_union_node = UnionNode::make(UnionMode::Positions);
   same_union_node->set_left_input(_mock_node1);
   same_union_node->set_right_input(_mock_node1);

--- a/src/test/logical_query_plan/update_node_test.cpp
+++ b/src/test/logical_query_plan/update_node_test.cpp
@@ -29,7 +29,7 @@ TEST_F(UpdateNodeTest, Description) { EXPECT_EQ(_update_node->description(), "[U
 
 TEST_F(UpdateNodeTest, TableName) { EXPECT_EQ(_update_node->table_name, "table_a"); }
 
-TEST_F(UpdateNodeTest, HashEquals) {
+TEST_F(UpdateNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_update_node, *_update_node);
 
   const auto other_mock_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Long, "a"}}));
@@ -39,23 +39,18 @@ TEST_F(UpdateNodeTest, HashEquals) {
   const auto other_update_node_c = UpdateNode::make("table_a", other_mock_node, _mock_node);
   const auto other_update_node_d = UpdateNode::make("table_a", _mock_node, other_mock_node);
   const auto other_update_node_e = UpdateNode::make("table_a", other_mock_node, other_mock_node);
-  const auto other_update_node_f = UpdateNode::make("table_a", other_mock_node);
 
   EXPECT_EQ(*_update_node, *other_update_node_a);
   EXPECT_NE(*_update_node, *other_update_node_b);
   EXPECT_NE(*_update_node, *other_update_node_c);
   EXPECT_NE(*_update_node, *other_update_node_d);
   EXPECT_NE(*_update_node, *other_update_node_e);
-  EXPECT_NE(*_update_node, *other_update_node_f);
-  EXPECT_NE(*other_update_node_e, *other_update_node_f);
 
   EXPECT_EQ(_update_node->hash(), other_update_node_a->hash());
   EXPECT_NE(_update_node->hash(), other_update_node_b->hash());
   EXPECT_NE(_update_node->hash(), other_update_node_c->hash());
   EXPECT_NE(_update_node->hash(), other_update_node_d->hash());
   EXPECT_NE(_update_node->hash(), other_update_node_e->hash());
-  EXPECT_NE(_update_node->hash(), other_update_node_f->hash());
-  EXPECT_NE(other_update_node_e->hash(), other_update_node_f->hash());
 }
 
 TEST_F(UpdateNodeTest, Copy) { EXPECT_EQ(*_update_node->deep_copy(), *_update_node); }

--- a/src/test/logical_query_plan/validate_node_test.cpp
+++ b/src/test/logical_query_plan/validate_node_test.cpp
@@ -18,7 +18,7 @@ class ValidateNodeTest : public BaseTest {
 
 TEST_F(ValidateNodeTest, Description) { EXPECT_EQ(_validate_node->description(), "[Validate]"); }
 
-TEST_F(ValidateNodeTest, HashEquals) {
+TEST_F(ValidateNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_validate_node, *_validate_node);
 
   EXPECT_EQ(*_validate_node, *ValidateNode::make());

--- a/src/test/storage/table_column_definition_test.cpp
+++ b/src/test/storage/table_column_definition_test.cpp
@@ -12,7 +12,7 @@ class TableColumnDefinitionTest : public BaseTest {
   void SetUp() override {}
 };
 
-TEST_F(TableColumnDefinitionTest, HashEquals) {
+TEST_F(TableColumnDefinitionTest, HashingAndEqualityCheck) {
   TableColumnDefinition column_definition{"a", DataType::Int, false};
   TableColumnDefinition equal_column_definition{"a", DataType::Int, false};
   TableColumnDefinition different_column_definition_a{"c", DataType::Int, false};


### PR DESCRIPTION
* Remove necessity to use const cast by making visit_lqp() support const LQPs
* HashEquals -> HashingAndEqualityCheck because "HashEquals" to me sound like "test whether hashes are equal", not "test whether hashing and equality checks work"
* Remove the left_input==right_input seed from the LQP hash - the only test that this broke was a IMO malformed test with an UpdateNode with only one input (should always be two, right?)