### PR TITLE
Run chunk pruning after between composition

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -96,12 +96,14 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   optimizer->add_rule(std::make_unique<ColumnPruningRule>());
 
-  optimizer->add_rule(std::make_unique<ChunkPruningRule>());
-
   // Run before SubqueryToJoinRule, since the Semi/Anti Joins it introduces are opaque to the JoinOrderingRule
   optimizer->add_rule(std::make_unique<JoinOrderingRule>());
 
   optimizer->add_rule(std::make_unique<BetweenCompositionRule>());
+
+  // Prune chunks after the BetweenCompositionRule ran, as `a >= 5 AND a <= 7` may not be prunable predicates while
+  // `a BETWEEN 5 and 7` is.
+  optimizer->add_rule(std::make_unique<ChunkPruningRule>());
 
   // Position the predicates after the JoinOrderingRule ran. The JOR manipulates predicate placement as well, but
   // for now we want the PredicateReorderingRule to have the final say on predicate positions


### PR DESCRIPTION
Prune chunks after the BetweenCompositionRule ran, as `a >= 5 AND a <= 7` may not be prunable predicates while `a BETWEEN 5 and 7` is. Also prune only once all predicates are pushed down.

```
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 01       | 0.60651409626  | 37   | 0.606586277485 | 37   | +0%        |                          0.9863 |
| TPC-H 02       | 8.91521930695  | 535  | 8.79386711121  | 528  | -1%        |                          0.0000 |
| TPC-H 03       | 6.18643331528  | 372  | 6.36393642426  | 382  | +3%        |                          0.0000 |
| TPC-H 04       | 7.65977621078  | 460  | 7.66319561005  | 460  | +0%        |                          0.9113 |
| TPC-H 05       | 4.1903295517   | 252  | 4.00621032715  | 241  | -4%        |                          0.0000 |
| TPC-H 06       | 106.514526367  | 6391 | 107.293365479  | 6438 | +1%        |                          0.0000 |
| TPC-H 07       | 1.59403967857  | 96   | 1.57555985451  | 95   | -1%        |                          0.0269 |
| TPC-H 08       | 5.01469039917  | 301  | 5.56011152267  | 334  | +11%       |                          0.0000 |
| TPC-H 09       | 1.54667651653  | 93   | 1.58216619492  | 95   | +2%        |                          0.0000 |
| TPC-H 10       | 3.0907535553   | 186  | 3.08473491669  | 186  | -0%        |                          0.5984 |
| TPC-H 11       | 25.2146530151  | 1513 | 25.3028144836  | 1519 | +0%        |                          0.0007 |
| TPC-H 12       | 8.5431470871   | 513  | 8.54920959473  | 513  | +0%        |                          0.3214 |
| TPC-H 13       | 2.32613396645  | 140  | 2.31693601608  | 140  | -0%        |                          0.1166 |
| TPC-H 14       | 46.5960960388  | 2796 | 46.760055542   | 2806 | +0%        |                          0.0000 |
| TPC-H 15       | 73.2578201294  | 4396 | 73.2980499268  | 4398 | +0%        |                          0.4407 |
| TPC-H 16       | 7.19012928009  | 432  | 7.18328046799  | 432  | -0%        |                          0.2561 |
| TPC-H 17       | 1.32355487347  | 80   | 1.32691907883  | 80   | +0%        |                          0.3699 |
| TPC-H 18       | 0.791804969311 | 48   | 0.784848690033 | 48   | -1%        |                          0.0670 |
| TPC-H 19       | 8.55182170868  | 514  | 8.59450435638  | 516  | +0%        |                          0.0012 |
| TPC-H 20       | 2.88092517853  | 173  | 2.6809668541   | 161  | -7%        |                          0.0000 |
| TPC-H 21       | 1.51750218868  | 92   | 1.51057910919  | 91   | -0%        |                          0.0975 |
| TPC-H 22       | 12.8655824661  | 772  | 13.6430568695  | 819  | +6%        |                          0.0000 |
| geometric mean |                |      |                |      | +0%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```