### PR TITLE
CI: RelWithDebInfo for TSAN

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,8 +67,8 @@ try {
           mkdir clang-release-addr-ub-sanitizers && cd clang-release-addr-ub-sanitizers && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
           mkdir clang-release && cd clang-release && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. &\
           mkdir clang-release-addr-ub-sanitizers-no-numa && cd clang-release-addr-ub-sanitizers-no-numa && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_ADDR_UB_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
-          mkdir clang-release-thread-sanitizer && cd clang-release-thread-sanitizer && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_THREAD_SANITIZATION=ON .. &\
-          mkdir clang-release-thread-sanitizer-no-numa && cd clang-release-thread-sanitizer-no-numa && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_THREAD_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
+          mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_THREAD_SANITIZATION=ON .. &\
+          mkdir clang-relwithdebinfo-thread-sanitizer-no-numa && cd clang-relwithdebinfo-thread-sanitizer-no-numa && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DENABLE_THREAD_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
           mkdir gcc-debug && cd gcc-debug && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
           mkdir gcc-release && cd gcc-release && cmake -DCI_BUILD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ .. &\
           wait"
@@ -193,25 +193,25 @@ try {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizersNoNuma")
             }
           }
-        }, clangReleaseThreadSanitizer: {
-          stage("clang-release:thread-sanitizer") {
+        }, clangRelWithDebInfoThreadSanitizer: {
+          stage("clang-relwithdebinfo:thread-sanitizer") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6))"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-release-thread-sanitizer/hyriseTest clang-release-thread-sanitizer"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-release-thread-sanitizer/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-release-thread-sanitizer"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-release-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6))"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
             } else {
-              Utils.markStageSkippedForConditional("clangReleaseThreadSanitizer")
+              Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
             }
           }
-        }, clangReleaseThreadSanitizerNoNuma: {
-          stage("clang-release:thread-sanitizer w/o NUMA") {
+        }, clangRelWithDebInfoThreadSanitizerNoNuma: {
+          stage("clang-relwithdebinfo:thread-sanitizer w/o NUMA") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6))"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-release-thread-sanitizer-no-numa/hyriseTest clang-release-thread-sanitizer-no-numa"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-release-thread-sanitizer-no-numa/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-release-thread-sanitizer-no-numa"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6))"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseTest clang-relwithdebinfo-thread-sanitizer-no-numa"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseSystemTest ${exclude_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer-no-numa"
             } else {
-              Utils.markStageSkippedForConditional("clangReleaseThreadSanitizerNoNuma")
+              Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizerNoNuma")
             }
           }
         }, clangDebugCoverage: {

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -45,7 +45,6 @@ void MvccDeletePlugin::_logical_delete_loop() {
         // Calculate metric 1 – Chunk invalidation level
         const double invalidated_rows_ratio = static_cast<double>(chunk->invalid_row_count()) / chunk->size();
         const bool criterion1 = (DELETE_THRESHOLD_PERCENTAGE_INVALIDATED_ROWS <= invalidated_rows_ratio);
-        std::cout << "Chunk " << chunk_id << " - invalidated_rows_ratio: " << invalidated_rows_ratio << std::endl;
 
         if (!criterion1) {
           continue;
@@ -60,8 +59,6 @@ void MvccDeletePlugin::_logical_delete_loop() {
                                 if (b == MvccData::MAX_COMMIT_ID) return false;
                                 return a < b;
                               });
-        std::cout << "Chunk " << chunk_id << " - highest_end_commit_id: " << highest_end_commit_id << std::endl;
-        std::cout << "\twaiting until " << highest_end_commit_id + DELETE_THRESHOLD_LAST_COMMIT << " <= " << Hyrise::get().transaction_manager.last_commit_id() << std::endl; // NOLINT
 
         const bool criterion2 =
             highest_end_commit_id + DELETE_THRESHOLD_LAST_COMMIT <= Hyrise::get().transaction_manager.last_commit_id();
@@ -79,8 +76,6 @@ void MvccDeletePlugin::_logical_delete_loop() {
 
           std::unique_lock<std::mutex> lock(_mutex_physical_delete_queue);
           _physical_delete_queue.emplace(table, chunk_id);
-        } else {
-          std::cout << "!!! CONFLICT !!!" << std::endl;
         }
       }
     }

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -45,6 +45,7 @@ void MvccDeletePlugin::_logical_delete_loop() {
         // Calculate metric 1 – Chunk invalidation level
         const double invalidated_rows_ratio = static_cast<double>(chunk->invalid_row_count()) / chunk->size();
         const bool criterion1 = (DELETE_THRESHOLD_PERCENTAGE_INVALIDATED_ROWS <= invalidated_rows_ratio);
+        std::cout << "Chunk " << chunk_id << " - invalidated_rows_ratio: " << invalidated_rows_ratio << std::endl;
 
         if (!criterion1) {
           continue;
@@ -59,6 +60,8 @@ void MvccDeletePlugin::_logical_delete_loop() {
                                 if (b == MvccData::MAX_COMMIT_ID) return false;
                                 return a < b;
                               });
+        std::cout << "Chunk " << chunk_id << " - highest_end_commit_id: " << highest_end_commit_id << std::endl;
+        std::cout << "\twaiting until " << highest_end_commit_id + DELETE_THRESHOLD_LAST_COMMIT << " <= " << Hyrise::get().transaction_manager.last_commit_id() << std::endl; // NOLINT
 
         const bool criterion2 =
             highest_end_commit_id + DELETE_THRESHOLD_LAST_COMMIT <= Hyrise::get().transaction_manager.last_commit_id();
@@ -76,6 +79,8 @@ void MvccDeletePlugin::_logical_delete_loop() {
 
           std::unique_lock<std::mutex> lock(_mutex_physical_delete_queue);
           _physical_delete_queue.emplace(table, chunk_id);
+        } else {
+          std::cout << "!!! CONFLICT !!!" << std::endl;
         }
       }
     }

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -245,7 +245,7 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
       // To increase the global _last_commit_id, we need to execute a transaction with read-write operators
       // We perform some dummy updates so that the table is unmodified and the validation routine does not complain
       auto pipeline =
-          SQLPipelineBuilder{std::string{"UPDATE " + _t_name_test + " SET number = number WHERE number = 0"}}
+          SQLPipelineBuilder{std::string{"UPDATE " + _t_name_test + " SET number = number WHERE number = -1"}}
               .create_pipeline();
 
       // Execute and verify update transaction

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -62,7 +62,7 @@ class MvccDeletePluginSystemTest : public BaseTest {
    * Updates a single row to make it invalid in its chunk. Data modification is not involved, so the row gets reinserted
    * at the end of the table.
    * - Updates start at position 220 (INITIAL_UPDATE_OFFSET), so the first chunk stays untouched.
-   * - Updates stop just before the end of Chunk 3, so that it is "fresh" and not cleaned up.
+   * - Updates stop just before the end of Chunk 3 (at position 598), so that it is "fresh" and not cleaned up.
    */
   void update_next_row() {
     if (_counter == INITIAL_CHUNK_COUNT * CHUNK_SIZE - 2) return;  // -> if (_counter == 598)...
@@ -267,7 +267,6 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
   {
     auto attempts_remaining = max_attempts;
     while (attempts_remaining--) {
-      std::cout << "attempts_remaining: " << attempts_remaining << std::endl;
       // Chunk 3 should have been logically deleted by now
       const auto chunk3 = _table->get_chunk(ChunkID{2});
       EXPECT_TRUE(chunk3);

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -175,7 +175,7 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
       std::this_thread::sleep_for(MvccDeletePlugin::IDLE_DELAY_LOGICAL_DELETE);
     }
     // Check that we have not given up
-    EXPECT_GT(attempts_remaining, -1);
+    ASSERT_GT(attempts_remaining, -1);
   }
 
   // (6) Verify the correctness of the logical delete operation.
@@ -212,7 +212,7 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
     }
 
     // Check that we have not given up
-    EXPECT_GT(attempts_remaining, -1);
+    ASSERT_GT(attempts_remaining, -1);
   }
 
   // (9) Check after conditions
@@ -239,6 +239,16 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
 
   // (11) Prepare clean-up of chunk 3
   {
+    // Wait for the previous updates to finish
+    {
+      auto attempts_remaining = max_attempts;
+      while (_counter < INITIAL_CHUNK_COUNT * CHUNK_SIZE - 2) {
+        std::this_thread::sleep_for(100);
+      }
+      // Check that we have not given up
+      ASSERT_GT(attempts_remaining, -1);
+    }
+
     // Kill a couple of commit IDs so that criterion 2 is fulfilled and chunk 3 is eligible for clean-up, too.
     for (auto transaction_idx = CommitID{0}; transaction_idx < MvccDeletePlugin::DELETE_THRESHOLD_LAST_COMMIT;
          ++transaction_idx) {
@@ -267,7 +277,7 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
       std::this_thread::sleep_for(MvccDeletePlugin::IDLE_DELAY_LOGICAL_DELETE);
     }
     // Check that we have not given up
-    EXPECT_GT(attempts_remaining, -1);
+    ASSERT_GT(attempts_remaining, -1);
   }
 
   // (13) Verify the correctness of the logical delete operation.

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -257,6 +257,7 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
   {
     auto attempts_remaining = max_attempts;
     while (attempts_remaining--) {
+      std::cout << "attempts_remaining: " << attempts_remaining << std::endl;
       // Chunk 3 should have been logically deleted by now
       const auto chunk3 = _table->get_chunk(ChunkID{2});
       EXPECT_TRUE(chunk3);

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -243,7 +243,7 @@ TEST_F(MvccDeletePluginSystemTest, CheckPlugin) {
     {
       auto attempts_remaining = max_attempts;
       while (_counter < INITIAL_CHUNK_COUNT * CHUNK_SIZE - 2) {
-        std::this_thread::sleep_for(100);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
       // Check that we have not given up
       ASSERT_GT(attempts_remaining, -1);


### PR DESCRIPTION
* Hopefully fixes the MVCC Delete Plugin Freezes

* Should help us in tracking down the spurious CI fails. Adds 5 minutes to those steps, but since we are usually waiting for clang-tidy anyway, it should not be noticeable.