### PR TITLE
Fix chunk size in benchmarks, add join side in viz

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ try {
               sh "./scripts/test/hyriseConsole_test.py clang-release"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-              sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
+              sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
             } else {
               Utils.markStageSkippedForConditional("clangRelease")
@@ -114,11 +114,11 @@ try {
               sh "./scripts/test/hyriseConsole_test.py clang-debug"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-              sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
+              sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
               sh "./scripts/test/hyriseConsole_test.py gcc-debug"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-              sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
+              sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
             } else {
               Utils.markStageSkippedForConditional("debugSystemTests")
@@ -162,7 +162,7 @@ try {
               sh "./scripts/test/hyriseConsole_test.py gcc-release"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-              sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
+              sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
             }
           } else {
               Utils.markStageSkippedForConditional("gccRelease")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,10 +97,10 @@ try {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "./clang-release/hyriseTest clang-release"
               sh "./clang-release/hyriseSystemTest clang-release"
-              sh "cd clang-release; ../scripts/test/hyriseConsole_test.py ."
-              sh "cd clang-release; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
-              sh "cd clang-release; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
-              sh "cd clang-release; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
+              sh "./scripts/test/hyriseConsole_test.py clang-release"
+              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
+              sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
+              sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
 
             } else {
               Utils.markStageSkippedForConditional("clangRelease")
@@ -111,14 +111,14 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
               sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-              sh "cd clang-debug; ../scripts/test/hyriseConsole_test.py ."
-              sh "cd clang-debug; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
-              sh "cd clang-debug; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
-              sh "cd clang-debug; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
-              sh "cd gcc-debug; ../scripts/test/hyriseConsole_test.py ."
-              sh "cd gcc-debug; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
-              sh "cd gcc-debug; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
-              sh "cd gcc-debug; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
+              sh "./scripts/test/hyriseConsole_test.py clang-debug"
+              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+              sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+              sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
+              sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+              sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+              sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
 
             } else {
               Utils.markStageSkippedForConditional("debugSystemTests")
@@ -159,10 +159,10 @@ try {
               sh "export CCACHE_BASEDIR=`pwd`; cd gcc-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "./gcc-release/hyriseTest gcc-release"
               sh "./gcc-release/hyriseSystemTest gcc-release"
-              sh "cd gcc-release; ../scripts/test/hyriseConsole_test.py ."
-              sh "cd gcc-release; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
-              sh "cd gcc-release; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
-              sh "cd gcc-release; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
+              sh "./scripts/test/hyriseConsole_test.py gcc-release"
+              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+              sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+              sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." # Own folder to isolate visualization
             }
           } else {
               Utils.markStageSkippedForConditional("gccRelease")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,10 +97,10 @@ try {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "./clang-release/hyriseTest clang-release"
               sh "./clang-release/hyriseSystemTest clang-release"
-              sh "./scripts/test/hyriseConsole_test.py clang-release"
-              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
-              sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-              sh "./scripts/test/hyriseBenchmarkTPCH_test.py clang-release"
+              sh "cd clang-release; ../scripts/test/hyriseConsole_test.py ."
+              sh "cd clang-release; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
+              sh "cd clang-release; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
+              sh "cd clang-release; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
 
             } else {
               Utils.markStageSkippedForConditional("clangRelease")
@@ -111,14 +111,14 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
               sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-              sh "./scripts/test/hyriseConsole_test.py clang-debug"
-              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-              sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-              sh "./scripts/test/hyriseBenchmarkTPCH_test.py clang-debug"
-              sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-              sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-              sh "./scripts/test/hyriseBenchmarkTPCH_test.py gcc-debug"
+              sh "cd clang-debug; ../scripts/test/hyriseConsole_test.py ."
+              sh "cd clang-debug; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
+              sh "cd clang-debug; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
+              sh "cd clang-debug; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
+              sh "cd gcc-debug; ../scripts/test/hyriseConsole_test.py ."
+              sh "cd gcc-debug; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
+              sh "cd gcc-debug; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
+              sh "cd gcc-debug; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
 
             } else {
               Utils.markStageSkippedForConditional("debugSystemTests")
@@ -159,10 +159,10 @@ try {
               sh "export CCACHE_BASEDIR=`pwd`; cd gcc-release && make all -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "./gcc-release/hyriseTest gcc-release"
               sh "./gcc-release/hyriseSystemTest gcc-release"
-              sh "./scripts/test/hyriseConsole_test.py gcc-release"
-              sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-              sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-              sh "./scripts/test/hyriseBenchmarkTPCH_test.py gcc-release"
+              sh "cd gcc-release; ../scripts/test/hyriseConsole_test.py ."
+              sh "cd gcc-release; ../scripts/test/hyriseBenchmarkJoinOrder_test.py ."
+              sh "cd gcc-release; ../scripts/test/hyriseBenchmarkFileBased_test.py ."
+              sh "cd gcc-release; ../scripts/test/hyriseBenchmarkTPCH_test.py ."
             }
           } else {
               Utils.markStageSkippedForConditional("gccRelease")

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -72,6 +72,7 @@ def main():
 
   arguments = {}
   arguments["--scale"] = ".005"
+  arguments["--chunk_size"] = "10000"
   arguments["--queries"] = "'2,4,6'"
   arguments["--time"] = "10"
   arguments["--runs"] = "100"
@@ -91,7 +92,7 @@ def main():
   benchmark.expect("Running benchmark in 'Ordered' mode")
   benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'LZ4'")
-  benchmark.expect("Chunk size is 100000")
+  benchmark.expect("Chunk size is 10000")
   benchmark.expect("Max runs per item is 100")
   benchmark.expect("Max duration per item is 10 seconds")
   benchmark.expect("Warmup duration per item is 10 seconds")
@@ -102,6 +103,17 @@ def main():
 
   close_benchmark(benchmark)
   check_exit_status(benchmark)
+
+  visualization_file = 'TPC-H_06-PQP.svg'
+  if not os.path.isfile(visualization_file):
+    print ("ERROR: Cannot find visualization file " + visualization_file)
+    sys.exit(1)
+  with open(visualization_file) as f:
+    # Check whether the (a) the GetTable node exists and (b) the chunk count is correct for the given scale factor
+    if not '2/4 chunk(s)' in f:
+      print ("ERROR: Did not find expected pruning information in the visualization file")
+      sys.exit(1)
+
 
   if return_error:
     sys.exit(1)

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -110,7 +110,7 @@ def main():
     sys.exit(1)
   with open(visualization_file) as f:
     # Check whether the (a) the GetTable node exists and (b) the chunk count is correct for the given scale factor
-    if not '/4 chunk(s)' in f:
+    if not '/4 chunk(s)' in f.read():
       print ("ERROR: Did not find expected pruning information in the visualization file")
       sys.exit(1)
 

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -110,7 +110,7 @@ def main():
     sys.exit(1)
   with open(visualization_file) as f:
     # Check whether the (a) the GetTable node exists and (b) the chunk count is correct for the given scale factor
-    if not '2/4 chunk(s)' in f:
+    if not '/4 chunk(s)' in f:
       print ("ERROR: Did not find expected pruning information in the visualization file")
       sys.exit(1)
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -54,7 +54,8 @@ void AbstractTableGenerator::generate_and_store() {
       auto& table = table_info_by_name[table_name].table;
       auto table_wrapper = std::make_shared<TableWrapper>(table);
       table_wrapper->execute();
-      auto sort = std::make_shared<Sort>(table_wrapper, table->column_id_by_name(column_name));
+      auto sort = std::make_shared<Sort>(table_wrapper, table->column_id_by_name(column_name), OrderByMode::Ascending,
+                                         _benchmark_config->chunk_size);
       sort->execute();
       const auto immutable_sorted_table = sort->get_output();
       table = std::make_shared<Table>(immutable_sorted_table->column_definitions(), TableType::Data,

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
@@ -196,8 +196,8 @@ std::string TPCHBenchmarkItemRunner::_build_query(const BenchmarkItemID item_id)
       const auto begin_date = calculate_date(boost::gregorian::date{1993, 01, 01}, diff * 12);
       const auto end_date = calculate_date(boost::gregorian::date{1993, 01, 01}, (diff + 1) * 12);
 
-      static std::uniform_real_distribution<> discount_dist{0.02f, 0.09f};
-      const auto discount = discount_dist(random_engine);
+      static std::uniform_int_distribution<> discount_dist{2, 9};
+      const auto discount = 0.01f * discount_dist(random_engine);
 
       std::uniform_int_distribution<> quantity_dist{24, 25};
       const auto quantity = quantity_dist(random_engine);
@@ -297,7 +297,7 @@ std::string TPCHBenchmarkItemRunner::_build_query(const BenchmarkItemID item_id)
     }
 
     case 14 - 1: {
-      std::uniform_int_distribution<> date_diff_dist{0, 47};
+      std::uniform_int_distribution<> date_diff_dist{0, 5*12};
       const auto diff = date_diff_dist(random_engine);
       const auto begin_date = calculate_date(boost::gregorian::date{1993, 01, 01}, diff);
       const auto end_date = calculate_date(boost::gregorian::date{1993, 01, 01}, diff + 1);

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -42,6 +42,7 @@ struct VizEdgeInfo {
   double pen_width = 1.0;
   std::string dir = "forward";
   std::string style = "solid";
+  std::string arrowhead = "normal";
 };
 
 template <typename GraphBase>
@@ -55,6 +56,8 @@ class AbstractVisualizer {
   static const uint8_t MAX_LABEL_WIDTH = 50;
 
  public:
+  enum class InputSide { Left, Right };
+
   AbstractVisualizer() : AbstractVisualizer(GraphvizConfig{}, VizGraphInfo{}, VizVertexInfo{}, VizEdgeInfo{}) {}
 
   AbstractVisualizer(GraphvizConfig graphviz_config, VizGraphInfo graph_info, VizVertexInfo vertex_info,
@@ -83,6 +86,7 @@ class AbstractVisualizer {
     _add_property("penwidth", &VizEdgeInfo::pen_width);
     _add_property("style", &VizEdgeInfo::style);
     _add_property("dir", &VizEdgeInfo::dir);
+    _add_property("arrowhead", &VizEdgeInfo::arrowhead);
   }
 
   virtual ~AbstractVisualizer() = default;

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -120,7 +120,7 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
   info.label = label_stream.str();
   info.pen_width = pen_width;
   if (to->input_count() == 2) {
-    info.arrowhead = side == InputSide::Left ? "normallbox" : "normalrdiamond";
+    info.arrowhead = side == InputSide::Left ? "lnormal" : "rnormal";
   }
 
   _add_edge(from, to, info);

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -52,13 +52,13 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
   if (node->left_input()) {
     auto left_input = node->left_input();
     _build_subtree(left_input, visualized_nodes, visualized_sub_queries);
-    _build_dataflow(left_input, node);
+    _build_dataflow(left_input, node, InputSide::Left);
   }
 
   if (node->right_input()) {
     auto right_input = node->right_input();
     _build_subtree(right_input, visualized_nodes, visualized_sub_queries);
-    _build_dataflow(right_input, node);
+    _build_dataflow(right_input, node, InputSide::Right);
   }
 
   // Visualize subqueries
@@ -83,7 +83,7 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
 }
 
 void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from,
-                                    const std::shared_ptr<AbstractLQPNode>& to) {
+                                    const std::shared_ptr<AbstractLQPNode>& to, const InputSide side) {
   float row_count, row_percentage = 100.0f;
   double pen_width;
 
@@ -119,6 +119,9 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
   VizEdgeInfo info = _default_edge;
   info.label = label_stream.str();
   info.pen_width = pen_width;
+  if (to->input_count() == 2) {
+    info.arrowhead = side == InputSide::Left ? "normallbox" : "normalrdiamond";
+  }
 
   _add_edge(from, to, info);
 }

--- a/src/lib/visualization/lqp_visualizer.hpp
+++ b/src/lib/visualization/lqp_visualizer.hpp
@@ -28,7 +28,8 @@ class LQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
                       std::unordered_set<std::shared_ptr<const AbstractLQPNode>>& visualized_nodes,
                       ExpressionUnorderedSet& visualized_sub_queries);
 
-  void _build_dataflow(const std::shared_ptr<AbstractLQPNode>& from, const std::shared_ptr<AbstractLQPNode>& to);
+  void _build_dataflow(const std::shared_ptr<AbstractLQPNode>& from, const std::shared_ptr<AbstractLQPNode>& to,
+                       const InputSide side);
 
   CardinalityEstimator _cardinality_estimator;
 };

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -40,13 +40,13 @@ void PQPVisualizer::_build_subtree(const std::shared_ptr<const AbstractOperator>
   if (op->input_left()) {
     auto left = op->input_left();
     _build_subtree(left, visualized_ops);
-    _build_dataflow(left, op);
+    _build_dataflow(left, op, InputSide::Left);
   }
 
   if (op->input_right()) {
     auto right = op->input_right();
     _build_subtree(right, visualized_ops);
-    _build_dataflow(right, op);
+    _build_dataflow(right, op, InputSide::Right);
   }
 
   switch (op->type()) {
@@ -91,7 +91,7 @@ void PQPVisualizer::_visualize_subqueries(const std::shared_ptr<const AbstractOp
 }
 
 void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator>& from,
-                                    const std::shared_ptr<const AbstractOperator>& to) {
+                                    const std::shared_ptr<const AbstractOperator>& to, const InputSide side) {
   VizEdgeInfo info = _default_edge;
 
   if (const auto& output = from->get_output()) {
@@ -104,6 +104,9 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
     info.label = stream.str();
 
     info.pen_width = output->row_count();
+    if (to->input_right() != nullptr) {
+      info.arrowhead = side == InputSide::Left ? "normallbox" : "normalrdiamond";
+    }
   }
 
   _add_edge(from, to, info);

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -105,7 +105,7 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
 
     info.pen_width = output->row_count();
     if (to->input_right() != nullptr) {
-      info.arrowhead = side == InputSide::Left ? "normallbox" : "normalrdiamond";
+      info.arrowhead = side == InputSide::Left ? "lnormal" : "rnormal";
     }
   }
 

--- a/src/lib/visualization/pqp_visualizer.hpp
+++ b/src/lib/visualization/pqp_visualizer.hpp
@@ -28,7 +28,7 @@ class PQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
                              std::unordered_set<std::shared_ptr<const AbstractOperator>>& visualized_ops);
 
   void _build_dataflow(const std::shared_ptr<const AbstractOperator>& from,
-                       const std::shared_ptr<const AbstractOperator>& to);
+                       const std::shared_ptr<const AbstractOperator>& to, const InputSide side);
 
   void _add_operator(const std::shared_ptr<const AbstractOperator>& op);
 };


### PR DESCRIPTION
fixes #1840 

Also, as the query plans become more complex, this changes the arrowheads of multi-input nodes to identify the input sides. This is so that we don't mistake the visually left input of this semi join to be the probe side.