### PR TITLE
ReferenceSegment: Use iterable instead of accessor where possible

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -411,6 +411,8 @@ set(
     storage/chunk_encoder.hpp
     storage/constraints/table_constraint_definition.hpp
     storage/create_iterable_from_segment.hpp
+    storage/create_iterable_from_reference_segment.ipp
+    storage/create_iterable_from_segment.ipp
     storage/dictionary_segment/attribute_vector_iterable.hpp
     storage/dictionary_segment.cpp
     storage/dictionary_segment/dictionary_encoder.hpp

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -67,8 +67,8 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
           auto right_iterable =
               ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{*right_typed_segment};
 
-          left_iterable.with_iterators([&](auto left_it, const auto left_end) {
-            right_iterable.with_iterators([&](auto right_it, const auto right_end) {
+          left_iterable.with_iterators([&](auto left_it, const auto [[maybe_unused]] left_end) {
+            right_iterable.with_iterators([&](auto right_it, const auto [[maybe_unused]] right_end) {
               if constexpr (std::is_same_v<std::decay_t<decltype(left_it)>,
                                            std::decay_t<decltype(right_it)>>) {  // NOLINT
                 // Either both reference segments use the MultipleChunkIterator (which uses erased accessors anyway)

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -67,8 +67,8 @@ std::shared_ptr<PosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID chunk_i
           auto right_iterable =
               ReferenceSegmentIterable<ColumnDataType, EraseReferencedSegmentType::No>{*right_typed_segment};
 
-          left_iterable.with_iterators([&](auto left_it, const auto [[maybe_unused]] left_end) {
-            right_iterable.with_iterators([&](auto right_it, const auto [[maybe_unused]] right_end) {
+          left_iterable.with_iterators([&](auto left_it, [[maybe_unused]] const auto left_end) {
+            right_iterable.with_iterators([&](auto right_it, [[maybe_unused]] const auto right_end) {
               if constexpr (std::is_same_v<std::decay_t<decltype(left_it)>,
                                            std::decay_t<decltype(right_it)>>) {  // NOLINT
                 // Either both reference segments use the MultipleChunkIterator (which uses erased accessors anyway)

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -7,7 +7,6 @@
 #include "resolve_type.hpp"
 #include "storage/chunk.hpp"
 #include "storage/create_iterable_from_segment.hpp"
-#include "storage/reference_segment/create_iterable_from_segment.hpp"
 #include "storage/reference_segment/reference_segment_iterable.hpp"
 #include "storage/segment_iterables/any_segment_iterable.hpp"
 #include "storage/segment_iterate.hpp"

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -7,6 +7,7 @@
 #include "resolve_type.hpp"
 #include "storage/chunk.hpp"
 #include "storage/create_iterable_from_segment.hpp"
+#include "storage/reference_segment/create_iterable_from_segment.hpp"
 #include "storage/reference_segment/reference_segment_iterable.hpp"
 #include "storage/segment_iterables/any_segment_iterable.hpp"
 #include "storage/segment_iterate.hpp"

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -6,14 +6,15 @@
 
 #include "base_value_segment.hpp"
 #include "chunk.hpp"
-#include "table.hpp"
-#include "types.hpp"
-
+#include "resolve_type.hpp"
 #include "statistics/generate_pruning_statistics.hpp"
 #include "storage/base_encoded_segment.hpp"
+#include "storage/reference_segment.hpp"
 #include "storage/segment_encoding_utils.hpp"
 #include "storage/segment_iterables/any_segment_iterable.hpp"
 #include "storage/value_segment.hpp"
+#include "table.hpp"
+#include "types.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {

--- a/src/lib/storage/create_iterable_from_reference_segment.ipp
+++ b/src/lib/storage/create_iterable_from_reference_segment.ipp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "storage/reference_segment/reference_segment_iterable.hpp"
+
+namespace opossum {
+
+template <typename T, bool EraseSegmentType, EraseReferencedSegmentType erase_referenced_segment_type>
+auto create_iterable_from_segment(const ReferenceSegment& segment) {
+  if constexpr (EraseSegmentType) {
+    return create_any_segment_iterable<T>(segment);
+  } else {
+    return ReferenceSegmentIterable<T, erase_referenced_segment_type>{segment};
+  }
+}
+
+}  // namespace opossum

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -78,5 +78,5 @@ auto create_iterable_from_segment(const ReferenceSegment& segment);
 }  // namespace opossum
 
 // Include these only now to break up include dependencies
-#include "create_iterable_from_segment.ipp"
 #include "create_iterable_from_reference_segment.ipp"
+#include "create_iterable_from_segment.ipp"

--- a/src/lib/storage/create_iterable_from_segment.hpp
+++ b/src/lib/storage/create_iterable_from_segment.hpp
@@ -1,13 +1,26 @@
 #pragma once
 
-#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
-#include "storage/frame_of_reference_segment/frame_of_reference_segment_iterable.hpp"
-#include "storage/lz4_segment/lz4_segment_iterable.hpp"
-#include "storage/run_length_segment/run_length_segment_iterable.hpp"
-#include "storage/segment_iterables/any_segment_iterable.hpp"
-#include "storage/value_segment/value_segment_iterable.hpp"
+#include "types.hpp"
 
 namespace opossum {
+
+template <typename T>
+class ValueSegment;
+
+template <typename T>
+class DictionarySegment;
+
+template <typename T>
+class RunLengthSegment;
+
+template <typename T>
+class FixedStringDictionarySegment;
+
+template <typename T, typename>
+class FrameOfReferenceSegment;
+
+template <typename T>
+class LZ4Segment;
 
 class ReferenceSegment;
 template <typename T, EraseReferencedSegmentType>
@@ -25,85 +38,36 @@ class ReferenceSegmentIterable;
  * In debug mode, create_iterable_from_segment returns a type erased
  * iterable, i.e., all iterators have the same type
  *
+ * Functions must be forward-declared because otherwise, we run into
+ * circular include dependencies.
+ *
  * @{
  */
 
 template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
-auto create_iterable_from_segment(const ValueSegment<T>& segment) {
-  if constexpr (EraseSegmentType) {
-    return create_any_segment_iterable<T>(segment);
-  } else {
-    return ValueSegmentIterable<T>{segment};
-  }
-}
+auto create_iterable_from_segment(const ValueSegment<T>& segment);
 
 template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
-auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
-#ifdef HYRISE_ERASE_DICTIONARY
-  PerformanceWarning("DictionarySegmentIterable erased by compile-time setting");
-  return AnySegmentIterable<T>(DictionarySegmentIterable<T, pmr_vector<T>>(segment));
-#else
-  if constexpr (EraseSegmentType) {
-    return create_any_segment_iterable<T>(segment);
-  } else {
-    return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
-  }
-#endif
-}
+auto create_iterable_from_segment(const DictionarySegment<T>& segment);
 
 template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
-auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
-#ifdef HYRISE_ERASE_RUNLENGTH
-  PerformanceWarning("RunLengthSegmentIterable erased by compile-time setting");
-  return AnySegmentIterable<T>(RunLengthSegmentIterable<T>(segment));
-#else
-  if constexpr (EraseSegmentType) {
-    return create_any_segment_iterable<T>(segment);
-  } else {
-    return RunLengthSegmentIterable<T>{segment};
-  }
-#endif
-}
+auto create_iterable_from_segment(const RunLengthSegment<T>& segment);
 
 template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
-auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
-#ifdef HYRISE_ERASE_FIXEDSTRINGDICTIONARY
-  PerformanceWarning("FixedStringDictionarySegmentIterable erased by compile-time setting");
-  return AnySegmentIterable<T>(DictionarySegmentIterable<T, FixedStringVector>(segment));
-#else
-  if constexpr (EraseSegmentType) {
-    return create_any_segment_iterable<T>(segment);
-  } else {
-    return DictionarySegmentIterable<T, FixedStringVector>{segment};
-  }
-#endif
-}
+auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment);
 
-template <typename T, bool EraseSegmentType = HYRISE_DEBUG>
-auto create_iterable_from_segment(const FrameOfReferenceSegment<T>& segment) {
-#ifdef HYRISE_ERASE_FRAMEOFREFERENCE
-  PerformanceWarning("FrameOfReferenceSegmentIterable erased by compile-time setting");
-  return AnySegmentIterable<T>(FrameOfReferenceSegmentIterable<T>(segment));
-#else
-  if constexpr (EraseSegmentType) {
-    return create_any_segment_iterable<T>(segment);
-  } else {
-    return FrameOfReferenceSegmentIterable<T>{segment};
-  }
-#endif
+template <typename T, typename Enabled, bool EraseSegmentType = HYRISE_DEBUG>
+auto create_iterable_from_segment(const FrameOfReferenceSegment<T, Enabled>& segment);
+
+// Fix template deduction so that we can call `create_iterable_from_segment<T, false>` on FrameOfReferenceSegments
+template <typename T, bool EraseSegmentType, typename Enabled>
+auto create_iterable_from_segment(const FrameOfReferenceSegment<T, Enabled>& segment) {
+  return create_iterable_from_segment<T, Enabled, EraseSegmentType>(segment);
 }
 
 template <typename T, bool EraseSegmentType = true>
-auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
-  // LZ4Segment always gets erased as its decoding is so slow, the virtual function calls won't make
-  // a difference. If we'd allow it to not be erased we'd risk compile time increase creeping in for no benefit
-  return AnySegmentIterable<T>(LZ4SegmentIterable<T>(segment));
-}
+auto create_iterable_from_segment(const LZ4Segment<T>& segment);
 
-/**
- * This function must be forward-declared because ReferenceSegmentIterable
- * includes this file leading to a circular dependency
- */
 template <typename T, bool EraseSegmentType = HYRISE_DEBUG,
           EraseReferencedSegmentType = (HYRISE_DEBUG ? EraseReferencedSegmentType::Yes
                                                      : EraseReferencedSegmentType::No)>
@@ -113,4 +77,6 @@ auto create_iterable_from_segment(const ReferenceSegment& segment);
 
 }  // namespace opossum
 
+// Include these only now to break up include dependencies
 #include "create_iterable_from_segment.ipp"
+#include "create_iterable_from_reference_segment.ipp"

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -3,8 +3,8 @@
 #include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
 #include "storage/frame_of_reference_segment/frame_of_reference_segment_iterable.hpp"
 #include "storage/lz4_segment/lz4_segment_iterable.hpp"
-#include "storage/segment_iterables/any_segment_iterable.hpp"
 #include "storage/run_length_segment/run_length_segment_iterable.hpp"
+#include "storage/segment_iterables/any_segment_iterable.hpp"
 #include "storage/value_segment/value_segment_iterable.hpp"
 
 namespace opossum {

--- a/src/lib/storage/create_iterable_from_segment.ipp
+++ b/src/lib/storage/create_iterable_from_segment.ipp
@@ -1,16 +1,84 @@
 #pragma once
 
-#include "reference_segment/reference_segment_iterable.hpp"
+#include "storage/dictionary_segment/dictionary_segment_iterable.hpp"
+#include "storage/frame_of_reference_segment/frame_of_reference_segment_iterable.hpp"
+#include "storage/lz4_segment/lz4_segment_iterable.hpp"
+#include "storage/segment_iterables/any_segment_iterable.hpp"
+#include "storage/run_length_segment/run_length_segment_iterable.hpp"
+#include "storage/value_segment/value_segment_iterable.hpp"
 
 namespace opossum {
 
-template <typename T, bool EraseSegmentType, EraseReferencedSegmentType erase_referenced_segment_type>
-auto create_iterable_from_segment(const ReferenceSegment& segment) {
+template <typename T, bool EraseSegmentType>
+auto create_iterable_from_segment(const ValueSegment<T>& segment) {
   if constexpr (EraseSegmentType) {
     return create_any_segment_iterable<T>(segment);
   } else {
-    return ReferenceSegmentIterable<T, erase_referenced_segment_type>{segment};
+    return ValueSegmentIterable<T>{segment};
   }
+}
+
+template <typename T, bool EraseSegmentType>
+auto create_iterable_from_segment(const DictionarySegment<T>& segment) {
+#ifdef HYRISE_ERASE_DICTIONARY
+  PerformanceWarning("DictionarySegmentIterable erased by compile-time setting");
+  return AnySegmentIterable<T>(DictionarySegmentIterable<T, pmr_vector<T>>(segment));
+#else
+  if constexpr (EraseSegmentType) {
+    return create_any_segment_iterable<T>(segment);
+  } else {
+    return DictionarySegmentIterable<T, pmr_vector<T>>{segment};
+  }
+#endif
+}
+
+template <typename T, bool EraseSegmentType>
+auto create_iterable_from_segment(const RunLengthSegment<T>& segment) {
+#ifdef HYRISE_ERASE_RUNLENGTH
+  PerformanceWarning("RunLengthSegmentIterable erased by compile-time setting");
+  return AnySegmentIterable<T>(RunLengthSegmentIterable<T>(segment));
+#else
+  if constexpr (EraseSegmentType) {
+    return create_any_segment_iterable<T>(segment);
+  } else {
+    return RunLengthSegmentIterable<T>{segment};
+  }
+#endif
+}
+
+template <typename T, bool EraseSegmentType>
+auto create_iterable_from_segment(const FixedStringDictionarySegment<T>& segment) {
+#ifdef HYRISE_ERASE_FIXEDSTRINGDICTIONARY
+  PerformanceWarning("FixedStringDictionarySegmentIterable erased by compile-time setting");
+  return AnySegmentIterable<T>(DictionarySegmentIterable<T, FixedStringVector>(segment));
+#else
+  if constexpr (EraseSegmentType) {
+    return create_any_segment_iterable<T>(segment);
+  } else {
+    return DictionarySegmentIterable<T, FixedStringVector>{segment};
+  }
+#endif
+}
+
+template <typename T, typename Enabled, bool EraseSegmentType>
+auto create_iterable_from_segment(const FrameOfReferenceSegment<T, Enabled>& segment) {
+#ifdef HYRISE_ERASE_FRAMEOFREFERENCE
+  PerformanceWarning("FrameOfReferenceSegmentIterable erased by compile-time setting");
+  return AnySegmentIterable<T>(FrameOfReferenceSegmentIterable<T>(segment));
+#else
+  if constexpr (EraseSegmentType) {
+    return create_any_segment_iterable<T>(segment);
+  } else {
+    return FrameOfReferenceSegmentIterable<T>{segment};
+  }
+#endif
+}
+
+template <typename T, bool EraseSegmentType>
+auto create_iterable_from_segment(const LZ4Segment<T>& segment) {
+  // LZ4Segment always gets erased as its decoding is so slow, the virtual function calls won't make
+  // a difference. If we'd allow it to not be erased we'd risk compile time increase creeping in for no benefit
+  return AnySegmentIterable<T>(LZ4SegmentIterable<T>(segment));
 }
 
 }  // namespace opossum

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -29,16 +29,16 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
     const auto referenced_table = _segment.referenced_table();
     const auto referenced_column_id = _segment.referenced_column_id();
 
-    const auto& pos_list = *_segment.pos_list();
+    const auto& pos_list = _segment.pos_list();
 
-    const auto begin_it = pos_list.begin();
-    const auto end_it = pos_list.end();
+    const auto begin_it = pos_list->begin();
+    const auto end_it = pos_list->end();
 
     // If we are guaranteed that the reference segment refers to a single non-NULL chunk, we can do some optimizations.
     // For example, we can use a single, non-virtual segment accessor instead of having to keep multiple and using
     // virtual method calls. If begin_it is NULL, chunk_id will be INVALID_CHUNK_ID. Therefore, we skip this case.
 
-    if (pos_list.references_single_chunk() && pos_list.size() > 0 && !begin_it->is_null()) {
+    if (pos_list->references_single_chunk() && pos_list->size() > 0 && !begin_it->is_null()) {
       auto referenced_segment = referenced_table->get_chunk(begin_it->chunk_id)->get_segment(referenced_column_id);
 
       bool functor_was_called = false;
@@ -71,12 +71,9 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
           if constexpr (std::is_same_v<SegmentType, LZ4Segment<T>>) return;
 
           if constexpr (!std::is_same_v<SegmentType, ReferenceSegment>) {
-            auto accessor = std::make_shared<SegmentAccessor<T, SegmentType>>(typed_segment);
+            const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
+            segment_iterable.with_iterators(pos_list, functor);
 
-            auto begin = SingleChunkIterator<SegmentAccessor<T, SegmentType>>{accessor, begin_it, begin_it};
-            auto end = SingleChunkIterator<SegmentAccessor<T, SegmentType>>{accessor, begin_it, end_it};
-
-            functor(begin, end);
             functor_was_called = true;
           } else {
             Fail("Found ReferenceSegment pointing to ReferenceSegment");

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -93,8 +93,6 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
 
       const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
       segment_iterable.with_iterators(pos_list, functor);
-
-      functor(begin, end);
     } else {
       using Accessors = std::vector<std::shared_ptr<AbstractSegmentAccessor<T>>>;
 

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "storage/create_iterable_from_segment.hpp"
 #include "storage/dictionary_segment.hpp"
 #include "storage/fixed_string_dictionary_segment.hpp"
 #include "storage/frame_of_reference_segment.hpp"
@@ -14,8 +15,6 @@
 #include "storage/segment_iterables.hpp"
 
 namespace opossum {
-
-enum class EraseReferencedSegmentType : bool { Yes = true, No = false };
 
 template <typename T, EraseReferencedSegmentType erase_reference_segment_type>
 class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable<T, erase_reference_segment_type>> {

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -96,8 +96,8 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
       auto accessor =
           std::shared_ptr<AbstractSegmentAccessor<T>>{std::move(create_segment_accessor<T>(referenced_segment))};
 
-      auto begin = SingleChunkIterator<AbstractSegmentAccessor<T>>{accessor, begin_it, begin_it};
-      auto end = SingleChunkIterator<AbstractSegmentAccessor<T>>{accessor, begin_it, end_it};
+      const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
+      segment_iterable.with_iterators(pos_list, functor);
 
       functor(begin, end);
     } else {

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -13,6 +13,7 @@
 #include "storage/run_length_segment.hpp"
 #include "storage/segment_accessor.hpp"
 #include "storage/segment_iterables.hpp"
+#include "storage/segment_iterables/any_segment_iterable.hpp"
 
 namespace opossum {
 
@@ -91,7 +92,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
 
       // The functor was not called yet, because we did not instantiate specialized code for the segment type.
 
-      const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
+      const auto segment_iterable = create_any_segment_iterable<T>(typed_segment);
       segment_iterable.with_iterators(pos_list, functor);
     } else {
       using Accessors = std::vector<std::shared_ptr<AbstractSegmentAccessor<T>>>;

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -90,11 +90,6 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
       if (functor_was_called) return;
 
       // The functor was not called yet, because we did not instantiate specialized code for the segment type.
-      // As accessor is an AbstractSegmentAccessor here, functor only gets initialized only once, no matter how many
-      // different accessors there might be.
-
-      auto accessor =
-          std::shared_ptr<AbstractSegmentAccessor<T>>{std::move(create_segment_accessor<T>(referenced_segment))};
 
       const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
       segment_iterable.with_iterators(pos_list, functor);

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -92,7 +92,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
 
       // The functor was not called yet, because we did not instantiate specialized code for the segment type.
 
-      const auto segment_iterable = create_any_segment_iterable<T>(typed_segment);
+      const auto segment_iterable = create_any_segment_iterable<T>(*referenced_segment);
       segment_iterable.with_iterators(pos_list, functor);
     } else {
       using Accessors = std::vector<std::shared_ptr<AbstractSegmentAccessor<T>>>;

--- a/src/lib/storage/segment_iterables/any_segment_iterable.hpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.hpp
@@ -3,7 +3,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include "storage/reference_segment/reference_segment_iterable.hpp"
 #include "storage/segment_iterables.hpp"
 #include "storage/segment_iterables/any_segment_iterator.hpp"
 
@@ -11,6 +10,8 @@ namespace opossum {
 
 template <typename ValueType>
 class AnySegmentIterable;
+
+class BaseSegment;
 
 /**
  * @brief Wraps passed segment iterable in an AnySegmentIterable

--- a/src/lib/storage/value_segment/value_segment_iterable.hpp
+++ b/src/lib/storage/value_segment/value_segment_iterable.hpp
@@ -200,17 +200,4 @@ class ValueSegmentIterable : public PointAccessibleSegmentIterable<ValueSegmentI
   };
 };
 
-template <typename T>
-struct is_value_segment_iterable {
-  static constexpr auto value = false;
-};
-
-template <template <typename T> typename Iterable, typename T>
-struct is_value_segment_iterable<Iterable<T>> {
-  static constexpr auto value = std::is_same_v<ValueSegmentIterable<T>, Iterable<T>>;
-};
-
-template <typename T>
-inline constexpr bool is_value_segment_iterable_v = is_value_segment_iterable<T>::value;
-
 }  // namespace opossum

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -251,6 +251,8 @@ enum class HasNullTerminator : bool { Yes = true, No = false };
 
 enum class SendExecutionInfo : bool { Yes = true, No = false };
 
+enum class EraseReferencedSegmentType : bool { Yes = true, No = false };
+
 // Used as a template parameter that is passed whenever we conditionally erase the type of a template. This is done to
 // reduce the compile time at the cost of the runtime performance. Examples are iterators, which are replaced by
 // AnySegmentIterators that use virtual method calls.

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -2,6 +2,7 @@
 
 #include "operators/join_hash/join_hash_steps.hpp"
 #include "operators/table_wrapper.hpp"
+#include "storage/create_iterable_from_segment.hpp"
 #include "resolve_type.hpp"
 
 namespace opossum {

--- a/src/test/operators/join_hash_steps_test.cpp
+++ b/src/test/operators/join_hash_steps_test.cpp
@@ -2,8 +2,8 @@
 
 #include "operators/join_hash/join_hash_steps.hpp"
 #include "operators/table_wrapper.hpp"
-#include "storage/create_iterable_from_segment.hpp"
 #include "resolve_type.hpp"
+#include "storage/create_iterable_from_segment.hpp"
 
 namespace opossum {
 


### PR DESCRIPTION
When we are looking at a ReferenceSegment that points at a single segment, it makes more sense to use that segments iterator instead of using accessors:

```diff
 +----------------+----------------+-------+----------------+-------+------------+---------+
 | Benchmark      | prev. iter/s   | runs  | new iter/s     | runs  | change [%] | p-value |
 +----------------+----------------+-------+----------------+-------+------------+---------+
+| TPC-H 01       | 0.591941773891 | 36    | 0.684819757938 | 42    | +16%       |  0.0000 |
 | TPC-H 02       | 68.1781997681  | 4091  | 66.9826126099  | 4019  | -2%        |  0.0202 |
+| TPC-H 03       | 6.9803276062   | 419   | 7.40183210373  | 445   | +6%        |  0.0000 |
 | TPC-H 04       | 6.87540578842  | 413   | 6.71953058243  | 404   | -2%        |  0.0001 |
+| TPC-H 05       | 3.4995496273   | 211   | 3.78297424316  | 227   | +8%        |  0.0000 |
+| TPC-H 06       | 198.962280273  | 11938 | 236.195739746  | 14172 | +19%       |  0.0000 |
 | TPC-H 07       | 7.41563415527  | 445   | 7.39740276337  | 444   | -0%        |  0.7218 |
+| TPC-H 08       | 5.79976272583  | 349   | 6.13998270035  | 369   | +6%        |  0.0000 |
+| TPC-H 09       | 1.49156761169  | 90    | 1.57876753807  | 95    | +6%        |  0.0000 |
 | TPC-H 10       | 2.61136102676  | 157   | 2.67503213882  | 161   | +2%        |  0.0043 |
 | TPC-H 11       | 28.869146347   | 1733  | 28.764081955   | 1726  | -0%        |  0.0064 |
-| TPC-H 12       | 8.78120422363  | 527   | 7.99289464951  | 480   | -9%        |  0.0000 |
+| TPC-H 13       | 2.16691184044  | 131   | 2.31267619133  | 139   | +7%        |  0.0000 |
+| TPC-H 14       | 45.4273376465  | 2726  | 48.926322937   | 2936  | +8%        |  0.0000 |
+| TPC-H 15       | 71.3107147217  | 4279  | 88.6862106323  | 5322  | +24%       |  0.0000 |
+| TPC-H 16       | 6.92698097229  | 416   | 7.28291988373  | 437   | +5%        |  0.0000 |
 | TPC-H 17       | 4.65258264542  | 280   | 4.54031658173  | 273   | -2%        |  0.0002 |
+| TPC-H 18       | 0.77457690239  | 47    | 0.824911534786 | 50    | +6%        |  0.0000 |
 | TPC-H 19       | 8.66394901276  | 521   | 8.84604549408  | 531   | +2%        |  0.0257 |
 | TPC-H 20       | 25.9511432648  | 1558  | 26.3029403687  | 1579  | +1%        |  0.0000 |
 | TPC-H 21       | 1.16310191154  | 70    | 1.18264293671  | 71    | +2%        |  0.0056 |
+| TPC-H 22       | 14.0375976562  | 843   | 16.4996814728  | 990   | +18%       |  0.0000 |
+| geometric mean |                |       |                |       | +5%        |         |
 +----------------+----------------+-------+----------------+-------+------------+---------+
```

@mflueggen - Since you had some exposure to iterators and accessors, do you think you could have a look?