### PR TITLE
Fix crashing randomized test: missing fixtures keeps storage manager alive

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,15 +21,15 @@ if [ ! -z "$output" ]; then
 	exitcode=1
 fi
 
-# Gtest's TEST() should not be used. Use TEST_F() instead.
+# Gtest's TEST() should not be used. Use TEST_F() instead. This might require additional test classes but ensures that state is cleaned up properly.
 output=$(grep -rn '^TEST(' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  TEST() should not be used as it does not clean up global state (e.g., the Hyrise singleton)./')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1
 fi
 
-# Gtest's TEST() should not be used. Use TEST_F() instead.
-output=$(grep -rn ':\w*(?:public|protected|private)?\w+::testing::Test' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  TEST() should not be used as it does not clean up global state (e.g., the Hyrise singleton)./')
+# Tests should inherit from BaseTest or BaseTestWithParams of base_test.hpp to ensure proper destruction.
+output=$(grep -rEn ':[[:space:]]*(public|protected|private)?[[:space:]]+::testing::Test' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Tests should inherit from BaseTest\/BaseTestWithParams to ensure a proper clean up./')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -21,6 +21,13 @@ if [ ! -z "$output" ]; then
 	exitcode=1
 fi
 
+# Gtest's TEST() should not be used. Use TEST_F() instead.
+output=$(grep -rn '^TEST(' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  TEST() should not be used as it does not clean up global state (e.g., the Hyrise singleton)./')
+if [ ! -z "$output" ]; then
+	echo "$output"
+	exitcode=1
+fi
+
 # The singleton pattern should not be manually implemented
 output=$(grep -rn 'static[^:]*instance;' --exclude singleton.hpp src | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Singletons should not be implemented manually. Have a look at src\/lib\/utils\/singleton.hpp/')
 if [ ! -z "$output" ]; then

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -28,6 +28,13 @@ if [ ! -z "$output" ]; then
 	exitcode=1
 fi
 
+# Gtest's TEST() should not be used. Use TEST_F() instead.
+output=$(grep -rn ':\w*(?:public|protected|private)?\w+::testing::Test' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  TEST() should not be used as it does not clean up global state (e.g., the Hyrise singleton)./')
+if [ ! -z "$output" ]; then
+	echo "$output"
+	exitcode=1
+fi
+
 # The singleton pattern should not be manually implemented
 output=$(grep -rn 'static[^:]*instance;' --exclude singleton.hpp src | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Singletons should not be implemented manually. Have a look at src\/lib\/utils\/singleton.hpp/')
 if [ ! -z "$output" ]; then

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -5,9 +5,10 @@
 #include <utility>
 #include <vector>
 
+#include "gtest/gtest.h"
+
 #include "cache/cache.hpp"
 #include "expression/expression_functional.hpp"
-#include "gtest/gtest.h"
 #include "hyrise.hpp"
 #include "logical_query_plan/mock_node.hpp"
 #include "operators/abstract_operator.hpp"

--- a/src/test/benchmarklib/sqlite_add_indices_test.cpp
+++ b/src/test/benchmarklib/sqlite_add_indices_test.cpp
@@ -1,12 +1,10 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "operators/print.hpp"
 #include "storage/table.hpp"
-#include "testing_assert.hpp"
 #include "utils/sqlite_add_indices.hpp"
 #include "utils/sqlite_wrapper.hpp"
 

--- a/src/test/benchmarklib/table_builder_test.cpp
+++ b/src/test/benchmarklib/table_builder_test.cpp
@@ -2,7 +2,6 @@
 
 #include "all_type_variant.hpp"
 #include "table_builder.hpp"
-#include "testing_assert.hpp"
 
 namespace opossum {
 

--- a/src/test/benchmarklib/table_builder_test.cpp
+++ b/src/test/benchmarklib/table_builder_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "../base_test.hpp"
 
 #include "all_type_variant.hpp"
 #include "table_builder.hpp"
@@ -11,7 +11,9 @@ const auto table_builder_test_types = boost::hana::tuple<int32_t, std::optional<
 const auto table_builder_test_names = boost::hana::make_tuple("a", "b", "c");
 }  // namespace
 
-TEST(TableBuilderTest, CreateColumnsWithCorrectNamesAndTypesAndNullables) {
+class TableBuilderTest : public BaseTest {};
+
+TEST_F(TableBuilderTest, CreateColumnsWithCorrectNamesAndTypesAndNullables) {
   auto table_builder = TableBuilder(4, table_builder_test_types, table_builder_test_names);
   const auto table = table_builder.finish_table();
 
@@ -23,7 +25,7 @@ TEST(TableBuilderTest, CreateColumnsWithCorrectNamesAndTypesAndNullables) {
   EXPECT_EQ(table->columns_are_nullable(), std::vector({false, true, false}));
 }
 
-TEST(TableBuilderTest, AppendsRows) {
+TEST_F(TableBuilderTest, AppendsRows) {
   auto table_builder = TableBuilder(4, table_builder_test_types, table_builder_test_names);
   table_builder.append_row(42, 42.0f, "42");
   table_builder.append_row(43, std::optional<float>{}, "43");

--- a/src/test/cache/cache_test.cpp
+++ b/src/test/cache/cache_test.cpp
@@ -14,7 +14,7 @@ namespace opossum {
 class CachePolicyTest : public BaseTest {};
 
 // LRU Strategy
-TEST(CachePolicyTest, LRUCacheTest) {
+TEST_F(CachePolicyTest, LRUCacheTest) {
   LRUCache<int, int> cache(2);
 
   ASSERT_FALSE(cache.has(1));
@@ -50,7 +50,7 @@ TEST(CachePolicyTest, LRUCacheTest) {
 }
 
 // LRU-K (K = 2)
-TEST(CachePolicyTest, LRU2CacheTest) {
+TEST_F(CachePolicyTest, LRU2CacheTest) {
   LRUKCache<2, int, int> cache(2);
 
   ASSERT_FALSE(cache.has(1));
@@ -86,7 +86,7 @@ TEST(CachePolicyTest, LRU2CacheTest) {
 }
 
 // GDS Strategy
-TEST(CachePolicyTest, GDSCacheTest) {
+TEST_F(CachePolicyTest, GDSCacheTest) {
   GDSCache<int, int> cache(2);
 
   ASSERT_FALSE(cache.has(1));
@@ -137,7 +137,7 @@ TEST(CachePolicyTest, GDSCacheTest) {
 }
 
 // GDFS Strategy
-TEST(CachePolicyTest, GDFSCacheTest) {
+TEST_F(CachePolicyTest, GDFSCacheTest) {
   GDFSCache<int, int> cache(2);
 
   ASSERT_FALSE(cache.has(1));
@@ -191,7 +191,7 @@ TEST(CachePolicyTest, GDFSCacheTest) {
 }
 
 // Random Replacement Strategy
-TEST(CachePolicyTest, RandomCacheTest) {
+TEST_F(CachePolicyTest, RandomCacheTest) {
   RandomCache<int, int> cache(3);
 
   ASSERT_FALSE(cache.has(1));
@@ -235,7 +235,7 @@ TEST(CachePolicyTest, RandomCacheTest) {
 }
 
 // Test the default cache (uses GDFS).
-TEST(CachePolicyTest, Iterators) {
+TEST_F(CachePolicyTest, Iterators) {
   Cache<int, int> cache(2);
 
   cache.set(0, 100);

--- a/src/test/concurrency/commit_context_test.cpp
+++ b/src/test/concurrency/commit_context_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/commit_context.hpp"
 #include "types.hpp"

--- a/src/test/concurrency/transaction_context_test.cpp
+++ b/src/test/concurrency/transaction_context_test.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"

--- a/src/test/concurrency/transaction_manager_test.cpp
+++ b/src/test/concurrency/transaction_manager_test.cpp
@@ -2,7 +2,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"

--- a/src/test/cost_estimation/abstract_cost_estimator_test.cpp
+++ b/src/test/cost_estimation/abstract_cost_estimator_test.cpp
@@ -1,6 +1,6 @@
 #include <unordered_map>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "cost_estimation/abstract_cost_estimator.hpp"
 #include "expression/expression_functional.hpp"
@@ -31,7 +31,7 @@ class MockCostEstimator : public AbstractCostEstimator {
 
 namespace opossum {
 
-class AbstractCostEstimatorTest : public ::testing::Test {
+class AbstractCostEstimatorTest : public BaseTest {
  public:
   void SetUp() override {
     node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}}, "a");

--- a/src/test/expression/expression_evaluator_to_pos_list_test.cpp
+++ b/src/test/expression/expression_evaluator_to_pos_list_test.cpp
@@ -1,6 +1,6 @@
 #include <optional>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/arithmetic_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
@@ -20,14 +20,13 @@
 #include "operators/table_scan.hpp"
 #include "operators/table_wrapper.hpp"
 #include "storage/table.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class ExpressionEvaluatorToPosListTest : public ::testing::Test {
+class ExpressionEvaluatorToPosListTest : public BaseTest {
  public:
   void SetUp() override {
     table_a = load_table("resources/test_data/tbl/expression_evaluator/input_a.tbl", 4);

--- a/src/test/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/expression/expression_evaluator_to_values_test.cpp
@@ -1,6 +1,6 @@
 #include <optional>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/arithmetic_expression.hpp"
 #include "expression/binary_predicate_expression.hpp"
@@ -22,14 +22,13 @@
 #include "operators/table_scan.hpp"
 #include "operators/table_wrapper.hpp"
 #include "storage/table.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class ExpressionEvaluatorToValuesTest : public ::testing::Test {
+class ExpressionEvaluatorToValuesTest : public BaseTest {
  public:
   void SetUp() override {
     // Load table_a

--- a/src/test/expression/expression_result_test.cpp
+++ b/src/test/expression/expression_result_test.cpp
@@ -1,10 +1,11 @@
+#include "base_test.hpp"
+
 #include "expression/evaluation/expression_result.hpp"
 #include "expression/evaluation/expression_result_views.hpp"
-#include "gtest/gtest.h"
 
 namespace opossum {
 
-class ExpressionResultTest : public ::testing::Test {
+class ExpressionResultTest : public BaseTest {
  public:
   template <typename ExpectedViewType>
   bool check_view(std::vector<typename ExpectedViewType::Type> values, std::vector<bool> nulls) {

--- a/src/test/expression/expression_utils_test.cpp
+++ b/src/test/expression/expression_utils_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "expression/expression_utils.hpp"
@@ -9,7 +9,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class ExpressionUtilsTest : public ::testing::Test {
+class ExpressionUtilsTest : public BaseTest {
  public:
   void SetUp() override {
     node_a =

--- a/src/test/expression/like_matcher_test.cpp
+++ b/src/test/expression/like_matcher_test.cpp
@@ -1,6 +1,6 @@
 #include <string>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/evaluation/like_matcher.hpp"
 
@@ -8,7 +8,7 @@ using namespace std::string_literals;  // NOLINT
 
 namespace opossum {
 
-class LikeMatcherTest : public ::testing::Test {
+class LikeMatcherTest : public BaseTest {
  public:
   bool match(const std::string& value, const std::string& pattern) const {
     auto result = false;

--- a/src/test/gtest_case_template.cpp
+++ b/src/test/gtest_case_template.cpp
@@ -1,4 +1,3 @@
-#include <gtest/gtest.h>
 #include "base_test.hpp"
 
 namespace opossum {

--- a/src/test/lib/all_parameter_variant_test.cpp
+++ b/src/test/lib/all_parameter_variant_test.cpp
@@ -1,10 +1,8 @@
 #include <string>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "logical_query_plan/stored_table_node.hpp"
-
 #include "all_parameter_variant.hpp"
 #include "types.hpp"
 

--- a/src/test/lib/all_type_variant_test.cpp
+++ b/src/test/lib/all_type_variant_test.cpp
@@ -1,9 +1,9 @@
 #include <cstdlib>
 #include <string>
 
+#include <boost/variant.hpp>
+
 #include "base_test.hpp"
-#include "boost/variant.hpp"
-#include "gtest/gtest.h"
 
 #include "types.hpp"
 

--- a/src/test/lib/fixed_string_test.cpp
+++ b/src/test/lib/fixed_string_test.cpp
@@ -2,7 +2,7 @@
 #include <string_view>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+
 #include "storage/fixed_string_dictionary_segment/fixed_string.hpp"
 
 namespace opossum {

--- a/src/test/lib/hyrise_test.cpp
+++ b/src/test/lib/hyrise_test.cpp
@@ -1,7 +1,5 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
-#include "./utils/plugin_test_utils.hpp"
 #include "concurrency/transaction_manager.hpp"
 #include "hyrise.hpp"
 #include "operators/delete.hpp"
@@ -11,6 +9,7 @@
 #include "storage/table.hpp"
 #include "types.hpp"
 #include "utils/plugin_manager.hpp"
+#include "utils/plugin_test_utils.hpp"
 
 namespace opossum {
 

--- a/src/test/lib/import_export/binary/binary_parser_test.cpp
+++ b/src/test/lib/import_export/binary/binary_parser_test.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "import_export/binary/binary_parser.hpp"

--- a/src/test/lib/import_export/binary/binary_writer_test.cpp
+++ b/src/test/lib/import_export/binary/binary_writer_test.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "import_export/binary/binary_writer.hpp"
 #include "operators/table_scan.hpp"

--- a/src/test/lib/import_export/csv/csv_meta_test.cpp
+++ b/src/test/lib/import_export/csv/csv_meta_test.cpp
@@ -1,5 +1,4 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "import_export/csv/csv_meta.hpp"
 

--- a/src/test/lib/import_export/csv/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv/csv_parser_test.cpp
@@ -1,10 +1,8 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "import_export/csv/csv_parser.hpp"
 #include "storage/table.hpp"
-
 #include "scheduler/immediate_execution_scheduler.hpp"
 #include "scheduler/node_queue_scheduler.hpp"
 #include "scheduler/operator_task.hpp"

--- a/src/test/lib/import_export/csv/csv_writer_test.cpp
+++ b/src/test/lib/import_export/csv/csv_writer_test.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "import_export/csv/csv_meta.hpp"
 #include "import_export/csv/csv_writer.hpp"

--- a/src/test/lib/null_value_test.cpp
+++ b/src/test/lib/null_value_test.cpp
@@ -1,9 +1,9 @@
 #include <memory>
 #include <string_view>
 
-#include "all_type_variant.hpp"
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+
+#include "all_type_variant.hpp"
 #include "null_value.hpp"
 
 namespace opossum {

--- a/src/test/lib/utils/load_table_test.cpp
+++ b/src/test/lib/utils/load_table_test.cpp
@@ -1,5 +1,4 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/table.hpp"
 #include "utils/load_table.hpp"

--- a/src/test/lib/utils/verify_tables_test.cpp
+++ b/src/test/lib/utils/verify_tables_test.cpp
@@ -1,5 +1,4 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/table.hpp"
 

--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "expression/expression_utils.hpp"
@@ -14,7 +14,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class AggregateNodeTest : public ::testing::Test {
+class AggregateNodeTest : public BaseTest {
  protected:
   void SetUp() override {
     _mock_node = MockNode::make(

--- a/src/test/logical_query_plan/alias_node_test.cpp
+++ b/src/test/logical_query_plan/alias_node_test.cpp
@@ -1,18 +1,17 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/lqp_column_expression.hpp"
 #include "logical_query_plan/alias_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/mock_node.hpp"
 #include "operators/table_wrapper.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 
 using namespace std::string_literals;  // NOLINT
 
 namespace opossum {
 
-class AliasNodeTest : public ::testing::Test {
+class AliasNodeTest : public BaseTest {
  public:
   void SetUp() override {
     mock_node = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});

--- a/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
+++ b/src/test/logical_query_plan/create_prepared_plan_node_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/create_prepared_plan_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -8,7 +8,7 @@
 
 namespace opossum {
 
-class CreatePreparedPlanNodeTest : public ::testing::Test {
+class CreatePreparedPlanNodeTest : public BaseTest {
  public:
   void SetUp() override {
     lqp = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));

--- a/src/test/logical_query_plan/create_table_node_test.cpp
+++ b/src/test/logical_query_plan/create_table_node_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/create_table_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -9,7 +9,7 @@
 
 namespace opossum {
 
-class CreateTableNodeTest : public ::testing::Test {
+class CreateTableNodeTest : public BaseTest {
  public:
   void SetUp() override {
     column_definitions.emplace_back("a", DataType::Int, false);

--- a/src/test/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/logical_query_plan/create_view_node_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/create_view_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -7,7 +7,7 @@
 
 namespace opossum {
 
-class CreateViewNodeTest : public ::testing::Test {
+class CreateViewNodeTest : public BaseTest {
  public:
   void SetUp() override {
     _view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));

--- a/src/test/logical_query_plan/drop_table_node_test.cpp
+++ b/src/test/logical_query_plan/drop_table_node_test.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/drop_table_node.hpp"
 
 namespace opossum {
 
-class DropTableNodeTest : public ::testing::Test {
+class DropTableNodeTest : public BaseTest {
  public:
   void SetUp() override { drop_table_node = DropTableNode::make("some_table", false); }
 

--- a/src/test/logical_query_plan/drop_view_node_test.cpp
+++ b/src/test/logical_query_plan/drop_view_node_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/drop_view_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -6,7 +6,7 @@
 
 namespace opossum {
 
-class DropViewNodeTest : public ::testing::Test {
+class DropViewNodeTest : public BaseTest {
  public:
   void SetUp() override { _drop_view_node = DropViewNode::make("some_view", false); }
 

--- a/src/test/logical_query_plan/dummy_table_node_test.cpp
+++ b/src/test/logical_query_plan/dummy_table_node_test.cpp
@@ -1,13 +1,13 @@
 #include <memory>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/dummy_table_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 
 namespace opossum {
 
-class DummyTableNodeTest : public ::testing::Test {
+class DummyTableNodeTest : public BaseTest {
  protected:
   void SetUp() override { _dummy_table_node = DummyTableNode::make(); }
 

--- a/src/test/logical_query_plan/insert_node_test.cpp
+++ b/src/test/logical_query_plan/insert_node_test.cpp
@@ -1,7 +1,5 @@
 #include <memory>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "logical_query_plan/insert_node.hpp"
@@ -9,7 +7,7 @@
 
 namespace opossum {
 
-class InsertNodeTest : public ::testing::Test {
+class InsertNodeTest : public BaseTest {
  protected:
   void SetUp() override { _insert_node = InsertNode::make("table_a"); }
 

--- a/src/test/logical_query_plan/join_node_test.cpp
+++ b/src/test/logical_query_plan/join_node_test.cpp
@@ -1,8 +1,6 @@
 #include <memory>
 #include <utility>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
@@ -15,7 +13,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class JoinNodeTest : public ::testing::Test {
+class JoinNodeTest : public BaseTest {
  protected:
   void SetUp() override {
     _mock_node_a = MockNode::make(

--- a/src/test/logical_query_plan/limit_node_test.cpp
+++ b/src/test/logical_query_plan/limit_node_test.cpp
@@ -1,7 +1,5 @@
 #include <memory>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
@@ -12,7 +10,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class LimitNodeTest : public ::testing::Test {
+class LimitNodeTest : public BaseTest {
  protected:
   void SetUp() override { _limit_node = LimitNode::make(value_(10)); }
 

--- a/src/test/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/logical_query_plan/logical_query_plan_test.cpp
@@ -1,4 +1,5 @@
 #include "base_test.hpp"
+
 #include "expression/expression_functional.hpp"
 #include "expression/lqp_column_expression.hpp"
 #include "hyrise.hpp"
@@ -10,7 +11,6 @@
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "logical_query_plan/union_node.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 #include "utils/string_utils.hpp"
 

--- a/src/test/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
+++ b/src/test/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
@@ -1,4 +1,5 @@
 #include "base_test.hpp"
+
 #include "expression/expression_functional.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
@@ -21,8 +22,6 @@
 #include "logical_query_plan/update_node.hpp"
 #include "logical_query_plan/validate_node.hpp"
 #include "utils/load_table.hpp"
-
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/logical_query_plan/lqp_utils_test.cpp
@@ -1,6 +1,5 @@
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
+
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/aggregate_node.hpp"

--- a/src/test/logical_query_plan/mock_node_test.cpp
+++ b/src/test/logical_query_plan/mock_node_test.cpp
@@ -1,8 +1,6 @@
 #include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
@@ -14,7 +12,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class MockNodeTest : public ::testing::Test {
+class MockNodeTest : public BaseTest {
  protected:
   void SetUp() override {
     _mock_node_a = MockNode::make(MockNode::ColumnDefinitions{

--- a/src/test/logical_query_plan/projection_node_test.cpp
+++ b/src/test/logical_query_plan/projection_node_test.cpp
@@ -2,8 +2,6 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "expression/abstract_expression.hpp"

--- a/src/test/logical_query_plan/static_table_node_test.cpp
+++ b/src/test/logical_query_plan/static_table_node_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/static_table_node.hpp"
@@ -7,7 +7,7 @@
 
 namespace opossum {
 
-class StaticTableNodeTest : public ::testing::Test {
+class StaticTableNodeTest : public BaseTest {
  public:
   void SetUp() override {
     column_definitions.emplace_back("a", DataType::Int, false);

--- a/src/test/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/logical_query_plan/stored_table_node_test.cpp
@@ -1,8 +1,6 @@
 #include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"

--- a/src/test/logical_query_plan/union_node_test.cpp
+++ b/src/test/logical_query_plan/union_node_test.cpp
@@ -1,7 +1,5 @@
 #include <memory>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "logical_query_plan/lqp_utils.hpp"

--- a/src/test/logical_query_plan/update_node_test.cpp
+++ b/src/test/logical_query_plan/update_node_test.cpp
@@ -1,8 +1,6 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"

--- a/src/test/logical_query_plan/validate_node_test.cpp
+++ b/src/test/logical_query_plan/validate_node_test.cpp
@@ -1,7 +1,5 @@
 #include <memory>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
 
 #include "logical_query_plan/lqp_utils.hpp"

--- a/src/test/lossless_cast_test.cpp
+++ b/src/test/lossless_cast_test.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "lossless_cast.hpp"
 
 namespace opossum {
 
-class LosslessCastTest : public ::testing::Test {};
+class LosslessCastTest : public BaseTest {};
 
 TEST_F(LosslessCastTest, IdenticalSourceAndTarget) {
   EXPECT_EQ(lossless_cast<int32_t>(int32_t(5)), int32_t(5));

--- a/src/test/lossy_cast_test.cpp
+++ b/src/test/lossy_cast_test.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "lossy_cast.hpp"
 
 namespace opossum {
 
-class LossyCastTest : public ::testing::Test {};
+class LossyCastTest : public BaseTest {};
 
 TEST_F(LossyCastTest, LossyVariantCast) {
   EXPECT_EQ(lossy_variant_cast<int32_t>(int32_t(5)), int32_t(5));

--- a/src/test/memory/numa_memory_resource_test.cpp
+++ b/src/test/memory/numa_memory_resource_test.cpp
@@ -1,7 +1,7 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+
 #if HYRISE_NUMA_SUPPORT
 #include <numa.h>
 #endif

--- a/src/test/operators/aggregate_test.cpp
+++ b/src/test/operators/aggregate_test.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "operators/abstract_read_only_operator.hpp"
 #include "operators/aggregate_hash.hpp"

--- a/src/test/operators/alias_operator_test.cpp
+++ b/src/test/operators/alias_operator_test.cpp
@@ -1,13 +1,12 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "operators/alias_operator.hpp"
 #include "operators/table_wrapper.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 
 namespace opossum {
 
-class AliasOperatorTest : public ::testing::Test {
+class AliasOperatorTest : public BaseTest {
  public:
   void SetUp() override {
     const auto table_wrapper =

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"

--- a/src/test/operators/difference_test.cpp
+++ b/src/test/operators/difference_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "expression/pqp_column_expression.hpp"

--- a/src/test/operators/export_test.cpp
+++ b/src/test/operators/export_test.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "constant_mappings.hpp"
 #include "import_export/csv/csv_meta.hpp"

--- a/src/test/operators/get_table_test.cpp
+++ b/src/test/operators/get_table_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"

--- a/src/test/operators/import_test.cpp
+++ b/src/test/operators/import_test.cpp
@@ -2,7 +2,6 @@
 #include <string>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "import_export/file_type.hpp"

--- a/src/test/operators/index_scan_test.cpp
+++ b/src/test/operators/index_scan_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "logical_query_plan/lqp_translator.hpp"

--- a/src/test/operators/insert_test.cpp
+++ b/src/test/operators/insert_test.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "expression/expression_functional.hpp"

--- a/src/test/operators/join_hash_test.cpp
+++ b/src/test/operators/join_hash_test.cpp
@@ -108,7 +108,7 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
   EXPECT_NE(join_operator_copy->input_right(), nullptr);
 }
 
-TEST(OperatorsJoinHashTestStatic, RadixBitCalculation) {
+TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
   // Simple cases: handle minimal inputs and very large inputs
   EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 1), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int>(0, 1), 0ul);

--- a/src/test/operators/join_hash_traits_test.cpp
+++ b/src/test/operators/join_hash_traits_test.cpp
@@ -1,7 +1,6 @@
 #include <string>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "operators/join_hash/join_hash_traits.hpp"
 

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "operators/join_hash/join_hash_steps.hpp"
 
@@ -11,7 +11,7 @@ namespace opossum {
  * All these tests are executed for the main numeric types.
  */
 template <typename T>
-class JoinHashTypesTest : public ::testing::Test {};
+class JoinHashTypesTest : public BaseTest {};
 
 template <typename T, typename HashType>
 void test_hash_map(const std::vector<T>& values) {

--- a/src/test/operators/join_index_test.cpp
+++ b/src/test/operators/join_index_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "all_type_variant.hpp"
 #include "operators/join_index.hpp"

--- a/src/test/operators/join_nested_loop_test.cpp
+++ b/src/test/operators/join_nested_loop_test.cpp
@@ -6,7 +6,7 @@
 
 namespace opossum {
 
-class OperatorsJoinNestedLoopTest : public ::testing::Test {
+class OperatorsJoinNestedLoopTest : public BaseTest {
  public:
   void SetUp() override {
     const auto dummy_table =

--- a/src/test/operators/join_sort_merge_test.cpp
+++ b/src/test/operators/join_sort_merge_test.cpp
@@ -6,7 +6,7 @@
 
 namespace opossum {
 
-class OperatorsJoinSortMergeTest : public ::testing::Test {
+class OperatorsJoinSortMergeTest : public BaseTest {
  public:
   void SetUp() override {
     const auto dummy_table =

--- a/src/test/operators/join_verification_test.cpp
+++ b/src/test/operators/join_verification_test.cpp
@@ -6,7 +6,7 @@
 
 namespace opossum {
 
-class OperatorsJoinVerificationTest : public ::testing::Test {
+class OperatorsJoinVerificationTest : public BaseTest {
  public:
   void SetUp() override {
     const auto dummy_table =

--- a/src/test/operators/limit_test.cpp
+++ b/src/test/operators/limit_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "operators/limit.hpp"

--- a/src/test/operators/maintenance/create_prepared_plan_test.cpp
+++ b/src/test/operators/maintenance/create_prepared_plan_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "logical_query_plan/create_prepared_plan_node.hpp"

--- a/src/test/operators/maintenance/create_table_test.cpp
+++ b/src/test/operators/maintenance/create_table_test.cpp
@@ -1,7 +1,7 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+#include "utils/assert.hpp"
 
 #include "concurrency/transaction_context.hpp"
 #include "expression/expression_functional.hpp"
@@ -13,8 +13,6 @@
 #include "operators/table_wrapper.hpp"
 #include "operators/validate.hpp"
 #include "storage/table.hpp"
-
-#include "utils/assert.hpp"
 
 namespace opossum {
 

--- a/src/test/operators/maintenance/create_view_test.cpp
+++ b/src/test/operators/maintenance/create_view_test.cpp
@@ -1,7 +1,7 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+#include "utils/assert.hpp"
 
 #include "hyrise.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -9,8 +9,6 @@
 #include "operators/maintenance/create_view.hpp"
 #include "storage/lqp_view.hpp"
 #include "storage/table.hpp"
-
-#include "utils/assert.hpp"
 
 namespace opossum {
 

--- a/src/test/operators/maintenance/drop_table_test.cpp
+++ b/src/test/operators/maintenance/drop_table_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "operators/maintenance/drop_table.hpp"

--- a/src/test/operators/maintenance/drop_view_test.cpp
+++ b/src/test/operators/maintenance/drop_view_test.cpp
@@ -1,15 +1,13 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+#include "utils/assert.hpp"
 
 #include "hyrise.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "operators/maintenance/drop_view.hpp"
 #include "storage/lqp_view.hpp"
 #include "storage/table.hpp"
-
-#include "utils/assert.hpp"
 
 namespace opossum {
 

--- a/src/test/operators/operator_deep_copy_test.cpp
+++ b/src/test/operators/operator_deep_copy_test.cpp
@@ -2,7 +2,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "hyrise.hpp"

--- a/src/test/operators/operator_join_predicate_test.cpp
+++ b/src/test/operators/operator_join_predicate_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -9,7 +9,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class OperatorJoinPredicateTest : public ::testing::Test {
+class OperatorJoinPredicateTest : public BaseTest {
  public:
   void SetUp() override {
     node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});

--- a/src/test/operators/operator_scan_predicate_test.cpp
+++ b/src/test/operators/operator_scan_predicate_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -8,7 +8,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class OperatorScanPredicateTest : public ::testing::Test {
+class OperatorScanPredicateTest : public BaseTest {
  public:
   void SetUp() override {
     node = MockNode::make(

--- a/src/test/operators/product_test.cpp
+++ b/src/test/operators/product_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "operators/abstract_read_only_operator.hpp"
 #include "operators/product.hpp"

--- a/src/test/operators/projection_test.cpp
+++ b/src/test/operators/projection_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "expression/pqp_column_expression.hpp"

--- a/src/test/operators/sort_test.cpp
+++ b/src/test/operators/sort_test.cpp
@@ -3,7 +3,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "operators/abstract_read_only_operator.hpp"
 #include "operators/join_nested_loop.hpp"

--- a/src/test/operators/table_scan_sorted_segment_search_test.cpp
+++ b/src/test/operators/table_scan_sorted_segment_search_test.cpp
@@ -1,5 +1,5 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+
 #include "operators/table_scan/sorted_segment_search.hpp"
 #include "storage/segment_iterate.hpp"
 

--- a/src/test/operators/table_scan_string_test.cpp
+++ b/src/test/operators/table_scan_string_test.cpp
@@ -6,7 +6,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/evaluation/like_matcher.hpp"
 #include "operators/abstract_read_only_operator.hpp"

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "operators/abstract_read_only_operator.hpp"

--- a/src/test/operators/union_all_test.cpp
+++ b/src/test/operators/union_all_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/pqp_column_expression.hpp"
 #include "operators/projection.hpp"

--- a/src/test/operators/update_test.cpp
+++ b/src/test/operators/update_test.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "expression/pqp_column_expression.hpp"

--- a/src/test/operators/validate_test.cpp
+++ b/src/test/operators/validate_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "expression/expression_functional.hpp"

--- a/src/test/operators/validate_visibility_test.cpp
+++ b/src/test/operators/validate_visibility_test.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "hyrise.hpp"

--- a/src/test/optimizer/dp_ccp_test.cpp
+++ b/src/test/optimizer/dp_ccp_test.cpp
@@ -11,7 +11,6 @@
 #include "statistics/attribute_statistics.hpp"
 #include "statistics/cardinality_estimator.hpp"
 #include "statistics/table_statistics.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 
 /**

--- a/src/test/optimizer/enumerate_ccp_test.cpp
+++ b/src/test/optimizer/enumerate_ccp_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "../base_test.hpp"
 
 #include "optimizer/join_ordering/enumerate_ccp.hpp"
 
@@ -18,11 +18,13 @@ bool equals(const std::pair<boost::dynamic_bitset<>, boost::dynamic_bitset<>>& l
 
 namespace opossum {
 
+class EnumerateCcpTest : public BaseTest {};
+
 /**
  * Test that the correct CCPs are enumerated for _very_ simple graphs and that they are enumerated in the correct order
  */
 
-TEST(EnumerateCcpTest, Simple) {
+TEST_F(EnumerateCcpTest, Simple) {
   std::vector<std::pair<size_t, size_t>> edges{{0, 1}};
 
   const auto pairs = EnumerateCcp{2, edges}();  // NOLINT - {}()
@@ -32,7 +34,7 @@ TEST(EnumerateCcpTest, Simple) {
   EXPECT_TRUE(equals(pairs[0], std::make_pair(0b01ul, 0b10ul)));
 }
 
-TEST(EnumerateCcpTest, Chain) {
+TEST_F(EnumerateCcpTest, Chain) {
   std::vector<std::pair<size_t, size_t>> edges{{0, 1}, {1, 2}, {2, 3}};
 
   const auto pairs = EnumerateCcp{4, edges}();  // NOLINT - {}()
@@ -51,7 +53,7 @@ TEST(EnumerateCcpTest, Chain) {
   EXPECT_TRUE(equals(pairs[9], std::make_pair(0b0111ul, 0b1000ul)));
 }
 
-TEST(EnumerateCcpTest, Ring) {
+TEST_F(EnumerateCcpTest, Ring) {
   std::vector<std::pair<size_t, size_t>> edges{{0, 1}, {1, 2}, {2, 0}};
 
   const auto pairs = EnumerateCcp{3, edges}();  // NOLINT - {}()
@@ -66,7 +68,7 @@ TEST(EnumerateCcpTest, Ring) {
   EXPECT_TRUE(equals(pairs[5], std::make_pair(0b101ul, 0b010ul)));
 }
 
-TEST(EnumerateCcpTest, Star) {
+TEST_F(EnumerateCcpTest, Star) {
   std::vector<std::pair<size_t, size_t>> edges{{0, 1}, {0, 2}, {0, 3}};
 
   const auto pairs = EnumerateCcp{4, edges}();  // NOLINT - {}()
@@ -87,7 +89,7 @@ TEST(EnumerateCcpTest, Star) {
   EXPECT_TRUE(equals(pairs[11], std::make_pair(0b1101ul, 0b0010ul)));
 }
 
-TEST(EnumerateCcpTest, Clique) {
+TEST_F(EnumerateCcpTest, Clique) {
   std::vector<std::pair<size_t, size_t>> edges{{0, 1}, {0, 2}, {0, 3}, {1, 2}, {2, 3}, {1, 3}};
 
   const auto pairs = EnumerateCcp{4, edges}();  // NOLINT - {}()
@@ -120,7 +122,7 @@ TEST(EnumerateCcpTest, Clique) {
   EXPECT_TRUE(equals(pairs[24], std::make_pair(0b1101ul, 0b0010ul)));
 }
 
-TEST(EnumerateCcpTest, RandomJoinGraphShape) {
+TEST_F(EnumerateCcpTest, RandomJoinGraphShape) {
   /**
    *    0
    *   / \
@@ -150,7 +152,7 @@ TEST(EnumerateCcpTest, RandomJoinGraphShape) {
   EXPECT_TRUE(equals(pairs[14], std::make_pair(0b01011ul, 0b00100ul)));
 }
 
-TEST(EnumerateCcpTest, ArbitraryVertexNumbering) {
+TEST_F(EnumerateCcpTest, ArbitraryVertexNumbering) {
   std::vector<std::pair<size_t, size_t>> edges{{0, 2}, {2, 1}};
 
   const auto pairs = EnumerateCcp{3, edges}();  // NOLINT - {}()

--- a/src/test/optimizer/join_graph_test.cpp
+++ b/src/test/optimizer/join_graph_test.cpp
@@ -1,6 +1,6 @@
 #include <sstream>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -11,7 +11,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class JoinGraphTest : public ::testing::Test {
+class JoinGraphTest : public BaseTest {
  public:
   void SetUp() override {
     node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}}, "a");

--- a/src/test/optimizer/optimizer_test.cpp
+++ b/src/test/optimizer/optimizer_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/join_node.hpp"
@@ -11,13 +11,12 @@
 #include "logical_query_plan/sort_node.hpp"
 #include "optimizer/optimizer.hpp"
 #include "optimizer/strategy/abstract_rule.hpp"
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class OptimizerTest : public ::testing::Test {
+class OptimizerTest : public BaseTest {
  public:
   void SetUp() override {
     node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}}, "node_a");

--- a/src/test/optimizer/strategy/between_composition_rule_test.cpp
+++ b/src/test/optimizer/strategy/between_composition_rule_test.cpp
@@ -2,9 +2,9 @@
 #include <string>
 #include <vector>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
+#include "utils/assert.hpp"
+
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/mock_node.hpp"
@@ -15,7 +15,6 @@
 #include "optimizer/strategy/between_composition_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
 #include "statistics/table_statistics.hpp"
-#include "utils/assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -4,12 +4,13 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+#include "utils/assert.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/lqp_translator.hpp"
+#include "logical_query_plan/mock_node.hpp"
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/sort_node.hpp"
@@ -23,10 +24,6 @@
 #include "storage/chunk.hpp"
 #include "storage/chunk_encoder.hpp"
 #include "storage/table.hpp"
-
-#include "utils/assert.hpp"
-
-#include "logical_query_plan/mock_node.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "strategy_base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/delete_node.hpp"
@@ -12,9 +12,6 @@
 #include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/update_node.hpp"
 #include "optimizer/strategy/column_pruning_rule.hpp"
-
-#include "strategy_base_test.hpp"
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "strategy_base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/delete_node.hpp"
@@ -12,9 +12,6 @@
 #include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/update_node.hpp"
 #include "optimizer/strategy/dependent_group_by_reduction_rule.hpp"
-
-#include "strategy_base_test.hpp"
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/expression_reduction_rule_test.cpp
+++ b/src/test/optimizer/strategy/expression_reduction_rule_test.cpp
@@ -11,7 +11,6 @@
 #include "optimizer/strategy/expression_reduction_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
 #include "storage/table_column_definition.hpp"
-#include "testing_assert.hpp"
 #include "types.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT

--- a/src/test/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/optimizer/strategy/index_scan_rule_test.cpp
@@ -5,7 +5,7 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+#include "utils/assert.hpp"
 
 #include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
@@ -22,7 +22,6 @@
 #include "storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
-#include "utils/assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/join_ordering_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_ordering_rule_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "strategy_base_test.hpp"
 
 #include "cost_estimation/cost_estimator_logical.hpp"
 #include "expression/expression_functional.hpp"
@@ -9,8 +9,6 @@
 #include "optimizer/strategy/join_ordering_rule.hpp"
 #include "statistics/attribute_statistics.hpp"
 #include "statistics/table_statistics.hpp"
-
-#include "strategy_base_test.hpp"
 
 /**
  * We can't actually test much about the JoinOrderingRule, since it is highly dependent on the underlying algorithms

--- a/src/test/optimizer/strategy/join_predicate_ordering_rule_test.cpp
+++ b/src/test/optimizer/strategy/join_predicate_ordering_rule_test.cpp
@@ -1,9 +1,6 @@
 #include <numeric>
 
-#include "gtest/gtest.h"
-
 #include "strategy_base_test.hpp"
-#include "testing_assert.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "expression/lqp_column_expression.hpp"

--- a/src/test/optimizer/strategy/predicate_merge_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_merge_rule_test.cpp
@@ -6,7 +6,6 @@
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/union_node.hpp"
 #include "optimizer/strategy/predicate_merge_rule.hpp"
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
@@ -14,7 +13,6 @@
 #include "logical_query_plan/validate_node.hpp"
 #include "optimizer/strategy/predicate_placement_rule.hpp"
 #include "optimizer/strategy/strategy_base_test.hpp"
-#include "testing_assert.hpp"
 #include "types.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT

--- a/src/test/optimizer/strategy/predicate_reordering_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_reordering_rule_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"

--- a/src/test/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -6,7 +6,6 @@
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/union_node.hpp"
 #include "optimizer/strategy/predicate_split_up_rule.hpp"
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 

--- a/src/test/optimizer/strategy/strategy_base_test.hpp
+++ b/src/test/optimizer/strategy/strategy_base_test.hpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 namespace opossum {
 

--- a/src/test/optimizer/strategy/subquery_to_join_rule_test.cpp
+++ b/src/test/optimizer/strategy/subquery_to_join_rule_test.cpp
@@ -1,7 +1,4 @@
-#include "gtest/gtest.h"
-
 #include "strategy_base_test.hpp"
-#include "testing_assert.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "expression/expression_utils.hpp"

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -3,7 +3,6 @@
 #include <thread>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "../../plugins/mvcc_delete_plugin.hpp"
 #include "expression/expression_functional.hpp"

--- a/src/test/plugins/mvcc_delete_plugin_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "../../plugins/mvcc_delete_plugin.hpp"
 #include "../utils/plugin_test_utils.hpp"

--- a/src/test/server/postgres_protocol_handler_test.cpp
+++ b/src/test/server/postgres_protocol_handler_test.cpp
@@ -1,8 +1,6 @@
 #include <algorithm>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
-
 #include "mock_socket.hpp"
 
 #include "server/postgres_protocol_handler.hpp"

--- a/src/test/server/query_handler_test.cpp
+++ b/src/test/server/query_handler_test.cpp
@@ -1,5 +1,4 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "server/query_handler.hpp"
 

--- a/src/test/server/read_buffer_test.cpp
+++ b/src/test/server/read_buffer_test.cpp
@@ -1,8 +1,6 @@
 #include <boost/asio.hpp>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
-
 #include "mock_socket.hpp"
 
 #include "server/read_buffer.hpp"

--- a/src/test/server/result_serializer_test.cpp
+++ b/src/test/server/result_serializer_test.cpp
@@ -1,6 +1,4 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
-
 #include "mock_socket.hpp"
 
 #include "server/postgres_protocol_handler.hpp"

--- a/src/test/server/write_buffer_test.cpp
+++ b/src/test/server/write_buffer_test.cpp
@@ -1,8 +1,6 @@
 #include <boost/asio.hpp>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
-
 #include "mock_socket.hpp"
 
 #include "server/write_buffer.hpp"

--- a/src/test/sql/sql_pipeline_statement_test.cpp
+++ b/src/test/sql/sql_pipeline_statement_test.cpp
@@ -1,11 +1,11 @@
 #include <memory>
 #include <string>
 #include <utility>
+
 #include "base_test.hpp"
 
 #include "SQLParser.h"
 #include "SQLParserResult.h"
-#include "gtest/gtest.h"
 
 #include "cache/cache.hpp"
 #include "hyrise.hpp"

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -1,13 +1,13 @@
 #include <memory>
 #include <string>
 #include <utility>
+
 #include "base_test.hpp"
 
 #include "SQLParser.h"
 #include "SQLParserResult.h"
-#include "gtest/gtest.h"
-#include "logical_query_plan/join_node.hpp"
 
+#include "logical_query_plan/join_node.hpp"
 #include "hyrise.hpp"
 #include "operators/abstract_join_operator.hpp"
 #include "operators/print.hpp"

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -1,4 +1,5 @@
 #include "base_test.hpp"
+
 #include "constant_mappings.hpp"
 #include "expression/abstract_expression.hpp"
 #include "expression/expression_functional.hpp"
@@ -28,7 +29,6 @@
 #include "sql/create_sql_parser_error_message.hpp"
 #include "sql/sql_translator.hpp"
 #include "storage/table.hpp"
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 #include "utils/meta_table_manager.hpp"
 

--- a/src/test/sql/sqlite_testrunner/sqlite_testrunner.hpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_testrunner.hpp
@@ -11,9 +11,9 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
-#include "SQLParser.h"
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+
+#include "SQLParser.h"
 
 #include "concurrency/transaction_context.hpp"
 #include "constant_mappings.hpp"

--- a/src/test/sql/sqlite_testrunner/sqlite_wrapper_test.cpp
+++ b/src/test/sql/sqlite_testrunner/sqlite_wrapper_test.cpp
@@ -1,14 +1,13 @@
 #include <optional>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
-#include "testing_assert.hpp"
 #include "utils/load_table.hpp"
 #include "utils/sqlite_wrapper.hpp"
 
 namespace opossum {
 
-class SQLiteWrapperTest : public ::testing::Test {
+class SQLiteWrapperTest : public BaseTest {
  public:
   void SetUp() override { sqlite_wrapper.emplace(); }
 

--- a/src/test/statistics/attribute_statistics_test.cpp
+++ b/src/test/statistics/attribute_statistics_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "statistics/attribute_statistics.hpp"
 #include "statistics/statistics_objects/counting_quotient_filter.hpp"
@@ -8,7 +8,7 @@
 
 namespace opossum {
 
-class AttributeStatisticsTest : public ::testing::Test {};
+class AttributeStatisticsTest : public BaseTest {};
 
 TEST_F(AttributeStatisticsTest, SetStatisticsObject) {
   AttributeStatistics<int32_t> attribute_statistics;

--- a/src/test/statistics/cardinality_estimator_test.cpp
+++ b/src/test/statistics/cardinality_estimator_test.cpp
@@ -1,9 +1,8 @@
 #include <memory>
 #include <vector>
 
-#include "gtest/gtest.h"
-
 #include "base_test.hpp"
+
 #include "expression/expression_functional.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/aggregate_node.hpp"

--- a/src/test/statistics/join_graph_statistics_cache_test.cpp
+++ b/src/test/statistics/join_graph_statistics_cache_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
@@ -15,7 +15,7 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class JoinGraphStatisticsCacheTest : public ::testing::Test {
+class JoinGraphStatisticsCacheTest : public BaseTest {
  public:
   void SetUp() override {
     node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}});

--- a/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
@@ -173,15 +173,17 @@ TYPED_TEST(CountingQuotientFilterTypedTest, HashBits) {
   }
 }
 
+class CountingQuotientFilterTest : public BaseTest {};
+
 // Floating point types are not supported.
-TEST(CountingQuotientFilterTest, FloatingPointTypesUnsupported) {
+TEST_F(CountingQuotientFilterTest, FloatingPointTypesUnsupported) {
   EXPECT_NO_THROW(CountingQuotientFilter<int>(4, 4));
 
   EXPECT_THROW(CountingQuotientFilter<float>(4, 4), std::logic_error);
   EXPECT_THROW(CountingQuotientFilter<double>(4, 4), std::logic_error);
 }
 
-TEST(CountingQuotientFilterTest, QuotientSizes) {
+TEST_F(CountingQuotientFilterTest, QuotientSizes) {
   // Quotient needs to be larger than zero.
   EXPECT_THROW(CountingQuotientFilter<int>(0, 4), std::logic_error);
 

--- a/src/test/statistics/statistics_objects/equal_distinct_count_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/equal_distinct_count_histogram_test.cpp
@@ -3,7 +3,6 @@
 #include <string>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "statistics/statistics_objects/equal_distinct_count_histogram.hpp"
 #include "statistics/statistics_objects/generic_histogram.hpp"

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "constant_mappings.hpp"
 #include "statistics/statistics_objects/generic_histogram.hpp"

--- a/src/test/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/min_max_filter_test.cpp
@@ -5,8 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
-
 #include "utils/assert.hpp"
 
 #include "statistics/statistics_objects/min_max_filter.hpp"
@@ -15,7 +13,7 @@
 namespace opossum {
 
 template <typename T>
-class MinMaxFilterTest : public ::testing::Test {
+class MinMaxFilterTest : public BaseTest {
  protected:
   void SetUp() override {
     _values = pmr_vector<T>{-1000, 2, 3, 4, 7, 8, 10, 17, 123456};
@@ -34,7 +32,7 @@ class MinMaxFilterTest : public ::testing::Test {
 
 // the test data for strings needs to be handled differently from numerics
 template <>
-class MinMaxFilterTest<pmr_string> : public ::testing::Test {
+class MinMaxFilterTest<pmr_string> : public BaseTest {
  protected:
   void SetUp() override {
     _values = pmr_vector<pmr_string>{"aa", "bb", "b", "bbbbba", "bbbbbb", "bbbbbc", "c"};

--- a/src/test/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/range_filter_test.cpp
@@ -315,8 +315,10 @@ TYPED_TEST(RangeFilterTest, SliceWithPredicateReturnsNullptr) {
   EXPECT_EQ(filter->sliced(PredicateCondition::GreaterThan, this->_max_value), nullptr);
 }
 
+class RangeFilterTestUntyped : public BaseTest {};
+
 // Test predicates which are not supported by the range filter
-TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
+TEST_F(RangeFilterTestUntyped, DoNotPruneUnsupportedPredicates) {
   const pmr_vector<int> values{-1000, -900, 900, 1000};
   const auto filter = RangeFilter<int>::build_filter(values);
 

--- a/src/test/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/range_filter_test.cpp
@@ -261,27 +261,6 @@ TYPED_TEST(RangeFilterTest, LargeValueRange) {
                                         static_cast<TypeParam>(0.38 * lowest)));
 }
 
-// Test predicates which are not supported by the range filter
-TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
-  const pmr_vector<int> values{-1000, -900, 900, 1000};
-  const auto filter = RangeFilter<int>::build_filter(values);
-
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNull, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::In, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotIn, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNull, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNotNull, {17}));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNull, NULL_VALUE));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNotNull, NULL_VALUE));
-
-  // For the default filter, the following value is prunable.
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Equals, 1));
-  // But malformed predicates are skipped intentionally and are thus not prunable
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Equals, 1, NULL_VALUE));
-}
-
 TYPED_TEST(RangeFilterTest, Sliced) {
   using Ranges = std::vector<std::pair<TypeParam, TypeParam>>;
 
@@ -334,6 +313,27 @@ TYPED_TEST(RangeFilterTest, SliceWithPredicateReturnsNullptr) {
   EXPECT_NE(filter->sliced(PredicateCondition::LessThanEquals, this->_min_value), nullptr);
   EXPECT_NE(filter->sliced(PredicateCondition::GreaterThanEquals, this->_max_value), nullptr);
   EXPECT_EQ(filter->sliced(PredicateCondition::GreaterThan, this->_max_value), nullptr);
+}
+
+// Test predicates which are not supported by the range filter
+TEST(RangeFilterTest, DoNotPruneUnsupportedPredicates) {
+  const pmr_vector<int> values{-1000, -900, 900, 1000};
+  const auto filter = RangeFilter<int>::build_filter(values);
+
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNull, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::In, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotIn, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNull, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNotNull, {17}));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNull, NULL_VALUE));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::IsNotNull, NULL_VALUE));
+
+  // For the default filter, the following value is prunable.
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Equals, 1));
+  // But malformed predicates are skipped intentionally and are thus not prunable
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Equals, 1, NULL_VALUE));
 }
 
 }  // namespace opossum

--- a/src/test/statistics/statistics_objects/range_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/range_filter_test.cpp
@@ -7,18 +7,16 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
-
-#include "utils/assert.hpp"
 
 #include "statistics/statistics_objects/min_max_filter.hpp"
 #include "statistics/statistics_objects/range_filter.hpp"
 #include "types.hpp"
+#include "utils/assert.hpp"
 
 namespace opossum {
 
 template <typename T>
-class RangeFilterTest : public ::testing::Test {
+class RangeFilterTest : public BaseTest {
  protected:
   void SetUp() override {
     // Manually created vector. Largest exlusive gap (only gap when gap_count == 1) will

--- a/src/test/statistics/statistics_objects/string_histogram_domain_test.cpp
+++ b/src/test/statistics/statistics_objects/string_histogram_domain_test.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "statistics/statistics_objects/histogram_domain.hpp"
 
 namespace opossum {
 
-class StringHistogramDomainTest : public ::testing::Test {
+class StringHistogramDomainTest : public BaseTest {
  public:
   StringHistogramDomain domain_a{'a', 'z', 4u};
 };

--- a/src/test/statistics/table_statistics_test.cpp
+++ b/src/test/statistics/table_statistics_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "statistics/attribute_statistics.hpp"
 #include "statistics/generate_pruning_statistics.hpp"
@@ -8,7 +8,7 @@
 
 namespace opossum {
 
-class TableStatisticsTest : public ::testing::Test {};
+class TableStatisticsTest : public BaseTest {};
 
 TEST_F(TableStatisticsTest, FromTable) {
   const auto table = load_table("resources/test_data/tbl/int_with_nulls_large.tbl", 20);

--- a/src/test/storage/adaptive_radix_tree_index_test.cpp
+++ b/src/test/storage/adaptive_radix_tree_index_test.cpp
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 #include "types.hpp"
 
 #include "storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp"

--- a/src/test/storage/any_segment_iterable_test.cpp
+++ b/src/test/storage/any_segment_iterable_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/chunk_encoder.hpp"
 #include "storage/create_iterable_from_segment.hpp"

--- a/src/test/storage/btree_index_test.cpp
+++ b/src/test/storage/btree_index_test.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/base_segment.hpp"
 #include "storage/chunk.hpp"

--- a/src/test/storage/chunk_encoder_test.cpp
+++ b/src/test/storage/chunk_encoder_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "all_type_variant.hpp"
 #include "operators/table_scan.hpp"

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "resolve_type.hpp"
 #include "storage/base_segment.hpp"

--- a/src/test/storage/composite_group_key_index_test.cpp
+++ b/src/test/storage/composite_group_key_index_test.cpp
@@ -6,12 +6,11 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
+
 #include "storage/base_segment.hpp"
 #include "storage/chunk.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/variable_length_key_proxy.hpp"
-
 #include "types.hpp"
 
 namespace {

--- a/src/test/storage/compressed_vector_test.cpp
+++ b/src/test/storage/compressed_vector_test.cpp
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/segment_encoding_utils.hpp"
 #include "storage/vector_compression/resolve_compressed_vector_type.hpp"

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -3,7 +3,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/chunk_encoder.hpp"
 #include "storage/dictionary_segment.hpp"

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -4,7 +4,6 @@
 #include <sstream>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "constant_mappings.hpp"
 #include "storage/create_iterable_from_segment.hpp"

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -5,7 +5,6 @@
 #include <sstream>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "constant_mappings.hpp"
 #include "storage/create_iterable_from_segment.hpp"

--- a/src/test/storage/encoding_test.hpp
+++ b/src/test/storage/encoding_test.hpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "storage/chunk_encoder.hpp"
 #include "storage/encoding_type.hpp"
@@ -12,7 +12,7 @@
 namespace opossum {
 
 // Base Class for tests that should be run with various encodings
-class EncodingTest : public ::testing::TestWithParam<SegmentEncodingSpec> {
+class EncodingTest : public BaseTestWithParam<SegmentEncodingSpec> {
  public:
   std::shared_ptr<Table> load_table_with_encoding(const std::string& path,
                                                   ChunkOffset max_chunk_size = Chunk::MAX_SIZE) {

--- a/src/test/storage/fixed_string_dictionary_segment_test.cpp
+++ b/src/test/storage/fixed_string_dictionary_segment_test.cpp
@@ -3,7 +3,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/chunk_encoder.hpp"
 #include "storage/fixed_string_dictionary_segment.hpp"

--- a/src/test/storage/fixed_string_vector_test.cpp
+++ b/src/test/storage/fixed_string_vector_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/fixed_string_dictionary_segment/fixed_string_vector.hpp"
 

--- a/src/test/storage/group_key_index_test.cpp
+++ b/src/test/storage/group_key_index_test.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/base_segment.hpp"
 #include "storage/chunk.hpp"

--- a/src/test/storage/iterables_test.cpp
+++ b/src/test/storage/iterables_test.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/chunk_encoder.hpp"
 #include "storage/dictionary_segment.hpp"

--- a/src/test/storage/lz4_segment_test.cpp
+++ b/src/test/storage/lz4_segment_test.cpp
@@ -3,7 +3,6 @@
 #include <utility>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "all_type_variant.hpp"
 #include "storage/chunk.hpp"

--- a/src/test/storage/materialize_test.cpp
+++ b/src/test/storage/materialize_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "encoding_test.hpp"
 #include "expression/expression_functional.hpp"

--- a/src/test/storage/multi_segment_index_test.cpp
+++ b/src/test/storage/multi_segment_index_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/base_segment.hpp"
 #include "storage/chunk.hpp"

--- a/src/test/storage/prepared_plan_test.cpp
+++ b/src/test/storage/prepared_plan_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/aggregate_node.hpp"
@@ -9,13 +9,12 @@
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "storage/prepared_plan.hpp"
-#include "testing_assert.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class PreparedPlanTest : public ::testing::Test {
+class PreparedPlanTest : public BaseTest {
  public:
   void SetUp() override {
     node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}});

--- a/src/test/storage/reference_segment_test.cpp
+++ b/src/test/storage/reference_segment_test.cpp
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "operators/abstract_operator.hpp"

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "../base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/base_segment.hpp"
 #include "storage/dictionary_segment.hpp"

--- a/src/test/storage/simd_bp128_test.cpp
+++ b/src/test/storage/simd_bp128_test.cpp
@@ -5,12 +5,10 @@
 #include <boost/hana/pair.hpp>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/vector_compression/simd_bp128/simd_bp128_compressor.hpp"
 #include "storage/vector_compression/simd_bp128/simd_bp128_vector.hpp"
 #include "storage/vector_compression/vector_compression.hpp"
-
 #include "types.hpp"
 
 namespace opossum {

--- a/src/test/storage/single_segment_index_test.cpp
+++ b/src/test/storage/single_segment_index_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/base_segment.hpp"
 #include "storage/chunk.hpp"
@@ -13,7 +12,6 @@
 #include "storage/index/b_tree/b_tree_index.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
-
 #include "resolve_type.hpp"
 #include "types.hpp"
 

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "logical_query_plan/stored_table_node.hpp"

--- a/src/test/storage/table_column_definition_test.cpp
+++ b/src/test/storage/table_column_definition_test.cpp
@@ -1,7 +1,6 @@
 #include <memory>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/table_column_definition.hpp"
 

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "resolve_type.hpp"
 #include "storage/table.hpp"

--- a/src/test/storage/value_segment_test.cpp
+++ b/src/test/storage/value_segment_test.cpp
@@ -3,7 +3,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/value_segment.hpp"
 

--- a/src/test/storage/variable_length_key_base_test.cpp
+++ b/src/test/storage/variable_length_key_base_test.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/index/group_key/variable_length_key_base.hpp"
 #include "types.hpp"

--- a/src/test/storage/variable_length_key_store_test.cpp
+++ b/src/test/storage/variable_length_key_store_test.cpp
@@ -7,11 +7,9 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/index/group_key/variable_length_key_proxy.hpp"
 #include "storage/index/group_key/variable_length_key_store.hpp"
-
 #include "types.hpp"
 
 namespace opossum {

--- a/src/test/storage/variable_length_key_test.cpp
+++ b/src/test/storage/variable_length_key_test.cpp
@@ -1,5 +1,4 @@
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "storage/index/group_key/variable_length_key.hpp"
 

--- a/src/test/synthetic_table_generator_test.cpp
+++ b/src/test/synthetic_table_generator_test.cpp
@@ -7,7 +7,9 @@
 
 namespace opossum {
 
-TEST(SyntheticTableGeneratorTest, StringGeneration) {
+class SyntheticTableGeneratorTest : public BaseTest {};
+
+TEST_F(SyntheticTableGeneratorTest, StringGeneration) {
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(0), "          ");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(1), "         1");
   EXPECT_EQ(SyntheticTableGenerator::generate_value<pmr_string>(2), "         2");
@@ -20,7 +22,7 @@ TEST(SyntheticTableGeneratorTest, StringGeneration) {
   ASSERT_THROW(SyntheticTableGenerator::generate_value<pmr_string>(-17), std::logic_error);
 }
 
-TEST(SyntheticTableGeneratorTest, ThrowOnParameterLengthMismatch) {
+TEST_F(SyntheticTableGeneratorTest, ThrowOnParameterLengthMismatch) {
   auto table_generator = std::make_shared<SyntheticTableGenerator>();
   const auto uniform_distribution = ColumnDataDistribution::make_uniform_config(0.0, 1.0);
 
@@ -31,7 +33,7 @@ TEST(SyntheticTableGeneratorTest, ThrowOnParameterLengthMismatch) {
                std::logic_error);
 }
 
-TEST(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
+TEST_F(SyntheticTableGeneratorTest, TestGeneratedValueRange) {
   constexpr auto row_count = size_t{100};
   constexpr auto chunk_size = size_t{10};
   auto table_generator = std::make_shared<SyntheticTableGenerator>();

--- a/src/test/tasks/chunk_compression_task_test.cpp
+++ b/src/test/tasks/chunk_compression_task_test.cpp
@@ -4,7 +4,6 @@
 #include <vector>
 
 #include "base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "operators/get_table.hpp"

--- a/src/test/testing_assert.hpp
+++ b/src/test/testing_assert.hpp
@@ -4,8 +4,6 @@
 #include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
-
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "operators/abstract_operator.hpp"

--- a/src/test/tpc/tpcds_db_generator_test.cpp
+++ b/src/test/tpc/tpcds_db_generator_test.cpp
@@ -2,7 +2,6 @@
 
 #include "hyrise.hpp"
 #include "import_export/csv/csv_parser.hpp"
-#include "testing_assert.hpp"
 #include "tpcds/tpcds_table_generator.hpp"
 #include "utils/load_table.hpp"
 

--- a/src/test/tpc/tpcds_db_generator_test.cpp
+++ b/src/test/tpc/tpcds_db_generator_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "hyrise.hpp"
 #include "import_export/csv/csv_parser.hpp"
@@ -18,7 +18,9 @@ std::shared_ptr<Table> load_csv(const std::string& file_name) {
 
 namespace opossum {
 
-TEST(TpcdsTableGeneratorTest, TableContentsFirstRows) {
+class TpcdsTableGeneratorTest : public BaseTest {};
+
+TEST_F(TpcdsTableGeneratorTest, TableContentsFirstRows) {
   /**
    * Check whether the data that TpcdsTableGenerator generates is the exact same that dsdgen generates.
    * Since dsdgen does not support very small scale factors only generate and check first rows for each table.
@@ -67,7 +69,7 @@ TEST(TpcdsTableGeneratorTest, TableContentsFirstRows) {
   }
 }
 
-TEST(TpcdsTableGeneratorTest, GenerateAndStoreRowCounts) {
+TEST_F(TpcdsTableGeneratorTest, GenerateAndStoreRowCounts) {
   /**
  * Check whether all TPC-DS tables are created by the TpcdsTableGenerator and added to the StorageManager.
  * Then check whether the row count is correct for all tables.

--- a/src/test/tpc/tpch_db_generator_test.cpp
+++ b/src/test/tpc/tpch_db_generator_test.cpp
@@ -1,7 +1,6 @@
 #include "base_test.hpp"
 
 #include "hyrise.hpp"
-#include "testing_assert.hpp"
 #include "tpch/tpch_table_generator.hpp"
 #include "utils/load_table.hpp"
 

--- a/src/test/tpc/tpch_db_generator_test.cpp
+++ b/src/test/tpc/tpch_db_generator_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "hyrise.hpp"
 #include "testing_assert.hpp"
@@ -7,7 +7,9 @@
 
 namespace opossum {
 
-TEST(TPCHTableGeneratorTest, SmallScaleFactor) {
+class TPCHTableGeneratorTest : public BaseTest {};
+
+TEST_F(TPCHTableGeneratorTest, SmallScaleFactor) {
   /**
    * Check whether the data that TPCHTableGenerator generates with a scale factor of 0.01 is the exact same that dbgen
    *     generates
@@ -50,7 +52,7 @@ TEST(TPCHTableGeneratorTest, SmallScaleFactor) {
   EXPECT_TABLE_EQ_ORDERED(table_info_by_name.at("region").table, load_table(dir_002 + "region.tbl", chunk_size));
 }
 
-TEST(TPCHTableGeneratorTest, RowCountsMediumScaleFactor) {
+TEST_F(TPCHTableGeneratorTest, RowCountsMediumScaleFactor) {
   /**
    * Mostly intended to generate coverage and trigger potential leaks in third_party/tpch_dbgen
    */
@@ -66,7 +68,7 @@ TEST(TPCHTableGeneratorTest, RowCountsMediumScaleFactor) {
   EXPECT_EQ(table_info_by_name.at("region").table->row_count(), std::floor(5));
 }
 
-TEST(TpchTableGeneratorTest, GenerateAndStore) {
+TEST_F(TPCHTableGeneratorTest, GenerateAndStore) {
   EXPECT_FALSE(Hyrise::get().storage_manager.has_table("part"));
   EXPECT_FALSE(Hyrise::get().storage_manager.has_table("supplier"));
   EXPECT_FALSE(Hyrise::get().storage_manager.has_table("partsupp"));

--- a/src/test/utils/column_ids_after_pruning_test.cpp
+++ b/src/test/utils/column_ids_after_pruning_test.cpp
@@ -1,10 +1,12 @@
-#include "gtest/gtest.h"
+#include "../base_test.hpp"
 
 #include "utils/column_ids_after_pruning.hpp"
 
 namespace opossum {
 
-TEST(ColumnPruning, ColumnIDMapping) {
+class ColumnIdsAfterPruningTest : public BaseTest {};
+
+TEST_F(ColumnIdsAfterPruningTest, ColumnIDMapping) {
   auto actual_column_mapping = column_ids_after_pruning(6, {ColumnID{0}, ColumnID{1}, ColumnID{2}});
   auto expected_column_mapping = std::vector<std::optional<ColumnID>>{std::nullopt, std::nullopt, std::nullopt,
                                                                       ColumnID{0},  ColumnID{1},  ColumnID{2}};

--- a/src/test/utils/format_bytes_test.cpp
+++ b/src/test/utils/format_bytes_test.cpp
@@ -1,10 +1,12 @@
-#include "gtest/gtest.h"
+#include "../base_test.hpp"
 
 #include "utils/format_bytes.hpp"
 
 namespace opossum {
 
-TEST(Format, Bytes) {
+class FormatBytesTest : public BaseTest {};
+
+TEST_F(FormatBytesTest, Bytes) {
   EXPECT_EQ(format_bytes(0), "0B");
   EXPECT_EQ(format_bytes(11), "11B");
   EXPECT_EQ(format_bytes(1'234), "1.234KB");

--- a/src/test/utils/format_duration_test.cpp
+++ b/src/test/utils/format_duration_test.cpp
@@ -1,4 +1,4 @@
-#include "gtest/gtest.h"
+#include "../base_test.hpp"
 
 #include "utils/format_duration.hpp"
 
@@ -6,7 +6,9 @@ using namespace std::chrono_literals;  // NOLINT
 
 namespace opossum {
 
-TEST(Format, Duration) {
+class FormatDurationTest : public BaseTest {};
+
+TEST_F(FormatDurationTest, Duration) {
   // It seems std::chrono_literals can't handle `12'345'678`, otherwise I'd use it here...
   EXPECT_EQ(format_duration(0ns), "0 ns");
   EXPECT_EQ(format_duration(11ns), "11 ns");

--- a/src/test/utils/lossless_predicate_cast_test.cpp
+++ b/src/test/utils/lossless_predicate_cast_test.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
+#include "base_test.hpp"
 
 #include "utils/lossless_predicate_cast.hpp"
 
 namespace opossum {
 
-class LosslessPredicateCastTest : public ::testing::Test {};
+class LosslessPredicateCastTest : public BaseTest {};
 
 TEST_F(LosslessPredicateCastTest, NextFloatTowards) {
   // 3 is directly representable as a float

--- a/src/test/utils/meta_table_manager_test.cpp
+++ b/src/test/utils/meta_table_manager_test.cpp
@@ -8,7 +8,7 @@ namespace opossum {
 
 class MetaTableManagerTest : public BaseTest {};
 
-TEST(MetaTableManagerTest, TableBasedMetaData) {
+TEST_F(MetaTableManagerTest, TableBasedMetaData) {
   // This tests a bunch of meta tables that are somehow related to the tables stored in the StorageManager.
   auto& storage_manager = Hyrise::get().storage_manager;
 

--- a/src/test/utils/singleton_test.cpp
+++ b/src/test/utils/singleton_test.cpp
@@ -1,5 +1,4 @@
 #include "../base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "hyrise.hpp"
 #include "utils/singleton.hpp"

--- a/src/test/utils/size_estimation_utils_test.cpp
+++ b/src/test/utils/size_estimation_utils_test.cpp
@@ -5,7 +5,9 @@
 
 namespace opossum {
 
-TEST(SizeEstimationUtilsTest, SingleString) {
+class SizeEstimationUtilsTest : public BaseTest {};
+
+TEST_F(SizeEstimationUtilsTest, SingleString) {
   auto string1 = std::string{"a"};
   auto string2 = pmr_string{"b"};
 
@@ -14,7 +16,7 @@ TEST(SizeEstimationUtilsTest, SingleString) {
 }
 
 // Check early out of estimation
-TEST(SizeEstimationUtilsTest, EmptyVector) {
+TEST_F(SizeEstimationUtilsTest, EmptyVector) {
   const auto empty_vector = pmr_vector<pmr_string>{};
   const auto expected_size = sizeof(pmr_vector<pmr_string>);
 
@@ -23,7 +25,7 @@ TEST(SizeEstimationUtilsTest, EmptyVector) {
 }
 
 // Check that sampling works as expected when the input vector is shorter than the minimal sample size.
-TEST(SizeEstimationUtilsTest, SizeSmallerThanSampleSize) {
+TEST_F(SizeEstimationUtilsTest, SizeSmallerThanSampleSize) {
   // Small vector with strings that are stored within the initial string object (SSO)
   pmr_vector<pmr_string> small_vector{"a", "b", "c"};
 
@@ -34,7 +36,7 @@ TEST(SizeEstimationUtilsTest, SizeSmallerThanSampleSize) {
   EXPECT_EQ(string_vector_memory_usage(small_vector, MemoryUsageCalculationMode::Full), expected_size);
 }
 
-TEST(SizeEstimationUtilsTest, StringVectorExceedingSSOLengths) {
+TEST_F(SizeEstimationUtilsTest, StringVectorExceedingSSOLengths) {
   constexpr auto large_string_length = size_t{500};
   constexpr auto vector_length = size_t{200};
   const auto large_string = pmr_string(large_string_length, '#');

--- a/src/test/utils/string_utils_test.cpp
+++ b/src/test/utils/string_utils_test.cpp
@@ -1,5 +1,4 @@
 #include "../base_test.hpp"
-#include "gtest/gtest.h"
 
 #include "utils/string_utils.hpp"
 


### PR DESCRIPTION
#1968 changed a test to be non-fixtured (changed from `TEST_F` to `TEST`) which uses the storage manager. This was dump because the storage manager is not reset after the test.
For the randomized tests of the CI, by chance there could be tests following that also create a table `int_int` (e.g., the union tests). This will crash since the table already exists.

I grepped for tests that contain the `storage_manager` and do not use fixtures. The found tests look good. I also looked for cases that do not inherit from BaseTest, but did not find one that uses the storage manager.

The greps:
```
find . -type f -exec grep -q storage_manager {} \; -exec grep -l '^TEST(' {} \;
find . -type f -exec grep -q storage_manager {} \; -exec grep -l 'Test : public ::testing::Test' {} \;
```

We should not allow noobs to write tests.