### PR TITLE
Clean up hyriseSystemTest and unify encoding enumerations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
+exclude_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings.*:TPCHTestNoJITPreparedStatements.*'
 
 try {
   node('master') {
@@ -148,7 +149,7 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
-              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest clang-debug-addr-ub-sanitizers"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
             } else {
               Utils.markStageSkippedForConditional("clangDebugAddrUBSanitizers")
             }
@@ -172,7 +173,7 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
-              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest clang-release-addr-ub-sanitizers"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
             } else {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
             }
@@ -182,7 +183,7 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseTest clang-release-addr-ub-sanitizers-no-numa"
-              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseSystemTest clang-release-addr-ub-sanitizers-no-numa"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-release-addr-ub-sanitizers-no-numa"
             } else {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizersNoNuma")
             }
@@ -192,7 +193,7 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-thread-sanitizer && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "TSAN_OPTIONS=suppressions=resources/.tsan-ignore.txt ./clang-release-thread-sanitizer/hyriseTest clang-release-thread-sanitizer"
-              sh "TSAN_OPTIONS=suppressions=resources/.tsan-ignore.txt ./clang-release-thread-sanitizer/hyriseSystemTest clang-release-thread-sanitizer"
+              sh "TSAN_OPTIONS=suppressions=resources/.tsan-ignore.txt ./clang-release-thread-sanitizer/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-release-thread-sanitizer"
             } else {
               Utils.markStageSkippedForConditional("clangReleaseThreadSanitizer")
             }
@@ -202,7 +203,7 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 3))"
               sh "TSAN_OPTIONS=suppressions=resources/.tsan-ignore.txt ./clang-release-thread-sanitizer-no-numa/hyriseTest clang-release-thread-sanitizer-no-numa"
-              sh "TSAN_OPTIONS=suppressions=resources/.tsan-ignore.txt ./clang-release-thread-sanitizer-no-numa/hyriseSystemTest clang-release-thread-sanitizer-no-numa"
+              sh "TSAN_OPTIONS=suppressions=resources/.tsan-ignore.txt ./clang-release-thread-sanitizer-no-numa/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-release-thread-sanitizer-no-numa"
             } else {
               Utils.markStageSkippedForConditional("clangReleaseThreadSanitizerNoNuma")
             }

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -8,6 +8,7 @@
 #include <boost/hana/tuple.hpp>
 #include <boost/hana/type.hpp>
 
+#include <array>
 #include <cstdint>
 
 #include "all_type_variant.hpp"
@@ -66,5 +67,22 @@ struct SegmentEncodingSpec {
 };
 
 using ChunkEncodingSpec = std::vector<SegmentEncodingSpec>;
+
+constexpr std::array<EncodingType, 6> all_encoding_types = {
+    EncodingType::Unencoded,        EncodingType::Dictionary,
+    EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
+    EncodingType::RunLength,        EncodingType::LZ4};
+
+constexpr std::array<SegmentEncodingSpec, 10> all_segment_encoding_specs = {{
+    {EncodingType::Unencoded},
+    {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+    {EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
+    {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
+    {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::LZ4, VectorCompressionType::SimdBp128},
+    {EncodingType::RunLength}}};
 
 }  // namespace opossum

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -68,21 +68,19 @@ struct SegmentEncodingSpec {
 
 using ChunkEncodingSpec = std::vector<SegmentEncodingSpec>;
 
-constexpr std::array<EncodingType, 6> all_encoding_types = {
-    EncodingType::Unencoded,        EncodingType::Dictionary,
-    EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
-    EncodingType::RunLength,        EncodingType::LZ4};
+constexpr std::array all_encoding_types{EncodingType::Unencoded,        EncodingType::Dictionary,
+                                        EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
+                                        EncodingType::RunLength,        EncodingType::LZ4};
 
-constexpr std::array<SegmentEncodingSpec, 10> all_segment_encoding_specs = {
-    {{EncodingType::Unencoded},
-     {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
-     {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-     {EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
-     {EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
-     {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
-     {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
-     {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
-     {EncodingType::LZ4, VectorCompressionType::SimdBp128},
-     {EncodingType::RunLength}}};
+constexpr std::array all_segment_encoding_specs{SegmentEncodingSpec{EncodingType::Unencoded},
+    SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
+    SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+    SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
+    SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
+    SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
+    SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
+    SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
+    SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128},
+    SegmentEncodingSpec{EncodingType::RunLength}};
 
 }  // namespace opossum

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -73,16 +73,16 @@ constexpr std::array<EncodingType, 6> all_encoding_types = {
     EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
     EncodingType::RunLength,        EncodingType::LZ4};
 
-constexpr std::array<SegmentEncodingSpec, 10> all_segment_encoding_specs = {{
-    {EncodingType::Unencoded},
-    {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-    {EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
-    {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
-    {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::LZ4, VectorCompressionType::SimdBp128},
-    {EncodingType::RunLength}}};
+constexpr std::array<SegmentEncodingSpec, 10> all_segment_encoding_specs = {
+    {{EncodingType::Unencoded},
+     {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
+     {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+     {EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
+     {EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
+     {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
+     {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
+     {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
+     {EncodingType::LZ4, VectorCompressionType::SimdBp128},
+     {EncodingType::RunLength}}};
 
 }  // namespace opossum

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -68,11 +68,12 @@ struct SegmentEncodingSpec {
 
 using ChunkEncodingSpec = std::vector<SegmentEncodingSpec>;
 
-constexpr std::array all_encoding_types{EncodingType::Unencoded,        EncodingType::Dictionary,
-                                        EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
-                                        EncodingType::RunLength,        EncodingType::LZ4};
+inline constexpr std::array all_encoding_types{EncodingType::Unencoded,        EncodingType::Dictionary,
+                                               EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
+                                               EncodingType::RunLength,        EncodingType::LZ4};
 
-constexpr std::array all_segment_encoding_specs{SegmentEncodingSpec{EncodingType::Unencoded},
+inline constexpr std::array all_segment_encoding_specs{
+    SegmentEncodingSpec{EncodingType::Unencoded},
     SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
     SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
     SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -162,6 +162,18 @@ class BaseTestWithParam
 
     return chunk_encoding_spec;
   }
+
+  static std::vector<SegmentEncodingSpec> get_supporting_segment_encodings_specs(const DataType data_type, const bool include_unencoded = true) {
+  std::vector<SegmentEncodingSpec> segment_encodings;
+  for (const auto& spec : all_segment_encoding_specs) {
+    // Include all encoding types, if they support the given data type. As some tests work on encoded segments only,
+    // it further tested if the encoding is Unencoded and if Unencoded should be included or not.
+    if (encoding_supports_data_type(spec.encoding_type, data_type) && (spec.encoding_type != EncodingType::Unencoded || include_unencoded)) {
+      segment_encodings.emplace_back(spec);
+    }
+  }
+  return segment_encodings;
+}
 };
 
 using BaseTest = BaseTestWithParam<void>;

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -167,8 +167,9 @@ class BaseTestWithParam
                                                                                  const bool include_unencoded = true) {
     std::vector<SegmentEncodingSpec> segment_encodings;
     for (const auto& spec : all_segment_encoding_specs) {
-      // Include all encoding types, if they support the given data type. As some tests work on encoded segments only,
-      // it further tested if the encoding is Unencoded and if Unencoded should be included or not.
+      // Add all encoding types to the returned vector if they support the given data type. As some test cases work on
+      // encoded segments only, it is further tested if the segment is not encoded and if segments of type Unencoded
+      // should be included or not (flag `include_unencoded`).
       if (encoding_supports_data_type(spec.encoding_type, data_type) &&
           (spec.encoding_type != EncodingType::Unencoded || include_unencoded)) {
         segment_encodings.emplace_back(spec);

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -163,17 +163,19 @@ class BaseTestWithParam
     return chunk_encoding_spec;
   }
 
-  static std::vector<SegmentEncodingSpec> get_supporting_segment_encodings_specs(const DataType data_type, const bool include_unencoded = true) {
-  std::vector<SegmentEncodingSpec> segment_encodings;
-  for (const auto& spec : all_segment_encoding_specs) {
-    // Include all encoding types, if they support the given data type. As some tests work on encoded segments only,
-    // it further tested if the encoding is Unencoded and if Unencoded should be included or not.
-    if (encoding_supports_data_type(spec.encoding_type, data_type) && (spec.encoding_type != EncodingType::Unencoded || include_unencoded)) {
-      segment_encodings.emplace_back(spec);
+  static std::vector<SegmentEncodingSpec> get_supporting_segment_encodings_specs(const DataType data_type,
+                                                                                 const bool include_unencoded = true) {
+    std::vector<SegmentEncodingSpec> segment_encodings;
+    for (const auto& spec : all_segment_encoding_specs) {
+      // Include all encoding types, if they support the given data type. As some tests work on encoded segments only,
+      // it further tested if the encoding is Unencoded and if Unencoded should be included or not.
+      if (encoding_supports_data_type(spec.encoding_type, data_type) &&
+          (spec.encoding_type != EncodingType::Unencoded || include_unencoded)) {
+        segment_encodings.emplace_back(spec);
+      }
     }
+    return segment_encodings;
   }
-  return segment_encodings;
-}
 };
 
 using BaseTest = BaseTestWithParam<void>;

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -167,10 +167,6 @@ class JoinTestRunner : public BaseTestWithParam<JoinTestConfiguration> {
     const auto all_input_table_types =
         std::vector{InputTableType::Data, InputTableType::IndividualPosLists, InputTableType::SharedPosList};
 
-    const auto all_encoding_types = std::vector{EncodingType::Unencoded,        EncodingType::Dictionary,
-                                                EncodingType::FrameOfReference, EncodingType::FixedStringDictionary,
-                                                EncodingType::RunLength,        EncodingType::LZ4};
-
     // clang-format off
     JoinTestConfiguration default_configuration{
       InputTableConfiguration{

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -5,9 +5,7 @@
 namespace opossum {
 
 INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
-                         testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
-                                          testing::ValuesIn({EncodingType::Dictionary, EncodingType::RunLength,
-                                                             EncodingType::FixedStringDictionary,
-                                                             EncodingType::FrameOfReference, EncodingType::LZ4})));
+                         testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::Values(false),
+                                          testing::ValuesIn(all_encoding_types)));
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -8,6 +8,6 @@ INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
                          testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()), testing::ValuesIn({false}),
                                           testing::ValuesIn({EncodingType::Dictionary, EncodingType::RunLength,
                                                              EncodingType::FixedStringDictionary,
-                                                             EncodingType::FrameOfReference})));
+                                                             EncodingType::FrameOfReference, EncodingType::LZ4})));
 
 }  // namespace opossum

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -27,15 +27,7 @@ class AnySegmentIterableTest : public BaseTestWithParam<SegmentEncodingSpec> {
                            {ChunkID{0}, ChunkOffset{1}}, {ChunkID{0}, ChunkOffset{1}}, {ChunkID{0}, ChunkOffset{5}}};
     position_filter = std::make_shared<PosList>(std::move(row_ids));
     position_filter->guarantee_single_chunk();
-
-    for (const auto& spec : all_segment_encoding_specs) {
-      if (encoding_supports_data_type(spec.encoding_type, DataType::Int)) {
-        int_supporting_segment_encodings.emplace_back(spec);
-      }
-    }
   }
-
-  inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;
 
   void SetUp() override {
     const auto segment_encoding_spec = GetParam();
@@ -93,5 +85,5 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(AnySegmentIterableTestInstances, AnySegmentIterableTest,
-                         ::testing::ValuesIn(AnySegmentIterableTest::int_supporting_segment_encodings), formatter);
+                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::Int, true)), formatter);
 }  // namespace opossum

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -15,7 +15,6 @@
 
 namespace opossum {
 
-// TODO(anyone): add testing of other data types as well
 class AnySegmentIterableTest : public BaseTestWithParam<SegmentEncodingSpec> {
  public:
   static void SetUpTestCase() {

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -29,7 +29,10 @@ class AnySegmentIterableTest : public BaseTestWithParam<SegmentEncodingSpec> {
     position_filter = std::make_shared<PosList>(std::move(row_ids));
     position_filter->guarantee_single_chunk();
 
-    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(), std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) { return encoding_supports_data_type(spec.encoding_type, DataType::Int); });
+    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
+                 std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) {
+                   return encoding_supports_data_type(spec.encoding_type, DataType::Int);
+                 });
   }
 
   inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;
@@ -89,6 +92,6 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   return string;
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    AnySegmentIterableTestInstances, AnySegmentIterableTest, ::testing::ValuesIn(AnySegmentIterableTest::int_supporting_segment_encodings), formatter);
+INSTANTIATE_TEST_SUITE_P(AnySegmentIterableTestInstances, AnySegmentIterableTest,
+                         ::testing::ValuesIn(AnySegmentIterableTest::int_supporting_segment_encodings), formatter);
 }  // namespace opossum

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -28,10 +28,11 @@ class AnySegmentIterableTest : public BaseTestWithParam<SegmentEncodingSpec> {
     position_filter = std::make_shared<PosList>(std::move(row_ids));
     position_filter->guarantee_single_chunk();
 
-    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
-                 std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) {
-                   return encoding_supports_data_type(spec.encoding_type, DataType::Int);
-                 });
+    for (const auto& spec : all_segment_encoding_specs) {
+      if (encoding_supports_data_type(spec.encoding_type, DataType::Int)) {
+        int_supporting_segment_encodings.emplace_back(spec);
+      }
+    }
   }
 
   inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -85,5 +85,6 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(AnySegmentIterableTestInstances, AnySegmentIterableTest,
-                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::Int, true)), formatter);
+                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::Int, true)),
+                         formatter);
 }  // namespace opossum

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -24,10 +24,12 @@ namespace opossum {
 class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
  public:
   static void SetUpTestCase() {  // called ONCE before the tests
-    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
-                 std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) {
-                   return encoding_supports_data_type(spec.encoding_type, DataType::Int);
-                 });
+    // Only use encodings that support integer values (see encoded_string_segment_test.cpp for strings)
+    for (const auto& spec : all_segment_encoding_specs) {
+      if (encoding_supports_data_type(spec.encoding_type, DataType::Int)) {
+        int_supporting_segment_encodings.emplace_back(spec);
+      }
+    }
   }
 
   inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -22,18 +22,6 @@
 namespace opossum {
 
 class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
- public:
-  static void SetUpTestCase() {  // called ONCE before the tests
-    // Only use encodings that support integer values (see encoded_string_segment_test.cpp for strings)
-    for (const auto& spec : all_segment_encoding_specs) {
-      if (encoding_supports_data_type(spec.encoding_type, DataType::Int)) {
-        int_supporting_segment_encodings.emplace_back(spec);
-      }
-    }
-  }
-
-  inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;
-
  protected:
   static constexpr auto max_value = 1'024;
 
@@ -145,7 +133,7 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedSegmentTest,
-                         ::testing::ValuesIn(EncodedSegmentTest::int_supporting_segment_encodings), formatter);
+                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::Int, false)), formatter);
 
 TEST_P(EncodedSegmentTest, EncodeEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_concurrent_vector<int32_t>{});

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -133,7 +133,8 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedSegmentTest,
-                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::Int, false)), formatter);
+                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::Int, false)),
+                         formatter);
 
 TEST_P(EncodedSegmentTest, EncodeEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_concurrent_vector<int32_t>{});

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -22,9 +22,12 @@
 namespace opossum {
 
 class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
-public:
+ public:
   static void SetUpTestCase() {  // called ONCE before the tests
-    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(), std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) { return encoding_supports_data_type(spec.encoding_type, DataType::Int); });
+    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
+                 std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) {
+                   return encoding_supports_data_type(spec.encoding_type, DataType::Int);
+                 });
   }
 
   inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;
@@ -139,8 +142,8 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   return string;
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    SegmentEncodingSpecs, EncodedSegmentTest, ::testing::ValuesIn(EncodedSegmentTest::int_supporting_segment_encodings), formatter);
+INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedSegmentTest,
+                         ::testing::ValuesIn(EncodedSegmentTest::int_supporting_segment_encodings), formatter);
 
 TEST_P(EncodedSegmentTest, EncodeEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_concurrent_vector<int32_t>{});

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -22,6 +22,13 @@
 namespace opossum {
 
 class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
+public:
+  static void SetUpTestCase() {  // called ONCE before the tests
+    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(), std::back_inserter(int_supporting_segment_encodings), [](SegmentEncodingSpec spec) { return encoding_supports_data_type(spec.encoding_type, DataType::Int); });
+  }
+
+  inline static std::vector<SegmentEncodingSpec> int_supporting_segment_encodings;
+
  protected:
   static constexpr auto max_value = 1'024;
 
@@ -133,15 +140,7 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(
-    SegmentEncodingSpecs, EncodedSegmentTest,
-    ::testing::Values(SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-                      SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
-                      SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
-                      SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
-                      SegmentEncodingSpec{EncodingType::RunLength},
-                      SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128},
-                      SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned}),
-    formatter);
+    SegmentEncodingSpecs, EncodedSegmentTest, ::testing::ValuesIn(EncodedSegmentTest::int_supporting_segment_encodings), formatter);
 
 TEST_P(EncodedSegmentTest, EncodeEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_concurrent_vector<int32_t>{});

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -25,7 +25,10 @@ namespace opossum {
 class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
  public:
   static void SetUpTestCase() {  // called ONCE before the tests
-    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(), std::back_inserter(string_supporting_segment_encodings), [](SegmentEncodingSpec spec) { return encoding_supports_data_type(spec.encoding_type, DataType::String); });
+    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
+                 std::back_inserter(string_supporting_segment_encodings), [](SegmentEncodingSpec spec) {
+                   return encoding_supports_data_type(spec.encoding_type, DataType::String);
+                 });
   }
 
   inline static std::vector<SegmentEncodingSpec> string_supporting_segment_encodings;
@@ -138,7 +141,8 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
   return string;
 };
 
-INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedStringSegmentTest, ::testing::ValuesIn(EncodedStringSegmentTest::string_supporting_segment_encodings), formatter);
+INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedStringSegmentTest,
+                         ::testing::ValuesIn(EncodedStringSegmentTest::string_supporting_segment_encodings), formatter);
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableEmptyStringSegment) {
   auto value_segment = create_empty_string_value_segment();

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -132,7 +132,8 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedStringSegmentTest,
-                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::String, false)), formatter);
+                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::String, false)),
+                         formatter);
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableEmptyStringSegment) {
   auto value_segment = create_empty_string_value_segment();

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -23,18 +23,6 @@
 namespace opossum {
 
 class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
- public:
-  static void SetUpTestCase() {  // called ONCE before the tests
-    // Only use encodings that support string values (see encoded_segment_test.cpp for integers)
-    for (const auto& spec : all_segment_encoding_specs) {
-      if (encoding_supports_data_type(spec.encoding_type, DataType::String)) {
-        string_supporting_segment_encodings.emplace_back(spec);
-      }
-    }
-  }
-
-  inline static std::vector<SegmentEncodingSpec> string_supporting_segment_encodings;
-
  protected:
   static constexpr auto max_length = 32;
   static constexpr auto row_count = size_t{1u} << 10;
@@ -144,7 +132,7 @@ auto formatter = [](const ::testing::TestParamInfo<SegmentEncodingSpec> info) {
 };
 
 INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedStringSegmentTest,
-                         ::testing::ValuesIn(EncodedStringSegmentTest::string_supporting_segment_encodings), formatter);
+                         ::testing::ValuesIn(BaseTest::get_supporting_segment_encodings_specs(DataType::String, false)), formatter);
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableEmptyStringSegment) {
   auto value_segment = create_empty_string_value_segment();

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -25,10 +25,12 @@ namespace opossum {
 class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
  public:
   static void SetUpTestCase() {  // called ONCE before the tests
-    std::copy_if(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
-                 std::back_inserter(string_supporting_segment_encodings), [](SegmentEncodingSpec spec) {
-                   return encoding_supports_data_type(spec.encoding_type, DataType::String);
-                 });
+    // Only use encodings that support string values (see encoded_segment_test.cpp for integers)
+    for (const auto& spec : all_segment_encoding_specs) {
+      if (encoding_supports_data_type(spec.encoding_type, DataType::String)) {
+        string_supporting_segment_encodings.emplace_back(spec);
+      }
+    }
   }
 
   inline static std::vector<SegmentEncodingSpec> string_supporting_segment_encodings;

--- a/src/test/storage/encoding_test.hpp
+++ b/src/test/storage/encoding_test.hpp
@@ -31,13 +31,4 @@ class EncodingTest : public ::testing::TestWithParam<SegmentEncodingSpec> {
   }
 };
 
-const SegmentEncodingSpec all_segment_encoding_specs[]{
-    {EncodingType::Unencoded},
-    {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-    {EncodingType::FrameOfReference},
-    {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::LZ4, VectorCompressionType::SimdBp128},
-    {EncodingType::RunLength}};
-
 }  // namespace opossum

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -152,7 +152,6 @@ TEST_P(MaterializeTest, MaterializeNullsTwoSegments) {
 }
 
 INSTANTIATE_TEST_SUITE_P(MaterializeTestInstances, MaterializeTest,
-                         ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                                             std::end(all_segment_encoding_specs)));
+                         ::testing::ValuesIn(all_segment_encoding_specs));
 
 }  // namespace opossum

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -151,7 +151,6 @@ TEST_P(MaterializeTest, MaterializeNullsTwoSegments) {
   EXPECT_EQ(expected, nulls);
 }
 
-INSTANTIATE_TEST_SUITE_P(MaterializeTestInstances, MaterializeTest,
-                         ::testing::ValuesIn(all_segment_encoding_specs));
+INSTANTIATE_TEST_SUITE_P(MaterializeTestInstances, MaterializeTest, ::testing::ValuesIn(all_segment_encoding_specs));
 
 }  // namespace opossum

--- a/src/test/storage/segment_iterators_test.cpp
+++ b/src/test/storage/segment_iterators_test.cpp
@@ -197,7 +197,6 @@ bool operator<(const AbstractSegmentPosition<T>&, const AbstractSegmentPosition<
 }
 
 INSTANTIATE_TEST_SUITE_P(SegmentIteratorsTestInstances, SegmentIteratorsTest,
-                         ::testing::ValuesIn(std::begin(all_segment_encoding_specs),
-                                             std::end(all_segment_encoding_specs)));
+                         ::testing::ValuesIn(all_segment_encoding_specs));
 
 }  // namespace opossum


### PR DESCRIPTION
This PR limits the testing of encoding types for sanitizer runs of hyriseSystemTest.

Further, it fixes #1673 by adding two fixed arrays of encoding types and all segment encoding specs to `encoding_types.hpp`. Tests now iterate over these lists (sometimes with explicit filtering in case some encodings to not support data types) instead of the cumbersome and error-prone listing of encodings (which lead to cases that encodings haven't been tested).