### PR TITLE
Modifications to LZ4 iterable

### DIFF
--- a/src/lib/storage/lz4_segment/lz4_segment_iterable.hpp
+++ b/src/lib/storage/lz4_segment/lz4_segment_iterable.hpp
@@ -48,7 +48,7 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
     auto decompressed_filtered_segment = std::vector<ValueType>(position_filter_size);
 
     // _segment.decompress() takes the currently cached block (reference) and its id in addition to the requested
-    // element. If the requested element in not within that block, the next block will be decompressed and written to
+    // element. If the requested element is not within that block, the next block will be decompressed and written to
     // `cached_block` while the value and the new block id are returned. In case the requested element in within the
     // cached block, the value and the input block id are returned.
     for (auto index = size_t{0u}; index < position_filter_size; ++index) {
@@ -61,12 +61,12 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
 
     auto begin = PointAccessIterator<ValueIterator>{
         decompressed_filtered_segment.begin(),
-        _segment.null_values() ? std::optional<NullValueIterator>{_segment.null_values()->cbegin()}
+        _segment.null_values() ? _segment.null_values()->cbegin()
                                : std::optional<NullValueIterator>{},
         position_filter->cbegin(), position_filter->cbegin()};
     auto end = PointAccessIterator<ValueIterator>{decompressed_filtered_segment.begin(),
                                                   _segment.null_values()
-                                                      ? std::optional<NullValueIterator>{_segment.null_values()->cend()}
+                                                      ? _segment.null_values()->cend()
                                                       : std::optional<NullValueIterator>{},
                                                   position_filter->cbegin(), position_filter->cend()};
 
@@ -90,7 +90,7 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
 
    public:
     // Begin and End Iterator
-    explicit Iterator(ValueIterator data_it, const std::optional<NullValueIterator> null_value_it)
+    explicit Iterator(ValueIterator data_it, std::optional<NullValueIterator> null_value_it)
         : _chunk_offset{0u}, _data_it{std::move(data_it)}, _null_value_it{std::move(null_value_it)} {}
 
    private:
@@ -140,7 +140,7 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
     using NullValueIterator = typename pmr_vector<bool>::const_iterator;
 
     // Begin Iterator
-    PointAccessIterator(DataIteratorType data_it, const std::optional<NullValueIterator>& null_value_it,
+    PointAccessIterator(DataIteratorType data_it, std::optional<NullValueIterator> null_value_it,
                         PosList::const_iterator position_filter_begin, PosList::const_iterator position_filter_it)
         : BasePointAccessSegmentIterator<PointAccessIterator<ValueIterator>,
                                          SegmentPosition<T>>{std::move(position_filter_begin),

--- a/src/lib/storage/lz4_segment/lz4_segment_iterable.hpp
+++ b/src/lib/storage/lz4_segment/lz4_segment_iterable.hpp
@@ -24,8 +24,10 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
     auto decompressed_segment = _segment.decompress();
 
     std::optional<NullValueIterator> null_opt_value_iter;
-    auto begin = Iterator<ValueIterator>{decompressed_segment.cbegin(), _segment.null_values() ? _segment.null_values()->cbegin() : null_opt_value_iter};
-    auto end = Iterator<ValueIterator>{decompressed_segment.cend(), _segment.null_values() ? _segment.null_values()->cend() : null_opt_value_iter};
+    auto begin = Iterator<ValueIterator>{
+        decompressed_segment.cbegin(), _segment.null_values() ? _segment.null_values()->cbegin() : null_opt_value_iter};
+    auto end = Iterator<ValueIterator>{decompressed_segment.cend(),
+                                       _segment.null_values() ? _segment.null_values()->cend() : null_opt_value_iter};
     functor(begin, end);
   }
 
@@ -66,7 +68,8 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
         const auto& row_id = (*position_filter)[index];
         position_filter_indexed[index] = {row_id, index};
       }
-      std::sort(position_filter_indexed.begin(), position_filter_indexed.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+      std::sort(position_filter_indexed.begin(), position_filter_indexed.end(),
+                [](const auto& a, const auto& b) { return a.first < b.first; });
 
       for (auto index = size_t{0u}; index < position_filter_size; ++index) {
         const auto& position = position_filter_indexed[index].first;
@@ -87,10 +90,14 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
     }
 
     std::optional<NullValueIterator> null_opt_value_iter;
-    auto begin = PointAccessIterator<ValueIterator>{decompressed_filtered_segment.begin(), _segment.null_values() ? _segment.null_values()->cbegin() : null_opt_value_iter,
-                                                    position_filter->cbegin(), position_filter->cbegin()};
-    auto end = PointAccessIterator<ValueIterator>{decompressed_filtered_segment.begin(), _segment.null_values() ? _segment.null_values()->cend() : null_opt_value_iter,
-                                                  position_filter->cbegin(), position_filter->cend()};
+    auto begin = PointAccessIterator<ValueIterator>{
+        decompressed_filtered_segment.begin(),
+        _segment.null_values() ? _segment.null_values()->cbegin() : null_opt_value_iter, position_filter->cbegin(),
+        position_filter->cbegin()};
+    auto end = PointAccessIterator<ValueIterator>{
+        decompressed_filtered_segment.begin(),
+        _segment.null_values() ? _segment.null_values()->cend() : null_opt_value_iter, position_filter->cbegin(),
+        position_filter->cend()};
 
     functor(begin, end);
   }
@@ -142,7 +149,9 @@ class LZ4SegmentIterable : public PointAccessibleSegmentIterable<LZ4SegmentItera
       return std::ptrdiff_t{other._chunk_offset} - std::ptrdiff_t{_chunk_offset};
     }
 
-    SegmentPosition<T> dereference() const { return SegmentPosition<T>{*_data_it, _null_value_it ? **_null_value_it : false, _chunk_offset}; }
+    SegmentPosition<T> dereference() const {
+      return SegmentPosition<T>{*_data_it, _null_value_it ? **_null_value_it : false, _chunk_offset};
+    }
 
    private:
     ChunkOffset _chunk_offset;


### PR DESCRIPTION
When not erasing LZ4 iterables, it turned out that certain std algorithms cannot use the iterators. With @mrks 's help, these issues have been fixed.  This change further allows to use unerased LZ4 segments, which are of relevance for my compression selection work and @krichly's spatial work.

Further, it adds a slight change to the caching of blocks. With this change, an iterable that is accessed multiple times, can still profit from LZ4-block caching (will be relevant for upcoming changes to the segment accessors).

TPC-H (gcc, sf=1, nemea):
```diff
 +----------------+-----------------------+------+----------------------+------+------------+-------------------+
 | Benchmark      | prev. iter/s          | runs | new iter/s           | runs | change [%] |           p-value |
 +----------------+-----------------------+------+----------------------+------+------------+-------------------+
 | TPC-H 01       | 0.0077946605160832405 | 1    | 0.007878044620156288 | 1    | +1%        | (not enough runs) |
 | TPC-H 02       | 0.15306907892227173   | 10   | 0.1545109897851944   | 10   | +1%        |            0.0003 |
 | TPC-H 03       | 0.1601416915655136    | 10   | 0.16082912683486938  | 10   | +0%        |            0.0161 |
 | TPC-H 04       | 0.3642721176147461    | 22   | 0.37286096811294556  | 23   | +2%        |            0.0000 |
 | TPC-H 05       | 0.03404029458761215   | 3    | 0.033995673060417175 | 3    | -0%        | (not enough runs) |
+| TPC-H 06       | 1.9570527076721191    | 118  | 2.0897433757781982   | 126  | +7%        |            0.0069 |
 | TPC-H 07       | 0.16901127994060516   | 11   | 0.16961240768432617  | 11   | +0%        |            0.0014 |
 | TPC-H 08       | 0.15593402087688446   | 10   | 0.1585163027048111   | 10   | +2%        |            0.0000 |
 | TPC-H 09       | 0.026666978374123573  | 2    | 0.0267617329955101   | 2    | +0%        | (not enough runs) |
 | TPC-H 10       | 0.1189955472946167    | 8    | 0.12087590247392654  | 8    | +2%        | (not enough runs) |
 | TPC-H 11       | 0.4064975678920746    | 25   | 0.41653311252593994  | 25   | +2%        |            0.0000 |
 | TPC-H 12       | 0.05560759827494621   | 4    | 0.05629827082157135  | 4    | +1%        | (not enough runs) |
 | TPC-H 13       | 0.223331481218338     | 14   | 0.22616297006607056  | 14   | +1%        |            0.0000 |
 | TPC-H 14       | 1.095063328742981     | 66   | 1.1197049617767334   | 68   | +2%        |            0.0000 |
 | TPC-H 15       | 0.4771794378757477    | 29   | 0.47672492265701294  | 29   | -0%        |            0.7583 |
 | TPC-H 16       | 0.08077448606491089   | 5    | 0.0832173302769661   | 5    | +3%        | (not enough runs) |
 | TPC-H 17       | 0.021238891407847404  | 2    | 0.021426254883408546 | 2    | +1%        | (not enough runs) |
 | TPC-H 18       | 0.018045440316200256  | 2    | 0.018120162189006805 | 2    | +0%        | (not enough runs) |
+| TPC-H 19       | 0.3555009961128235    | 22   | 0.462495356798172    | 28   | +30%       |            0.0000 |
 | TPC-H 20       | 0.059324923902750015  | 4    | 0.05963096022605896  | 4    | +1%        | (not enough runs) |
 | TPC-H 21       | 0.012740414589643478  | 1    | 0.012884444557130337 | 1    | +1%        | (not enough runs) |
 | TPC-H 22       | 0.15871000289916992   | 10   | 0.15976382791996002  | 10   | +1%        |            0.0000 |
 | geometric mean |                       |      |                      |      | +3%        |                   |
 +----------------+-----------------------+------+----------------------+------+------------+-------------------+
```