### PR TITLE
Format compare_benchmarks.py output for Github

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -129,7 +129,7 @@ table.justify_columns[6] = 'right'
 # If github_format is set, format the output in the style of a diff file where added lines (starting with +) are
 # colored green, removed lines (starting with -) are red, and others (starting with an empty space) are black.
 # Because terminaltables (unsurprisingly) does not support this hack, we need to post-process the result string,
-# searching for the control codes that define lines formatted as green or red.
+# searching for the control codes that define text to be formatted as green or red.
 
 result = str(table.table)
 if github_format:

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -54,14 +54,13 @@ def calculate_and_format_p_value(old, new):
     new_runtime = sum(runtime for runtime in new_durations)
     if (old_runtime < min_runtime_ns or new_runtime < min_runtime_ns):
         is_significant = False
-        notes += "(run time too short) "
-
-    if (len(old_durations) < min_iterations or len(new_durations) < min_iterations):
+        return "(run time too short)"
+    elif (len(old_durations) < min_iterations or len(new_durations) < min_iterations):
         is_significant = False
-        notes += "(not enough runs) "
-
-    color = 'green' if is_significant else 'white'
-    return colored(notes + "{0:.4f}".format(p_value), color)
+        return "(not enough runs)"
+    else:
+        color = 'green' if is_significant else 'white'
+        return colored("{0:.4f}".format(p_value), color)
 
 
 if (not len(sys.argv) in [3, 4]):
@@ -82,7 +81,7 @@ if old_data['context']['benchmark_mode'] != new_data['context']['benchmark_mode'
 diffs = []
 
 table_data = []
-table_data.append(["Benchmark", "prev. iter/s", "runs", "new iter/s", "runs", "change [%]", "p-value (significant if <" + str(p_value_significance_threshold) + ")"])
+table_data.append(["Benchmark", "prev. iter/s", "runs", "new iter/s", "runs", "change [%]", "p-value"])
 
 for old, new in zip(old_data['benchmarks'], new_data['benchmarks']):
     name = old['name']

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -64,7 +64,7 @@ def calculate_and_format_p_value(old, new):
     return colored(notes + "{0:.4f}".format(p_value), color)
 
 
-if(len(sys.argv) != 3 and len(sys.argv) != 4):
+if (not len(sys.argv) in [3, 4]):
     exit("Usage: " + sys.argv[0] + " benchmark1.json benchmark2.json [--github]")
 
 # Format the output as a diff (prepending - and +) so that Github shows colors
@@ -133,7 +133,7 @@ table.justify_columns[6] = 'right'
 
 result = str(table.table)
 if github_format:
-    new_result = ''
+    new_result = '```diff\n'
     green_control_sequence = colored('', 'green')[0:5]
     red_control_sequence = colored('', 'red')[0:5]
 
@@ -146,12 +146,9 @@ if github_format:
             new_result += ' '
 
         new_result += line + '\n'
+    new_result += '```'
     result = new_result
 
 print("")
-if github_format:
-    print("```diff")
 print(result)
-if github_format:
-    print("```")
 print("")


### PR DESCRIPTION
I always liked the colored version of this better. Now, we can have it on Github, too.

```diff
 +----------------+----------------+------+---------------+------+------------+-----------------------------------------------+
 | Benchmark      | prev. iter/s   | runs | new iter/s    | runs | change [%] |               p-value (significant if <0.001) |
 +----------------+----------------+------+---------------+------+------------+-----------------------------------------------+
+| 01             | 20.7994117737  | 208  | 21.9238319397 | 220  | +5%        |                   (run time too short) 0.0000 |
+| 03             | 16.0511054993  | 161  | 28.5994300842 | 287  | +78%       |                   (run time too short) 0.0000 |
+| 06             | 16.8967514038  | 169  | 29.4084148407 | 295  | +74%       |                   (run time too short) 0.0000 |
-| 07             | 11.2185573578  | 113  | 8.90366268158 | 90   | -21%       |                   (run time too short) 0.0000 |
...