### PR TITLE
Improve get_chunk == nullptr documentation

### DIFF
--- a/src/benchmark/operators/join_benchmark.cpp
+++ b/src/benchmark/operators/join_benchmark.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<TableWrapper> generate_table(const size_t number_of_rows) {
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
       chunk->create_index<AdaptiveRadixTreeIndex>(std::vector<ColumnID>{column_id});

--- a/src/benchmark/operators/join_benchmark.cpp
+++ b/src/benchmark/operators/join_benchmark.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<TableWrapper> generate_table(const size_t number_of_rows) {
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     for (ColumnID column_id{0}; column_id < chunk->column_count(); ++column_id) {
       chunk->create_index<AdaptiveRadixTreeIndex>(std::vector<ColumnID>{column_id});

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -148,7 +148,7 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
         if (my_chunk >= table->chunk_count()) return;
 
         const auto chunk = table->get_chunk(ChunkID{my_chunk});
-        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
         if (!is_chunk_encoding_spec_satisfied(chunk_encoding_spec, get_chunk_encoding_spec(*chunk))) {
           ChunkEncoder::encode_chunk(chunk, column_data_types, chunk_encoding_spec);
           encoding_performed = true;

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -148,7 +148,7 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
         if (my_chunk >= table->chunk_count()) return;
 
         const auto chunk = table->get_chunk(ChunkID{my_chunk});
-        Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
         if (!is_chunk_encoding_spec_satisfied(chunk_encoding_spec, get_chunk_encoding_spec(*chunk))) {
           ChunkEncoder::encode_chunk(chunk, column_data_types, chunk_encoding_spec);
           encoding_performed = true;

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -1573,7 +1573,7 @@ std::vector<std::shared_ptr<ExpressionResult<Result>>> ExpressionEvaluator::_pru
       const auto chunk_count = table->chunk_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         const auto chunk = table->get_chunk(chunk_id);
-        Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
         const auto& result_segment = *chunk->get_segment(ColumnID{0});
         segment_iterate<Result>(result_segment, [&](const auto& position) {
@@ -1589,7 +1589,7 @@ std::vector<std::shared_ptr<ExpressionResult<Result>>> ExpressionEvaluator::_pru
       const auto chunk_count = table->chunk_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         const auto chunk = table->get_chunk(chunk_id);
-        Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
         const auto& result_segment = *chunk->get_segment(ColumnID{0});
         segment_iterate<Result>(result_segment, [&](const auto& position) {

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -1573,7 +1573,7 @@ std::vector<std::shared_ptr<ExpressionResult<Result>>> ExpressionEvaluator::_pru
       const auto chunk_count = table->chunk_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         const auto chunk = table->get_chunk(chunk_id);
-        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
         const auto& result_segment = *chunk->get_segment(ColumnID{0});
         segment_iterate<Result>(result_segment, [&](const auto& position) {
@@ -1589,7 +1589,7 @@ std::vector<std::shared_ptr<ExpressionResult<Result>>> ExpressionEvaluator::_pru
       const auto chunk_count = table->chunk_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         const auto chunk = table->get_chunk(chunk_id);
-        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
         const auto& result_segment = *chunk->get_segment(ColumnID{0});
         segment_iterate<Result>(result_segment, [&](const auto& position) {

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<const Table> AliasOperator::_on_execute() {
   const auto chunk_count = input_table.chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
-    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     auto output_segments = Segments{};
     output_segments.reserve(input_table.column_count());

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<const Table> AliasOperator::_on_execute() {
   const auto chunk_count = input_table.chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
-    Assert(input_chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     auto output_segments = Segments{};
     output_segments.reserve(input_table.column_count());

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<const Table> Difference::_on_execute() {
   const auto chunk_count_right = input_table_right()->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count_right; chunk_id++) {
     const auto chunk = input_table_right()->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     // creating a temporary row representation with strings to be filled segment-wise
     auto string_row_vector = std::vector<std::stringstream>(chunk->size());
@@ -74,7 +74,7 @@ std::shared_ptr<const Table> Difference::_on_execute() {
   const auto chunk_count_left = input_table_left()->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count_left; chunk_id++) {
     const auto in_chunk = input_table_left()->get_chunk(chunk_id);
-    Assert(in_chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(in_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     Segments output_segments;
 

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<const Table> Difference::_on_execute() {
   const auto chunk_count_right = input_table_right()->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count_right; chunk_id++) {
     const auto chunk = input_table_right()->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     // creating a temporary row representation with strings to be filled segment-wise
     auto string_row_vector = std::vector<std::stringstream>(chunk->size());
@@ -74,7 +74,7 @@ std::shared_ptr<const Table> Difference::_on_execute() {
   const auto chunk_count_left = input_table_left()->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count_left; chunk_id++) {
     const auto in_chunk = input_table_left()->get_chunk(chunk_id);
-    Assert(in_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(in_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     Segments output_segments;
 

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -148,7 +148,7 @@ void ExportBinary::_write_header(const Table& table, std::ofstream& ofstream) {
 
 void ExportBinary::_write_chunk(const Table& table, std::ofstream& ofstream, const ChunkID& chunk_id) {
   const auto chunk = table.get_chunk(chunk_id);
-  Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+  Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
   export_value(ofstream, static_cast<ChunkOffset>(chunk->size()));
 
   // Iterating over all segments of this chunk and exporting them

--- a/src/lib/operators/export_binary.cpp
+++ b/src/lib/operators/export_binary.cpp
@@ -148,7 +148,7 @@ void ExportBinary::_write_header(const Table& table, std::ofstream& ofstream) {
 
 void ExportBinary::_write_chunk(const Table& table, std::ofstream& ofstream, const ChunkID& chunk_id) {
   const auto chunk = table.get_chunk(chunk_id);
-  Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+  Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
   export_value(ofstream, static_cast<ChunkOffset>(chunk->size()));
 
   // Iterating over all segments of this chunk and exporting them

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -82,7 +82,7 @@ void ExportCsv::_generate_content_file(const std::shared_ptr<const Table>& table
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     for (ChunkOffset chunk_offset = 0; chunk_offset < chunk->size(); ++chunk_offset) {
       for (ColumnID column_id{0}; column_id < table->column_count(); ++column_id) {

--- a/src/lib/operators/export_csv.cpp
+++ b/src/lib/operators/export_csv.cpp
@@ -82,7 +82,7 @@ void ExportCsv::_generate_content_file(const std::shared_ptr<const Table>& table
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     for (ChunkOffset chunk_offset = 0; chunk_offset < chunk->size(); ++chunk_offset) {
       for (ColumnID column_id{0}; column_id < table->column_count(); ++column_id) {

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<const Table> IndexScan::_on_execute() {
     const auto chunk_count = _in_table->chunk_count();
     for (auto chunk_id = ChunkID{0u}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = _in_table->get_chunk(chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       jobs.push_back(_create_job_and_schedule(chunk_id, output_mutex));
     }

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -46,7 +46,7 @@ std::shared_ptr<const Table> IndexScan::_on_execute() {
     const auto chunk_count = _in_table->chunk_count();
     for (auto chunk_id = ChunkID{0u}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = _in_table->get_chunk(chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       jobs.push_back(_create_job_and_schedule(chunk_id, output_mutex));
     }

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -190,7 +190,7 @@ inline std::vector<size_t> determine_chunk_offsets(const std::shared_ptr<const T
     chunk_offsets[chunk_id] = offset;
 
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     offset += chunk->size();
   }
@@ -812,7 +812,7 @@ inline PosListsByChunk setup_pos_lists_by_chunk(const std::shared_ptr<const Tabl
     // Iterate over every chunk and add the chunks segment with column_id to pos_list_ptrs
     for (ChunkID chunk_id{0}; chunk_id < input_chunks_count; ++chunk_id) {
       const auto chunk = input_table->get_chunk(chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       const auto& ref_segment_uncasted = chunk->get_segment(column_id);
       const auto ref_segment = std::static_pointer_cast<const ReferenceSegment>(ref_segment_uncasted);

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -190,7 +190,7 @@ inline std::vector<size_t> determine_chunk_offsets(const std::shared_ptr<const T
     chunk_offsets[chunk_id] = offset;
 
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     offset += chunk->size();
   }
@@ -812,7 +812,7 @@ inline PosListsByChunk setup_pos_lists_by_chunk(const std::shared_ptr<const Tabl
     // Iterate over every chunk and add the chunks segment with column_id to pos_list_ptrs
     for (ChunkID chunk_id{0}; chunk_id < input_chunks_count; ++chunk_id) {
       const auto chunk = input_table->get_chunk(chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       const auto& ref_segment_uncasted = chunk->get_segment(column_id);
       const auto ref_segment = std::static_pointer_cast<const ReferenceSegment>(ref_segment_uncasted);

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -106,7 +106,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count = _probe_input_table->chunk_count();
     for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count; ++probe_chunk_id) {
       const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       _probe_matches[probe_chunk_id].resize(chunk->size());
     }
@@ -116,7 +116,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count = _index_input_table->chunk_count();
     for (ChunkID index_chunk_id{0}; index_chunk_id < chunk_count; ++index_chunk_id) {
       const auto chunk = _index_input_table->get_chunk(index_chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       _index_matches[index_chunk_id].resize(chunk->size());
     }
@@ -141,7 +141,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count_index_input_table = _index_input_table->chunk_count();
     for (ChunkID index_chunk_id{0}; index_chunk_id < chunk_count_index_input_table; ++index_chunk_id) {
       const auto index_chunk = _index_input_table->get_chunk(index_chunk_id);
-      Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       if (index_chunk->size() == 0) {
         continue;
@@ -161,7 +161,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
 
       if (reference_segment_pos_list->references_single_chunk()) {
         const auto index_data_table_chunk = index_data_table->get_chunk((*reference_segment_pos_list)[0].chunk_id);
-        Assert(index_data_table_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+        Assert(index_data_table_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
         const auto& indexes = index_data_table_chunk->get_indexes(index_data_table_column_ids);
 
         if (!indexes.empty()) {
@@ -173,7 +173,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
           const auto chunk_count_probe_input_table = _probe_input_table->chunk_count();
           for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count_probe_input_table; ++probe_chunk_id) {
             const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-            Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+            Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
             const auto& probe_segment = chunk->get_segment(_adjusted_primary_predicate.column_ids.first);
             segment_with_iterators(*probe_segment, [&](auto probe_iter, const auto probe_end) {
@@ -196,7 +196,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count_index_input_table = _index_input_table->chunk_count();
     for (ChunkID index_chunk_id{0}; index_chunk_id < chunk_count_index_input_table; ++index_chunk_id) {
       const auto index_chunk = _index_input_table->get_chunk(index_chunk_id);
-      Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       const auto& indexes =
           index_chunk->get_indexes(std::vector<ColumnID>{_adjusted_primary_predicate.column_ids.second});
@@ -210,7 +210,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
         const auto chunk_count_probe_input_table = _probe_input_table->chunk_count();
         for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count_probe_input_table; ++probe_chunk_id) {
           const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-          Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+          Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
           const auto& probe_segment = chunk->get_segment(_adjusted_primary_predicate.column_ids.first);
           segment_with_iterators(*probe_segment, [&](auto probe_iter, const auto probe_end) {
@@ -261,7 +261,7 @@ void JoinIndex::_fallback_nested_loop(const ChunkID index_chunk_id, const bool t
   auto& performance_data = static_cast<PerformanceData&>(*_performance_data);
 
   const auto index_chunk = _index_input_table->get_chunk(index_chunk_id);
-  Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+  Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
   const auto& index_segment = index_chunk->get_segment(_adjusted_primary_predicate.column_ids.second);
   const auto& index_pos_list_size_pre_fallback = _index_pos_list->size();
@@ -269,7 +269,7 @@ void JoinIndex::_fallback_nested_loop(const ChunkID index_chunk_id, const bool t
   const auto chunk_count = _probe_input_table->chunk_count();
   for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count; ++probe_chunk_id) {
     const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     const auto& probe_segment = chunk->get_segment(_adjusted_primary_predicate.column_ids.first);
     JoinNestedLoop::JoinParams params{*_probe_pos_list,
@@ -470,7 +470,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
     const auto chunk_count = _probe_input_table->chunk_count();
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = _probe_input_table->get_chunk(chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       const auto chunk_size = chunk->size();
       for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
@@ -496,7 +496,7 @@ void JoinIndex::_write_output_segments(Segments& output_segments, const std::sha
         ChunkID current_chunk_id{0};
 
         const auto first_chunk_input_table = input_table->get_chunk(ChunkID{0});
-        Assert(first_chunk_input_table, "Physically deleted chunk should not reach this point, see get_chunk.");
+        Assert(first_chunk_input_table, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
         auto reference_segment =
             std::static_pointer_cast<const ReferenceSegment>(first_chunk_input_table->get_segment(column_id));
 
@@ -515,7 +515,7 @@ void JoinIndex::_write_output_segments(Segments& output_segments, const std::sha
               current_chunk_id = row.chunk_id;
 
               const auto chunk = input_table->get_chunk(current_chunk_id);
-              Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+              Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
               reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(chunk->get_segment(column_id));
             }

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -106,7 +106,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count = _probe_input_table->chunk_count();
     for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count; ++probe_chunk_id) {
       const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       _probe_matches[probe_chunk_id].resize(chunk->size());
     }
@@ -116,7 +116,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count = _index_input_table->chunk_count();
     for (ChunkID index_chunk_id{0}; index_chunk_id < chunk_count; ++index_chunk_id) {
       const auto chunk = _index_input_table->get_chunk(index_chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       _index_matches[index_chunk_id].resize(chunk->size());
     }
@@ -141,7 +141,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count_index_input_table = _index_input_table->chunk_count();
     for (ChunkID index_chunk_id{0}; index_chunk_id < chunk_count_index_input_table; ++index_chunk_id) {
       const auto index_chunk = _index_input_table->get_chunk(index_chunk_id);
-      Assert(index_chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       if (index_chunk->size() == 0) {
         continue;
@@ -161,7 +161,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
 
       if (reference_segment_pos_list->references_single_chunk()) {
         const auto index_data_table_chunk = index_data_table->get_chunk((*reference_segment_pos_list)[0].chunk_id);
-        Assert(index_data_table_chunk, "Did not expect deleted chunk here.");  // see #1686
+        Assert(index_data_table_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
         const auto& indexes = index_data_table_chunk->get_indexes(index_data_table_column_ids);
 
         if (!indexes.empty()) {
@@ -173,7 +173,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
           const auto chunk_count_probe_input_table = _probe_input_table->chunk_count();
           for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count_probe_input_table; ++probe_chunk_id) {
             const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-            Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+            Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
             const auto& probe_segment = chunk->get_segment(_adjusted_primary_predicate.column_ids.first);
             segment_with_iterators(*probe_segment, [&](auto probe_iter, const auto probe_end) {
@@ -196,7 +196,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
     const auto chunk_count_index_input_table = _index_input_table->chunk_count();
     for (ChunkID index_chunk_id{0}; index_chunk_id < chunk_count_index_input_table; ++index_chunk_id) {
       const auto index_chunk = _index_input_table->get_chunk(index_chunk_id);
-      Assert(index_chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       const auto& indexes =
           index_chunk->get_indexes(std::vector<ColumnID>{_adjusted_primary_predicate.column_ids.second});
@@ -210,7 +210,7 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
         const auto chunk_count_probe_input_table = _probe_input_table->chunk_count();
         for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count_probe_input_table; ++probe_chunk_id) {
           const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-          Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+          Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
           const auto& probe_segment = chunk->get_segment(_adjusted_primary_predicate.column_ids.first);
           segment_with_iterators(*probe_segment, [&](auto probe_iter, const auto probe_end) {
@@ -261,7 +261,7 @@ void JoinIndex::_fallback_nested_loop(const ChunkID index_chunk_id, const bool t
   auto& performance_data = static_cast<PerformanceData&>(*_performance_data);
 
   const auto index_chunk = _index_input_table->get_chunk(index_chunk_id);
-  Assert(index_chunk, "Did not expect deleted chunk here.");  // see #1686
+  Assert(index_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
   const auto& index_segment = index_chunk->get_segment(_adjusted_primary_predicate.column_ids.second);
   const auto& index_pos_list_size_pre_fallback = _index_pos_list->size();
@@ -269,7 +269,7 @@ void JoinIndex::_fallback_nested_loop(const ChunkID index_chunk_id, const bool t
   const auto chunk_count = _probe_input_table->chunk_count();
   for (ChunkID probe_chunk_id{0}; probe_chunk_id < chunk_count; ++probe_chunk_id) {
     const auto chunk = _probe_input_table->get_chunk(probe_chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     const auto& probe_segment = chunk->get_segment(_adjusted_primary_predicate.column_ids.first);
     JoinNestedLoop::JoinParams params{*_probe_pos_list,
@@ -379,7 +379,9 @@ std::vector<IndexRange> JoinIndex::_index_ranges_for_value(const SegmentPosition
         range_end = index->cend();
         break;
       }
-      default: { Fail("Unsupported comparison type encountered"); }
+      default: {
+        Fail("Unsupported comparison type encountered");
+      }
     }
     index_ranges.emplace_back(IndexRange{range_begin, range_end});
   }
@@ -468,7 +470,7 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
     const auto chunk_count = _probe_input_table->chunk_count();
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = _probe_input_table->get_chunk(chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       const auto chunk_size = chunk->size();
       for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
@@ -494,7 +496,7 @@ void JoinIndex::_write_output_segments(Segments& output_segments, const std::sha
         ChunkID current_chunk_id{0};
 
         const auto first_chunk_input_table = input_table->get_chunk(ChunkID{0});
-        Assert(first_chunk_input_table, "Did not expect deleted chunk here.");  // see #1686
+        Assert(first_chunk_input_table, "Physically deleted chunk should not reach this point, see get_chunk.");
         auto reference_segment =
             std::static_pointer_cast<const ReferenceSegment>(first_chunk_input_table->get_segment(column_id));
 
@@ -513,7 +515,7 @@ void JoinIndex::_write_output_segments(Segments& output_segments, const std::sha
               current_chunk_id = row.chunk_id;
 
               const auto chunk = input_table->get_chunk(current_chunk_id);
-              Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+              Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
               reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(chunk->get_segment(column_id));
             }

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   const auto chunk_count_right = right_table->chunk_count();
   for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right; ++chunk_id_right) {
     const auto chunk_right = right_table->get_chunk(chunk_id_right);
-    Assert(chunk_right, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     right_matches_by_chunk[chunk_id_right].resize(chunk_right->size());
   }
@@ -153,7 +153,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   const auto chunk_count_left = left_table->chunk_count();
   for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < chunk_count_left; ++chunk_id_left) {
     const auto chunk_left = left_table->get_chunk(chunk_id_left);
-    Assert(chunk_left, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     auto segment_left = chunk_left->get_segment(left_column_id);
 
@@ -165,7 +165,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
 
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right; ++chunk_id_right) {
       const auto chunk_right = right_table->get_chunk(chunk_id_right);
-      Assert(chunk_right, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       const auto segment_right = chunk_right->get_segment(right_column_id);
 
@@ -200,7 +200,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   if (_mode == JoinMode::FullOuter) {
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right; ++chunk_id_right) {
       const auto chunk_right = right_table->get_chunk(chunk_id_right);
-      Assert(chunk_right, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       const auto chunk_size = chunk_right->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
@@ -219,7 +219,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
 
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_left; ++chunk_id) {
       const auto chunk_left = left_table->get_chunk(chunk_id);
-      Assert(chunk_left, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk.");
       const auto chunk_size = chunk_left->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (left_matches_by_chunk[chunk_id][chunk_offset] ^ invert) {

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   const auto chunk_count_right = right_table->chunk_count();
   for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right; ++chunk_id_right) {
     const auto chunk_right = right_table->get_chunk(chunk_id_right);
-    Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     right_matches_by_chunk[chunk_id_right].resize(chunk_right->size());
   }
@@ -153,7 +153,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   const auto chunk_count_left = left_table->chunk_count();
   for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < chunk_count_left; ++chunk_id_left) {
     const auto chunk_left = left_table->get_chunk(chunk_id_left);
-    Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     auto segment_left = chunk_left->get_segment(left_column_id);
 
@@ -165,7 +165,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
 
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right; ++chunk_id_right) {
       const auto chunk_right = right_table->get_chunk(chunk_id_right);
-      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       const auto segment_right = chunk_right->get_segment(right_column_id);
 
@@ -200,7 +200,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   if (_mode == JoinMode::FullOuter) {
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right; ++chunk_id_right) {
       const auto chunk_right = right_table->get_chunk(chunk_id_right);
-      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       const auto chunk_size = chunk_right->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
@@ -219,7 +219,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
 
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_left; ++chunk_id) {
       const auto chunk_left = left_table->get_chunk(chunk_id);
-      Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
       const auto chunk_size = chunk_left->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
         if (left_matches_by_chunk[chunk_id][chunk_offset] ^ invert) {

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -74,7 +74,7 @@ class ColumnMaterializer {
     std::vector<std::shared_ptr<AbstractTask>> jobs;
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = input->get_chunk(chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       const auto samples_to_write = std::min(samples_per_chunk, chunk->size());
       subsamples.push_back(Subsample<T>(samples_to_write));

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -74,7 +74,7 @@ class ColumnMaterializer {
     std::vector<std::shared_ptr<AbstractTask>> jobs;
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = input->get_chunk(chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       const auto samples_to_write = std::min(samples_per_chunk, chunk->size());
       subsamples.push_back(Subsample<T>(samples_to_write));

--- a/src/lib/operators/limit.cpp
+++ b/src/lib/operators/limit.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<const Table> Limit::_on_execute() {
   const auto chunk_count = input_table->chunk_count();
   for (size_t i = 0; i < num_rows && chunk_id < chunk_count; chunk_id++) {
     const auto input_chunk = input_table->get_chunk(chunk_id);
-    Assert(input_chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     Segments output_segments;
 

--- a/src/lib/operators/limit.cpp
+++ b/src/lib/operators/limit.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<const Table> Limit::_on_execute() {
   const auto chunk_count = input_table->chunk_count();
   for (size_t i = 0; i < num_rows && chunk_id < chunk_count; chunk_id++) {
     const auto input_chunk = input_table->get_chunk(chunk_id);
-    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     Segments output_segments;
 

--- a/src/lib/operators/multi_predicate_join/multi_predicate_join_evaluator.cpp
+++ b/src/lib/operators/multi_predicate_join/multi_predicate_join_evaluator.cpp
@@ -61,7 +61,7 @@ std::vector<std::unique_ptr<AbstractSegmentAccessor<T>>> MultiPredicateJoinEvalu
   const auto chunk_count = table.chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table.get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     const auto& segment = chunk->get_segment(column_id);
     accessors[chunk_id] = create_segment_accessor<T>(segment);

--- a/src/lib/operators/multi_predicate_join/multi_predicate_join_evaluator.cpp
+++ b/src/lib/operators/multi_predicate_join/multi_predicate_join_evaluator.cpp
@@ -61,7 +61,7 @@ std::vector<std::unique_ptr<AbstractSegmentAccessor<T>>> MultiPredicateJoinEvalu
   const auto chunk_count = table.chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table.get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     const auto& segment = chunk->get_segment(column_id);
     accessors[chunk_id] = create_segment_accessor<T>(segment);

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -37,11 +37,11 @@ std::shared_ptr<const Table> Product::_on_execute() {
 
   for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < chunk_count_left_table; ++chunk_id_left) {
     const auto chunk_left = input_table_left()->get_chunk(chunk_id_left);
-    Assert(chunk_left, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right_table; ++chunk_id_right) {
       const auto chunk_right = input_table_right()->get_chunk(chunk_id_right);
-      Assert(chunk_right, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       _add_product_of_two_chunks(output, chunk_id_left, chunk_id_right);
     }

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -37,11 +37,11 @@ std::shared_ptr<const Table> Product::_on_execute() {
 
   for (ChunkID chunk_id_left = ChunkID{0}; chunk_id_left < chunk_count_left_table; ++chunk_id_left) {
     const auto chunk_left = input_table_left()->get_chunk(chunk_id_left);
-    Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk_left, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     for (ChunkID chunk_id_right = ChunkID{0}; chunk_id_right < chunk_count_right_table; ++chunk_id_right) {
       const auto chunk_right = input_table_right()->get_chunk(chunk_id_right);
-      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk_right, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       _add_product_of_two_chunks(output, chunk_id_left, chunk_id_right);
     }

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   const auto chunk_count_input_table = input_table.chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_input_table; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
-    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     auto output_segments = Segments{expressions.size()};
 
@@ -104,7 +104,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
 
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_input_table; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
-    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     // The output chunk contains all rows that are in the stored chunk, including invalid rows. We forward this
     // information so that following operators (currently, the Validate operator) can use it for optimizations.

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   const auto chunk_count_input_table = input_table.chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_input_table; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
-    Assert(input_chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     auto output_segments = Segments{expressions.size()};
 
@@ -104,7 +104,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
 
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_input_table; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
-    Assert(input_chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     // The output chunk contains all rows that are in the stored chunk, including invalid rows. We forward this
     // information so that following operators (currently, the Validate operator) can use it for optimizations.

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -224,7 +224,7 @@ class Sort::SortImpl : public AbstractReadOnlyOperatorImpl {
     const auto chunk_count = _table_in->chunk_count();
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = _table_in->get_chunk(chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       auto base_segment = chunk->get_segment(_column_id);
 

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -224,7 +224,7 @@ class Sort::SortImpl : public AbstractReadOnlyOperatorImpl {
     const auto chunk_count = _table_in->chunk_count();
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = _table_in->get_chunk(chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       auto base_segment = chunk->get_segment(_column_id);
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -97,7 +97,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
   for (ChunkID chunk_id{0u}; chunk_id < chunk_count; ++chunk_id) {
     if (excluded_chunk_set.count(chunk_id)) continue;
     const auto chunk_in = in_table->get_chunk(chunk_id);
-    Assert(chunk_in, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     // chunk_in – Copy by value since copy by reference is not possible due to the limited scope of the for-iteration.
     auto job_task = std::make_shared<JobTask>([this, chunk_id, chunk_in, &in_table, &output_mutex, &output_chunks]() {

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -97,7 +97,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
   for (ChunkID chunk_id{0u}; chunk_id < chunk_count; ++chunk_id) {
     if (excluded_chunk_set.count(chunk_id)) continue;
     const auto chunk_in = in_table->get_chunk(chunk_id);
-    Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     // chunk_in – Copy by value since copy by reference is not possible due to the limited scope of the for-iteration.
     auto job_task = std::make_shared<JobTask>([this, chunk_id, chunk_in, &in_table, &output_mutex, &output_chunks]() {

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<const Table> UnionAll::_on_execute() {
     const auto chunk_count = input->chunk_count();
     for (ChunkID in_chunk_id{0}; in_chunk_id < chunk_count; in_chunk_id++) {
       const auto chunk = input->get_chunk(in_chunk_id);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       // creating empty chunk to add segments with positions
       Segments output_segments;

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<const Table> UnionAll::_on_execute() {
     const auto chunk_count = input->chunk_count();
     for (ChunkID in_chunk_id{0}; in_chunk_id < chunk_count; in_chunk_id++) {
       const auto chunk = input->get_chunk(in_chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       // creating empty chunk to add segments with positions
       Segments output_segments;

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -108,7 +108,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
 
   while (job_end_chunk_id < chunk_count) {
     const auto chunk = in_table->get_chunk(job_end_chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     // Small chunks are bundled together to avoid unnecessary scheduling overhead.
     // Therefore, we count the number of rows to ensure a minimum of rows per job (default chunk size).
@@ -146,7 +146,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& in_table, co
                                 std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex) const {
   for (auto chunk_id = chunk_id_start; chunk_id <= chunk_id_end; ++chunk_id) {
     const auto chunk_in = in_table->get_chunk(chunk_id);
-    Assert(chunk_in, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     Segments output_segments;
     auto pos_list_out = std::make_shared<const PosList>();

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -108,7 +108,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
 
   while (job_end_chunk_id < chunk_count) {
     const auto chunk = in_table->get_chunk(job_end_chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     // Small chunks are bundled together to avoid unnecessary scheduling overhead.
     // Therefore, we count the number of rows to ensure a minimum of rows per job (default chunk size).
@@ -146,7 +146,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& in_table, co
                                 std::vector<std::shared_ptr<Chunk>>& output_chunks, std::mutex& output_mutex) const {
   for (auto chunk_id = chunk_id_start; chunk_id <= chunk_id_end; ++chunk_id) {
     const auto chunk_in = in_table->get_chunk(chunk_id);
-    Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     Segments output_segments;
     auto pos_list_out = std::make_shared<const PosList>();

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -136,7 +136,7 @@ void ChunkEncoder::encode_chunks(const std::shared_ptr<Table>& table, const std:
   for (auto chunk_id : chunk_ids) {
     Assert(chunk_id < table->chunk_count(), "Chunk with given ID does not exist.");
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     const auto& chunk_encoding_spec = chunk_encoding_specs.at(chunk_id);
     encode_chunk(chunk, column_data_types, chunk_encoding_spec);
@@ -150,7 +150,7 @@ void ChunkEncoder::encode_chunks(const std::shared_ptr<Table>& table, const std:
   for (auto chunk_id : chunk_ids) {
     Assert(chunk_id < table->chunk_count(), "Chunk with given ID does not exist.");
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     encode_chunk(chunk, column_data_types, segment_encoding_spec);
   }
@@ -164,7 +164,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
 
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     const auto chunk_encoding_spec = chunk_encoding_specs[chunk_id];
     encode_chunk(chunk, column_types, chunk_encoding_spec);
@@ -180,7 +180,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     encode_chunk(chunk, column_types, chunk_encoding_spec);
   }
@@ -193,7 +193,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     encode_chunk(chunk, column_types, segment_encoding_spec);
   }

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -136,7 +136,7 @@ void ChunkEncoder::encode_chunks(const std::shared_ptr<Table>& table, const std:
   for (auto chunk_id : chunk_ids) {
     Assert(chunk_id < table->chunk_count(), "Chunk with given ID does not exist.");
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     const auto& chunk_encoding_spec = chunk_encoding_specs.at(chunk_id);
     encode_chunk(chunk, column_data_types, chunk_encoding_spec);
@@ -150,7 +150,7 @@ void ChunkEncoder::encode_chunks(const std::shared_ptr<Table>& table, const std:
   for (auto chunk_id : chunk_ids) {
     Assert(chunk_id < table->chunk_count(), "Chunk with given ID does not exist.");
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     encode_chunk(chunk, column_data_types, segment_encoding_spec);
   }
@@ -164,7 +164,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
 
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     const auto chunk_encoding_spec = chunk_encoding_specs[chunk_id];
     encode_chunk(chunk, column_types, chunk_encoding_spec);
@@ -180,7 +180,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     encode_chunk(chunk, column_types, chunk_encoding_spec);
   }
@@ -193,7 +193,7 @@ void ChunkEncoder::encode_all_chunks(const std::shared_ptr<Table>& table,
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     encode_chunk(chunk, column_types, segment_encoding_spec);
   }

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -81,14 +81,14 @@ class Table : private Noncopyable {
    * @defgroup Accessing and adding Chunks
    * @{
    */
-  // Returns the number of chunks, or, more correctly, the ID of the last chunk plus one (see get_chunk)
+  // Returns the number of chunks, or, more correctly, the ID of the last chunk plus one (see get_chunk / #1686).
   // This cannot exceed ChunkID (uint32_t).
   ChunkID chunk_count() const;
 
   // Returns the chunk with the given id. If a previously existing chunk has been physically deleted by the
   // MvccDeletePlugin, this returns nullptr. In the execution engine, it is the GetTable operator's job to
-  // filter these nullptrs and return only existing chunks to the following operator. Thus, all operators
-  // should assert the absence of nullptrs.
+  // filter these nullptrs and return only existing chunks to the following operator. Thus, all other operators
+  // should not accept nullptrs and instead assert that this function returned a chunk.
   std::shared_ptr<Chunk> get_chunk(ChunkID chunk_id);
   std::shared_ptr<const Chunk> get_chunk(ChunkID chunk_id) const;
 
@@ -183,7 +183,7 @@ class Table : private Noncopyable {
     const auto chunk_count = _chunks.size();
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
       auto chunk = std::atomic_load(&_chunks[chunk_id]);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
       chunk->create_index<Index>(column_ids);
     }

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -81,10 +81,14 @@ class Table : private Noncopyable {
    * @defgroup Accessing and adding Chunks
    * @{
    */
-  // returns the number of chunks (cannot exceed ChunkID (uint32_t))
+  // Returns the number of chunks, or, more correctly, the ID of the last chunk plus one (see get_chunk)
+  // This cannot exceed ChunkID (uint32_t).
   ChunkID chunk_count() const;
 
-  // returns the chunk with the given id
+  // Returns the chunk with the given id. If a previously existing chunk has been physically deleted by the
+  // MvccDeletePlugin, this returns nullptr. In the execution engine, it is the GetTable operator's job to
+  // filter these nullptrs and return only existing chunks to the following operator. Thus, all operators
+  // should assert the absence of nullptrs.
   std::shared_ptr<Chunk> get_chunk(ChunkID chunk_id);
   std::shared_ptr<const Chunk> get_chunk(ChunkID chunk_id) const;
 
@@ -179,7 +183,7 @@ class Table : private Noncopyable {
     const auto chunk_count = _chunks.size();
     for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
       auto chunk = std::atomic_load(&_chunks[chunk_id]);
-      Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
       chunk->create_index<Index>(column_ids);
     }

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -27,7 +27,7 @@ void ChunkCompressionTask::_on_execute() {
   for (auto chunk_id : _chunk_ids) {
     Assert(chunk_id < table->chunk_count(), "Chunk with given ID does not exist.");
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Did not expect deleted chunk here.");  // see #1686
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
 
     DebugAssert(_chunk_is_completed(chunk, table->max_chunk_size()),
                 "Chunk is not completed and thus can’t be compressed.");

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -27,7 +27,7 @@ void ChunkCompressionTask::_on_execute() {
   for (auto chunk_id : _chunk_ids) {
     Assert(chunk_id < table->chunk_count(), "Chunk with given ID does not exist.");
     const auto chunk = table->get_chunk(chunk_id);
-    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk.");
+    Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     DebugAssert(_chunk_is_completed(chunk, table->max_chunk_size()),
                 "Chunk is not completed and thus can’t be compressed.");


### PR DESCRIPTION
My seminar group found the reference to #1686 confusing and somehow ended up at #1643 (?!) without understanding why we checked for nullptr. Hopefully this is a bit clearer.