### PR TITLE
Update Google Test

### DIFF
--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -259,7 +259,7 @@ class CacheTest : public BaseTest {};
 // Here, all cache types are defined.
 using CacheTypes = ::testing::Types<LRUCache<int, int>, LRUKCache<2, int, int>, GDSCache<int, int>, GDFSCache<int, int>,
                                     RandomCache<int, int>>;
-TYPED_TEST_CASE(CacheTest, CacheTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(CacheTest, CacheTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(CacheTest, Size) {
   TypeParam cache(3);

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -139,7 +139,7 @@ class OperatorsAggregateTest : public BaseTest {
 };
 
 using AggregateTypes = ::testing::Types<AggregateHash, AggregateSort>;
-TYPED_TEST_CASE(OperatorsAggregateTest, AggregateTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(OperatorsAggregateTest, AggregateTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(OperatorsAggregateTest, OperatorName) {
   auto aggregate = std::make_shared<TypeParam>(

--- a/src/test/operators/index_scan_test.cpp
+++ b/src/test/operators/index_scan_test.cpp
@@ -106,7 +106,7 @@ typedef ::testing::Types<GroupKeyIndex, AdaptiveRadixTreeIndex, CompositeGroupKe
                          BTreeIndex /* add further indexes */>
     DerivedIndexes;
 
-TYPED_TEST_CASE(OperatorsIndexScanTest, DerivedIndexes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(OperatorsIndexScanTest, DerivedIndexes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(OperatorsIndexScanTest, SingleColumnScanOnDataTable) {
   // we do not need to check for a non existing value, because that happens automatically when we scan the second chunk

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -49,7 +49,7 @@ void test_hash_map(const std::vector<T>& values) {
 }
 
 using DataTypes = ::testing::Types<int, float, double>;
-TYPED_TEST_CASE(JoinHashTypesTest, DataTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(JoinHashTypesTest, DataTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinHashTypesTest, BuildSingleValueLargePosList) {
   int test_item_count = 500;

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -132,7 +132,7 @@ class JoinIndexTest : public BaseTest {
 
 typedef ::testing::Types<AdaptiveRadixTreeIndex, CompositeGroupKeyIndex, BTreeIndex, GroupKeyIndex> DerivedIndices;
 
-TYPED_TEST_CASE(JoinIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(JoinIndexTest, DerivedIndices, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinIndexTest, LeftJoinFallBack) {
   this->test_join_output(this->_table_wrapper_a_no_index, this->_table_wrapper_b_no_index,

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -587,10 +587,10 @@ TEST_P(JoinTestRunner, TestJoin) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(JoinNestedLoop, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinNestedLoop>()));
-INSTANTIATE_TEST_CASE_P(JoinHash, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()));
-INSTANTIATE_TEST_CASE_P(JoinSortMerge, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()));
+INSTANTIATE_TEST_SUITE_P(JoinNestedLoop, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinNestedLoop>()));
+INSTANTIATE_TEST_SUITE_P(JoinHash, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()));
+INSTANTIATE_TEST_SUITE_P(JoinSortMerge, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()));
 // INSTANTIATE_TEST_CASE_P(JoinIndex, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinIndex>()));
-INSTANTIATE_TEST_CASE_P(JoinMPSM, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()));
+INSTANTIATE_TEST_SUITE_P(JoinMPSM, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()));
 
 }  // namespace opossum

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -587,10 +587,14 @@ TEST_P(JoinTestRunner, TestJoin) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(JoinNestedLoop, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinNestedLoop>()));
-INSTANTIATE_TEST_SUITE_P(JoinHash, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()));
-INSTANTIATE_TEST_SUITE_P(JoinSortMerge, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()));
+INSTANTIATE_TEST_SUITE_P(JoinNestedLoop, JoinTestRunner,
+                         testing::ValuesIn(JoinTestRunner::create_configurations<JoinNestedLoop>()));
+INSTANTIATE_TEST_SUITE_P(JoinHash, JoinTestRunner,
+                         testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()));
+INSTANTIATE_TEST_SUITE_P(JoinSortMerge, JoinTestRunner,
+                         testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()));
 // INSTANTIATE_TEST_CASE_P(JoinIndex, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinIndex>()));
-INSTANTIATE_TEST_SUITE_P(JoinMPSM, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()));
+INSTANTIATE_TEST_SUITE_P(JoinMPSM, JoinTestRunner,
+                         testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()));
 
 }  // namespace opossum

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -593,7 +593,8 @@ INSTANTIATE_TEST_SUITE_P(JoinHash, JoinTestRunner,
                          testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()));
 INSTANTIATE_TEST_SUITE_P(JoinSortMerge, JoinTestRunner,
                          testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()));
-// INSTANTIATE_TEST_CASE_P(JoinIndex, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinIndex>()));
+// INSTANTIATE_TEST_SUITE_P(JoinIndex, JoinTestRunner,
+//                          testing::ValuesIn(JoinTestRunner::create_configurations<JoinIndex>()));
 INSTANTIATE_TEST_SUITE_P(JoinMPSM, JoinTestRunner,
                          testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()));
 

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -587,12 +587,10 @@ TEST_P(JoinTestRunner, TestJoin) {
   }
 }
 
-// clang-format off
-INSTANTIATE_TEST_CASE_P(JoinNestedLoop, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinNestedLoop>()), );  // NOLINT
-INSTANTIATE_TEST_CASE_P(JoinHash, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()), );  // NOLINT
-INSTANTIATE_TEST_CASE_P(JoinSortMerge, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()), );  // NOLINT
-// INSTANTIATE_TEST_CASE_P(JoinIndex, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinIndex>()), );  // NOLINT
-INSTANTIATE_TEST_CASE_P(JoinMPSM, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()), );  // NOLINT
-// clang-format on
+INSTANTIATE_TEST_CASE_P(JoinNestedLoop, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinNestedLoop>()));
+INSTANTIATE_TEST_CASE_P(JoinHash, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinHash>()));
+INSTANTIATE_TEST_CASE_P(JoinSortMerge, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinSortMerge>()));
+// INSTANTIATE_TEST_CASE_P(JoinIndex, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinIndex>()));
+INSTANTIATE_TEST_CASE_P(JoinMPSM, JoinTestRunner, testing::ValuesIn(JoinTestRunner::create_configurations<JoinMPSM>()));
 
 }  // namespace opossum

--- a/src/test/operators/operator_deep_copy_test.cpp
+++ b/src/test/operators/operator_deep_copy_test.cpp
@@ -56,7 +56,7 @@ class DeepCopyTestJoin : public OperatorDeepCopyTest {};
 
 // here we define all Join types
 using JoinTypes = ::testing::Types<JoinNestedLoop, JoinHash, JoinSortMerge, JoinMPSM>;
-TYPED_TEST_CASE(DeepCopyTestJoin, JoinTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(DeepCopyTestJoin, JoinTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(DeepCopyTestJoin, DeepCopyJoin) {
   std::shared_ptr<Table> expected_result =

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -58,7 +58,7 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
 
 // As long as two implementation of dictionary encoding exist, this ensure to run the tests for both.
 INSTANTIATE_TEST_SUITE_P(DictionaryEncodingTypes, OperatorsSortTest, ::testing::Values(EncodingType::Dictionary),
-                        formatter);
+                         formatter);
 
 TEST_P(OperatorsSortTest, AscendingSortOfOneColumn) {
   std::shared_ptr<Table> expected_result = load_table("resources/test_data/tbl/int_float_sorted.tbl", 2);

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -57,7 +57,7 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
 };
 
 // As long as two implementation of dictionary encoding exist, this ensure to run the tests for both.
-INSTANTIATE_TEST_CASE_P(DictionaryEncodingTypes, OperatorsSortTest, ::testing::Values(EncodingType::Dictionary),
+INSTANTIATE_TEST_SUITE_P(DictionaryEncodingTypes, OperatorsSortTest, ::testing::Values(EncodingType::Dictionary),
                         formatter);
 
 TEST_P(OperatorsSortTest, AscendingSortOfOneColumn) {

--- a/src/test/operators/table_scan_between_test.cpp
+++ b/src/test/operators/table_scan_between_test.cpp
@@ -184,7 +184,7 @@ TEST_P(TableScanBetweenTest, Exclusive) {
   _test_between_scan(exclusive_tests, PredicateCondition::BetweenExclusive);
 }
 
-INSTANTIATE_TEST_CASE_P(TableScanBetweenTestInstances, TableScanBetweenTest, testing::ValuesIn(create_test_params()),
+INSTANTIATE_TEST_SUITE_P(TableScanBetweenTestInstances, TableScanBetweenTest, testing::ValuesIn(create_test_params()),
                         TypedOperatorBaseTest::format);
 
 }  // namespace opossum

--- a/src/test/operators/table_scan_between_test.cpp
+++ b/src/test/operators/table_scan_between_test.cpp
@@ -185,6 +185,6 @@ TEST_P(TableScanBetweenTest, Exclusive) {
 }
 
 INSTANTIATE_TEST_SUITE_P(TableScanBetweenTestInstances, TableScanBetweenTest, testing::ValuesIn(create_test_params()),
-                        TypedOperatorBaseTest::format);
+                         TypedOperatorBaseTest::format);
 
 }  // namespace opossum

--- a/src/test/operators/table_scan_sorted_segment_search_test.cpp
+++ b/src/test/operators/table_scan_sorted_segment_search_test.cpp
@@ -69,7 +69,7 @@ class OperatorsTableScanSortedSegmentSearchTest : public BaseTest, public ::test
 };
 
 // clang-format off
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     Predicates, OperatorsTableScanSortedSegmentSearchTest,
     ::testing::Combine(
         ::testing::Values(

--- a/src/test/operators/table_scan_string_test.cpp
+++ b/src/test/operators/table_scan_string_test.cpp
@@ -62,9 +62,9 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(EncodingTypes, OperatorsTableScanStringTest,
-                        ::testing::Values(EncodingType::Unencoded, EncodingType::Dictionary,
-                                          EncodingType::FixedStringDictionary, EncodingType::RunLength),
-                        formatter);
+                         ::testing::Values(EncodingType::Unencoded, EncodingType::Dictionary,
+                                           EncodingType::FixedStringDictionary, EncodingType::RunLength),
+                         formatter);
 
 TEST_P(OperatorsTableScanStringTest, ScanEquals) {
   auto scan = create_table_scan(_tw_string_compressed, ColumnID{1}, PredicateCondition::Equals, "Reeperbahn");

--- a/src/test/operators/table_scan_string_test.cpp
+++ b/src/test/operators/table_scan_string_test.cpp
@@ -61,7 +61,7 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
   return std::to_string(static_cast<uint32_t>(info.param));
 };
 
-INSTANTIATE_TEST_CASE_P(EncodingTypes, OperatorsTableScanStringTest,
+INSTANTIATE_TEST_SUITE_P(EncodingTypes, OperatorsTableScanStringTest,
                         ::testing::Values(EncodingType::Unencoded, EncodingType::Dictionary,
                                           EncodingType::FixedStringDictionary, EncodingType::RunLength),
                         formatter);

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -257,9 +257,9 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(EncodingTypes, OperatorsTableScanTest,
-                        ::testing::Values(EncodingType::Unencoded, EncodingType::Dictionary, EncodingType::RunLength,
-                                          EncodingType::FrameOfReference),
-                        formatter);
+                         ::testing::Values(EncodingType::Unencoded, EncodingType::Dictionary, EncodingType::RunLength,
+                                           EncodingType::FrameOfReference),
+                         formatter);
 
 TEST_P(OperatorsTableScanTest, DoubleScan) {
   std::shared_ptr<Table> expected_result = load_table("resources/test_data/tbl/int_float_filtered.tbl", 2);

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -256,7 +256,7 @@ auto formatter = [](const ::testing::TestParamInfo<EncodingType> info) {
   return std::to_string(static_cast<uint32_t>(info.param));
 };
 
-INSTANTIATE_TEST_CASE_P(EncodingTypes, OperatorsTableScanTest,
+INSTANTIATE_TEST_SUITE_P(EncodingTypes, OperatorsTableScanTest,
                         ::testing::Values(EncodingType::Unencoded, EncodingType::Dictionary, EncodingType::RunLength,
                                           EncodingType::FrameOfReference),
                         formatter);

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -4,7 +4,7 @@
 
 namespace opossum {
 
-INSTANTIATE_TEST_CASE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
+INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
                         testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
                                          testing::ValuesIn({EncodingType::Dictionary, EncodingType::RunLength,
                                                             EncodingType::FixedStringDictionary,

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -5,9 +5,9 @@
 namespace opossum {
 
 INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
-                        testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
-                                         testing::ValuesIn({EncodingType::Dictionary, EncodingType::RunLength,
-                                                            EncodingType::FixedStringDictionary,
-                                                            EncodingType::FrameOfReference})), );  // NOLINT
+                         testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
+                                          testing::ValuesIn({EncodingType::Dictionary, EncodingType::RunLength,
+                                                             EncodingType::FixedStringDictionary,
+                                                             EncodingType::FrameOfReference})));
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 #if HYRISE_JIT_SUPPORT
 
 // Test JIT with unencoded and dictionary encoded tables (the latter just for good measure)
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SQLiteTestRunnerJIT, SQLiteTestRunner,
     testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({true}),
                      testing::ValuesIn({EncodingType::Unencoded,

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_jit.cpp
@@ -9,7 +9,7 @@ INSTANTIATE_TEST_SUITE_P(
     SQLiteTestRunnerJIT, SQLiteTestRunner,
     testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({true}),
                      testing::ValuesIn({EncodingType::Unencoded,
-                                        EncodingType::Dictionary})), );  // NOLINT(whitespace/parens)  // NOLINT
+                                        EncodingType::Dictionary})));
 
 #endif
 

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
@@ -2,9 +2,9 @@
 
 namespace opossum {
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SQLiteTestRunnerUnencoded, SQLiteTestRunner,
     testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
-                     testing::ValuesIn({EncodingType::Unencoded})), );  // NOLINT(whitespace/parens)  // NOLINT
+                     testing::ValuesIn({EncodingType::Unencoded})));
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
@@ -2,9 +2,8 @@
 
 namespace opossum {
 
-INSTANTIATE_TEST_SUITE_P(
-    SQLiteTestRunnerUnencoded, SQLiteTestRunner,
-    testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
-                     testing::ValuesIn({EncodingType::Unencoded})));
+INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerUnencoded, SQLiteTestRunner,
+                         testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
+                                          testing::ValuesIn({EncodingType::Unencoded})));
 
 }  // namespace opossum

--- a/src/test/statistics/chunk_statistics/range_filter_test.cpp
+++ b/src/test/statistics/chunk_statistics/range_filter_test.cpp
@@ -37,7 +37,7 @@ class RangeFilterTest : public ::testing::Test {
 };
 
 using FilterTypes = ::testing::Types<int, float, double>;
-TYPED_TEST_CASE(RangeFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(RangeFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
   const auto lowest = std::numeric_limits<TypeParam>::lowest();

--- a/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
@@ -122,7 +122,7 @@ class CountingQuotientFilterTypedTest : public BaseTest {
 };
 
 using Types = ::testing::Types<int32_t, int64_t, pmr_string>;
-TYPED_TEST_CASE(CountingQuotientFilterTypedTest, Types, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(CountingQuotientFilterTypedTest, Types, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(CountingQuotientFilterTypedTest, ValueCounts) {
   this->test_value_counts(this->cqf2);

--- a/src/test/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/min_max_filter_test.cpp
@@ -51,7 +51,7 @@ class MinMaxFilterTest<pmr_string> : public ::testing::Test {
 };
 
 using FilterTypes = ::testing::Types<int, float, double, pmr_string>;
-TYPED_TEST_CASE(MinMaxFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(MinMaxFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(MinMaxFilterTest, CanPruneOnBounds) {
   auto filter = std::make_unique<MinMaxFilter<TypeParam>>(this->_values.front(), this->_values.back());

--- a/src/test/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/range_filter_test.cpp
@@ -39,7 +39,7 @@ class RangeFilterTest : public ::testing::Test {
 };
 
 using FilterTypes = ::testing::Types<int, float, double>;
-TYPED_TEST_CASE(RangeFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(RangeFilterTest, FilterTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(RangeFilterTest, ValueRangeTooLarge) {
   const auto lowest = std::numeric_limits<TypeParam>::lowest();

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -80,6 +80,6 @@ INSTANTIATE_TEST_SUITE_P(
                       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
                       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
                       SegmentEncodingSpec{EncodingType::FrameOfReference}, SegmentEncodingSpec{EncodingType::RunLength},
-                      SegmentEncodingSpec{EncodingType::LZ4}), );  // NOLINT
+                      SegmentEncodingSpec{EncodingType::LZ4}));
 
 }  // namespace opossum

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -74,7 +74,7 @@ TEST_P(AnySegmentIterableTest, IntWithPositionFilter) {
   EXPECT_EQ(index, position_filter->size());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AnySegmentIterableTestInstances, AnySegmentIterableTest,
     ::testing::Values(SegmentEncodingSpec{EncodingType::Unencoded}, SegmentEncodingSpec{EncodingType::Dictionary},
                       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -76,7 +76,7 @@ auto formatter = [](const ::testing::TestParamInfo<VectorCompressionType> info) 
   return string;
 };
 
-INSTANTIATE_TEST_CASE_P(VectorCompressionTypes, CompressedVectorTest,
+INSTANTIATE_TEST_SUITE_P(VectorCompressionTypes, CompressedVectorTest,
                         ::testing::Values(VectorCompressionType::SimdBp128,
                                           VectorCompressionType::FixedSizeByteAligned),
                         formatter);

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -77,9 +77,9 @@ auto formatter = [](const ::testing::TestParamInfo<VectorCompressionType> info) 
 };
 
 INSTANTIATE_TEST_SUITE_P(VectorCompressionTypes, CompressedVectorTest,
-                        ::testing::Values(VectorCompressionType::SimdBp128,
-                                          VectorCompressionType::FixedSizeByteAligned),
-                        formatter);
+                         ::testing::Values(VectorCompressionType::SimdBp128,
+                                           VectorCompressionType::FixedSizeByteAligned),
+                         formatter);
 
 TEST_P(CompressedVectorTest, DecodeIncreasingSequenceUsingIterators) {
   const auto sequence = this->generate_sequence(4'200, 8u);

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -33,9 +33,9 @@ auto formatter = [](const ::testing::TestParamInfo<VectorCompressionType> info) 
 };
 
 INSTANTIATE_TEST_SUITE_P(VectorCompressionTypes, StorageDictionarySegmentTest,
-                        ::testing::Values(VectorCompressionType::SimdBp128,
-                                          VectorCompressionType::FixedSizeByteAligned),
-                        formatter);
+                         ::testing::Values(VectorCompressionType::SimdBp128,
+                                           VectorCompressionType::FixedSizeByteAligned),
+                         formatter);
 
 TEST_P(StorageDictionarySegmentTest, LowerUpperBound) {
   for (int i = 0; i <= 10; i += 2) vs_int->append(i);

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -32,7 +32,7 @@ auto formatter = [](const ::testing::TestParamInfo<VectorCompressionType> info) 
   return string;
 };
 
-INSTANTIATE_TEST_CASE_P(VectorCompressionTypes, StorageDictionarySegmentTest,
+INSTANTIATE_TEST_SUITE_P(VectorCompressionTypes, StorageDictionarySegmentTest,
                         ::testing::Values(VectorCompressionType::SimdBp128,
                                           VectorCompressionType::FixedSizeByteAligned),
                         formatter);

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -132,7 +132,7 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   return string;
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SegmentEncodingSpecs, EncodedSegmentTest,
     ::testing::Values(SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
                       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -131,7 +131,7 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   return string;
 };
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SegmentEncodingSpecs, EncodedStringSegmentTest,
     ::testing::Values(SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
                       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -151,7 +151,7 @@ TEST_P(MaterializeTest, MaterializeNullsTwoSegments) {
   EXPECT_EQ(expected, nulls);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     MaterializeTestInstances, MaterializeTest,
     ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
                         std::end(all_segment_encoding_specs)), );  // NOLINT(whitespace/parens)  // NOLINT

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -154,6 +154,6 @@ TEST_P(MaterializeTest, MaterializeNullsTwoSegments) {
 INSTANTIATE_TEST_SUITE_P(
     MaterializeTestInstances, MaterializeTest,
     ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                        std::end(all_segment_encoding_specs)), );  // NOLINT(whitespace/parens)  // NOLINT
+                        std::end(all_segment_encoding_specs)));
 
 }  // namespace opossum

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -151,9 +151,8 @@ TEST_P(MaterializeTest, MaterializeNullsTwoSegments) {
   EXPECT_EQ(expected, nulls);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    MaterializeTestInstances, MaterializeTest,
-    ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                        std::end(all_segment_encoding_specs)));
+INSTANTIATE_TEST_SUITE_P(MaterializeTestInstances, MaterializeTest,
+                         ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
+                                             std::end(all_segment_encoding_specs)));
 
 }  // namespace opossum

--- a/src/test/storage/multi_segment_index_test.cpp
+++ b/src/test/storage/multi_segment_index_test.cpp
@@ -50,7 +50,7 @@ class MultiSegmentIndexTest : public BaseTest {
 
 // List of indexes to test
 typedef ::testing::Types<CompositeGroupKeyIndex> DerivedIndexes;
-TYPED_TEST_CASE(MultiSegmentIndexTest, DerivedIndexes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(MultiSegmentIndexTest, DerivedIndexes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(MultiSegmentIndexTest, FullRange) {
   auto begin_int_str = this->index_int_str->cbegin();

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -199,6 +199,6 @@ bool operator<(const AbstractSegmentPosition<T>&, const AbstractSegmentPosition<
 INSTANTIATE_TEST_SUITE_P(
     SegmentIteratorsTestInstances, SegmentIteratorsTest,
     ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                        std::end(all_segment_encoding_specs)), );  // NOLINT(whitespace/parens)  // NOLINT
+                        std::end(all_segment_encoding_specs)));
 
 }  // namespace opossum

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -196,9 +196,8 @@ bool operator<(const AbstractSegmentPosition<T>&, const AbstractSegmentPosition<
   return false;
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    SegmentIteratorsTestInstances, SegmentIteratorsTest,
-    ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                        std::end(all_segment_encoding_specs)));
+INSTANTIATE_TEST_SUITE_P(SegmentIteratorsTestInstances, SegmentIteratorsTest,
+                         ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
+                                             std::end(all_segment_encoding_specs)));
 
 }  // namespace opossum

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -196,7 +196,7 @@ bool operator<(const AbstractSegmentPosition<T>&, const AbstractSegmentPosition<
   return false;
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SegmentIteratorsTestInstances, SegmentIteratorsTest,
     ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
                         std::end(all_segment_encoding_specs)), );  // NOLINT(whitespace/parens)  // NOLINT

--- a/src/test/storage/simd_bp128_test.cpp
+++ b/src/test/storage/simd_bp128_test.cpp
@@ -72,7 +72,7 @@ auto formatter = [](const ::testing::TestParamInfo<uint8_t> info) {
   return std::to_string(static_cast<uint32_t>(info.param));
 };
 
-INSTANTIATE_TEST_CASE_P(BitSizes, SimdBp128Test, ::testing::Range(uint8_t{1}, uint8_t{33}), formatter);
+INSTANTIATE_TEST_SUITE_P(BitSizes, SimdBp128Test, ::testing::Range(uint8_t{1}, uint8_t{33}), formatter);
 
 TEST_P(SimdBp128Test, DecompressSequenceUsingIterators) {
   const auto sequence = generate_sequence(420);

--- a/src/test/storage/single_segment_index_test.cpp
+++ b/src/test/storage/single_segment_index_test.cpp
@@ -215,7 +215,7 @@ class SingleSegmentIndexTest : public BaseTest {
 
 // List of indexes to test
 typedef ::testing::Types<AdaptiveRadixTreeIndex, BTreeIndex, /*CompositeGroupKeyIndex,*/ GroupKeyIndex> DerivedIndexes;
-TYPED_TEST_CASE(SingleSegmentIndexTest, DerivedIndexes, );  // NOLINT(whitespace/parens)
+TYPED_TEST_SUITE(SingleSegmentIndexTest, DerivedIndexes, );  // NOLINT(whitespace/parens)
 
 /*
   Test cases:

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -105,7 +105,7 @@ TEST_P(TPCHTest, Test) {
                   FloatComparisonMode::RelativeDifference);
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TPCHTestNoJITNoPreparedStatements, TPCHTest,
     // TPCHBenchmarkItemRunner{false, 1.0f} is used only to get the list of all available queries
     testing::Combine(testing::ValuesIn(TPCHBenchmarkItemRunner{
@@ -113,7 +113,7 @@ INSTANTIATE_TEST_CASE_P(
                                            .items()),
                      testing::ValuesIn({false}), testing::ValuesIn({false})), );  // NOLINT(whitespace/parens)
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TPCHTestNoJITPreparedStatements, TPCHTest,
     testing::Combine(testing::ValuesIn(TPCHBenchmarkItemRunner{
                          std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1.0f}
@@ -122,7 +122,7 @@ INSTANTIATE_TEST_CASE_P(
 
 #if HYRISE_JIT_SUPPORT
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     TPCHTestJITPreparedStatements, TPCHTest,
     testing::Combine(testing::ValuesIn(TPCHBenchmarkItemRunner{
                          std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1.0f}

--- a/src/test/tpc/tpch_test.cpp
+++ b/src/test/tpc/tpch_test.cpp
@@ -111,14 +111,14 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(TPCHBenchmarkItemRunner{
                          std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1.0f}
                                            .items()),
-                     testing::ValuesIn({false}), testing::ValuesIn({false})), );  // NOLINT(whitespace/parens)
+                     testing::ValuesIn({false}), testing::ValuesIn({false})));
 
 INSTANTIATE_TEST_SUITE_P(
     TPCHTestNoJITPreparedStatements, TPCHTest,
     testing::Combine(testing::ValuesIn(TPCHBenchmarkItemRunner{
                          std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1.0f}
                                            .items()),
-                     testing::ValuesIn({false}), testing::ValuesIn({true})), );  // NOLINT(whitespace/parens)
+                     testing::ValuesIn({false}), testing::ValuesIn({true})));
 
 #if HYRISE_JIT_SUPPORT
 
@@ -127,7 +127,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::ValuesIn(TPCHBenchmarkItemRunner{
                          std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config()), false, 1.0f}
                                            .items()),
-                     testing::ValuesIn({true}), testing::ValuesIn({true})), );  // NOLINT(whitespace/parens)
+                     testing::ValuesIn({true}), testing::ValuesIn({true})));
 
 #endif
 


### PR DESCRIPTION
Updates the third party module of the Google Test framework.

With it goes the necessity to add an empty item at the list of some test instantiations and thus also some `NOLINT` are removed.

For `TYPED_TEST_SUITE` the problem remains (https://github.com/google/googletest/issues/2271).