### PR TITLE
Reference LQP nodes in PQP nodes

### DIFF
--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -204,8 +204,9 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
 
   // All chunks that have an index on column_ids are handled by an IndexScan. All other chunks are handled by
   // TableScan(s).
-  auto index_scan = std::make_shared<IndexScan>(input_operator, SegmentIndexType::GroupKey, column_ids,
-                                                predicate->predicate_condition, right_values, right_values2);
+  auto index_scan =
+      std::make_shared<IndexScan>(input_operator, SegmentIndexType::GroupKey, column_ids,
+                                  predicate->predicate_condition, right_values, right_values2, node->deep_copy());
 
   const auto table_scan = _translate_predicate_node_to_table_scan(node, input_operator);
 
@@ -217,7 +218,8 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
 
 std::shared_ptr<TableScan> LQPTranslator::_translate_predicate_node_to_table_scan(
     const std::shared_ptr<PredicateNode>& node, const std::shared_ptr<AbstractOperator>& input_operator) const {
-  return std::make_shared<TableScan>(input_operator, _translate_expression(node->predicate(), node->left_input()));
+  return std::make_shared<TableScan>(input_operator, _translate_expression(node->predicate(), node->left_input()),
+                                     node->deep_copy());
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_alias_node(
@@ -242,8 +244,8 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_projection_node(
   const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(node);
   const auto input_operator = translate_node(input_node);
 
-  return std::make_shared<Projection>(input_operator,
-                                      _translate_expressions(projection_node->node_expressions, input_node));
+  return std::make_shared<Projection>(
+      input_operator, _translate_expressions(projection_node->node_expressions, input_node), node->deep_copy());
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_sort_node(
@@ -380,7 +382,8 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_aggregate_node(
     group_by_column_ids.emplace_back(*column_id);
   }
 
-  return std::make_shared<AggregateHash>(input_operator, aggregate_column_definitions, group_by_column_ids);
+  return std::make_shared<AggregateHash>(input_operator, aggregate_column_definitions, group_by_column_ids,
+                                         node->deep_copy());
 }
 
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_limit_node(

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -8,8 +8,9 @@ namespace opossum {
 
 AbstractAggregateOperator::AbstractAggregateOperator(const std::shared_ptr<AbstractOperator>& in,
                                                      const std::vector<AggregateColumnDefinition>& aggregates,
-                                                     const std::vector<ColumnID>& groupby_column_ids)
-    : AbstractReadOnlyOperator(OperatorType::Aggregate, in),
+                                                     const std::vector<ColumnID>& groupby_column_ids,
+                                                     const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractReadOnlyOperator(OperatorType::Aggregate, in, nullptr, lqp_node),
       _aggregates{aggregates},
       _groupby_column_ids{groupby_column_ids} {
   /*

--- a/src/lib/operators/abstract_aggregate_operator.hpp
+++ b/src/lib/operators/abstract_aggregate_operator.hpp
@@ -162,7 +162,8 @@ class AbstractAggregateOperator : public AbstractReadOnlyOperator {
  public:
   AbstractAggregateOperator(const std::shared_ptr<AbstractOperator>& in,
                             const std::vector<AggregateColumnDefinition>& aggregates,
-                            const std::vector<ColumnID>& groupby_column_ids);
+                            const std::vector<ColumnID>& groupby_column_ids,
+                            const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::vector<AggregateColumnDefinition>& aggregates() const;
 

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -14,8 +14,9 @@ AbstractJoinOperator::AbstractJoinOperator(const OperatorType type, const std::s
                                            const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                                            const OperatorJoinPredicate& primary_predicate,
                                            const std::vector<OperatorJoinPredicate>& secondary_predicates,
+                                           const std::shared_ptr<const AbstractLQPNode>& lqp_node,
                                            std::unique_ptr<OperatorPerformanceData> performance_data)
-    : AbstractReadOnlyOperator(type, left, right, std::move(performance_data)),
+    : AbstractReadOnlyOperator(type, left, right, lqp_node, std::move(performance_data)),
       _mode(mode),
       _primary_predicate(primary_predicate),
       _secondary_predicates(secondary_predicates) {

--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -38,6 +38,7 @@ class AbstractJoinOperator : public AbstractReadOnlyOperator {
       const OperatorType type, const std::shared_ptr<const AbstractOperator>& left,
       const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
       const OperatorJoinPredicate& primary_predicate, const std::vector<OperatorJoinPredicate>& secondary_predicates,
+      const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr,
       std::unique_ptr<OperatorPerformanceData> performance_data = std::make_unique<OperatorPerformanceData>());
 
   JoinMode mode() const;

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -19,8 +19,13 @@ namespace opossum {
 
 AbstractOperator::AbstractOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator>& left,
                                    const std::shared_ptr<const AbstractOperator>& right,
+                                   const std::shared_ptr<const AbstractLQPNode>& lqp_node,
                                    std::unique_ptr<OperatorPerformanceData> performance_data)
-    : _type(type), _input_left(left), _input_right(right), _performance_data(std::move(performance_data)) {}
+    : _type(type),
+      _input_left(left),
+      _input_right(right),
+      _lqp_node(lqp_node),
+      _performance_data(std::move(performance_data)) {}
 
 OperatorType AbstractOperator::type() const { return _type; }
 
@@ -118,6 +123,8 @@ std::shared_ptr<AbstractOperator> AbstractOperator::mutable_input_left() const {
 std::shared_ptr<AbstractOperator> AbstractOperator::mutable_input_right() const {
   return std::const_pointer_cast<AbstractOperator>(_input_right);
 }
+
+std::shared_ptr<const AbstractLQPNode> AbstractOperator::lqp_node() const { return _lqp_node; }
 
 const OperatorPerformanceData& AbstractOperator::performance_data() const { return *_performance_data; }
 

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -71,6 +71,7 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
   AbstractOperator(
       const OperatorType type, const std::shared_ptr<const AbstractOperator>& left = nullptr,
       const std::shared_ptr<const AbstractOperator>& right = nullptr,
+      const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr,
       std::unique_ptr<OperatorPerformanceData> performance_data = std::make_unique<OperatorPerformanceData>());
 
   virtual ~AbstractOperator() = default;
@@ -118,6 +119,8 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
   std::shared_ptr<const Table> input_table_left() const;
   std::shared_ptr<const Table> input_table_right() const;
 
+  std::shared_ptr<const AbstractLQPNode> lqp_node() const;
+
   // Return data about the operators performance (runtime, e.g.) AFTER it has been executed.
   const OperatorPerformanceData& performance_data() const;
 
@@ -157,6 +160,8 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
   // Shared pointers to input operators, can be nullptr.
   std::shared_ptr<const AbstractOperator> _input_left;
   std::shared_ptr<const AbstractOperator> _input_right;
+
+  std::shared_ptr<const AbstractLQPNode> _lqp_node;
 
   // Is nullptr until the operator is executed
   std::shared_ptr<const Table> _output;

--- a/src/lib/operators/abstract_read_only_operator.cpp
+++ b/src/lib/operators/abstract_read_only_operator.cpp
@@ -6,6 +6,12 @@
 
 namespace opossum {
 
+AbstractReadOnlyOperator::AbstractReadOnlyOperator(const OperatorType type,
+                                                   const std::shared_ptr<const AbstractOperator>& left,
+                                                   const std::shared_ptr<const AbstractOperator>& right,
+                                                   const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractOperator(type, left, right, lqp_node) {}
+
 std::shared_ptr<const Table> AbstractReadOnlyOperator::_on_execute(std::shared_ptr<TransactionContext>) {
   return _on_execute();
 }

--- a/src/lib/operators/abstract_read_only_operator.hpp
+++ b/src/lib/operators/abstract_read_only_operator.hpp
@@ -14,6 +14,10 @@ class AbstractReadOnlyOperator : public AbstractOperator {
  public:
   using AbstractOperator::AbstractOperator;
 
+  AbstractReadOnlyOperator(const OperatorType type, const std::shared_ptr<const AbstractOperator>& left = nullptr,
+                           const std::shared_ptr<const AbstractOperator>& right = nullptr,
+                           const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
+
  protected:
   // This override exists so that all AbstractReadOnlyOperators can ignore the transaction context
   // Apart from Validate and GetTable, none of the read-only operators needs the transaction context.

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -53,8 +53,9 @@ namespace opossum {
 
 AggregateHash::AggregateHash(const std::shared_ptr<AbstractOperator>& in,
                              const std::vector<AggregateColumnDefinition>& aggregates,
-                             const std::vector<ColumnID>& groupby_column_ids)
-    : AbstractAggregateOperator(in, aggregates, groupby_column_ids) {}
+                             const std::vector<ColumnID>& groupby_column_ids,
+                             const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractAggregateOperator(in, aggregates, groupby_column_ids, lqp_node) {}
 
 const std::string& AggregateHash::name() const {
   static const auto name = std::string{"AggregateHash"};

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -94,7 +94,8 @@ using DistinctAggregateType = int8_t;
 class AggregateHash : public AbstractAggregateOperator {
  public:
   AggregateHash(const std::shared_ptr<AbstractOperator>& in, const std::vector<AggregateColumnDefinition>& aggregates,
-                const std::vector<ColumnID>& groupby_column_ids);
+                const std::vector<ColumnID>& groupby_column_ids,
+                const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
 

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -18,8 +18,9 @@ namespace opossum {
 
 IndexScan::IndexScan(const std::shared_ptr<const AbstractOperator>& in, const SegmentIndexType index_type,
                      const std::vector<ColumnID>& left_column_ids, const PredicateCondition predicate_condition,
-                     const std::vector<AllTypeVariant>& right_values, const std::vector<AllTypeVariant>& right_values2)
-    : AbstractReadOnlyOperator{OperatorType::IndexScan, in},
+                     const std::vector<AllTypeVariant>& right_values, const std::vector<AllTypeVariant>& right_values2,
+                     const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractReadOnlyOperator{OperatorType::IndexScan, in, nullptr, lqp_node},
       _index_type{index_type},
       _left_column_ids{left_column_ids},
       _predicate_condition{predicate_condition},

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -23,7 +23,8 @@ class IndexScan : public AbstractReadOnlyOperator {
  public:
   IndexScan(const std::shared_ptr<const AbstractOperator>& in, const SegmentIndexType index_type,
             const std::vector<ColumnID>& left_column_ids, const PredicateCondition predicate_condition,
-            const std::vector<AllTypeVariant>& right_values, const std::vector<AllTypeVariant>& right_values2 = {});
+            const std::vector<AllTypeVariant>& right_values, const std::vector<AllTypeVariant>& right_values2 = {},
+            const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const final;
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -41,8 +41,9 @@ JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator>& left,
                    const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                    const OperatorJoinPredicate& primary_predicate,
                    const std::vector<OperatorJoinPredicate>& secondary_predicates,
-                   const std::optional<size_t>& radix_bits)
-    : AbstractJoinOperator(OperatorType::JoinHash, left, right, mode, primary_predicate, secondary_predicates),
+                   const std::optional<size_t>& radix_bits, const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractJoinOperator(OperatorType::JoinHash, left, right, mode, primary_predicate, secondary_predicates,
+                           lqp_node),
       _radix_bits(radix_bits) {}
 
 const std::string& JoinHash::name() const {

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -26,7 +26,8 @@ class JoinHash : public AbstractJoinOperator {
   JoinHash(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,
            const JoinMode mode, const OperatorJoinPredicate& primary_predicate,
            const std::vector<OperatorJoinPredicate>& secondary_predicates = {},
-           const std::optional<size_t>& radix_bits = std::nullopt);
+           const std::optional<size_t>& radix_bits = std::nullopt,
+           const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
   std::string description(DescriptionMode description_mode) const override;

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -47,9 +47,10 @@ bool JoinIndex::supports(const JoinConfiguration config) {
 JoinIndex::JoinIndex(const std::shared_ptr<const AbstractOperator>& left,
                      const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                      const OperatorJoinPredicate& primary_predicate,
-                     const std::vector<OperatorJoinPredicate>& secondary_predicates, const IndexSide index_side)
+                     const std::vector<OperatorJoinPredicate>& secondary_predicates, const IndexSide index_side,
+                     const std::shared_ptr<const AbstractLQPNode>& lqp_node)
     : AbstractJoinOperator(OperatorType::JoinIndex, left, right, mode, primary_predicate, secondary_predicates,
-                           std::make_unique<JoinIndex::PerformanceData>()),
+                           lqp_node, std::make_unique<JoinIndex::PerformanceData>()),
       _index_side(index_side),
       _adjusted_primary_predicate(primary_predicate) {
   if (_index_side == IndexSide::Left) {
@@ -379,7 +380,9 @@ std::vector<IndexRange> JoinIndex::_index_ranges_for_value(const SegmentPosition
         range_end = index->cend();
         break;
       }
-      default: { Fail("Unsupported comparison type encountered"); }
+      default: {
+        Fail("Unsupported comparison type encountered");
+      }
     }
     index_ranges.emplace_back(IndexRange{range_begin, range_end});
   }

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -35,7 +35,8 @@ class JoinIndex : public AbstractJoinOperator {
   JoinIndex(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,
             const JoinMode mode, const OperatorJoinPredicate& primary_predicate,
             const std::vector<OperatorJoinPredicate>& secondary_predicates = {},
-            const IndexSide index_side = IndexSide::Right);
+            const IndexSide index_side = IndexSide::Right,
+            const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
 

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -77,8 +77,10 @@ bool JoinNestedLoop::supports(const JoinConfiguration config) { return true; }
 JoinNestedLoop::JoinNestedLoop(const std::shared_ptr<const AbstractOperator>& left,
                                const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                                const OperatorJoinPredicate& primary_predicate,
-                               const std::vector<OperatorJoinPredicate>& secondary_predicates)
-    : AbstractJoinOperator(OperatorType::JoinNestedLoop, left, right, mode, primary_predicate, secondary_predicates) {
+                               const std::vector<OperatorJoinPredicate>& secondary_predicates,
+                               const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractJoinOperator(OperatorType::JoinNestedLoop, left, right, mode, primary_predicate, secondary_predicates,
+                           lqp_node) {
   // TODO(moritz) incorporate into supports()?
 }
 

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -22,7 +22,8 @@ class JoinNestedLoop : public AbstractJoinOperator {
   JoinNestedLoop(const std::shared_ptr<const AbstractOperator>& left,
                  const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                  const OperatorJoinPredicate& primary_predicate,
-                 const std::vector<OperatorJoinPredicate>& secondary_predicates = {});
+                 const std::vector<OperatorJoinPredicate>& secondary_predicates = {},
+                 const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
 

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -43,8 +43,10 @@ bool JoinSortMerge::supports(const JoinConfiguration config) {
 JoinSortMerge::JoinSortMerge(const std::shared_ptr<const AbstractOperator>& left,
                              const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                              const OperatorJoinPredicate& primary_predicate,
-                             const std::vector<OperatorJoinPredicate>& secondary_predicates)
-    : AbstractJoinOperator(OperatorType::JoinSortMerge, left, right, mode, primary_predicate, secondary_predicates) {}
+                             const std::vector<OperatorJoinPredicate>& secondary_predicates,
+                             const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractJoinOperator(OperatorType::JoinSortMerge, left, right, mode, primary_predicate, secondary_predicates,
+                           lqp_node) {}
 
 std::shared_ptr<AbstractOperator> JoinSortMerge::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_input_left,

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -26,7 +26,8 @@ class JoinSortMerge : public AbstractJoinOperator {
   JoinSortMerge(const std::shared_ptr<const AbstractOperator>& left,
                 const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
                 const OperatorJoinPredicate& primary_predicate,
-                const std::vector<OperatorJoinPredicate>& secondary_predicates = {});
+                const std::vector<OperatorJoinPredicate>& secondary_predicates = {},
+                const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
 

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -17,8 +17,9 @@
 namespace opossum {
 
 Projection::Projection(const std::shared_ptr<const AbstractOperator>& in,
-                       const std::vector<std::shared_ptr<AbstractExpression>>& expressions)
-    : AbstractReadOnlyOperator(OperatorType::Projection, in), expressions(expressions) {}
+                       const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
+                       const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractReadOnlyOperator(OperatorType::Projection, in, nullptr, lqp_node), expressions(expressions) {}
 
 const std::string& Projection::name() const {
   static const auto name = std::string{"Projection"};

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -21,7 +21,8 @@ namespace opossum {
 class Projection : public AbstractReadOnlyOperator {
  public:
   Projection(const std::shared_ptr<const AbstractOperator>& in,
-             const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
+             const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
+             const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -41,8 +41,9 @@
 namespace opossum {
 
 TableScan::TableScan(const std::shared_ptr<const AbstractOperator>& in,
-                     const std::shared_ptr<AbstractExpression>& predicate)
-    : AbstractReadOnlyOperator{OperatorType::TableScan, in}, _predicate(predicate) {}
+                     const std::shared_ptr<AbstractExpression>& predicate,
+                     const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractReadOnlyOperator{OperatorType::TableScan, in, nullptr, lqp_node}, _predicate(predicate) {}
 
 const std::shared_ptr<AbstractExpression>& TableScan::predicate() const { return _predicate; }
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -20,7 +20,8 @@ class TableScan : public AbstractReadOnlyOperator {
   friend class LQPTranslatorTest;
 
  public:
-  TableScan(const std::shared_ptr<const AbstractOperator>& in, const std::shared_ptr<AbstractExpression>& predicate);
+  TableScan(const std::shared_ptr<const AbstractOperator>& in, const std::shared_ptr<AbstractExpression>& predicate,
+            const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::shared_ptr<AbstractExpression>& predicate() const;
 

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -52,8 +52,8 @@ bool Validate::_is_entire_chunk_visible(const std::shared_ptr<const Chunk>& chun
   return snapshot_commit_id >= max_begin_cid && chunk->invalid_row_count() == 0;
 }
 
-Validate::Validate(const std::shared_ptr<AbstractOperator>& in)
-    : AbstractReadOnlyOperator(OperatorType::Validate, in) {}
+Validate::Validate(const std::shared_ptr<AbstractOperator>& in, const std::shared_ptr<const AbstractLQPNode>& lqp_node)
+    : AbstractReadOnlyOperator(OperatorType::Validate, in, nullptr, lqp_node) {}
 
 const std::string& Validate::name() const {
   static const auto name = std::string{"Validate"};

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -20,7 +20,8 @@ class Validate : public AbstractReadOnlyOperator {
   friend class OperatorsValidateTest;
 
  public:
-  explicit Validate(const std::shared_ptr<AbstractOperator>& in);
+  explicit Validate(const std::shared_ptr<AbstractOperator>& in,
+                    const std::shared_ptr<const AbstractLQPNode>& lqp_node = nullptr);
 
   const std::string& name() const override;
 

--- a/src/test/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/logical_query_plan/lqp_translator_test.cpp
@@ -399,6 +399,18 @@ TEST_F(LQPTranslatorTest, PredicateNodeBetweenScan) {
   EXPECT_EQ(*table_scan_op->predicate(), *between_inclusive_(a, 42, 1337));
 }
 
+TEST_F(LQPTranslatorTest, LqpNodeAccess) {
+  // Tests the accessability of the origin LQP node after translation
+  auto predicate_node = PredicateNode::make(between_inclusive_(int_float_a, 42, 1337), int_float_node);
+  const auto op = LQPTranslator{}.translate_node(predicate_node);
+
+  const auto lqp_node = op->lqp_node();
+  const auto recovered_node = std::dynamic_pointer_cast<const PredicateNode>(lqp_node);
+
+  EXPECT_TRUE(recovered_node);
+  EXPECT_EQ(recovered_node->predicate()->hash(), predicate_node->predicate()->hash());
+}
+
 TEST_F(LQPTranslatorTest, PredicateNodeIndexScan) {
   /**
    * Build LQP and translate to PQP


### PR DESCRIPTION
This is a discussion PR to reference LQP nodes in PQP nodes during translation.

This PR is a first attempt to allow better parsing of the plan cache and was initially "proposed"/envisioined by @Bensk1 and @mrzzzrm . One of the main motivations was to retrieve the actual physical column when parsing scans/join etc.

Parsing of PQPs is something that @Bensk1  and I already do often, and what will probably be done much more often in the future (NVM, bachelor's project, ...). This PR is one of several PRs coming which will lay the foundation for the best self-pimping database ever.

There is a just a simple test included and I have probably not covered all cases to consider, yet. But should be enough to discuss the issue.