### PR TITLE
Correct two words in LQP utils

### DIFF
--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -132,7 +132,7 @@ enum class LQPUpwardVisitation { VisitOutputs, DoNotVisitOutputs };
 /**
  * Calls the passed @param visitor on @param lqp and recursively on each node that uses it as an OUTPUT. If the LQP is
  * used as a subquery, the users of the subquery are not visited.
- * The visitor returns `LQPVisitation`, indicating whether the current nodes's input should be visited
+ * The visitor returns `LQPUpwardVisitation`, indicating whether the current nodes's input should be visited
  * as well.
  * Each node is visited exactly once.
  *

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -98,7 +98,7 @@ enum class LQPVisitation { VisitInputs, DoNotVisitInputs };
 
 /**
  * Calls the passed @param visitor on @param lqp and recursively on its INPUTS. This will NOT visit subqueries.
- * The visitor returns `ExpressionVisitation`, indicating whether the current nodes's input should be visited
+ * The visitor returns `LQPVisitation`, indicating whether the current nodes's input should be visited
  * as well. The algorithm is breadth-first search.
  * Each node is visited exactly once.
  *
@@ -132,7 +132,7 @@ enum class LQPUpwardVisitation { VisitOutputs, DoNotVisitOutputs };
 /**
  * Calls the passed @param visitor on @param lqp and recursively on each node that uses it as an OUTPUT. If the LQP is
  * used as a subquery, the users of the subquery are not visited.
- * The visitor returns `ExpressionVisitation`, indicating whether the current nodes's input should be visited
+ * The visitor returns `LQPVisitation`, indicating whether the current nodes's input should be visited
  * as well.
  * Each node is visited exactly once.
  *


### PR DESCRIPTION
Working with LQP and stumbled upon this wording.

Not sure if we could merge `LQPUpwardVisitation` and `LQPVisitation`.