### PR TITLE
Retrieve access frequency of cached elements

### DIFF
--- a/src/lib/cache/abstract_cache_impl.hpp
+++ b/src/lib/cache/abstract_cache_impl.hpp
@@ -66,8 +66,6 @@ class AbstractCacheImpl {
   virtual ErasedIterator begin() = 0;
   virtual ErasedIterator end() = 0;
 
-  size_t frequency(const Key& key) { Fail("Cache implementation does not suppport frequency()."); }
-
   // Return the capacity of the cache.
   size_t capacity() const { return _capacity; }
 

--- a/src/lib/cache/abstract_cache_impl.hpp
+++ b/src/lib/cache/abstract_cache_impl.hpp
@@ -4,8 +4,6 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
-#include "utils/assert.hpp"
-
 namespace opossum {
 
 // Generic template for a cache implementation.

--- a/src/lib/cache/abstract_cache_impl.hpp
+++ b/src/lib/cache/abstract_cache_impl.hpp
@@ -4,6 +4,8 @@
 
 #include <boost/iterator/iterator_facade.hpp>
 
+#include "utils/assert.hpp"
+
 namespace opossum {
 
 // Generic template for a cache implementation.
@@ -63,6 +65,8 @@ class AbstractCacheImpl {
 
   virtual ErasedIterator begin() = 0;
   virtual ErasedIterator end() = 0;
+
+  size_t frequency(const Key& key) { Fail("Cache implementation does not suppport frequency()."); }
 
   // Return the capacity of the cache.
   size_t capacity() const { return _capacity; }

--- a/src/lib/cache/cache.hpp
+++ b/src/lib/cache/cache.hpp
@@ -78,6 +78,8 @@ class Cache {
 
   Iterator end() { return _impl->end(); }
 
+  size_t frequency(const Key& key) { return _impl->frequency(key); }
+
  protected:
   // Underlying cache eviction strategy.
   std::unique_ptr<AbstractCacheImpl<Key, Value>> _impl;

--- a/src/lib/cache/cache.hpp
+++ b/src/lib/cache/cache.hpp
@@ -61,6 +61,8 @@ class Cache {
 
   void resize(size_t capacity) { _impl->resize(capacity); }
 
+  // Returns the access frequency of a cached item (=1 for set(), +1 for each get()).
+  // Returns 0 for keys not being cache-resident.
   size_t size() const { return _impl->size(); }
 
   // Returns a reference to the underlying cache.

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -134,6 +134,10 @@ class GDFSCache : public AbstractCacheImpl<Key, Value> {
 
   size_t frequency(const Key& key) {
     const auto it = _map.find(key);
+    if (it == _map.end()) {
+      return size_t{0};
+    }
+
     Handle handle = it->second;
     GDFSCacheEntry& entry = (*handle);
     return entry.frequency;

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -132,6 +132,13 @@ class GDFSCache : public AbstractCacheImpl<Key, Value> {
 
   ErasedIterator end() { return ErasedIterator{std::make_unique<Iterator>(_map.end())}; }
 
+  size_t frequency(const Key& key) {
+    const auto it = _map.find(key);
+    Handle handle = it->second;
+    GDFSCacheEntry& entry = (*handle);
+    return entry.frequency;
+  }
+
  protected:
   // Priority queue to hold all elements. Implemented as max-heap.
   boost::heap::fibonacci_heap<GDFSCacheEntry> _queue;

--- a/src/lib/sql/sql_pipeline_builder.hpp
+++ b/src/lib/sql/sql_pipeline_builder.hpp
@@ -38,7 +38,7 @@ class SQLPipelineBuilder final {
   // Plan caches used if `with_{l/p}qp_cache()` are not used in this builder. Both default caches can be nullptr
   // themselves. If both default_{l/p}qp_cache and _{l/p}qp_cache are nullptr, no plan caching is used.
   // These default caches stem from the extended discussion in #1615 and are mainly for Plugins, whose only
-  // way of communicating with Hyrise are global variables. TODO(anybody) remove them again with #1677?
+  // way of communicating with Hyrise are global variables.
   static std::shared_ptr<SQLPhysicalPlanCache> default_pqp_cache;
   static std::shared_ptr<SQLLogicalPlanCache> default_lqp_cache;
 

--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -47,8 +47,6 @@ TEST(CachePolicyTest, LRUCacheTest) {
   ASSERT_FALSE(cache.has(3));
   ASSERT_EQ(5, cache.get(1));  // Hit.
   ASSERT_EQ(4, cache.get(2));  // Hit.
-
-  ASSERT_THROW(cache.frequency(2), std::logic_error);  // key exists, but no frequency() for LRU
 }
 
 // LRU-K (K = 2)
@@ -85,8 +83,6 @@ TEST(CachePolicyTest, LRU2CacheTest) {
 
   ASSERT_EQ(5, cache.get(1));  // Hit.
   ASSERT_EQ(6, cache.get(3));  // Hit.
-
-  ASSERT_THROW(cache.frequency(2), std::logic_error);  // key exists, but no frequency() for LRU2
 }
 
 // GDS Strategy
@@ -138,8 +134,6 @@ TEST(CachePolicyTest, GDSCacheTest) {
   ASSERT_FALSE(cache.has(1));
   ASSERT_TRUE(cache.has(2));
   ASSERT_TRUE(cache.has(3));
-
-  ASSERT_THROW(cache.frequency(3), std::logic_error);  // key exists, but no frequency() for GDS
 }
 
 // GDFS Strategy
@@ -238,8 +232,6 @@ TEST(CachePolicyTest, RandomCacheTest) {
   // We can only expect the most recent insertion to be in the cache.
   ASSERT_TRUE(cache.has(6));
   ASSERT_EQ(53, cache.get(6));  // Hit.
-
-  ASSERT_THROW(cache.frequency(6), std::logic_error);  // key exists, but no frequency() for Random
 }
 
 // Test the default cache (uses GDFS).

--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -193,6 +193,7 @@ TEST(CachePolicyTest, GDFSCacheTest) {
   ASSERT_TRUE(cache.has(3));
 
   ASSERT_EQ(cache.frequency(3), 3);
+  ASSERT_EQ(cache.frequency(100), 0);
 }
 
 // Random Replacement Strategy

--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -47,6 +47,8 @@ TEST(CachePolicyTest, LRUCacheTest) {
   ASSERT_FALSE(cache.has(3));
   ASSERT_EQ(5, cache.get(1));  // Hit.
   ASSERT_EQ(4, cache.get(2));  // Hit.
+
+  ASSERT_THROW(cache.frequency(2), std::logic_error);  // key exists, but no frequency() for LRU
 }
 
 // LRU-K (K = 2)
@@ -83,6 +85,8 @@ TEST(CachePolicyTest, LRU2CacheTest) {
 
   ASSERT_EQ(5, cache.get(1));  // Hit.
   ASSERT_EQ(6, cache.get(3));  // Hit.
+
+  ASSERT_THROW(cache.frequency(2), std::logic_error);  // key exists, but no frequency() for LRU2
 }
 
 // GDS Strategy
@@ -134,6 +138,8 @@ TEST(CachePolicyTest, GDSCacheTest) {
   ASSERT_FALSE(cache.has(1));
   ASSERT_TRUE(cache.has(2));
   ASSERT_TRUE(cache.has(3));
+
+  ASSERT_THROW(cache.frequency(3), std::logic_error);  // key exists, but no frequency() for GDS
 }
 
 // GDFS Strategy
@@ -185,6 +191,8 @@ TEST(CachePolicyTest, GDFSCacheTest) {
   ASSERT_FALSE(cache.has(1));
   ASSERT_TRUE(cache.has(2));
   ASSERT_TRUE(cache.has(3));
+
+  ASSERT_EQ(cache.frequency(3), 3);
 }
 
 // Random Replacement Strategy
@@ -229,6 +237,8 @@ TEST(CachePolicyTest, RandomCacheTest) {
   // We can only expect the most recent insertion to be in the cache.
   ASSERT_TRUE(cache.has(6));
   ASSERT_EQ(53, cache.get(6));  // Hit.
+
+  ASSERT_THROW(cache.frequency(6), std::logic_error);  // key exists, but no frequency() for Random
 }
 
 // Test the default cache (uses GDFS).


### PR DESCRIPTION
This PR introduces the `frequency()` method to the cache. The GDFS cache (which is the only one used right now) has a nice `F` in the name and we should use that.

The function is not implemented for other cache. On the one hand, they aren't used anyways. On the other hand, as far as I can tell they do not store any frequency information.