### PR TITLE
A potpourri of smaller fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 fi
 
                 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 --slave /usr/bin/g++ g++ /usr/bin/g++-9
-                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-9 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-9 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-9
+                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-9 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-9 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-9 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-9 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-9 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-9
             else
                 echo "Error during installation."
                 exit 1

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -5,7 +5,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
 	clang_format="/usr/local/opt/llvm/bin/clang-format"
 	format_cmd="$clang_format -i -style=file '{}'"
 elif [[ "$unamestr" == 'Linux' ]]; then
-	format_cmd="clang-format-7 -i -style=file '{}'"
+	format_cmd="clang-format -i -style=file '{}'"
 fi
 
 

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -23,6 +23,7 @@ def main():
   arguments["--scheduler"] = "false"
   arguments["--clients"] = "1"
   arguments["--cache_binary_tables"] = "true"
+  arguments["--visualize"] = "true"
 
   os.system("rm -rf " + arguments["--table_path"] + "/*.bin")
 
@@ -32,6 +33,7 @@ def main():
   benchmark.expect("Running in single-threaded mode")
   benchmark.expect("1 simulated clients are scheduling items in parallel")
   benchmark.expect("Running benchmark in 'Shuffled' mode")
+  benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'Unencoded'")
   benchmark.expect("Chunk size is 100000")
   benchmark.expect("Max runs per item is 100")
@@ -82,7 +84,6 @@ def main():
   arguments["--compression"] = "'SIMD-BP128'"
   arguments["--scheduler"] = "true"
   arguments["--clients"] = "4"
-  arguments["--visualize"] = "true"
   arguments["--verify"] = "true"
 
   benchmark = initialize(arguments, "hyriseBenchmarkFileBased", True)
@@ -90,7 +91,6 @@ def main():
   benchmark.expect("Running in multi-threaded mode using all available cores")
   benchmark.expect("4 simulated clients are scheduling items in parallel")
   benchmark.expect("Running benchmark in 'Ordered' mode")
-  benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'LZ4'")
   benchmark.expect("Chunk size is 100000")
   benchmark.expect("Max runs per item is 100")

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -23,7 +23,6 @@ def main():
   arguments["--scheduler"] = "false"
   arguments["--clients"] = "1"
   arguments["--cache_binary_tables"] = "true"
-  arguments["--visualize"] = "true"
 
   os.system("rm -rf " + arguments["--table_path"] + "/*.bin")
 
@@ -33,7 +32,6 @@ def main():
   benchmark.expect("Running in single-threaded mode")
   benchmark.expect("1 simulated clients are scheduling items in parallel")
   benchmark.expect("Running benchmark in 'Shuffled' mode")
-  benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'Unencoded'")
   benchmark.expect("Chunk size is 100000")
   benchmark.expect("Max runs per item is 100")

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -22,6 +22,7 @@ def main():
   arguments["--clients"] = "1"
   arguments["--cache_binary_tables"] = "true"
   arguments["--scheduler"] = "false"
+  arguments["--visualize"] = "true"
 
   os.system("rm -rf " + arguments["--table_path"] + "/*.bin")
 
@@ -31,6 +32,7 @@ def main():
   benchmark.expect("Running in single-threaded mode")
   benchmark.expect("1 simulated clients are scheduling items in parallel")
   benchmark.expect("Running benchmark in 'Shuffled' mode")
+  benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'Unencoded'")
   benchmark.expect("Chunk size is 100000")
   benchmark.expect("Max runs per item is 100")
@@ -82,7 +84,6 @@ def main():
   arguments["--compression"] = "'Fixed-size byte-aligned'"
   arguments["--scheduler"] = "true"
   arguments["--clients"] = "4"
-  arguments["--visualize"] = "true"
   arguments["--verify"] = "true"
 
   benchmark = initialize(arguments, "hyriseBenchmarkJoinOrder", True)
@@ -90,7 +91,6 @@ def main():
   benchmark.expect("Running in multi-threaded mode using all available cores")
   benchmark.expect("4 simulated clients are scheduling items in parallel")
   benchmark.expect("Running benchmark in 'Ordered' mode")
-  benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'LZ4'")
   benchmark.expect("Chunk size is 100000")
   benchmark.expect("Max runs per item is 2")

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -22,7 +22,6 @@ def main():
   arguments["--clients"] = "1"
   arguments["--cache_binary_tables"] = "true"
   arguments["--scheduler"] = "false"
-  arguments["--visualize"] = "true"
 
   os.system("rm -rf " + arguments["--table_path"] + "/*.bin")
 
@@ -32,7 +31,6 @@ def main():
   benchmark.expect("Running in single-threaded mode")
   benchmark.expect("1 simulated clients are scheduling items in parallel")
   benchmark.expect("Running benchmark in 'Shuffled' mode")
-  benchmark.expect("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
   benchmark.expect("Encoding is 'Unencoded'")
   benchmark.expect("Chunk size is 100000")
   benchmark.expect("Max runs per item is 100")
@@ -101,6 +99,8 @@ def main():
   benchmark.expect("Benchmarking queries from third_party/join-order-benchmark")
   benchmark.expect("Running on tables from resources/test_data/imdb_sample/")
   benchmark.expect("Multi-threaded Topology:")
+  benchmark.expect("- Warming up for 10a")
+  benchmark.expect("- Benchmarking 10a")
 
   close_benchmark(benchmark)
   check_exit_status(benchmark)

--- a/src/benchmarklib/benchmark_sql_executor.cpp
+++ b/src/benchmarklib/benchmark_sql_executor.cpp
@@ -100,15 +100,28 @@ void BenchmarkSQLExecutor::_compare_tables(const std::shared_ptr<const Table>& e
   }
 }
 
-void BenchmarkSQLExecutor::_visualize(SQLPipeline& pipeline) const {
+void BenchmarkSQLExecutor::_visualize(SQLPipeline& pipeline) {
   GraphvizConfig graphviz_config;
   graphviz_config.format = "svg";
 
   const auto& lqps = pipeline.get_optimized_logical_plans();
   const auto& pqps = pipeline.get_physical_plans();
 
-  LQPVisualizer{graphviz_config, {}, {}, {}}.visualize(lqps, *_visualize_prefix + "-LQP.svg");
-  PQPVisualizer{graphviz_config, {}, {}, {}}.visualize(pqps, *_visualize_prefix + "-PQP.svg");
+  auto prefix = *_visualize_prefix;
+
+  if (_num_visualized_plans == 1) {
+    // We have multiple SQL pipelines in this benchmark item - rename the existing file
+    std::filesystem::rename(prefix + "-LQP.svg", prefix + "-0-LQP.svg");
+    std::filesystem::rename(prefix + "-PQP.svg", prefix + "-0-PQP.svg");
+  }
+  if (_num_visualized_plans > 0) {
+    prefix += "-" + std::to_string(_num_visualized_plans);
+  }
+
+  LQPVisualizer{graphviz_config, {}, {}, {}}.visualize(lqps, prefix + "-LQP.svg");
+  PQPVisualizer{graphviz_config, {}, {}, {}}.visualize(pqps, prefix + "-PQP.svg");
+
+  ++_num_visualized_plans;
 }
 
 }  // namespace opossum

--- a/src/benchmarklib/benchmark_sql_executor.cpp
+++ b/src/benchmarklib/benchmark_sql_executor.cpp
@@ -110,7 +110,7 @@ void BenchmarkSQLExecutor::_visualize(SQLPipeline& pipeline) {
   auto prefix = *_visualize_prefix;
 
   if (_num_visualized_plans == 1) {
-    // We have multiple SQL pipelines in this benchmark item - rename the existing file
+    // We have already visualized a prior SQL pipeline in this benchmark item - rename the existing file
     std::filesystem::rename(prefix + "-LQP.svg", prefix + "-0-LQP.svg");
     std::filesystem::rename(prefix + "-PQP.svg", prefix + "-0-PQP.svg");
   }

--- a/src/benchmarklib/benchmark_sql_executor.hpp
+++ b/src/benchmarklib/benchmark_sql_executor.hpp
@@ -44,7 +44,7 @@ class BenchmarkSQLExecutor {
 
   const std::shared_ptr<SQLiteWrapper> _sqlite_wrapper;
   const std::optional<std::string> _visualize_prefix;
-  int _num_visualized_plans{0};
+  uint64_t _num_visualized_plans{0};
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/benchmark_sql_executor.hpp
+++ b/src/benchmarklib/benchmark_sql_executor.hpp
@@ -40,10 +40,11 @@ class BenchmarkSQLExecutor {
                        const std::shared_ptr<const Table>& actual_result_table,
                        const std::optional<const std::string>& description = std::nullopt);
   void _verify_with_sqlite(SQLPipeline& pipeline);
-  void _visualize(SQLPipeline& pipeline) const;
+  void _visualize(SQLPipeline& pipeline);
 
   const std::shared_ptr<SQLiteWrapper> _sqlite_wrapper;
   const std::optional<std::string> _visualize_prefix;
+  int _num_visualized_plans{0};
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -79,6 +79,7 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
 
   const auto enable_visualization = json_config.value("visualize", default_config.enable_visualization);
   if (enable_visualization) {
+    Assert(clients == 1, "Cannot visualize plans with multiple clients as files may be overwritten");
     std::cout << "- Visualizing the plans into SVG files. This will make the performance numbers invalid." << std::endl;
   }
 

--- a/src/lib/operators/abstract_read_write_operator.cpp
+++ b/src/lib/operators/abstract_read_write_operator.cpp
@@ -63,4 +63,25 @@ void AbstractReadWriteOperator::_mark_as_failed() {
   _state = ReadWriteOperatorState::Failed;
 }
 
+std::ostream& operator<<(std::ostream& stream, const ReadWriteOperatorState& phase) {
+  switch (phase) {
+    case ReadWriteOperatorState::Pending:
+      stream << "Pending";
+      break;
+    case ReadWriteOperatorState::Executed:
+      stream << "Executed";
+      break;
+    case ReadWriteOperatorState::Failed:
+      stream << "Failed";
+      break;
+    case ReadWriteOperatorState::RolledBack:
+      stream << "RolledBack";
+      break;
+    case ReadWriteOperatorState::Committed:
+      stream << "Committed";
+      break;
+  }
+  return stream;
+}
+
 }  // namespace opossum

--- a/src/lib/operators/abstract_read_write_operator.hpp
+++ b/src/lib/operators/abstract_read_write_operator.hpp
@@ -21,6 +21,8 @@ enum class ReadWriteOperatorState {
   Committed    // Changes have been committed.
 };
 
+std::ostream& operator<<(std::ostream& stream, const ReadWriteOperatorState& phase);
+
 /**
  * AbstractReadWriteOperator is the superclass of all operators that need write access to tables.
  * It mainly provides the commit_records and rollback_records methods,

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
@@ -44,8 +44,8 @@ void rewrite_to_join(const std::shared_ptr<AbstractLQPNode>& node,
     list_as_table->append_chunk({value_segment});
   });
 
-  // All regular tables have statistics. Even if the JoinOrderingRule already ran, add statistics to the dummy table so
-  // that following rules, which expect statistics to be present, do not run into problems.
+  // Add statistics to the dummy table so that following rules or other steps (such as the LQPVisualizer), which
+  // expect statistics to be present, do not run into problems.
   list_as_table->set_table_statistics(TableStatistics::from_table(*list_as_table));
 
   // Create a join node

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -19,6 +19,7 @@
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/static_table_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/validate_node.hpp"
@@ -158,6 +159,12 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
       output_table_statistics = left_input_table_statistics;
     } break;
 
+    case LQPNodeType::StaticTable: {
+      const auto static_table_node = std::dynamic_pointer_cast<StaticTableNode>(lqp);
+      output_table_statistics = static_table_node->table->table_statistics();
+      Assert(output_table_statistics, "This StaticTableNode has no statistics");
+    } break;
+
     case LQPNodeType::StoredTable: {
       const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(lqp);
 
@@ -198,7 +205,6 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
     case LQPNodeType::Delete:
     case LQPNodeType::DropView:
     case LQPNodeType::DropTable:
-    case LQPNodeType::StaticTable:
     case LQPNodeType::DummyTable: {
       auto empty_column_statistics = std::vector<std::shared_ptr<BaseAttributeStatistics>>();
       output_table_statistics = std::make_shared<TableStatistics>(std::move(empty_column_statistics), Cardinality{0});

--- a/src/test/optimizer/strategy/in_expression_rewrite_rule_test.cpp
+++ b/src/test/optimizer/strategy/in_expression_rewrite_rule_test.cpp
@@ -2,6 +2,7 @@
 #include "logical_query_plan/union_node.hpp"
 #include "optimizer/strategy/in_expression_rewrite_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
+#include "statistics/cardinality_estimator.hpp"
 #include "storage/table.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
@@ -10,7 +11,11 @@ namespace opossum {
 
 class InExpressionRewriteRuleTest : public StrategyBaseTest {
   void SetUp() override {
-    node = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "col_a"}, {DataType::Float, "col_b"}});
+    // col_a has 1000 entries across 200 values linearly distributed between 1 and 200
+    node = create_mock_node_with_statistics(
+        MockNode::ColumnDefinitions{{DataType::Int, "col_a"}, {DataType::Float, "col_b"}}, 1000,
+        {{GenericHistogram<int32_t>::with_single_bin(1, 200, 1000, 200),
+          GenericHistogram<float>::with_single_bin(1.0f, 50.0f, 100, 10)}});
     col_a = lqp_column_(node->get_column("col_a"));
     col_b = lqp_column_(node->get_column("col_b"));
 
@@ -248,12 +253,16 @@ TEST_F(InExpressionRewriteRuleTest, JoinStrategy) {
 TEST_F(InExpressionRewriteRuleTest, AutoStrategy) {
   auto rule = std::make_shared<InExpressionRewriteRule>();
 
+  const auto cardinality_estimator = CardinalityEstimator{};
+
   {
     // Disjunction for single element
     const auto input_lqp = PredicateNode::make(single_element_in_expression, node);
     const auto result_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
     const auto expected_lqp = PredicateNode::make(equals_(col_a, 1), node);
     EXPECT_LQP_EQ(result_lqp, expected_lqp);
+
+    EXPECT_FLOAT_EQ(cardinality_estimator.estimate_cardinality(result_lqp), 1000.f / 200 * 1);
   }
 
   {
@@ -261,6 +270,8 @@ TEST_F(InExpressionRewriteRuleTest, AutoStrategy) {
     const auto input_lqp = PredicateNode::make(five_element_in_expression, node);
     const auto result_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
     EXPECT_EQ(result_lqp, input_lqp);
+
+    // No cardinality check here, as unmodified IN expressions are currently not estimated by the CardinalityEstimator.
   }
 
   {
@@ -284,6 +295,8 @@ TEST_F(InExpressionRewriteRuleTest, AutoStrategy) {
 
     EXPECT_LQP_EQ(result_lqp, expected_lqp);
     EXPECT_TABLE_EQ_UNORDERED(static_cast<StaticTableNode&>(*result_lqp->right_input()).table, table);
+
+    EXPECT_NEAR(cardinality_estimator.estimate_cardinality(result_lqp), 1000.f / 200 * 100, 10);
   }
 
   {

--- a/src/test/optimizer/strategy/in_expression_rewrite_rule_test.cpp
+++ b/src/test/optimizer/strategy/in_expression_rewrite_rule_test.cpp
@@ -271,7 +271,9 @@ TEST_F(InExpressionRewriteRuleTest, AutoStrategy) {
     const auto result_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
     EXPECT_EQ(result_lqp, input_lqp);
 
-    // No cardinality check here, as unmodified IN expressions are currently not estimated by the CardinalityEstimator.
+    // No cardinality check here, as an IN expression with 5 elements will not be touched (see
+    // MAX_ELEMENTS_FOR_DISJUNCTION and MIN_ELEMENTS_FOR_JOIN). These InExpressions are currently not supported by the
+    // CardinalityEstimator.
   }
 
   {

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -877,11 +877,7 @@ TEST_F(CardinalityEstimatorTest, NonQueryNodes) {
   // Test that, basically, the CardinalityEstimator doesn't crash when processing non-query nodes. There is not much
   // more to test here
 
-  const auto column_definitions = TableColumnDefinitions{{"a", DataType::Int, false}};
-  const auto static_table_node = StaticTableNode::make(Table::create_dummy_table(column_definitions));
-  EXPECT_EQ(estimator.estimate_cardinality(static_table_node), 0.0f);
-
-  const auto create_table_lqp = CreateTableNode::make("t", false, static_table_node);
+  const auto create_table_lqp = CreateTableNode::make("t", false, node_a);
   EXPECT_EQ(estimator.estimate_cardinality(create_table_lqp), 0.0f);
 
   const auto prepared_plan = std::make_shared<PreparedPlan>(node_a, std::vector<ParameterID>{});


### PR DESCRIPTION
Some minor things that I had lying around. As none of these should have any effect on benchmarks etc., I hope that compressing them into one PR should be fine

* Make clang-format work independent of current clang version
* Make visualization work if benchmark item has multiple SQL pipelines (e.g., TPC-C)
* Make `ReadWriteOperatorState` printable
* Fix visualization of `x IN (...)` when the IN expression is rewritten to a join