### PR TITLE
CardinalityEstimator: Estimate IN expressions

### DIFF
--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -381,7 +381,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_predicate_node(
       // Cannot handle subqueries
       return input_table_statistics;
     }
-    
+
     const auto& list_expression = static_cast<const ListExpression&>(*in_expression->set());
     auto expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
     expressions.reserve(list_expression.elements().size());

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -5,6 +5,7 @@
 
 #include "attribute_statistics.hpp"
 #include "expression/abstract_expression.hpp"
+#include "expression/expression_functional.hpp"
 #include "expression/expression_utils.hpp"
 #include "expression/logical_expression.hpp"
 #include "expression/lqp_subquery_expression.hpp"
@@ -67,6 +68,8 @@ std::optional<float> estimate_null_value_ratio_of_column(const TableStatistics& 
 }  // namespace
 
 namespace opossum {
+
+using namespace opossum::expression_functional;  // NOLINT
 
 std::shared_ptr<AbstractCardinalityEstimator> CardinalityEstimator::new_instance() const {
   return std::make_shared<CardinalityEstimator>();
@@ -370,6 +373,25 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_predicate_node(
 
     const auto row_count = Cardinality{input_table_statistics->row_count * PLACEHOLDER_SELECTIVITY_HIGH};
     return std::make_shared<TableStatistics>(std::move(output_column_statistics), row_count);
+  }
+
+  if (const auto in_expression = std::dynamic_pointer_cast<InExpression>(predicate)) {
+    // Estimate `x IN (1, 2, 3)` by treating it as `x = 1 OR x = 2 ...`
+    if (in_expression->set()->type != ExpressionType::List) {
+      // Cannot handle subqueries
+      return input_table_statistics;
+    }
+    
+    const auto& list_expression = static_cast<const ListExpression&>(*in_expression->set());
+    auto expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
+    expressions.reserve(list_expression.elements().size());
+    for (const auto& list_element : list_expression.elements()) {
+      expressions.emplace_back(equals_(in_expression->value(), list_element));
+    }
+
+    const auto disjunction = inflate_logical_expressions(expressions, LogicalOperator::Or);
+    const auto new_predicate_node = PredicateNode::make(disjunction, predicate_node.left_input());
+    return estimate_predicate_node(*new_predicate_node, input_table_statistics);
   }
 
   const auto operator_scan_predicates = OperatorScanPredicate::from_expression(*predicate, predicate_node);

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -608,6 +608,16 @@ TEST_F(CardinalityEstimatorTest, PredicateOrDoesNotIncreaseCardinality) {
   EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 100);
 }
 
+TEST_F(CardinalityEstimatorTest, PredicateIn) {
+  // clang-format off
+  const auto input_lqp =
+  PredicateNode::make(in_(a_a, list_(10, 11, 12, 13, 14)),
+      node_a);
+  // clang-format on
+
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 20);
+}
+
 TEST_F(CardinalityEstimatorTest, PredicateTwoOnDifferentColumns) {
   // clang-format off
   const auto input_lqp =

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -611,11 +611,11 @@ TEST_F(CardinalityEstimatorTest, PredicateOrDoesNotIncreaseCardinality) {
 TEST_F(CardinalityEstimatorTest, PredicateIn) {
   // clang-format off
   const auto input_lqp =
-  PredicateNode::make(in_(a_a, list_(10, 11, 12, 13, 14)),
+  PredicateNode::make(in_(a_a, list_(10, 11, 12, 13)),
       node_a);
   // clang-format on
 
-  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 20);
+  EXPECT_FLOAT_EQ(estimator.estimate_cardinality(input_lqp), 40);
 }
 
 TEST_F(CardinalityEstimatorTest, PredicateTwoOnDifferentColumns) {


### PR DESCRIPTION
Used in 12,16,19,22, so 5 and 8 are outliers.

```diff
 +----------------+----------------+-------+----------------+-------+------------+---------+
 | Benchmark      | prev. iter/s   | runs  | new iter/s     | runs  | change [%] | p-value |
 +----------------+----------------+-------+----------------+-------+------------+---------+
 | TPC-H 01       | 0.591941773891 | 36    | 0.612216353416 | 37    | +3%        |  0.0000 |
 | TPC-H 02       | 68.1781997681  | 4091  | 69.1267700195  | 4148  | +1%        |  0.0698 |
 | TPC-H 03       | 6.9803276062   | 419   | 7.15190076828  | 430   | +2%        |  0.0000 |
 | TPC-H 04       | 6.87540578842  | 413   | 6.80770301819  | 409   | -1%        |  0.0882 |
+| TPC-H 05       | 3.4995496273   | 211   | 3.74816703796  | 225   | +7%        |  0.0000 |
 | TPC-H 06       | 198.962280273  | 11938 | 196.293258667  | 11778 | -1%        |  0.0000 |
 | TPC-H 07       | 7.41563415527  | 445   | 7.46271800995  | 448   | +1%        |  0.3650 |
+| TPC-H 08       | 5.79976272583  | 349   | 6.349858284    | 382   | +9%        |  0.0000 |
 | TPC-H 09       | 1.49156761169  | 90    | 1.51345682144  | 91    | +1%        |  0.0089 |
 | TPC-H 10       | 2.61136102676  | 157   | 2.65156984329  | 160   | +2%        |  0.0709 |
 | TPC-H 11       | 28.869146347   | 1733  | 28.7212409973  | 1724  | -1%        |  0.0003 |
+| TPC-H 12       | 8.78120422363  | 527   | 15.1570482254  | 910   | +73%       |  0.0000 |
 | TPC-H 13       | 2.16691184044  | 131   | 2.22021603584  | 134   | +2%        |  0.0000 |
 | TPC-H 14       | 45.4273376465  | 2726  | 46.4511070251  | 2788  | +2%        |  0.0000 |
 | TPC-H 15       | 71.3107147217  | 4279  | 72.3120040894  | 4339  | +1%        |  0.0000 |
+| TPC-H 16       | 6.92698097229  | 416   | 7.34974384308  | 442   | +6%        |  0.0000 |
 | TPC-H 17       | 4.65258264542  | 280   | 4.70856332779  | 283   | +1%        |  0.1013 |
 | TPC-H 18       | 0.77457690239  | 47    | 0.798327207565 | 48    | +3%        |  0.0018 |
 | TPC-H 19       | 8.66394901276  | 521   | 8.33226585388  | 501   | -4%        |  0.0000 |
 | TPC-H 20       | 25.9511432648  | 1558  | 26.4489650726  | 1587  | +2%        |  0.0000 |
 | TPC-H 21       | 1.16310191154  | 70    | 1.17002856731  | 71    | +1%        |  0.5146 |
 | TPC-H 22       | 14.0375976562  | 843   | 13.9244394302  | 836   | -1%        |  0.0161 |
 | geometric mean |                |       |                |       | +4%        |         |
 +----------------+----------------+-------+----------------+-------+------------+---------+
```