### PR TITLE
Projection: Forward dictionaries when materializing

### DIFF
--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -105,7 +105,6 @@ std::shared_ptr<const Table> Projection::_on_execute() {
           // If the ReferenceSegment references a single (FixedString)DictionarySegment, do not materialize it as a
           // ValueSegment, but re-use its dictionary and only copy the value ids.
           auto referenced_dictionary_segment = std::shared_ptr<BaseDictionarySegment>{};
-          // TODO also handle FixedStringDictionary
 
           const auto& pos_list = reference_segment->pos_list();
           if (pos_list->references_single_chunk()) {

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -12,7 +12,10 @@
 #include "expression/expression_utils.hpp"
 #include "expression/pqp_column_expression.hpp"
 #include "expression/value_expression.hpp"
+#include "storage/resolve_encoded_segment_type.hpp"
+#include "storage/segment_iterables/create_iterable_from_attribute_vector.hpp"
 #include "storage/segment_iterate.hpp"
+#include "storage/vector_compression/vector_compression.hpp"
 #include "utils/assert.hpp"
 
 namespace opossum {
@@ -86,35 +89,93 @@ std::shared_ptr<const Table> Projection::_on_execute() {
         // The current column will be returned without any logical modifications. As other columns do get modified (and
         // returned as a ValueSegment), all segments (including this one) need to become ValueSegments. This segment is
         // not yet a ValueSegment (otherwise forward_columns would be true); thus we need to materialize it.
+
+        // TODO(jk): Once we have a smart pos list that knows that a single chunk is referenced in its entirety, we can
+        //           simply forward that chunk here instead of materializing it.
+
         const auto pqp_column_expression = std::static_pointer_cast<PQPColumnExpression>(expression);
         const auto segment = input_chunk->get_segment(pqp_column_expression->column_id);
 
         resolve_data_type(expression->data_type(), [&](const auto data_type) {
           using ColumnDataType = typename decltype(data_type)::type;
-          bool has_null = false;
-          auto values = pmr_concurrent_vector<ColumnDataType>(segment->size());
-          auto null_values = pmr_concurrent_vector<bool>(segment->size());
 
-          auto chunk_offset = ChunkOffset{0};
-          segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
-            if (position.is_null()) {
-              has_null = true;
-              null_values[chunk_offset] = true;
-            } else {
-              values[chunk_offset] = position.value();
-            }
-            ++chunk_offset;
-          });
+          const auto reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment);
+          DebugAssert(reference_segment, "Expected ReferenceSegment");
 
-          auto value_segment = std::shared_ptr<ValueSegment<ColumnDataType>>{};
-          if (has_null) {
-            value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
-          } else {
-            value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values));
+          // If the ReferenceSegment references a single (FixedString)DictionarySegment, do not materialize it as a
+          // ValueSegment, but re-use its dictionary and only copy the value ids.
+          auto referenced_dictionary_segment = std::shared_ptr<BaseDictionarySegment>{};
+          // TODO also handle FixedStringDictionary
+
+          const auto& pos_list = reference_segment->pos_list();
+          if (pos_list->references_single_chunk()) {
+            const auto& referenced_table = reference_segment->referenced_table();
+            const auto& referenced_chunk = referenced_table->get_chunk(pos_list->common_chunk_id());
+            const auto& referenced_segment = referenced_chunk->get_segment(pqp_column_expression->column_id);
+            referenced_dictionary_segment = std::dynamic_pointer_cast<BaseDictionarySegment>(referenced_segment);
           }
 
-          output_segments[column_id] = std::move(value_segment);
-          column_is_nullable[column_id] = has_null;
+          if (referenced_dictionary_segment) {
+            // Resolving the BaseDictionarySegment so that we can handle both regular and fixed-string dictionaries
+            resolve_encoded_segment_type<ColumnDataType>(
+                *referenced_dictionary_segment, [&](const auto& typed_segment) {
+                  using DictionarySegmentType = std::decay_t<decltype(typed_segment)>;
+
+                  if constexpr (std::is_same_v<DictionarySegmentType, DictionarySegment<ColumnDataType>> ||
+                                std::is_same_v<DictionarySegmentType, FixedStringDictionarySegment<ColumnDataType>>) {
+                    const auto& dictionary = typed_segment.dictionary();
+
+                    auto filtered_attribute_vector = pmr_vector<ValueID::base_type>(pos_list->size());
+
+                    auto iterable = create_iterable_from_attribute_vector(typed_segment);
+                    auto chunk_offset = ChunkOffset{0};
+                    iterable.with_iterators(pos_list, [&](auto it, auto end) {
+                      while (it != end) {
+                        filtered_attribute_vector[chunk_offset] = it->value();
+                        ++it;
+                        ++chunk_offset;
+                      }
+                    });
+
+                    auto compressed_attribute_vector =
+                        compress_vector(filtered_attribute_vector, VectorCompressionType::FixedSizeByteAligned, {});
+                    output_segments[column_id] = std::make_shared<DictionarySegment<ColumnDataType>>(
+                        dictionary, std::move(compressed_attribute_vector),
+                        referenced_dictionary_segment->null_value_id());
+                  } else {
+                    Fail("Referenced segment was dynamically casted to BaseDictionarySegment, but resolve failed");
+                  }
+                });
+          } else {
+            // End of dictionary segment shortcut - handle all other referenced segments and ReferenceSegments that
+            // reference more than a single chunk by materializing themm into a ValueSegment
+            bool has_null = false;
+            auto values = pmr_concurrent_vector<ColumnDataType>(segment->size());
+            auto null_values = pmr_concurrent_vector<bool>(
+                input_table.column_is_nullable(pqp_column_expression->column_id) ? segment->size() : 0);
+
+            auto chunk_offset = ChunkOffset{0};
+            segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
+              if (position.is_null()) {
+                DebugAssert(!null_values.empty(), "Mismatching NULL information");
+                has_null = true;
+                null_values[chunk_offset] = true;
+              } else {
+                values[chunk_offset] = position.value();
+              }
+              ++chunk_offset;
+            });
+
+            auto value_segment = std::shared_ptr<ValueSegment<ColumnDataType>>{};
+            if (has_null) {
+              value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
+            } else {
+              value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values));
+            }
+
+            output_segments[column_id] = std::move(value_segment);
+            column_is_nullable[column_id] = has_null;
+          }
         });
       } else {
         auto output_segment = evaluator.evaluate_expression_to_segment(*expression);


### PR DESCRIPTION
Creating string vectors and copying strings is expensive. In cases where the projection needs to materialize a dictionary segment without modifications, it is cheaper to reuse the existing dictionary and simply materialize the value ids.

```diff
 +----------------+----------------+-------+----------------+-------+------------+---------+
 | Benchmark      | prev. iter/s   | runs  | new iter/s     | runs  | change [%] | p-value |
 +----------------+----------------+-------+----------------+-------+------------+---------+
+| TPC-H 01       | 0.672982573509 | 41    | 0.747316241264 | 45    | +11%       |  0.0000 |
 | TPC-H 02       | 71.4696502686  | 4289  | 71.8923034668  | 4315  | +1%        |  0.3648 |
 | TPC-H 03       | 7.58716583252  | 456   | 7.53408670425  | 453   | -1%        |  0.1666 |
 | TPC-H 04       | 7.09241390228  | 426   | 7.01621389389  | 421   | -1%        |  0.0107 |
 | TPC-H 05       | 3.70531916618  | 223   | 3.67264556885  | 221   | -1%        |  0.4061 |
 | TPC-H 06       | 226.626724243  | 13598 | 221.978652954  | 13319 | -2%        |  0.0000 |
 | TPC-H 07       | 7.66849040985  | 461   | 7.49309015274  | 450   | -2%        |  0.0003 |
 | TPC-H 08       | 6.62870359421  | 398   | 6.54881429672  | 393   | -1%        |  0.0115 |
 | TPC-H 09       | 1.61372458935  | 97    | 1.57233858109  | 95    | -3%        |  0.0000 |
 | TPC-H 10       | 3.01184558868  | 181   | 2.96028923988  | 178   | -2%        |  0.0093 |
 | TPC-H 11       | 30.6885433197  | 1842  | 30.4481258392  | 1827  | -1%        |  0.0000 |
 | TPC-H 12       | 14.6099348068  | 877   | 14.4844436646  | 870   | -1%        |  0.0000 |
 | TPC-H 13       | 2.39138484001  | 144   | 2.36621665955  | 142   | -1%        |  0.0004 |
 | TPC-H 14       | 49.2020378113  | 2953  | 49.0165214539  | 2941  | -0%        |  0.0000 |
 | TPC-H 15       | 97.9041519165  | 5875  | 100.673370361  | 6041  | +3%        |  0.0000 |
 | TPC-H 16       | 7.37342834473  | 443   | 7.28166055679  | 437   | -1%        |  0.0000 |
 | TPC-H 17       | 5.01125812531  | 301   | 5.07592821121  | 305   | +1%        |  0.1203 |
 | TPC-H 18       | 1.22325026989  | 74    | 1.22107195854  | 74    | -0%        |  0.9034 |
+| TPC-H 19       | 9.08268928528  | 545   | 10.1608562469  | 610   | +12%       |  0.0000 |
 | TPC-H 20       | 27.6554985046  | 1660  | 27.9258518219  | 1676  | +1%        |  0.0000 |
 | TPC-H 21       | 1.19655299187  | 72    | 1.18900215626  | 72    | -1%        |  0.3285 |
 | TPC-H 22       | 16.3743419647  | 983   | 15.9181756973  | 956   | -3%        |  0.0000 |
 | geometric mean |                |       |                |       | +0%        |         |
 +----------------+----------------+-------+----------------+-------+------------+---------+
```

No idea why Q19 is acting up lately, but as long as its performance only goes up, I won't complain ;)

While there are more projections in TPC-H with costly string copies, it only applies to Q1 because the other projections are post-join and thus the ReferenceSegments do not reference a single chunk.