### PR TITLE
Fix table scan for clang 9 and AVX512 machines

### DIFF
--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -200,7 +200,7 @@ class AbstractTableScanImpl {
       // vectorized automatically.
 
       // NOLINTNEXTLINE
-      ;  // clang-format off
+      {}  // clang-format off
       #pragma omp simd safelen(BLOCK_SIZE)
       // clang-format on
       for (auto i = size_t{0}; i < BLOCK_SIZE; ++i) {


### PR DESCRIPTION
The latest clang 9 does not like the line `;  // clang-format off` which is used to prevent clang-format from removing the indentation.
This has not been tested by the CI machine as the machine does not see the AVX512 code (happened on Nemea).

The simple "fix" is to use a `{}` over a `;`.