### PR TITLE
SQL keyword "table" as column name in meta manager

### DIFF
--- a/resources/test_data/tbl/meta_tables/meta_chunks.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_chunks.tbl
@@ -1,4 +1,4 @@
-table|chunk_id|rows|invalid_rows|cleanup_commit_id
+table_name|chunk_id|row_count|invalid_rows|cleanup_commit_id
 string|int|long|long|long_null
 int_int|0|2|0|null
 int_int|1|1|0|null

--- a/resources/test_data/tbl/meta_tables/meta_chunks.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_chunks.tbl
@@ -1,4 +1,4 @@
-table_name|chunk_id|row_count|invalid_rows|cleanup_commit_id
+table_name|chunk_id|row_count|invalid_row_count|cleanup_commit_id
 string|int|long|long|long_null
 int_int|0|2|0|null
 int_int|1|1|0|null

--- a/resources/test_data/tbl/meta_tables/meta_chunks_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_chunks_updated.tbl
@@ -1,4 +1,4 @@
-table_name|chunk_id|row_count|invalid_rows|cleanup_commit_id
+table_name|chunk_id|row_count|invalid_row_count|cleanup_commit_id
 string|int|long|long|long_null
 int_int|0|2|1|null
 int_int|1|1|0|null

--- a/resources/test_data/tbl/meta_tables/meta_chunks_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_chunks_updated.tbl
@@ -1,4 +1,4 @@
-table|chunk_id|rows|invalid_rows|cleanup_commit_id
+table_name|chunk_id|row_count|invalid_rows|cleanup_commit_id
 string|int|long|long|long_null
 int_int|0|2|1|null
 int_int|1|1|0|null

--- a/resources/test_data/tbl/meta_tables/meta_columns.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_columns.tbl
@@ -1,4 +1,4 @@
-table|name|data_type|nullable
+table_name|column_name|data_type|nullable
 string|string|string|int
 int_int|a|int|0
 int_int|b|int|0

--- a/resources/test_data/tbl/meta_tables/meta_columns_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_columns_updated.tbl
@@ -1,4 +1,4 @@
-table|name|data_type|nullable
+table_name|column_name|data_type|nullable
 string|string|string|int
 int_int|a|int|0
 int_int|b|int|0

--- a/resources/test_data/tbl/meta_tables/meta_segments.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments.tbl
@@ -1,4 +1,4 @@
-table|chunk_id|column_id|column_name|column_data_type|encoding
+table_name|chunk_id|column_id|column_name|column_data_type|encoding_name
 string|int|int|string|string|string_null
 int_int|0|0|a|int|null
 int_int|0|1|b|int|null

--- a/resources/test_data/tbl/meta_tables/meta_segments_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_updated.tbl
@@ -1,4 +1,4 @@
-table|chunk_id|column_id|column_name|column_data_type|encoding
+table_name|chunk_id|column_id|column_name|column_data_type|encoding_name
 string|int|int|string|string|string_null
 int_int|0|0|a|int|null
 int_int|0|1|b|int|null

--- a/resources/test_data/tbl/meta_tables/meta_tables.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_tables.tbl
@@ -1,4 +1,4 @@
-table|column_count|row_count|chunk_count|max_chunk_size
+table_name|column_count|row_count|chunk_count|max_chunk_size
 string|int|long|int|int
 int_int|2|3|2|2
 int_int_int_null|3|4|1|100

--- a/resources/test_data/tbl/meta_tables/meta_tables_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_tables_updated.tbl
@@ -1,4 +1,4 @@
-table|column_count|row_count|chunk_count|max_chunk_size
+table_name|column_count|row_count|chunk_count|max_chunk_size
 string|int|long|int|int
 int_int|2|4|3|2
 int_int_int_null|3|5|2|100

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -69,7 +69,7 @@ std::shared_ptr<Table> MetaTableManager::generate_chunks_table() {
   const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
                                               {"chunk_id", DataType::Int, false},
                                               {"row_count", DataType::Long, false},
-                                              {"invalid_rows", DataType::Long, false},
+                                              {"invalid_row_count", DataType::Long, false},
                                               {"cleanup_commit_id", DataType::Long, true}};
   auto output_table = std::make_shared<Table>(columns, TableType::Data, std::nullopt, UseMvcc::Yes);
 

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<Table> MetaTableManager::generate_table(const std::string& table
 }
 
 std::shared_ptr<Table> MetaTableManager::generate_tables_table() {
-  const auto columns = TableColumnDefinitions{{"table", DataType::String, false},
+  const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
                                               {"column_count", DataType::Int, false},
                                               {"row_count", DataType::Long, false},
                                               {"chunk_count", DataType::Int, false},
@@ -48,7 +48,7 @@ std::shared_ptr<Table> MetaTableManager::generate_tables_table() {
 }
 
 std::shared_ptr<Table> MetaTableManager::generate_columns_table() {
-  const auto columns = TableColumnDefinitions{{"table", DataType::String, false},
+  const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
                                               {"name", DataType::String, false},
                                               {"data_type", DataType::String, false},
                                               {"nullable", DataType::Int, false}};
@@ -66,7 +66,7 @@ std::shared_ptr<Table> MetaTableManager::generate_columns_table() {
 }
 
 std::shared_ptr<Table> MetaTableManager::generate_chunks_table() {
-  const auto columns = TableColumnDefinitions{{"table", DataType::String, false},
+  const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
                                               {"chunk_id", DataType::Int, false},
                                               {"rows", DataType::Long, false},
                                               {"invalid_rows", DataType::Long, false},
@@ -88,7 +88,7 @@ std::shared_ptr<Table> MetaTableManager::generate_chunks_table() {
 }
 
 std::shared_ptr<Table> MetaTableManager::generate_segments_table() {
-  const auto columns = TableColumnDefinitions{{"table", DataType::String, false},
+  const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
                                               {"chunk_id", DataType::Int, false},
                                               {"column_id", DataType::Int, false},
                                               {"column_name", DataType::String, false},

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -49,7 +49,7 @@ std::shared_ptr<Table> MetaTableManager::generate_tables_table() {
 
 std::shared_ptr<Table> MetaTableManager::generate_columns_table() {
   const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
-                                              {"name", DataType::String, false},
+                                              {"column_name", DataType::String, false},
                                               {"data_type", DataType::String, false},
                                               {"nullable", DataType::Int, false}};
   auto output_table = std::make_shared<Table>(columns, TableType::Data, std::nullopt, UseMvcc::Yes);
@@ -68,7 +68,7 @@ std::shared_ptr<Table> MetaTableManager::generate_columns_table() {
 std::shared_ptr<Table> MetaTableManager::generate_chunks_table() {
   const auto columns = TableColumnDefinitions{{"table_name", DataType::String, false},
                                               {"chunk_id", DataType::Int, false},
-                                              {"rows", DataType::Long, false},
+                                              {"row_count", DataType::Long, false},
                                               {"invalid_rows", DataType::Long, false},
                                               {"cleanup_commit_id", DataType::Long, true}};
   auto output_table = std::make_shared<Table>(columns, TableType::Data, std::nullopt, UseMvcc::Yes);
@@ -93,7 +93,7 @@ std::shared_ptr<Table> MetaTableManager::generate_segments_table() {
                                               {"column_id", DataType::Int, false},
                                               {"column_name", DataType::String, false},
                                               {"column_data_type", DataType::String, false},
-                                              {"encoding", DataType::String, true}};
+                                              {"encoding_name", DataType::String, true}};
   // Vector compression is not yet included because #1286 makes it a pain to map it to a string.
   auto output_table = std::make_shared<Table>(columns, TableType::Data, std::nullopt, UseMvcc::Yes);
 

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -1863,7 +1863,7 @@ TEST_F(SQLTranslatorTest, ShowColumns) {
 
   // clang-format off
   const auto stored_table_node = StoredTableNode::make(MetaTableManager::META_PREFIX + "columns");
-  const auto table_name_column = stored_table_node->get_column("table");
+  const auto table_name_column = stored_table_node->get_column("table_name");
   const auto expected_lqp =
       PredicateNode::make(equals_(table_name_column, "int_float"),
         stored_table_node);

--- a/src/test/utils/meta_table_manager_test.cpp
+++ b/src/test/utils/meta_table_manager_test.cpp
@@ -51,7 +51,7 @@ TEST_F(MetaTableManagerTest, TableBasedMetaData) {
 
   {
     // TEST SQL features on meta tables
-    const auto result = SQLPipelineBuilder{"SELECT COUNT(*) FROM meta_tables WHERE \"table\" = 'int_int'"}
+    const auto result = SQLPipelineBuilder{"SELECT COUNT(*) FROM meta_tables WHERE table_name = 'int_int'"}
                            .create_pipeline()
                            .get_result_table();
 


### PR DESCRIPTION
The meta table manager currently uses `table` as a column name. A student (thanks Caterina) just informed me that queries such as `select table, chunk_id from meta_chunks` can thus not be executed. While a simple `select "table"` is sufficient, I'd say we should better not have SQL keywords as column names.

Further, `column_name` & `column`  and `row_count` & `rows` have been unified.