### PR TITLE
Forward a chunk's ordered-by information to GetTable

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -63,6 +63,7 @@ void AbstractTableGenerator::generate_and_store() {
       for (auto chunk_id = ChunkID{0}; chunk_id < immutable_sorted_table->chunk_count(); ++chunk_id) {
         auto mvcc_data = std::make_shared<MvccData>(immutable_sorted_table->get_chunk(chunk_id)->size(), CommitID{0});
         table->append_chunk(immutable_sorted_table->get_chunk(chunk_id)->segments(), mvcc_data);
+        table->get_chunk(chunk_id)->set_ordered_by({table->column_id_by_name(column_name), OrderByMode::Ascending});
       }
 
       std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -44,6 +44,7 @@ void AbstractTableGenerator::generate_and_store() {
     std::cout << "- Sorting tables" << std::endl;
 
     for (const auto& [table_name, column_name] : sort_order_by_table) {
+      const auto order_by_mode = OrderByMode::Ascending;  // currently fixed to ascending
       std::cout << "-  Sorting '" << table_name << "' by '" << column_name << "' " << std::flush;
       Timer per_table_timer;
 
@@ -54,7 +55,7 @@ void AbstractTableGenerator::generate_and_store() {
       auto& table = table_info_by_name[table_name].table;
       auto table_wrapper = std::make_shared<TableWrapper>(table);
       table_wrapper->execute();
-      auto sort = std::make_shared<Sort>(table_wrapper, table->column_id_by_name(column_name), OrderByMode::Ascending,
+      auto sort = std::make_shared<Sort>(table_wrapper, table->column_id_by_name(column_name), order_by_mode,
                                          _benchmark_config->chunk_size);
       sort->execute();
       const auto immutable_sorted_table = sort->get_output();
@@ -63,7 +64,7 @@ void AbstractTableGenerator::generate_and_store() {
       for (auto chunk_id = ChunkID{0}; chunk_id < immutable_sorted_table->chunk_count(); ++chunk_id) {
         auto mvcc_data = std::make_shared<MvccData>(immutable_sorted_table->get_chunk(chunk_id)->size(), CommitID{0});
         table->append_chunk(immutable_sorted_table->get_chunk(chunk_id)->segments(), mvcc_data);
-        table->get_chunk(chunk_id)->set_ordered_by({table->column_id_by_name(column_name), OrderByMode::Ascending});
+        table->get_chunk(chunk_id)->set_ordered_by({table->column_id_by_name(column_name), order_by_mode});
       }
 
       std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -175,8 +175,8 @@ std::shared_ptr<const Table> GetTable::_on_execute() {
         }
 
         if (chunk_ordered_by && chunk_ordered_by->first == stored_column_id) {
-          chunk_ordered_by->first = ColumnID{static_cast<uint16_t>(std::distance(_pruned_column_ids.begin(),
-                                                                                 pruned_column_ids_iter))};
+          chunk_ordered_by->first =
+              ColumnID{static_cast<uint16_t>(std::distance(_pruned_column_ids.begin(), pruned_column_ids_iter))};
         }
 
         *output_segments_iter = stored_chunk->get_segment(stored_column_id);

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -244,4 +244,20 @@ TEST_F(OperatorsGetTableTest, Copy) {
   EXPECT_EQ(get_table_b_copy->pruned_column_ids(), std::vector{ColumnID{0}});
 }
 
+TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
+  auto table = Hyrise::get().storage_manager.get_table("int_int_float");
+  table->get_chunk(ChunkID{0})->set_ordered_by({ColumnID{0}, OrderByMode::Ascending});
+  table->get_chunk(ChunkID{1})->set_ordered_by({ColumnID{2}, OrderByMode::Descending});
+
+  auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector{ColumnID{1}});
+  get_table->execute();
+
+  auto get_table_output = get_table->get_output();
+  EXPECT_EQ(get_table_output->get_chunk(ChunkID{0})->ordered_by()->first, ColumnID{0});
+  EXPECT_EQ(get_table_output->get_chunk(ChunkID{1})->ordered_by()->first, ColumnID{1});
+  EXPECT_EQ(get_table_output->get_chunk(ChunkID{0})->ordered_by()->second, OrderByMode::Ascending);
+  EXPECT_EQ(get_table_output->get_chunk(ChunkID{1})->ordered_by()->second, OrderByMode::Descending);
+  EXPECT_FALSE(get_table_output->get_chunk(ChunkID{2})->ordered_by().has_value());
+}
+
 }  // namespace opossum

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -251,7 +251,8 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
   // with column pruning
   {
-    auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector{ColumnID{1}});
+    auto get_table =
+        std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector{ColumnID{1}});
     get_table->execute();
 
     auto get_table_output = get_table->get_output();
@@ -264,7 +265,8 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
   // without column pruning
   {
-    auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector{});
+    auto get_table =
+        std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector<ColumnID>{});
     get_table->execute();
 
     auto get_table_output = get_table->get_output();

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -284,8 +284,8 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
     auto get_table_output = get_table->get_output();
     EXPECT_EQ(get_table_output->column_count(), 1);
-    EXPECT_FALSE(get_table_output->get_chunk(ChunkID{0})->ordered_by().has_value());
-    EXPECT_FALSE(get_table_output->get_chunk(ChunkID{0})->ordered_by().has_value());
+    EXPECT_FALSE(get_table_output->get_chunk(ChunkID{0})->ordered_by());
+    EXPECT_FALSE(get_table_output->get_chunk(ChunkID{0})->ordered_by());
   }
 }
 

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -256,6 +256,7 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
     get_table->execute();
 
     auto get_table_output = get_table->get_output();
+    EXPECT_EQ(get_table_output->column_count(), 2);
     EXPECT_EQ(get_table_output->get_chunk(ChunkID{0})->ordered_by()->first, ColumnID{0});
     EXPECT_EQ(get_table_output->get_chunk(ChunkID{1})->ordered_by()->first, ColumnID{1});
     EXPECT_EQ(get_table_output->get_chunk(ChunkID{0})->ordered_by()->second, OrderByMode::Ascending);
@@ -270,8 +271,21 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
     get_table->execute();
 
     auto get_table_output = get_table->get_output();
+    EXPECT_EQ(get_table_output->column_count(), 3);
     EXPECT_EQ(get_table_output->get_chunk(ChunkID{1})->ordered_by()->first, ColumnID{2});
     EXPECT_EQ(get_table_output->get_chunk(ChunkID{1})->ordered_by()->second, OrderByMode::Descending);
+  }
+
+  // pruning the columns on which chunks are sorted
+  {
+    auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{},
+                                                         std::vector{ColumnID{0}, ColumnID{2}});
+    get_table->execute();
+
+    auto get_table_output = get_table->get_output();
+    EXPECT_EQ(get_table_output->column_count(), 1);
+    EXPECT_FALSE(get_table_output->get_chunk(ChunkID{0})->ordered_by().has_value());
+    EXPECT_FALSE(get_table_output->get_chunk(ChunkID{0})->ordered_by().has_value());
   }
 }
 


### PR DESCRIPTION
Currently, the order-by information is not carried through to the table scan. This PR adapts (i) the abstract table generator to add the sorted information to the chunks (in case sorting is requested for the benchmark) and (ii) the get table operator to forward and adapt (in case of column pruning) this information.

For the benchmarks, basically nothing changed. Only TPC-H Q3 has a qualifying scan, but the impact is not significant.
```
+----------------+-------------------+------+-------------------+------+------------+---------------------------------+
| Benchmark      | prev. iter/s      | runs | new iter/s        | runs | change [%] | p-value (significant if <0.001) |
+----------------+-------------------+------+-------------------+------+------------+---------------------------------+
| TPC-H 03       | 0.825697124004364 | 199  | 0.830946326255798 | 200  | +1%        |                          0.0075 |
| geometric mean |                   |      |                   |      | +1%        |                                 |
+----------------+-------------------+------+-------------------+------+------------+---------------------------------+
```