### PR TITLE
Projection: Better forward of ReferenceSegments

### DIFF
--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -90,13 +90,13 @@ std::shared_ptr<const Table> Projection::_on_execute() {
         const auto segment = input_chunk->get_segment(pqp_column_expression->column_id);
 
         resolve_data_type(expression->data_type(), [&](const auto data_type) {
-          using DataType = typename decltype(data_type)::type;
+          using ColumnDataType = typename decltype(data_type)::type;
           bool has_null = false;
-          auto values = pmr_concurrent_vector<DataType>(segment->size());
+          auto values = pmr_concurrent_vector<ColumnDataType>(segment->size());
           auto null_values = pmr_concurrent_vector<bool>(segment->size());
 
           auto chunk_offset = ChunkOffset{0};
-          segment_iterate<DataType>(*segment, [&](const auto& position) {
+          segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
             if (position.is_null()) {
               has_null = true;
               null_values[chunk_offset] = true;
@@ -106,11 +106,11 @@ std::shared_ptr<const Table> Projection::_on_execute() {
             ++chunk_offset;
           });
 
-          auto value_segment = std::shared_ptr<ValueSegment<DataType>>{};
+          auto value_segment = std::shared_ptr<ValueSegment<ColumnDataType>>{};
           if (has_null) {
-            value_segment = std::make_shared<ValueSegment<DataType>>(std::move(values), std::move(null_values));
+            value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
           } else {
-            value_segment = std::make_shared<ValueSegment<DataType>>(std::move(values));
+            value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values));
           }
 
           output_segments[column_id] = std::move(value_segment);

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       const auto& expression = expressions[column_id];
 
       // Forward input column if possible
-      if (forward_columns) {
+      if (expression->type == ExpressionType::PQPColumn && forward_columns) {
         const auto pqp_column_expression = std::static_pointer_cast<PQPColumnExpression>(expression);
         output_segments[column_id] = input_chunk->get_segment(pqp_column_expression->column_id);
         column_is_nullable[column_id] =


### PR DESCRIPTION
For any table, we require all segments to be either ReferenceSegments or not. Thus, when the Projection creates a single ValueSegment, all other ReferenceSegments have to be converted into ValueSegments. Currently, this happens via the ExpressionEvaluator, which has a couple of unnecessary abstractions for this. By doing this step in the projection itself, we can save some time:

```diff
 +----------------+----------------+-------+----------------+-------+------------+---------+
 | Benchmark      | prev. iter/s   | runs  | new iter/s     | runs  | change [%] | p-value |
 +----------------+----------------+-------+----------------+-------+------------+---------+
 | TPC-H 01       | 0.591941773891 | 36    | 0.614538609982 | 37    | +4%        |  0.0000 |
 | TPC-H 02       | 68.1781997681  | 4091  | 66.7094421387  | 4003  | -2%        |  0.0044 |
 | TPC-H 03       | 6.9803276062   | 419   | 7.26622486115  | 436   | +4%        |  0.0000 |
 | TPC-H 04       | 6.87540578842  | 413   | 6.85076665878  | 412   | -0%        |  0.4591 |
+| TPC-H 05       | 3.4995496273   | 211   | 3.85983896255  | 232   | +10%       |  0.0000 |
 | TPC-H 06       | 198.962280273  | 11938 | 198.411514282  | 11905 | -0%        |  0.0458 |
 | TPC-H 07       | 7.41563415527  | 445   | 7.32884645462  | 440   | -1%        |  0.1001 |
+| TPC-H 08       | 5.79976272583  | 349   | 6.23874807358  | 375   | +8%        |  0.0000 |
 | TPC-H 09       | 1.49156761169  | 90    | 1.53204488754  | 92    | +3%        |  0.0000 |
+| TPC-H 10       | 2.61136102676  | 157   | 2.75670576096  | 166   | +6%        |  0.0000 |
 | TPC-H 11       | 28.869146347   | 1733  | 28.2791900635  | 1697  | -2%        |  0.0000 |
 | TPC-H 12       | 8.78120422363  | 527   | 8.70268154144  | 523   | -1%        |  0.0000 |
 | TPC-H 13       | 2.16691184044  | 131   | 2.21104550362  | 133   | +2%        |  0.0000 |
 | TPC-H 14       | 45.4273376465  | 2726  | 46.188533783   | 2772  | +2%        |  0.0000 |
 | TPC-H 15       | 71.3107147217  | 4279  | 68.9120635986  | 4135  | -3%        |  0.0000 |
 | TPC-H 16       | 6.92698097229  | 416   | 6.9563832283   | 418   | +0%        |  0.2133 |
 | TPC-H 17       | 4.65258264542  | 280   | 4.54050970078  | 273   | -2%        |  0.0006 |
+| TPC-H 18       | 0.77457690239  | 47    | 0.826413154602 | 50    | +7%        |  0.0000 |
 | TPC-H 19       | 8.66394901276  | 521   | 8.58924388885  | 516   | -1%        |  0.3671 |
 | TPC-H 20       | 25.9511432648  | 1558  | 25.4696979523  | 1529  | -2%        |  0.0000 |
 | TPC-H 21       | 1.16310191154  | 70    | 1.14416277409  | 69    | -2%        |  0.0992 |
 | TPC-H 22       | 14.0375976562  | 843   | 13.876742363   | 833   | -1%        |  0.0014 |
 | geometric mean |                |       |                |       | +1%        |         |
 +----------------+----------------+-------+----------------+-------+------------+---------+
```

No new tests, as this is a shortcut for something that has to happen anyway.
