### PR TITLE
Enable Cache Implementation Access

### DIFF
--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -28,8 +28,8 @@ BenchmarkRunner::BenchmarkRunner(const BenchmarkConfig& config,
       _benchmark_item_runner(std::move(benchmark_item_runner)),
       _table_generator(std::move(table_generator)),
       _context(context) {
-  SQLPipelineBuilder::default_pqp_cache = std::make_shared<SQLPhysicalPlanCache>();
-  SQLPipelineBuilder::default_lqp_cache = std::make_shared<SQLLogicalPlanCache>();
+  Hyrise::get().default_pqp_cache = std::make_shared<SQLPhysicalPlanCache>();
+  Hyrise::get().default_lqp_cache = std::make_shared<SQLLogicalPlanCache>();
 
   // Initialise the scheduler if the benchmark was requested to run multi-threaded
   if (config.enable_scheduler) {

--- a/src/lib/cache/cache.hpp
+++ b/src/lib/cache/cache.hpp
@@ -90,12 +90,9 @@ class Cache {
   Iterator unsafe_begin() { return _impl->begin(); }
   Iterator unsafe_end() { return _impl->end(); }
 
-  // Returns the access frequency of a cached item (=1 for set(), +1 for each get()). Returns 0 for keys not being
-  // cache-resident.
-  size_t frequency(const Key& key) {
-    std::shared_lock<std::shared_mutex> lock(_mutex);
-    return _impl->frequency(key);
-  }
+  // Returns a reference to the underlying cache.
+  AbstractCacheImpl<Key, Value>& unsafe_cache() { return *_impl; }
+  const AbstractCacheImpl<Key, Value>& unsafe_cache() const { return *_impl; }
 
  protected:
   // Underlying cache eviction strategy.

--- a/src/lib/hyrise.cpp
+++ b/src/lib/hyrise.cpp
@@ -24,6 +24,9 @@ Hyrise::Hyrise() {
 void Hyrise::reset() {
   Hyrise::get().scheduler()->finish();
   get() = Hyrise{};
+
+  SQLPipelineBuilder::default_pqp_cache = nullptr;
+  SQLPipelineBuilder::default_lqp_cache = nullptr;
 }
 
 const std::shared_ptr<AbstractScheduler>& Hyrise::scheduler() const { return _scheduler; }

--- a/src/lib/hyrise.cpp
+++ b/src/lib/hyrise.cpp
@@ -24,9 +24,6 @@ Hyrise::Hyrise() {
 void Hyrise::reset() {
   Hyrise::get().scheduler()->finish();
   get() = Hyrise{};
-
-  SQLPipelineBuilder::default_pqp_cache = nullptr;
-  SQLPipelineBuilder::default_lqp_cache = nullptr;
 }
 
 const std::shared_ptr<AbstractScheduler>& Hyrise::scheduler() const { return _scheduler; }

--- a/src/lib/hyrise.hpp
+++ b/src/lib/hyrise.hpp
@@ -4,6 +4,7 @@
 #include "concurrency/transaction_manager.hpp"
 #include "scheduler/immediate_execution_scheduler.hpp"
 #include "scheduler/topology.hpp"
+#include "sql/sql_plan_cache.hpp"
 #include "storage/storage_manager.hpp"
 #include "utils/meta_table_manager.hpp"
 #include "utils/plugin_manager.hpp"
@@ -34,6 +35,11 @@ class Hyrise : public Singleton<Hyrise> {
   TransactionManager transaction_manager;
   MetaTableManager meta_table_manager;
   Topology topology;
+
+  // Plan caches used by the SQLPipelineBuilder if `with_{l/p}qp_cache()` are not used. Both default caches can be
+  // nullptr themselves. If both default_{l/p}qp_cache and _{l/p}qp_cache are nullptr, no plan caching is used.
+  std::shared_ptr<SQLPhysicalPlanCache> default_pqp_cache;
+  std::shared_ptr<SQLLogicalPlanCache> default_lqp_cache;
 
   // The BenchmarkRunner is available here so that non-benchmark components can add information to the benchmark
   // result JSON.

--- a/src/lib/sql/sql_pipeline_builder.cpp
+++ b/src/lib/sql/sql_pipeline_builder.cpp
@@ -1,13 +1,11 @@
 #include "sql_pipeline_builder.hpp"
+#include "hyrise.hpp"
 #include "utils/tracing/probes.hpp"
 
 namespace opossum {
 
-std::shared_ptr<SQLPhysicalPlanCache> SQLPipelineBuilder::default_pqp_cache{};
-std::shared_ptr<SQLLogicalPlanCache> SQLPipelineBuilder::default_lqp_cache{};
-
 SQLPipelineBuilder::SQLPipelineBuilder(const std::string& sql)
-    : _sql(sql), _pqp_cache(default_pqp_cache), _lqp_cache(default_lqp_cache) {}
+    : _sql(sql), _pqp_cache(Hyrise::get().default_pqp_cache), _lqp_cache(Hyrise::get().default_lqp_cache) {}
 
 SQLPipelineBuilder& SQLPipelineBuilder::with_mvcc(const UseMvcc use_mvcc) {
   _use_mvcc = use_mvcc;

--- a/src/lib/sql/sql_pipeline_builder.hpp
+++ b/src/lib/sql/sql_pipeline_builder.hpp
@@ -35,13 +35,6 @@ class Optimizer;
  */
 class SQLPipelineBuilder final {
  public:
-  // Plan caches used if `with_{l/p}qp_cache()` are not used in this builder. Both default caches can be nullptr
-  // themselves. If both default_{l/p}qp_cache and _{l/p}qp_cache are nullptr, no plan caching is used.
-  // These default caches stem from the extended discussion in #1615 and are mainly for Plugins, whose only
-  // way of communicating with Hyrise are global variables.
-  static std::shared_ptr<SQLPhysicalPlanCache> default_pqp_cache;
-  static std::shared_ptr<SQLLogicalPlanCache> default_lqp_cache;
-
   explicit SQLPipelineBuilder(const std::string& sql);
 
   SQLPipelineBuilder& with_mvcc(const UseMvcc use_mvcc);

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -74,8 +74,6 @@ class BaseTestWithParam
    */
   ~BaseTestWithParam() {
     Hyrise::reset();
-    SQLPipelineBuilder::default_pqp_cache = nullptr;
-    SQLPipelineBuilder::default_lqp_cache = nullptr;
   }
 
   static std::shared_ptr<AbstractExpression> get_column_expression(const std::shared_ptr<AbstractOperator>& op,

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -72,9 +72,7 @@ class BaseTestWithParam
    * safely without preventing the BaseTest-cleanup from happening.
    * GTest runs the destructor right after TearDown(): https://github.com/abseil/googletest/blob/master/googletest/docs/faq.md#should-i-use-the-constructordestructor-of-the-test-fixture-or-setupteardown
    */
-  ~BaseTestWithParam() {
-    Hyrise::reset();
-  }
+  ~BaseTestWithParam() { Hyrise::reset(); }
 
   static std::shared_ptr<AbstractExpression> get_column_expression(const std::shared_ptr<AbstractOperator>& op,
                                                                    const ColumnID column_id) {

--- a/src/test/sql/query_plan_cache_test.cpp
+++ b/src/test/sql/query_plan_cache_test.cpp
@@ -148,18 +148,18 @@ TEST_F(QueryPlanCacheTest, AutomaticQueryOperatorCacheLRUK2) {
 TEST_F(QueryPlanCacheTest, CachedPQPFrequencyCount) {
   // Create pipeline and pass pqp cache. Verify that this does not change default_pqp_cache.
   auto sql_pipeline = SQLPipelineBuilder{Q1}.with_pqp_cache(cache).create_pipeline_statement();
-  EXPECT_EQ(SQLPipelineBuilder::default_pqp_cache, nullptr);
+  EXPECT_EQ(Hyrise::get().default_pqp_cache, nullptr);
 
   // Setting default_pqp_cache and verify it's set.
-  SQLPipelineBuilder::default_pqp_cache = cache;
-  EXPECT_NE(SQLPipelineBuilder::default_pqp_cache, nullptr);
+  Hyrise::get().default_pqp_cache = cache;
+  EXPECT_NE(Hyrise::get().default_pqp_cache, nullptr);
 
   // Create new pipeline, without setting a cache (default cache set previously). Execute pipeline and check if
   // frequency of query is as expected.
   auto new_sql_pipeline = SQLPipelineBuilder{Q1}.create_pipeline_statement();
   new_sql_pipeline.get_result_table();
   auto& gdfs_cache = dynamic_cast<GDFSCache<std::string, std::shared_ptr<AbstractOperator>>&>(
-      SQLPipelineBuilder::default_pqp_cache->unsafe_cache());
+      Hyrise::get().default_pqp_cache->unsafe_cache());
   EXPECT_EQ(1, gdfs_cache.frequency(Q1));
 }
 

--- a/src/test/sql/query_plan_cache_test.cpp
+++ b/src/test/sql/query_plan_cache_test.cpp
@@ -143,4 +143,24 @@ TEST_F(QueryPlanCacheTest, AutomaticQueryOperatorCacheLRUK2) {
   EXPECT_EQ(5u, _query_plan_cache_hits);
 }
 
+// Check access to PQP cache. When set, check the underlying cache implementation, and verify that it is a GDFS cache
+// that supports retrieving the cache frequency count.
+TEST_F(QueryPlanCacheTest, CachedPQPFrequencyCount) {
+  // Create pipeline and pass pqp cache. Verify that this does not change default_pqp_cache.
+  auto sql_pipeline = SQLPipelineBuilder{Q1}.with_pqp_cache(cache).create_pipeline_statement();
+  EXPECT_EQ(SQLPipelineBuilder::default_pqp_cache, nullptr);
+
+  // Setting default_pqp_cache and verify it's set.
+  SQLPipelineBuilder::default_pqp_cache = cache;
+  EXPECT_NE(SQLPipelineBuilder::default_pqp_cache, nullptr);
+
+  // Create new pipeline, without setting a cache (default cache set previously). Execute pipeline and check if
+  // frequency of query is as expected.
+  auto new_sql_pipeline = SQLPipelineBuilder{Q1}.create_pipeline_statement();
+  new_sql_pipeline.get_result_table();
+  auto& gdfs_cache = dynamic_cast<GDFSCache<std::string, std::shared_ptr<AbstractOperator>>&>(SQLPipelineBuilder::default_pqp_cache->unsafe_cache());
+  EXPECT_EQ(1, gdfs_cache.frequency(Q1));
+}
+
+
 }  // namespace opossum

--- a/src/test/sql/query_plan_cache_test.cpp
+++ b/src/test/sql/query_plan_cache_test.cpp
@@ -158,9 +158,9 @@ TEST_F(QueryPlanCacheTest, CachedPQPFrequencyCount) {
   // frequency of query is as expected.
   auto new_sql_pipeline = SQLPipelineBuilder{Q1}.create_pipeline_statement();
   new_sql_pipeline.get_result_table();
-  auto& gdfs_cache = dynamic_cast<GDFSCache<std::string, std::shared_ptr<AbstractOperator>>&>(SQLPipelineBuilder::default_pqp_cache->unsafe_cache());
+  auto& gdfs_cache = dynamic_cast<GDFSCache<std::string, std::shared_ptr<AbstractOperator>>&>(
+      SQLPipelineBuilder::default_pqp_cache->unsafe_cache());
   EXPECT_EQ(1, gdfs_cache.frequency(Q1));
 }
-
 
 }  // namespace opossum

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -7,8 +7,8 @@
 #include "SQLParser.h"
 #include "SQLParserResult.h"
 
-#include "logical_query_plan/join_node.hpp"
 #include "hyrise.hpp"
+#include "logical_query_plan/join_node.hpp"
 #include "operators/abstract_join_operator.hpp"
 #include "operators/print.hpp"
 #include "operators/validate.hpp"
@@ -635,8 +635,8 @@ TEST_F(SQLPipelineTest, DefaultPlanCaches) {
   EXPECT_FALSE(sql_pipeline_statement_0.lqp_cache);
 
   // Default caches
-  SQLPipelineBuilder::default_pqp_cache = default_pqp_cache;
-  SQLPipelineBuilder::default_lqp_cache = default_lqp_cache;
+  Hyrise::get().default_pqp_cache = default_pqp_cache;
+  Hyrise::get().default_lqp_cache = default_lqp_cache;
   const auto sql_pipeline_1 = SQLPipelineBuilder{"SELECT * FROM table_a"}.create_pipeline();
   EXPECT_EQ(sql_pipeline_1.pqp_cache, default_pqp_cache);
   EXPECT_EQ(sql_pipeline_1.lqp_cache, default_lqp_cache);


### PR DESCRIPTION
This PR brings back the possibility to access the cache implementation that is used. This is necessary to access certain methods that are not implemented for all cache implementations (e.g., the access counter via `frequency()` in GDFS). This method is called `unsafe_cache()` in accordance with the recent changes to the cache (#1980) and to denote that this access is inherently unsafe as concurrent modifications are likely to happen.

Further:
 * added a test that documents the behaviour of `default_pqp_cache` which was not obvious to me, thus it might help others as well
 * removed `frequency()` from cache.hpp as it is not part of the abstract cache interface anyways (see discussion in #1932)