### PR TITLE
TPC-H: Remove comment about non-random values

### DIFF
--- a/resources/tpch_validation_queries.sql
+++ b/resources/tpch_validation_queries.sql
@@ -66,7 +66,7 @@ SELECT l_returnflag, l_linestatus, SUM(l_quantity) as sum_qty, SUM(l_extendedpri
 -- The limit is not part of the printed query but hidden in the specification text.
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. Changed to ordering in the FROM clause for better join ordering
 SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment FROM "part", partsupp, supplier, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND p_size = 15 AND p_type like '%BRASS' AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'EUROPE' AND ps_supplycost = (SELECT min(ps_supplycost) FROM supplier, partsupp, nation, region WHERE p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey AND r_name = 'EUROPE') ORDER BY s_acctbal DESC, n_name, s_name, p_partkey LIMIT 100;
 
@@ -86,7 +86,7 @@ SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comme
 -- The limit is not part of the printed query but hidden in the specification text.
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. implicit type conversions for arithmetic operations are not supported
 --    a. changed 1 to 1.0 explicitly
 --  3. Be aware that we ignore the column ordering here.
@@ -115,7 +115,7 @@ SELECT l_orderkey, SUM(l_extendedprice*(1.0-l_discount)) as revenue, o_orderdate
 -- ORDER BY o_orderpriority;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -152,7 +152,7 @@ SELECT o_orderpriority, count(*) as order_count FROM orders WHERE o_orderdate >=
 --      revenue DESC;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -206,7 +206,7 @@ SELECT sum(l_extendedprice*l_discount) AS REVENUE FROM lineitem WHERE l_shipdate
 -- ORDER BY supp_nation, cust_nation, l_year;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -258,7 +258,7 @@ SELECT supp_nation, cust_nation, l_year, SUM(volume) as revenue FROM (SELECT n1.
 -- ORDER BY o_year;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --  3. Extract is not supported
@@ -293,7 +293,7 @@ SELECT o_year, SUM(case when nation = 'BRAZIL' then volume else 0 end) / SUM(vol
 -- ORDER BY nation, o_year DESC;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. Extract is not supported
 --    a. Use SUBSTR instead
 --  3. implicit type conversions for arithmetic operations are not supported
@@ -341,7 +341,7 @@ SELECT nation, o_year, SUM(amount) as sum_profit FROM (SELECT n_name as nation, 
 -- The limit is not part of the printed query but hidden in the specification text.
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -375,7 +375,7 @@ SELECT c_custkey, c_name, SUM(l_extendedprice * (1.0 - l_discount)) as revenue, 
 -- ORDER BY value DESC;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 SELECT ps_partkey, SUM(ps_supplycost * ps_availqty) as value FROM partsupp, supplier, nation WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY' GROUP BY ps_partkey having SUM(ps_supplycost * ps_availqty) > (SELECT SUM(ps_supplycost * ps_availqty) * 0.0001 FROM partsupp, supplier, nation WHERE ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_name = 'GERMANY') ORDER BY value DESC;
 
 
@@ -407,7 +407,7 @@ SELECT ps_partkey, SUM(ps_supplycost * ps_availqty) as value FROM partsupp, supp
 -- ORDER BY l_shipmode;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -431,7 +431,7 @@ SELECT l_shipmode, SUM(case when o_orderpriority ='1-URGENT' or o_orderpriority 
 -- ORDER BY custdist DESC, c_count DESC;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 SELECT c_count, count(*) as custdist FROM (SELECT c_custkey, count(o_orderkey) as c_count FROM customer left outer join orders on c_custkey = o_custkey AND o_comment not like '%special%request%' GROUP BY c_custkey) as c_orders GROUP BY c_count ORDER BY custdist DESC, c_count DESC;
 
 
@@ -451,7 +451,7 @@ SELECT c_count, count(*) as custdist FROM (SELECT c_custkey, count(o_orderkey) a
 --    AND l_shipdate < date '[DATE]' + interval '1' month;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -485,7 +485,7 @@ SELECT 100.00 * SUM(case when p_type like 'PROMO%' then l_extendedprice*(1.0-l_d
 -- drop view revenue[STREAM_ID];
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. "revenue[STREAM_ID]" renamed to "revenue"
 --  2. dates are not supported
 --    a. use strings as data type for now
@@ -518,7 +518,7 @@ drop view revenue;
 -- ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt FROM partsupp, "part" WHERE p_partkey = ps_partkey AND p_brand <> 'Brand#45' AND p_type not like 'MEDIUM POLISHED%' AND p_size in (49, 14, 23, 45, 19, 3, 36, 9) AND ps_suppkey not in (SELECT s_suppkey FROM supplier WHERE s_comment like '%Customer%Complaints%') GROUP BY p_brand, p_type, p_size ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
 
 
@@ -539,7 +539,7 @@ SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt FROM 
 --    );
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 SELECT SUM(l_extendedprice) / 7.0 as avg_yearly FROM lineitem, "part" WHERE p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container = 'MED BOX' AND l_quantity < (SELECT 0.2 * avg(l_quantity) FROM lineitem WHERE l_partkey = p_partkey);
 
 
@@ -565,7 +565,7 @@ SELECT SUM(l_extendedprice) / 7.0 as avg_yearly FROM lineitem, "part" WHERE p_pa
 -- The limit is not part of the printed query but hidden in the specification text.
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity) FROM customer, orders, lineitem WHERE o_orderkey in (SELECT l_orderkey FROM lineitem GROUP BY l_orderkey having SUM(l_quantity) > 300) AND c_custkey = o_custkey AND o_orderkey = l_orderkey GROUP BY c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice ORDER BY o_totalprice DESC, o_orderdate LIMIT 100;
 
 
@@ -605,7 +605,7 @@ SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity)
 --    );
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. implicit type conversions for arithmetic operations are not supported
 --    a. changed 1 to 1.0 explicitly
 SELECT SUM(l_extendedprice * (1.0 - l_discount)) as revenue FROM lineitem, "part" WHERE (p_partkey = l_partkey AND p_brand = 'Brand#12' AND p_container in ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG') AND l_quantity >= 1 AND l_quantity <= 1 + 10 AND p_size between 1 AND 5 AND l_shipmode in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') or (p_partkey = l_partkey AND p_brand = 'Brand#23' AND p_container in ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK') AND l_quantity >= 10 AND l_quantity <= 10 + 10 AND p_size between 1 AND 10 AND l_shipmode in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON') or (p_partkey = l_partkey AND p_brand = 'Brand#34' AND p_container in ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG') AND l_quantity >= 20 AND l_quantity <= 20 + 10 AND p_size between 1 AND 15 AND l_shipmode in ('AIR', 'AIR REG') AND l_shipinstruct = 'DELIVER IN PERSON');
@@ -641,7 +641,7 @@ SELECT SUM(l_extendedprice * (1.0 - l_discount)) as revenue FROM lineitem, "part
 -- ORDER BY s_name;
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation
@@ -682,7 +682,7 @@ SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey in (SELECT ps_sup
 -- The limit is not part of the printed query but hidden in the specification text.
 --
 -- Changes:
---  1. Random values are hardcoded
+--  1. This file contains hard-coded parameters to facilitate copy-and-paste into the console
 --  2. dates are not supported
 --    a. use strings as data type for now
 --    b. pre-calculate date operation

--- a/src/benchmarklib/tpch/tpch_queries.cpp
+++ b/src/benchmarklib/tpch/tpch_queries.cpp
@@ -71,9 +71,6 @@ const char* const tpch_query_1 =
  * LIMIT 100;
  *
  * The limit is not part of the printed query but hidden in the specification text.
- *
- * Changes:
- *  1. Random values are hardcoded
  */
 const char* const tpch_query_2 =
     R"(SELECT s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment
@@ -98,9 +95,6 @@ const char* const tpch_query_2 =
  * LIMIT 10
  *
  * The limit is not part of the printed query but hidden in the specification text.
- *
- * Changes:
- *  1. Random values are hardcoded
  */
 const char* const tpch_query_3 =
     R"(SELECT l_orderkey, SUM(l_extendedprice*(1-l_discount)) as revenue, o_orderdate, o_shippriority
@@ -134,8 +128,7 @@ const char* const tpch_query_3 =
  * ORDER BY o_orderpriority;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
@@ -176,8 +169,7 @@ const char* const tpch_query_4 =
  *      revenue DESC;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
@@ -243,11 +235,10 @@ const char* const tpch_query_6 =
  * ORDER BY supp_nation, cust_nation, l_year;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
- *  3. Extract is not supported
+ *  2. Extract is not supported
  *    a. Use SUBSTR instead (because our date columns are strings AND SQLite doesn't support EXTRACT)
  */
 const char* const tpch_query_7 =
@@ -326,10 +317,9 @@ const char* const tpch_query_7 =
  * ORDER BY o_year;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
- *  3. Extract is not supported
+ *  2. Extract is not supported
  *    a. Use SUBSTR instead (because our date columns are strings AND SQLite doesn't support EXTRACT)
  */
 const char* const tpch_query_8 =
@@ -369,8 +359,7 @@ const char* const tpch_query_8 =
  * ORDER BY nation, o_year DESC;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. Extract is not supported
+ *  1. Extract is not supported
  *    a. Use SUBSTR instead
  */
 const char* const tpch_query_9 =
@@ -422,8 +411,7 @@ const char* const tpch_query_9 =
  * The limit is not part of the printed query but hidden in the specification text.
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
@@ -459,10 +447,6 @@ const char* const tpch_query_10 =
  *        AND n_name = '[NATION]'
  *    )
  * ORDER BY value DESC;
- *
- * Changes:
- *  1. Random values are hardcoded
-
  */
 const char* const tpch_query_11 =
     R"(SELECT ps_partkey, SUM(ps_supplycost * ps_availqty) as value FROM partsupp, supplier, nation
@@ -500,8 +484,7 @@ const char* const tpch_query_11 =
  * ORDER BY l_shipmode;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
@@ -531,8 +514,7 @@ const char* const tpch_query_12 =
  * ORDER BY custdist DESC, c_count DESC;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. Subselect column aliases are moved into subselect because SQLite does not support aliases at the original position
+ *  1. Subselect column aliases are moved into subselect because SQLite does not support aliases at the original position
  */
 
 const char* const tpch_query_13 =
@@ -557,8 +539,7 @@ const char* const tpch_query_13 =
  *    AND l_shipdate < date '[DATE]' + interval '1' month;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
@@ -593,8 +574,7 @@ const char* const tpch_query_14 =
  * drop view revenue[STREAM_ID];
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. "revenue[STREAM_ID]" renamed to "revenue"
+ *  1. "revenue[STREAM_ID]" renamed to "revenue_view"
  *  2. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
@@ -629,10 +609,6 @@ const char* const tpch_query_15 =
  *    )
  * GROUP BY p_brand, p_type, p_size
  * ORDER BY supplier_cnt DESC, p_brand, p_type, p_size;
- *
- * Changes:
- *  1. Random values are hardcoded
-
  */
 const char* const tpch_query_16 =
     R"(SELECT p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
@@ -657,10 +633,6 @@ const char* const tpch_query_16 =
  *        FROM lineitem
  *        WHERE l_partkey = p_partkey
  *    );
- *
- * Changes:
- *  1. Random values are hardcoded
-
  */
 const char* const tpch_query_17 =
     R"(SELECT SUM(l_extendedprice) / 7.0 as avg_yearly FROM lineitem, part WHERE p_partkey = l_partkey
@@ -688,10 +660,6 @@ const char* const tpch_query_17 =
  * LIMIT 100;
  *
  * The limit is not part of the printed query but hidden in the specification text.
- *
- * Changes:
- *  1. Random values are hardcoded
-
  */
 const char* const tpch_query_18 =
     R"(SELECT c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, SUM(l_quantity)
@@ -735,9 +703,6 @@ const char* const tpch_query_18 =
  *        AND l_shipmode in ('AIR', 'AIR REG')
  *        AND l_shipinstruct = 'DELIVER IN PERSON'
  *    );
- *
- * Changes:
- *  1. Random values are hardcoded
  */
 const char* const tpch_query_19 =
 
@@ -781,8 +746,7 @@ const char* const tpch_query_19 =
  * ORDER BY s_name;
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
  */
@@ -828,8 +792,7 @@ const char* const tpch_query_20 =
  * The limit is not part of the printed query but hidden in the specification text.
  *
  * Changes:
- *  1. Random values are hardcoded
- *  2. dates are not supported
+ *  1. dates are not supported
  *    a. use strings as data type for now
  *    b. pre-calculate date operation
 


### PR DESCRIPTION
We've never removed the comment about the TPC-H query parameters being hardcoded, even though we changed that a looong time ago.