### PR TITLE
Generate MetaTables only once

### DIFF
--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -40,7 +40,7 @@ void StorageManager::drop_table(const std::string& name) {
 
 std::shared_ptr<Table> StorageManager::get_table(const std::string& name) const {
   if (MetaTableManager::is_meta_table_name(name)) {
-    return Hyrise::get().meta_table_manager.generate_table(name.substr(MetaTableManager::META_PREFIX.size()));
+    return Hyrise::get().meta_table_manager.generate_table_stub(name.substr(MetaTableManager::META_PREFIX.size()));
   }
 
   const auto iter = _tables.find(name);

--- a/src/lib/utils/meta_table_manager.hpp
+++ b/src/lib/utils/meta_table_manager.hpp
@@ -18,14 +18,21 @@ class MetaTableManager : public Noncopyable {
 
   // Generates the meta table specified by table_name (which should not include the prefix)
   std::shared_ptr<Table> generate_table(const std::string& table_name) const;
+  std::shared_ptr<Table> generate_table_stub(const std::string& table_name) const;
 
   // Generator methods for the different meta tables
   static std::shared_ptr<Table> generate_tables_table();
+  static std::shared_ptr<Table> generate_tables_table_stub();
   static std::shared_ptr<Table> generate_columns_table();
+  static std::shared_ptr<Table> generate_columns_table_stub();
   static std::shared_ptr<Table> generate_chunks_table();
+  static std::shared_ptr<Table> generate_chunks_table_stub();
   static std::shared_ptr<Table> generate_chunk_sort_orders_table();
+  static std::shared_ptr<Table> generate_chunk_sort_orders_table_stub();
   static std::shared_ptr<Table> generate_segments_table();
+  static std::shared_ptr<Table> generate_segments_table_stub();
   static std::shared_ptr<Table> generate_accurate_segments_table();
+  static std::shared_ptr<Table> generate_accurate_segments_table_stub();
 
   // Returns name.starts_with(META_PREFIX) as stdlibc++ does not support starts_with yet.
   static bool is_meta_table_name(const std::string& name);
@@ -34,7 +41,7 @@ class MetaTableManager : public Noncopyable {
   friend class Hyrise;
   MetaTableManager();
 
-  std::unordered_map<std::string, std::function<std::shared_ptr<Table>(void)>> _methods;
+  std::unordered_map<std::string, std::vector<std::function<std::shared_ptr<Table>(void)>>> _methods;
   std::vector<std::string> _table_names;
 };
 


### PR DESCRIPTION
Addressing issue: #1979 meta tables are created multiple times when being queried

idea: 
* StorageManager::get_table() produces an empty table stub that can be used by the sql translator
* GetTable::GetTable() triggers the actual generation of the content 

potential problem: 
* there might be multiple GetTable() calls in one query yielding again multiple table generations