### PR TITLE
Faster synthetic table creation

### DIFF
--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -229,7 +229,7 @@ BENCHMARK_F(TPCHDataMicroBenchmarkFixture, BM_TPCHQ4WithExistsSubquery)(benchmar
   for (auto _ : state) {
     const auto pqp = LQPTranslator{}.translate_node(lqp);
     const auto tasks = OperatorTask::make_tasks_from_operator(pqp, CleanupTemporaries::Yes);
-    Hyrise::get().scheduler().schedule_and_wait_for_tasks(tasks);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
   }
 }
 
@@ -247,7 +247,7 @@ BENCHMARK_F(TPCHDataMicroBenchmarkFixture, BM_TPCHQ4WithUnnestedSemiJoin)(benchm
   for (auto _ : state) {
     const auto pqp = LQPTranslator{}.translate_node(lqp);
     const auto tasks = OperatorTask::make_tasks_from_operator(pqp, CleanupTemporaries::Yes);
-    Hyrise::get().scheduler().schedule_and_wait_for_tasks(tasks);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
   }
 }
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -134,7 +134,7 @@ void BenchmarkRunner::run() {
     Assert(!any_verification_failed, "Verification failed");
   }
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 }
 
 void BenchmarkRunner::_benchmark_shuffled() {
@@ -187,7 +187,7 @@ void BenchmarkRunner::_benchmark_shuffled() {
   }
 
   // Wait for the rest of the tasks that didn't make it in time - they will not count towards the results
-  Hyrise::get().scheduler().wait_for_all_tasks();
+  Hyrise::get().scheduler()->wait_for_all_tasks();
   Assert(_currently_running_clients == 0, "All runs must be finished at this point");
 }
 
@@ -231,7 +231,7 @@ void BenchmarkRunner::_benchmark_ordered() {
     }
 
     // Wait for the rest of the tasks that didn't make it in time - they will not count toward the results
-    Hyrise::get().scheduler().wait_for_all_tasks();
+    Hyrise::get().scheduler()->wait_for_all_tasks();
     Assert(_currently_running_clients == 0, "All runs must be finished at this point");
   }
 }
@@ -267,7 +267,7 @@ void BenchmarkRunner::_schedule_item_run(const BenchmarkItemID item_id) {
 
   // No need to check if the benchmark uses the scheduler or not as this method executes tasks immediately if the
   // scheduler is not set.
-  Hyrise::get().scheduler().schedule_tasks<JobTask>({task});
+  Hyrise::get().scheduler()->schedule_tasks<JobTask>({task});
 }
 
 void BenchmarkRunner::_warmup(const BenchmarkItemID item_id) {
@@ -296,7 +296,7 @@ void BenchmarkRunner::_warmup(const BenchmarkItemID item_id) {
   _state.set_done();
 
   // Wait for the rest of the tasks that didn't make it in time
-  Hyrise::get().scheduler().wait_for_all_tasks();
+  Hyrise::get().scheduler()->wait_for_all_tasks();
   Assert(_currently_running_clients == 0, "All runs must be finished at this point");
 }
 

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -33,7 +33,8 @@ pmr_concurrent_vector<T> create_typed_segment_values(const std::vector<int>& val
 
   auto insert_position = size_t{0};
   for (const auto& value : values) {
-    result[insert_position++] = SyntheticTableGenerator::generate_value<T>(value);
+    result[insert_position] = SyntheticTableGenerator::generate_value<T>(value);
+    ++insert_position;
   }
 
   return result;
@@ -164,8 +165,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
 
         if (segment_encoding_specs) {
           /**
-          * For chunk sizes <1M, parallelizing the segment creation is not worth the overhead, because chunk encoding 
-          * dominates the runtime. Nonetheless, a single thread for the chunk encoder (which itself is parallelizing
+          * As the runtime of the table generation is dominated by the chunk encoding, parallelizing the actual data
+          * generation barely impact the runtime. Nonetheless, a single thread for the chunk encoder (which itself is parallelizing
           * internally) ensures that the segment creation is not blocked by the encoding of the previous chunk. To
           * avoid overparallelizing, there is at most one thread for encode_chunk() at any time.
           **/

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -146,7 +146,13 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
           if (chunk_index * chunk_size + (row_offset + 1) > num_rows - 2) {
             break;
           }
-          values.push_back(generate_value_by_distribution_type());
+
+          if constexpr (std::is_same_v<ColumnDataType, pmr_string> && column_data_distribution.distribution_type == DataDistributionType::NormalSkewed) {
+            // shift values and remove negative ones, because negative values cannot converted to strings as of now
+            values.push_back(abs(generate_value_by_distribution_type() + 10'000));
+          } else {
+            values.push_back(generate_value_by_distribution_type());
+          }
         }
 
         segments[column_index] =

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -167,7 +167,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
           * For chunk sizes <1M, parallelizing the segment creation is not worth the overhead, because chunk encoding 
           * dominates the runtime. Nonetheless, a single thread for the chunk encoder (which itself is parallelizing
           * internally) ensures that the segment creation is not blocked by the encoding of the previous chunk. To
-          * avoid overparallelizing, calls to encode_chunk are not parallelized.
+          * avoid overparallelizing, there is at most one thread for encode_chunk() at any time.
           **/
           if (!encoder_threads.empty()) {
             encoder_threads.back().join();

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -146,14 +146,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
           if (chunk_index * chunk_size + (row_offset + 1) > num_rows - 2) {
             break;
           }
-
-          if (std::is_same_v<ColumnDataType, pmr_string> &&
-                        column_data_distribution.distribution_type == DataDistributionType::NormalSkewed) {
-            // shift values and remove negative ones, because negative values cannot converted to strings as of now
-            values.push_back(abs(generate_value_by_distribution_type() + 10'000));
-          } else {
-            values.push_back(generate_value_by_distribution_type());
-          }
+          values.push_back(generate_value_by_distribution_type());
         }
 
         segments[column_index] =

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -13,13 +13,16 @@
 #include "boost/math/distributions/skew_normal.hpp"
 #include "boost/math/distributions/uniform.hpp"
 
+#include "hyrise.hpp"
+#include "scheduler/abstract_task.hpp"
+#include "scheduler/job_task.hpp"
+#include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/topology.hpp"
-
+#include "statistics/generate_pruning_statistics.hpp"
 #include "storage/chunk.hpp"
 #include "storage/chunk_encoder.hpp"
 #include "storage/table.hpp"
 #include "storage/value_segment.hpp"
-
 #include "resolve_type.hpp"
 #include "types.hpp"
 
@@ -49,9 +52,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(const size_t num_
                                                                const SegmentEncodingSpec segment_encoding_spec) {
   auto table =
       generate_table({num_columns, {ColumnDataDistribution::make_uniform_config(0.0, _max_different_value)}},
-                     {num_columns, {DataType::Int}}, num_rows, chunk_size, std::nullopt, std::nullopt, UseMvcc::No);
-
-  ChunkEncoder::encode_all_chunks(table, segment_encoding_spec);
+                     {num_columns, {DataType::Int}}, num_rows, chunk_size,
+                     std::vector<SegmentEncodingSpec>(num_columns, segment_encoding_spec), std::nullopt, UseMvcc::No);
 
   return table;
 }
@@ -73,8 +75,15 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
            "Length of value distributions needs to equal length of column encodings.");
   }
 
+  // To speed up the table generation, the node scheduler is used. To not interfere with any settings for the actual
+  // Hyrise process (e.g., the test runner or the calibration), the current scheduler is stored, replaced, and
+  // eventually set again.
+  Hyrise::get().scheduler()->wait_for_all_tasks();
+  const auto previous_scheduler = Hyrise::get().scheduler();
+  Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
+
   const auto num_columns = column_data_distributions.size();
-  const auto num_chunks = std::ceil(static_cast<double>(num_rows) / static_cast<double>(chunk_size));
+  const auto num_chunks = static_cast<size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(chunk_size)));
 
   // add column definitions and initialize each value vector
   TableColumnDefinitions column_definitions;
@@ -88,104 +97,105 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
   auto pseudorandom_engine = std::mt19937{};
 
   pseudorandom_engine.seed(random_device());
-  auto encoder_threads = std::vector<std::thread>{};
 
   for (auto chunk_index = ChunkOffset{0}; chunk_index < num_chunks; ++chunk_index) {
+    std::vector<std::shared_ptr<AbstractTask>> jobs;
+    jobs.reserve(static_cast<size_t>(num_chunks));
+
     Segments segments(num_columns);
-    for (auto column_index = ColumnID{0}; column_index < num_columns; ++column_index) {
-      resolve_data_type(column_data_types[column_index], [&](const auto column_data_type) {
-        using ColumnDataType = typename decltype(column_data_type)::type;
 
-        std::vector<int> values;
-        values.reserve(chunk_size);
-        const auto& column_data_distribution = column_data_distributions[column_index];
+    for (auto column_index = ColumnID{0}; column_index < num_chunks; ++column_index) {
+      jobs.emplace_back(std::make_shared<JobTask>([&]() {
+        resolve_data_type(column_data_types[column_index], [&, column_index](const auto column_data_type) {
+          using ColumnDataType = typename decltype(column_data_type)::type;
 
-        auto probability_dist = std::uniform_real_distribution{0.0, 1.0};
-        auto generate_value_by_distribution_type = std::function<int(void)>{};
+          std::vector<int> values;
+          values.reserve(chunk_size);
+          const auto& column_data_distribution = column_data_distributions[column_index];
 
-        // generate distribution from column configuration
-        switch (column_data_distribution.distribution_type) {
-          case DataDistributionType::Uniform: {
-            const auto uniform_dist = boost::math::uniform_distribution<double>{column_data_distribution.min_value,
-                                                                                column_data_distribution.max_value};
-            generate_value_by_distribution_type = [uniform_dist, &probability_dist, &pseudorandom_engine]() {
-              const auto probability = probability_dist(pseudorandom_engine);
-              return static_cast<int>(std::round(boost::math::quantile(uniform_dist, probability)));
-            };
-            break;
+          auto probability_dist = std::uniform_real_distribution{0.0, 1.0};
+          auto generate_value_by_distribution_type = std::function<int(void)>{};
+
+          // generate distribution from column configuration
+          switch (column_data_distribution.distribution_type) {
+            case DataDistributionType::Uniform: {
+              const auto uniform_dist = boost::math::uniform_distribution<double>{column_data_distribution.min_value,
+                                                                                  column_data_distribution.max_value};
+              generate_value_by_distribution_type = [uniform_dist, &probability_dist, &pseudorandom_engine]() {
+                const auto probability = probability_dist(pseudorandom_engine);
+                return static_cast<int>(std::round(boost::math::quantile(uniform_dist, probability)));
+              };
+              break;
+            }
+            case DataDistributionType::NormalSkewed: {
+              const auto skew_dist = boost::math::skew_normal_distribution<double>{column_data_distribution.skew_location,
+                                                                                   column_data_distribution.skew_scale,
+                                                                                   column_data_distribution.skew_shape};
+              generate_value_by_distribution_type = [skew_dist, &probability_dist, &pseudorandom_engine]() {
+                const auto probability = probability_dist(pseudorandom_engine);
+                return static_cast<int>(std::round(boost::math::quantile(skew_dist, probability) * 10));
+              };
+              break;
+            }
+            case DataDistributionType::Pareto: {
+              const auto pareto_dist = boost::math::pareto_distribution<double>{column_data_distribution.pareto_scale,
+                                                                                column_data_distribution.pareto_shape};
+              generate_value_by_distribution_type = [pareto_dist, &probability_dist, &pseudorandom_engine]() {
+                const auto probability = probability_dist(pseudorandom_engine);
+                return static_cast<int>(std::round(boost::math::quantile(pareto_dist, probability)));
+              };
+              break;
+            }
           }
-          case DataDistributionType::NormalSkewed: {
-            const auto skew_dist = boost::math::skew_normal_distribution<double>{column_data_distribution.skew_location,
-                                                                                 column_data_distribution.skew_scale,
-                                                                                 column_data_distribution.skew_shape};
-            generate_value_by_distribution_type = [skew_dist, &probability_dist, &pseudorandom_engine]() {
-              const auto probability = probability_dist(pseudorandom_engine);
-              return static_cast<int>(std::round(boost::math::quantile(skew_dist, probability) * 10));
-            };
-            break;
-          }
-          case DataDistributionType::Pareto: {
-            const auto pareto_dist = boost::math::pareto_distribution<double>{column_data_distribution.pareto_scale,
-                                                                              column_data_distribution.pareto_shape};
-            generate_value_by_distribution_type = [pareto_dist, &probability_dist, &pseudorandom_engine]() {
-              const auto probability = probability_dist(pseudorandom_engine);
-              return static_cast<int>(std::round(boost::math::quantile(pareto_dist, probability)));
-            };
-            break;
-          }
-        }
 
-        /**
-        * Generate values according to distribution. We first add the given min and max values of that column to avoid
-        * early exists via dictionary pruning (no matter which values are later searched, the local segment
-        * dictionaries cannot prune them early). In the main loop, we thus execute the loop two times less.
-        **/
-        values.push_back(static_cast<int>(column_data_distribution.min_value));
-        values.push_back(static_cast<int>(column_data_distribution.max_value));
-        for (auto row_offset = size_t{0}; row_offset < chunk_size - 2; ++row_offset) {
-          // bounds check
-          if (chunk_index * chunk_size + (row_offset + 1) > num_rows - 2) {
-            break;
-          }
-          values.push_back(generate_value_by_distribution_type());
-        }
-
-        segments[column_index] =
-            std::make_shared<ValueSegment<ColumnDataType>>(create_typed_segment_values<ColumnDataType>(values));
-      });
-
-      // add full chunk to table
-      if (column_index == num_columns - 1) {
-        if (use_mvcc == UseMvcc::Yes) {
-          const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
-          table->append_chunk(segments, mvcc_data);
-        } else {
-          table->append_chunk(segments);
-        }
-
-        if (segment_encoding_specs) {
           /**
-          * As the runtime of the table generation is dominated by the chunk encoding, parallelizing the actual data
-          * generation barely impact the runtime. Nonetheless, a single thread for the chunk encoder (which itself is parallelizing
-          * internally) ensures that the segment creation is not blocked by the encoding of the previous chunk. To
-          * avoid overparallelizing, there is at most one thread for encode_chunk() at any time.
+          * Generate values according to distribution. We first add the given min and max values of that column to avoid
+          * early exists via dictionary pruning (no matter which values are later searched, the local segment
+          * dictionaries cannot prune them early). In the main loop, we thus execute the loop two times less.
           **/
-          if (!encoder_threads.empty()) {
-            encoder_threads.back().join();
+          values.push_back(static_cast<int>(column_data_distribution.min_value));
+          values.push_back(static_cast<int>(column_data_distribution.max_value));
+          for (auto row_offset = size_t{0}; row_offset < chunk_size - 2; ++row_offset) {
+            // bounds check
+            if (chunk_index * chunk_size + (row_offset + 1) > num_rows - 2) {
+              break;
+            }
+            values.push_back(generate_value_by_distribution_type());
           }
 
-          const auto chunk_id = ChunkID{table->chunk_count() - 1};
-          encoder_threads.emplace_back([&, chunk_id] {
-            ChunkEncoder::encode_chunk(table->get_chunk(chunk_id), table->column_data_types(), *segment_encoding_specs,
-                                       true);
-          });
+          segments[column_index] =
+              std::make_shared<ValueSegment<ColumnDataType>>(create_typed_segment_values<ColumnDataType>(values));
+        });
+
+        // add full chunk to table
+        if (column_index == num_columns - 1) {
+          if (use_mvcc == UseMvcc::Yes) {
+            const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
+            table->append_chunk(segments, mvcc_data);
+          } else {
+            table->append_chunk(segments);
+          }
+
+          // get added chunk, mark it as immutable and add statistics
+          const auto& added_chunk = table->get_chunk(ChunkID{table->chunk_count() - 1});
+          added_chunk->mark_immutable();
+          if (!added_chunk->pruning_statistics()) {
+            generate_chunk_pruning_statistics(added_chunk);
+          }
+
+          if (segment_encoding_specs) {
+            for (auto column_id_to_encode = ColumnID{0}; column_id_to_encode < num_columns; ++column_id_to_encode)
+              ChunkEncoder::encode_segment(added_chunk->get_segment(column_id_to_encode), table->column_data_types()[column_id_to_encode], segment_encoding_specs->at(column_id_to_encode));
+          }
         }
-      }
+      }));
+      jobs.back()->schedule();
     }
+    Hyrise::get().scheduler()->wait_for_tasks(jobs);
   }
 
-  encoder_threads.back().join();
-
+  Hyrise::get().set_scheduler(previous_scheduler);  // set scheduler back to previous one.
   return table;
 }
+
 }  // namespace opossum

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -105,8 +105,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
 
     Segments segments(num_columns);
 
-    for (auto column_index = ColumnID{0}; column_index < num_chunks; ++column_index) {
-      jobs.emplace_back(std::make_shared<JobTask>([&]() {
+    for (auto column_index = ColumnID{0}; column_index < num_columns; ++column_index) {
+      jobs.emplace_back(std::make_shared<JobTask>([&, column_index]() {
         resolve_data_type(column_data_types[column_index], [&, column_index](const auto column_data_type) {
           using ColumnDataType = typename decltype(column_data_type)::type;
 
@@ -197,7 +197,9 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
     Hyrise::get().scheduler()->wait_for_tasks(jobs);
   }
 
+  Hyrise::get().scheduler()->wait_for_all_tasks();
   Hyrise::get().set_scheduler(previous_scheduler);  // set scheduler back to previous one.
+
   return table;
 }
 

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -14,6 +14,7 @@
 #include "boost/math/distributions/uniform.hpp"
 
 #include "hyrise.hpp"
+#include "resolve_type.hpp"
 #include "scheduler/abstract_task.hpp"
 #include "scheduler/job_task.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
@@ -23,7 +24,6 @@
 #include "storage/chunk_encoder.hpp"
 #include "storage/table.hpp"
 #include "storage/value_segment.hpp"
-#include "resolve_type.hpp"
 #include "types.hpp"
 
 namespace {
@@ -83,7 +83,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
 
   const auto num_columns = column_data_distributions.size();
-  const auto num_chunks = static_cast<size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(chunk_size)));
+  const auto num_chunks =
+      static_cast<size_t>(std::ceil(static_cast<double>(num_rows) / static_cast<double>(chunk_size)));
 
   // add column definitions and initialize each value vector
   TableColumnDefinitions column_definitions;
@@ -128,9 +129,9 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
               break;
             }
             case DataDistributionType::NormalSkewed: {
-              const auto skew_dist = boost::math::skew_normal_distribution<double>{column_data_distribution.skew_location,
-                                                                                   column_data_distribution.skew_scale,
-                                                                                   column_data_distribution.skew_shape};
+              const auto skew_dist = boost::math::skew_normal_distribution<double>{
+                  column_data_distribution.skew_location, column_data_distribution.skew_scale,
+                  column_data_distribution.skew_shape};
               generate_value_by_distribution_type = [skew_dist, &probability_dist, &pseudorandom_engine]() {
                 const auto probability = probability_dist(pseudorandom_engine);
                 return static_cast<int>(std::round(boost::math::quantile(skew_dist, probability) * 10));
@@ -185,7 +186,9 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
 
           if (segment_encoding_specs) {
             for (auto column_id_to_encode = ColumnID{0}; column_id_to_encode < num_columns; ++column_id_to_encode)
-              ChunkEncoder::encode_segment(added_chunk->get_segment(column_id_to_encode), table->column_data_types()[column_id_to_encode], segment_encoding_specs->at(column_id_to_encode));
+              ChunkEncoder::encode_segment(added_chunk->get_segment(column_id_to_encode),
+                                           table->column_data_types()[column_id_to_encode],
+                                           segment_encoding_specs->at(column_id_to_encode));
           }
         }
       }));

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -147,7 +147,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
             break;
           }
 
-          if constexpr (std::is_same_v<ColumnDataType, pmr_string> && column_data_distribution.distribution_type == DataDistributionType::NormalSkewed) {
+          if constexpr (std::is_same_v<ColumnDataType, pmr_string> &&
+                        column_data_distribution.distribution_type == DataDistributionType::NormalSkewed) {
             // shift values and remove negative ones, because negative values cannot converted to strings as of now
             values.push_back(abs(generate_value_by_distribution_type() + 10'000));
           } else {

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -149,7 +149,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
           values.push_back(generate_value_by_distribution_type());
         }
 
-        segments[column_index] = 
+        segments[column_index] =
             std::make_shared<ValueSegment<ColumnDataType>>(create_typed_segment_values<ColumnDataType>(values));
       });
 
@@ -175,7 +175,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
 
           const auto chunk_id = ChunkID{table->chunk_count() - 1};
           encoder_threads.emplace_back([&, chunk_id] {
-            ChunkEncoder::encode_chunk(table->get_chunk(chunk_id), table->column_data_types(), *segment_encoding_specs, true);
+            ChunkEncoder::encode_chunk(table->get_chunk(chunk_id), table->column_data_types(), *segment_encoding_specs,
+                                       true);
           });
         }
       }

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -147,7 +147,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
             break;
           }
 
-          if constexpr (std::is_same_v<ColumnDataType, pmr_string> &&
+          if (std::is_same_v<ColumnDataType, pmr_string> &&
                         column_data_distribution.distribution_type == DataDistributionType::NormalSkewed) {
             // shift values and remove negative ones, because negative values cannot converted to strings as of now
             values.push_back(abs(generate_value_by_distribution_type() + 10'000));

--- a/src/benchmarklib/synthetic_table_generator.hpp
+++ b/src/benchmarklib/synthetic_table_generator.hpp
@@ -32,7 +32,7 @@ struct ColumnDataDistribution {
 
   static ColumnDataDistribution make_skewed_normal_config(const double skew_location = 0.0,
                                                           const double skew_scale = 1.0,
-                                                          const double skew_shape = 0.0) {
+                                                          const double skew_shape = 0.0001) {
     ColumnDataDistribution c{};
     c.skew_location = skew_location;
     c.skew_scale = skew_scale;

--- a/src/benchmarklib/synthetic_table_generator.hpp
+++ b/src/benchmarklib/synthetic_table_generator.hpp
@@ -109,9 +109,6 @@ class SyntheticTableGenerator {
                                        'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
                                        'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
       const size_t chars_base = chars.size();
-
-      // For the current settings, integer valures are guaranteed to not exceed the value range. However, the assertion
-      // is kept as the generated string length might change or the interface (e.g., taking size_t input).
       Assert(static_cast<double>(input) < std::pow(chars_base, variable_string_length),
              "Input too large. Cannot be represented in " + std::to_string(variable_string_length) + " chars.");
 
@@ -128,8 +125,6 @@ class SyntheticTableGenerator {
       }
 
       return result;
-    } else {
-      Fail("Requested type not supported.");
     }
   }
 

--- a/src/benchmarklib/synthetic_table_generator.hpp
+++ b/src/benchmarklib/synthetic_table_generator.hpp
@@ -30,7 +30,7 @@ struct ColumnDataDistribution {
     return c;
   }
 
-  static ColumnDataDistribution make_skewed_normal_config(const double skew_location = 1000.0,
+  static ColumnDataDistribution make_skewed_normal_config(const double skew_location = 0.0,
                                                           const double skew_scale = 1.0,
                                                           const double skew_shape = 0.0) {
     ColumnDataDistribution c{};

--- a/src/benchmarklib/synthetic_table_generator.hpp
+++ b/src/benchmarklib/synthetic_table_generator.hpp
@@ -30,11 +30,11 @@ struct ColumnDataDistribution {
     return c;
   }
 
-  static ColumnDataDistribution make_skewed_normal_config(const double skew_location = 0.0,
-                                                          const double skew_scale = 1.0,
-                                                          // Temporary work around for https://github.com/boostorg/math/issues/254.
-                                                          // TODO(anyone): reset to 0.0 when Hyrise's boost has the fix.
-                                                          const double skew_shape = 0.0001) {
+  static ColumnDataDistribution make_skewed_normal_config(
+      const double skew_location = 0.0, const double skew_scale = 1.0,
+      // Temporary work around for https://github.com/boostorg/math/issues/254.
+      // TODO(anyone): reset to 0.0 when Hyrise's boost has the fix.
+      const double skew_shape = 0.0001) {
     ColumnDataDistribution c{};
     c.skew_location = skew_location;
     c.skew_scale = skew_scale;

--- a/src/benchmarklib/synthetic_table_generator.hpp
+++ b/src/benchmarklib/synthetic_table_generator.hpp
@@ -32,6 +32,8 @@ struct ColumnDataDistribution {
 
   static ColumnDataDistribution make_skewed_normal_config(const double skew_location = 0.0,
                                                           const double skew_scale = 1.0,
+                                                          // Temporary work around for https://github.com/boostorg/math/issues/254.
+                                                          // TODO(anyone): reset to 0.0 when Hyrise's boost has the fix.
                                                           const double skew_shape = 0.0001) {
     ColumnDataDistribution c{};
     c.skew_location = skew_location;

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,14 +1,10 @@
 #include <iostream>
 
 #include "types.hpp"
-#include "synthetic_table_generator.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-	for (int i = 0; i < 4'000'000; ++i) {
-		if (SyntheticTableGenerator::generate_value<pmr_string>(i) == "      EPIC") {
-			std::cout << i << std::endl;
-		}
-	}
+  std::cout << "Hello world!!" << std::endl;
+  return 0;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,10 +1,42 @@
+#include <algorithm>
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <random>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
+#include "synthetic_table_generator.hpp"
 #include "types.hpp"
+
+#include "boost/math/distributions/pareto.hpp"
+#include "boost/math/distributions/skew_normal.hpp"
+#include "boost/math/distributions/uniform.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-  std::cout << "Hello world!!" << std::endl;
-  return 0;
+  int min = -100000;
+  for (int i = 0; i < 100'000'000; ++i) {
+    std::random_device random_device;
+    auto pseudorandom_engine = std::mt19937{};
+
+    pseudorandom_engine.seed(random_device());
+    auto probability_dist = std::uniform_real_distribution{0.0, 1.0};
+    auto generate_value_by_distribution_type = std::function<int(void)>{};
+
+    const auto skew_dist = boost::math::skew_normal_distribution<double>{1000.0, 1.0, 1.0};
+    generate_value_by_distribution_type = [skew_dist, &probability_dist, &pseudorandom_engine]() {
+      const auto probability = probability_dist(pseudorandom_engine);
+      return static_cast<int>(std::round(boost::math::quantile(skew_dist, probability) * 10));
+    };
+    const auto value = generate_value_by_distribution_type();
+    min = std::min(min, value);
+    if (value < 0) {
+      std::cout << i << " - " << value << std::endl;
+    }
+  }
+  std::cout << "Done ... " << min << std::endl;
 }

--- a/src/bin/playground.cpp
+++ b/src/bin/playground.cpp
@@ -1,42 +1,10 @@
-#include <algorithm>
-#include <functional>
 #include <iostream>
-#include <memory>
-#include <random>
-#include <string>
-#include <thread>
-#include <utility>
-#include <vector>
 
-#include "synthetic_table_generator.hpp"
 #include "types.hpp"
-
-#include "boost/math/distributions/pareto.hpp"
-#include "boost/math/distributions/skew_normal.hpp"
-#include "boost/math/distributions/uniform.hpp"
 
 using namespace opossum;  // NOLINT
 
 int main() {
-  int min = -100000;
-  for (int i = 0; i < 100'000'000; ++i) {
-    std::random_device random_device;
-    auto pseudorandom_engine = std::mt19937{};
-
-    pseudorandom_engine.seed(random_device());
-    auto probability_dist = std::uniform_real_distribution{0.0, 1.0};
-    auto generate_value_by_distribution_type = std::function<int(void)>{};
-
-    const auto skew_dist = boost::math::skew_normal_distribution<double>{1000.0, 1.0, 1.0};
-    generate_value_by_distribution_type = [skew_dist, &probability_dist, &pseudorandom_engine]() {
-      const auto probability = probability_dist(pseudorandom_engine);
-      return static_cast<int>(std::round(boost::math::quantile(skew_dist, probability) * 10));
-    };
-    const auto value = generate_value_by_distribution_type();
-    min = std::min(min, value);
-    if (value < 0) {
-      std::cout << i << " - " << value << std::endl;
-    }
-  }
-  std::cout << "Done ... " << min << std::endl;
+  std::cout << "Hello world!!" << std::endl;
+  return 0;
 }

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -11,7 +11,6 @@
 
 #include "expression/abstract_expression.hpp"
 #include "expression/aggregate_expression.hpp"
-#include "storage/encoding_type.hpp"
 #include "storage/table.hpp"
 #include "storage/vector_compression/vector_compression.hpp"
 #include "utils/make_bimap.hpp"
@@ -71,6 +70,15 @@ std::ostream& operator<<(std::ostream& stream, EncodingType encoding_type) {
 
 std::ostream& operator<<(std::ostream& stream, VectorCompressionType vector_compression_type) {
   return stream << vector_compression_type_to_string.left.at(vector_compression_type);
+}
+
+std::ostream& operator<<(std::ostream& stream, const SegmentEncodingSpec& spec) {
+  stream << spec.encoding_type;
+  if (spec.vector_compression_type) {
+    stream << "-" << *spec.vector_compression_type;
+  }
+
+  return stream;
 }
 
 }  // namespace opossum

--- a/src/lib/constant_mappings.hpp
+++ b/src/lib/constant_mappings.hpp
@@ -7,6 +7,7 @@
 
 #include "all_type_variant.hpp"
 #include "expression/function_expression.hpp"
+#include "storage/encoding_type.hpp"
 #include "types.hpp"
 
 namespace opossum {
@@ -27,5 +28,6 @@ std::ostream& operator<<(std::ostream& stream, FunctionType function_type);
 std::ostream& operator<<(std::ostream& stream, DataType data_type);
 std::ostream& operator<<(std::ostream& stream, EncodingType encoding_type);
 std::ostream& operator<<(std::ostream& stream, VectorCompressionType vector_compression_type);
+std::ostream& operator<<(std::ostream& stream, const SegmentEncodingSpec& spec);
 
 }  // namespace opossum

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -969,7 +969,7 @@ std::shared_ptr<const Table> ExpressionEvaluator::_evaluate_subquery_expression_
   row_pqp->set_parameters(parameters);
 
   const auto tasks = OperatorTask::make_tasks_from_operator(row_pqp, CleanupTemporaries::Yes);
-  Hyrise::get().scheduler().schedule_and_wait_for_tasks(tasks);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
 
   return row_pqp->get_output();
 }

--- a/src/lib/hyrise.cpp
+++ b/src/lib/hyrise.cpp
@@ -22,11 +22,11 @@ Hyrise::Hyrise() {
 }
 
 void Hyrise::reset() {
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
   get() = Hyrise{};
 }
 
-AbstractScheduler& Hyrise::scheduler() const { return *_scheduler; }
+const std::shared_ptr<AbstractScheduler>& Hyrise::scheduler() const { return _scheduler; }
 
 void Hyrise::set_scheduler(const std::shared_ptr<AbstractScheduler>& new_scheduler) {
   _scheduler->finish();

--- a/src/lib/hyrise.hpp
+++ b/src/lib/hyrise.hpp
@@ -26,7 +26,7 @@ class Hyrise : public Singleton<Hyrise> {
   // You should be very sure that this is what you want.
   static void reset();
 
-  AbstractScheduler& scheduler() const;
+  const std::shared_ptr<AbstractScheduler>& scheduler() const;
 
   void set_scheduler(const std::shared_ptr<AbstractScheduler>& new_scheduler);
 

--- a/src/lib/import_export/csv_parser.cpp
+++ b/src/lib/import_export/csv_parser.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const std::
     tasks.back()->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(tasks);
+  Hyrise::get().scheduler()->wait_for_tasks(tasks);
 
   for (auto& segments : segments_by_chunks) {
     DebugAssert(!segments.empty(), "Empty chunks shouldn't occur when importing CSV");

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -268,7 +268,7 @@ void AggregateHash::_aggregate() {
     jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   /*
   AGGREGATION PHASE

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<const Table> IndexScan::_on_execute() {
     }
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   return _out_table;
 }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -380,7 +380,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     }));
     jobs.back()->schedule();
 
-    Hyrise::get().scheduler().wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
     // Short cut for AntiNullAsTrue
     //   If there is any NULL value on the build side, do not bother probing as no tuples can be emitted

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -307,7 +307,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
     }));
     jobs.back()->schedule();
   }
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   return RadixContainer<T>{elements, std::vector<size_t>{elements->size()}, null_value_bitvector};
 }
@@ -365,7 +365,7 @@ std::vector<std::optional<PosHashTable<HashedType>>> build(const RadixContainer<
     jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   return hash_tables;
 }
@@ -508,7 +508,7 @@ RadixContainer<T> partition_radix_parallel(const RadixContainer<T>& radix_contai
     jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   return radix_output;
 }
@@ -666,7 +666,7 @@ void probe(const RadixContainer<ProbeColumnType>& probe_radix_container,
     jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 }
 
 template <typename ProbeColumnType, typename HashedType, JoinMode mode>
@@ -780,7 +780,7 @@ void probe_semi_anti(const RadixContainer<ProbeColumnType>& radix_probe_column,
     jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 }
 
 using PosLists = std::vector<std::shared_ptr<const PosList>>;

--- a/src/lib/operators/join_mpsm.cpp
+++ b/src/lib/operators/join_mpsm.cpp
@@ -400,7 +400,7 @@ class JoinMPSM::JoinMPSMImpl : public AbstractJoinOperatorImpl {
       jobs.back()->schedule(static_cast<NodeID>(cluster_number));
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(jobs);
   }
 
   /**

--- a/src/lib/operators/join_mpsm/column_materializer_numa.hpp
+++ b/src/lib/operators/join_mpsm/column_materializer_numa.hpp
@@ -107,7 +107,7 @@ class ColumnMaterializerNUMA {
       jobs.back()->schedule(numa_node_id);
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
     for (auto& partition : (*output)) {
       // removes null pointers, this is important since we currently opt against using mutexes so we have sparse vectors

--- a/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
+++ b/src/lib/operators/join_mpsm/radix_cluster_sort_numa.hpp
@@ -214,7 +214,7 @@ class RadixClusterSortNUMA {
       job->schedule(node_id);
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(cluster_jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(cluster_jobs);
 
     DebugAssert(output_table.materialized_segments.size() == _cluster_count,
                 "Error in clustering: Number of output segments does not match the number of clusters.");
@@ -248,7 +248,7 @@ class RadixClusterSortNUMA {
       job->schedule(node_id);
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(cluster_jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(cluster_jobs);
 
     return output;
   }
@@ -294,7 +294,7 @@ class RadixClusterSortNUMA {
       job->schedule(numa_node);
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(repartition_jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(repartition_jobs);
 
     return homogenous_partitions;
   }
@@ -316,7 +316,7 @@ class RadixClusterSortNUMA {
       }
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(sort_jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(sort_jobs);
   }
 
  public:

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -786,7 +786,7 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
       jobs.back()->schedule();
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
     // The outer joins for the non-equi cases
     // Note: Equi outer joins can be integrated into the main algorithm, while these can not.

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -84,7 +84,7 @@ class ColumnMaterializer {
       jobs.back()->schedule();
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
     auto gathered_samples = std::vector<T>();
     gathered_samples.reserve(samples_per_chunk * chunk_count);

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -194,7 +194,7 @@ class RadixClusterSort {
       job->schedule();
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(histogram_jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(histogram_jobs);
 
     // Aggregate the chunks histograms to a table histogram and initialize the insert positions for each chunk
     for (auto& chunk_information : table_information.chunk_information) {
@@ -228,7 +228,7 @@ class RadixClusterSort {
       job->schedule();
     }
 
-    Hyrise::get().scheduler().wait_for_tasks(cluster_jobs);
+    Hyrise::get().scheduler()->wait_for_tasks(cluster_jobs);
 
     return output_table;
   }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
     job_task->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
     job_end_chunk_id++;
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->wait_for_tasks(jobs);
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -60,7 +60,7 @@ void AbstractTask::set_done_callback(const std::function<void()>& done_callback)
 void AbstractTask::schedule(NodeID preferred_node_id) {
   _mark_as_scheduled();
 
-  Hyrise::get().scheduler().schedule(shared_from_this(), preferred_node_id, _priority);
+  Hyrise::get().scheduler()->schedule(shared_from_this(), preferred_node_id, _priority);
 }
 
 void AbstractTask::_join() {

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -123,7 +123,7 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
 
   /**
    * Blocks the calling thread until the Task finished executing.
-   * This is only called from non-Worker threads and from Hyrise::get().scheduler().wait_for_tasks().
+   * This is only called from non-Worker threads and from Hyrise::get().scheduler()->wait_for_tasks().
    */
   void _join();
 

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -48,7 +48,7 @@ void Worker::operator()() {
 
   _set_affinity();
 
-  while (Hyrise::get().scheduler().active()) {
+  while (Hyrise::get().scheduler()->active()) {
     _work();
   }
 }
@@ -59,7 +59,7 @@ void Worker::_work() {
   if (!task) {
     // Simple work stealing without explicitly transferring data between nodes.
     auto work_stealing_successful = false;
-    for (auto& queue : Hyrise::get().scheduler().queues()) {
+    for (auto& queue : Hyrise::get().scheduler()->queues()) {
       if (queue == _queue) {
         continue;
       }
@@ -93,7 +93,7 @@ void Worker::_work() {
 void Worker::start() { _thread = std::thread(&Worker::operator(), this); }
 
 void Worker::join() {
-  Assert(!Hyrise::get().scheduler().active(), "Worker can't be join()-ed while the scheduler is still active");
+  Assert(!Hyrise::get().scheduler()->active(), "Worker can't be join()-ed while the scheduler is still active");
   _thread.join();
 }
 

--- a/src/lib/server/task_runner.hpp
+++ b/src/lib/server/task_runner.hpp
@@ -30,7 +30,7 @@ auto TaskRunner::dispatch_server_task(std::shared_ptr<TResult> task) -> decltype
   using opossum::then_operator::then;
   using TaskList = std::vector<std::shared_ptr<AbstractTask>>;
 
-  Hyrise::get().scheduler().schedule_tasks(TaskList({task}));
+  Hyrise::get().scheduler()->schedule_tasks(TaskList({task}));
 
   return task->get_future()
       .then(boost::launch::sync,

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -226,7 +226,7 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipelineSta
 
   DTRACE_PROBE3(HYRISE, TASKS_PER_STATEMENT, reinterpret_cast<uintptr_t>(&tasks), _sql_string.c_str(),
                 reinterpret_cast<uintptr_t>(this));
-  Hyrise::get().scheduler().schedule_and_wait_for_tasks(tasks);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
 
   if (was_rolled_back()) {
     return {SQLPipelineStatus::RolledBack, _result_table};

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -95,11 +95,10 @@ std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<
 void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::vector<DataType>& column_data_types,
                                 const ChunkEncodingSpec& chunk_encoding_spec, const bool encode_in_parallel) {
   const auto column_count = chunk->column_count();
-  Assert((column_data_types.size() == column_count),
-         "Number of column types must match the chunk’s column count.");
+  Assert((column_data_types.size() == column_count), "Number of column types must match the chunk’s column count.");
   Assert((chunk_encoding_spec.size() == column_count),
          "Number of column encoding specs must match the chunk’s column count.");
-  
+
   auto next_column_id = std::atomic_ushort{0};
   auto threads = std::vector<std::thread>{};
   const auto thread_count = std::min(column_count, static_cast<uint16_t>(std::thread::hardware_concurrency()));

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -1,6 +1,7 @@
 #include "chunk_encoder.hpp"
 
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "base_value_segment.hpp"
@@ -92,21 +93,41 @@ std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<
 }
 
 void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::vector<DataType>& column_data_types,
-                                const ChunkEncodingSpec& chunk_encoding_spec) {
-  Assert((column_data_types.size() == chunk->column_count()),
+                                const ChunkEncodingSpec& chunk_encoding_spec, const bool encode_in_parallel) {
+  const auto column_count = chunk->column_count();
+  Assert((column_data_types.size() == column_count),
          "Number of column types must match the chunk’s column count.");
-  Assert((chunk_encoding_spec.size() == chunk->column_count()),
+  Assert((chunk_encoding_spec.size() == column_count),
          "Number of column encoding specs must match the chunk’s column count.");
+  
+  auto next_column_id = std::atomic_ushort{0};
+  auto threads = std::vector<std::thread>{};
+  const auto thread_count = std::min(column_count, static_cast<uint16_t>(std::thread::hardware_concurrency()));
 
-  for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
-    const auto spec = chunk_encoding_spec[column_id];
+  for (auto thread_id = 0u; thread_id < static_cast<uint>(thread_count); ++thread_id) {
+    const auto task = [&] {
+      while (true) {
+        const auto current_column_id = ColumnID{next_column_id++};
+        if (current_column_id >= column_count) return;
 
-    const auto data_type = column_data_types[column_id];
-    const auto base_segment = chunk->get_segment(column_id);
+        const auto spec = chunk_encoding_spec[current_column_id];
 
-    const auto encoded_segment = encode_segment(base_segment, data_type, spec);
-    chunk->replace_segment(column_id, encoded_segment);
+        const auto data_type = column_data_types[current_column_id];
+        const auto base_segment = chunk->get_segment(current_column_id);
+
+        const auto encoded_segment = encode_segment(base_segment, data_type, spec);
+        chunk->replace_segment(current_column_id, encoded_segment);
+      }
+    };
+
+    if (encode_in_parallel) {
+      threads.emplace_back(task);
+    } else {
+      task();
+    }
   }
+
+  for (auto& thread : threads) thread.join();
 
   chunk->mark_immutable();
 

--- a/src/lib/storage/chunk_encoder.hpp
+++ b/src/lib/storage/chunk_encoder.hpp
@@ -35,11 +35,14 @@ class ChunkEncoder {
   /**
    * @brief Encodes a chunk
    *
-   * Encodes a chunk using the passed encoding specifications.
-   * Reduces also the fragmentation of the chunk’s MVCC data.
+   * Encodes a chunk using the passed encoding specifications. Reduces also the fragmentation of the chunk’s MVCC data.
+   * 
+   * thread_per_segment allows to parallelize the encoding. It defaults to false since encoding is expected to be a
+   * background process with a minimal overhead. The scheduler is not used in order to parallelize even when the
+   * scheduler is disabled.
    */
   static void encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::vector<DataType>& column_data_types,
-                           const ChunkEncodingSpec& chunk_encoding_spec);
+                           const ChunkEncodingSpec& chunk_encoding_spec, const bool encode_in_parallel = false);
 
   /**
    * @brief Encodes a chunk using the same SegmentEncodingSpec

--- a/src/lib/storage/chunk_encoder.hpp
+++ b/src/lib/storage/chunk_encoder.hpp
@@ -36,13 +36,9 @@ class ChunkEncoder {
    * @brief Encodes a chunk
    *
    * Encodes a chunk using the passed encoding specifications. Reduces also the fragmentation of the chunk’s MVCC data.
-   * 
-   * thread_per_segment allows to parallelize the encoding. It defaults to false since encoding is expected to be a
-   * background process with a minimal overhead. The scheduler is not used in order to parallelize even when the
-   * scheduler is disabled.
    */
   static void encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::vector<DataType>& column_data_types,
-                           const ChunkEncodingSpec& chunk_encoding_spec, const bool encode_in_parallel = false);
+                           const ChunkEncodingSpec& chunk_encoding_spec);
 
   /**
    * @brief Encodes a chunk using the same SegmentEncodingSpec

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -80,7 +80,6 @@ inline constexpr std::array all_segment_encoding_specs{
     SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
     SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
     SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
-    SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
     SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128},
     SegmentEncodingSpec{EncodingType::RunLength}};
 

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -455,14 +455,15 @@ std::optional<CompressedVectorType> LZ4Segment<T>::compressed_vector_type() cons
   return std::nullopt;
 }
 
+// Right now, vector compression is fixed to SimdBp128. This method nonetheless checks for the actual vector
+// compression type. So if the vector compression becomes configurable, this method does not need to be touched.
 template <>
 std::optional<CompressedVectorType> LZ4Segment<pmr_string>::compressed_vector_type() const {
+  std::optional<CompressedVectorType> type;
   if (_string_offsets) {
-    CompressedVectorType type = CompressedVectorType::SimdBp128;  // initialize for GCC
     resolve_compressed_vector_type(*(*_string_offsets), [&](const auto& vector) { type = vector.type(); });
-    return type;
   }
-  return std::nullopt;
+  return type;
 }
 
 EXPLICITLY_INSTANTIATE_DATA_TYPES(LZ4Segment);

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -459,9 +459,7 @@ template <>
 std::optional<CompressedVectorType> LZ4Segment<pmr_string>::compressed_vector_type() const {
   if (_string_offsets) {
     CompressedVectorType type;
-    resolve_compressed_vector_type(*(*_string_offsets), [&](const auto& vector) {
-      type = vector.type();
-    });
+    resolve_compressed_vector_type(*(*_string_offsets), [&](const auto& vector) { type = vector.type(); });
     return type;
   }
   return std::nullopt;

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -458,7 +458,7 @@ std::optional<CompressedVectorType> LZ4Segment<T>::compressed_vector_type() cons
 template <>
 std::optional<CompressedVectorType> LZ4Segment<pmr_string>::compressed_vector_type() const {
   if (_string_offsets) {
-    CompressedVectorType type;
+    CompressedVectorType type = CompressedVectorType::SimdBp128;  // initialize for GCC
     resolve_compressed_vector_type(*(*_string_offsets), [&](const auto& vector) { type = vector.type(); });
     return type;
   }

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -9,6 +9,7 @@
 #include "resolve_type.hpp"
 #include "storage/vector_compression/base_compressed_vector.hpp"
 #include "storage/vector_compression/base_vector_decompressor.hpp"
+#include "storage/vector_compression/resolve_compressed_vector_type.hpp"
 #include "utils/assert.hpp"
 #include "utils/performance_warning.hpp"
 
@@ -451,6 +452,18 @@ EncodingType LZ4Segment<T>::encoding_type() const {
 
 template <typename T>
 std::optional<CompressedVectorType> LZ4Segment<T>::compressed_vector_type() const {
+  return std::nullopt;
+}
+
+template <>
+std::optional<CompressedVectorType> LZ4Segment<pmr_string>::compressed_vector_type() const {
+  if (_string_offsets) {
+    CompressedVectorType type;
+    resolve_compressed_vector_type(*(*_string_offsets), [&](const auto& vector) {
+      type = vector.type();
+    });
+    return type;
+  }
   return std::nullopt;
 }
 

--- a/src/lib/storage/lz4_segment/lz4_encoder.hpp
+++ b/src/lib/storage/lz4_segment/lz4_encoder.hpp
@@ -224,8 +224,8 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
     }
 
     // Compress the offsets with SimdBp128 vector compression to reduce the memory footprint of the LZ4 segment.
-    // SimdBp128 is chosen over FSBA, since it compresses better and the performance advantage of FSBA is neglectable,
-    // because runtime is dominated by the LZ4 encoding/decoding anyways.
+    // SimdBp128 is chosen over fixed size byte-aligned (FSBA) vector compression, since it compresses better and the
+    // performance advantage of FSBA is neglectable, because runtime is dominated by the LZ4 encoding/decoding anyways.
     auto compressed_offsets = compress_vector(offsets, VectorCompressionType::SimdBp128, allocator, {offsets.back()});
 
     /**

--- a/src/lib/storage/lz4_segment/lz4_encoder.hpp
+++ b/src/lib/storage/lz4_segment/lz4_encoder.hpp
@@ -224,7 +224,7 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
     }
 
     // Compress the offsets with a vector compression method to reduce the memory footprint of the LZ4 segment.
-    auto compressed_offsets = compress_vector(offsets, vector_compression_type(), allocator, {offsets.back()});
+    auto compressed_offsets = compress_vector(offsets, VectorCompressionType::SimdBp128, allocator, {offsets.back()});
 
     /**
      * Pre-compute a zstd dictionary if the input data is split among multiple blocks. This dictionary allows

--- a/src/lib/storage/lz4_segment/lz4_encoder.hpp
+++ b/src/lib/storage/lz4_segment/lz4_encoder.hpp
@@ -223,7 +223,9 @@ class LZ4Encoder : public SegmentEncoder<LZ4Encoder> {
                                                           nullptr, _block_size, 0u, 0u, null_values.size());
     }
 
-    // Compress the offsets with a vector compression method to reduce the memory footprint of the LZ4 segment.
+    // Compress the offsets with SimdBp128 vector compression to reduce the memory footprint of the LZ4 segment.
+    // SimdBp128 is chosen over FSBA, since it compresses better and the performance advantage of FSBA is neglectable,
+    // because runtime is dominated by the LZ4 encoding/decoding anyways.
     auto compressed_offsets = compress_vector(offsets, VectorCompressionType::SimdBp128, allocator, {offsets.back()});
 
     /**

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -162,7 +162,7 @@ void StorageManager::export_all_tables_as_csv(const std::string& path) {
     job_task->schedule();
   }
 
-  Hyrise::get().scheduler().wait_for_tasks(tasks);
+  Hyrise::get().scheduler()->wait_for_tasks(tasks);
 }
 
 std::ostream& operator<<(std::ostream& stream, const StorageManager& storage_manager) {

--- a/src/lib/tasks/server/execute_server_prepared_statement_task.cpp
+++ b/src/lib/tasks/server/execute_server_prepared_statement_task.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 void ExecuteServerPreparedStatementTask::_on_execute() {
   try {
     const auto tasks = OperatorTask::make_tasks_from_operator(_prepared_plan, CleanupTemporaries::Yes);
-    Hyrise::get().scheduler().schedule_and_wait_for_tasks(tasks);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
     auto result_table = tasks.back()->get_operator()->get_output();
     _promise.set_value(std::move(result_table));
   } catch (const std::exception&) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -204,6 +204,7 @@ set (
     ${SHARED_SOURCES}
     server/server_test_runner.cpp
     sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+    synthetic_table_generator_test.cpp
     tpc/tpcds_db_generator_test.cpp
     tpc/tpch_test.cpp
     tpc/tpch_db_generator_test.cpp

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -184,6 +184,7 @@ class BaseTestWithParam
         }
       }
     }
+  }
 
   static std::vector<SegmentEncodingSpec> get_supporting_segment_encodings_specs(const DataType data_type,
                                                                                  const bool include_unencoded = true) {

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -163,7 +163,7 @@ class BaseTestWithParam
     return chunk_encoding_spec;
   }
 
-  static void verify_encoding(const std::shared_ptr<Chunk>& chunk, const ChunkEncodingSpec& spec) {
+  static void assert_chunk_encoding(const std::shared_ptr<Chunk>& chunk, const ChunkEncodingSpec& spec) {
     const auto column_count = chunk->column_count();
     for (auto column_id = ColumnID{0u}; column_id < column_count; ++column_id) {
       const auto segment = chunk->get_segment(column_id);
@@ -171,15 +171,15 @@ class BaseTestWithParam
 
       if (segment_spec.encoding_type == EncodingType::Unencoded) {
         const auto value_segment = std::dynamic_pointer_cast<const BaseValueSegment>(segment);
-        EXPECT_NE(value_segment, nullptr);
+        ASSERT_NE(value_segment, nullptr);
       } else {
         const auto encoded_segment = std::dynamic_pointer_cast<const BaseEncodedSegment>(segment);
-        EXPECT_NE(encoded_segment, nullptr);
-        EXPECT_EQ(encoded_segment->encoding_type(), segment_spec.encoding_type);
+        ASSERT_NE(encoded_segment, nullptr);
+        ASSERT_EQ(encoded_segment->encoding_type(), segment_spec.encoding_type);
         if (segment_spec.vector_compression_type && encoded_segment->compressed_vector_type()) {
           // Both optionals need to be set for comparison, because some encodings only use vector compression for
           // certain types (e.g., LZ4 for pmr_string segments).
-          EXPECT_EQ(*segment_spec.vector_compression_type,
+          ASSERT_EQ(*segment_spec.vector_compression_type,
                     parent_vector_compression_type(*encoded_segment->compressed_vector_type()));
         }
       }

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -162,6 +162,29 @@ class BaseTestWithParam
 
     return chunk_encoding_spec;
   }
+
+  static void verify_encoding(const std::shared_ptr<Chunk>& chunk, const ChunkEncodingSpec& spec) {
+    const auto column_count = chunk->column_count();
+    for (auto column_id = ColumnID{0u}; column_id < column_count; ++column_id) {
+      const auto segment = chunk->get_segment(column_id);
+      const auto segment_spec = spec.at(column_id);
+
+      if (segment_spec.encoding_type == EncodingType::Unencoded) {
+        const auto value_segment = std::dynamic_pointer_cast<const BaseValueSegment>(segment);
+        EXPECT_NE(value_segment, nullptr);
+      } else {
+        const auto encoded_segment = std::dynamic_pointer_cast<const BaseEncodedSegment>(segment);
+        EXPECT_NE(encoded_segment, nullptr);
+        EXPECT_EQ(encoded_segment->encoding_type(), segment_spec.encoding_type);
+        if (segment_spec.vector_compression_type && encoded_segment->compressed_vector_type()) {
+          // Both optionals need to be set for comparison, because some encodings only use vector compression for
+          // certain types (e.g., LZ4 for pmr_string segments).
+          EXPECT_EQ(*segment_spec.vector_compression_type,
+                    parent_vector_compression_type(*encoded_segment->compressed_vector_type()));
+        }
+      }
+    }
+  }
 };
 
 using BaseTest = BaseTestWithParam<void>;

--- a/src/test/operators/import_csv_test.cpp
+++ b/src/test/operators/import_csv_test.cpp
@@ -133,7 +133,7 @@ TEST_F(OperatorsImportCsvTest, Parallel) {
     expected_table->append({458.7f, 12345});
   }
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
   EXPECT_TABLE_EQ_ORDERED(importer->get_operator()->get_output(), expected_table);
   Hyrise::get().set_scheduler(std::make_shared<ImmediateExecutionScheduler>());
 }

--- a/src/test/operators/operator_deep_copy_test.cpp
+++ b/src/test/operators/operator_deep_copy_test.cpp
@@ -205,7 +205,7 @@ TEST_F(OperatorDeepCopyTest, Subquery) {
 
   const auto copied_plan = sql_pipeline.get_physical_plan()->deep_copy();
   const auto tasks = OperatorTask::make_tasks_from_operator(copied_plan, CleanupTemporaries::Yes);
-  Hyrise::get().scheduler().schedule_and_wait_for_tasks(tasks);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
 
   const auto copied_result = tasks.back()->get_operator()->get_output();
 

--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -99,7 +99,7 @@ class SchedulerTest : public BaseTest {
           jobs.emplace_back(job);
         }
 
-        Hyrise::get().scheduler().wait_for_tasks(jobs);
+        Hyrise::get().scheduler()->wait_for_tasks(jobs);
       });
       task->schedule();
       tasks.emplace_back(task);
@@ -118,7 +118,7 @@ TEST_F(SchedulerTest, BasicTest) {
 
   increment_counter_in_subtasks(counter);
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 
   ASSERT_EQ(counter, 30u);
 
@@ -139,7 +139,7 @@ TEST_F(SchedulerTest, LinearDependenciesWithScheduler) {
 
   stress_linear_dependencies(counter);
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 
   ASSERT_EQ(counter, 3u);
 }
@@ -152,7 +152,7 @@ TEST_F(SchedulerTest, MultipleDependenciesWithScheduler) {
 
   stress_multiple_dependencies(counter);
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 
   ASSERT_EQ(counter, 4u);
 }
@@ -165,7 +165,7 @@ TEST_F(SchedulerTest, DiamondDependenciesWithScheduler) {
 
   stress_diamond_dependencies(counter);
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 
   ASSERT_EQ(counter, 7u);
 }
@@ -206,7 +206,7 @@ TEST_F(SchedulerTest, MultipleOperators) {
   gt_task->schedule();
   ts_task->schedule();
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 
   auto expected_result = load_table("resources/test_data/tbl/int_float_filtered2.tbl", 1);
   EXPECT_TABLE_EQ_UNORDERED(ts->get_output(), expected_result);
@@ -221,21 +221,21 @@ TEST_F(SchedulerTest, VerifyTaskQueueSetup) {
   }
   Hyrise::get().topology.use_non_numa_topology(4);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
-  EXPECT_EQ(1, Hyrise::get().scheduler().queues().size());
+  EXPECT_EQ(1, Hyrise::get().scheduler()->queues().size());
 
   Hyrise::get().topology.use_fake_numa_topology(4);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
-  EXPECT_EQ(4, Hyrise::get().scheduler().queues().size());
+  EXPECT_EQ(4, Hyrise::get().scheduler()->queues().size());
 
   Hyrise::get().topology.use_fake_numa_topology(4, 2);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
-  EXPECT_EQ(2, Hyrise::get().scheduler().queues().size());
+  EXPECT_EQ(2, Hyrise::get().scheduler()->queues().size());
 
   Hyrise::get().topology.use_fake_numa_topology(4, 4);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
-  EXPECT_EQ(1, Hyrise::get().scheduler().queues().size());
+  EXPECT_EQ(1, Hyrise::get().scheduler()->queues().size());
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 }
 
 TEST_F(SchedulerTest, SingleWorkerGuaranteeProgress) {
@@ -247,14 +247,14 @@ TEST_F(SchedulerTest, SingleWorkerGuaranteeProgress) {
     auto subtask = std::make_shared<JobTask>([&task_done]() { task_done = true; });
 
     subtask->schedule();
-    Hyrise::get().scheduler().wait_for_tasks(std::vector<std::shared_ptr<AbstractTask>>{subtask});
+    Hyrise::get().scheduler()->wait_for_tasks(std::vector<std::shared_ptr<AbstractTask>>{subtask});
   });
 
   task->schedule();
-  Hyrise::get().scheduler().wait_for_tasks(std::vector<std::shared_ptr<AbstractTask>>{task});
+  Hyrise::get().scheduler()->wait_for_tasks(std::vector<std::shared_ptr<AbstractTask>>{task});
   EXPECT_TRUE(task_done);
 
-  Hyrise::get().scheduler().finish();
+  Hyrise::get().scheduler()->finish();
 }
 
 }  // namespace opossum

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -50,16 +50,6 @@ class ChunkEncoderTest : public BaseTest {
   std::shared_ptr<Table> _table;
 };
 
-TEST_F(ChunkEncoderTest, ParentVectorCompressionType) {
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
-            VectorCompressionType::FixedSizeByteAligned);
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
-            VectorCompressionType::FixedSizeByteAligned);
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
-            VectorCompressionType::FixedSizeByteAligned);
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::SimdBp128), VectorCompressionType::SimdBp128);
-}
-
 TEST_F(ChunkEncoderTest, EncodeSingleChunk) {
   const auto chunk_encoding_spec =
       ChunkEncodingSpec{{EncodingType::Dictionary}, {EncodingType::RunLength}, {EncodingType::Dictionary}};

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -64,11 +64,11 @@ TEST_F(ChunkEncoderTest, EncodeSingleChunk) {
   EXPECT_EQ(types, _table->column_data_types());
   EXPECT_EQ(column_count, _table->column_count());
   EXPECT_EQ(row_count, _table->row_count());
-  verify_encoding(chunk, chunk_encoding_spec);
+  assert_chunk_encoding(chunk, chunk_encoding_spec);
 
   // Re-encoding with the same configuration
   ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
-  verify_encoding(chunk, chunk_encoding_spec);
+  assert_chunk_encoding(chunk, chunk_encoding_spec);
 }
 
 TEST_F(ChunkEncoderTest, LeaveOneSegmentUnencoded) {
@@ -80,7 +80,7 @@ TEST_F(ChunkEncoderTest, LeaveOneSegmentUnencoded) {
 
   ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
 
-  verify_encoding(chunk, chunk_encoding_spec);
+  assert_chunk_encoding(chunk, chunk_encoding_spec);
 }
 
 TEST_F(ChunkEncoderTest, UnencodeEncodedSegments) {
@@ -90,12 +90,12 @@ TEST_F(ChunkEncoderTest, UnencodeEncodedSegments) {
   const auto chunk_encoding_spec =
       ChunkEncodingSpec{{EncodingType::Dictionary}, {EncodingType::RunLength}, {EncodingType::LZ4}};
   ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
-  verify_encoding(chunk, chunk_encoding_spec);
+  assert_chunk_encoding(chunk, chunk_encoding_spec);
 
   const auto chunk_unencoding_spec =
       ChunkEncodingSpec{{EncodingType::Unencoded}, {EncodingType::Unencoded}, {EncodingType::Unencoded}};
   ChunkEncoder::encode_chunk(chunk, types, chunk_unencoding_spec);
-  verify_encoding(chunk, chunk_unencoding_spec);
+  assert_chunk_encoding(chunk, chunk_unencoding_spec);
 }
 
 TEST_F(ChunkEncoderTest, ThrowOnEncodingReferenceSegments) {
@@ -126,7 +126,7 @@ TEST_F(ChunkEncoderTest, EncodeWholeTable) {
   for (auto chunk_id = ChunkID{0u}; chunk_id < _table->chunk_count(); ++chunk_id) {
     const auto chunk = _table->get_chunk(chunk_id);
     const auto& spec = chunk_encoding_specs.at(chunk_id);
-    verify_encoding(chunk, spec);
+    assert_chunk_encoding(chunk, spec);
   }
 }
 
@@ -138,7 +138,7 @@ TEST_F(ChunkEncoderTest, EncodeWholeTableUsingSameEncoding) {
 
   for (auto chunk_id = ChunkID{0u}; chunk_id < _table->chunk_count(); ++chunk_id) {
     const auto chunk = _table->get_chunk(chunk_id);
-    verify_encoding(chunk, chunk_encoding_spec);
+    assert_chunk_encoding(chunk, chunk_encoding_spec);
   }
 }
 
@@ -154,13 +154,13 @@ TEST_F(ChunkEncoderTest, EncodeMultipleChunks) {
   for (auto chunk_id : chunk_ids) {
     const auto chunk = _table->get_chunk(chunk_id);
     const auto& spec = chunk_encoding_specs.at(chunk_id);
-    verify_encoding(chunk, spec);
+    assert_chunk_encoding(chunk, spec);
   }
 
   const auto unencoded_chunk_spec =
       ChunkEncodingSpec{{EncodingType::Unencoded}, {EncodingType::Unencoded}, {EncodingType::Unencoded}};
 
-  verify_encoding(_table->get_chunk(ChunkID{1u}), unencoded_chunk_spec);
+  assert_chunk_encoding(_table->get_chunk(ChunkID{1u}), unencoded_chunk_spec);
 }
 
 TEST_F(ChunkEncoderTest, EncodeMultipleChunksUsingSameEncoding) {
@@ -173,12 +173,12 @@ TEST_F(ChunkEncoderTest, EncodeMultipleChunksUsingSameEncoding) {
 
   for (auto chunk_id : chunk_ids) {
     const auto chunk = _table->get_chunk(chunk_id);
-    verify_encoding(chunk, chunk_encoding_spec);
+    assert_chunk_encoding(chunk, chunk_encoding_spec);
   }
 
   const auto unencoded_chunk_spec = ChunkEncodingSpec{3u, SegmentEncodingSpec{EncodingType::Unencoded}};
 
-  verify_encoding(_table->get_chunk(ChunkID{1u}), unencoded_chunk_spec);
+  assert_chunk_encoding(_table->get_chunk(ChunkID{1u}), unencoded_chunk_spec);
 }
 
 TEST_F(ChunkEncoderTest, ReencodingTable) {
@@ -200,35 +200,9 @@ TEST_F(ChunkEncoderTest, ReencodingTable) {
     ChunkEncoder::encode_all_chunks(_table, chunk_encoding_spec);
     const auto chunk_count = _table->chunk_count();
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
-      verify_encoding(_table->get_chunk(chunk_id), chunk_encoding_spec);
+      assert_chunk_encoding(_table->get_chunk(chunk_id), chunk_encoding_spec);
     }
   }
 }
-
-class ParallelChunkEncoderTest : public testing::TestWithParam<std::tuple<size_t, bool>> {};
-
-TEST_P(ParallelChunkEncoderTest, EncodeChunk) {
-  static const auto max_chunk_size = 5u;
-
-  auto _table = ChunkEncoderTest::create_test_table(max_chunk_size, max_chunk_size, std::get<0>(GetParam()));
-
-  const auto chunk_encoding_spec =
-      std::vector<SegmentEncodingSpec>(std::get<0>(GetParam()), {EncodingType::Dictionary});
-
-  const auto types = _table->column_data_types();
-  const auto column_count = _table->column_count();
-  const auto row_count = _table->row_count();
-  const auto chunk = _table->get_chunk(ChunkID{0u});
-
-  ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec, std::get<1>(GetParam()));
-
-  EXPECT_EQ(types, _table->column_data_types());
-  EXPECT_EQ(column_count, _table->column_count());
-  EXPECT_EQ(row_count, _table->row_count());
-  BaseTest::verify_encoding(chunk, chunk_encoding_spec);
-}
-
-INSTANTIATE_TEST_SUITE_P(ParallizationModesChunkEncoder, ParallelChunkEncoderTest,
-                         testing::Combine(testing::Values(1ul, 10ul), testing::Bool()));
 
 }  // namespace opossum

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -24,11 +24,12 @@ class ChunkEncoderTest : public BaseTest {
     static const auto row_count = 15u;
     static const auto max_chunk_size = 5u;
     static const auto column_count = 3u;
-    
+
     _table = create_test_table(row_count, max_chunk_size, column_count);
   }
 
-  static std::shared_ptr<Table> create_test_table(const size_t row_count, const size_t max_chunk_size, const size_t column_count) {
+  static std::shared_ptr<Table> create_test_table(const size_t row_count, const size_t max_chunk_size,
+                                                  const size_t column_count) {
     TableColumnDefinitions column_definitions;
 
     for (auto column_id = 0u; column_id < column_count; ++column_id) {
@@ -49,11 +50,13 @@ class ChunkEncoderTest : public BaseTest {
   std::shared_ptr<Table> _table;
 };
 
-
 TEST(ChunkEncoderTest, ParentVectorCompressionType) {
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned), VectorCompressionType::FixedSizeByteAligned);
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned), VectorCompressionType::FixedSizeByteAligned);
-  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned), VectorCompressionType::FixedSizeByteAligned);
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
+            VectorCompressionType::FixedSizeByteAligned);
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
+            VectorCompressionType::FixedSizeByteAligned);
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
+            VectorCompressionType::FixedSizeByteAligned);
   ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::SimdBp128), VectorCompressionType::SimdBp128);
 }
 
@@ -115,7 +118,7 @@ TEST_F(ChunkEncoderTest, ThrowOnEncodingReferenceSegments) {
 
   EXPECT_EQ(_table->row_count(), table_scan->get_output()->row_count());
 
-  const auto chunk_encoding_spec = 
+  const auto chunk_encoding_spec =
       ChunkEncodingSpec{{EncodingType::Dictionary}, {EncodingType::Dictionary}, {EncodingType::Dictionary}};
   auto chunk = std::const_pointer_cast<Chunk>(table_scan->get_output()->get_chunk(ChunkID{0u}));
   const auto types = _table->column_data_types();
@@ -219,7 +222,8 @@ TEST_P(ParallelChunkEncoderTest, EncodeChunk) {
 
   auto _table = ChunkEncoderTest::create_test_table(max_chunk_size, max_chunk_size, std::get<0>(GetParam()));
 
-  const auto chunk_encoding_spec = std::vector<SegmentEncodingSpec>(std::get<0>(GetParam()), {EncodingType::Dictionary});
+  const auto chunk_encoding_spec =
+      std::vector<SegmentEncodingSpec>(std::get<0>(GetParam()), {EncodingType::Dictionary});
 
   const auto types = _table->column_data_types();
   const auto column_count = _table->column_count();
@@ -234,6 +238,7 @@ TEST_P(ParallelChunkEncoderTest, EncodeChunk) {
   BaseTest::verify_encoding(chunk, chunk_encoding_spec);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParallizationModesChunkEncoder, ParallelChunkEncoderTest, testing::Combine(testing::Values(1ul, 10ul), testing::Bool()));
+INSTANTIATE_TEST_SUITE_P(ParallizationModesChunkEncoder, ParallelChunkEncoderTest,
+                         testing::Combine(testing::Values(1ul, 10ul), testing::Bool()));
 
 }  // namespace opossum

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -7,6 +7,8 @@
 #include "gtest/gtest.h"
 
 #include "all_type_variant.hpp"
+#include "operators/table_scan.hpp"
+#include "operators/table_wrapper.hpp"
 #include "storage/base_encoded_segment.hpp"
 #include "storage/base_value_segment.hpp"
 #include "storage/chunk.hpp"
@@ -19,57 +21,60 @@ namespace opossum {
 class ChunkEncoderTest : public BaseTest {
  public:
   void SetUp() override {
+    static const auto row_count = 15u;
     static const auto max_chunk_size = 5u;
-
     static const auto column_count = 3u;
+    
+    _table = create_test_table(row_count, max_chunk_size, column_count);
+  }
+
+  static std::shared_ptr<Table> create_test_table(const size_t row_count, const size_t max_chunk_size, const size_t column_count) {
     TableColumnDefinitions column_definitions;
+
     for (auto column_id = 0u; column_id < column_count; ++column_id) {
       const auto column_name = std::to_string(column_id);
       column_definitions.emplace_back(column_name, DataType::Int, false);
     }
-    _table = std::make_shared<Table>(column_definitions, TableType::Data, max_chunk_size);
+    auto table = std::make_shared<Table>(column_definitions, TableType::Data, max_chunk_size);
 
-    static const auto row_count = max_chunk_size * 3u;
     for (auto row_id = 0u; row_id < row_count; ++row_id) {
       const auto row = std::vector<AllTypeVariant>(column_count, AllTypeVariant{static_cast<int32_t>(row_id)});
-      _table->append(row);
+      table->append(row);
     }
-  }
 
- protected:
-  void verify_encoding(const std::shared_ptr<Chunk>& chunk, const ChunkEncodingSpec& spec) {
-    for (auto column_id = ColumnID{0u}; column_id < chunk->column_count(); ++column_id) {
-      const auto segment = chunk->get_segment(column_id);
-      const auto segment_spec = spec.at(column_id);
-
-      if (segment_spec.encoding_type == EncodingType::Unencoded) {
-        const auto value_segment = std::dynamic_pointer_cast<const BaseValueSegment>(segment);
-        EXPECT_NE(value_segment, nullptr);
-      } else {
-        const auto encoded_segment = std::dynamic_pointer_cast<const BaseEncodedSegment>(segment);
-        EXPECT_NE(encoded_segment, nullptr);
-        EXPECT_EQ(encoded_segment->encoding_type(), segment_spec.encoding_type);
-        if (segment_spec.vector_compression_type) {
-          EXPECT_EQ(*segment_spec.vector_compression_type,
-                    parent_vector_compression_type(*encoded_segment->compressed_vector_type()));
-        }
-      }
-    }
+    return table;
   }
 
  protected:
   std::shared_ptr<Table> _table;
 };
 
+
+TEST(ChunkEncoderTest, ParentVectorCompressionType) {
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned), VectorCompressionType::FixedSizeByteAligned);
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned), VectorCompressionType::FixedSizeByteAligned);
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned), VectorCompressionType::FixedSizeByteAligned);
+  ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::SimdBp128), VectorCompressionType::SimdBp128);
+}
+
 TEST_F(ChunkEncoderTest, EncodeSingleChunk) {
   const auto chunk_encoding_spec =
       ChunkEncodingSpec{{EncodingType::Dictionary}, {EncodingType::RunLength}, {EncodingType::Dictionary}};
 
-  auto types = _table->column_data_types();
+  const auto types = _table->column_data_types();
+  const auto column_count = _table->column_count();
+  const auto row_count = _table->row_count();
   const auto chunk = _table->get_chunk(ChunkID{0u});
 
   ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
 
+  EXPECT_EQ(types, _table->column_data_types());
+  EXPECT_EQ(column_count, _table->column_count());
+  EXPECT_EQ(row_count, _table->row_count());
+  verify_encoding(chunk, chunk_encoding_spec);
+
+  // Re-encoding with the same configuration
+  ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
   verify_encoding(chunk, chunk_encoding_spec);
 }
 
@@ -77,12 +82,44 @@ TEST_F(ChunkEncoderTest, LeaveOneSegmentUnencoded) {
   const auto chunk_encoding_spec =
       ChunkEncodingSpec{{EncodingType::Unencoded}, {EncodingType::RunLength}, {EncodingType::Dictionary}};
 
-  auto types = _table->column_data_types();
+  const auto types = _table->column_data_types();
   const auto chunk = _table->get_chunk(ChunkID{0u});
 
   ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
 
   verify_encoding(chunk, chunk_encoding_spec);
+}
+
+TEST_F(ChunkEncoderTest, UnencodeEncodedSegments) {
+  const auto types = _table->column_data_types();
+  const auto chunk = _table->get_chunk(ChunkID{0u});
+
+  const auto chunk_encoding_spec =
+      ChunkEncodingSpec{{EncodingType::Dictionary}, {EncodingType::RunLength}, {EncodingType::LZ4}};
+  ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec);
+  verify_encoding(chunk, chunk_encoding_spec);
+
+  const auto chunk_unencoding_spec =
+      ChunkEncodingSpec{{EncodingType::Unencoded}, {EncodingType::Unencoded}, {EncodingType::Unencoded}};
+  ChunkEncoder::encode_chunk(chunk, types, chunk_unencoding_spec);
+  verify_encoding(chunk, chunk_unencoding_spec);
+}
+
+TEST_F(ChunkEncoderTest, ThrowOnEncodingReferenceSegments) {
+  auto table_wrapper = std::make_shared<TableWrapper>(_table);
+  table_wrapper->execute();
+
+  auto a = PQPColumnExpression::from_table(*_table, "0");
+  auto table_scan = std::make_shared<TableScan>(table_wrapper, greater_than_equals_(a, 0));
+  table_scan->execute();
+
+  EXPECT_EQ(_table->row_count(), table_scan->get_output()->row_count());
+
+  const auto chunk_encoding_spec = 
+      ChunkEncodingSpec{{EncodingType::Dictionary}, {EncodingType::Dictionary}, {EncodingType::Dictionary}};
+  auto chunk = std::const_pointer_cast<Chunk>(table_scan->get_output()->get_chunk(ChunkID{0u}));
+  const auto types = _table->column_data_types();
+  EXPECT_THROW(ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec), std::logic_error);
 }
 
 TEST_F(ChunkEncoderTest, EncodeWholeTable) {
@@ -174,5 +211,29 @@ TEST_F(ChunkEncoderTest, ReencodingTable) {
     }
   }
 }
+
+class ParallelChunkEncoderTest : public testing::TestWithParam<std::tuple<size_t, bool>> {};
+
+TEST_P(ParallelChunkEncoderTest, EncodeChunk) {
+  static const auto max_chunk_size = 5u;
+
+  auto _table = ChunkEncoderTest::create_test_table(max_chunk_size, max_chunk_size, std::get<0>(GetParam()));
+
+  const auto chunk_encoding_spec = std::vector<SegmentEncodingSpec>(std::get<0>(GetParam()), {EncodingType::Dictionary});
+
+  const auto types = _table->column_data_types();
+  const auto column_count = _table->column_count();
+  const auto row_count = _table->row_count();
+  const auto chunk = _table->get_chunk(ChunkID{0u});
+
+  ChunkEncoder::encode_chunk(chunk, types, chunk_encoding_spec, std::get<1>(GetParam()));
+
+  EXPECT_EQ(types, _table->column_data_types());
+  EXPECT_EQ(column_count, _table->column_count());
+  EXPECT_EQ(row_count, _table->row_count());
+  BaseTest::verify_encoding(chunk, chunk_encoding_spec);
+}
+
+INSTANTIATE_TEST_SUITE_P(ParallizationModesChunkEncoder, ParallelChunkEncoderTest, testing::Combine(testing::Values(1ul, 10ul), testing::Bool()));
 
 }  // namespace opossum

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -50,7 +50,7 @@ class ChunkEncoderTest : public BaseTest {
   std::shared_ptr<Table> _table;
 };
 
-TEST(ChunkEncoderTest, ParentVectorCompressionType) {
+TEST_F(ChunkEncoderTest, ParentVectorCompressionType) {
   ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),
             VectorCompressionType::FixedSizeByteAligned);
   ASSERT_EQ(parent_vector_compression_type(CompressedVectorType::FixedSize4ByteAligned),

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -7,6 +7,7 @@
 
 #include "storage/vector_compression/resolve_compressed_vector_type.hpp"
 #include "storage/vector_compression/vector_compression.hpp"
+#include "storage/segment_encoding_utils.hpp"
 
 #include "constant_mappings.hpp"
 #include "types.hpp"
@@ -53,6 +54,7 @@ class CompressedVectorTest : public BaseTestWithParam<VectorCompressionType> {
 
     auto encoded_vector = compress_vector(vector, compression_type, {}, {max()});
     EXPECT_EQ(encoded_vector->size(), vector.size());
+    EXPECT_EQ(parent_vector_compression_type(encoded_vector->type()), GetParam());
 
     return encoded_vector;
   }

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -54,7 +54,7 @@ class CompressedVectorTest : public BaseTestWithParam<VectorCompressionType> {
 
     auto encoded_vector = compress_vector(vector, compression_type, {}, {max()});
     EXPECT_EQ(encoded_vector->size(), vector.size());
-    EXPECT_EQ(parent_vector_compression_type(encoded_vector->type()), GetParam());
+    EXPECT_EQ(parent_vector_compression_type(encoded_vector->type()), compression_type);
 
     return encoded_vector;
   }

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -5,9 +5,9 @@
 #include "base_test.hpp"
 #include "gtest/gtest.h"
 
+#include "storage/segment_encoding_utils.hpp"
 #include "storage/vector_compression/resolve_compressed_vector_type.hpp"
 #include "storage/vector_compression/vector_compression.hpp"
-#include "storage/segment_encoding_utils.hpp"
 
 #include "constant_mappings.hpp"
 #include "types.hpp"

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -90,7 +90,7 @@ TEST_P(SyntheticTableGeneratorDataTypeTests, IntegerTable) {
 
   for (auto chunk_id = ChunkID{0}; chunk_id < generated_chunk_count; ++chunk_id) {
     const auto& chunk = table->get_chunk(chunk_id);
-    BaseTest::verify_encoding(chunk, supported_segment_encodings);
+    BaseTest::assert_chunk_encoding(chunk, supported_segment_encodings);
   }
 }
 

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -47,11 +47,6 @@ TEST(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
   EXPECT_EQ(table->chunk_count(), row_count / chunk_size);
 }
 
-TEST(SyntheticTableGeneratorTest, ThrowOnGenerateUnsupportedValue) {
-  struct A {};
-  ASSERT_THROW(SyntheticTableGenerator::generate_value<A>(17), std::logic_error);
-}
-
 using Params = std::tuple<DataType, ColumnDataDistribution>;
 
 class SyntheticTableGeneratorDataTypeTests : public testing::TestWithParam<Params> {};

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "hyrise.hpp"
 #include "storage/encoding_type.hpp"

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "storage/chunk_encoder_test.cpp"
 
 #include "hyrise.hpp"
 #include "storage/encoding_type.hpp"
@@ -25,8 +24,10 @@ TEST(SyntheticTableGeneratorTest, ThrowOnParameterLengthMismatch) {
   const auto uniform_distribution = ColumnDataDistribution::make_uniform_config(0.0, 1.0);
 
   // vectors storing the column properties are expected to have the same length
-  ASSERT_THROW(table_generator->generate_table({uniform_distribution, uniform_distribution}, {DataType::Int}, 15, 10), std::logic_error);
-  ASSERT_THROW(table_generator->generate_table({uniform_distribution}, {DataType::Int, DataType::Int}, 15, 10), std::logic_error);
+  ASSERT_THROW(table_generator->generate_table({uniform_distribution, uniform_distribution}, {DataType::Int}, 15, 10),
+               std::logic_error);
+  ASSERT_THROW(table_generator->generate_table({uniform_distribution}, {DataType::Int, DataType::Int}, 15, 10),
+               std::logic_error);
 }
 
 TEST(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
@@ -35,7 +36,8 @@ TEST(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
   auto table_generator = std::make_shared<SyntheticTableGenerator>();
   auto uniform_distribution_0_1 = ColumnDataDistribution::make_uniform_config(0.0, 1.0);
 
-  auto table = table_generator->generate_table({uniform_distribution_0_1}, {DataType::Double}, row_count, chunk_size, {{EncodingType::Dictionary}});
+  auto table = table_generator->generate_table({uniform_distribution_0_1}, {DataType::Double}, row_count, chunk_size,
+                                               {{EncodingType::Dictionary}});
   for (auto table_row_id = size_t{0}; table_row_id < 100; ++table_row_id) {
     const auto value = table->get_value<double>(ColumnID{0}, table_row_id);
     ASSERT_TRUE(value >= 0.0 && value <= 1.0);
@@ -68,13 +70,16 @@ TEST_P(SyntheticTableGeneratorDataTypeTests, IntegerTable) {
     }
     return SegmentEncodingSpec{EncodingType::Unencoded};
   };
-  std::transform(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(), std::back_inserter(supported_segment_encodings), replace_unsupporting_encoding_types);
+  std::transform(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(),
+                 std::back_inserter(supported_segment_encodings), replace_unsupporting_encoding_types);
 
   const auto test_data_types = std::vector<DataType>(supported_segment_encodings.size(), tested_data_type);
-  const auto test_data_distributions = std::vector<ColumnDataDistribution>(supported_segment_encodings.size(), std::get<1>(GetParam()));
+  const auto test_data_distributions =
+      std::vector<ColumnDataDistribution>(supported_segment_encodings.size(), std::get<1>(GetParam()));
   const auto column_names = std::vector<std::string>(supported_segment_encodings.size(), "column_name");
 
-  auto table = table_generator->generate_table(test_data_distributions, test_data_types, row_count, chunk_size, supported_segment_encodings, column_names);
+  auto table = table_generator->generate_table(test_data_distributions, test_data_types, row_count, chunk_size,
+                                               supported_segment_encodings, column_names);
 
   const auto generated_chunk_count = table->chunk_count();
   const auto generated_column_count = table->column_count();
@@ -96,13 +101,13 @@ TEST_P(SyntheticTableGeneratorDataTypeTests, IntegerTable) {
 auto formatter = [](const testing::TestParamInfo<Params> info) {
   auto stream = std::stringstream{};
   switch (std::get<1>(info.param).distribution_type) {
-    case DataDistributionType::Uniform :
-      stream<<  "Uniform";
+    case DataDistributionType::Uniform:
+      stream << "Uniform";
       break;
-    case DataDistributionType::Pareto :
+    case DataDistributionType::Pareto:
       stream << "Pareto";
       break;
-    case DataDistributionType::NormalSkewed :
+    case DataDistributionType::NormalSkewed:
       stream << "Skewed";
   }
 
@@ -110,7 +115,11 @@ auto formatter = [](const testing::TestParamInfo<Params> info) {
   return stream.str();
 };
 
-INSTANTIATE_TEST_SUITE_P(SyntheticTableGeneratorDataType, SyntheticTableGeneratorDataTypeTests, testing::Combine(testing::Values(DataType::Int, DataType::Long, DataType::Float, DataType::Double, DataType::String),
-  testing::Values(ColumnDataDistribution::make_uniform_config(0.0, 10'000), ColumnDataDistribution::make_pareto_config(), ColumnDataDistribution::make_skewed_normal_config())),
-  formatter);
+INSTANTIATE_TEST_SUITE_P(SyntheticTableGeneratorDataType, SyntheticTableGeneratorDataTypeTests,
+                         testing::Combine(testing::Values(DataType::Int, DataType::Long, DataType::Float,
+                                                          DataType::Double, DataType::String),
+                                          testing::Values(ColumnDataDistribution::make_uniform_config(0.0, 10'000),
+                                                          ColumnDataDistribution::make_pareto_config(),
+                                                          ColumnDataDistribution::make_skewed_normal_config())),
+                         formatter);
 }  // namespace opossum

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -1,0 +1,131 @@
+#include "gtest/gtest.h"
+#include "storage/chunk_encoder_test.cpp"
+
+#include "hyrise.hpp"
+#include "storage/encoding_type.hpp"
+#include "storage/table.hpp"
+#include "synthetic_table_generator.hpp"
+
+namespace opossum {
+
+TEST(SyntheticTableGeneratorTest, StringGeneration) {
+  ASSERT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(0), "          ");
+  ASSERT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(1), "         1");
+  ASSERT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(2), "         2");
+
+  // Negative values are not supported.
+  ASSERT_THROW(SyntheticTableGenerator::generate_value<pmr_string>(-17), std::logic_error);
+}
+
+TEST(SyntheticTableGeneratorTest, ThrowOnParameterLengthMismatch) {
+  auto table_generator = std::make_shared<SyntheticTableGenerator>();
+  const auto uniform_distribution = ColumnDataDistribution::make_uniform_config(0.0, 1.0);
+
+  // vectors storing the column properties are expected to have the same length
+  ASSERT_THROW(table_generator->generate_table({uniform_distribution, uniform_distribution}, {DataType::Int}, 15, 10), std::logic_error);
+  ASSERT_THROW(table_generator->generate_table({uniform_distribution}, {DataType::Int, DataType::Int}, 15, 10), std::logic_error);
+}
+
+TEST(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
+  constexpr auto row_count = size_t{100};
+  constexpr auto chunk_size = size_t{10};
+  auto table_generator = std::make_shared<SyntheticTableGenerator>();
+  auto uniform_distribution_0_1 = ColumnDataDistribution::make_uniform_config(0.0, 1.0);
+
+  auto table = table_generator->generate_table({uniform_distribution_0_1}, {DataType::Double}, row_count, chunk_size, {{EncodingType::Dictionary}});
+  for (auto table_row_id = size_t{0}; table_row_id < 100; ++table_row_id) {
+    const auto value = table->get_value<double>(ColumnID{0}, table_row_id);
+    ASSERT_TRUE(value >= 0.0 && value <= 1.0);
+  }
+
+  ASSERT_EQ(table->row_count(), row_count);
+  ASSERT_EQ(table->chunk_count(), row_count / chunk_size);
+}
+
+TEST(SyntheticTableGeneratorTest, ThrowOnGenerateUnsupportedValue) {
+  struct A {};
+  ASSERT_THROW(SyntheticTableGenerator::generate_value<A>(17), std::logic_error);
+}
+
+using Params = std::tuple<DataType, ColumnDataDistribution>;
+
+class SyntheticTableGeneratorDataTypeTests : public testing::TestWithParam<Params> {};
+
+TEST_P(SyntheticTableGeneratorDataTypeTests, IntegerTable) {
+  constexpr auto row_count = size_t{25};
+  constexpr auto chunk_size = size_t{10};
+
+  const auto tested_data_type = std::get<0>(GetParam());
+  auto table_generator = std::make_shared<SyntheticTableGenerator>();
+
+  ///////////////////////
+  ///////////////////////
+  ///////////////////////
+  const std::array<SegmentEncodingSpec, 10> all_segment_encoding_specs = {{
+    {EncodingType::Unencoded},
+    {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+    {EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
+    {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
+    // {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::LZ4, VectorCompressionType::SimdBp128},
+    {EncodingType::RunLength}}};
+  ///////////////////////
+  ///////////////////////
+  ///////////////////////
+
+  std::vector<SegmentEncodingSpec> supported_segment_encodings;
+  auto replace_unsupporting_encoding_types = [&](SegmentEncodingSpec spec) {
+    if (encoding_supports_data_type(spec.encoding_type, tested_data_type)) {
+      return spec;
+    }
+    return SegmentEncodingSpec{EncodingType::Unencoded};
+  };
+  std::transform(all_segment_encoding_specs.begin(), all_segment_encoding_specs.end(), std::back_inserter(supported_segment_encodings), replace_unsupporting_encoding_types);
+
+  const auto test_data_types = std::vector<DataType>(supported_segment_encodings.size(), tested_data_type);
+  const auto test_data_distributions = std::vector<ColumnDataDistribution>(supported_segment_encodings.size(), std::get<1>(GetParam()));
+  const auto column_names = std::vector<std::string>(supported_segment_encodings.size(), "column_name");
+
+  auto table = table_generator->generate_table(test_data_distributions, test_data_types, row_count, chunk_size, supported_segment_encodings, column_names);
+
+  const auto generated_chunk_count = table->chunk_count();
+  const auto generated_column_count = table->column_count()
+  ASSERT_EQ(table->row_count(), row_count);
+  ASSERT_EQ(generated_chunk_count, static_cast<size_t>(std::round(static_cast<float>(row_count) / chunk_size)));
+  ASSERT_EQ(generated_column_count, supported_segment_encodings.size());
+
+  for (auto column_id = ColumnID{0}; column_id < generated_column_count; ++column_id) {
+    ASSERT_EQ(table->column_data_type(column_id), tested_data_type);
+    ASSERT_EQ(table->column_name(column_id), "column_name");
+  }
+
+  for (auto chunk_id = ChunkID{0}; chunk_id < generated_chunk_count; ++chunk_id) {
+    const auto& chunk = table->get_chunk(chunk_id);
+    BaseTest::verify_encoding(chunk, supported_segment_encodings);
+  }
+}
+
+auto formatter = [](const testing::TestParamInfo<Params> info) {
+  auto stream = std::stringstream{};
+  switch (std::get<1>(info.param).distribution_type) {
+    case DataDistributionType::Uniform :
+      stream<<  "Uniform";
+      break;
+    case DataDistributionType::Pareto :
+      stream << "Pareto";
+      break;
+    case DataDistributionType::NormalSkewed :
+      stream << "Skewed";
+  }
+
+  stream << "_" << data_type_to_string.left.at(std::get<0>(info.param));
+  return stream.str();
+};
+
+INSTANTIATE_TEST_SUITE_P(SyntheticTableGeneratorDataType, SyntheticTableGeneratorDataTypeTests, testing::Combine(testing::Values(DataType::Int, DataType::Long, DataType::Float, DataType::Double, DataType::String),
+  testing::Values(ColumnDataDistribution::make_uniform_config(0.0, 10'000), ColumnDataDistribution::make_pareto_config(), ColumnDataDistribution::make_skewed_normal_config())),
+  formatter);
+}  // namespace opossum

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -61,24 +61,6 @@ TEST_P(SyntheticTableGeneratorDataTypeTests, IntegerTable) {
   const auto tested_data_type = std::get<0>(GetParam());
   auto table_generator = std::make_shared<SyntheticTableGenerator>();
 
-  ///////////////////////
-  ///////////////////////
-  ///////////////////////
-  const std::array<SegmentEncodingSpec, 10> all_segment_encoding_specs = {{
-    {EncodingType::Unencoded},
-    {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-    {EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::FrameOfReference, VectorCompressionType::SimdBp128},
-    {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
-    // {EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned},
-    {EncodingType::LZ4, VectorCompressionType::SimdBp128},
-    {EncodingType::RunLength}}};
-  ///////////////////////
-  ///////////////////////
-  ///////////////////////
-
   std::vector<SegmentEncodingSpec> supported_segment_encodings;
   auto replace_unsupporting_encoding_types = [&](SegmentEncodingSpec spec) {
     if (encoding_supports_data_type(spec.encoding_type, tested_data_type)) {

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -9,9 +9,12 @@
 namespace opossum {
 
 TEST(SyntheticTableGeneratorTest, StringGeneration) {
-  ASSERT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(0), "          ");
-  ASSERT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(1), "         1");
-  ASSERT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(2), "         2");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(0), "          ");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(1), "         1");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(2), "         2");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(117), "        1t");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(50'018), "       D0k");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(3'433'820), "      EPIC");
 
   // Negative values are not supported.
   ASSERT_THROW(SyntheticTableGenerator::generate_value<pmr_string>(-17), std::logic_error);
@@ -38,8 +41,8 @@ TEST(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
     ASSERT_TRUE(value >= 0.0 && value <= 1.0);
   }
 
-  ASSERT_EQ(table->row_count(), row_count);
-  ASSERT_EQ(table->chunk_count(), row_count / chunk_size);
+  EXPECT_EQ(table->row_count(), row_count);
+  EXPECT_EQ(table->chunk_count(), row_count / chunk_size);
 }
 
 TEST(SyntheticTableGeneratorTest, ThrowOnGenerateUnsupportedValue) {
@@ -92,14 +95,14 @@ TEST_P(SyntheticTableGeneratorDataTypeTests, IntegerTable) {
   auto table = table_generator->generate_table(test_data_distributions, test_data_types, row_count, chunk_size, supported_segment_encodings, column_names);
 
   const auto generated_chunk_count = table->chunk_count();
-  const auto generated_column_count = table->column_count()
-  ASSERT_EQ(table->row_count(), row_count);
-  ASSERT_EQ(generated_chunk_count, static_cast<size_t>(std::round(static_cast<float>(row_count) / chunk_size)));
-  ASSERT_EQ(generated_column_count, supported_segment_encodings.size());
+  const auto generated_column_count = table->column_count();
+  EXPECT_EQ(table->row_count(), row_count);
+  EXPECT_EQ(generated_chunk_count, static_cast<size_t>(std::round(static_cast<float>(row_count) / chunk_size)));
+  EXPECT_EQ(generated_column_count, supported_segment_encodings.size());
 
   for (auto column_id = ColumnID{0}; column_id < generated_column_count; ++column_id) {
-    ASSERT_EQ(table->column_data_type(column_id), tested_data_type);
-    ASSERT_EQ(table->column_name(column_id), "column_name");
+    EXPECT_EQ(table->column_data_type(column_id), tested_data_type);
+    EXPECT_EQ(table->column_name(column_id), "column_name");
   }
 
   for (auto chunk_id = ChunkID{0}; chunk_id < generated_chunk_count; ++chunk_id) {

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -115,11 +115,13 @@ auto formatter = [](const testing::TestParamInfo<Params> info) {
   return stream.str();
 };
 
+// For the skewed distribution, we use a location of 1,000 to move the distribution far into the positive number range.
+// The reason is that string values cannot be generated for negative values.
 INSTANTIATE_TEST_SUITE_P(SyntheticTableGeneratorDataType, SyntheticTableGeneratorDataTypeTests,
                          testing::Combine(testing::Values(DataType::Int, DataType::Long, DataType::Float,
                                                           DataType::Double, DataType::String),
                                           testing::Values(ColumnDataDistribution::make_uniform_config(0.0, 10'000),
                                                           ColumnDataDistribution::make_pareto_config(),
-                                                          ColumnDataDistribution::make_skewed_normal_config())),
+                                                          ColumnDataDistribution::make_skewed_normal_config(1'000.0))),
                          formatter);
 }  // namespace opossum

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -11,6 +11,7 @@ TEST(SyntheticTableGeneratorTest, StringGeneration) {
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(0), "          ");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(1), "         1");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(2), "         2");
+  EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(17), "         H");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(117), "        1t");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(50'018), "       D0k");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(3'433'820), "      EPIC");


### PR DESCRIPTION
This PR improves the runtime of the synthetic table generator. Mainly by using std::threads (similar to the benchmarking encoder). 

Time to create a large table for the model calibration went from `166s` to `56s` on a four core laptop.

It further does the following:
 * add tests for the synthetic table generator
 * add test to the chunk encoder
 * fixes LZ4 to SimdBp128 vector compression (which was the idea from the beginning since LZ4 is all about compression ratios) and adapts the encodings listings accordingly
 * fix a bug concerning MVCC data