### PR TITLE
Make LQP/Expression equals more efficient

### DIFF
--- a/src/lib/expression/abstract_expression.cpp
+++ b/src/lib/expression/abstract_expression.cpp
@@ -27,6 +27,7 @@ bool AbstractExpression::is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
 }
 
 bool AbstractExpression::operator==(const AbstractExpression& other) const {
+  if (this == &other) return true;
   if (type != other.type) return false;
   if (!expressions_equal(arguments, other.arguments)) return false;
   return _shallow_equals(other);

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -246,6 +246,7 @@ bool AbstractLQPNode::is_column_nullable(const ColumnID column_id) const {
 }
 
 bool AbstractLQPNode::operator==(const AbstractLQPNode& rhs) const {
+  if (this == &rhs) return true;
   return !lqp_find_subplan_mismatch(shared_from_this(), rhs.shared_from_this());
 }
 


### PR DESCRIPTION
For an expensive `operator==`, we should check for object identify before diving deep into the comparison of input nodes / expressions.

```diff
 +----------------+----------------+-------+---------------+-------+------------+---------+
 | Benchmark      | prev. iter/s   | runs  | new iter/s    | runs  | change [%] | p-value |
 +----------------+----------------+-------+---------------+-------+------------+---------+
 | TPC-H 01       | 0.675015389919 | 41    | 0.68032002449 | 41    | +1%        |  0.2273 |
 | TPC-H 02       | 69.8773880005  | 4194  | 72.3441390991 | 4341  | +4%        |  0.0000 |
 | TPC-H 03       | 7.38249874115  | 443   | 7.3743019104  | 443   | -0%        |  0.8475 |
 | TPC-H 04       | 6.83276081085  | 410   | 7.05099821091 | 424   | +3%        |  0.0000 |
 | TPC-H 05       | 3.67781090736  | 221   | 3.8606364727  | 232   | +5%        |  0.0000 |
 | TPC-H 06       | 210.025177002  | 12602 | 208.360656738 | 12502 | -1%        |  0.0000 |
 | TPC-H 07       | 7.46829414368  | 449   | 7.52423238754 | 452   | +1%        |  0.2211 |
+| TPC-H 08       | 5.46047496796  | 328   | 6.13406229019 | 369   | +12%       |  0.0000 |
 | TPC-H 09       | 1.57808148861  | 95    | 1.57358634472 | 95    | -0%        |  0.5540 |
 | TPC-H 10       | 2.9701063633   | 179   | 2.94799351692 | 177   | -1%        |  0.2506 |
 | TPC-H 11       | 29.6565418243  | 1780  | 30.1364097595 | 1809  | +2%        |  0.0000 |
 | TPC-H 12       | 14.2747764587  | 857   | 14.4343328476 | 867   | +1%        |  0.0000 |
 | TPC-H 13       | 2.40615415573  | 145   | 2.3460290432  | 141   | -2%        |  0.0000 |
 | TPC-H 14       | 49.0321846008  | 2942  | 48.5004501343 | 2911  | -1%        |  0.0000 |
 | TPC-H 15       | 96.7774353027  | 5807  | 96.5101699829 | 5791  | -0%        |  0.0001 |
 | TPC-H 16       | 7.37466144562  | 443   | 7.4688076973  | 449   | +1%        |  0.0000 |
+| TPC-H 17       | 4.50997495651  | 271   | 4.78541851044 | 288   | +6%        |  0.0000 |
 | TPC-H 18       | 1.2927646637   | 78    | 1.23358237743 | 75    | -5%        |  0.0000 |
+| TPC-H 19       | 8.41294765472  | 505   | 9.34739875793 | 561   | +11%       |  0.0000 |
 | TPC-H 20       | 27.314207077   | 1639  | 28.0965442657 | 1686  | +3%        |  0.0000 |
+| TPC-H 21       | 1.13661110401  | 69    | 1.19478678703 | 72    | +5%        |  0.0000 |
 | TPC-H 22       | 15.8440980911  | 951   | 16.5419807434 | 993   | +4%        |  0.0000 |
 | geometric mean |                |       |               |       | +2%        |         |
 +----------------+----------------+-------+---------------+-------+------------+---------+
```

@julianmenzler Just realized that this also applies to LQPs, so I wrote this up real quick.