### PR TITLE
Fix performance regression in JOB

### DIFF
--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -32,8 +32,9 @@ std::string ColumnLikeTableScanImpl::description() const { return "ColumnLike"; 
 void ColumnLikeTableScanImpl::_scan_non_reference_segment(const BaseSegment& segment, const ChunkID chunk_id,
                                                           PosList& matches,
                                                           const std::shared_ptr<const PosList>& position_filter) const {
-  // Select optimized or generic scanning implementation based on segment type
-  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment); dictionary_segment && dictionary_segment->unique_values_count() <= segment.size()) {
+  // For dictionary segments where the number of unique values is at least the number of (potentially filtered) input
+  // rows, use an optimized implementation.
+  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment); dictionary_segment && (!position_filter || dictionary_segment->unique_values_count() <= position_filter->size())) {
     _scan_dictionary_segment(*dictionary_segment, chunk_id, matches, position_filter);
   } else {
     _scan_generic_segment(segment, chunk_id, matches, position_filter);
@@ -44,11 +45,9 @@ void ColumnLikeTableScanImpl::_scan_generic_segment(const BaseSegment& segment, 
                                                     PosList& matches,
                                                     const std::shared_ptr<const PosList>& position_filter) const {
   segment_with_iterators_filtered(segment, position_filter, [&](auto it, [[maybe_unused]] const auto end) {
-    // Don't instantiate this for this for DictionarySegments and ReferenceSegments to save compile time.
-    // DictionarySegments are handled in _scan_dictionary_segment()
-    // ReferenceSegments are handled via position_filter
-    if constexpr (!is_dictionary_segment_iterable_v<typename decltype(it)::IterableType> &&
-                  !is_reference_segment_iterable_v<typename decltype(it)::IterableType>) {
+    // Don't instantiate this for this for ReferenceSegments to save compile time as ReferenceSegments are handled
+    // via position_filter
+    if constexpr (!is_reference_segment_iterable_v<typename decltype(it)::IterableType>) {
       using ColumnDataType = typename decltype(it)::ValueType;
 
       if constexpr (std::is_same_v<ColumnDataType, pmr_string>) {
@@ -60,7 +59,7 @@ void ColumnLikeTableScanImpl::_scan_generic_segment(const BaseSegment& segment, 
         Fail("Can only handle strings");
       }
     } else {
-      Fail("Dictionary and ReferenceSegments have their own code paths and should be handled there");
+      Fail("ReferenceSegments have their own code paths and should be handled there");
     }
   });
 }
@@ -68,6 +67,9 @@ void ColumnLikeTableScanImpl::_scan_generic_segment(const BaseSegment& segment, 
 void ColumnLikeTableScanImpl::_scan_dictionary_segment(const BaseDictionarySegment& segment, const ChunkID chunk_id,
                                                        PosList& matches,
                                                        const std::shared_ptr<const PosList>& position_filter) const {
+  // First, build a bitmap containing 1s/0s for matching/non-matching dictionary values. Second, iterate over the
+  // attribute vector and check against the bitmap. If too many input rows have already been removed (are not part of
+  // position_filter), this optimization is detrimental. See caller for that case. 
   std::pair<size_t, std::vector<bool>> result;
 
   if (segment.encoding_type() == EncodingType::Dictionary) {

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -33,7 +33,7 @@ void ColumnLikeTableScanImpl::_scan_non_reference_segment(const BaseSegment& seg
                                                           PosList& matches,
                                                           const std::shared_ptr<const PosList>& position_filter) const {
   // Select optimized or generic scanning implementation based on segment type
-  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment)) {
+  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment) && dictionary_segment->unique_values_count() <= segment->size()) {
     _scan_dictionary_segment(*dictionary_segment, chunk_id, matches, position_filter);
   } else {
     _scan_generic_segment(segment, chunk_id, matches, position_filter);

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -47,7 +47,7 @@ void ColumnLikeTableScanImpl::_scan_generic_segment(const BaseSegment& segment, 
                                                     PosList& matches,
                                                     const std::shared_ptr<const PosList>& position_filter) const {
   segment_with_iterators_filtered(segment, position_filter, [&](auto it, [[maybe_unused]] const auto end) {
-    // Don't instantiate this for this for ReferenceSegments to save compile time as ReferenceSegments are handled
+    // Don't instantiate this for ReferenceSegments to save compile time as ReferenceSegments are handled
     // via position_filter
     if constexpr (!is_reference_segment_iterable_v<typename decltype(it)::IterableType>) {
       using ColumnDataType = typename decltype(it)::ValueType;

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -32,8 +32,8 @@ std::string ColumnLikeTableScanImpl::description() const { return "ColumnLike"; 
 void ColumnLikeTableScanImpl::_scan_non_reference_segment(const BaseSegment& segment, const ChunkID chunk_id,
                                                           PosList& matches,
                                                           const std::shared_ptr<const PosList>& position_filter) const {
-  // For dictionary segments where the number of unique values is at least the number of (potentially filtered) input
-  // rows, use an optimized implementation.
+  // For dictionary segments where the number of unique values is not higher than the number of (potentially filtered)
+  // input rows, use an optimized implementation.
   if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment);
       dictionary_segment &&
       (!position_filter || dictionary_segment->unique_values_count() <= position_filter->size())) {

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -33,7 +33,7 @@ void ColumnLikeTableScanImpl::_scan_non_reference_segment(const BaseSegment& seg
                                                           PosList& matches,
                                                           const std::shared_ptr<const PosList>& position_filter) const {
   // Select optimized or generic scanning implementation based on segment type
-  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment) && dictionary_segment->unique_values_count() <= segment->size()) {
+  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment); dictionary_segment && dictionary_segment->unique_values_count() <= segment.size()) {
     _scan_dictionary_segment(*dictionary_segment, chunk_id, matches, position_filter);
   } else {
     _scan_generic_segment(segment, chunk_id, matches, position_filter);

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -34,7 +34,9 @@ void ColumnLikeTableScanImpl::_scan_non_reference_segment(const BaseSegment& seg
                                                           const std::shared_ptr<const PosList>& position_filter) const {
   // For dictionary segments where the number of unique values is at least the number of (potentially filtered) input
   // rows, use an optimized implementation.
-  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment); dictionary_segment && (!position_filter || dictionary_segment->unique_values_count() <= position_filter->size())) {
+  if (const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment);
+      dictionary_segment &&
+      (!position_filter || dictionary_segment->unique_values_count() <= position_filter->size())) {
     _scan_dictionary_segment(*dictionary_segment, chunk_id, matches, position_filter);
   } else {
     _scan_generic_segment(segment, chunk_id, matches, position_filter);
@@ -69,7 +71,7 @@ void ColumnLikeTableScanImpl::_scan_dictionary_segment(const BaseDictionarySegme
                                                        const std::shared_ptr<const PosList>& position_filter) const {
   // First, build a bitmap containing 1s/0s for matching/non-matching dictionary values. Second, iterate over the
   // attribute vector and check against the bitmap. If too many input rows have already been removed (are not part of
-  // position_filter), this optimization is detrimental. See caller for that case. 
+  // position_filter), this optimization is detrimental. See caller for that case.
   std::pair<size_t, std::vector<bool>> result;
 
   if (segment.encoding_type() == EncodingType::Dictionary) {


### PR DESCRIPTION
fixes #1839 - we still have some queries that run slower, but the -99% parts are gone. Given that we don't really optimize for the JOB, that should be good enough for now.

Splitting up `x LIKE '...' OR x LIKE '...'` into two predicates (#1791) enables the TableScan to use the ColumnLikeTableScanImpl. That implementation first builds a bitmap of the entire dictionary, then checks the value id against that bitmap. If the number of input rows is significantly lower than the size of the dictionary (because the input has already been filtered), that is a bad idea. Now, we only scan the entire dictionary if the filtered segment has no more unique values in the dictionary than rows in the input.

old:
![Screenshot 2019-09-17 at 13 33 12](https://user-images.githubusercontent.com/575106/65038415-33bac500-d950-11e9-8747-7ef4aebdbbf1.png)

regression:
![Screenshot 2019-09-17 at 13 35 03](https://user-images.githubusercontent.com/575106/65038425-39180f80-d950-11e9-8486-ffa74211ebd0.png)

new:
![Screenshot 2019-09-17 at 13 54 02](https://user-images.githubusercontent.com/575106/65039463-a036c380-d952-11e9-9980-bf754fbea081.png)
