### PR TITLE
Plot operator breakdown

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import json
 import sys

--- a/scripts/plot_operator_breakdown.py
+++ b/scripts/plot_operator_breakdown.py
@@ -41,15 +41,9 @@ for file in sorted(glob.glob('*-PQP.svg')):
         for operator_name in row_strings[0].split('|'):
             operator_names.append(operator_name.strip())
 
-        # Quick'n dirty conversion from time string to nanoseconds
+        # Convert time string to nanoseconds and add to operator_durations
         for operator_duration_str in row_strings[1].split('|'):
-            operator_duration_str = operator_duration_str.replace(' min ', ' * 60 * 1e9 + ')
-            operator_duration_str = operator_duration_str.replace(' s ', ' * 1e9 + ')
-            operator_duration_str = operator_duration_str.replace(' ms ', ' * 1e6 + ')
-            operator_duration_str = operator_duration_str.replace(' µs ', ' * 1e3 + ')
-            operator_duration_str = operator_duration_str.replace(' ns ', ' + ')
-            operator_duration_str += '0'
-            operator_duration = float(eval(operator_duration_str))
+            operator_duration = pd.Timedelta(operator_duration_str.replace('µ', 'u')).total_seconds() * 1e9
             operator_durations.append(operator_duration)
 
         operator_breakdown = dict(zip(operator_names, operator_durations))

--- a/scripts/plot_operator_breakdown.py
+++ b/scripts/plot_operator_breakdown.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+
+"""
+When called in a folder containing *-PQP.svg files, this script extracts the aggregated operator runtimes from the
+table at the bottom right of the graph, parses it, and plots it. While this is slightly hacky, it allows us to retrieve
+that information without blowing up the code of the Hyrise core.
+"""
+
+import glob
+import matplotlib.pyplot as plt
+import pandas as pd
+import re
+import sys
+
+if(len(sys.argv) != 1):
+    exit("Call without arguments in a folder containing *-PQP.svg files")
+
+benchmarks = []
+
+all_operator_breakdowns = {}
+for file in sorted(glob.glob('*-PQP.svg')):
+    operator_breakdown = {}
+    with open(file, 'r') as svg:
+        svg_string = svg.read().replace("\n", '|')
+
+        # Find the "total by operator" table using a non-greedy search until the end of the <g> object
+        table_string = re.findall(r'Total by operator(.*?)</g>', svg_string)[0]
+
+        # Replace all objects within the table string, also trim newlines (rewritten to |) at the begin and the end
+        table_string = re.sub(r'<.*?>', '', table_string)
+        table_string = re.sub(r'^\|*', '', table_string)
+        table_string = re.sub(r'\|*$', '', table_string)
+
+        row_strings = table_string.split('||')
+
+        # The svg table stores data in a columnar orientation, so we first extract the operator names, then their
+        # durations
+        operator_names = []
+        operator_durations = []
+
+        for operator_name in row_strings[0].split('|'):
+            operator_names.append(operator_name.strip())
+
+        # Quick'n dirty conversion from time string to nanoseconds
+        for operator_duration_str in row_strings[1].split('|'):
+            operator_duration_str = operator_duration_str.replace(' min ', ' * 60 * 1e9 + ')
+            operator_duration_str = operator_duration_str.replace(' s ', ' * 1e9 + ')
+            operator_duration_str = operator_duration_str.replace(' ms ', ' * 1e6 + ')
+            operator_duration_str = operator_duration_str.replace(' µs ', ' * 1e3 + ')
+            operator_duration_str = operator_duration_str.replace(' ns ', ' + ')
+            operator_duration_str += '0'
+            operator_duration = float(eval(operator_duration_str))
+            operator_durations.append(operator_duration)
+
+        operator_breakdown = dict(zip(operator_names, operator_durations))
+
+        # Ignore the "total" line
+        del operator_breakdown['total']
+
+    # Store in all_operator_breakdowns
+    all_operator_breakdowns[file.replace('-PQP.svg', '').replace('TPC-H_', 'Q')] = operator_breakdown
+
+# Make operators the columns and order by operator name
+df = pd.DataFrame(all_operator_breakdowns).transpose()
+df = df.reindex(sorted(df.columns, reverse=True), axis=1)
+
+df.loc["Total"] = df.sum() / df.count()
+
+# Normalize data from nanoseconds to percentage of total cost (calculated by dividing the cells value by the total of
+# the row it appears in)
+df.iloc[:,0:] = df.iloc[:,0:].apply(lambda x: x / x.sum(), axis=1)
+
+# Drop all operators that do not exceed 1% in any query
+df = df[df > .01].dropna(axis = 'columns', how = 'all')
+print(df)
+
+# Plot it
+ax = df.plot.bar(stacked=True, figsize=(2 + len(df) / 4, 4))
+ax.set_yticklabels(['{:,.0%}'.format(x) for x in ax.get_yticks()])
+ax.set_ylabel('Share of run time\n(Hiding ops <1%)')
+
+# Reverse legend so that it matches the stacked bars
+handles, labels = ax.get_legend_handles_labels()
+lgd = ax.legend(reversed(handles), reversed(labels), loc='center left', ncol=1, bbox_to_anchor=(1.0, 0.5))
+
+plt.tight_layout()
+plt.savefig('operator_breakdown.pdf', bbox_extra_artists=(lgd,), bbox_inches='tight')

--- a/scripts/plot_operator_breakdown.py
+++ b/scripts/plot_operator_breakdown.py
@@ -64,15 +64,24 @@ for file in sorted(glob.glob('*-PQP.svg')):
 df = pd.DataFrame(all_operator_breakdowns).transpose()
 df = df.reindex(sorted(df.columns, reverse=True), axis=1)
 
-df.loc["Total"] = df.sum() / df.count()
+
+df = df.fillna(0)
+
+# Calculate share of total execution time (i.e., longer running benchmark items are weighted more)
+df.loc["Absolute"] = df.sum() / df.count()
 
 # Normalize data from nanoseconds to percentage of total cost (calculated by dividing the cells value by the total of
 # the row it appears in)
 df.iloc[:,0:] = df.iloc[:,0:].apply(lambda x: x / x.sum(), axis=1)
 
+# Calculate relative share of operator (i.e., weighing all benchmark items the same) - have to ignore the "Absolute"
+# row for that
+df.loc["Relative"] = df.head(-1).sum() / df.head(-1).count()
+
+print(df)
+
 # Drop all operators that do not exceed 1% in any query
 df = df[df > .01].dropna(axis = 'columns', how = 'all')
-print(df)
 
 # Plot it
 ax = df.plot.bar(stacked=True, figsize=(2 + len(df) / 4, 4))

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -53,7 +53,8 @@ void PQPVisualizer::_build_graph(const std::vector<std::shared_ptr<AbstractOpera
     // Print third column (relative operator duration)
     operator_breakdown_stream << "|";
     for (const auto& [_, nanoseconds] : duration_by_operator_name) {
-      operator_breakdown_stream << round(static_cast<double>(nanoseconds.count()) / total_nanoseconds.count() * 100) << " %\\l";
+      operator_breakdown_stream << round(static_cast<double>(nanoseconds.count()) / total_nanoseconds.count() * 100)
+                                << " %\\l";
     }
     operator_breakdown_stream << " \\l";
 

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -2,6 +2,7 @@
 #include <string>
 #include <utility>
 
+#include "constant_mappings.hpp"
 #include "expression/expression_utils.hpp"
 #include "expression/pqp_subquery_expression.hpp"
 #include "operators/limit.hpp"
@@ -26,6 +27,43 @@ void PQPVisualizer::_build_graph(const std::vector<std::shared_ptr<AbstractOpera
 
   for (const auto& plan : plans) {
     _build_subtree(plan, visualized_ops);
+  }
+
+  {
+    // Print the "Total by operator" box using graphviz's record type. Using HTML labels would be slightly nicer, but
+    // boost always encloses the label in quotes, which breaks them.
+    std::stringstream operator_breakdown_stream;
+    operator_breakdown_stream << "{Total by operator|{";
+
+    // Print first column (operator name)
+    for (const auto& [operator_name, _] : duration_by_operator_name) {
+      operator_breakdown_stream << " " << operator_name << " \\r";
+    }
+    operator_breakdown_stream << "total\\r";
+
+    // Print second column (operator duration) and track total duration
+    operator_breakdown_stream << "|";
+    auto total_nanoseconds = std::chrono::nanoseconds{};
+    for (const auto& [_, nanoseconds] : duration_by_operator_name) {
+      operator_breakdown_stream << " " << format_duration(nanoseconds) << " \\l";
+      total_nanoseconds += nanoseconds;
+    }
+    operator_breakdown_stream << " " << format_duration(total_nanoseconds) << " \\l";
+
+    // Print third column (relative operator duration)
+    operator_breakdown_stream << "|";
+    for (const auto& [_, nanoseconds] : duration_by_operator_name) {
+      operator_breakdown_stream << round(static_cast<double>(nanoseconds.count()) / total_nanoseconds.count() * 100) << " %\\l";
+    }
+    operator_breakdown_stream << " \\l";
+
+    operator_breakdown_stream << "}}";
+
+    VizVertexInfo vertex_info = _default_vertex;
+    vertex_info.shape = "record";
+    vertex_info.label = operator_breakdown_stream.str();
+
+    boost::add_vertex(vertex_info, _graph);
   }
 }
 
@@ -122,6 +160,8 @@ void PQPVisualizer::_add_operator(const std::shared_ptr<const AbstractOperator>&
     label += "\n\n" + format_duration(total);
     info.pen_width = total.count();
   }
+
+  duration_by_operator_name[op->name()] += op->performance_data().walltime;
 
   info.label = label;
   _add_vertex(op, info);

--- a/src/lib/visualization/pqp_visualizer.hpp
+++ b/src/lib/visualization/pqp_visualizer.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <unordered_map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "expression/abstract_expression.hpp"

--- a/src/lib/visualization/pqp_visualizer.hpp
+++ b/src/lib/visualization/pqp_visualizer.hpp
@@ -33,7 +33,7 @@ class PQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
 
   void _add_operator(const std::shared_ptr<const AbstractOperator>& op);
 
-  std::unordered_map<std::string, std::chrono::nanoseconds> duration_by_operator_name;
+  std::unordered_map<std::string, std::chrono::nanoseconds> _duration_by_operator_name;
 };
 
 }  // namespace opossum

--- a/src/lib/visualization/pqp_visualizer.hpp
+++ b/src/lib/visualization/pqp_visualizer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <unordered_map>
 #include <memory>
 #include <string>
 #include <utility>
@@ -31,6 +32,8 @@ class PQPVisualizer : public AbstractVisualizer<std::vector<std::shared_ptr<Abst
                        const std::shared_ptr<const AbstractOperator>& to, const InputSide side);
 
   void _add_operator(const std::shared_ptr<const AbstractOperator>& op);
+
+  std::unordered_map<std::string, std::chrono::nanoseconds> duration_by_operator_name;
 };
 
 }  // namespace opossum


### PR DESCRIPTION
This adds a table at the lower right corner of each PQP visualization that shows the aggregate runtime per operator:

<img width="402" alt="Screenshot 2020-02-07 at 08 41 51" src="https://user-images.githubusercontent.com/575106/74010474-dfa79000-4985-11ea-84ee-b78a58f35417.png">

Also, this adds a script that accumulates this information over different *PQP.svg files:

![operator_breakdown](https://user-images.githubusercontent.com/575106/74011225-8b9dab00-4987-11ea-8013-db872e6470d6.png)

I don't particularly like the colors but haven't found a nice color scheme that doesn't imply some type of ordering.