### PR TITLE
Jenkins: disable ccache for clang

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,9 +85,7 @@ try {
           mkdir clang-debug-addr-ub-sanitizers && cd clang-debug-addr-ub-sanitizers &&                                 ${cmake}           ${debug}          ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
           mkdir clang-release-addr-ub-sanitizers && cd clang-release-addr-ub-sanitizers &&                             ${cmake}           ${release}        ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
           mkdir clang-release && cd clang-release &&                                                                   ${cmake}           ${release}        ${clang}          .. &\
-          mkdir clang-release-addr-ub-sanitizers-no-numa && cd clang-release-addr-ub-sanitizers-no-numa &&             ${cmake}           ${release}        ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON -DENABLE_NUMA_SUPPORT=OFF .. &\
           mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&                   ${cmake}           ${relwithdebinfo} ${clang}          -DENABLE_THREAD_SANITIZATION=ON .. &\
-          mkdir clang-relwithdebinfo-thread-sanitizer-no-numa && cd clang-relwithdebinfo-thread-sanitizer-no-numa &&   ${cmake}           ${relwithdebinfo} ${clang}          -DENABLE_THREAD_SANITIZATION=ON  -DENABLE_NUMA_SUPPORT=OFF .. &\
           mkdir gcc-debug && cd gcc-debug &&                                                                           ${cmake} ${ccache} ${debug}          ${gcc}            .. &\
           mkdir gcc-release && cd gcc-release &&                                                                       ${cmake} ${ccache} ${release}        ${gcc}            .. &\
           wait"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,21 +73,23 @@ try {
           // Disable ASLR for the gcc build process (not for the resulting executable) to stop this from happening:
           disable_aslr = 'setarch x86_64 -R'
 
-          // Run cmake once in isolation and build jemalloc to avoid race conditions with autoconf (#1413)
-          sh "mkdir clang-debug && cd clang-debug &&                                                                   ${cmake} ${debug}                    ${clang} ${unity} .. && make -j libjemalloc-build"
+          // jemalloc's autoconf operates outside of the build folder (#1413). If we start two cmake instances at the same time, we run into conflicts.
+          // Thus, run this one (any one, really) first, so that the autoconf step can finish in peace.
+
+          sh "mkdir clang-debug && cd clang-debug &&                                                  ${cmake} ${debug}                    ${clang} ${unity} .. && make -j libjemalloc-build"
 
           // Configure the rest in parallel
           // clang + precompiled headers + ccache is broken: https://gitlab.kitware.com/cmake/cmake/issues/19923
-          // Some confirgurations don't use unity builds as this would break the ccache use across different PRs.
+          // Some configurations don't use unity builds as this would break the ccache use across different PRs.
           // For clang-tidy, ccache does not have an effect, so we use unity there.
-          sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                                         ${cmake}           ${debug}          ${clang} ${unity} -DENABLE_CLANG_TIDY=ON .. &\
-          mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                                   ${cmake}           ${debug}          ${clang} ${unity} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
-          mkdir clang-debug-addr-ub-sanitizers && cd clang-debug-addr-ub-sanitizers &&                                 ${cmake}           ${debug}          ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
-          mkdir clang-release-addr-ub-sanitizers && cd clang-release-addr-ub-sanitizers &&                             ${cmake}           ${release}        ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
-          mkdir clang-release && cd clang-release &&                                                                   ${cmake}           ${release}        ${clang}          .. &\
-          mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&                   ${cmake}           ${relwithdebinfo} ${clang}          -DENABLE_THREAD_SANITIZATION=ON .. &\
-          mkdir gcc-debug && cd gcc-debug &&                                                                           ${cmake} ${ccache} ${debug}          ${gcc}            .. &\
-          mkdir gcc-release && cd gcc-release &&                                                                       ${cmake} ${ccache} ${release}        ${gcc}            .. &\
+          sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                        ${cmake}           ${debug}          ${clang} ${unity} -DENABLE_CLANG_TIDY=ON .. &\
+          mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                  ${cmake}           ${debug}          ${clang} ${unity} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
+          mkdir clang-debug-addr-ub-sanitizers && cd clang-debug-addr-ub-sanitizers &&                ${cmake}           ${debug}          ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
+          mkdir clang-release-addr-ub-sanitizers && cd clang-release-addr-ub-sanitizers &&            ${cmake}           ${release}        ${clang}          -DENABLE_ADDR_UB_SANITIZATION=ON .. &\
+          mkdir clang-release && cd clang-release &&                                                  ${cmake}           ${release}        ${clang}          .. &\
+          mkdir clang-relwithdebinfo-thread-sanitizer && cd clang-relwithdebinfo-thread-sanitizer &&  ${cmake}           ${relwithdebinfo} ${clang}          -DENABLE_THREAD_SANITIZATION=ON .. &\
+          mkdir gcc-debug && cd gcc-debug &&                                                          ${cmake} ${ccache} ${debug}          ${gcc}            .. &\
+          mkdir gcc-release && cd gcc-release &&                                                      ${cmake} ${ccache} ${release}        ${gcc}            .. &\
           wait"
         }
 


### PR DESCRIPTION
Hopefully this stops CI from ruining everyone's day.

Seems to be a known issue: https://gitlab.kitware.com/cmake/cmake/issues/19923

Also removes the no-numa builds. We don't do too much differently there and the no-libnuma support is tested in the mac build anyway.