### PR TITLE
Add detailed descriptions for LQP nodes and expressions

### DIFF
--- a/src/lib/expression/abstract_expression.cpp
+++ b/src/lib/expression/abstract_expression.cpp
@@ -43,9 +43,7 @@ size_t AbstractExpression::hash() const {
   return hash;
 }
 
-std::string AbstractExpression::as_column_name() const {
-  return description(DescriptionMode::ColumnName);
-}
+std::string AbstractExpression::as_column_name() const { return description(DescriptionMode::ColumnName); }
 
 size_t AbstractExpression::_shallow_hash() const { return 0; }
 

--- a/src/lib/expression/abstract_expression.cpp
+++ b/src/lib/expression/abstract_expression.cpp
@@ -43,6 +43,10 @@ size_t AbstractExpression::hash() const {
   return hash;
 }
 
+std::string AbstractExpression::as_column_name() const {
+  return description(DescriptionMode::ColumnName);
+}
+
 size_t AbstractExpression::_shallow_hash() const { return 0; }
 
 bool AbstractExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
@@ -52,15 +56,16 @@ bool AbstractExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) cons
 
 ExpressionPrecedence AbstractExpression::_precedence() const { return ExpressionPrecedence::Highest; }
 
-std::string AbstractExpression::_enclose_argument_as_column_name(const AbstractExpression& argument) const {
+std::string AbstractExpression::_enclose_argument(const AbstractExpression& argument,
+                                                  const DescriptionMode mode) const {
   // TODO(anybody) Using >= to make divisions ("(2/3)/4") and logical operations ("(a AND (b OR c))") unambiguous -
   //               Sadly this makes cases where the parentheses could be avoided look ugly ("(2+3)+4")
 
   if (static_cast<std::underlying_type_t<ExpressionPrecedence>>(argument._precedence()) >=
       static_cast<std::underlying_type_t<ExpressionPrecedence>>(_precedence())) {
-    return "("s + argument.as_column_name() + ")";
+    return "("s + argument.description(mode) + ")";
   } else {
-    return argument.as_column_name();
+    return argument.description(mode);
   }
 }
 

--- a/src/lib/expression/abstract_expression.hpp
+++ b/src/lib/expression/abstract_expression.hpp
@@ -65,9 +65,19 @@ class AbstractExpression : public std::enable_shared_from_this<AbstractExpressio
   virtual std::shared_ptr<AbstractExpression> deep_copy() const = 0;
 
   /**
-   * @return a human readable string representing the Expression that can be used as a column name
+   * @return the expression's column name or, optionally, a more detailed description of the expression
    */
-  virtual std::string as_column_name() const = 0;
+  enum class DescriptionMode {
+    ColumnName,  // returns only the column name (e.g., name)
+    Detailed     // additionally includes the address of referenced nodes
+  };
+  virtual std::string description(const DescriptionMode mode = DescriptionMode::Detailed) const = 0;
+
+  /**
+   * @return a human readable string representing the Expression that can be used as a column name
+   *         (shortcut for description(DescriptionMode::ColumnName))
+   */
+  std::string as_column_name() const;
 
   /**
    * @return the DataType of the result of the expression
@@ -105,7 +115,7 @@ class AbstractExpression : public std::enable_shared_from_this<AbstractExpressio
   virtual bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const;
 
   /**
-   * Used internally in _enclose_argument_as_column_name() to put parentheses around expression arguments if they have a lower
+   * Used internally in _enclose_argument to put parentheses around expression arguments if they have a lower
    * precedence than the expression itself.
    * Lower precedence indicates tighter binding, compare https://en.cppreference.com/w/cpp/language/operator_precedence
    *
@@ -114,15 +124,15 @@ class AbstractExpression : public std::enable_shared_from_this<AbstractExpressio
   virtual ExpressionPrecedence _precedence() const;
 
   /**
-   * @return    argument.as_column_name(), enclosed by parentheses if the argument precedence is lower than
+   * @return    argument.description(mode), enclosed by parentheses if the argument precedence is lower than
    *            this->_precedence()
    */
-  std::string _enclose_argument_as_column_name(const AbstractExpression& argument) const;
+  std::string _enclose_argument(const AbstractExpression& argument, const DescriptionMode mode) const;
 };
 
 // So that google test, e.g., prints readable error messages
 inline std::ostream& operator<<(std::ostream& stream, const AbstractExpression& expression) {
-  return stream << expression.as_column_name();
+  return stream << expression.description();
 }
 
 // Wrapper around expression->hash(), to enable hash based containers containing std::shared_ptr<AbstractExpression>

--- a/src/lib/expression/abstract_expression.hpp
+++ b/src/lib/expression/abstract_expression.hpp
@@ -68,7 +68,7 @@ class AbstractExpression : public std::enable_shared_from_this<AbstractExpressio
    * @return the expression's column name or, optionally, a more detailed description of the expression
    */
   enum class DescriptionMode {
-    ColumnName,  // returns only the column name (e.g., name)
+    ColumnName,  // returns only the column name
     Detailed     // additionally includes the address of referenced nodes
   };
   virtual std::string description(const DescriptionMode mode = DescriptionMode::Detailed) const = 0;

--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -35,8 +35,9 @@ std::string AggregateExpression::description(const DescriptionMode mode) const {
     if (mode == DescriptionMode::ColumnName) {
       stream << "COUNT(*)";
     } else {
-      stream << "COUNT(" << dynamic_cast<const LQPColumnExpression*>(&*argument())->column_reference.original_node()
-             << ".*)";
+      const auto column_expression = dynamic_cast<const LQPColumnExpression*>(&*argument());
+      DebugAssert(column_expression, "Expected aggregate argument to be column expression");
+      stream << "COUNT(" << column_expression->column_reference.original_node() << ".*)";
     }
   } else {
     stream << aggregate_function << "(";

--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -25,17 +25,22 @@ std::shared_ptr<AbstractExpression> AggregateExpression::deep_copy() const {
   return std::make_shared<AggregateExpression>(aggregate_function, argument()->deep_copy());
 }
 
-std::string AggregateExpression::as_column_name() const {
+std::string AggregateExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
   if (aggregate_function == AggregateFunction::CountDistinct) {
     Assert(argument(), "COUNT(DISTINCT ...) requires an argument");
-    stream << "COUNT(DISTINCT " << argument()->as_column_name() << ")";
+    stream << "COUNT(DISTINCT " << argument()->description(mode) << ")";
   } else if (is_count_star(*this)) {
-    stream << "COUNT(*)";
+    if (mode == DescriptionMode::ColumnName) {
+      stream << "COUNT(*)";
+    } else {
+      stream << "COUNT(" << dynamic_cast<const LQPColumnExpression*>(&*argument())->column_reference.original_node()
+             << ".*)";
+    }
   } else {
     stream << aggregate_function << "(";
-    if (argument()) stream << argument()->as_column_name();
+    if (argument()) stream << argument()->description(mode);
     stream << ")";
   }
 

--- a/src/lib/expression/aggregate_expression.hpp
+++ b/src/lib/expression/aggregate_expression.hpp
@@ -13,7 +13,7 @@ class AggregateExpression : public AbstractExpression {
   std::shared_ptr<AbstractExpression> argument() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const AggregateFunction aggregate_function;

--- a/src/lib/expression/arithmetic_expression.cpp
+++ b/src/lib/expression/arithmetic_expression.cpp
@@ -47,11 +47,11 @@ DataType ArithmeticExpression::data_type() const {
   return expression_common_type(left_operand()->data_type(), right_operand()->data_type());
 }
 
-std::string ArithmeticExpression::as_column_name() const {
+std::string ArithmeticExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
-  stream << _enclose_argument_as_column_name(*left_operand()) << " " << arithmetic_operator << " "
-         << _enclose_argument_as_column_name(*right_operand());
+  stream << _enclose_argument(*left_operand(), mode) << " " << arithmetic_operator << " "
+         << _enclose_argument(*right_operand(), mode);
 
   return stream.str();
 }

--- a/src/lib/expression/arithmetic_expression.hpp
+++ b/src/lib/expression/arithmetic_expression.hpp
@@ -23,7 +23,7 @@ class ArithmeticExpression : public AbstractExpression {
   const std::shared_ptr<AbstractExpression>& right_operand() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const ArithmeticOperator arithmetic_operator;

--- a/src/lib/expression/between_expression.cpp
+++ b/src/lib/expression/between_expression.cpp
@@ -27,11 +27,10 @@ std::shared_ptr<AbstractExpression> BetweenExpression::deep_copy() const {
                                              upper_bound()->deep_copy());
 }
 
-std::string BetweenExpression::as_column_name() const {
+std::string BetweenExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << _enclose_argument_as_column_name(*value()) << " " << predicate_condition << " "
-         << _enclose_argument_as_column_name(*lower_bound()) << " AND "
-         << _enclose_argument_as_column_name(*upper_bound());
+  stream << _enclose_argument(*value(), mode) << " " << predicate_condition << " "
+         << _enclose_argument(*lower_bound(), mode) << " AND " << _enclose_argument(*upper_bound(), mode);
   return stream.str();
 }
 

--- a/src/lib/expression/between_expression.hpp
+++ b/src/lib/expression/between_expression.hpp
@@ -17,7 +17,7 @@ class BetweenExpression : public AbstractPredicateExpression {
   const std::shared_ptr<AbstractExpression>& upper_bound() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
 
  protected:
   ExpressionPrecedence _precedence() const override;

--- a/src/lib/expression/binary_predicate_expression.cpp
+++ b/src/lib/expression/binary_predicate_expression.cpp
@@ -33,12 +33,12 @@ std::shared_ptr<AbstractExpression> BinaryPredicateExpression::deep_copy() const
                                                      right_operand()->deep_copy());
 }
 
-std::string BinaryPredicateExpression::as_column_name() const {
+std::string BinaryPredicateExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
-  stream << _enclose_argument_as_column_name(*left_operand()) << " ";
+  stream << _enclose_argument(*left_operand(), mode) << " ";
   stream << predicate_condition << " ";
-  stream << _enclose_argument_as_column_name(*right_operand());
+  stream << _enclose_argument(*right_operand(), mode);
 
   return stream.str();
 }

--- a/src/lib/expression/binary_predicate_expression.hpp
+++ b/src/lib/expression/binary_predicate_expression.hpp
@@ -16,7 +16,7 @@ class BinaryPredicateExpression : public AbstractPredicateExpression {
   const std::shared_ptr<AbstractExpression>& right_operand() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
 
  protected:
   ExpressionPrecedence _precedence() const override;

--- a/src/lib/expression/case_expression.cpp
+++ b/src/lib/expression/case_expression.cpp
@@ -17,11 +17,11 @@ const std::shared_ptr<AbstractExpression>& CaseExpression::then() const { return
 
 const std::shared_ptr<AbstractExpression>& CaseExpression::otherwise() const { return arguments[2]; }
 
-std::string CaseExpression::as_column_name() const {
+std::string CaseExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
-  stream << "CASE WHEN " << when()->as_column_name() << " THEN " << then()->as_column_name() << " ELSE "
-         << otherwise()->as_column_name() << " END";
+  stream << "CASE WHEN " << when()->description(mode) << " THEN " << then()->description(mode) << " ELSE "
+         << otherwise()->description(mode) << " END";
 
   return stream.str();
 }

--- a/src/lib/expression/case_expression.hpp
+++ b/src/lib/expression/case_expression.hpp
@@ -24,7 +24,7 @@ class CaseExpression : public AbstractExpression {
   const std::shared_ptr<AbstractExpression>& otherwise() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
  protected:

--- a/src/lib/expression/cast_expression.cpp
+++ b/src/lib/expression/cast_expression.cpp
@@ -13,9 +13,9 @@ std::shared_ptr<AbstractExpression> CastExpression::deep_copy() const {
   return std::make_shared<CastExpression>(argument()->deep_copy(), _data_type);
 }
 
-std::string CastExpression::as_column_name() const {
+std::string CastExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << "CAST(" << argument()->as_column_name() << " AS " << _data_type << ")";
+  stream << "CAST(" << argument()->description(mode) << " AS " << _data_type << ")";
   return stream.str();
 }
 

--- a/src/lib/expression/cast_expression.hpp
+++ b/src/lib/expression/cast_expression.hpp
@@ -16,7 +16,7 @@ class CastExpression : public AbstractExpression {
   CastExpression(const std::shared_ptr<AbstractExpression>& argument, const DataType data_type);
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   std::shared_ptr<AbstractExpression> argument() const;

--- a/src/lib/expression/correlated_parameter_expression.cpp
+++ b/src/lib/expression/correlated_parameter_expression.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<AbstractExpression> CorrelatedParameterExpression::deep_copy() c
   return copy;
 }
 
-std::string CorrelatedParameterExpression::as_column_name() const {
+std::string CorrelatedParameterExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
   stream << "Parameter[";
   stream << "name=" << _referenced_expression_info.column_name << ";";

--- a/src/lib/expression/correlated_parameter_expression.hpp
+++ b/src/lib/expression/correlated_parameter_expression.hpp
@@ -35,7 +35,7 @@ class CorrelatedParameterExpression : public AbstractExpression {
 
   bool requires_computation() const override;
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const ParameterID parameter_id;

--- a/src/lib/expression/exists_expression.cpp
+++ b/src/lib/expression/exists_expression.cpp
@@ -20,10 +20,10 @@ std::shared_ptr<AbstractExpression> ExistsExpression::subquery() const {
   return arguments[0];
 }
 
-std::string ExistsExpression::as_column_name() const {
+std::string ExistsExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
   stream << (exists_expression_type == ExistsExpressionType::Exists ? "EXISTS" : "NOT EXISTS");
-  stream << "(" << subquery()->as_column_name() << ")";
+  stream << "(" << subquery()->description(mode) << ")";
   return stream.str();
 }
 

--- a/src/lib/expression/exists_expression.hpp
+++ b/src/lib/expression/exists_expression.hpp
@@ -17,7 +17,7 @@ class ExistsExpression : public AbstractExpression {
   std::shared_ptr<AbstractExpression> subquery() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const ExistsExpressionType exists_expression_type;

--- a/src/lib/expression/expression_precedence.hpp
+++ b/src/lib/expression/expression_precedence.hpp
@@ -4,7 +4,7 @@
 
 namespace opossum {
 
-// Precedence levels for parenthesizing expression arguments. See AbstractExpression::_enclose_argument_as_column_name()
+// Precedence levels for parenthesizing expression arguments. See AbstractExpression::_enclose_argument
 enum class ExpressionPrecedence : uint32_t {
   Highest = 0,
   UnaryPredicate,

--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -119,12 +119,13 @@ std::shared_ptr<LQPColumnExpression> expression_adapt_to_different_lqp(const LQP
   return std::make_shared<LQPColumnExpression>(adapted_column_reference);
 }
 
-std::string expression_column_names(const std::vector<std::shared_ptr<AbstractExpression>>& expressions) {
+std::string expression_descriptions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
+                                    const AbstractExpression::DescriptionMode mode) {
   std::stringstream stream;
 
-  if (!expressions.empty()) stream << expressions.front()->as_column_name();
+  if (!expressions.empty()) stream << expressions.front()->description(mode);
   for (auto expression_idx = size_t{1}; expression_idx < expressions.size(); ++expression_idx) {
-    stream << ", " << expressions[expression_idx]->as_column_name();
+    stream << ", " << expressions[expression_idx]->description(mode);
   }
 
   return stream.str();

--- a/src/lib/expression/expression_utils.hpp
+++ b/src/lib/expression/expression_utils.hpp
@@ -42,8 +42,8 @@ bool expression_equal_to_expression_in_different_lqp(const AbstractExpression& e
 std::vector<std::shared_ptr<AbstractExpression>> expressions_deep_copy(
     const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
-/*
- * Recurse through the expression and replace them according to replacements, where applicable
+/**
+ * Recurse through the expression and replace them according to @param mapping, where applicable
  */
 void expression_deep_replace(std::shared_ptr<AbstractExpression>& expression,
                              const ExpressionUnorderedMap<std::shared_ptr<AbstractExpression>>& mapping);
@@ -72,9 +72,10 @@ std::shared_ptr<LQPColumnExpression> expression_adapt_to_different_lqp(const LQP
                                                                        const LQPNodeMapping& node_mapping);
 
 /**
- * Create a comma separated string with the AbstractExpression::as_column_name() of each expression
+ * Create a comma separated string with the AbstractExpression::description(mode) of each expression
  */
-std::string expression_column_names(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
+std::string expression_descriptions(const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
+                                    const AbstractExpression::DescriptionMode mode);
 
 enum class ExpressionVisitation { VisitArguments, DoNotVisitArguments };
 

--- a/src/lib/expression/extract_expression.cpp
+++ b/src/lib/expression/extract_expression.cpp
@@ -36,9 +36,9 @@ std::shared_ptr<AbstractExpression> ExtractExpression::deep_copy() const {
   return std::make_shared<ExtractExpression>(datetime_component, from()->deep_copy());
 }
 
-std::string ExtractExpression::as_column_name() const {
+std::string ExtractExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << "EXTRACT(" << datetime_component << " FROM " << from()->as_column_name() << ")";
+  stream << "EXTRACT(" << datetime_component << " FROM " << from()->description(mode) << ")";
   return stream.str();
 }
 

--- a/src/lib/expression/extract_expression.hpp
+++ b/src/lib/expression/extract_expression.hpp
@@ -20,7 +20,7 @@ class ExtractExpression : public AbstractExpression {
   ExtractExpression(const DatetimeComponent datetime_component, const std::shared_ptr<AbstractExpression>& from);
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   std::shared_ptr<AbstractExpression> from() const;

--- a/src/lib/expression/function_expression.cpp
+++ b/src/lib/expression/function_expression.cpp
@@ -31,12 +31,12 @@ std::shared_ptr<AbstractExpression> FunctionExpression::deep_copy() const {
   return std::make_shared<FunctionExpression>(function_type, expressions_deep_copy(arguments));
 }
 
-std::string FunctionExpression::as_column_name() const {
+std::string FunctionExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
   stream << function_type << "(";
   for (auto argument_idx = size_t{0}; argument_idx < arguments.size(); ++argument_idx) {
-    stream << arguments[argument_idx]->as_column_name();
+    stream << arguments[argument_idx]->description(mode);
     if (argument_idx + 1 < arguments.size()) stream << ",";
   }
   stream << ")";

--- a/src/lib/expression/function_expression.hpp
+++ b/src/lib/expression/function_expression.hpp
@@ -16,7 +16,7 @@ class FunctionExpression : public AbstractExpression {
                      const std::vector<std::shared_ptr<AbstractExpression>>& arguments);
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   FunctionType function_type;

--- a/src/lib/expression/in_expression.cpp
+++ b/src/lib/expression/in_expression.cpp
@@ -25,11 +25,11 @@ std::shared_ptr<AbstractExpression> InExpression::deep_copy() const {
   return std::make_shared<InExpression>(predicate_condition, value()->deep_copy(), set()->deep_copy());
 }
 
-std::string InExpression::as_column_name() const {
+std::string InExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << _enclose_argument_as_column_name(*value()) << " ";
+  stream << _enclose_argument(*value(), mode) << " ";
   stream << predicate_condition << " ";
-  stream << set()->as_column_name();
+  stream << set()->description(mode);
   return stream.str();
 }
 

--- a/src/lib/expression/in_expression.hpp
+++ b/src/lib/expression/in_expression.hpp
@@ -22,7 +22,7 @@ class InExpression : public AbstractPredicateExpression {
   const std::shared_ptr<AbstractExpression>& set() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
 };
 
 }  // namespace opossum

--- a/src/lib/expression/is_null_expression.cpp
+++ b/src/lib/expression/is_null_expression.cpp
@@ -19,13 +19,13 @@ std::shared_ptr<AbstractExpression> IsNullExpression::deep_copy() const {
   return std::make_shared<IsNullExpression>(predicate_condition, operand()->deep_copy());
 }
 
-std::string IsNullExpression::as_column_name() const {
+std::string IsNullExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
   if (predicate_condition == PredicateCondition::IsNull) {
-    stream << _enclose_argument_as_column_name(*operand()) << " IS NULL";
+    stream << _enclose_argument(*operand(), mode) << " IS NULL";
   } else {
-    stream << _enclose_argument_as_column_name(*operand()) << " IS NOT NULL";
+    stream << _enclose_argument(*operand(), mode) << " IS NOT NULL";
   }
 
   return stream.str();

--- a/src/lib/expression/is_null_expression.hpp
+++ b/src/lib/expression/is_null_expression.hpp
@@ -13,7 +13,7 @@ class IsNullExpression : public AbstractPredicateExpression {
   const std::shared_ptr<AbstractExpression>& operand() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
 
  protected:
   ExpressionPrecedence _precedence() const override;

--- a/src/lib/expression/list_expression.cpp
+++ b/src/lib/expression/list_expression.cpp
@@ -20,8 +20,8 @@ std::shared_ptr<AbstractExpression> ListExpression::deep_copy() const {
   return std::make_shared<ListExpression>(expressions_deep_copy(arguments));
 }
 
-std::string ListExpression::as_column_name() const {
-  return std::string("(") + expression_column_names(arguments) + ")";
+std::string ListExpression::description(const DescriptionMode mode) const {
+  return std::string("(") + expression_descriptions(arguments, mode) + ")";
 }
 
 bool ListExpression::_shallow_equals(const AbstractExpression& expression) const {

--- a/src/lib/expression/list_expression.hpp
+++ b/src/lib/expression/list_expression.hpp
@@ -18,7 +18,7 @@ class ListExpression : public AbstractExpression {
   const std::vector<std::shared_ptr<AbstractExpression>>& elements() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
 
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;

--- a/src/lib/expression/logical_expression.cpp
+++ b/src/lib/expression/logical_expression.cpp
@@ -33,10 +33,10 @@ std::shared_ptr<AbstractExpression> LogicalExpression::deep_copy() const {
                                              right_operand()->deep_copy());
 }
 
-std::string LogicalExpression::as_column_name() const {
+std::string LogicalExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << _enclose_argument_as_column_name(*left_operand()) << " " << logical_operator << " "
-         << _enclose_argument_as_column_name(*right_operand());
+  stream << _enclose_argument(*left_operand(), mode) << " " << logical_operator << " "
+         << _enclose_argument(*right_operand(), mode);
   return stream.str();
 }
 

--- a/src/lib/expression/logical_expression.hpp
+++ b/src/lib/expression/logical_expression.hpp
@@ -19,7 +19,7 @@ class LogicalExpression : public AbstractExpression {
   const std::shared_ptr<AbstractExpression>& right_operand() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const LogicalOperator logical_operator;

--- a/src/lib/expression/lqp_column_expression.cpp
+++ b/src/lib/expression/lqp_column_expression.cpp
@@ -18,17 +18,14 @@ std::shared_ptr<AbstractExpression> LQPColumnExpression::deep_copy() const {
   return std::make_shared<LQPColumnExpression>(column_reference);
 }
 
-std::string LQPColumnExpression::as_column_name() const {
+std::string LQPColumnExpression::description(const DescriptionMode mode) const {
   // Even if the LQP is invalid, we still want to be able to print it as good as possible
   const auto original_node = column_reference.original_node();
   if (!original_node) return "<Expired Column>";
   if (column_reference.original_column_id() == INVALID_COLUMN_ID) return "INVALID_COLUMN_ID";
 
   if (original_node->type == LQPNodeType::StoredTable) {
-    std::stringstream stream;
-    stream << column_reference;
-    return stream.str();
-
+    return column_reference.description(mode);
   } else if (original_node->type == LQPNodeType::Mock) {
     const auto mock_node = std::static_pointer_cast<const MockNode>(original_node);
 

--- a/src/lib/expression/lqp_column_expression.hpp
+++ b/src/lib/expression/lqp_column_expression.hpp
@@ -13,7 +13,7 @@ class LQPColumnExpression : public AbstractExpression {
   explicit LQPColumnExpression(const LQPColumnReference& column_reference);
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
   bool requires_computation() const override;
 

--- a/src/lib/expression/lqp_subquery_expression.cpp
+++ b/src/lib/expression/lqp_subquery_expression.cpp
@@ -33,14 +33,14 @@ std::shared_ptr<AbstractExpression> LQPSubqueryExpression::deep_copy() const {
   return std::make_shared<LQPSubqueryExpression>(lqp_copy, parameter_ids, expressions_deep_copy(arguments));
 }
 
-std::string LQPSubqueryExpression::as_column_name() const {
+std::string LQPSubqueryExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
   stream << "SUBQUERY (LQP, " << lqp.get();
 
   if (!arguments.empty()) {
     stream << ", Parameters: ";
     for (auto parameter_idx = size_t{0}; parameter_idx < arguments.size(); ++parameter_idx) {
-      stream << "[" << arguments[parameter_idx]->as_column_name() << ", id=" << parameter_ids[parameter_idx] << "]";
+      stream << "[" << arguments[parameter_idx]->description(mode) << ", id=" << parameter_ids[parameter_idx] << "]";
       if (parameter_idx + 1 < arguments.size()) stream << ", ";
     }
   }

--- a/src/lib/expression/lqp_subquery_expression.hpp
+++ b/src/lib/expression/lqp_subquery_expression.hpp
@@ -28,7 +28,7 @@ class LQPSubqueryExpression : public AbstractExpression {
                         const std::vector<std::shared_ptr<AbstractExpression>>& parameter_expressions);
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   // Returns whether this query is correlated, i.e., uses external parameters

--- a/src/lib/expression/placeholder_expression.cpp
+++ b/src/lib/expression/placeholder_expression.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<AbstractExpression> PlaceholderExpression::deep_copy() const {
   return std::make_shared<PlaceholderExpression>(parameter_id);
 }
 
-std::string PlaceholderExpression::as_column_name() const {
+std::string PlaceholderExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
   stream << "Placeholder[id=" << std::to_string(parameter_id) << "]";
   return stream.str();

--- a/src/lib/expression/placeholder_expression.hpp
+++ b/src/lib/expression/placeholder_expression.hpp
@@ -14,7 +14,7 @@ class PlaceholderExpression : public AbstractExpression {
 
   bool requires_computation() const override;
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const ParameterID parameter_id;

--- a/src/lib/expression/pqp_column_expression.cpp
+++ b/src/lib/expression/pqp_column_expression.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<AbstractExpression> PQPColumnExpression::deep_copy() const {
   return std::make_shared<PQPColumnExpression>(column_id, _data_type, _nullable, _column_name);
 }
 
-std::string PQPColumnExpression::as_column_name() const { return _column_name; }
+std::string PQPColumnExpression::description(const DescriptionMode mode) const { return _column_name; }
 
 DataType PQPColumnExpression::data_type() const { return _data_type; }
 

--- a/src/lib/expression/pqp_column_expression.hpp
+++ b/src/lib/expression/pqp_column_expression.hpp
@@ -19,7 +19,7 @@ class PQPColumnExpression : public AbstractExpression {
                       const std::string& column_name);
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
   bool requires_computation() const override;
 

--- a/src/lib/expression/pqp_subquery_expression.cpp
+++ b/src/lib/expression/pqp_subquery_expression.cpp
@@ -36,7 +36,7 @@ DataType PQPSubqueryExpression::data_type() const {
 
 bool PQPSubqueryExpression::is_correlated() const { return !parameters.empty(); }
 
-std::string PQPSubqueryExpression::as_column_name() const {
+std::string PQPSubqueryExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
   stream << "SUBQUERY (PQP, " << pqp.get() << ")";
   return stream.str();

--- a/src/lib/expression/pqp_subquery_expression.hpp
+++ b/src/lib/expression/pqp_subquery_expression.hpp
@@ -25,7 +25,7 @@ class PQPSubqueryExpression : public AbstractExpression {
   explicit PQPSubqueryExpression(const std::shared_ptr<AbstractOperator>& pqp, const Parameters& parameters = {});
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   // Returns whether this query is correlated, i.e., uses external parameters

--- a/src/lib/expression/unary_minus_expression.cpp
+++ b/src/lib/expression/unary_minus_expression.cpp
@@ -17,9 +17,9 @@ std::shared_ptr<AbstractExpression> UnaryMinusExpression::deep_copy() const {
   return std::make_shared<UnaryMinusExpression>(argument());
 }
 
-std::string UnaryMinusExpression::as_column_name() const {
+std::string UnaryMinusExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << "-" << _enclose_argument_as_column_name(*argument());
+  stream << "-" << _enclose_argument(*argument(), mode);
   return stream.str();
 }
 

--- a/src/lib/expression/unary_minus_expression.hpp
+++ b/src/lib/expression/unary_minus_expression.hpp
@@ -14,7 +14,7 @@ class UnaryMinusExpression : public AbstractExpression {
   std::shared_ptr<AbstractExpression> argument() const;
 
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
  protected:

--- a/src/lib/expression/value_expression.cpp
+++ b/src/lib/expression/value_expression.cpp
@@ -16,7 +16,7 @@ std::shared_ptr<AbstractExpression> ValueExpression::deep_copy() const {
   return std::make_shared<ValueExpression>(value);
 }
 
-std::string ValueExpression::as_column_name() const {
+std::string ValueExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
 
   if (value.type() == typeid(pmr_string)) {

--- a/src/lib/expression/value_expression.hpp
+++ b/src/lib/expression/value_expression.hpp
@@ -14,7 +14,7 @@ class ValueExpression : public AbstractExpression {
 
   bool requires_computation() const override;
   std::shared_ptr<AbstractExpression> deep_copy() const override;
-  std::string as_column_name() const override;
+  std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 
   const AllTypeVariant value;

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -78,7 +78,7 @@ size_t AbstractLQPNode::hash() const {
         boost::hash_combine(hash, expression->hash());
       }
       boost::hash_combine(hash, node->type);
-      boost::hash_combine(hash, node->_shallow_hash());
+      boost::hash_combine(hash, node->_on_shallow_hash());
       return LQPVisitation::VisitInputs;
     } else {
       return LQPVisitation::DoNotVisitInputs;
@@ -88,7 +88,7 @@ size_t AbstractLQPNode::hash() const {
   return hash;
 }
 
-size_t AbstractLQPNode::_shallow_hash() const { return 0; }
+size_t AbstractLQPNode::_on_shallow_hash() const { return 0; }
 
 std::shared_ptr<AbstractLQPNode> AbstractLQPNode::left_input() const { return _inputs[0]; }
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -308,7 +308,7 @@ void AbstractLQPNode::_add_output_pointer(const std::shared_ptr<AbstractLQPNode>
   _outputs.emplace_back(output);
 }
 
-static AbstractExpression::DescriptionMode AbstractLQPNode::_expression_description_mode(const DescriptionMode mode) {
+AbstractExpression::DescriptionMode AbstractLQPNode::_expression_description_mode(const DescriptionMode mode) {
   switch (mode) {
     case DescriptionMode::Short:
       return AbstractExpression::DescriptionMode::ColumnName;

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -308,7 +308,7 @@ void AbstractLQPNode::_add_output_pointer(const std::shared_ptr<AbstractLQPNode>
   _outputs.emplace_back(output);
 }
 
-AbstractExpression::DescriptionMode AbstractLQPNode::_expression_description_mode(const DescriptionMode mode) const {
+static AbstractExpression::DescriptionMode AbstractLQPNode::_expression_description_mode(const DescriptionMode mode) {
   switch (mode) {
     case DescriptionMode::Short:
       return AbstractExpression::DescriptionMode::ColumnName;

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -315,6 +315,7 @@ AbstractExpression::DescriptionMode AbstractLQPNode::_expression_description_mod
     case DescriptionMode::Detailed:
       return AbstractExpression::DescriptionMode::Detailed;
   }
+  Fail("Unhandled DescriptionMode");
 }
 
 std::ostream& operator<<(std::ostream& stream, const AbstractLQPNode& node) {

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -308,6 +308,15 @@ void AbstractLQPNode::_add_output_pointer(const std::shared_ptr<AbstractLQPNode>
   _outputs.emplace_back(output);
 }
 
+AbstractExpression::DescriptionMode AbstractLQPNode::_expression_description_mode(const DescriptionMode mode) const {
+  switch (mode) {
+    case DescriptionMode::Short:
+      return AbstractExpression::DescriptionMode::ColumnName;
+    case DescriptionMode::Detailed:
+      return AbstractExpression::DescriptionMode::Detailed;
+  }
+}
+
 std::ostream& operator<<(std::ostream& stream, const AbstractLQPNode& node) {
   // Recursively collect all LQPs in LQPSubqueryExpressions (and any anywhere within those) in this LQP into a list and
   // then print them
@@ -323,10 +332,11 @@ std::ostream& operator<<(std::ostream& stream, const AbstractLQPNode& node) {
     };
 
     const auto node_print_fn = [](const auto& node2, auto& stream2) {
-      stream2 << node2->description();
+      stream2 << node2->description(AbstractLQPNode::DescriptionMode::Detailed);
       if (!node2->comment.empty()) {
         stream2 << " (" << node2->comment << ")";
       }
+      stream2 << " @ " << node2;
     };
 
     print_directed_acyclic_graph<const AbstractLQPNode>(root.shared_from_this(), get_inputs_fn, node_print_fn, stream);

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -5,11 +5,10 @@
 #include <vector>
 
 #include "enable_make_for_lqp_node.hpp"
+#include "expression/abstract_expression.hpp"
 #include "types.hpp"
 
 namespace opossum {
-
-class AbstractExpression;
 
 enum class LQPNodeType {
   Aggregate,
@@ -55,7 +54,8 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   /**
    * @return a string describing this node, but nothing about its inputs.
    */
-  virtual std::string description() const = 0;
+  enum class DescriptionMode { Short, Detailed };
+  virtual std::string description(const DescriptionMode mode = DescriptionMode::Short) const = 0;
 
   /**
    * @defgroup Access the outputs/inputs
@@ -169,6 +169,11 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
    * automatically added to the description.
    */
   std::string comment;
+
+  /*
+   * Converts an AbstractLQPNode::DescriptionMode to an AbstractExpression::DescriptionMode
+   */
+  AbstractExpression::DescriptionMode _expression_description_mode(const DescriptionMode mode) const;
 
  protected:
   /**

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -180,7 +180,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
    * Override to hash data fields in derived types. No override needed if derived expression has no
    * data members.
    */
-  virtual size_t _shallow_hash() const;
+  virtual size_t _on_shallow_hash() const;
   virtual std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const = 0;
   virtual bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const = 0;
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -173,7 +173,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   /*
    * Converts an AbstractLQPNode::DescriptionMode to an AbstractExpression::DescriptionMode
    */
-  AbstractExpression::DescriptionMode _expression_description_mode(const DescriptionMode mode) const;
+  static AbstractExpression::DescriptionMode _expression_description_mode(const DescriptionMode mode);
 
  protected:
   /**

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -170,11 +170,6 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
    */
   std::string comment;
 
-  /*
-   * Converts an AbstractLQPNode::DescriptionMode to an AbstractExpression::DescriptionMode
-   */
-  static AbstractExpression::DescriptionMode _expression_description_mode(const DescriptionMode mode);
-
  protected:
   /**
    * Override to hash data fields in derived types. No override needed if derived expression has no
@@ -183,6 +178,11 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   virtual size_t _on_shallow_hash() const;
   virtual std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const = 0;
   virtual bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const = 0;
+
+  /*
+   * Converts an AbstractLQPNode::DescriptionMode to an AbstractExpression::DescriptionMode
+   */
+  static AbstractExpression::DescriptionMode _expression_description_mode(const DescriptionMode mode);
 
  private:
   std::shared_ptr<AbstractLQPNode> _deep_copy_impl(LQPNodeMapping& node_mapping) const;

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -32,14 +32,15 @@ AggregateNode::AggregateNode(const std::vector<std::shared_ptr<AbstractExpressio
             node_expressions.begin() + group_by_expressions.size());
 }
 
-std::string AggregateNode::description() const {
+std::string AggregateNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
   std::stringstream stream;
 
   stream << "[Aggregate] ";
 
   stream << "GroupBy: [";
   for (auto expression_idx = size_t{0}; expression_idx < aggregate_expressions_begin_idx; ++expression_idx) {
-    stream << node_expressions[expression_idx]->as_column_name();
+    stream << node_expressions[expression_idx]->description(expression_mode);
     if (expression_idx + 1 < aggregate_expressions_begin_idx) stream << ", ";
   }
   stream << "] ";
@@ -47,7 +48,7 @@ std::string AggregateNode::description() const {
   stream << "Aggregates: [";
   for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < node_expressions.size();
        ++expression_idx) {
-    stream << node_expressions[expression_idx]->as_column_name();
+    stream << node_expressions[expression_idx]->description(expression_mode);
     if (expression_idx + 1 < node_expressions.size()) stream << ", ";
   }
   stream << "]";

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<AbstractLQPNode> AggregateNode::_on_shallow_copy(LQPNodeMapping&
       expressions_copy_and_adapt_to_different_lqp(aggregate_expressions, node_mapping));
 }
 
-size_t AggregateNode::_shallow_hash() const { return aggregate_expressions_begin_idx; }
+size_t AggregateNode::_on_shallow_hash() const { return aggregate_expressions_begin_idx; }
 
 bool AggregateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& aggregate_node = static_cast<const AggregateNode&>(rhs);

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -23,7 +23,7 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
   AggregateNode(const std::vector<std::shared_ptr<AbstractExpression>>& group_by_expressions,
                 const std::vector<std::shared_ptr<AbstractExpression>>& aggregate_expressions);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -31,7 +31,7 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
   const size_t aggregate_expressions_begin_idx;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -33,7 +33,7 @@ const std::vector<std::shared_ptr<AbstractExpression>>& AliasNode::column_expres
   return node_expressions;
 }
 
-size_t AliasNode::_shallow_hash() const {
+size_t AliasNode::_on_shallow_hash() const {
   size_t hash{0};
   for (const auto& alias : aliases) {
     boost::hash_combine(hash, alias);

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -13,14 +13,15 @@ AliasNode::AliasNode(const std::vector<std::shared_ptr<AbstractExpression>>& exp
   Assert(expressions.size() == aliases.size(), "Number of expressions and number of aliases has to be equal.");
 }
 
-std::string AliasNode::description() const {
+std::string AliasNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
   std::stringstream stream;
   stream << "[Alias] ";
   for (auto column_id = ColumnID{0}; column_id < node_expressions.size(); ++column_id) {
-    if (node_expressions[column_id]->as_column_name() == aliases[column_id]) {
+    if (node_expressions[column_id]->description(expression_mode) == aliases[column_id]) {
       stream << aliases[column_id];
     } else {
-      stream << node_expressions[column_id]->as_column_name() << " AS " << aliases[column_id];
+      stream << node_expressions[column_id]->description(expression_mode) << " AS " << aliases[column_id];
     }
 
     if (column_id + 1u < node_expressions.size()) stream << ", ";

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -22,7 +22,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
   const std::vector<std::string> aliases;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -16,7 +16,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
   AliasNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
             const std::vector<std::string>& aliases);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 
   const std::vector<std::string> aliases;

--- a/src/lib/logical_query_plan/create_prepared_plan_node.cpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.cpp
@@ -19,7 +19,7 @@ std::string CreatePreparedPlanNode::description(const DescriptionMode mode) cons
   return stream.str();
 }
 
-size_t CreatePreparedPlanNode::_shallow_hash() const {
+size_t CreatePreparedPlanNode::_on_shallow_hash() const {
   auto hash = prepared_plan->hash();
   boost::hash_combine(hash, name);
   return hash;

--- a/src/lib/logical_query_plan/create_prepared_plan_node.cpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.cpp
@@ -10,7 +10,7 @@ CreatePreparedPlanNode::CreatePreparedPlanNode(const std::string& name,
                                                const std::shared_ptr<PreparedPlan>& prepared_plan)
     : BaseNonQueryNode(LQPNodeType::CreatePreparedPlan), name(name), prepared_plan(prepared_plan) {}
 
-std::string CreatePreparedPlanNode::description() const {
+std::string CreatePreparedPlanNode::description(const DescriptionMode mode) const {
   std::stringstream stream;
   stream << "[CreatePreparedPlan] '" << name << "' {\n";
   stream << *prepared_plan;

--- a/src/lib/logical_query_plan/create_prepared_plan_node.hpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.hpp
@@ -13,7 +13,7 @@ class CreatePreparedPlanNode : public EnableMakeForLQPNode<CreatePreparedPlanNod
  public:
   CreatePreparedPlanNode(const std::string& name, const std::shared_ptr<PreparedPlan>& prepared_plan);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   std::string name;
   std::shared_ptr<PreparedPlan> prepared_plan;

--- a/src/lib/logical_query_plan/create_prepared_plan_node.hpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.hpp
@@ -19,7 +19,7 @@ class CreatePreparedPlanNode : public EnableMakeForLQPNode<CreatePreparedPlanNod
   std::shared_ptr<PreparedPlan> prepared_plan;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/create_table_node.cpp
+++ b/src/lib/logical_query_plan/create_table_node.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 CreateTableNode::CreateTableNode(const std::string& table_name, const bool if_not_exists)
     : BaseNonQueryNode(LQPNodeType::CreateTable), table_name(table_name), if_not_exists(if_not_exists) {}
 
-std::string CreateTableNode::description() const {
+std::string CreateTableNode::description(const DescriptionMode mode) const {
   std::ostringstream stream;
 
   stream << "[CreateTable] " << (if_not_exists ? "IfNotExists " : "");

--- a/src/lib/logical_query_plan/create_table_node.cpp
+++ b/src/lib/logical_query_plan/create_table_node.cpp
@@ -19,7 +19,7 @@ std::string CreateTableNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-size_t CreateTableNode::_shallow_hash() const {
+size_t CreateTableNode::_on_shallow_hash() const {
   auto hash = boost::hash_value(table_name);
   boost::hash_combine(hash, if_not_exists);
   return hash;

--- a/src/lib/logical_query_plan/create_table_node.hpp
+++ b/src/lib/logical_query_plan/create_table_node.hpp
@@ -21,7 +21,7 @@ class CreateTableNode : public EnableMakeForLQPNode<CreateTableNode>, public Bas
   const bool if_not_exists;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/create_table_node.hpp
+++ b/src/lib/logical_query_plan/create_table_node.hpp
@@ -15,7 +15,7 @@ class CreateTableNode : public EnableMakeForLQPNode<CreateTableNode>, public Bas
  public:
   CreateTableNode(const std::string& table_name, bool if_not_exists);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::string table_name;
   const bool if_not_exists;

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -11,7 +11,7 @@ CreateViewNode::CreateViewNode(const std::string& view_name, const std::shared_p
                                const bool if_not_exists)
     : BaseNonQueryNode(LQPNodeType::CreateView), view_name(view_name), view(view), if_not_exists(if_not_exists) {}
 
-std::string CreateViewNode::description() const {
+std::string CreateViewNode::description(const DescriptionMode mode) const {
   std::ostringstream stream;
   stream << "[CreateView] " << (if_not_exists ? "IfNotExists " : "");
   stream << "Name: " << view_name << ", Columns: ";

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -25,7 +25,7 @@ std::string CreateViewNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-size_t CreateViewNode::_shallow_hash() const {
+size_t CreateViewNode::_on_shallow_hash() const {
   auto hash = boost::hash_value(view_name);
   boost::hash_combine(hash, view);
   boost::hash_combine(hash, if_not_exists);

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -15,7 +15,7 @@ class CreateViewNode : public EnableMakeForLQPNode<CreateViewNode>, public BaseN
  public:
   CreateViewNode(const std::string& view_name, const std::shared_ptr<LQPView>& view, bool if_not_exists);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::string view_name;
   const std::shared_ptr<LQPView> view;

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -22,7 +22,7 @@ class CreateViewNode : public EnableMakeForLQPNode<CreateViewNode>, public BaseN
   const bool if_not_exists;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -11,13 +11,7 @@ namespace opossum {
 
 DeleteNode::DeleteNode() : AbstractLQPNode(LQPNodeType::Delete) {}
 
-std::string DeleteNode::description() const {
-  std::ostringstream desc;
-
-  desc << "[Delete]";
-
-  return desc.str();
-}
+std::string DeleteNode::description(const DescriptionMode mode) const { return "[Delete]"; }
 
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -14,7 +14,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
  public:
   DeleteNode();
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 

--- a/src/lib/logical_query_plan/drop_table_node.cpp
+++ b/src/lib/logical_query_plan/drop_table_node.cpp
@@ -9,7 +9,7 @@ std::string DropTableNode::description(const DescriptionMode mode) const {
   return std::string("[DropTable] Name: '") + table_name + "'";
 }
 
-size_t DropTableNode::_shallow_hash() const {
+size_t DropTableNode::_on_shallow_hash() const {
   auto hash = boost::hash_value(table_name);
   boost::hash_combine(hash, if_exists);
   return hash;

--- a/src/lib/logical_query_plan/drop_table_node.cpp
+++ b/src/lib/logical_query_plan/drop_table_node.cpp
@@ -5,7 +5,9 @@ namespace opossum {
 DropTableNode::DropTableNode(const std::string& table_name, const bool if_exists)
     : BaseNonQueryNode(LQPNodeType::DropTable), table_name(table_name), if_exists(if_exists) {}
 
-std::string DropTableNode::description() const { return std::string("[DropTable] Name: '") + table_name + "'"; }
+std::string DropTableNode::description(const DescriptionMode mode) const {
+  return std::string("[DropTable] Name: '") + table_name + "'";
+}
 
 size_t DropTableNode::_shallow_hash() const {
   auto hash = boost::hash_value(table_name);

--- a/src/lib/logical_query_plan/drop_table_node.hpp
+++ b/src/lib/logical_query_plan/drop_table_node.hpp
@@ -15,7 +15,7 @@ class DropTableNode : public EnableMakeForLQPNode<DropTableNode>, public BaseNon
   const bool if_exists;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/drop_table_node.hpp
+++ b/src/lib/logical_query_plan/drop_table_node.hpp
@@ -9,7 +9,7 @@ class DropTableNode : public EnableMakeForLQPNode<DropTableNode>, public BaseNon
  public:
   DropTableNode(const std::string& table_name, bool if_exists);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::string table_name;
   const bool if_exists;

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -16,7 +16,7 @@ DropViewNode::DropViewNode(const std::string& view_name, const bool if_exists)
 
 std::string DropViewNode::description(const DescriptionMode mode) const { return "[Drop] View: '"s + view_name + "'"; }
 
-size_t DropViewNode::_shallow_hash() const {
+size_t DropViewNode::_on_shallow_hash() const {
   auto hash = boost::hash_value(view_name);
   boost::hash_combine(hash, if_exists);
   return hash;

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -14,7 +14,7 @@ namespace opossum {
 DropViewNode::DropViewNode(const std::string& view_name, const bool if_exists)
     : BaseNonQueryNode(LQPNodeType::DropView), view_name(view_name), if_exists(if_exists) {}
 
-std::string DropViewNode::description() const { return "[Drop] View: '"s + view_name + "'"; }
+std::string DropViewNode::description(const DescriptionMode mode) const { return "[Drop] View: '"s + view_name + "'"; }
 
 size_t DropViewNode::_shallow_hash() const {
   auto hash = boost::hash_value(view_name);

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -20,7 +20,7 @@ class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public BaseNonQu
   const bool if_exists;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -14,7 +14,7 @@ class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public BaseNonQu
  public:
   DropViewNode(const std::string& view_name, bool if_exists);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::string view_name;
   const bool if_exists;

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -12,7 +12,7 @@ namespace opossum {
 
 DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
-std::string DummyTableNode::description() const { return "[DummyTable]"; }
+std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& DummyTableNode::column_expressions() const {
   return _column_expressions;

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -16,7 +16,7 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
  public:
   DummyTableNode();
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -27,7 +27,7 @@ const std::vector<std::shared_ptr<AbstractExpression>>& InsertNode::column_expre
   return empty_vector;
 }
 
-size_t InsertNode::_shallow_hash() const { return boost::hash_value(table_name); }
+size_t InsertNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 
 std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return InsertNode::make(table_name);

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -12,7 +12,7 @@ namespace opossum {
 
 InsertNode::InsertNode(const std::string& table_name) : AbstractLQPNode(LQPNodeType::Insert), table_name(table_name) {}
 
-std::string InsertNode::description() const {
+std::string InsertNode::description(const DescriptionMode mode) const {
   std::ostringstream desc;
 
   desc << "[Insert] Into table '" << table_name << "'";

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -22,7 +22,7 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
   const std::string table_name;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -15,7 +15,7 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
  public:
   explicit InsertNode(const std::string& table_name);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -98,7 +98,7 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
 
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicates() const { return node_expressions; }
 
-size_t JoinNode::_shallow_hash() const { return boost::hash_value(join_mode); }
+size_t JoinNode::_on_shallow_hash() const { return boost::hash_value(join_mode); }
 
 std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   if (!join_predicates().empty()) {

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -32,19 +32,21 @@ JoinNode::JoinNode(const JoinMode join_mode, const std::vector<std::shared_ptr<A
   Assert(!join_predicates.empty(), "Non-Cross Joins require predicates");
 }
 
-std::string JoinNode::description() const {
+std::string JoinNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
+
   std::stringstream stream;
   stream << "[Join] Mode: " << join_mode;
 
   for (const auto& predicate : join_predicates()) {
-    stream << " [" << predicate->as_column_name() << "]";
+    stream << " [" << predicate->description(expression_mode) << "]";
   }
 
   return stream.str();
 }
 
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::column_expressions() const {
-  Assert(left_input() && right_input(), "Both inputs need to be set to determine a JoiNode's output expressions");
+  Assert(left_input() && right_input(), "Both inputs need to be set to determine a JoinNode's output expressions");
 
   /**
    * Update the JoinNode's output expressions every time they are requested. An overhead, but keeps the LQP code simple.

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -28,7 +28,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   // Constructor for multi predicated joins
   JoinNode(const JoinMode join_mode, const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -37,7 +37,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   JoinMode join_mode;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 

--- a/src/lib/logical_query_plan/limit_node.cpp
+++ b/src/lib/logical_query_plan/limit_node.cpp
@@ -12,9 +12,11 @@ namespace opossum {
 LimitNode::LimitNode(const std::shared_ptr<AbstractExpression>& num_rows_expression)
     : AbstractLQPNode(LQPNodeType::Limit, {num_rows_expression}) {}
 
-std::string LimitNode::description() const {
+std::string LimitNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
+
   std::stringstream stream;
-  stream << "[Limit] " << num_rows_expression()->as_column_name();
+  stream << "[Limit] " << num_rows_expression()->description(expression_mode);
   return stream.str();
 }
 

--- a/src/lib/logical_query_plan/limit_node.hpp
+++ b/src/lib/logical_query_plan/limit_node.hpp
@@ -13,7 +13,7 @@ class LimitNode : public EnableMakeForLQPNode<LimitNode>, public AbstractLQPNode
  public:
   explicit LimitNode(const std::shared_ptr<AbstractExpression>& num_rows_expression);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   std::shared_ptr<AbstractExpression> num_rows_expression() const;
 

--- a/src/lib/logical_query_plan/logical_plan_root_node.cpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.cpp
@@ -8,7 +8,7 @@ namespace opossum {
 
 LogicalPlanRootNode::LogicalPlanRootNode() : AbstractLQPNode(LQPNodeType::Root) {}
 
-std::string LogicalPlanRootNode::description() const { return "[LogicalPlanRootNode]"; }
+std::string LogicalPlanRootNode::description(const DescriptionMode mode) const { return "[LogicalPlanRootNode]"; }
 
 std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return make();

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -18,7 +18,7 @@ class LogicalPlanRootNode : public EnableMakeForLQPNode<LogicalPlanRootNode>, pu
  public:
   LogicalPlanRootNode();
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/logical_query_plan/lqp_column_reference.cpp
+++ b/src/lib/logical_query_plan/lqp_column_reference.cpp
@@ -24,34 +24,44 @@ bool LQPColumnReference::operator==(const LQPColumnReference& rhs) const {
   return original_node() == rhs.original_node() && _original_column_id == rhs._original_column_id;
 }
 
-std::ostream& operator<<(std::ostream& os, const LQPColumnReference& column_reference) {
-  const auto original_node = column_reference.original_node();
-  Assert(original_node, "OriginalNode has expired");
+std::string LQPColumnReference::description(AbstractExpression::DescriptionMode mode) const {
+  const auto locked_original_node = original_node();
+  Assert(locked_original_node, "OriginalNode has expired");
 
-  if (column_reference.original_column_id() == INVALID_COLUMN_ID) {
-    os << "INVALID_COLUMN_ID";
-    return os;
+  std::stringstream output;
+  if (mode == AbstractExpression::DescriptionMode::Detailed) {
+    output << locked_original_node << ".";
   }
 
-  switch (original_node->type) {
+  if (_original_column_id == INVALID_COLUMN_ID) {
+    output << "INVALID_COLUMN_ID";
+    return output.str();
+  }
+
+  switch (locked_original_node->type) {
     case LQPNodeType::StoredTable: {
-      const auto stored_table_node = std::static_pointer_cast<const StoredTableNode>(column_reference.original_node());
+      const auto stored_table_node = std::static_pointer_cast<const StoredTableNode>(locked_original_node);
       const auto table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
-      os << table->column_name(column_reference.original_column_id());
+      output << table->column_name(_original_column_id);
     } break;
     case LQPNodeType::Mock: {
-      const auto mock_node = std::static_pointer_cast<const MockNode>(column_reference.original_node());
-      os << mock_node->column_definitions().at(column_reference.original_column_id()).second;
+      const auto mock_node = std::static_pointer_cast<const MockNode>(locked_original_node);
+      output << mock_node->column_definitions().at(_original_column_id).second;
     } break;
     case LQPNodeType::StaticTable: {
-      const auto static_table_node = std::static_pointer_cast<const StaticTableNode>(column_reference.original_node());
+      const auto static_table_node = std::static_pointer_cast<const StaticTableNode>(locked_original_node);
       const auto& table = static_table_node->table;
-      os << table->column_name(column_reference.original_column_id());
+      output << table->column_name(_original_column_id);
     } break;
     default:
       Fail("Unexpected original_node for LQPColumnReference");
   }
 
+  return output.str();
+}
+
+std::ostream& operator<<(std::ostream& os, const LQPColumnReference& column_reference) {
+  os << column_reference.description(AbstractExpression::DescriptionMode::Detailed);
   return os;
 }
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_column_reference.hpp
+++ b/src/lib/logical_query_plan/lqp_column_reference.hpp
@@ -31,7 +31,7 @@ class LQPColumnReference final {
   ColumnID _original_column_id{INVALID_COLUMN_ID};
 };
 
-// std::ostream& operator<<(std::ostream& os, const LQPColumnReference& column_reference);
+std::ostream& operator<<(std::ostream& os, const LQPColumnReference& column_reference);
 }  // namespace opossum
 
 namespace std {

--- a/src/lib/logical_query_plan/lqp_column_reference.hpp
+++ b/src/lib/logical_query_plan/lqp_column_reference.hpp
@@ -2,11 +2,10 @@
 
 #include <memory>
 
+#include "expression/abstract_expression.hpp"
 #include "types.hpp"
 
 namespace opossum {
-
-class AbstractLQPNode;
 
 /**
  * Used for identifying a Column in an LQP by the Node and the ColumnID in that node in which it was created.
@@ -23,13 +22,16 @@ class LQPColumnReference final {
 
   bool operator==(const LQPColumnReference& rhs) const;
 
+  // Indirection through AbstractExpression will be gone with #1893
+  std::string description(AbstractExpression::DescriptionMode mode) const;
+
  private:
   // Needs to be weak since Nodes can hold ColumnReferences referring to themselves
   std::weak_ptr<const AbstractLQPNode> _original_node;
   ColumnID _original_column_id{INVALID_COLUMN_ID};
 };
 
-std::ostream& operator<<(std::ostream& os, const LQPColumnReference& column_reference);
+// std::ostream& operator<<(std::ostream& os, const LQPColumnReference& column_reference);
 }  // namespace opossum
 
 namespace std {

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -111,7 +111,6 @@ std::shared_ptr<AbstractLQPNode> MockNode::_on_shallow_copy(LQPNodeMapping& node
   const auto mock_node = MockNode::make(_column_definitions, name);
   mock_node->set_table_statistics(_table_statistics);
   mock_node->set_pruned_column_ids(_pruned_column_ids);
-  mock_node->name = name;
   return mock_node;
 }
 

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -95,7 +95,7 @@ void MockNode::set_table_statistics(const std::shared_ptr<TableStatistics>& tabl
   _table_statistics = table_statistics;
 }
 
-size_t MockNode::_shallow_hash() const {
+size_t MockNode::_on_shallow_hash() const {
   auto hash = boost::hash_value(_table_statistics);
   for (const auto& pruned_column_id : _pruned_column_ids) {
     boost::hash_combine(hash, static_cast<size_t>(pruned_column_id));

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -70,7 +70,7 @@ void MockNode::set_pruned_column_ids(const std::vector<ColumnID>& pruned_column_
 
 const std::vector<ColumnID>& MockNode::pruned_column_ids() const { return _pruned_column_ids; }
 
-std::string MockNode::description() const {
+std::string MockNode::description(const DescriptionMode mode) const {
   std::ostringstream stream;
   stream << "[MockNode '"s << name.value_or("Unnamed") << "'] Columns:";
 
@@ -108,7 +108,7 @@ size_t MockNode::_shallow_hash() const {
 }
 
 std::shared_ptr<AbstractLQPNode> MockNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  const auto mock_node = MockNode::make(_column_definitions);
+  const auto mock_node = MockNode::make(_column_definitions, name);
   mock_node->set_table_statistics(_table_statistics);
   mock_node->set_pruned_column_ids(_pruned_column_ids);
   mock_node->name = name;

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -42,7 +42,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
   const std::vector<ColumnID>& pruned_column_ids() const;
   /** @} */
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::shared_ptr<TableStatistics>& table_statistics() const;
   void set_table_statistics(const std::shared_ptr<TableStatistics>& table_statistics);

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -50,7 +50,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
   std::optional<std::string> name;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -30,7 +30,7 @@ std::string PredicateNode::description(const DescriptionMode mode) const {
 
 std::shared_ptr<AbstractExpression> PredicateNode::predicate() const { return node_expressions[0]; }
 
-size_t PredicateNode::_shallow_hash() const { return boost::hash_value(scan_type); }
+size_t PredicateNode::_on_shallow_hash() const { return boost::hash_value(scan_type); }
 
 std::shared_ptr<AbstractLQPNode> PredicateNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return std::make_shared<PredicateNode>(expression_copy_and_adapt_to_different_lqp(*predicate(), node_mapping));

--- a/src/lib/logical_query_plan/predicate_node.cpp
+++ b/src/lib/logical_query_plan/predicate_node.cpp
@@ -20,9 +20,11 @@ namespace opossum {
 PredicateNode::PredicateNode(const std::shared_ptr<AbstractExpression>& predicate)
     : AbstractLQPNode(LQPNodeType::Predicate, {predicate}) {}
 
-std::string PredicateNode::description() const {
+std::string PredicateNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
+
   std::stringstream stream;
-  stream << "[Predicate] " << predicate()->as_column_name();
+  stream << "[Predicate] " << predicate()->description(expression_mode);
   return stream.str();
 }
 

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -27,7 +27,7 @@ class PredicateNode : public EnableMakeForLQPNode<PredicateNode>, public Abstrac
  public:
   explicit PredicateNode(const std::shared_ptr<AbstractExpression>& predicate);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   std::shared_ptr<AbstractExpression> predicate() const;
 

--- a/src/lib/logical_query_plan/predicate_node.hpp
+++ b/src/lib/logical_query_plan/predicate_node.hpp
@@ -34,7 +34,7 @@ class PredicateNode : public EnableMakeForLQPNode<PredicateNode>, public Abstrac
   ScanType scan_type{ScanType::TableScan};
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -11,10 +11,12 @@ namespace opossum {
 ProjectionNode::ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions)
     : AbstractLQPNode(LQPNodeType::Projection, expressions) {}
 
-std::string ProjectionNode::description() const {
+std::string ProjectionNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
+
   std::stringstream stream;
 
-  stream << "[Projection] " << expression_column_names(node_expressions);
+  stream << "[Projection] " << expression_descriptions(node_expressions, expression_mode);
 
   return stream.str();
 }

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -11,7 +11,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
  public:
   explicit ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -17,13 +17,15 @@ SortNode::SortNode(const std::vector<std::shared_ptr<AbstractExpression>>& expre
   Assert(expressions.size() == order_by_modes.size(), "Expected as many Expressions as OrderByModes");
 }
 
-std::string SortNode::description() const {
+std::string SortNode::description(const DescriptionMode mode) const {
+  const auto expression_mode = _expression_description_mode(mode);
+
   std::stringstream stream;
 
   stream << "[Sort] ";
 
   for (auto expression_idx = size_t{0}; expression_idx < node_expressions.size(); ++expression_idx) {
-    stream << node_expressions[expression_idx]->as_column_name() << " ";
+    stream << node_expressions[expression_idx]->description(expression_mode) << " ";
     stream << "(" << order_by_modes[expression_idx] << ")";
 
     if (expression_idx + 1 < node_expressions.size()) stream << ", ";

--- a/src/lib/logical_query_plan/sort_node.cpp
+++ b/src/lib/logical_query_plan/sort_node.cpp
@@ -33,7 +33,7 @@ std::string SortNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-size_t SortNode::_shallow_hash() const {
+size_t SortNode::_on_shallow_hash() const {
   size_t hash{0};
   for (const auto& order_by_mode : order_by_modes) {
     boost::hash_combine(hash, order_by_mode);

--- a/src/lib/logical_query_plan/sort_node.hpp
+++ b/src/lib/logical_query_plan/sort_node.hpp
@@ -17,7 +17,7 @@ class SortNode : public EnableMakeForLQPNode<SortNode>, public AbstractLQPNode {
   explicit SortNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions,
                     const std::vector<OrderByMode>& order_by_modes);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::vector<OrderByMode> order_by_modes;
 

--- a/src/lib/logical_query_plan/sort_node.hpp
+++ b/src/lib/logical_query_plan/sort_node.hpp
@@ -22,7 +22,7 @@ class SortNode : public EnableMakeForLQPNode<SortNode>, public AbstractLQPNode {
   const std::vector<OrderByMode> order_by_modes;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -47,7 +47,7 @@ bool StaticTableNode::is_column_nullable(const ColumnID column_id) const {
   return table->column_is_nullable(column_id);
 }
 
-size_t StaticTableNode::_shallow_hash() const {
+size_t StaticTableNode::_on_shallow_hash() const {
   size_t hash{0};
   for (const auto& column_definition : table->column_definitions()) {
     boost::hash_combine(hash, column_definition.hash());

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 StaticTableNode::StaticTableNode(const std::shared_ptr<Table>& table)
     : BaseNonQueryNode(LQPNodeType::StaticTable), table(table) {}
 
-std::string StaticTableNode::description() const {
+std::string StaticTableNode::description(const DescriptionMode mode) const {
   std::ostringstream stream;
 
   stream << "[StaticTable]:"

--- a/src/lib/logical_query_plan/static_table_node.hpp
+++ b/src/lib/logical_query_plan/static_table_node.hpp
@@ -25,7 +25,7 @@ class StaticTableNode : public EnableMakeForLQPNode<StaticTableNode>, public Bas
  protected:
   mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _column_expressions;
 
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/static_table_node.hpp
+++ b/src/lib/logical_query_plan/static_table_node.hpp
@@ -15,7 +15,7 @@ class StaticTableNode : public EnableMakeForLQPNode<StaticTableNode>, public Bas
  public:
   explicit StaticTableNode(const std::shared_ptr<Table>& table);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -128,7 +128,7 @@ std::vector<IndexStatistics> StoredTableNode::indexes_statistics() const {
   return pruned_indexes_statistics;
 }
 
-size_t StoredTableNode::_shallow_hash() const {
+size_t StoredTableNode::_on_shallow_hash() const {
   size_t hash{0};
   boost::hash_combine(hash, table_name);
   for (const auto& pruned_chunk_id : _pruned_chunk_ids) {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -49,7 +49,7 @@ void StoredTableNode::set_pruned_column_ids(const std::vector<ColumnID>& pruned_
 
 const std::vector<ColumnID>& StoredTableNode::pruned_column_ids() const { return _pruned_column_ids; }
 
-std::string StoredTableNode::description() const {
+std::string StoredTableNode::description(const DescriptionMode mode) const {
   const auto stored_table = Hyrise::get().storage_manager.get_table(table_name);
 
   std::ostringstream stream;

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -50,7 +50,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   std::shared_ptr<TableStatistics> table_statistics;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -39,7 +39,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
 
   std::vector<IndexStatistics> indexes_statistics() const;
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -13,7 +13,9 @@ namespace opossum {
 
 UnionNode::UnionNode(const UnionMode union_mode) : AbstractLQPNode(LQPNodeType::Union), union_mode(union_mode) {}
 
-std::string UnionNode::description() const { return "[UnionNode] Mode: " + union_mode_to_string.left.at(union_mode); }
+std::string UnionNode::description(const DescriptionMode mode) const {
+  return "[UnionNode] Mode: " + union_mode_to_string.left.at(union_mode);
+}
 
 const std::vector<std::shared_ptr<AbstractExpression>>& UnionNode::column_expressions() const {
   Assert(expressions_equal(left_input()->column_expressions(), right_input()->column_expressions()),

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -29,7 +29,7 @@ bool UnionNode::is_column_nullable(const ColumnID column_id) const {
   return left_input()->is_column_nullable(column_id) || right_input()->is_column_nullable(column_id);
 }
 
-size_t UnionNode::_shallow_hash() const { return boost::hash_value(union_mode); }
+size_t UnionNode::_on_shallow_hash() const { return boost::hash_value(union_mode); }
 
 std::shared_ptr<AbstractLQPNode> UnionNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return UnionNode::make(union_mode);

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -20,7 +20,7 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
   const UnionMode union_mode;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -13,7 +13,7 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
  public:
   explicit UnionNode(const UnionMode union_mode);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -31,7 +31,7 @@ const std::vector<std::shared_ptr<AbstractExpression>>& UpdateNode::column_expre
   return empty_vector;
 }
 
-size_t UpdateNode::_shallow_hash() const { return boost::hash_value(table_name); }
+size_t UpdateNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& update_node_rhs = static_cast<const UpdateNode&>(rhs);

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -12,7 +12,7 @@ namespace opossum {
 
 UpdateNode::UpdateNode(const std::string& table_name) : BaseNonQueryNode(LQPNodeType::Update), table_name(table_name) {}
 
-std::string UpdateNode::description() const {
+std::string UpdateNode::description(const DescriptionMode mode) const {
   std::ostringstream desc;
 
   desc << "[Update] Table: '" << table_name << "'";

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -24,7 +24,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
   const std::string table_name;
 
  protected:
-  size_t _shallow_hash() const override;
+  size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 };

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -17,7 +17,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
  public:
   explicit UpdateNode(const std::string& table_name);
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
   const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
 

--- a/src/lib/logical_query_plan/validate_node.cpp
+++ b/src/lib/logical_query_plan/validate_node.cpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 ValidateNode::ValidateNode() : AbstractLQPNode(LQPNodeType::Validate) {}
 
-std::string ValidateNode::description() const { return "[Validate]"; }
+std::string ValidateNode::description(const DescriptionMode mode) const { return "[Validate]"; }
 
 std::shared_ptr<AbstractLQPNode> ValidateNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   return ValidateNode::make();

--- a/src/lib/logical_query_plan/validate_node.hpp
+++ b/src/lib/logical_query_plan/validate_node.hpp
@@ -13,7 +13,7 @@ class ValidateNode : public EnableMakeForLQPNode<ValidateNode>, public AbstractL
  public:
   ValidateNode();
 
-  std::string description() const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/utils/string_utils.cpp
+++ b/src/lib/utils/string_utils.cpp
@@ -47,7 +47,7 @@ std::string trim_source_file_path(const std::string& path) {
 }
 
 std::string replace_addresses(const std::string& input) {
-  return std::regex_replace(input, std::regex{"0x[0-9A-Fa-f]{8,}"}, "0x00000000");
+  return std::regex_replace(input, std::regex{"0x[0-9A-Fa-f]{4,}"}, "0x00000000");
 }
 
 }  // namespace opossum

--- a/src/lib/utils/string_utils.cpp
+++ b/src/lib/utils/string_utils.cpp
@@ -1,7 +1,9 @@
+#include "string_utils.hpp"
+
+#include <regex>
+
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
-
-#include "string_utils.hpp"
 
 namespace opossum {
 
@@ -42,6 +44,10 @@ std::string trim_source_file_path(const std::string& path) {
 
   // "+ 1", since we want "src/lib/file.cpp" and not "/src/lib/file.cpp"
   return path.substr(src_pos + 1);
+}
+
+std::string replace_addresses(const std::string& input) {
+  return std::regex_replace(input, std::regex{"0x[0-9A-Fa-f]{8,}"}, "0x00000000");
 }
 
 }  // namespace opossum

--- a/src/lib/utils/string_utils.hpp
+++ b/src/lib/utils/string_utils.hpp
@@ -19,4 +19,8 @@ std::string plugin_name_from_path(const std::filesystem::path& path);
 // "/long/very/long/path/1234/src/lib/file.cpp" to "src/lib/file.cpp"
 std::string trim_source_file_path(const std::string& path);
 
+// Some description() implementations print addresses, which are non-deterministic. This method replaces them with
+// a dummy address (e.g., for testing).
+std::string replace_addresses(const std::string& input);
+
 }  // namespace opossum

--- a/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
+++ b/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
@@ -4,6 +4,7 @@
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/mock_node.hpp"
 #include "storage/prepared_plan.hpp"
+#include "utils/string_utils.hpp"
 
 namespace opossum {
 
@@ -21,10 +22,11 @@ class CreatePreparedPlanNodeTest : public ::testing::Test {
 };
 
 TEST_F(CreatePreparedPlanNodeTest, Description) {
-  EXPECT_EQ(create_prepared_plan_node->description(),
+  // Use short description mode as addresses are non-deterministic
+  EXPECT_EQ(replace_addresses(create_prepared_plan_node->description(AbstractLQPNode::DescriptionMode::Short)),
             R"([CreatePreparedPlan] 'some_prepared_plan' {
 ParameterIDs: []
-[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns
+[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns @ 0x00000000
 })");
 }
 

--- a/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
+++ b/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
@@ -22,8 +22,7 @@ class CreatePreparedPlanNodeTest : public ::testing::Test {
 };
 
 TEST_F(CreatePreparedPlanNodeTest, Description) {
-  // Use short description mode as addresses are non-deterministic
-  EXPECT_EQ(replace_addresses(create_prepared_plan_node->description(AbstractLQPNode::DescriptionMode::Short)),
+  EXPECT_EQ(replace_addresses(create_prepared_plan_node->description(AbstractLQPNode::DescriptionMode::Detailed)),
             R"([CreatePreparedPlan] 'some_prepared_plan' {
 ParameterIDs: []
 [0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns @ 0x00000000

--- a/src/test/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/logical_query_plan/create_view_node_test.cpp
@@ -21,15 +21,16 @@ class CreateViewNodeTest : public ::testing::Test {
 };
 
 TEST_F(CreateViewNodeTest, Description) {
-  EXPECT_EQ(_create_view_node->description(),
+  // Use short description mode as addresses are non-deterministic
+  EXPECT_EQ(replace_addresses(_create_view_node->description(AbstractLQPNode::DescriptionMode::Short)),
             "[CreateView] Name: some_view, Columns: a FROM (\n"
-            "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns\n"
+            "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns @ 0x00000000\n"
             ")");
 
   const auto _create_view_node_2 = CreateViewNode::make("some_view", _view, true);
-  EXPECT_EQ(_create_view_node_2->description(),
+  EXPECT_EQ(replace_addresses(_create_view_node_2->description(AbstractLQPNode::DescriptionMode::Short)),
             "[CreateView] IfNotExists Name: some_view, Columns: a FROM (\n"
-            "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns\n"
+            "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns @ 0x00000000\n"
             ")");
 }
 

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -388,7 +388,9 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
 
 0x00000000: 
 [0] [Predicate] 0x00000000.a = SUBQUERY (LQP, 0x00000000) @ 0x00000000
- \_[1] [StoredTable] Name: 'int_int_int' pruned: 0/1 chunk(s), 0/3 column(s) @ 0x00000000)");
+ \_[1] [StoredTable] Name: 'int_int_int' pruned: 0/1 chunk(s), 0/3 column(s) @ 0x00000000
+
+)");
 }
 
 TEST_F(LogicalQueryPlanTest, DeepCopySubqueries) {

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -379,7 +379,7 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
   stream << *lqp;
 
   EXPECT_EQ(replace_addresses(stream.str()),
-            R"(=========[0] [Predicate] 0x00000000.a > SUBQUERY (LQP, 0x00000000) @ 0x00000000
+            R"([0] [Predicate] 0x00000000.a > SUBQUERY (LQP, 0x00000000) @ 0x00000000
  \_[1] [StoredTable] Name: 'int_int' pruned: 0/1 chunk(s), 0/2 column(s) @ 0x00000000
 -------- Subqueries ---------
 0x00000000:

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -382,11 +382,11 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
             R"([0] [Predicate] 0x00000000.a > SUBQUERY (LQP, 0x00000000) @ 0x00000000
  \_[1] [StoredTable] Name: 'int_int' pruned: 0/1 chunk(s), 0/2 column(s) @ 0x00000000
 -------- Subqueries ---------
-0x00000000:
+0x00000000: 
 [0] [Predicate] 0x00000000.a = 5 @ 0x00000000
  \_[1] [StoredTable] Name: 'int_int_int' pruned: 0/1 chunk(s), 0/3 column(s) @ 0x00000000
 
-0x00000000:
+0x00000000: 
 [0] [Predicate] 0x00000000.a = SUBQUERY (LQP, 0x00000000) @ 0x00000000
  \_[1] [StoredTable] Name: 'int_int_int' pruned: 0/1 chunk(s), 0/3 column(s) @ 0x00000000)");
 }

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -1,5 +1,3 @@
-#include <regex>
-
 #include "base_test.hpp"
 #include "expression/expression_functional.hpp"
 #include "expression/lqp_column_expression.hpp"
@@ -380,26 +378,17 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
   std::stringstream stream;
   stream << *lqp;
 
-  // Result is undeterministic, but should look something like (order and addresses may vary)
-  // [0] [Predicate] a > SUBQUERY (LQP, 0x4e2bda0, Parameters: )
-  //  \_[1] [StoredTable] Name: 'int_int'
-  // -------- Sub Queries ---------
-  // 0x4e2d160:
-  // [0] [Predicate] a = 5
-  //  \_[1] [StoredTable] Name: 'int_int_int'
+  EXPECT_EQ(replace_addresses(stream.str()),
+            R"(=========[0] [Predicate] 0x00000000.a > SUBQUERY (LQP, 0x00000000) @ 0x00000000
+ \_[1] [StoredTable] Name: 'int_int' pruned: 0/1 chunk(s), 0/2 column(s) @ 0x00000000
+-------- Subqueries ---------
+0x00000000:
+[0] [Predicate] 0x00000000.a = 5 @ 0x00000000
+ \_[1] [StoredTable] Name: 'int_int_int' pruned: 0/1 chunk(s), 0/3 column(s) @ 0x00000000
 
-  // 0x4e2bda0:
-  // [0] [Predicate] a = SUBQUERY (LQP, 0x4e2d160, Parameters: )
-  //  \_[1] [StoredTable] Name: 'int_int_int'
-
-  EXPECT_TRUE(std::regex_search(
-      stream.str().c_str(),
-      std::regex{R"(\[0\] \[Predicate\] 0x[a-z0-9]+\.a \> SUBQUERY \(LQP, 0x[a-z0-9]+\) @ 0x[a-z0-9]+)"}));
-  EXPECT_TRUE(std::regex_search(stream.str().c_str(), std::regex{"Subqueries"}));
-  EXPECT_TRUE(std::regex_search(
-      stream.str().c_str(),
-      std::regex{R"(\[0\] \[Predicate\] 0x[a-z0-9]+\.a = SUBQUERY \(LQP, 0x[a-z0-9]+\) @ 0x[a-z0-9]+)"}));
-  EXPECT_TRUE(std::regex_search(stream.str().c_str(), std::regex{R"(\[0\] \[Predicate\] 0x[a-z0-9]+\.a = 5)"}));
+0x00000000:
+[0] [Predicate] 0x00000000.a = SUBQUERY (LQP, 0x00000000) @ 0x00000000
+ \_[1] [StoredTable] Name: 'int_int_int' pruned: 0/1 chunk(s), 0/3 column(s) @ 0x00000000)");
 }
 
 TEST_F(LogicalQueryPlanTest, DeepCopySubqueries) {

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -351,7 +351,6 @@ TEST_F(LogicalQueryPlanTest, PrintWithoutSubquery) {
   stream << *lqp;
 
   auto cleaned_str = replace_addresses(stream.str());
-  std::cout << "=====\n\n" << cleaned_str << "\n\n=====" << std::endl;
 
   EXPECT_EQ(cleaned_str, R"([0] [Predicate] 0x00000000.a > 5 @ 0x00000000
  \_[1] [Join] Mode: Inner [0x00000000.a = 0x00000000.a] @ 0x00000000
@@ -392,8 +391,6 @@ TEST_F(LogicalQueryPlanTest, PrintWithSubqueries) {
   // 0x4e2bda0:
   // [0] [Predicate] a = SUBQUERY (LQP, 0x4e2d160, Parameters: )
   //  \_[1] [StoredTable] Name: 'int_int_int'
-
-  std::cout << *lqp << std::endl;
 
   EXPECT_TRUE(std::regex_search(
       stream.str().c_str(),

--- a/src/test/logical_query_plan/mock_node_test.cpp
+++ b/src/test/logical_query_plan/mock_node_test.cpp
@@ -70,10 +70,12 @@ TEST_F(MockNodeTest, HashingAndEqualityCheck) {
 }
 
 TEST_F(MockNodeTest, Copy) {
-  EXPECT_EQ(*_mock_node_b, *_mock_node_b->deep_copy());
+  const auto copy = _mock_node_b->deep_copy();
+  EXPECT_EQ(*_mock_node_b, *copy);
 
   _mock_node_b->set_pruned_column_ids({ColumnID{1}});
-  EXPECT_EQ(*_mock_node_b, *_mock_node_b->deep_copy());
+  EXPECT_NE(*_mock_node_b, *copy);                       // TODO why didn't this fail?
+  EXPECT_EQ(*_mock_node_b, *_mock_node_b->deep_copy());  // TODO why didn't this fail?
 }
 
 TEST_F(MockNodeTest, NodeExpressions) { ASSERT_EQ(_mock_node_a->node_expressions.size(), 0u); }

--- a/src/test/logical_query_plan/mock_node_test.cpp
+++ b/src/test/logical_query_plan/mock_node_test.cpp
@@ -74,8 +74,8 @@ TEST_F(MockNodeTest, Copy) {
   EXPECT_EQ(*_mock_node_b, *copy);
 
   _mock_node_b->set_pruned_column_ids({ColumnID{1}});
-  EXPECT_NE(*_mock_node_b, *copy);                       // TODO why didn't this fail?
-  EXPECT_EQ(*_mock_node_b, *_mock_node_b->deep_copy());  // TODO why didn't this fail?
+  EXPECT_NE(*_mock_node_b, *copy);
+  EXPECT_EQ(*_mock_node_b, *_mock_node_b->deep_copy());
 }
 
 TEST_F(MockNodeTest, NodeExpressions) { ASSERT_EQ(_mock_node_a->node_expressions.size(), 0u); }

--- a/src/test/operators/maintenance/create_prepared_plan_test.cpp
+++ b/src/test/operators/maintenance/create_prepared_plan_test.cpp
@@ -26,9 +26,10 @@ class CreatePreparedPlanTest : public BaseTest {
 TEST_F(CreatePreparedPlanTest, OperatorName) { EXPECT_EQ(create_prepared_plan->name(), "CreatePreparedPlan"); }
 
 TEST_F(CreatePreparedPlanTest, OperatorDescription) {
-  EXPECT_EQ(create_prepared_plan->description(DescriptionMode::SingleLine), R"(CreatePreparedPlan 'prepared_plan_a' {
+  EXPECT_EQ(replace_addresses(create_prepared_plan->description(DescriptionMode::SingleLine)),
+            R"(CreatePreparedPlan 'prepared_plan_a' {
 ParameterIDs: []
-[0] [DummyTable]
+[0] [DummyTable] @ 0x00000000
 })");
 }
 


### PR DESCRIPTION
Problem: For **debug prints** (`std::cout << *lqp;`), we currently use `AbstractExpression:as_column_name`. For ambiguous column names, that is not really helpful:

```
(debug)> load resources/test_data/tbl/int_float.tbl t1
(debug)> load resources/test_data/tbl/int_float2.tbl t2
(debug)> SELECT * FROM t1, t2 WHERE t1.a = t2.a
[0] [Projection] a, b, a, b
 \_[1] [Join] Mode: Inner [a = a]
    \_[2] [Validate]
    |  \_[3] [StoredTable] Name: 't2' pruned: 0/1 chunk(s), 0/2 column(s)
    \_[4] [Validate]
       \_[5] [StoredTable] Name: 't1' pruned: 0/1 chunk(s), 0/2 column(s)
```

With this PR, we include the addresses of the source nodes:
<pre>
[0] [Projection] <b>0x12d6b2298</b>.a, 0x12d6b2298.b, 0x12d6b23d8.a, 0x12d6b23d8.b @ 0x12d6fe338
 \_[1] [Join] Mode: Inner [0x12d6b2298.a = 0x12d6b23d8.a] @ 0x12d6e0918
    \_[2] [Validate] @ 0x12d6fe158
    |  \_[3] [StoredTable] Name: 't2' pruned: 0/1 chunk(s), 0/2 column(s) @ 0x12d6b23d8
    \_[4] [Validate] @ 0x12d6fe018
       \_[5] [StoredTable] Name: 't1' pruned: 0/1 chunk(s), 0/2 column(s) @ <b>0x12d6b2298</b>
</pre>

This does not apply to the visualization, which is unchanged.

With this change, you can "easily" find the associated StoredTableNode. This will become even more important once my deduplication PR comes in where LQPColumnReferences (have to) contain disambiguation information:

<pre>
(debug)> load resources/test_data/tbl/int_float.tbl t
(debug)> SELECT t1.a + t2.a + t3.a FROM t t1, t t2, t t3 WHERE t1.a = 123 AND t2.a = 1234 AND t3.a = 12345
[0] [LogicalPlanRootNode] @ 0x125765c98
 \_[1] [Projection] ("a from 0x125666f58 via 0x1260a86d8(left)" + "<b>a from 0x125666f58 via 0x1260a8558(left) via 0x1260a86d8(right)</b>") + "a from 0x125666f58 via 0x1260a8558(right)" @ 0x1257683f8
    \_[2] [Join] Mode: Cross @ <b>0x1260a86d8</b>
       \_[3] [Validate] @ 0x125768358
       |  \_[4] [Predicate] "a from 0x125666f58" = 123 @ 0x1260a8318
       |     \_[5] [StoredTable] Name: 't' pruned: 0/1 chunk(s), 1/2 column(s) @ <b>0x125666f58</b>
       \_[6] [Join] Mode: Cross @ <b>0x1260a8558</b>
          \_[7] [Validate] @ 0x125768498
          |  \_[8] [Predicate] "a from 0x125666f58" = 1234 @ 0x1260a83d8
          |     \_Recurring Node --> [5]
          \_[9] [Validate] @ 0x125768538
             \_[10] [Predicate] "a from 0x125666f58" = 12345 @ 0x1260a8498
                \_Recurring Node --> [5]
</pre>

Also, harmonizes _on_shallow_copy, _on_shallow_equals and _on_shallow_hash (previously _shallow_hash).