### PR TITLE
Fix two small issues in the micro benchmarks

### DIFF
--- a/src/benchmark/operators/table_scan_sorted_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_sorted_benchmark.cpp
@@ -79,6 +79,11 @@ std::shared_ptr<TableWrapper> create_table(const DataType data_type, const int t
   }
 
   if (encoding_type != EncodingType::Unencoded) {
+    const auto chunk_count = table->chunk_count();
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      const auto& chunk = table->get_chunk(chunk_id);
+      chunk->finalize();
+    }
     ChunkEncoder::encode_all_chunks(table, SegmentEncodingSpec(encoding_type));
   }
 

--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -27,7 +27,7 @@ class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
   void SetUp(::benchmark::State& state) {
     auto& sm = Hyrise::get().storage_manager;
-    const auto scale_factor = 0.001f;
+    const auto scale_factor = 0.01f;
     const auto default_encoding = EncodingType::Dictionary;
 
     auto benchmark_config = BenchmarkConfig::get_default_config();


### PR DESCRIPTION
The effect of not running the micro benchmarks has shown. One issue in the sort table scan benchmark was that the `ChunkEncoder` no longer supports encoding of mutable chunks (it's now the writers task to finalize chunks). The other issue was that a scale factor of 0.001f for the TPC-H data generator is no longer possible. Changed to 0.01f.