### PR TITLE
Upgrade to clang-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ set(CURSES_NEED_NCURSES TRUE)
 # Dependencies
 find_package(FS REQUIRED)
 find_package(Numa)
-find_package(LLVM 7 CONFIG)
 find_package(Tbb REQUIRED)
 find_package(Readline REQUIRED)
 find_package(Curses REQUIRED)
@@ -96,12 +95,6 @@ find_package(Sqlite3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS container system thread)
 
 add_definitions(-DBOOST_THREAD_VERSION=5)
-
-if(${LLVM_FOUND})
-    # FindLLVM does not provide a LLVM_LIBRARY or LLVM_LIBRARIES output variable, so we have to build it ourselves
-    set(LLVM_LIBRARY ${LLVM_LIBRARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}LLVM${CMAKE_SHARED_LIBRARY_SUFFIX})
-    message(STATUS "Found llvm library: inc=${LLVM_INCLUDE_DIR}, lib=${LLVM_LIBRARY}")
-endif()
 
 # If we are building Hyrise for the CI server, we want to make sure that all optional features are available and can be tested
 if(DEFINED CI_BUILD)

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -4,20 +4,18 @@
 | ------------------------- | ---------------- | -------- | ------------------------------------- |
 | autoconf                  | >= 2.69          |    All   |                                    No |
 | boost                     | >= 1.65.0        |    All   |                                    No |
-| clang                     | 7.{0,1}          |    All   |                 Yes, if gcc installed |
-| clang-format              | 7.{0,1}          |    All   |                      Yes (formatting) |
-| clang-tidy                | 7.{0,1}          |    All   |                         Yes (linting) |
+| clang                     | >= 8.0           |    All   |                 Yes, if gcc installed |
+| clang-format              | >= 8.0           |    All   |                      Yes (formatting) |
+| clang-tidy                | >= 8.0           |    All   |                         Yes (linting) |
 | cmake                     | >= 3.9           |    All   |                                    No |
 | gcc                       | 8.{2,3}          |    All   | Yes, if clang installed, not for OS X |
 | gcovr                     | >= 3.2           |    All   |                        Yes (coverage) |
 | glob2                     | >= 0.5           |    All   |                     Yes (tests in CI) |
 | graphviz                  | any              |    All   |             Yes (query visualization) |
-| libclang-dev              | 7.1              |    Linux |                             Yes (JIT) |
 | libnuma-dev               | any              |    Linux |                            Yes (numa) |
 | libnuma1                  | any              |    Linux |                            Yes (numa) |
 | libpq-dev                 | >= 9             |    All   |                                    No |
-| llvm                      | any              |    All   |                 Yes (code sanitizers) |
-| llvm-7-tools              | 7                |    Linux |                                    No |
+| llvm-8-tools              | 8                |    Linux |                                    No |
 | parallel                  | any              |    All   |                                   Yes |
 | pexpect                   | >= 4             |    All   |                     Yes (tests in CI) |
 | postgresql-server-dev-all | >= 154           |    Linux |                                    No |

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update \
         libreadline-dev \
         libsqlite3-dev \
         libtbb-dev \
-        llvm-8-tools \
         man \
         parallel \
         postgresql-server-dev-all \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update \
         bash-completion \
         bc \
         ccache \
-        clang-7 \
-        clang-format-7 \
-        clang-tidy-7 \
+        clang-8 \
+        clang-format-8 \
+        clang-tidy-8 \
         cmake \
         curl \
         g++-8 \
@@ -19,7 +19,6 @@ RUN apt-get update \
         git \
         graphviz \
         $(apt-cache search --names-only '^libboost1.[0-9]+-all-dev$' | sort | tail -n 1 | cut -f1 -d' ') \
-        libclang-7-dev \
         libncurses5-dev \
         libnuma-dev \
         libnuma1 \
@@ -27,8 +26,7 @@ RUN apt-get update \
         libreadline-dev \
         libsqlite3-dev \
         libtbb-dev \
-        llvm \
-        llvm-7-tools \
+        llvm-8-tools \
         man \
         parallel \
         postgresql-server-dev-all \

--- a/install.sh
+++ b/install.sh
@@ -52,7 +52,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             if sudo apt-get update >/dev/null; then
                 boostall=$(apt-cache search --names-only '^libboost1.[0-9]+-all-dev$' | sort | tail -n 1 | cut -f1 -d' ')
                 # packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc ccache clang-7 clang-format-7 clang-tidy-7 cmake curl g++-8 gcc-8 gcovr git graphviz $boostall libclang-7-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev llvm llvm-7-tools man parallel postgresql-server-dev-all python2.7 python-glob2 python-pexpect python-pip sudo systemtap systemtap-sdt-dev valgrind &
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc ccache clang-8 clang-format-8 clang-tidy-8 cmake curl g++-8 gcc-8 gcovr git graphviz $boostall libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev llvm-8-tools man parallel postgresql-server-dev-all python2.7 python-glob2 python-pexpect python-pip sudo systemtap systemtap-sdt-dev valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during installation."

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -41,15 +41,6 @@ if [[ "$unamestr" == 'Darwin' ]]; then
    path_to_compiler='/usr/local/opt/llvm/bin/'
 fi
 
-# We need at least clang 7.0.1 for coverage: https://github.com/hyrise/hyrise/pull/1433#issuecomment-458082341
-installed_clang_version=`${path_to_compiler}clang++ --version | head -n1 | cut -d" " -f3 | cut -d"-" -f1`
-required_clang_version=7.0.1
-
-if verlt ${installed_clang_version} ${required_clang_version} ; then
-    echo "Minimum clang version $required_clang_version not met, is $installed_clang_version"
-    exit -1
-fi
-
 cmake -DCMAKE_CXX_COMPILER_LAUNCHER=$launcher -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=${path_to_compiler}clang -DCMAKE_CXX_COMPILER=${path_to_compiler}clang++ -DENABLE_COVERAGE=ON ..
 
 cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null || sysctl -n hw.ncpu)

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -70,7 +70,7 @@ echo Coverage Information is in ./coverage/index.html
 # Continuing only if diff output is needed with Linux/gcc
 if [ "true" == "$generate_badge" ]; then
 
-  ${path_to_compiler}llvm-cov report -ignore-filename-regex=specialization/llvm/ -instr-profile ./default.profdata build-coverage/hyriseTest ./src/lib/ > coverage.txt
+  ${path_to_compiler}llvm-cov report -instr-profile ./default.profdata build-coverage/hyriseTest ./src/lib/ > coverage.txt
 
   # coverage badge generation
   coverage_percent=$(tail -c 7 coverage.txt)

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -3,10 +3,6 @@
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then
 	clang_format="/usr/local/opt/llvm/bin/clang-format"
-	$clang_format --version | grep "version [67].0" >/dev/null
-	if [ $? -ne 0 ]; then
-		echo "incompatible clang-format version detected in $clang_format"
-	fi
 	format_cmd="$clang_format -i -style=file '{}'"
 elif [[ "$unamestr" == 'Linux' ]]; then
 	format_cmd="clang-format-7 -i -style=file '{}'"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,7 +46,7 @@ set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-shadow-field-in-constructor -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed)
+    add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-shadow-field-in-constructor -Wno-shadow-field -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed)
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/TargetLinkLibrariesSystem.cmake)

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -53,7 +53,7 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
 
   if (cores != default_config.cores || clients != default_config.clients) {
     if (!enable_scheduler) {
-      PerformanceWarning("'--cores' or '--clients' specified but ignored, because '--scheduler' is false")
+      PerformanceWarning("'--cores' or '--clients' specified but ignored, because '--scheduler' is false");
     }
   }
 

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -117,8 +117,10 @@ class AbstractTableScanImpl {
 
       // The OpenMP Pragma makes the compiler try harder to vectorize this and gives some hints to help with this.
       // We do not use the OpenMP runtime, but only the compiler pragmas (look up -fopenmp-simd).
+
+      // This empty block is used to convince clang-format to keep the pragma indented
       // NOLINTNEXTLINE
-      ;  // clang-format off
+      {}  // clang-format off
       #pragma omp simd reduction(|:mask) safelen(BLOCK_SIZE)
       // clang-format on
       for (size_t i = 0; i < BLOCK_SIZE; ++i) {
@@ -152,7 +154,7 @@ class AbstractTableScanImpl {
         const auto first_offset = left_it_for_offsets->chunk_offset();
 
         // NOLINTNEXTLINE
-        ;  // clang-format off
+        {}  // clang-format off
         #pragma omp simd safelen(BLOCK_SIZE)
         // clang-format on
         for (size_t i = 0; i < BLOCK_SIZE; ++i) {
@@ -164,7 +166,7 @@ class AbstractTableScanImpl {
         // Slow path - the chunk offsets are not guaranteed to be linear
 
         // NOLINTNEXTLINE
-        ;  // clang-format off
+        {}  // clang-format off
         #pragma omp simd safelen(BLOCK_SIZE)
         // clang-format on
         for (auto i = size_t{0}; i < BLOCK_SIZE; ++i) {

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -118,7 +118,7 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(const BaseDictionarySe
     return;
   }
 
-  _with_operator_for_dict_segment_scan(predicate_condition, [&](auto predicate_comparator) {
+  _with_operator_for_dict_segment_scan([&](auto predicate_comparator) {
     auto comparator = [predicate_comparator, search_value_id](const auto& position) {
       return predicate_comparator(position.value(), search_value_id);
     };

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.hpp
@@ -56,7 +56,7 @@ class ColumnVsValueTableScanImpl : public AbstractDereferencedColumnTableScanImp
   bool _value_matches_none(const BaseDictionarySegment& segment, const ValueID search_value_id) const;
 
   template <typename Functor>
-  void _with_operator_for_dict_segment_scan(const PredicateCondition predicate_condition, const Functor& func) const {
+  void _with_operator_for_dict_segment_scan(const Functor& func) const {
     switch (predicate_condition) {
       case PredicateCondition::Equals:
         func(std::equal_to<void>{});

--- a/src/lib/optimizer/join_ordering/join_graph.hpp
+++ b/src/lib/optimizer/join_ordering/join_graph.hpp
@@ -37,7 +37,6 @@ class JoinGraph final {
    */
   static std::vector<JoinGraph> build_all_in_lqp(const std::shared_ptr<AbstractLQPNode>& lqp);
 
-  JoinGraph() = default;
   JoinGraph(const std::vector<std::shared_ptr<AbstractLQPNode>>& vertices, const std::vector<JoinGraphEdge>& edges);
 
   /**

--- a/src/lib/storage/index/abstract_index.hpp
+++ b/src/lib/storage/index/abstract_index.hpp
@@ -62,7 +62,6 @@ class AbstractIndex : private Noncopyable {
   AbstractIndex() = delete;
   explicit AbstractIndex(const SegmentIndexType type);
   AbstractIndex(AbstractIndex&&) = default;
-  AbstractIndex& operator=(AbstractIndex&&) = default;
   virtual ~AbstractIndex() = default;
 
   /**

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -47,8 +47,6 @@ class AdaptiveRadixTreeIndex : public AbstractIndex {
 
   AdaptiveRadixTreeIndex(AdaptiveRadixTreeIndex&&) = default;
 
-  AdaptiveRadixTreeIndex& operator=(AdaptiveRadixTreeIndex&&) = default;
-
   virtual ~AdaptiveRadixTreeIndex() = default;
 
   /**

--- a/src/lib/storage/index/group_key/composite_group_key_index.hpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.hpp
@@ -51,7 +51,6 @@ class CompositeGroupKeyIndex : public AbstractIndex {
   static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
 
   CompositeGroupKeyIndex(CompositeGroupKeyIndex&&) = default;
-  CompositeGroupKeyIndex& operator=(CompositeGroupKeyIndex&&) = default;
   ~CompositeGroupKeyIndex() = default;
 
   explicit CompositeGroupKeyIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -66,7 +66,6 @@ class GroupKeyIndex : public AbstractIndex {
   GroupKeyIndex& operator=(const GroupKeyIndex&) = delete;
 
   GroupKeyIndex(GroupKeyIndex&&) = default;
-  GroupKeyIndex& operator=(GroupKeyIndex&&) = default;
 
   explicit GroupKeyIndex(const std::vector<std::shared_ptr<const BaseSegment>>& segments_to_index);
 

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
@@ -31,7 +31,6 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
   explicit SimdBp128Decompressor(const SimdBp128Vector& vector);
   SimdBp128Decompressor(const SimdBp128Decompressor& other);
 
-  SimdBp128Decompressor(SimdBp128Decompressor&& other) = default;
   ~SimdBp128Decompressor() = default;
 
   uint32_t get(size_t i) final {

--- a/src/lib/utils/performance_warning.hpp
+++ b/src/lib/utils/performance_warning.hpp
@@ -63,6 +63,7 @@ class PerformanceWarningDisabler {
   {                                                                                                    \
     static PerformanceWarningClass warn(std::string(text) + " at " + trim_source_file_path(__FILE__) + \
                                         ":" BOOST_PP_STRINGIZE(__LINE__));                             \
-  }  // NOLINT
+  }                                                                                                    \
+  static_assert(true, "End call of macro with a semicolon")
 
 }  // namespace opossum

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -25,7 +25,7 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
   Assert(!_plugins.count(name), "Loading plugin failed: A plugin with name " + name + " already exists.");
 
   PluginHandle plugin_handle = dlopen(path.c_str(), static_cast<uint8_t>(RTLD_NOW) | static_cast<uint8_t>(RTLD_LOCAL));
-  Assert(plugin_handle, "Loading plugin failed: " + dlerror());
+  Assert(plugin_handle, std::string{"Loading plugin failed: "} + dlerror());
 
   // abstract_plugin.hpp defines a macro for exporting plugins which makes them instantiable by providing a
   // factory method. See the sources of AbstractPlugin and TestPlugin for further details.

--- a/src/lib/utils/tracing/probes.hpp
+++ b/src/lib/utils/tracing/probes.hpp
@@ -28,39 +28,40 @@ constexpr bool is_valid_name(const char* name) {
 #if !__has_feature(thread_sanitizer)
 #define BUILD_PROBE_NAME(provider, probe, ...)                                                                     \
   static_assert(is_valid_name(#provider) && is_valid_name(#probe), "Provider and probe name must be upper case!"); \
-  provider##_##probe(__VA_ARGS__);
+  provider##_##probe(__VA_ARGS__);                                                                                 \
+  static_assert(true, "End DTRACE_PROBE statement with a semicolon")
 #else
-#define BUILD_PROBE_NAME(provider, probe, ...)
+#define BUILD_PROBE_NAME(provider, probe, ...) static_assert(true, "End DTRACE_PROBE statement with a semicolon")
 #endif
 #endif
 
-#define DTRACE_PROBE(provider, probe) BUILD_PROBE_NAME(provider, probe);
-#define DTRACE_PROBE1(provider, probe, param1) BUILD_PROBE_NAME(provider, probe, param1);
-#define DTRACE_PROBE2(provider, probe, param1, param2) BUILD_PROBE_NAME(provider, probe, param1, param2);
+#define DTRACE_PROBE(provider, probe) BUILD_PROBE_NAME(provider, probe)
+#define DTRACE_PROBE1(provider, probe, param1) BUILD_PROBE_NAME(provider, probe, param1)
+#define DTRACE_PROBE2(provider, probe, param1, param2) BUILD_PROBE_NAME(provider, probe, param1, param2)
 #define DTRACE_PROBE3(provider, probe, param1, param2, param3) BUILD_PROBE_NAME(provider, probe, param1, param2, param3)
 #define DTRACE_PROBE4(provider, probe, param1, param2, param3, param4) \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4)
 #define DTRACE_PROBE5(provider, probe, param1, param2, param3, param4, param5) \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5)
 #define DTRACE_PROBE6(provider, probe, param1, param2, param3, param4, param5, param6) \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6)
 #define DTRACE_PROBE7(provider, probe, param1, param2, param3, param4, param5, param6, param7) \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7)
 #define DTRACE_PROBE8(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8) \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8)
 #define DTRACE_PROBE9(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9) \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9)
 #define DTRACE_PROBE10(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9, \
                        param10)                                                                                 \
-  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10);
+  BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10)
 #define DTRACE_PROBE11(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9,      \
                        param10, param11)                                                                             \
   BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, \
-                   param11);
+                   param11)
 #define DTRACE_PROBE12(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9,      \
                        param10, param11, param12)                                                                    \
   BUILD_PROBE_NAME(provider, probe, param1, param2, param3, param4, param5, param6, param7, param8, param9, param10, \
-                   param11, param12);
+                   param11, param12)
 
 // If not MACOS
 #else

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -71,7 +71,7 @@ bool contained_in_query_plan(const std::shared_ptr<const AbstractOperator>& node
 // clang-format off
 #define EXPECT_SEGMENT_EQ(segment_to_test, expected_segment, order_sensitivity, type_cmp_mode, float_comparison_mode) \
   EXPECT_TRUE(segment_to_test && expected_segment && check_segment_equal(                                             \
-              segment_to_test, expected_segment, order_sensitivity, type_cmp_mode, float_comparison_mode));
+              segment_to_test, expected_segment, order_sensitivity, type_cmp_mode, float_comparison_mode))
 // clang-format on
 
 /**

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -169,7 +169,7 @@ endif()
 
 include(ExternalProject)
 if(APPLE)
-    set(MAC_INCLUDES "SDKROOT=\"/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\" CPATH=\"/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include\"")
+    set(MAC_INCLUDES "SDKROOT=\"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk\" CPATH=\"/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include\"")
 else()
     set(MAC_INCLUDES "")
 endif()


### PR DESCRIPTION
Not upgrading to clang-9 as Ubuntu 19.04 does not have it in its default sources and 19.10 has just landed. With all the changes going on right now, let's wait for the dust to settle.

fixes #1077