### PR TITLE
Fix Multi-threading issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -275,9 +275,9 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "mkdir ./clang-release-memcheck-test"
               // If this shows a leak, try --leak-check=full, which is slower but more precise
-              sh "valgrind --tool=memcheck --track-origins=yes --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
-              sh "valgrind --tool=memcheck --track-origins=yes --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 10"
-              sh "valgrind --tool=memcheck --track-origins=yes --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 10"
+              sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
+              sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 10"
+              sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 10"
             } else {
               Utils.markStageSkippedForConditional("memcheckReleaseTest")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,6 +179,7 @@ try {
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./scripts/test/hyriseBenchmarkTPCC_test.py clang-debug-addr-ub-sanitizers"
             } else {
               Utils.markStageSkippedForConditional("clangDebugAddrUBSanitizers")
             }
@@ -205,6 +206,7 @@ try {
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./scripts/test/hyriseBenchmarkTPCC_test.py clang-release-addr-ub-sanitizers"
             } else {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
             }
@@ -215,6 +217,8 @@ try {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseTest clang-release-addr-ub-sanitizers-no-numa"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers-no-numa"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./scripts/test/hyriseBenchmarkTPCC_test.py clang-release-addr-ub-sanitizers-no-numa"
             } else {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizersNoNuma")
             }
@@ -226,6 +230,7 @@ try {
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./scripts/test/hyriseBenchmarkTPCC_test.py clang-relwithdebinfo-thread-sanitizer"
             } else {
               Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
             }
@@ -236,6 +241,8 @@ try {
               sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseTest clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer-no-numa"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./scripts/test/hyriseBenchmarkTPCC_test.py clang-relwithdebinfo-thread-sanitizer-no-numa"
             } else {
               Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizerNoNuma")
             }
@@ -271,8 +278,9 @@ try {
             if (env.BRANCH_NAME == 'master' || full_ci) {
               sh "mkdir ./clang-release-memcheck-test"
               // If this shows a leak, try --leak-check=full, which is slower but more precise
-              sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
-              sh "valgrind --tool=memcheck --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+              sh "valgrind --tool=memcheck --track-origins=yes --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseTest clang-release-memcheck-test --gtest_filter=-NUMAMemoryResourceTest.BasicAllocate"
+              sh "valgrind --tool=memcheck --track-origins=yes --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCH -s .01 -r 1 --scheduler --cores 10"
+              sh "valgrind --tool=memcheck --track-origins=yes --error-exitcode=1 --gen-suppressions=all --num-callers=25 --suppressions=resources/.valgrind-ignore.txt ./clang-release/hyriseBenchmarkTPCC -s 1 --scheduler --cores 10"
             } else {
               Utils.markStageSkippedForConditional("memcheckReleaseTest")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -137,7 +137,6 @@ try {
               sh "./scripts/test/hyriseConsole_test.py gcc-debug"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-              sh "./scripts/test/hyriseBenchmarkTPCC_test.py gcc-debug"
               sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
             } else {
@@ -226,11 +225,10 @@ try {
         }, clangRelWithDebInfoThreadSanitizer: {
           stage("clang-relwithdebinfo:thread-sanitizer") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./scripts/test/hyriseBenchmarkTPCC_test.py clang-relwithdebinfo-thread-sanitizer"
             } else {
               Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
             }
@@ -238,11 +236,10 @@ try {
         }, clangRelWithDebInfoThreadSanitizerNoNuma: {
           stage("clang-relwithdebinfo:thread-sanitizer w/o NUMA") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseTest clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-              sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./scripts/test/hyriseBenchmarkTPCC_test.py clang-relwithdebinfo-thread-sanitizer-no-numa"
             } else {
               Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizerNoNuma")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ try {
         }, clangReleaseAddrUBSanitizersNoNuma: {
           stage("clang-release:addr-ub-sanitizers w/o NUMA") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseTest clang-release-addr-ub-sanitizers-no-numa"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers-no-numa"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
@@ -238,7 +238,7 @@ try {
         }, clangRelWithDebInfoThreadSanitizerNoNuma: {
           stage("clang-relwithdebinfo:thread-sanitizer w/o NUMA") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseTest clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,7 +214,7 @@ try {
         }, clangReleaseAddrUBSanitizersNoNuma: {
           stage("clang-release:addr-ub-sanitizers w/o NUMA") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseTest clang-release-addr-ub-sanitizers-no-numa"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers-no-numa"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ try {
         }, clangDebugAddrUBSanitizers: {
           stage("clang-debug:addr-ub-sanitizers") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
@@ -202,7 +202,7 @@ try {
         }, clangReleaseAddrUBSanitizers: {
           stage("clang-release:addr-ub-sanitizers") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
@@ -226,7 +226,7 @@ try {
         }, clangRelWithDebInfoThreadSanitizer: {
           stage("clang-relwithdebinfo:thread-sanitizer") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
@@ -238,7 +238,7 @@ try {
         }, clangRelWithDebInfoThreadSanitizerNoNuma: {
           stage("clang-relwithdebinfo:thread-sanitizer w/o NUMA") {
             if (env.BRANCH_NAME == 'master' || full_ci) {
-              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
+              sh "export CCACHE_BASEDIR=`pwd`; cd clang-relwithdebinfo-thread-sanitizer-no-numa && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCC -j \$(( \$(cat /proc/cpuinfo | grep processor | wc -l) / 6)) && ../scripts/analyze_ccache_usage.py"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseTest clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer-no-numa"
               sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer-no-numa/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"

--- a/resources/.tsan-ignore.txt
+++ b/resources/.tsan-ignore.txt
@@ -1,7 +1,7 @@
 # There are multiple data races identified in the uninstrumented libtbb (probably false positives)
 # However, be aware of concurrent_vector entries being potentially uninitialized:
 #   https://software.intel.com/en-us/blogs/2009/04/09/delusion-of-tbbconcurrent_vectors-size-or-3-ways-to-traverse-in-parallel-correctly
-race:^tbb::*
+race:tbb::*
 
 # "libstdc++ is not instrumented, so tsan misses atomic operations related to shared_ptr"
 # https://groups.google.com/forum/#!topic/thread-sanitizer/vz_s-t226Vg

--- a/scripts/test/hyriseBenchmarkTPCC_test.py
+++ b/scripts/test/hyriseBenchmarkTPCC_test.py
@@ -12,7 +12,6 @@ def main():
   arguments = {}
   arguments["--scale"] = "2"
   arguments["--time"] = "30"
-  arguments["--runs"] = "100"
   arguments["--verify"] = "true"
 
   benchmark = initialize(arguments, "hyriseBenchmarkTPCC", True)
@@ -30,15 +29,14 @@ def main():
   arguments = {}
   arguments["--scale"] = "1"
   arguments["--time"] = "60"
-  arguments["--runs"] = "100"
   arguments["--consistency_checks"] = "true"
   arguments["--scheduler"] = "true"
-  arguments["--clients"] = "5"
+  arguments["--clients"] = "10"
 
   benchmark = initialize(arguments, "hyriseBenchmarkTPCC", True)
 
   benchmark.expect_exact("Running in multi-threaded mode using all available cores")
-  benchmark.expect_exact("5 simulated clients are scheduling items in parallel")
+  benchmark.expect_exact("10 simulated clients are scheduling items in parallel")
   benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
   benchmark.expect_exact("TPC-C scale factor (number of warehouses) is 1")
   benchmark.expect_exact("Results for Delivery")

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -513,28 +513,27 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCCTableGenerator::generate
   Assert(!_benchmark_config->cache_binary_tables, "Caching binary tables is not yet supported for TPC-C");
 
   std::vector<std::thread> threads;
-  auto item_table = std::async(std::launch::async, &TPCCTableGenerator::generate_item_table, this);
-  auto warehouse_table = std::async(std::launch::async, &TPCCTableGenerator::generate_warehouse_table, this);
-  auto stock_table = std::async(std::launch::async, &TPCCTableGenerator::generate_stock_table, this);
-  auto district_table = std::async(std::launch::async, &TPCCTableGenerator::generate_district_table, this);
-  auto customer_table = std::async(std::launch::async, &TPCCTableGenerator::generate_customer_table, this);
-  auto history_table = std::async(std::launch::async, &TPCCTableGenerator::generate_history_table, this);
-  auto order_line_counts = std::async(std::launch::async, &TPCCTableGenerator::generate_order_line_counts, this).get();
-  auto order_table = std::async(std::launch::async, &TPCCTableGenerator::generate_order_table, this, order_line_counts);
-  auto order_line_table =
-      std::async(std::launch::async, &TPCCTableGenerator::generate_order_line_table, this, order_line_counts);
-  auto new_order_table = std::async(std::launch::async, &TPCCTableGenerator::generate_new_order_table, this);
+  auto item_table = generate_item_table();
+  auto warehouse_table = generate_warehouse_table();
+  auto stock_table = generate_stock_table();
+  auto district_table = generate_district_table();
+  auto customer_table = generate_customer_table();
+  auto history_table = generate_history_table();
+  auto new_order_table = generate_new_order_table();
 
-  return std::unordered_map<std::string, BenchmarkTableInfo>(
-      {{"ITEM", BenchmarkTableInfo{item_table.get()}},
-       {"WAREHOUSE", BenchmarkTableInfo{warehouse_table.get()}},
-       {"STOCK", BenchmarkTableInfo{stock_table.get()}},
-       {"DISTRICT", BenchmarkTableInfo{district_table.get()}},
-       {"CUSTOMER", BenchmarkTableInfo{customer_table.get()}},
-       {"HISTORY", BenchmarkTableInfo{history_table.get()}},
-       {"ORDER", BenchmarkTableInfo{order_table.get()}},
-       {"ORDER_LINE", BenchmarkTableInfo{order_line_table.get()}},
-       {"NEW_ORDER", BenchmarkTableInfo{new_order_table.get()}}});
+  auto order_line_counts = generate_order_line_counts();
+  auto order_table = generate_order_table(order_line_counts);
+  auto order_line_table = generate_order_line_table(order_line_counts);
+
+  return std::unordered_map<std::string, BenchmarkTableInfo>({{"ITEM", BenchmarkTableInfo{item_table}},
+                                                              {"WAREHOUSE", BenchmarkTableInfo{warehouse_table}},
+                                                              {"STOCK", BenchmarkTableInfo{stock_table}},
+                                                              {"DISTRICT", BenchmarkTableInfo{district_table}},
+                                                              {"CUSTOMER", BenchmarkTableInfo{customer_table}},
+                                                              {"HISTORY", BenchmarkTableInfo{history_table}},
+                                                              {"ORDER", BenchmarkTableInfo{order_table}},
+                                                              {"ORDER_LINE", BenchmarkTableInfo{order_line_table}},
+                                                              {"NEW_ORDER", BenchmarkTableInfo{new_order_table}}});
 }
 
 thread_local TPCCRandomGenerator TPCCTableGenerator::_random_gen;  // NOLINT

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -164,7 +164,7 @@ class TPCCTableGenerator : public AbstractTableGenerator {
           }
 
           // reset data
-          data.clear();
+          data = decltype(data){};
           data.reserve(chunk_size);
         }
         row_index++;

--- a/src/lib/cache/cache.hpp
+++ b/src/lib/cache/cache.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -24,22 +24,23 @@ class Cache {
   explicit Cache(size_t capacity = DefaultCacheCapacity)
       : _impl(std::move(std::make_unique<GDFSCache<Key, Value>>(capacity))) {}
 
-  virtual ~Cache() {}
-
   // Adds or refreshes the cache entry [query, value].
   void set(const Key& query, const Value& value) {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
     if (_impl->capacity() == 0) return;
 
-    std::lock_guard<std::mutex> lock(_mutex);
     _impl->set(query, value);
   }
 
-  // Tries to fetch the cache entry for the query into the result object.
-  // Returns true if the entry was found, false otherwise.
+  // Tries to fetch the cache entry for the query into the result object. Returns true if the entry was found, false
+  // otherwise. This needs a write lock to be acquired as most implementation update some type of access count when
+  // retrieving an entry.
   std::optional<Value> try_get(const Key& query) {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+
     if (_impl->capacity() == 0) return {};
 
-    std::lock_guard<std::mutex> lock(_mutex);
     if (!_impl->has(query)) {
       return {};
     }
@@ -47,46 +48,66 @@ class Cache {
   }
 
   // Checks whether an entry for the query exists.
-  bool has(const Key& query) const { return _impl->has(query); }
+  bool has(const Key& query) const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _impl->has(query);
+  }
 
-  // Returns and refreshes the cache entry for the given query.
-  // Causes undefined behavior if the query is not in the cache.
+  // Returns and refreshes the cache entry for the given query. Causes undefined behavior if the query is not in the
+  // cache. This needs a write lock to be acquired as most implementation update some type of access count when
+  // retrieving an entry.
+  // TODO(anyone): Change this to an assertion
   Value get_entry(const Key& query) {
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::unique_lock<std::shared_mutex> lock(_mutex);
     return _impl->get(query);
   }
 
   // Purges all entries from the cache.
-  void clear() { _impl->clear(); }
+  void clear() {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    _impl->clear();
+  }
 
-  void resize(size_t capacity) { _impl->resize(capacity); }
+  void resize(size_t capacity) {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    _impl->resize(capacity);
+  }
 
-  // Returns the access frequency of a cached item (=1 for set(), +1 for each get()).
-  // Returns 0 for keys not being cache-resident.
-  size_t size() const { return _impl->size(); }
+  size_t size() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _impl->size();
+  }
 
   // Returns a reference to the underlying cache.
-  AbstractCacheImpl<Key, Value>& cache() { return *_impl; }
-  const AbstractCacheImpl<Key, Value>& cache() const { return *_impl; }
+  // TODO: Is this actually needed?
+  AbstractCacheImpl<Key, Value>& unsafe_cache() { return *_impl; }
+  const AbstractCacheImpl<Key, Value>& unsafe_cache() const { return *_impl; }
 
-  // Replaces the underlying cache by creating a new object
-  // of the given cache type.
+  // Replaces the underlying cache by creating a new object of the given cache type.
   template <class cache_t>
   void replace_cache_impl(size_t capacity) {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
     _impl = std::make_unique<cache_t>(capacity);
   }
 
-  Iterator begin() { return _impl->begin(); }
+  // These methods are named "unsafe_" (similar to tbb's naming) because iterator does not hold a mutex. As such,
+  // modifications to the cache invalidate the iterators. While this is also true for begin()/end() in other data
+  // structures, the Cache class usually deals with concurrency.
+  Iterator unsafe_begin() { return _impl->begin(); }
+  Iterator unsafe_end() { return _impl->end(); }
 
-  Iterator end() { return _impl->end(); }
-
-  size_t frequency(const Key& key) { return _impl->frequency(key); }
+  // Returns the access frequency of a cached item (=1 for set(), +1 for each get()). Returns 0 for keys not being
+  // cache-resident.
+  size_t frequency(const Key& key) {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _impl->frequency(key);
+  }
 
  protected:
   // Underlying cache eviction strategy.
   std::unique_ptr<AbstractCacheImpl<Key, Value>> _impl;
 
-  std::mutex _mutex;
+  mutable std::shared_mutex _mutex;
 };
 
 }  // namespace opossum

--- a/src/lib/cache/cache.hpp
+++ b/src/lib/cache/cache.hpp
@@ -56,7 +56,6 @@ class Cache {
   // Returns and refreshes the cache entry for the given query. Causes undefined behavior if the query is not in the
   // cache. This needs a write lock to be acquired as most implementation update some type of access count when
   // retrieving an entry.
-  // TODO(anyone): Change this to an assertion
   Value get_entry(const Key& query) {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     return _impl->get(query);

--- a/src/lib/cache/cache.hpp
+++ b/src/lib/cache/cache.hpp
@@ -77,11 +77,6 @@ class Cache {
     return _impl->size();
   }
 
-  // Returns a reference to the underlying cache.
-  // TODO: Is this actually needed?
-  AbstractCacheImpl<Key, Value>& unsafe_cache() { return *_impl; }
-  const AbstractCacheImpl<Key, Value>& unsafe_cache() const { return *_impl; }
-
   // Replaces the underlying cache by creating a new object of the given cache type.
   template <class cache_t>
   void replace_cache_impl(size_t capacity) {

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -95,6 +95,7 @@ class GDFSCache : public AbstractCacheImpl<Key, Value> {
 
   Value& get(const Key& key) {
     auto it = _map.find(key);
+    DebugAssert(it != _map.end(), "key not present");
     Handle handle = it->second;
     GDFSCacheEntry& entry = (*handle);
     entry.frequency++;

--- a/src/lib/cache/gds_cache.hpp
+++ b/src/lib/cache/gds_cache.hpp
@@ -91,6 +91,7 @@ class GDSCache : public AbstractCacheImpl<Key, Value> {
 
   Value& get(const Key& key) {
     auto it = _map.find(key);
+    DebugAssert(it != _map.end(), "key not present");
     Handle handle = it->second;
     GDSCacheEntry& entry = (*handle);
     entry.priority = _inflation + entry.cost / entry.size;

--- a/src/lib/cache/lru_cache.hpp
+++ b/src/lib/cache/lru_cache.hpp
@@ -61,6 +61,7 @@ class LRUCache : public AbstractCacheImpl<Key, Value> {
   // Causes undefined behavior if the key is not in the cache.
   Value& get(const Key& key) {
     auto it = _map.find(key);
+    DebugAssert(it != _map.end(), "key not present");
     _list.splice(_list.begin(), _list, it->second);
     return it->second->second;
   }

--- a/src/lib/cache/lru_k_cache.hpp
+++ b/src/lib/cache/lru_k_cache.hpp
@@ -118,6 +118,8 @@ class LRUKCache : public AbstractCacheImpl<Key, Value> {
     ++_access_counter;
 
     auto it = _map.find(key);
+    DebugAssert(it != _map.end(), "key not present");
+
     Handle handle = it->second;
     LRUKCacheEntry& entry = (*handle);
     entry.add_history_entry(_access_counter);

--- a/src/lib/cache/random_cache.hpp
+++ b/src/lib/cache/random_cache.hpp
@@ -71,6 +71,8 @@ class RandomCache : public AbstractCacheImpl<Key, Value> {
   // Retrieves the value cached at the key.
   Value& get(const Key& key) {
     auto it = _map.find(key);
+    DebugAssert(it != _map.end(), "key not present");
+
     return _list[it->second].second;
   }
 

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -253,7 +253,7 @@ void Insert::_on_rollback_records() {
 
     for (auto chunk_offset = target_chunk_range.begin_chunk_offset; chunk_offset < target_chunk_range.end_chunk_offset;
          ++chunk_offset) {
-      mvcc_data->begin_cids[chunk_offset] = 0u;
+      mvcc_data->set_begin_cid(chunk_offset, 0u);
       mvcc_data->tids[chunk_offset] = 0u;
     }
   }

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -162,17 +162,17 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
     // Executes the given action for every row id of the table in this range.
     template <typename F>
     void for_every_row_id(std::unique_ptr<MaterializedSegmentList<T>>& table, F action) {
-      for (size_t cluster = start.cluster; cluster <= end.cluster; ++cluster) {
-        size_t start_index = (cluster == start.cluster) ? start.index : 0;
-        size_t end_index = (cluster == end.cluster) ? end.index : (*table)[cluster]->size();
 // False positive with gcc and tsan (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92194)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+      for (size_t cluster = start.cluster; cluster <= end.cluster; ++cluster) {
+        size_t start_index = (cluster == start.cluster) ? start.index : 0;
+        size_t end_index = (cluster == end.cluster) ? end.index : (*table)[cluster]->size();
         for (size_t index = start_index; index < end_index; ++index) {
           action((*(*table)[cluster])[index].row_id);
-#pragma GCC diagnostic pop
         }
       }
+#pragma GCC diagnostic pop
     }
   };
 

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -126,7 +126,6 @@ class AbstractVisualizer {
       for (auto iter = iter_pair.first; iter != iter_pair.second; ++iter) {
         max_unnormalized_width = std::max(max_unnormalized_width, std::log(_graph[*iter].pen_width) / log_base);
       }
-#pragma GCC diagnostic pop
       if (max_unnormalized_width == 0.0) {
         // All widths are the same, don't do anything
         return;
@@ -138,6 +137,7 @@ class AbstractVisualizer {
         auto& pen_width = _graph[*iter].pen_width;
         pen_width = 1.0 + std::max(0.0, std::log(pen_width) / log_base - offset);
       }
+#pragma GCC diagnostic pop
     };
     normalize_penwidths(boost::vertices(_graph));
     normalize_penwidths(boost::edges(_graph));

--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -246,7 +246,8 @@ TEST(CachePolicyTest, Iterators) {
   auto element_count = size_t{0};
   auto value_sum = size_t{0};
 
-  for (const auto& [key, value] : cache) {
+  for (auto it = cache.unsafe_begin(); it != cache.unsafe_end(); ++it) {
+    const auto& [key, value] = *it;
     ++element_count;
     value_sum += value;
     ASSERT_EQ(value, 100);

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -30,7 +30,6 @@ enum class InputSide { Left, Right };
 // input itself is already a reference Table.
 enum class InputTableType {
   // Input Tables are data
-  // TODO add stress test where these grow (both in terms of number of chunks and size of the last chunk) while the join is executed
   Data,
   // Input Tables are reference Tables with all Segments of a Chunk having the same PosList.
   SharedPosList,

--- a/src/test/operators/join_test_runner.cpp
+++ b/src/test/operators/join_test_runner.cpp
@@ -30,6 +30,7 @@ enum class InputSide { Left, Right };
 // input itself is already a reference Table.
 enum class InputTableType {
   // Input Tables are data
+  // TODO add stress test where these grow (both in terms of number of chunks and size of the last chunk) while the join is executed
   Data,
   // Input Tables are reference Tables with all Segments of a Chunk having the same PosList.
   SharedPosList,


### PR DESCRIPTION
The recent TPC-C fails were caused by improved performance, which caused more MT issues to surface

* Cache::try_get did not acquire the mutex, so the GDFSCache got corrupted
* TPCCTableGenerator called a method on an expired object
* JoinHash could not deal with the table size / chunk count increasing while the table was being processed

Once this is merged, I can bring Jenkins back to 4 workers.