### PR TITLE
Update column statistics when chunks are pruned

### DIFF
--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -11,6 +11,7 @@
 namespace opossum {
 
 class LQPColumnExpression;
+class TableStatistics;
 
 /**
  * Represents a Table from the StorageManager in an LQP
@@ -43,6 +44,10 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::string table_name;
+
+  // By default, the StoredTableNode takes its statistics from the table. This field can be used to overwrite these
+  // statistics if they have changed from the original table, e.g., as the result of chunk pruning.
+  std::shared_ptr<TableStatistics> table_statistics;
 
  protected:
   size_t _shallow_hash() const override;

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -206,9 +206,9 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const
   // out of ten, the selectivity is now 100%. Updating the statistics is important so that the predicate ordering
   // can properly order the predicates.
   //
-  // For the column that the predicate pruned on, we remove chunk.size() that do not match the predicate from the
-  // histogram, assuming equidistribution among the pruned values. The other columns are simply scaled to reflect the
-  // reduced table size.
+  // For the column that the predicate pruned on, we remove chunk.size() values that do not match the predicate from
+  // the histogram, assuming equidistribution among the pruned values. The other columns are simply scaled to reflect
+  // the reduced table size.
 
   const auto column_count = old_statistics.column_statistics.size();
 

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -193,10 +193,7 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(std::
   column_statistics[predicate.column_id] = column_statistics[predicate.column_id]->pruned(predicate.predicate_condition, num_values_pruned, boost::get<AllTypeVariant>(predicate.value), predicate.value2 ? std::optional<AllTypeVariant>{boost::get<AllTypeVariant>(*predicate.value2)} : std::nullopt);
   // TODO scale other histograms
 
-  const auto statistics = std::make_shared<TableStatistics>(std::move(column_statistics), old_statistics->row_count - num_values_pruned);
-  std::cout << "=========" << std::endl;
-  std::cout << *statistics << std::endl;
-  return statistics;
+  return statistics = std::make_shared<TableStatistics>(std::move(column_statistics), old_statistics->row_count - num_values_pruned);
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -159,7 +159,7 @@ std::set<ChunkID> ChunkPruningRule::_compute_exclude_list(
 
     if (num_rows_pruned > size_t{0}) {
       const auto& old_statistics =
-        stored_table_node->table_statistics ? stored_table_node->table_statistics : table.table_statistics();
+          stored_table_node->table_statistics ? stored_table_node->table_statistics : table.table_statistics();
       const auto pruned_statistics = _prune_table_statistics(*old_statistics, operator_predicate, num_rows_pruned);
       stored_table_node->table_statistics = pruned_statistics;
     }
@@ -211,8 +211,11 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const
   // can properly order the predicates.
   //
   // For the column that the predicate pruned on, we remove num_rows_pruned values that do not match the predicate
-  // from the histogram, assuming equidistribution among the pruned values. The other columns are simply scaled to
-  // reflect the reduced table size.
+  // from the statistics. See the pruned() implementation of the different statistics types for details.
+  // The other columns are simply scaled to reflect the reduced table size.
+  //
+  // For now, this does not take any sorting on a chunk- or table-level into account. In the future, this may be done
+  // to further improve the accuracy of the statistics.
 
   const auto column_count = old_statistics.column_statistics.size();
 

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -200,6 +200,16 @@ bool ChunkPruningRule::_is_non_filtering_node(const AbstractLQPNode& node) const
 std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const TableStatistics& old_statistics,
                                                                            OperatorScanPredicate predicate,
                                                                            size_t num_values_pruned) const {
+  // If a chunk is pruned, we update the table statistics. This is so that the selectivity of the predicate that was
+  // used for pruning can be correctly estimated. Example: For a table that has sorted values from 1 to 100 and a chunk
+  // size of 10, the predicate `x > 90` has a selectivity of 10%. However, if the ChunkPruningRule removes nine chunks
+  // out of ten, the selectivity is now 100%. Updating the statistics is important so that the predicate ordering
+  // can properly order the predicates.
+  //
+  // For the column that the predicate pruned on, we remove chunk.size() that do not match the predicate from the
+  // histogram, assuming equidistribution among the pruned values. The other columns are simply scaled to reflect the
+  // reduced table size.
+
   const auto column_count = old_statistics.column_statistics.size();
 
   std::vector<std::shared_ptr<BaseAttributeStatistics>> column_statistics(column_count);
@@ -207,8 +217,8 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const
   const auto scale = 1 - (num_values_pruned / old_statistics.row_count);
   for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     if (column_id == predicate.column_id) {
-      column_statistics[column_id] = old_statistics.column_statistics[column_id]->pruned(num_values_pruned,
-          predicate.predicate_condition, boost::get<AllTypeVariant>(predicate.value),
+      column_statistics[column_id] = old_statistics.column_statistics[column_id]->pruned(
+          num_values_pruned, predicate.predicate_condition, boost::get<AllTypeVariant>(predicate.value),
           predicate.value2 ? std::optional<AllTypeVariant>{boost::get<AllTypeVariant>(*predicate.value2)}
                            : std::nullopt);
     } else {

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -143,7 +143,8 @@ std::set<ChunkID> ChunkPruningRule::_compute_exclude_list(
 
       const auto segment_statistics = (*pruning_statistics)[operator_predicate.column_id];
       if (_can_prune(*segment_statistics, condition, *value, value2)) {
-        const auto& old_statistics = stored_table_node->table_statistics ? stored_table_node->table_statistics : table.table_statistics();
+        const auto& old_statistics =
+            stored_table_node->table_statistics ? stored_table_node->table_statistics : table.table_statistics();
         const auto pruned_statistics = _prune_table_statistics(old_statistics, operator_predicate, chunk->size());
         stored_table_node->table_statistics = pruned_statistics;
         result.insert(chunk_id);
@@ -187,13 +188,17 @@ bool ChunkPruningRule::_is_non_filtering_node(const AbstractLQPNode& node) const
   return node.type == LQPNodeType::Alias || node.type == LQPNodeType::Projection || node.type == LQPNodeType::Sort;
 }
 
-std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(std::shared_ptr<TableStatistics> old_statistics, OperatorScanPredicate predicate, size_t num_values_pruned) const {
+std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(
+    std::shared_ptr<TableStatistics> old_statistics, OperatorScanPredicate predicate, size_t num_values_pruned) const {
   auto column_statistics = old_statistics->column_statistics;
 
-  column_statistics[predicate.column_id] = column_statistics[predicate.column_id]->pruned(predicate.predicate_condition, num_values_pruned, boost::get<AllTypeVariant>(predicate.value), predicate.value2 ? std::optional<AllTypeVariant>{boost::get<AllTypeVariant>(*predicate.value2)} : std::nullopt);
+  column_statistics[predicate.column_id] = column_statistics[predicate.column_id]->pruned(
+      predicate.predicate_condition, num_values_pruned, boost::get<AllTypeVariant>(predicate.value),
+      predicate.value2 ? std::optional<AllTypeVariant>{boost::get<AllTypeVariant>(*predicate.value2)} : std::nullopt);
   // TODO scale other histograms
 
-  return statistics = std::make_shared<TableStatistics>(std::move(column_statistics), old_statistics->row_count - num_values_pruned);
+  return statistics = std::make_shared<TableStatistics>(std::move(column_statistics),
+                                                        old_statistics->row_count - num_values_pruned);
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -193,8 +193,10 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(std::
   column_statistics[predicate.column_id] = column_statistics[predicate.column_id]->pruned(predicate.predicate_condition, num_values_pruned, boost::get<AllTypeVariant>(predicate.value), predicate.value2 ? std::optional<AllTypeVariant>{boost::get<AllTypeVariant>(*predicate.value2)} : std::nullopt);
   // TODO scale other histograms
 
-
-  return std::make_shared<TableStatistics>(std::move(column_statistics), old_statistics->row_count - num_values_pruned);
+  const auto statistics = std::make_shared<TableStatistics>(std::move(column_statistics), old_statistics->row_count - num_values_pruned);
+  std::cout << "=========" << std::endl;
+  std::cout << *statistics << std::endl;
+  return statistics;
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -207,8 +207,8 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const
   const auto scale = 1 - (num_values_pruned / old_statistics.row_count);
   for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     if (column_id == predicate.column_id) {
-      column_statistics[column_id] = old_statistics.column_statistics[column_id]->pruned(
-          predicate.predicate_condition, num_values_pruned, boost::get<AllTypeVariant>(predicate.value),
+      column_statistics[column_id] = old_statistics.column_statistics[column_id]->pruned(num_values_pruned,
+          predicate.predicate_condition, boost::get<AllTypeVariant>(predicate.value),
           predicate.value2 ? std::optional<AllTypeVariant>{boost::get<AllTypeVariant>(*predicate.value2)}
                            : std::nullopt);
     } else {

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -38,7 +38,7 @@ class ChunkPruningRule : public AbstractRule {
 
   bool _is_non_filtering_node(const AbstractLQPNode& node) const;
 
-  std::shared_ptr<TableStatistics> _prune_table_statistics(std::shared_ptr<TableStatistics> old_statistics,
+  std::shared_ptr<TableStatistics> _prune_table_statistics(const TableStatistics& old_statistics,
                                                            OperatorScanPredicate predicate,
                                                            size_t num_values_pruned) const;
 };

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -38,7 +38,9 @@ class ChunkPruningRule : public AbstractRule {
 
   bool _is_non_filtering_node(const AbstractLQPNode& node) const;
 
-  std::shared_ptr<TableStatistics> _prune_table_statistics(std::shared_ptr<TableStatistics> old_statistics, OperatorScanPredicate predicate, size_t num_values_pruned) const;
+  std::shared_ptr<TableStatistics> _prune_table_statistics(std::shared_ptr<TableStatistics> old_statistics,
+                                                           OperatorScanPredicate predicate,
+                                                           size_t num_values_pruned) const;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -40,7 +40,7 @@ class ChunkPruningRule : public AbstractRule {
 
   std::shared_ptr<TableStatistics> _prune_table_statistics(const TableStatistics& old_statistics,
                                                            OperatorScanPredicate predicate,
-                                                           size_t num_values_pruned) const;
+                                                           size_t num_rows_pruned) const;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "abstract_rule.hpp"
+#include "operators/operator_scan_predicate.hpp"
 #include "statistics/table_statistics.hpp"
 #include "types.hpp"
 
@@ -36,6 +37,8 @@ class ChunkPruningRule : public AbstractRule {
                   const AllTypeVariant& variant_value, const std::optional<AllTypeVariant>& variant_value2) const;
 
   bool _is_non_filtering_node(const AbstractLQPNode& node) const;
+
+  std::shared_ptr<TableStatistics> _prune_table_statistics(std::shared_ptr<TableStatistics> old_statistics, OperatorScanPredicate predicate, size_t num_values_pruned) const;
 };
 
 }  // namespace opossum

--- a/src/lib/statistics/attribute_statistics.cpp
+++ b/src/lib/statistics/attribute_statistics.cpp
@@ -108,6 +108,42 @@ std::shared_ptr<BaseAttributeStatistics> AttributeStatistics<T>::sliced(
   return statistics;
 }
 
+template <typename T>
+std::shared_ptr<BaseAttributeStatistics> AttributeStatistics<T>::pruned(
+    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const std::optional<AllTypeVariant>& variant_value2) const {
+  const auto statistics = std::make_shared<AttributeStatistics<T>>();
+
+  if (histogram) {
+    statistics->set_statistics_object(histogram->pruned(predicate_condition, num_values_pruned, variant_value, variant_value2));
+  }
+
+  if (null_value_ratio) {
+    // As the null value ratio statistics have no absolute row counts, we cannot prune here. Create an unmodified copy.
+    statistics->set_statistics_object(std::make_shared<NullValueRatioStatistics>(null_value_ratio->ratio));
+  }
+
+  // As pruning is on a table-level granularity, it does not make too much sense to implement pruning on chunk-level
+  // statistics such as the filters below.
+
+  if (min_max_filter) {
+    Fail("Pruning not implemented for min/max filters");
+  }
+
+  if (counting_quotient_filter) {
+    Fail("Pruning not implemented for counting quotient filters");
+  }
+
+  // NOLINTNEXTLINE clang-tidy is crazy and sees a "potentially unintended semicolon" here...
+  if constexpr (std::is_arithmetic_v<T>) {
+    if (range_filter) {
+      Fail("Pruning not implemented for range filters");
+    }
+  }
+
+  return statistics;
+}
+
 EXPLICITLY_INSTANTIATE_DATA_TYPES(AttributeStatistics);
 
 }  // namespace opossum

--- a/src/lib/statistics/attribute_statistics.cpp
+++ b/src/lib/statistics/attribute_statistics.cpp
@@ -115,7 +115,8 @@ std::shared_ptr<BaseAttributeStatistics> AttributeStatistics<T>::pruned(
   const auto statistics = std::make_shared<AttributeStatistics<T>>();
 
   if (histogram) {
-    statistics->set_statistics_object(histogram->pruned(predicate_condition, num_values_pruned, variant_value, variant_value2));
+    statistics->set_statistics_object(
+        histogram->pruned(predicate_condition, num_values_pruned, variant_value, variant_value2));
   }
 
   if (null_value_ratio) {

--- a/src/lib/statistics/attribute_statistics.cpp
+++ b/src/lib/statistics/attribute_statistics.cpp
@@ -110,13 +110,13 @@ std::shared_ptr<BaseAttributeStatistics> AttributeStatistics<T>::sliced(
 
 template <typename T>
 std::shared_ptr<BaseAttributeStatistics> AttributeStatistics<T>::pruned(
-    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
     const std::optional<AllTypeVariant>& variant_value2) const {
   const auto statistics = std::make_shared<AttributeStatistics<T>>();
 
   if (histogram) {
     statistics->set_statistics_object(
-        histogram->pruned(predicate_condition, num_values_pruned, variant_value, variant_value2));
+        histogram->pruned(num_values_pruned, predicate_condition, variant_value, variant_value2));
   }
 
   if (null_value_ratio) {

--- a/src/lib/statistics/attribute_statistics.hpp
+++ b/src/lib/statistics/attribute_statistics.hpp
@@ -38,7 +38,7 @@ class AttributeStatistics : public BaseAttributeStatistics {
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   std::shared_ptr<BaseAttributeStatistics> pruned(
-      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   std::shared_ptr<AbstractHistogram<T>> histogram;

--- a/src/lib/statistics/attribute_statistics.hpp
+++ b/src/lib/statistics/attribute_statistics.hpp
@@ -38,8 +38,8 @@ class AttributeStatistics : public BaseAttributeStatistics {
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   std::shared_ptr<BaseAttributeStatistics> pruned(
-    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
-    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
+      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   std::shared_ptr<AbstractHistogram<T>> histogram;
   std::shared_ptr<MinMaxFilter<T>> min_max_filter;

--- a/src/lib/statistics/attribute_statistics.hpp
+++ b/src/lib/statistics/attribute_statistics.hpp
@@ -37,6 +37,10 @@ class AttributeStatistics : public BaseAttributeStatistics {
       const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
+  std::shared_ptr<BaseAttributeStatistics> pruned(
+    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
+
   std::shared_ptr<AbstractHistogram<T>> histogram;
   std::shared_ptr<MinMaxFilter<T>> min_max_filter;
   std::shared_ptr<RangeFilter<T>> range_filter;

--- a/src/lib/statistics/base_attribute_statistics.cpp
+++ b/src/lib/statistics/base_attribute_statistics.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 BaseAttributeStatistics::BaseAttributeStatistics(const DataType data_type) : data_type(data_type) {}
 
 std::shared_ptr<BaseAttributeStatistics> BaseAttributeStatistics::pruned(
-    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
     const std::optional<AllTypeVariant>& variant_value2) const {
   Fail("Pruning has not yet been implemented for the given statistics object");
 }

--- a/src/lib/statistics/base_attribute_statistics.cpp
+++ b/src/lib/statistics/base_attribute_statistics.cpp
@@ -4,4 +4,10 @@ namespace opossum {
 
 BaseAttributeStatistics::BaseAttributeStatistics(const DataType data_type) : data_type(data_type) {}
 
+  std::shared_ptr<BaseAttributeStatistics> BaseAttributeStatistics::pruned(
+      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const std::optional<AllTypeVariant>& variant_value2) const {
+  	Fail("Pruning has not yet been implemented for the given statistics object");
+  }
+
 }  // namespace opossum

--- a/src/lib/statistics/base_attribute_statistics.cpp
+++ b/src/lib/statistics/base_attribute_statistics.cpp
@@ -4,10 +4,10 @@ namespace opossum {
 
 BaseAttributeStatistics::BaseAttributeStatistics(const DataType data_type) : data_type(data_type) {}
 
-  std::shared_ptr<BaseAttributeStatistics> BaseAttributeStatistics::pruned(
-      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
-      const std::optional<AllTypeVariant>& variant_value2) const {
-  	Fail("Pruning has not yet been implemented for the given statistics object");
-  }
+std::shared_ptr<BaseAttributeStatistics> BaseAttributeStatistics::pruned(
+    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const std::optional<AllTypeVariant>& variant_value2) const {
+  Fail("Pruning has not yet been implemented for the given statistics object");
+}
 
 }  // namespace opossum

--- a/src/lib/statistics/base_attribute_statistics.hpp
+++ b/src/lib/statistics/base_attribute_statistics.hpp
@@ -47,8 +47,8 @@ class BaseAttributeStatistics {
    * Creates a new AttributeStatistics with num_values_pruned rows that fulfill the predicate removed from the statistics
    */
   virtual std::shared_ptr<BaseAttributeStatistics> pruned(
-    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
-    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
+      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   const DataType data_type;
 };

--- a/src/lib/statistics/base_attribute_statistics.hpp
+++ b/src/lib/statistics/base_attribute_statistics.hpp
@@ -43,6 +43,13 @@ class BaseAttributeStatistics {
       const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const = 0;
 
+  /*
+   * Creates a new AttributeStatistics with num_values_pruned rows that fulfill the predicate removed from the statistics
+   */
+  virtual std::shared_ptr<BaseAttributeStatistics> pruned(
+    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
+
   const DataType data_type;
 };
 

--- a/src/lib/statistics/base_attribute_statistics.hpp
+++ b/src/lib/statistics/base_attribute_statistics.hpp
@@ -44,7 +44,9 @@ class BaseAttributeStatistics {
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const = 0;
 
   /*
-   * Creates a new AttributeStatistics with num_values_pruned rows that fulfill the predicate removed from the statistics
+   * Creates a new AttributeStatistics that reflects pruning on a given predicate where num_values_pruned have been
+   * pruned. That is, remove num_values_pruned that DO NOT satisfy the predicate from the statistics, assuming
+   * equidistribution.
    */
   virtual std::shared_ptr<BaseAttributeStatistics> pruned(
       const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,

--- a/src/lib/statistics/base_attribute_statistics.hpp
+++ b/src/lib/statistics/base_attribute_statistics.hpp
@@ -47,7 +47,7 @@ class BaseAttributeStatistics {
    * Creates a new AttributeStatistics with num_values_pruned rows that fulfill the predicate removed from the statistics
    */
   virtual std::shared_ptr<BaseAttributeStatistics> pruned(
-      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   const DataType data_type;

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -880,9 +880,9 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_semi_join(
     output_table_statistics = std::make_shared<TableStatistics>(std::move(column_statistics), cardinality);
   });
 
-  DebugAssert(output_table_statistics->row_count <=  // TODO make assert
-                  left_input_table_statistics.row_count * (1 + std::numeric_limits<float>::epsilon()),
-              "Semi join should not increase cardinality");
+  Assert(output_table_statistics->row_count <=
+             left_input_table_statistics.row_count * (1 + std::numeric_limits<float>::epsilon()),
+         "Semi join should not increase cardinality");
 
   return output_table_statistics;
 }

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -168,7 +168,6 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
         Assert(stored_table_node->table_statistics->column_statistics.size() == stored_table->column_count(), "Statistics in StoredTableNode should have same number of columns as original table");
         output_table_statistics =
           prune_column_statistics(stored_table_node->table_statistics, stored_table_node->pruned_column_ids());
-        std::cout << "using overwrite statistics" << std::endl;
       } else {
         output_table_statistics =
             prune_column_statistics(stored_table->table_statistics(), stored_table_node->pruned_column_ids());

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -165,9 +165,10 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
 
       if (stored_table_node->table_statistics) {
         // TableStatistics have changed from the original table's statistics
-        Assert(stored_table_node->table_statistics->column_statistics.size() == stored_table->column_count(), "Statistics in StoredTableNode should have same number of columns as original table");
+        Assert(stored_table_node->table_statistics->column_statistics.size() == stored_table->column_count(),
+               "Statistics in StoredTableNode should have same number of columns as original table");
         output_table_statistics =
-          prune_column_statistics(stored_table_node->table_statistics, stored_table_node->pruned_column_ids());
+            prune_column_statistics(stored_table_node->table_statistics, stored_table_node->pruned_column_ids());
       } else {
         output_table_statistics =
             prune_column_statistics(stored_table->table_statistics(), stored_table_node->pruned_column_ids());

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -880,8 +880,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_semi_join(
     output_table_statistics = std::make_shared<TableStatistics>(std::move(column_statistics), cardinality);
   });
 
-  Assert(output_table_statistics->row_count <=
-             left_input_table_statistics.row_count * (1 + std::numeric_limits<float>::epsilon()),
+  Assert(output_table_statistics->row_count <= left_input_table_statistics.row_count * 1.01f,
          "Semi join should not increase cardinality");
 
   return output_table_statistics;

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -159,10 +159,20 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
 
     case LQPNodeType::StoredTable: {
       const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(lqp);
+
       const auto stored_table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
       Assert(stored_table->table_statistics(), "Stored Table should have cardinality estimation statistics");
-      output_table_statistics =
-          prune_column_statistics(stored_table->table_statistics(), stored_table_node->pruned_column_ids());
+
+      if (stored_table_node->table_statistics) {
+        // TableStatistics have changed from the original table's statistics
+        Assert(stored_table_node->table_statistics->column_statistics.size() == stored_table->column_count(), "Statistics in StoredTableNode should have same number of columns as original table");
+        output_table_statistics =
+          prune_column_statistics(stored_table_node->table_statistics, stored_table_node->pruned_column_ids());
+        std::cout << "using overwrite statistics" << std::endl;
+      } else {
+        output_table_statistics =
+            prune_column_statistics(stored_table->table_statistics(), stored_table_node->pruned_column_ids());
+      }
     } break;
 
     case LQPNodeType::Validate: {

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -880,7 +880,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_semi_join(
     output_table_statistics = std::make_shared<TableStatistics>(std::move(column_statistics), cardinality);
   });
 
-  DebugAssert(output_table_statistics->row_count <=
+  DebugAssert(output_table_statistics->row_count <=  // TODO make assert
                   left_input_table_statistics.row_count * (1 + std::numeric_limits<float>::epsilon()),
               "Semi join should not increase cardinality");
 

--- a/src/lib/statistics/statistics_objects/abstract_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.cpp
@@ -140,7 +140,8 @@ float AbstractHistogram<T>::bin_ratio_less_than(const BinID bin_id, const T& val
     // Determine the common_prefix_lengths of bin_min and bin_max. E.g. bin_max=abcde and bin_max=abcz have a
     // common_prefix_length=3
     auto common_prefix_length = size_t{0};
-    const auto max_common_prefix_length = std::min(bin_min.length() - _domain.prefix_length, bin_max.length() - _domain.prefix_length);
+    const auto max_common_prefix_length =
+        std::min(bin_min.length() - _domain.prefix_length, bin_max.length() - _domain.prefix_length);
     for (; common_prefix_length < max_common_prefix_length; ++common_prefix_length) {
       if (bin_min[common_prefix_length] != bin_max[common_prefix_length]) {
         break;
@@ -175,7 +176,8 @@ float AbstractHistogram<T>::bin_ratio_less_than_equals(const BinID bin_id, const
     const auto bin_max = bin_maximum(bin_id);
 
     auto common_prefix_length = size_t{0};
-    const auto max_common_prefix_length = std::min(bin_min.length() - _domain.prefix_length, bin_max.length() - _domain.prefix_length);
+    const auto max_common_prefix_length =
+        std::min(bin_min.length() - _domain.prefix_length, bin_max.length() - _domain.prefix_length);
     for (; common_prefix_length < max_common_prefix_length; ++common_prefix_length) {
       if (bin_min[common_prefix_length] != bin_max[common_prefix_length]) {
         break;
@@ -609,7 +611,6 @@ template <typename T>
 std::shared_ptr<AbstractStatisticsObject> AbstractHistogram<T>::pruned(
     const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
     const std::optional<AllTypeVariant>& variant_value2) const {
-
   const auto value = lossy_variant_cast<T>(variant_value);
   DebugAssert(value, "pruned() cannot be called with NULL");
 

--- a/src/lib/statistics/statistics_objects/abstract_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.cpp
@@ -91,7 +91,6 @@ typename AbstractHistogram<T>::HistogramWidthType AbstractHistogram<T>::bin_widt
 }
 
 template <typename T>
-// TODO test the string optimization of this and bin_ratio_less_than_equals
 float AbstractHistogram<T>::bin_ratio_less_than(const BinID bin_id, const T& value) const {
   if (value <= bin_minimum(bin_id)) {
     return 0.0f;
@@ -609,13 +608,12 @@ std::shared_ptr<AbstractStatisticsObject> AbstractHistogram<T>::sliced(
 
 template <typename T>
 std::shared_ptr<AbstractStatisticsObject> AbstractHistogram<T>::pruned(
-    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
     const std::optional<AllTypeVariant>& variant_value2) const {
   const auto value = lossy_variant_cast<T>(variant_value);
   DebugAssert(value, "pruned() cannot be called with NULL");
 
-  // For each bin, bin_prunable_height holds
-  //TODO
+  // For each bin, bin_prunable_height holds the number of values that do not fulfill the predicate.
   std::vector<HistogramCountType> bin_prunable_height(bin_count());
 
   switch (predicate_condition) {

--- a/src/lib/statistics/statistics_objects/abstract_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.cpp
@@ -674,10 +674,9 @@ std::shared_ptr<AbstractStatisticsObject> AbstractHistogram<T>::pruned(
       DebugAssert(value2, "pruned() cannot be called with NULL");
 
       for (auto bin_id = BinID{0}; bin_id < bin_count(); ++bin_id) {
-        auto ratio_outside = Selectivity{};
-        ratio_outside += bin_ratio_less_than_equals(bin_id, *value2) - bin_ratio_less_than(bin_id, *value);
+        const auto ratio_inside = bin_ratio_less_than_equals(bin_id, *value2) - bin_ratio_less_than(bin_id, *value);
 
-        bin_prunable_height[bin_id] = bin_height(bin_id) * ratio_outside;
+        bin_prunable_height[bin_id] = bin_height(bin_id) * (Selectivity{1} - ratio_inside);
       }
     } break;
 

--- a/src/lib/statistics/statistics_objects/abstract_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.cpp
@@ -619,7 +619,9 @@ std::shared_ptr<AbstractStatisticsObject> AbstractHistogram<T>::pruned(
   const auto value = lossy_variant_cast<T>(variant_value);
   DebugAssert(value, "pruned() cannot be called with NULL");
 
-  // For each bin, bin_prunable_height holds the number of values that do not fulfill the predicate.
+  // For each bin, bin_prunable_height holds the number of values that do not fulfill the predicate. If we had some
+  // information about the sort order of the table, we might start pruning a GreaterThan predicate with the lowest
+  // value instead of uniformly pruning across all affected chunks as a future optimization.
   std::vector<HistogramCountType> bin_prunable_height(bin_count());
 
   switch (predicate_condition) {

--- a/src/lib/statistics/statistics_objects/abstract_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.cpp
@@ -188,12 +188,6 @@ float AbstractHistogram<T>::bin_ratio_less_than_equals(const BinID bin_id, const
     const auto max_repr = _domain.string_to_number(bin_max.substr(common_prefix_length));
     const auto bin_ratio = static_cast<float>(value_repr - min_repr) / (max_repr - min_repr + 1);
 
-    std::cout << "in_domain_value: " << in_domain_value << std::endl;
-    std::cout << "value_repr: " << value_repr << std::endl;
-    std::cout << "min_repr: " << min_repr << std::endl;
-    std::cout << "max_repr: " << max_repr << std::endl;
-    std::cout << "bin_ratio: " << bin_ratio << std::endl;
-
     return bin_ratio;
   }
 }
@@ -706,7 +700,6 @@ std::shared_ptr<AbstractStatisticsObject> AbstractHistogram<T>::pruned(
   for (auto bin_id = BinID{0}; bin_id < bin_count(); bin_id++) {
     const auto pruned_height = bin_prunable_height[bin_id] * pruning_ratio;
 
-    std::cout << "Bin " << bin_id << ": " << bin_prunable_height[bin_id] << " prunable, prune " << pruned_height << std::endl;
     builder.add_bin(bin_minimum(bin_id), bin_maximum(bin_id), bin_height(bin_id) - pruned_height,
                     bin_distinct_count(bin_id));
   }

--- a/src/lib/statistics/statistics_objects/abstract_histogram.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.hpp
@@ -115,6 +115,10 @@ class AbstractHistogram : public AbstractStatisticsObject {
       const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
+  std::shared_ptr<AbstractStatisticsObject> pruned(
+      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
+
   std::shared_ptr<AbstractStatisticsObject> scaled(const Selectivity selectivity) const override;
 
   /**
@@ -174,6 +178,11 @@ class AbstractHistogram : public AbstractStatisticsObject {
    * Returns the largest value in a bin.
    */
   virtual T bin_maximum(const BinID index) const = 0;
+
+  /**
+   * Returns whether the value is contained in a given bin
+   */
+  bool bin_contains(const BinID index, const T& value) const;
 
   /**
    * Returns the number of values in a bin.

--- a/src/lib/statistics/statistics_objects/abstract_histogram.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.hpp
@@ -116,7 +116,7 @@ class AbstractHistogram : public AbstractStatisticsObject {
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   std::shared_ptr<AbstractStatisticsObject> pruned(
-      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const override;
 
   std::shared_ptr<AbstractStatisticsObject> scaled(const Selectivity selectivity) const override;

--- a/src/lib/statistics/statistics_objects/abstract_histogram.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.hpp
@@ -180,7 +180,8 @@ class AbstractHistogram : public AbstractStatisticsObject {
   virtual T bin_maximum(const BinID index) const = 0;
 
   /**
-   * Returns whether the value is contained in a given bin
+   * Returns whether the value belongs into a given bin. This does not necessarily mean that the value is actually
+   * present.
    */
   bool bin_contains(const BinID index, const T& value) const;
 

--- a/src/lib/statistics/statistics_objects/abstract_histogram.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.hpp
@@ -217,6 +217,11 @@ class AbstractHistogram : public AbstractStatisticsObject {
   float bin_ratio_less_than_equals(const BinID bin_id, const T& value) const;
   /** @} */
 
+  /**
+   * Returns the share of the value range of a bin that is within [value, value2], i.e., BetweenInclusive
+   */
+  float bin_ratio_between(const BinID bin_id, const T& value, const T& value2) const;
+
  protected:
   // Call after constructor of the derived histogram has finished to check whether the bins are valid
   // (e.g. do not overlap).

--- a/src/lib/statistics/statistics_objects/abstract_statistics_object.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_statistics_object.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 AbstractStatisticsObject::AbstractStatisticsObject(const DataType data_type) : data_type(data_type) {}
 
 std::shared_ptr<AbstractStatisticsObject> AbstractStatisticsObject::pruned(
-    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
     const std::optional<AllTypeVariant>& variant_value2) const {
   Fail("Pruning has not yet been implemented for the given statistics object");
 }

--- a/src/lib/statistics/statistics_objects/abstract_statistics_object.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_statistics_object.cpp
@@ -4,10 +4,10 @@ namespace opossum {
 
 AbstractStatisticsObject::AbstractStatisticsObject(const DataType data_type) : data_type(data_type) {}
 
-  std::shared_ptr<AbstractStatisticsObject> AbstractStatisticsObject::pruned(
-      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
-      const std::optional<AllTypeVariant>& variant_value2) const {
-  	Fail("Pruning has not yet been implemented for the given statistics object");
-  }
+std::shared_ptr<AbstractStatisticsObject> AbstractStatisticsObject::pruned(
+    const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+    const std::optional<AllTypeVariant>& variant_value2) const {
+  Fail("Pruning has not yet been implemented for the given statistics object");
+}
 
 }  // namespace opossum

--- a/src/lib/statistics/statistics_objects/abstract_statistics_object.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_statistics_object.cpp
@@ -4,4 +4,10 @@ namespace opossum {
 
 AbstractStatisticsObject::AbstractStatisticsObject(const DataType data_type) : data_type(data_type) {}
 
+  std::shared_ptr<AbstractStatisticsObject> AbstractStatisticsObject::pruned(
+      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const std::optional<AllTypeVariant>& variant_value2) const {
+  	Fail("Pruning has not yet been implemented for the given statistics object");
+  }
+
 }  // namespace opossum

--- a/src/lib/statistics/statistics_objects/abstract_statistics_object.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_statistics_object.hpp
@@ -25,6 +25,14 @@ class AbstractStatisticsObject : private Noncopyable {
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const = 0;
 
   /**
+   * @return A statistics object that represents the data after `num_values_pruned` rows that satisfy the given condition
+   * have been removed
+   */
+  virtual std::shared_ptr<AbstractStatisticsObject> pruned(
+      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
+
+  /**
    * @return a statistics object that represents the data after a filter with the given selectivity has been applied.
    */
   virtual std::shared_ptr<AbstractStatisticsObject> scaled(const Selectivity selectivity) const = 0;

--- a/src/lib/statistics/statistics_objects/abstract_statistics_object.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_statistics_object.hpp
@@ -29,7 +29,7 @@ class AbstractStatisticsObject : private Noncopyable {
    * have been removed
    */
   virtual std::shared_ptr<AbstractStatisticsObject> pruned(
-      const PredicateCondition predicate_condition, const size_t num_values_pruned, const AllTypeVariant& variant_value,
+      const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   /**

--- a/src/lib/statistics/statistics_objects/abstract_statistics_object.hpp
+++ b/src/lib/statistics/statistics_objects/abstract_statistics_object.hpp
@@ -24,9 +24,10 @@ class AbstractStatisticsObject : private Noncopyable {
       const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
       const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const = 0;
 
-  /**
-   * @return A statistics object that represents the data after `num_values_pruned` rows that satisfy the given condition
-   * have been removed
+  /*
+   * @return A statistics object that reflects pruning on a given predicate where num_values_pruned have been
+   * pruned. That is, remove num_values_pruned that DO NOT satisfy the predicate from the statistics, assuming
+   * equidistribution.
    */
   virtual std::shared_ptr<AbstractStatisticsObject> pruned(
       const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,

--- a/src/lib/statistics/statistics_objects/histogram_domain.cpp
+++ b/src/lib/statistics/statistics_objects/histogram_domain.cpp
@@ -9,8 +9,6 @@ HistogramDomain<pmr_string>::HistogramDomain()
       // length were chosen so that the entire range of IntegralType is covered
       HistogramDomain<pmr_string>(' ', '~', 9) {}
 
-// TODO TPC-H 20 - warum wird p_name BETWEEN so schlecht abgeschätzt?
-
 HistogramDomain<pmr_string>::HistogramDomain(const char min_char, const char max_char, const size_t prefix_length)
     : min_char(min_char), max_char(max_char), prefix_length(prefix_length) {
   Assert(min_char <= max_char, "Invalid character range");

--- a/src/lib/statistics/statistics_objects/histogram_domain.cpp
+++ b/src/lib/statistics/statistics_objects/histogram_domain.cpp
@@ -9,6 +9,8 @@ HistogramDomain<pmr_string>::HistogramDomain()
       // length were chosen so that the entire range of IntegralType is covered
       HistogramDomain<pmr_string>(' ', '~', 9) {}
 
+// TODO TPC-H 20 - warum wird p_name BETWEEN so schlecht abgeschätzt?
+
 HistogramDomain<pmr_string>::HistogramDomain(const char min_char, const char max_char, const size_t prefix_length)
     : min_char(min_char), max_char(max_char), prefix_length(prefix_length) {
   Assert(min_char <= max_char, "Invalid character range");

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -114,7 +114,7 @@ set(
     optimizer/join_graph_test.cpp
     optimizer/optimizer_test.cpp
     optimizer/strategy/between_composition_rule_test.cpp
-    optimizer/strategy/chunk_pruning_test.cpp
+    optimizer/strategy/chunk_pruning_rule_test.cpp
     optimizer/strategy/column_pruning_rule_test.cpp
     optimizer/strategy/expression_reduction_rule_test.cpp
     optimizer/strategy/index_scan_rule_test.cpp

--- a/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -82,7 +82,8 @@ TEST_F(ChunkPruningRuleTest, SimplePruningTest) {
     std::vector<HistogramCountType> {1}};
   // clang-format on
 
-  const auto& column_statistics = dynamic_cast<AttributeStatistics<int32_t>&>(*stored_table_node->table_statistics->column_statistics[0]);
+  const auto& column_statistics =
+      dynamic_cast<AttributeStatistics<int32_t>&>(*stored_table_node->table_statistics->column_statistics[0]);
   const auto& actual_histogram = dynamic_cast<GenericHistogram<int32_t>&>(*column_statistics.histogram);
   EXPECT_EQ(actual_histogram, expected_histogram);
 }

--- a/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -32,7 +32,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class ChunkPruningTest : public StrategyBaseTest {
+class ChunkPruningRuleTest : public StrategyBaseTest {
  protected:
   void SetUp() override {
     auto& storage_manager = Hyrise::get().storage_manager;
@@ -58,7 +58,7 @@ class ChunkPruningTest : public StrategyBaseTest {
   std::shared_ptr<ChunkPruningRule> _rule;
 };
 
-TEST_F(ChunkPruningTest, SimplePruningTest) {
+TEST_F(ChunkPruningRuleTest, SimplePruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node =
@@ -71,9 +71,21 @@ TEST_F(ChunkPruningTest, SimplePruningTest) {
   std::vector<ChunkID> expected_chunk_ids = {ChunkID{1}};
   std::vector<ChunkID> pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
+
+  EXPECT_TRUE(stored_table_node->table_statistics);
+
+  // clang-format off
+  const auto expected_histogram = GenericHistogram<int32_t>{
+    std::vector<int32_t>            {12, 123, 12345},
+    std::vector<int32_t>            {12, 123, 12345},
+    std::vector<HistogramCountType> {0,  0,   2},
+    std::vector<HistogramCountType> {1,  1,   1}};
+  // clang-format on
+
+  std::cout << *stored_table_node->table_statistics << std::endl;
 }
 
-TEST_F(ChunkPruningTest, SimpleChinkPruningTestWithColumnPruning) {
+TEST_F(ChunkPruningRuleTest, SimpleChinkPruningTestWithColumnPruning) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
   stored_table_node->set_pruned_column_ids({ColumnID{0}});
 
@@ -89,7 +101,7 @@ TEST_F(ChunkPruningTest, SimpleChinkPruningTestWithColumnPruning) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, BetweenPruningTest) {
+TEST_F(ChunkPruningRuleTest, BetweenPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node = std::make_shared<PredicateNode>(
@@ -104,7 +116,7 @@ TEST_F(ChunkPruningTest, BetweenPruningTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, NoStatisticsAvailable) {
+TEST_F(ChunkPruningRuleTest, NoStatisticsAvailable) {
   auto table = Hyrise::get().storage_manager.get_table("uncompressed");
   auto chunk = table->get_chunk(ChunkID(0));
   EXPECT_FALSE(chunk->pruning_statistics());
@@ -123,7 +135,7 @@ TEST_F(ChunkPruningTest, NoStatisticsAvailable) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, TwoOperatorPruningTest) {
+TEST_F(ChunkPruningRuleTest, TwoOperatorPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node_0 =
@@ -142,7 +154,7 @@ TEST_F(ChunkPruningTest, TwoOperatorPruningTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, IntersectionPruningTest) {
+TEST_F(ChunkPruningRuleTest, IntersectionPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node_0 =
@@ -165,7 +177,7 @@ TEST_F(ChunkPruningTest, IntersectionPruningTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, ComparatorEdgeCasePruningTest_GreaterThan) {
+TEST_F(ChunkPruningRuleTest, ComparatorEdgeCasePruningTest_GreaterThan) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node =
@@ -180,7 +192,7 @@ TEST_F(ChunkPruningTest, ComparatorEdgeCasePruningTest_GreaterThan) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, ComparatorEdgeCasePruningTest_Equals) {
+TEST_F(ChunkPruningRuleTest, ComparatorEdgeCasePruningTest_Equals) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node =
@@ -195,7 +207,7 @@ TEST_F(ChunkPruningTest, ComparatorEdgeCasePruningTest_Equals) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, RangeFilterTest) {
+TEST_F(ChunkPruningRuleTest, RangeFilterTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node =
@@ -210,7 +222,7 @@ TEST_F(ChunkPruningTest, RangeFilterTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, LotsOfRangesFilterTest) {
+TEST_F(ChunkPruningRuleTest, LotsOfRangesFilterTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("long_compressed");
 
   auto predicate_node =
@@ -225,7 +237,7 @@ TEST_F(ChunkPruningTest, LotsOfRangesFilterTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, RunLengthSegmentPruningTest) {
+TEST_F(ChunkPruningRuleTest, RunLengthSegmentPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("run_length_compressed");
 
   auto predicate_node = std::make_shared<PredicateNode>(equals_(LQPColumnReference(stored_table_node, ColumnID{0}), 2));
@@ -239,7 +251,7 @@ TEST_F(ChunkPruningTest, RunLengthSegmentPruningTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, GetTablePruningTest) {
+TEST_F(ChunkPruningRuleTest, GetTablePruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   auto predicate_node =
@@ -264,7 +276,7 @@ TEST_F(ChunkPruningTest, GetTablePruningTest) {
   EXPECT_EQ(result_table->get_value<int>(ColumnID{0}, 0), 12345);
 }
 
-TEST_F(ChunkPruningTest, StringPruningTest) {
+TEST_F(ChunkPruningRuleTest, StringPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("string_compressed");
 
   auto predicate_node =
@@ -279,7 +291,7 @@ TEST_F(ChunkPruningTest, StringPruningTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, FixedStringPruningTest) {
+TEST_F(ChunkPruningRuleTest, FixedStringPruningTest) {
   auto stored_table_node = std::make_shared<StoredTableNode>("fixed_string_compressed");
 
   auto predicate_node =
@@ -294,7 +306,7 @@ TEST_F(ChunkPruningTest, FixedStringPruningTest) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, PrunePastNonFilteringNodes) {
+TEST_F(ChunkPruningRuleTest, PrunePastNonFilteringNodes) {
   auto stored_table_node = std::make_shared<StoredTableNode>("compressed");
 
   const auto a = stored_table_node->get_column("a");
@@ -318,7 +330,7 @@ TEST_F(ChunkPruningTest, PrunePastNonFilteringNodes) {
   EXPECT_EQ(pruned_chunk_ids, expected_chunk_ids);
 }
 
-TEST_F(ChunkPruningTest, ValueOutOfRange) {
+TEST_F(ChunkPruningRuleTest, ValueOutOfRange) {
   // Filters are not required to handle values out of their data type's range and the ColumnPruningRule currently
   // doesn't convert out-of-range values into the type's range
   // TODO(anybody) In the test LQP below, the ChunkPruningRule could convert the -3'000'000'000 to MIN_INT (but ONLY

--- a/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -76,11 +76,15 @@ TEST_F(ChunkPruningRuleTest, SimplePruningTest) {
 
   // clang-format off
   const auto expected_histogram = GenericHistogram<int32_t>{
-    std::vector<int32_t>            {12, 123, 12345},
-    std::vector<int32_t>            {12, 123, 12345},
-    std::vector<HistogramCountType> {0,  0,   2},
-    std::vector<HistogramCountType> {1,  1,   1}};
+    std::vector<int32_t>            {12345},
+    std::vector<int32_t>            {12345},
+    std::vector<HistogramCountType> {2},
+    std::vector<HistogramCountType> {1}};
   // clang-format on
+
+  const auto& column_statistics = dynamic_cast<AttributeStatistics<int32_t>&>(*stored_table_node->table_statistics->column_statistics[0]);
+  const auto& actual_histogram = dynamic_cast<GenericHistogram<int32_t>&>(*column_statistics.histogram);
+  EXPECT_EQ(actual_histogram, expected_histogram);
 }
 
 TEST_F(ChunkPruningRuleTest, SimpleChinkPruningTestWithColumnPruning) {

--- a/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -81,8 +81,6 @@ TEST_F(ChunkPruningRuleTest, SimplePruningTest) {
     std::vector<HistogramCountType> {0,  0,   2},
     std::vector<HistogramCountType> {1,  1,   1}};
   // clang-format on
-
-  std::cout << *stored_table_node->table_statistics << std::endl;
 }
 
 TEST_F(ChunkPruningRuleTest, SimpleChinkPruningTestWithColumnPruning) {

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -756,6 +756,28 @@ TEST_F(GenericHistogramTest, SlicedFloat) {
   test_sliced_with_predicates(histograms, predicates);
 }
 
+TEST_F(GenericHistogramTest, PrunedInt) {
+  // clang-format off
+
+  // Normal histogram, no special cases here
+  const auto histogram_a = std::make_shared<GenericHistogram<int32_t>>(
+    std::vector<int32_t>            { 1, 31, 60, 80},
+    std::vector<int32_t>            {25, 50, 60, 99},
+    std::vector<HistogramCountType> {40, 30, 5,  10},
+    std::vector<HistogramCountType> {10, 20, 1,  1});
+  // clang-format on
+
+  std::cout << *histogram_a << std::endl;
+
+  const auto pruned =
+            histogram_a->pruned(PredicateCondition::BetweenInclusive, 30, 31, 50);
+
+  std::cout << static_cast<GenericHistogram<int32_t>&>(*pruned) << std::endl;
+
+// TODO test all predicate types
+// TODO test matching boundary, histogram gap, middle
+}
+
 TEST_F(GenericHistogramTest, SplitAtEmptyBinBounds) {
   // clang-format off
   const auto histogram = GenericHistogram<int32_t>(

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -787,10 +787,10 @@ TEST_F(GenericHistogramTest, PrunedInt) {
         std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(55, PredicateCondition::GreaterThan, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
-      std::vector<int32_t>            { 1, 31, 60, 80},
-      std::vector<int32_t>            {25, 50, 60, 99},
-      std::vector<HistogramCountType> { 0, 15, 5,  10},
-      std::vector<HistogramCountType> {10, 20, 1,  1}};
+      std::vector<int32_t>            {31, 60, 80},
+      std::vector<int32_t>            {50, 60, 99},
+      std::vector<HistogramCountType> {15, 5,  10},
+      std::vector<HistogramCountType> {20, 1,  1}};
     // clang-format on
 
     EXPECT_EQ(*pruned, expected_histogram);
@@ -875,8 +875,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune by not equals predicate not found in any bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(15, PredicateCondition::NotEquals, 28));
+    const auto pruned =
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(15, PredicateCondition::NotEquals, 28));
 
     EXPECT_EQ(*pruned, *histogram);
   }
@@ -933,10 +933,10 @@ TEST_F(GenericHistogramTest, PrunedInt) {
         histogram->pruned(100, PredicateCondition::GreaterThan, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
-      std::vector<int32_t>            { 1, 31, 60, 80},
-      std::vector<int32_t>            {25, 50, 60, 99},
-      std::vector<HistogramCountType> { 0, 15, 5,  10},
-      std::vector<HistogramCountType> {10, 20, 1,  1}};
+      std::vector<int32_t>            {31, 60, 80},
+      std::vector<int32_t>            {50, 60, 99},
+      std::vector<HistogramCountType> {15, 5,  10},
+      std::vector<HistogramCountType> {20, 1,  1}};
     // clang-format on
 
     EXPECT_EQ(*pruned, expected_histogram);
@@ -977,10 +977,10 @@ TEST_F(GenericHistogramTest, PrunedString) {
         histogram->pruned(55, PredicateCondition::GreaterThan, "bl"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
-      std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
-      std::vector<pmr_string>        {"ax", "bv", "ce", "dq"},
-      std::vector<HistogramCountType>{ 0,   15,   5,    10},
-      std::vector<HistogramCountType>{10,   20,   1,    1},
+      std::vector<pmr_string>        {"bc", "ce", "cy"},
+      std::vector<pmr_string>        {"bv", "ce", "dq"},
+      std::vector<HistogramCountType>{15,   5,    10},
+      std::vector<HistogramCountType>{20,   1,    1},
       StringHistogramDomain{'a', 'z', 2u}};
     // clang-format on
 

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -815,7 +815,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
     // Prune eight values from the last two bins with the boundary being on a single bin's value
     const auto pruned =
         std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(8, PredicateCondition::LessThan, 60));
-    const auto remaining_ratio = 1.0f - 8.0f / 15.0f;
+    const auto remaining_ratio = 1.0f - 8.0f / (5.0f + 10.0f);
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -771,6 +771,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
         histogram->pruned(20, PredicateCondition::GreaterThanEquals, 26));
 
     // clang-format off
+    // This is what the histogram looks like after 20 values that are not >= 26 are pruned (aka. removed) from the
+    // statistics
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
       std::vector<int32_t>            {25, 50, 60, 99},

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -966,7 +966,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
       std::vector<pmr_string>        {"ax", "bv", "ce", "dq"},
-      std::vector<HistogramCountType>{40,   27,   4,    9},
+      std::vector<HistogramCountType>{40,   30,   5,    10},  // TODO
       std::vector<HistogramCountType>{10,   20,   1,    1},
       StringHistogramDomain{'a', 'z', 2u}};
     // clang-format on

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -767,7 +767,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune half of the values from the first bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::LessThan, 20, 26));
+    const auto pruned =
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::LessThan, 20, 26));
 
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
@@ -782,7 +783,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune all values from the first bin and half of the values from the second bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::LessThanEquals, 55, 40));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
+        histogram->pruned(PredicateCondition::LessThanEquals, 55, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -796,7 +798,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune three values from the last bin with the boundary being outside of any bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::GreaterThan, 3, 70));
+    const auto pruned =
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::GreaterThan, 3, 70));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -810,8 +813,9 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune eight values from the last two bins with the boundary being on a single bin's value
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::GreaterThanEquals, 8, 60));
-    const auto remaining_ratio = 1.0f-8.0f/15.0f;
+    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
+        histogram->pruned(PredicateCondition::GreaterThanEquals, 8, 60));
+    const auto remaining_ratio = 1.0f - 8.0f / 15.0f;
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -825,7 +829,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune by equals predicate with value found in second bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::Equals, 3, 32));
+    const auto pruned =
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::Equals, 3, 32));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -839,14 +844,16 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune by equals predicate with value not found anywhere
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::Equals, 7, 61));
+    const auto pruned =
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::Equals, 7, 61));
 
     EXPECT_EQ(*pruned, *histogram);
   }
 
   {
     // Prune by not equals predicate from first bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::NotEquals, 27, 21));
+    const auto pruned =
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::NotEquals, 27, 21));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -860,7 +867,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune by Between entirely contained in one bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::BetweenInclusive, 8, 40, 50));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
+        histogram->pruned(PredicateCondition::BetweenInclusive, 8, 40, 50));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -874,7 +882,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune by Between spanning three bins, covering half of the bins on both ends
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::BetweenExclusive, 5, 41, 89));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
+        histogram->pruned(PredicateCondition::BetweenExclusive, 5, 41, 89));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -888,7 +897,8 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 
   {
     // Prune by Between spanning two bins, with the begin value being outside of the histogram and the end value in the middle of the second bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::BetweenLowerExclusive, 11, -10, 40));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
+        histogram->pruned(PredicateCondition::BetweenLowerExclusive, 11, -10, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31,   60, 80},
@@ -902,7 +912,6 @@ TEST_F(GenericHistogramTest, PrunedInt) {
 }
 
 TEST_F(GenericHistogramTest, PrunedString) {
-
   // Same cardinalities as in PrunedInt, just with string values. Strings are chosen so that their numeric
   // representation is the same as the numbers used in PrunedInt, too.
   // clang-format off
@@ -915,7 +924,8 @@ TEST_F(GenericHistogramTest, PrunedString) {
 
   {
     // Prune half of the values from the first bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(histogram->pruned(PredicateCondition::LessThan, 20, "ay"));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
+        histogram->pruned(PredicateCondition::LessThan, 20, "ay"));
 
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
@@ -931,7 +941,8 @@ TEST_F(GenericHistogramTest, PrunedString) {
 
   {
     // Prune all values from the first bin and half of the values from the second bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(histogram->pruned(PredicateCondition::LessThanEquals, 55, "bl"));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
+        histogram->pruned(PredicateCondition::LessThanEquals, 55, "bl"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -946,7 +957,8 @@ TEST_F(GenericHistogramTest, PrunedString) {
 
   {
     // Prune by Between entirely contained in one bin
-    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(histogram->pruned(PredicateCondition::BetweenInclusive, 8, "bl", "bv"));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
+        histogram->pruned(PredicateCondition::BetweenInclusive, 8, "bl", "bv"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -961,7 +973,8 @@ TEST_F(GenericHistogramTest, PrunedString) {
 
   {
     // Prune by Between spanning three bins, covering half of the bins on both ends
-    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(histogram->pruned(PredicateCondition::BetweenExclusive, 5, "bm", "dg"));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
+        histogram->pruned(PredicateCondition::BetweenExclusive, 5, "bm", "dg"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -977,7 +990,8 @@ TEST_F(GenericHistogramTest, PrunedString) {
   {
     // Same as the last test, but this time, the search values are longer than the domain's common prefix.
     // Remember that string_to_number adds 1 for strings that are longer than the prefix.
-    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(histogram->pruned(PredicateCondition::BetweenExclusive, 5, "blaba", "dfqfqs"));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
+        histogram->pruned(PredicateCondition::BetweenExclusive, 5, "blaba", "dfqfqs"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -993,7 +1007,8 @@ TEST_F(GenericHistogramTest, PrunedString) {
   {
     // Same as the last test, but this time, the search values contain characters outside of the domain.
     // cX should be converted to ca, c{ to cz. This way, the third bin should be included fully and the fourth bin partially.
-    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(histogram->pruned(PredicateCondition::BetweenExclusive, 3, "cX", "c{"));
+    const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
+        histogram->pruned(PredicateCondition::BetweenExclusive, 3, "cX", "c{"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -768,7 +768,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune half of the values from the first bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::GreaterThanEquals, 20, 26));
+        histogram->pruned(20, PredicateCondition::GreaterThanEquals, 26));
 
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
@@ -784,7 +784,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune all values from the first bin and half of the values from the second bin
     const auto pruned =
-        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::GreaterThan, 55, 40));
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(55, PredicateCondition::GreaterThan, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -799,7 +799,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune three values from the last bin with the boundary being outside of any bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::LessThanEquals, 3, 70));
+        histogram->pruned(3, PredicateCondition::LessThanEquals, 70));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -814,7 +814,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune eight values from the last two bins with the boundary being on a single bin's value
     const auto pruned =
-        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::LessThan, 8, 60));
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(8, PredicateCondition::LessThan, 60));
     const auto remaining_ratio = 1.0f - 8.0f / 15.0f;
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
@@ -830,7 +830,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune by equals predicate with value found in first bin
     const auto pruned =
-        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::Equals, 27, 17));
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(27, PredicateCondition::Equals, 17));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -845,7 +845,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune by equals predicate with value not found anywhere
     const auto pruned =
-        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::Equals, 17, 61));
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(17, PredicateCondition::Equals, 61));
 
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
@@ -861,7 +861,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune by not equals predicate from first bin
     const auto pruned =
-        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(PredicateCondition::NotEquals, 3, 21));
+        std::static_pointer_cast<GenericHistogram<int32_t>>(histogram->pruned(3, PredicateCondition::NotEquals, 21));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -876,7 +876,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune by not equals predicate not found in any bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::NotEquals, 15, 28));  // TODO move num_rows to front
+        histogram->pruned(15, PredicateCondition::NotEquals, 28));
 
     EXPECT_EQ(*pruned, *histogram);
   }
@@ -884,7 +884,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune by Between entirely contained in one bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::BetweenInclusive, 14, 41, 50));
+        histogram->pruned(14, PredicateCondition::BetweenInclusive, 41, 50));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -899,7 +899,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune by Between spanning three bins, covering half of the bins on both ends
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::BetweenExclusive, 24, 41, 89));
+        histogram->pruned(24, PredicateCondition::BetweenExclusive, 41, 89));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -915,7 +915,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
     // Prune by Between spanning two bins, with the begin value being outside of the histogram and the end value in the
     // middle of the second bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::BetweenLowerExclusive, 12, -10, 40));
+        histogram->pruned(12, PredicateCondition::BetweenLowerExclusive, -10, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31,   60, 80},
@@ -930,7 +930,7 @@ TEST_F(GenericHistogramTest, PrunedInt) {
   {
     // Prune from the first and second bin. Prune more values than the bins contain.
     const auto pruned = std::static_pointer_cast<GenericHistogram<int32_t>>(
-        histogram->pruned(PredicateCondition::GreaterThan, 100, 40));
+        histogram->pruned(100, PredicateCondition::GreaterThan, 40));
     // clang-format off
     const auto expected_histogram = GenericHistogram<int32_t>{
       std::vector<int32_t>            { 1, 31, 60, 80},
@@ -957,7 +957,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
   {
     // Prune half of the values from the first bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
-        histogram->pruned(PredicateCondition::GreaterThanEquals, 20, "ay"));
+        histogram->pruned(20, PredicateCondition::GreaterThanEquals, "ay"));
 
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
@@ -974,7 +974,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
   {
     // Prune all values from the first bin and half of the values from the second bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
-        histogram->pruned(PredicateCondition::GreaterThan, 55, "bl"));
+        histogram->pruned(55, PredicateCondition::GreaterThan, "bl"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -990,7 +990,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
   {
     // Prune by Between entirely contained in one bin
     const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
-        histogram->pruned(PredicateCondition::BetweenInclusive, 14, "bl", "bu"));
+        histogram->pruned(14, PredicateCondition::BetweenInclusive, "bl", "bu"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -1006,7 +1006,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
   {
     // Prune by Between spanning three bins, covering half of the bins on both ends
     const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
-        histogram->pruned(PredicateCondition::BetweenExclusive, 24, "bm", "dg"));
+        histogram->pruned(24, PredicateCondition::BetweenExclusive, "bm", "dg"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -1023,7 +1023,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
     // Same as the last test, but this time, the search values are longer than the domain's common prefix.
     // Remember that string_to_number adds 1 for strings that are longer than the prefix.
     const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
-        histogram->pruned(PredicateCondition::BetweenExclusive, 24, "blaba", "dfqfqs"));
+        histogram->pruned(24, PredicateCondition::BetweenExclusive, "blaba", "dfqfqs"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},
@@ -1041,7 +1041,7 @@ TEST_F(GenericHistogramTest, PrunedString) {
     // cX should be converted to ca. This way, the third bin should be included fully and the fourth bin
     // partially.
     const auto pruned = std::static_pointer_cast<GenericHistogram<pmr_string>>(
-        histogram->pruned(PredicateCondition::BetweenExclusive, 15, "cX", "dg"));
+        histogram->pruned(15, PredicateCondition::BetweenExclusive, "cX", "dg"));
     // clang-format off
     const auto expected_histogram = GenericHistogram<pmr_string>{
       std::vector<pmr_string>        { "a", "bc", "ce", "cy"},


### PR DESCRIPTION
fixes #1672 

If a chunk is pruned, we update the table statistics. This is so that the selectivity of the predicate that was used for pruning can be correctly estimated. Example: For a table that has sorted values from 1 to 100 and a chunk size of 10, the predicate `x > 90` has a selectivity of 10%. However, if the ChunkPruningRule removes nine chunks out of ten, the selectivity is now 100%. Updating the statistics is important so that the predicate ordering can properly order the predicates. For the column that the predicate pruned on, we remove chunk.size() values that do not match the predicate from the histogram, assuming equidistribution among the pruned values. The other columns are simply scaled to reflect the reduced table size.

```
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 01       | 0.603997766972 | 37   | 0.606376945972 | 37   | +0%        |                          0.5331 |
| TPC-H 02       | 8.80610275269  | 529  | 8.84343624115  | 531  | +0%        |                          0.0470 |
| TPC-H 03       | 6.56616020203  | 394  | 6.59374427795  | 396  | +0%        |                          0.0129 |
| TPC-H 04       | 7.10575246811  | 427  | 7.08842229843  | 426  | -0%        |                          0.6785 |
| TPC-H 05       | 4.21703386307  | 254  | 4.22742652893  | 254  | +0%        |                          0.6531 |
| TPC-H 06       | 104.20526123   | 6253 | 144.336303711  | 8661 | +39%       |                          0.0000 |
| TPC-H 07       | 1.56881177425  | 95   | 1.55115008354  | 94   | -1%        |                          0.0228 |
| TPC-H 08       | 5.69246768951  | 342  | 5.16212844849  | 310  | -9%        |                          0.0000 |
| TPC-H 09       | 1.55829799175  | 94   | 1.5018081665   | 91   | -4%        |                          0.0000 |
| TPC-H 10       | 3.0416841507   | 183  | 3.0541908741   | 184  | +0%        |                          0.3401 |
| TPC-H 11       | 25.2049427032  | 1513 | 25.2570724487  | 1516 | +0%        |                          0.0473 |
| TPC-H 12       | 8.5094203949   | 511  | 8.39533805847  | 504  | -1%        |                          0.0000 |
| TPC-H 13       | 2.27774620056  | 137  | 2.30116820335  | 139  | +1%        |                          0.0000 |
| TPC-H 14       | 45.8149452209  | 2749 | 46.4754600525  | 2789 | +1%        |                          0.0000 |
| TPC-H 15       | 72.2236709595  | 4334 | 71.1981277466  | 4272 | -1%        |                          0.0000 |
| TPC-H 16       | 7.1074757576   | 427  | 7.01677083969  | 422  | -1%        |                          0.0000 |
| TPC-H 17       | 1.28215098381  | 77   | 1.2849419117   | 78   | +0%        |                          0.2416 |
| TPC-H 18       | 0.738323509693 | 45   | 0.777599096298 | 47   | +5%        |                          0.0000 |
| TPC-H 19       | 8.478931427    | 509  | 8.56902599335  | 515  | +1%        |                          0.0000 |
| TPC-H 20       | 2.79979515076  | 168  | 2.66847753525  | 161  | -5%        |                          0.0000 |
| TPC-H 21       | 1.50276696682  | 91   | 1.49180960655  | 90   | -1%        |                          0.0105 |
| TPC-H 22       | 13.1531352997  | 790  | 13.407740593   | 805  | +2%        |                          0.0000 |
| geometric mean |                |      |                |      | +1%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```