### PR TITLE
Add DESCRIBE as an alias for SHOW COLUMNS

### DIFF
--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -204,6 +204,11 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipeline::g
   return {SQLPipelineStatus::Success, tables.back()};
 }
 
+std::pair<SQLPipelineStatus, std::shared_ptr<const Table>> SQLPipeline::get_result_table() && {
+  // std::pair constructor will automatically convert the reference into a copy
+  return get_result_table();
+}
+
 std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> SQLPipeline::get_result_tables() & {
   if (_pipeline_status != SQLPipelineStatus::NotExecuted) {
     return {_pipeline_status, _result_tables};
@@ -232,6 +237,11 @@ std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> S
 
   _pipeline_status = SQLPipelineStatus::Success;
   return {_pipeline_status, _result_tables};
+}
+
+std::pair<SQLPipelineStatus, std::vector<std::shared_ptr<const Table>>> SQLPipeline::get_result_tables() && {
+  // std::pair constructor will automatically convert the reference into a copy
+  return get_result_tables();
 }
 
 std::shared_ptr<TransactionContext> SQLPipeline::transaction_context() const { return _transaction_context; }

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -193,7 +193,7 @@ const std::vector<std::vector<std::shared_ptr<OperatorTask>>>& SQLPipeline::get_
   return _tasks;
 }
 
-std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipeline::get_result_table() {
+std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipeline::get_result_table() & {
   const auto& [pipeline_status, tables] = get_result_tables();
 
   if (pipeline_status != SQLPipelineStatus::Success) {
@@ -204,7 +204,7 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipeline::g
   return {SQLPipelineStatus::Success, tables.back()};
 }
 
-std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> SQLPipeline::get_result_tables() {
+std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> SQLPipeline::get_result_tables() & {
   if (_pipeline_status != SQLPipelineStatus::NotExecuted) {
     return {_pipeline_status, _result_tables};
   }

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -67,14 +67,15 @@ class SQLPipeline : public Noncopyable {
   // The transaction status is somewhat redundant, as it could also be retrieved from the transaction_context. We
   // explicitly return it as part of get_result_table(s) to force the caller to take the possibility of a failed
   // transaction into account.
+  //
+  // If the pipeline is an xvalue, provide a variant that returns non-reference tables:
+  //   const auto result = SQLPipelineBuilder{"SELECT ..."}.create_pipeline().get_result_tables()
   std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> get_result_tables() &;
+  std::pair<SQLPipelineStatus, std::vector<std::shared_ptr<const Table>>> get_result_tables() &&;
 
   // Shorthand for `get_result_tables().back()`
   std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> get_result_table() &;
-
-  // Make sure that get_result_table(s) is not called on an expiring pipeline
-  void get_result_tables() const&& = delete;
-  void get_result_table() const&& = delete;
+  std::pair<SQLPipelineStatus, std::shared_ptr<const Table>> get_result_table() &&;
 
   // Returns the TransactionContext that was passed to the SQLPipelineStatement, or nullptr if none was passed in.
   std::shared_ptr<TransactionContext> transaction_context() const;

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -67,10 +67,14 @@ class SQLPipeline : public Noncopyable {
   // The transaction status is somewhat redundant, as it could also be retrieved from the transaction_context. We
   // explicitly return it as part of get_result_table(s) to force the caller to take the possibility of a failed
   // transaction into account.
-  std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> get_result_tables();
+  std::pair<SQLPipelineStatus, const std::vector<std::shared_ptr<const Table>>&> get_result_tables() &;
 
   // Shorthand for `get_result_tables().back()`
-  std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> get_result_table();
+  std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> get_result_table() &;
+
+  // Make sure that get_result_table(s) is not called on an expiring pipeline
+  void get_result_tables() const && = delete;
+  void get_result_table() const && = delete;
 
   // Returns the TransactionContext that was passed to the SQLPipelineStatement, or nullptr if none was passed in.
   std::shared_ptr<TransactionContext> transaction_context() const;

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -73,8 +73,8 @@ class SQLPipeline : public Noncopyable {
   std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> get_result_table() &;
 
   // Make sure that get_result_table(s) is not called on an expiring pipeline
-  void get_result_tables() const && = delete;
-  void get_result_table() const && = delete;
+  void get_result_tables() const&& = delete;
+  void get_result_table() const&& = delete;
 
   // Returns the TransactionContext that was passed to the SQLPipelineStatement, or nullptr if none was passed in.
   std::shared_ptr<TransactionContext> transaction_context() const;

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -29,6 +29,7 @@ Table::Table(const TableColumnDefinitions& column_definitions, const TableType t
       _use_mvcc(use_mvcc),
       _max_chunk_size(type == TableType::Data ? max_chunk_size.value_or(Chunk::DEFAULT_SIZE) : Chunk::MAX_SIZE),
       _append_mutex(std::make_unique<std::mutex>()) {
+  DebugAssert(!_column_definitions.empty(), "Cannot create table without columns");
   // _max_chunk_size has no meaning if the table is a reference table.
   DebugAssert(type == TableType::Data || !max_chunk_size, "Must not set max_chunk_size for reference tables");
   DebugAssert(!max_chunk_size || *max_chunk_size > 0, "Table must have a chunk size greater than 0.");

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -29,7 +29,6 @@ Table::Table(const TableColumnDefinitions& column_definitions, const TableType t
       _use_mvcc(use_mvcc),
       _max_chunk_size(type == TableType::Data ? max_chunk_size.value_or(Chunk::DEFAULT_SIZE) : Chunk::MAX_SIZE),
       _append_mutex(std::make_unique<std::mutex>()) {
-  DebugAssert(!_column_definitions.empty(), "Cannot create table without columns");
   // _max_chunk_size has no meaning if the table is a reference table.
   DebugAssert(type == TableType::Data || !max_chunk_size, "Must not set max_chunk_size for reference tables");
   DebugAssert(!max_chunk_size || *max_chunk_size > 0, "Table must have a chunk size greater than 0.");

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "constant_mappings.hpp"
 #include "hyrise.hpp"
+#include "statistics/table_statistics.hpp"
 #include "storage/base_encoded_segment.hpp"
 #include "storage/table.hpp"
 #include "storage/table_column_definition.hpp"
@@ -24,7 +25,9 @@ MetaTableManager::MetaTableManager() {
 const std::vector<std::string>& MetaTableManager::table_names() const { return _table_names; }
 
 std::shared_ptr<Table> MetaTableManager::generate_table(const std::string& table_name) const {
-  return _methods.at(table_name)();
+  const auto table = _methods.at(table_name)();
+  table->set_table_statistics(TableStatistics::from_table(*table));
+  return table;
 }
 
 std::shared_ptr<Table> MetaTableManager::generate_tables_table() const {

--- a/src/test/utils/meta_table_manager_test.cpp
+++ b/src/test/utils/meta_table_manager_test.cpp
@@ -48,6 +48,17 @@ TEST_F(MetaTableManagerTest, TableBasedMetaData) {
       EXPECT_TABLE_EQ_UNORDERED(meta_table, expected_table);
     }
   }
+
+  {
+    // TEST SQL features on meta tables
+    const auto result = SQLPipelineBuilder{"SELECT COUNT(*) FROM meta_tables WHERE \"table\" = 'int_int'"}
+                           .create_pipeline()
+                           .get_result_table();
+
+    EXPECT_EQ(result.first, SQLPipelineStatus::Success);
+
+    EXPECT_EQ(table.second->get_value<int64_t>(ColumnID{0}, 0), 1);
+  }
 }
 
 }  // namespace opossum

--- a/src/test/utils/meta_table_manager_test.cpp
+++ b/src/test/utils/meta_table_manager_test.cpp
@@ -56,8 +56,7 @@ TEST_F(MetaTableManagerTest, TableBasedMetaData) {
                            .get_result_table();
 
     EXPECT_EQ(result.first, SQLPipelineStatus::Success);
-
-    EXPECT_EQ(table.second->get_value<int64_t>(ColumnID{0}, 0), 1);
+    EXPECT_EQ(result.second->get_value<int64_t>(ColumnID{0}, 0), 1);
   }
 }
 


### PR DESCRIPTION
* fixes #1787 
* fixes predicates on meta tables
* fixes UB if `get_result_table` was called on xvalue pipeline:
```
      const auto result = SQLPipelineBuilder{"SELECT * FROM int_int"}
                             .create_pipeline()
                             .get_result_table();
```
As `get_result_table` would return a pair containing a reference to the result table, which is stored in the now expired pipeline, accessing the table was previously UB. We now copy the `shared_ptr<Table>` if necessary.