### PR TITLE
SQLite test runner: Print line numbers

### DIFF
--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -46,8 +46,8 @@ void SQLiteTestRunner::SetUpTestCase() {
 
   _table_cache_per_encoding.emplace(EncodingType::Unencoded, unencoded_table_cache);
 
-  opossum::Hyrise::get().topology.use_numa_topology();
-  opossum::Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
+  Hyrise::get().topology.use_numa_topology();
+  Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
 }
 
 void SQLiteTestRunner::SetUp() {
@@ -137,7 +137,7 @@ std::vector<std::pair<size_t, std::string>> SQLiteTestRunner::queries() {
   std::ifstream file("resources/test_data/sqlite_testrunner_queries.sql");
   std::string query;
 
-  auto next_line = size_t{0};
+  auto next_line = size_t{0};  // Incremented before first use
   while (std::getline(file, query)) {
     ++next_line;
     if (query.empty() || query.substr(0, 2) == "--") continue;

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -129,26 +129,31 @@ void SQLiteTestRunner::SetUp() {
   }
 }
 
-std::vector<std::string> SQLiteTestRunner::queries() {
-  static std::vector<std::string> queries;
+std::vector<std::pair<size_t, std::string>> SQLiteTestRunner::queries() {
+  static std::vector<std::pair<size_t, std::string>> queries;
 
   if (!queries.empty()) return queries;
 
   std::ifstream file("resources/test_data/sqlite_testrunner_queries.sql");
   std::string query;
 
+  auto next_line = size_t{0};
   while (std::getline(file, query)) {
+    ++next_line;
     if (query.empty() || query.substr(0, 2) == "--") continue;
-    queries.emplace_back(std::move(query));
+
+    queries.emplace_back(next_line - 1, std::move(query));
   }
 
   return queries;
 }
 
 TEST_P(SQLiteTestRunner, CompareToSQLite) {
-  const auto [sql, encoding_type] = GetParam();
+  const auto [query_pair, encoding_type] = GetParam();
+  const auto& [line, sql] = query_pair;
 
-  SCOPED_TRACE("Query '" + sql + "' with encoding " + encoding_type_to_string.left.at(encoding_type));
+  SCOPED_TRACE("Query '" + sql + "' from line " + std::to_string(line) + " with encoding " +
+               encoding_type_to_string.left.at(encoding_type));
 
   auto sql_pipeline = SQLPipelineBuilder{sql}.create_pipeline();
 

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -142,7 +142,7 @@ std::vector<std::pair<size_t, std::string>> SQLiteTestRunner::queries() {
     ++next_line;
     if (query.empty() || query.substr(0, 2) == "--") continue;
 
-    queries.emplace_back(next_line - 1, std::move(query));
+    queries.emplace_back(next_line, std::move(query));
   }
 
   return queries;

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.hpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.hpp
@@ -16,6 +16,7 @@
 #include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
+#include "constant_mappings.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/create_view_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -32,7 +33,7 @@
 
 namespace opossum {
 
-using SQLiteTestRunnerParam = std::tuple<std::string /* sql */, EncodingType>;
+using SQLiteTestRunnerParam = std::tuple<std::pair<size_t /* line */, std::string /* sql */>, EncodingType>;
 
 class SQLiteTestRunner : public BaseTestWithParam<SQLiteTestRunnerParam> {
  public:
@@ -53,11 +54,20 @@ class SQLiteTestRunner : public BaseTestWithParam<SQLiteTestRunnerParam> {
 
   void SetUp() override;
 
-  static std::vector<std::string> queries();
+  // Returns pair of the line in the sql file and the query itself
+  static std::vector<std::pair<size_t, std::string>> queries();
 
   inline static std::unique_ptr<SQLiteWrapper> _sqlite;
   inline static std::map<EncodingType, TableCache> _table_cache_per_encoding;
   inline static std::string _master_table_suffix = "_master_copy";
+};
+
+auto sqlite_testrunner_formatter = [](const ::testing::TestParamInfo<SQLiteTestRunnerParam>& info) {
+  const auto query_pair = std::get<0>(info.param);
+  const auto encoding_type = std::get<1>(info.param);
+
+  return std::string{"Line"} + std::to_string(query_pair.first) + "With" +
+         encoding_type_to_string.left.at(encoding_type);
 };
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.hpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.hpp
@@ -63,8 +63,8 @@ class SQLiteTestRunner : public BaseTestWithParam<SQLiteTestRunnerParam> {
 };
 
 auto sqlite_testrunner_formatter = [](const ::testing::TestParamInfo<SQLiteTestRunnerParam>& info) {
-  const auto query_pair = std::get<0>(info.param);
-  const auto encoding_type = std::get<1>(info.param);
+  const auto& query_pair = std::get<0>(info.param);
+  const auto& encoding_type = std::get<1>(info.param);
 
   return std::string{"Line"} + std::to_string(query_pair.first) + "With" +
          encoding_type_to_string.left.at(encoding_type);

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_encodings.cpp
@@ -5,7 +5,8 @@
 namespace opossum {
 
 INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerEncodings, SQLiteTestRunner,
-                         testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()),
-                                          testing::ValuesIn(all_encoding_types)));
+                         testing::Combine(::testing::ValuesIn(SQLiteTestRunner::queries()),
+                                          ::testing::ValuesIn(all_encoding_types)),
+                         sqlite_testrunner_formatter);
 
 }  // namespace opossum

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner_unencoded.cpp
@@ -4,6 +4,7 @@ namespace opossum {
 
 INSTANTIATE_TEST_SUITE_P(SQLiteTestRunnerUnencoded, SQLiteTestRunner,
                          testing::Combine(testing::ValuesIn(SQLiteTestRunner::queries()),
-                                          testing::ValuesIn({EncodingType::Unencoded})));
+                                          testing::ValuesIn({EncodingType::Unencoded})),
+                         sqlite_testrunner_formatter);
 
 }  // namespace opossum


### PR DESCRIPTION
This has happened one time too often:

```
[ RUN      ] SQLiteTestRunnerEncodings/SQLiteTestRunner.CompareToSQLite/876
Segmentation fault (core dumped)
script returned exit code 139
```

By making the line number within the .sql file part of the test names, it will be easier to trace this back to the SQL query that caused the segfault:

```
[ RUN      ] SQLiteTestRunnerEncodings/SQLiteTestRunner.CompareToSQLite/Line309WithUnencoded
[       OK ] SQLiteTestRunnerEncodings/SQLiteTestRunner.CompareToSQLite/Line309WithUnencoded (12 ms)
```