### PR TITLE
Better estimation for correlated parameters

### DIFF
--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -242,15 +242,27 @@ void expressions_set_transaction_context(const std::vector<std::shared_ptr<Abstr
   }
 }
 
-bool expression_contains_placeholders(const std::shared_ptr<AbstractExpression>& expression) {
+bool expression_contains_placeholder(const std::shared_ptr<AbstractExpression>& expression) {
   auto placeholder_found = false;
 
   visit_expression(expression, [&](const auto& sub_expression) {
     placeholder_found |= std::dynamic_pointer_cast<PlaceholderExpression>(sub_expression) != nullptr;
-    return ExpressionVisitation::VisitArguments;
+    return !placeholder_found ? ExpressionVisitation::VisitArguments : ExpressionVisitation::DoNotVisitArguments;
   });
 
   return placeholder_found;
+}
+
+bool expression_contains_correlated_parameter(const std::shared_ptr<AbstractExpression>& expression) {
+  auto correlated_parameter_found = false;
+
+  visit_expression(expression, [&](const auto& sub_expression) {
+    correlated_parameter_found |= std::dynamic_pointer_cast<CorrelatedParameterExpression>(sub_expression) != nullptr;
+    return !correlated_parameter_found ? ExpressionVisitation::VisitArguments
+                                       : ExpressionVisitation::DoNotVisitArguments;
+  });
+
+  return correlated_parameter_found;
 }
 
 std::optional<AllTypeVariant> expression_get_value_or_parameter(const AbstractExpression& expression) {

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -148,7 +148,8 @@ void expression_set_transaction_context(const std::shared_ptr<AbstractExpression
 void expressions_set_transaction_context(const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
                                          const std::weak_ptr<TransactionContext>& transaction_context);
 
-bool expression_contains_placeholders(const std::shared_ptr<AbstractExpression>& expression);
+bool expression_contains_placeholder(const std::shared_ptr<AbstractExpression>& expression);
+bool expression_contains_correlated_parameter(const std::shared_ptr<AbstractExpression>& expression);
 
 /**
  * @return  The value of a CorrelatedParameterExpression or ValueExpression

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -382,7 +382,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_insert(const hsql::In
   for (auto column_id = ColumnID{0}; column_id < target_table->column_count(); ++column_id) {
     // Always cast if the expression contains a placeholder, since we can't know the actual data type of the expression
     // until it is replaced.
-    if (expression_contains_placeholders(column_expressions[column_id]) ||
+    if (expression_contains_placeholder(column_expressions[column_id]) ||
         target_table->column_data_type(column_id) != column_expressions[column_id]->data_type()) {
       column_expressions[column_id] = cast_(column_expressions[column_id], target_table->column_data_type(column_id));
     }
@@ -459,7 +459,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_translate_update(const hsql::Up
   for (auto column_id = ColumnID{0}; column_id < target_table->column_count(); ++column_id) {
     // Always cast if the expression contains a placeholder, since we can't know the actual data type of the expression
     // until it is replaced.
-    if (expression_contains_placeholders(update_expressions[column_id]) ||
+    if (expression_contains_placeholder(update_expressions[column_id]) ||
         target_table->column_data_type(column_id) != update_expressions[column_id]->data_type()) {
       update_expressions[column_id] = cast_(update_expressions[column_id], target_table->column_data_type(column_id));
     }

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -296,11 +296,10 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_predicate_node(
   // of searching for a single value would be reasonable. However, it is likely that the SubqueryToJoinRule will
   // rewrite this query so that the CorrelatedParameterExpression will turn into an LQPColumnExpression that is part
   // of a join predicate. However, since the JoinOrderingRule is executed before the SubqueryToJoinRule, it would
-  // create a different join order if it assumes `orders` to be filtered down to very few values. For now, we ignore
-  // correlated predicates in the cardinality estimation, i.e., we assume that they return 100% of all matching values.
-  // This is not perfect, but better than estimating `num_rows / distinct_values`.
+  // create a different join order if it assumes `orders` to be filtered down to very few values. For now, we return
+  // PLACEHOLDER_SELECTIVITY_HIGH. This is not perfect, but better than estimating `num_rows / distinct_values`.
   if (expression_contains_correlated_parameter(predicate)) {
-    return input_table_statistics;
+    return input_table_statistics->scaled(PLACEHOLDER_SELECTIVITY_HIGH);
   }
 
   const auto operator_scan_predicates = OperatorScanPredicate::from_expression(*predicate, predicate_node);

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -891,9 +891,8 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_semi_join(
     output_table_statistics = std::make_shared<TableStatistics>(std::move(column_statistics), cardinality);
   });
 
-  DebugAssert(output_table_statistics->row_count <=
-                  left_input_table_statistics.row_count * (1 + std::numeric_limits<float>::epsilon()),
-              "Semi join should not increase cardinality");
+  Assert(output_table_statistics->row_count <= left_input_table_statistics.row_count * 1.01f,
+         "Semi join should not increase cardinality");
 
   return output_table_statistics;
 }

--- a/src/test/expression/expression_utils_test.cpp
+++ b/src/test/expression/expression_utils_test.cpp
@@ -73,8 +73,8 @@ TEST_F(ExpressionUtilsTest, ExpressionContainsPlaceholders) {
 
 TEST_F(ExpressionUtilsTest, ExpressionContainsCorrelatedParameter) {
   EXPECT_FALSE(expression_contains_correlated_parameter(and_(greater_than_(a_a, 5), equals_(a_c, 7))));
-  EXPECT_FALSE(
-      expression_contains_correlated_parameter(and_(greater_than_(a_a, placeholder_(ParameterID{5})), equals_(a_c, 7))));
+  EXPECT_FALSE(expression_contains_correlated_parameter(
+      and_(greater_than_(a_a, placeholder_(ParameterID{5})), equals_(a_c, 7))));
   EXPECT_TRUE(expression_contains_correlated_parameter(
       and_(greater_than_(a_a, correlated_parameter_(ParameterID{5}, lqp_column_(a_a))), equals_(a_c, 7))));
 }

--- a/src/test/expression/expression_utils_test.cpp
+++ b/src/test/expression/expression_utils_test.cpp
@@ -64,4 +64,19 @@ TEST_F(ExpressionUtilsTest, ExpressionCommonType) {
   EXPECT_EQ(expression_common_type(DataType::String, DataType::String), DataType::String);
 }
 
+TEST_F(ExpressionUtilsTest, ExpressionContainsPlaceholders) {
+  EXPECT_FALSE(expression_contains_placeholder(and_(greater_than_(a_a, 5), equals_(a_c, 7))));
+  EXPECT_TRUE(expression_contains_placeholder(and_(greater_than_(a_a, placeholder_(ParameterID{5})), equals_(a_c, 7))));
+  EXPECT_FALSE(expression_contains_placeholder(
+      and_(greater_than_(a_a, correlated_parameter_(ParameterID{5}, lqp_column_(a_a))), equals_(a_c, 7))));
+}
+
+TEST_F(ExpressionUtilsTest, ExpressionContainsCorrelatedParameter) {
+  EXPECT_FALSE(expression_contains_correlated_parameter(and_(greater_than_(a_a, 5), equals_(a_c, 7))));
+  EXPECT_FALSE(
+      expression_contains_correlated_parameter(and_(greater_than_(a_a, placeholder_(ParameterID{5})), equals_(a_c, 7))));
+  EXPECT_TRUE(expression_contains_correlated_parameter(
+      and_(greater_than_(a_a, correlated_parameter_(ParameterID{5}, lqp_column_(a_a))), equals_(a_c, 7))));
+}
+
 }  // namespace opossum

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -638,9 +638,9 @@ TEST_F(CardinalityEstimatorTest, PredicateMultipleWithCorrelatedParameter) {
       node_a));
   // clang-format on
 
-  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 50.0f);
-  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()), 100.0f);
-  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()->left_input()), 100.0f);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 45.0f);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()), 90.0f);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()->left_input()), 90.0f);
 }
 
 TEST_F(CardinalityEstimatorTest, PredicateWithNull) {

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -630,6 +630,19 @@ TEST_F(CardinalityEstimatorTest, PredicateWithValuePlaceholder) {
   EXPECT_FLOAT_EQ(estimator.estimate_cardinality(lqp_e), 25.0f);
 }
 
+TEST_F(CardinalityEstimatorTest, PredicateMultipleWithCorrelatedParameter) {
+  // clang-format off
+  const auto input_lqp =
+  PredicateNode::make(greater_than_(a_a, 50),  // s=0.5
+    PredicateNode::make(less_than_equals_(a_b, correlated_parameter_(ParameterID{1}, a_a)),
+      node_a));
+  // clang-format on
+
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 50.0f);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()), 100.0f);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()->left_input()), 100.0f);
+}
+
 TEST_F(CardinalityEstimatorTest, PredicateWithNull) {
   const auto lqp_a = PredicateNode::make(equals_(a_a, NullValue{}), node_a);
   EXPECT_FLOAT_EQ(estimator.estimate_cardinality(lqp_a), 0.0f);

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -640,7 +640,7 @@ TEST_F(CardinalityEstimatorTest, PredicateMultipleWithCorrelatedParameter) {
 
   EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 45.0f);
   EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()), 90.0f);
-  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()->left_input()), 90.0f);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp->left_input()->left_input()), 100.0f);
 }
 
 TEST_F(CardinalityEstimatorTest, PredicateWithNull) {


### PR DESCRIPTION
Estimating correlated parameters is tricky. Example: `SELECT c_custkey, (SELECT AVG(o_totalprice) FROM orders WHERE o_custkey = c_custkey) FROM customer`. If the subquery was executed for each customer row, assuming that the predicate has a selectivity matching that of searching for a single value would be reasonable. However, it is likely that the SubqueryToJoinRule will rewrite this query so that the CorrelatedParameterExpression will turn into an LQPColumnExpression that is part of a join predicate. However, since the JoinOrderingRule is executed before the SubqueryToJoinRule, it would create a different join order if it assumes `orders` to be filtered down to very few values.

For now, return a high selectivity (90%) for predicates that contain correlated parameters.

```
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| TPC-H 01       | 0.603997766972 | 37   | 0.599644362926 | 36   | -1%        |                          0.2460 |
| TPC-H 02       | 8.80610275269  | 529  | 12.5669145584  | 755  | +43%       |                          0.0000 |
| TPC-H 03       | 6.56616020203  | 394  | 6.19677686691  | 372  | -6%        |                          0.0000 |
| TPC-H 04       | 7.10575246811  | 427  | 7.18575429916  | 432  | +1%        |                          0.0640 |
| TPC-H 05       | 4.21703386307  | 254  | 4.28961229324  | 258  | +2%        |                          0.0013 |
| TPC-H 06       | 104.20526123   | 6253 | 105.503204346  | 6331 | +1%        |                          0.0000 |
| TPC-H 07       | 1.56881177425  | 95   | 1.57832992077  | 95   | +1%        |                          0.1955 |
| TPC-H 08       | 5.69246768951  | 342  | 5.85608959198  | 352  | +3%        |                          0.0000 |
| TPC-H 09       | 1.55829799175  | 94   | 1.59413540363  | 96   | +2%        |                          0.0000 |
| TPC-H 10       | 3.0416841507   | 183  | 3.08877801895  | 186  | +2%        |                          0.0003 |
| TPC-H 11       | 25.2049427032  | 1513 | 25.477897644   | 1529 | +1%        |                          0.0000 |
| TPC-H 12       | 8.5094203949   | 511  | 8.76309013367  | 526  | +3%        |                          0.0000 |
| TPC-H 13       | 2.27774620056  | 137  | 2.34696745872  | 141  | +3%        |                          0.0000 |
| TPC-H 14       | 45.8149452209  | 2749 | 46.3246841431  | 2780 | +1%        |                          0.0000 |
| TPC-H 15       | 72.2236709595  | 4334 | 73.2289428711  | 4394 | +1%        |                          0.0000 |
| TPC-H 16       | 7.1074757576   | 427  | 7.21664094925  | 433  | +2%        |                          0.0000 |
| TPC-H 17       | 1.28215098381  | 77   | 1.32711160183  | 80   | +4%        |                          0.0000 |
| TPC-H 18       | 0.738323509693 | 45   | 0.783916532993 | 48   | +6%        |                          0.0000 |
| TPC-H 19       | 8.478931427    | 509  | 8.64408111572  | 519  | +2%        |                          0.0000 |
| TPC-H 20       | 2.79979515076  | 168  | 2.87834811211  | 173  | +3%        |                          0.0000 |
| TPC-H 21       | 1.50276696682  | 91   | 1.53083264828  | 92   | +2%        |                          0.0000 |
| TPC-H 22       | 13.1531352997  | 790  | 13.4136724472  | 806  | +2%        |                          0.0000 |
| geometric mean |                |      |                |      | +3%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```

```
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] | p-value (significant if <0.001) |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
| 01             | 20.5546588898  | 1234 | 20.6565246582  | 1240 | +0%        |                          0.0000 |
| 03             | 16.7388420105  | 1005 | 16.2883319855  | 978  | -3%        |                          0.0000 |
| 06             | 0.533318698406 | 32   | 0.537437081337 | 33   | +1%        |                          0.0000 |
| 07             | 10.8764400482  | 653  | 10.5741243362  | 635  | -3%        |                          0.0000 |
| 09             | 4.09987688065  | 246  | 4.09121513367  | 246  | -0%        |                          0.0001 |
| 10             | 6.97489023209  | 419  | 7.00748872757  | 421  | +0%        |                          0.1052 |
| 13             | 4.58616876602  | 276  | 4.41563844681  | 265  | -4%        |                          0.0000 |
| 15             | 29.9804668427  | 1799 | 30.6352767944  | 1839 | +2%        |                          0.0000 |
| 17             | 9.67246818542  | 581  | 11.7382497787  | 705  | +21%       |                          0.0000 |
| 19             | 13.3370742798  | 801  | 14.8021478653  | 889  | +11%       |                          0.0000 |
| 25             | 12.1815385818  | 732  | 13.3545284271  | 802  | +10%       |                          0.0000 |
| 26             | 22.6851921082  | 1362 | 23.1699714661  | 1391 | +2%        |                          0.0000 |
| 28             | 6.98072624207  | 419  | 6.92576265335  | 416  | -1%        |                          0.0000 |
| 29             | 12.7061796188  | 763  | 13.9469356537  | 837  | +10%       |                          0.0000 |
| 31             | 1.16839337349  | 71   | 1.17936396599  | 71   | +1%        |                          0.0279 |
| 34             | 14.1728401184  | 851  | 13.8358812332  | 831  | -2%        |                          0.0001 |
| 35             | 0.109525054693 | 7    | 0.108274661005 | 7    | -1%        |        (not enough runs) 0.0000 |
| 39a            | 0.573596119881 | 35   | 0.562838792801 | 34   | -2%        |                          0.0049 |
| 39b            | 0.580547809601 | 35   | 0.564858078957 | 34   | -3%        |                          0.0000 |
| 41             | 44.9402961731  | 2697 | 44.9576034546  | 2698 | +0%        |                          0.6923 |
| 42             | 14.4026441574  | 865  | 16.3413677216  | 981  | +13%       |                          0.0000 |
| 43             | 2.9777276516   | 179  | 2.99961566925  | 180  | +1%        |                          0.0006 |
| 45             | 42.9389305115  | 2577 | 42.7053642273  | 2563 | -1%        |                          0.0000 |
| 48             | 4.52460193634  | 272  | 4.46834039688  | 269  | -1%        |                          0.0000 |
| 50             | 18.5921878815  | 1116 | 19.6232223511  | 1178 | +6%        |                          0.0000 |
| 52             | 15.6845340729  | 942  | 16.7869815826  | 1008 | +7%        |                          0.0000 |
| 55             | 14.1120491028  | 847  | 15.0032405853  | 901  | +6%        |                          0.0000 |
| 62             | 9.32352256775  | 560  | 9.26633548737  | 556  | -1%        |                          0.0000 |
| 65             | 8.08822822571  | 486  | 8.42535209656  | 506  | +4%        |                          0.0000 |
| 69             | 7.46158742905  | 448  | 7.64189481735  | 459  | +2%        |                          0.0000 |
| 73             | 19.1325492859  | 1148 | 21.4375267029  | 1287 | +12%       |                          0.0000 |
| 79             | 5.44301700592  | 327  | 6.26055288315  | 376  | +15%       |                          0.0000 |
| 81             | 34.6240463257  | 2078 | 34.7620620728  | 2086 | +0%        |                          0.0000 |
| 83             | 50.3758277893  | 3023 | 50.5445137024  | 3033 | +0%        |                          0.0000 |
| 88             | 8.93006515503  | 536  | 10.0734930038  | 605  | +13%       |                          0.0000 |
| 91             | 5.15497636795  | 310  | 5.20469045639  | 313  | +1%        |                          0.0000 |
| 93             | 3.5774409771   | 215  | 3.52235245705  | 212  | -2%        |                          0.0000 |
| 96             | 18.4491081238  | 1107 | 18.8548355103  | 1132 | +2%        |                          0.0005 |
| 97             | 2.00052595139  | 121  | 1.89816296101  | 114  | -5%        |                          0.0000 |
| 99             | 4.43048620224  | 266  | 4.60314559937  | 277  | +4%        |                          0.0000 |
| geometric mean |                |      |                |      | +3%        |                                 |
+----------------+----------------+------+----------------+------+------------+---------------------------------+
```