### PR TITLE
Enable encoding after binary import

### DIFF
--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -43,11 +43,13 @@ def main():
 	console.expect('Encoding "test_bin" using Unencoded')	
 
 	# Reload table with a specified encoding and check meta tables for applied encoding
-	console.sendline("load resources/test_data/bin/float.bin test_bin RunLength")
-	console.expect('Loading .*bin/float.bin into table "test_bin"')
-	console.expect('Table "test_bin" already existed. Replacing it.')
-	console.expect('Encoding "test_bin" using RunLength')
-	console.sendline("select encoding_name from meta_segments where table_name='test_bin' and chunk_id=0 and column_id=0")
+	console.sendline("load resources/test_data/bin/MultipleChunkSingleFloatColumn/Dictionary.bin test_bin_multichunk")
+	console.expect('Loading .*MultipleChunkSingleFloatColumn/Dictionary.bin into table "test_bin_multichunk"')
+	console.sendline("""load resources/test_data/bin/MultipleChunkSingleFloatColumn/Dictionary.bin test_bin_multichunk RunLength""")
+	console.expect('Loading .*MultipleChunkSingleFloatColumn/Dictionary.bin into table "test_bin_multichunk"')
+	console.expect('Table "test_bin_multichunk" already existed. Replacing it.')
+	console.expect('Encoding "test_bin_multichunk" using RunLength')
+	console.sendline("""select encoding_name from meta_segments where table_name='test_bin_multichunk' and chunk_id=0 and column_id=0""")
 	console.expect('RunLength')
 
 	# Test SQL statement

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -42,6 +42,14 @@ def main():
 	console.expect('Loading .*bin/float.bin into table "test_bin"')
 	console.expect('Encoding "test_bin" using Unencoded')	
 
+	# Reload table with a specified encoding and check meta tables for applied encoding
+	console.sendline("load resources/test_data/bin/float.bin test_bin RunLength")
+	console.expect('Loading .*bin/float.bin into table "test_bin"')
+	console.expect('Table "test_bin" already existed. Replacing it.')
+	console.expect('Encoding "test_bin" using RunLength')
+	console.sendline("select encoding_name from meta_segments where table_name='lineitem' and chunk_id=0 and column_id=0")
+	console.expect('RunLength')
+
 	# Test SQL statement
 	console.sendline("select sum(a) from test")
 	console.expect("786")

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -43,13 +43,11 @@ def main():
 	console.expect('Encoding "test_bin" using Unencoded')	
 
 	# Reload table with a specified encoding and check meta tables for applied encoding
-	console.sendline("load resources/test_data/bin/MultipleChunkSingleFloatColumn/Dictionary.bin test_bin_multichunk")
-	console.expect('Loading .*MultipleChunkSingleFloatColumn/Dictionary.bin into table "test_bin_multichunk"')
-	console.sendline("""load resources/test_data/bin/MultipleChunkSingleFloatColumn/Dictionary.bin test_bin_multichunk RunLength""")
-	console.expect('Loading .*MultipleChunkSingleFloatColumn/Dictionary.bin into table "test_bin_multichunk"')
-	console.expect('Table "test_bin_multichunk" already existed. Replacing it.')
-	console.expect('Encoding "test_bin_multichunk" using RunLength')
-	console.sendline("""select encoding_name from meta_segments where table_name='test_bin_multichunk' and chunk_id=0 and column_id=0""")
+	console.sendline("load resources/test_data/bin/float.bin test_bin RunLength")
+	console.expect('Loading .*bin/float.bin into table "test_bin"')
+	console.expect('Table "test_bin" already existed. Replacing it.')
+	console.expect('Encoding "test_bin" using RunLength')
+	console.sendline("select encoding_name from meta_segments where table_name='test_bin' and chunk_id=0 and column_id=0")
 	console.expect('RunLength')
 
 	# Test SQL statement

--- a/scripts/test/hyriseConsole_test.py
+++ b/scripts/test/hyriseConsole_test.py
@@ -47,7 +47,7 @@ def main():
 	console.expect('Loading .*bin/float.bin into table "test_bin"')
 	console.expect('Table "test_bin" already existed. Replacing it.')
 	console.expect('Encoding "test_bin" using RunLength')
-	console.sendline("select encoding_name from meta_segments where table_name='lineitem' and chunk_id=0 and column_id=0")
+	console.sendline("select encoding_name from meta_segments where table_name='test_bin' and chunk_id=0 and column_id=0")
 	console.expect('RunLength')
 
 	# Test SQL statement

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -527,7 +527,7 @@ int Console::_load_table(const std::string& args) {
   out("Loading " + std::string(filepath) + " into table \"" + tablename + "\"\n");
 
   if (Hyrise::get().storage_manager.has_table(tablename)) {
-    out("Table " + tablename + " already existed. Replacing it.\n");
+    out("Table \"" + tablename + "\" already existed. Replacing it.\n");
   }
 
   auto importer = std::make_shared<Import>(filepath, tablename, Chunk::DEFAULT_SIZE);
@@ -591,7 +591,7 @@ int Console::_export_table(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  out("Exporting " + tablename + " into \"" + filepath + "\" ...\n");
+  out("Exporting \"" + tablename + "\" into \"" + filepath + "\" ...\n");
   auto get_table = std::make_shared<GetTable>(tablename);
   get_table->execute();
 

--- a/src/lib/import_export/binary/binary_parser.cpp
+++ b/src/lib/import_export/binary/binary_parser.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<Table> BinaryParser::parse(const std::string& filename) {
 
   auto [table, chunk_count] = _read_header(file);
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
-    _import_chunk(file, table, chunk_id < (chunk_count - 1));
+    _import_chunk(file, table);
   }
 
   return table;
@@ -98,7 +98,7 @@ std::pair<std::shared_ptr<Table>, ChunkID> BinaryParser::_read_header(std::ifstr
   return std::make_pair(table, chunk_count);
 }
 
-void BinaryParser::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& table, const bool finalize_chunk) {
+void BinaryParser::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& table) {
   const auto row_count = _read_value<ChunkOffset>(file);
 
   Segments output_segments;
@@ -109,10 +109,7 @@ void BinaryParser::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& ta
 
   const auto mvcc_data = std::make_shared<MvccData>(row_count, CommitID{0});
   table->append_chunk(output_segments, mvcc_data);
-
-  if (finalize_chunk) {
-    table->get_chunk(ChunkID{table->chunk_count() - 1})->finalize();
-  }
+  table->last_chunk()->finalize();
 }
 
 std::shared_ptr<BaseSegment> BinaryParser::_import_segment(std::ifstream& file, ChunkOffset row_count,

--- a/src/lib/import_export/binary/binary_parser.hpp
+++ b/src/lib/import_export/binary/binary_parser.hpp
@@ -57,7 +57,7 @@ class BinaryParser {
    *
    * ¹Number of columns is provided in the binary header
    */
-  static void _import_chunk(std::ifstream& file, std::shared_ptr<Table>& table, const bool finalize_chunk = false);
+  static void _import_chunk(std::ifstream& file, std::shared_ptr<Table>& table, const bool finalize_chunk);
 
   // Calls the right _import_column<ColumnDataType> depending on the given data_type.
   static std::shared_ptr<BaseSegment> _import_segment(std::ifstream& file, ChunkOffset row_count, DataType data_type,

--- a/src/lib/import_export/binary/binary_parser.hpp
+++ b/src/lib/import_export/binary/binary_parser.hpp
@@ -57,7 +57,7 @@ class BinaryParser {
    *
    * ¹Number of columns is provided in the binary header
    */
-  static void _import_chunk(std::ifstream& file, std::shared_ptr<Table>& table);
+  static void _import_chunk(std::ifstream& file, std::shared_ptr<Table>& table, const bool finalize_chunk = false);
 
   // Calls the right _import_column<ColumnDataType> depending on the given data_type.
   static std::shared_ptr<BaseSegment> _import_segment(std::ifstream& file, ChunkOffset row_count, DataType data_type,

--- a/src/lib/import_export/binary/binary_parser.hpp
+++ b/src/lib/import_export/binary/binary_parser.hpp
@@ -57,7 +57,7 @@ class BinaryParser {
    *
    * ¹Number of columns is provided in the binary header
    */
-  static void _import_chunk(std::ifstream& file, std::shared_ptr<Table>& table, const bool finalize_chunk);
+  static void _import_chunk(std::ifstream& file, std::shared_ptr<Table>& table);
 
   // Calls the right _import_column<ColumnDataType> depending on the given data_type.
   static std::shared_ptr<BaseSegment> _import_segment(std::ifstream& file, ChunkOffset row_count, DataType data_type,

--- a/src/test/lib/import_export/binary/binary_parser_test.cpp
+++ b/src/test/lib/import_export/binary/binary_parser_test.cpp
@@ -64,8 +64,9 @@ TEST_P(BinaryParserMultiEncodingTest, MultipleChunkSingleFloatColumn) {
 
   EXPECT_TABLE_EQ_ORDERED(table, expected_table);
   EXPECT_EQ(table->chunk_count(), 2u);
+  // The binary importer finalizes all chunks
   EXPECT_FALSE(table->get_chunk(ChunkID{0})->is_mutable());
-  EXPECT_TRUE(table->get_chunk(ChunkID{1})->is_mutable());
+  EXPECT_FALSE(table->get_chunk(ChunkID{1})->is_mutable());
 }
 
 TEST_P(BinaryParserMultiEncodingTest, StringSegment) {

--- a/src/test/lib/import_export/binary/binary_parser_test.cpp
+++ b/src/test/lib/import_export/binary/binary_parser_test.cpp
@@ -64,6 +64,8 @@ TEST_P(BinaryParserMultiEncodingTest, MultipleChunkSingleFloatColumn) {
 
   EXPECT_TABLE_EQ_ORDERED(table, expected_table);
   EXPECT_EQ(table->chunk_count(), 2u);
+  EXPECT_FALSE(table->get_chunk(ChunkID{0})->is_mutable());
+  EXPECT_TRUE(table->get_chunk(ChunkID{1})->is_mutable());
 }
 
 TEST_P(BinaryParserMultiEncodingTest, StringSegment) {


### PR DESCRIPTION
While working on another PR, I found that tables are not encoded when being imported (e.g, using `load tpch_cached_tables/sf-0.100000/lineitem.bin lineitem LZ4`)in the console (not only here). 

The reason was that the binary importer does not finalize chunk. This PR finalizes chunk in the binary parser and adds tests.

Maybe an open discussion: do we want to finalize the last chunk? I'd say no, since this is unexpected behaviour in my opinion. It also could lead to cases where we finalize a single chunk with a few rows.