### PR TITLE
Make left/right side of joins deterministic

### DIFF
--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -72,8 +72,19 @@ const std::vector<ColumnID>& MockNode::pruned_column_ids() const { return _prune
 
 std::string MockNode::description() const {
   std::ostringstream stream;
-  stream << "[MockNode '"s << name.value_or("Unnamed") << "']";
-  stream << " pruned: " << _pruned_column_ids.size() << "/" << _column_definitions.size() << " columns";
+  stream << "[MockNode '"s << name.value_or("Unnamed") << "'] Columns:";
+
+  auto column_id = ColumnID{0};
+  for (const auto& column : _column_definitions) {
+    if (std::find(_pruned_column_ids.begin(), _pruned_column_ids.end(), column_id) != _pruned_column_ids.end()) {
+      ++column_id;
+      continue;
+    }
+    stream << " " << column.second;
+    ++column_id;
+  }
+
+  stream << " | pruned: " << _pruned_column_ids.size() << "/" << _column_definitions.size() << " columns";
 
   return stream.str();
 }

--- a/src/lib/optimizer/join_ordering/abstract_join_ordering_algorithm.hpp
+++ b/src/lib/optimizer/join_ordering/abstract_join_ordering_algorithm.hpp
@@ -22,7 +22,7 @@ class AbstractJoinOrderingAlgorithm {
       const std::shared_ptr<AbstractCostEstimator>& cost_estimator) const;
 
   std::shared_ptr<AbstractLQPNode> _add_join_to_plan(
-      const std::shared_ptr<AbstractLQPNode>& left_lqp, const std::shared_ptr<AbstractLQPNode>& right_lqp,
+      std::shared_ptr<AbstractLQPNode> left_lqp, std::shared_ptr<AbstractLQPNode> right_lqp,
       std::vector<std::shared_ptr<AbstractExpression>> join_predicates,
       const std::shared_ptr<AbstractCostEstimator>& cost_estimator) const;
 };

--- a/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
+++ b/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
@@ -24,7 +24,7 @@ TEST_F(CreatePreparedPlanNodeTest, Description) {
   EXPECT_EQ(create_prepared_plan_node->description(),
             R"([CreatePreparedPlan] 'some_prepared_plan' {
 ParameterIDs: []
-[0] [MockNode 'Unnamed'] pruned: 0/1 columns
+[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns
 })");
 }
 

--- a/src/test/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/logical_query_plan/create_view_node_test.cpp
@@ -23,13 +23,13 @@ class CreateViewNodeTest : public ::testing::Test {
 TEST_F(CreateViewNodeTest, Description) {
   EXPECT_EQ(_create_view_node->description(),
             "[CreateView] Name: some_view, Columns: a FROM (\n"
-            "[0] [MockNode 'Unnamed'] pruned: 0/1 columns\n"
+            "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns\n"
             ")");
 
   const auto _create_view_node_2 = CreateViewNode::make("some_view", _view, true);
   EXPECT_EQ(_create_view_node_2->description(),
             "[CreateView] IfNotExists Name: some_view, Columns: a FROM (\n"
-            "[0] [MockNode 'Unnamed'] pruned: 0/1 columns\n"
+            "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns\n"
             ")");
 }
 

--- a/src/test/logical_query_plan/mock_node_test.cpp
+++ b/src/test/logical_query_plan/mock_node_test.cpp
@@ -28,11 +28,11 @@ class MockNodeTest : public ::testing::Test {
 };
 
 TEST_F(MockNodeTest, Description) {
-  EXPECT_EQ(_mock_node_a->description(), "[MockNode 'Unnamed'] pruned: 0/4 columns");
-  EXPECT_EQ(_mock_node_b->description(), "[MockNode 'mock_name'] pruned: 0/2 columns");
+  EXPECT_EQ(_mock_node_a->description(), "[MockNode 'Unnamed'] Columns: a b c d | pruned: 0/4 columns");
+  EXPECT_EQ(_mock_node_b->description(), "[MockNode 'mock_name'] Columns: a b | pruned: 0/2 columns");
 
   _mock_node_a->set_pruned_column_ids({ColumnID{2}});
-  EXPECT_EQ(_mock_node_a->description(), "[MockNode 'Unnamed'] pruned: 1/4 columns");
+  EXPECT_EQ(_mock_node_a->description(), "[MockNode 'Unnamed'] Columns: a b d | pruned: 1/4 columns");
 }
 
 TEST_F(MockNodeTest, OutputColumnExpression) {

--- a/src/test/optimizer/dp_ccp_test.cpp
+++ b/src/test/optimizer/dp_ccp_test.cpp
@@ -75,10 +75,10 @@ TEST_F(DpCcpTest, JoinOrdering) {
   const auto expected_lqp =
   PredicateNode::make(equals_(b_a, c_a),
     JoinNode::make(JoinMode::Inner, expression_vector(equals_(a_a, c_a)),
+      node_c,
       JoinNode::make(JoinMode::Inner, equals_(a_a, b_a),
         node_a,
-        node_b),
-      node_c));
+        node_b)));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -100,10 +100,10 @@ TEST_F(DpCcpTest, CrossJoin) {
   // clang-format off
   const auto expected_lqp =
   JoinNode::make(JoinMode::Cross,
+    node_c,
     JoinNode::make(JoinMode::Inner, equals_(a_a, b_a),
       node_a,
-      node_b),
-    node_c);
+      node_b));
   // clang-format on
 
   EXPECT_LQP_EQ(expected_lqp, actual_lqp);
@@ -196,13 +196,13 @@ TEST_F(DpCcpTest, HyperEdge) {
   // clang-format off
   const auto expected_lqp =
   JoinNode::make(JoinMode::Cross,
+    node_d,
     PredicateNode::make(hyper_edge_predicate,
       JoinNode::make(JoinMode::Inner, equals_(c_a, a_a),
+        node_c,
         JoinNode::make(JoinMode::Inner, equals_(b_a, a_a),
           node_a,
-          node_b),
-        node_c)),
-    node_d);
+          node_b))));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -232,10 +232,10 @@ TEST_F(DpCcpTest, UncorrelatedPredicates) {
   // clang-format off
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, equals_(d_a, a_a),
-    node_a,
     PredicateNode::make(uncorrelated_predicate_b,
       PredicateNode::make(uncorrelated_predicate_a,
-        node_d)));
+        node_d)),
+    node_a);
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);

--- a/src/test/optimizer/greedy_operator_ordering_test.cpp
+++ b/src/test/optimizer/greedy_operator_ordering_test.cpp
@@ -76,13 +76,13 @@ TEST_F(GreedyOperatorOrderingTest, ChainQuery) {
   // clang-format off
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, equals_(a_a, b_a),
-    PredicateNode::make(greater_than_(a_a, 0),
-      node_a),
     JoinNode::make(JoinMode::Inner, equals_(b_a, c_a),
       node_b,
       JoinNode::make(JoinMode::Inner, equals_(c_a, d_a),
-        node_c,
-        node_d)));
+        node_d,
+        node_c)),
+    PredicateNode::make(greater_than_(a_a, 0),
+      node_a));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -101,12 +101,12 @@ TEST_F(GreedyOperatorOrderingTest, StarQuery) {
   // clang-format off
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, equals_(a_a, b_a),
-    node_b,
     JoinNode::make(JoinMode::Inner, equals_(a_a, d_a),
       JoinNode::make(JoinMode::Inner, equals_(a_a, c_a),
         node_a,
         node_c),
-      node_d));
+      node_d),
+    node_b);
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -133,14 +133,14 @@ TEST_F(GreedyOperatorOrderingTest, HyperEdges) {
   PredicateNode::make(greater_than_(add_(b_a, c_a), sub_(a_a, d_a)),
     PredicateNode::make(equals_(c_a, add_(d_a, a_a)),
       JoinNode::make(JoinMode::Cross,
-        node_a,
         PredicateNode::make(equals_(add_(b_a, c_a), d_a),
           JoinNode::make(JoinMode::Inner, equals_(b_a, c_a),
             node_b,
               PredicateNode::make(less_than_equals_(c_a, d_a),
                 JoinNode::make(JoinMode::Inner, expression_vector(equals_(c_a, d_a)),
-                  node_c,
-                  node_d)))))));
+                  node_d,
+                  node_c)))),
+        node_a)));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);

--- a/src/test/optimizer/join_graph_test.cpp
+++ b/src/test/optimizer/join_graph_test.cpp
@@ -68,10 +68,10 @@ TEST_F(JoinGraphTest, OutputToStream) {
   stream << join_graph;
 
   EXPECT_EQ(stream.str(), R"(==== Vertices ====
-[MockNode 'a'] pruned: 0/1 columns
-[MockNode 'b'] pruned: 0/1 columns
-[MockNode 'c'] pruned: 0/1 columns
-[MockNode 'd'] pruned: 0/1 columns
+[MockNode 'a'] Columns: a | pruned: 0/1 columns
+[MockNode 'b'] Columns: a | pruned: 0/1 columns
+[MockNode 'c'] Columns: a | pruned: 0/1 columns
+[MockNode 'd'] Columns: a | pruned: 0/1 columns
 ===== Edges ======
 Vertices: 0011; 1 predicates
 a = a

--- a/src/test/optimizer/strategy/join_ordering_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_ordering_rule_test.cpp
@@ -67,12 +67,12 @@ TEST_F(JoinOrderingRuleTest, MultipleJoinGraphs) {
   const auto expected_lqp =
   AggregateNode::make(expression_vector(a_a), expression_vector(),
     JoinNode::make(JoinMode::Inner, equals_(a_a, b_b),
-      node_a,
       JoinNode::make(JoinMode::Left, equals_(b_b, d_d),
         node_b,
         JoinNode::make(JoinMode::Inner, equals_(d_d, c_c),
           node_d,
-          node_c))));
+          node_c)),
+      node_a));
   // clang-format on
 
   const auto actual_lqp = apply_rule(rule, input_lqp);


### PR DESCRIPTION
To make the input sides more deterministic, we make sure that the larger input is on the right side. This helps future rules to identify common subplans. For plans with equal cardinalities, this might still result in non-deterministic orders. Deal with it once it becomes a problem - maybe use the hash? 

Also, adds the column names to the printed version of MockNodes. Trying to understand why two seemingly identical MockNodes were considered different took me longer than it should.

No performance difference in TPC-H yet - that will come with future rules.