### PR TITLE
TPC-H: Don't sort binary tables again, use cache by default

### DIFF
--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -89,7 +89,6 @@ def main():
   benchmark.expect_exact("Max duration per item is 10 seconds")
   benchmark.expect_exact("Warmup duration per item is 5 seconds")
   benchmark.expect_exact("Automatically verifying results with SQLite. This will make the performance numbers invalid.")
-  benchmark.expect_exact("Not caching tables as binary files")
   benchmark.expect_exact("Benchmarking queries from resources/test_data/queries/file_based/")
   benchmark.expect_exact("Running on tables from resources/test_data/tbl/file_based/")
   benchmark.expect_exact("Running subset of queries: select_statement")

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -22,7 +22,6 @@ def main():
   arguments["--encoding"] = "'Unencoded'"
   arguments["--scheduler"] = "false"
   arguments["--clients"] = "1"
-  arguments["--cache_binary_tables"] = "true"
 
   os.system("rm -rf " + arguments["--table_path"] + "/*.bin")
 

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -20,7 +20,6 @@ def main():
   arguments["--mode"] = "'Shuffled'"
   arguments["--encoding"] = "'Unencoded'"
   arguments["--clients"] = "1"
-  arguments["--cache_binary_tables"] = "true"
   arguments["--scheduler"] = "false"
 
   os.system("rm -rf " + arguments["--table_path"] + "/*.bin")

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -91,7 +91,6 @@ def main():
   benchmark.expect_exact("Max duration per item is 10 seconds")
   benchmark.expect_exact("Warmup duration per item is 2 seconds")
   benchmark.expect_exact("Automatically verifying results with SQLite. This will make the performance numbers invalid.")
-  benchmark.expect_exact("Not caching tables as binary files")
   benchmark.expect_exact("Benchmarking queries from third_party/join-order-benchmark")
   benchmark.expect_exact("Running on tables from resources/test_data/imdb_sample/")
   benchmark.expect_exact("Multi-threaded Topology:")

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -24,7 +24,7 @@ def main():
   arguments["--indexes"] = "true"
   arguments["--scheduler"] = "false"
   arguments["--clients"] = "1"
-  arguments["--cache_binary_tables"] = "false"
+  arguments["--dont_cache_binary_tables"] = "true"
 
   benchmark = initialize(arguments, "hyriseBenchmarkTPCH", True)
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -8,6 +8,7 @@
 #include "operators/table_wrapper.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
+#include "storage/segment_iterate.hpp"
 #include "utils/format_duration.hpp"
 #include "utils/timer.hpp"
 
@@ -43,24 +44,70 @@ void AbstractTableGenerator::generate_and_store() {
     std::cout << "- Sorting tables" << std::endl;
 
     for (const auto& [table_name, column_name] : sort_order_by_table) {
+      auto& table = table_info_by_name[table_name].table;
       const auto order_by_mode = OrderByMode::Ascending;  // currently fixed to ascending
-      std::cout << "-  Sorting '" << table_name << "' by '" << column_name << "' " << std::flush;
-      Timer per_table_timer;
+      const auto sort_column_id = table->column_id_by_name(column_name);
+      const auto chunk_count = table->chunk_count();
+
+      // Check if table is already sorted
+      auto is_sorted = true;
+      resolve_data_type(table->column_data_type(sort_column_id), [&](auto type) {
+        using ColumnDataType = typename decltype(type)::type;
+
+        auto last_value = std::optional<ColumnDataType>{};
+        for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+          const auto& segment = table->get_chunk(chunk_id)->get_segment(sort_column_id);
+          segment_with_iterators<ColumnDataType>(*segment, [&](auto it, const auto end) {
+            while (it != end) {
+              if (it->is_null()) {
+                if (last_value) {
+                  // NULLs should come before all values
+                  is_sorted = false;
+                  break;
+                }
+                continue;
+              }
+
+              if (!last_value || it->value() >= *last_value) {
+                last_value = it->value();
+              } else {
+                is_sorted = false;
+                break;
+              }
+
+              ++it;
+            }
+          });
+        }
+      });
+
+      if (is_sorted) {
+        std::cout << "-  Table '" << table_name << "' is already sorted by '" << column_name << "' " << std::endl;
+
+        for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+          table->get_chunk(chunk_id)->set_ordered_by({sort_column_id, order_by_mode});
+        }
+
+        continue;
+      }
 
       // We sort the tables after their creation so that we are independent of the order in which they are filled.
       // For this, we use the sort operator. Because it returns a `const Table`, we need to recreate the table and
       // migrate the sorted chunks to that table.
 
-      auto& table = table_info_by_name[table_name].table;
+      std::cout << "-  Sorting '" << table_name << "' by '" << column_name << "' " << std::flush;
+      Timer per_table_timer;
+
       auto table_wrapper = std::make_shared<TableWrapper>(table);
       table_wrapper->execute();
-      auto sort = std::make_shared<Sort>(table_wrapper, table->column_id_by_name(column_name), order_by_mode,
-                                         _benchmark_config->chunk_size);
+      auto sort = std::make_shared<Sort>(table_wrapper, sort_column_id, order_by_mode, _benchmark_config->chunk_size);
       sort->execute();
       const auto immutable_sorted_table = sort->get_output();
+
+      Assert(immutable_sorted_table->chunk_count() == table->chunk_count(), "Mismatching chunk_count");
+
       table = std::make_shared<Table>(immutable_sorted_table->column_definitions(), TableType::Data,
-                                      Chunk::DEFAULT_SIZE, UseMvcc::Yes);
-      const auto chunk_count = immutable_sorted_table->chunk_count();
+                                      table->target_chunk_size(), UseMvcc::Yes);
       const auto column_count = immutable_sorted_table->column_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         const auto chunk = immutable_sorted_table->get_chunk(chunk_id);
@@ -70,7 +117,7 @@ void AbstractTableGenerator::generate_and_store() {
           segments.emplace_back(chunk->get_segment(column_id));
         }
         table->append_chunk(segments, mvcc_data);
-        table->get_chunk(chunk_id)->set_ordered_by({table->column_id_by_name(column_name), order_by_mode});
+        table->get_chunk(chunk_id)->set_ordered_by({sort_column_id, order_by_mode});
       }
 
       std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -41,7 +41,7 @@ class BenchmarkConfig {
   uint32_t clients = 1;
   bool enable_visualization = false;
   bool verify = false;
-  bool cache_binary_tables = false;
+  bool cache_binary_tables = true;
   bool sql_metrics = false;
 
   static const char* description;

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -41,7 +41,7 @@ class BenchmarkConfig {
   uint32_t clients = 1;
   bool enable_visualization = false;
   bool verify = false;
-  bool cache_binary_tables = true;
+  bool cache_binary_tables = false;  // Defaults to false for internal use, but the CLI sets it to true by default
   bool sql_metrics = false;
 
   static const char* description;

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -401,6 +401,9 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
   // benchmarks interact with the BenchmarkRunner. At this moment, that does not seem to be worth the effort.
   const auto default_mode = (benchmark_name == "TPC-C Benchmark" ? "Shuffled" : "Ordered");
 
+  // TPC-C does not support binary caching
+  const auto default_dont_cache_binary_tables = (benchmark_name == "TPC-C Benchmark" ? true : false);
+
   // If you add a new option here, make sure to edit CLIConfigParser::basic_cli_options_to_json() so it contains the
   // newest options. Sadly, there is no way to to get all option keys to do this automatically.
   // clang-format off
@@ -421,7 +424,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint>()->default_value("1")) // NOLINT
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
+    ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value(default_dont_cache_binary_tables)) // NOLINT
     ("sql_metrics", "Track SQL metrics (parse time etc.) for each SQL query and add it to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")); // NOLINT
   // clang-format on
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -402,7 +402,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
   const auto default_mode = (benchmark_name == "TPC-C Benchmark" ? "Shuffled" : "Ordered");
 
   // TPC-C does not support binary caching
-  const auto default_dont_cache_binary_tables = (benchmark_name == "TPC-C Benchmark" ? true : false);
+  const auto default_dont_cache_binary_tables = (benchmark_name == "TPC-C Benchmark" ? "true" : "false");
 
   // If you add a new option here, make sure to edit CLIConfigParser::basic_cli_options_to_json() so it contains the
   // newest options. Sadly, there is no way to to get all option keys to do this automatically.

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -421,7 +421,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint>()->default_value("1")) // NOLINT
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("cache_binary_tables", "Cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
+    ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("sql_metrics", "Track SQL metrics (parse time etc.) for each SQL query and add it to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")); // NOLINT
   // clang-format on
 

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -175,7 +175,7 @@ nlohmann::json CLIConfigParser::basic_cli_options_to_json(const cxxopts::ParseRe
   json_config.emplace("visualize", parse_result["visualize"].as<bool>());
   json_config.emplace("output", parse_result["output"].as<std::string>());
   json_config.emplace("verify", parse_result["verify"].as<bool>());
-  json_config.emplace("cache_binary_tables", parse_result["cache_binary_tables"].as<bool>());
+  json_config.emplace("cache_binary_tables", !parse_result["dont_cache_binary_tables"].as<bool>());
   json_config.emplace("sql_metrics", parse_result["sql_metrics"].as<bool>());
 
   return json_config;

--- a/src/test/tpc/tpcc_test.cpp
+++ b/src/test/tpc/tpcc_test.cpp
@@ -16,7 +16,6 @@ class TPCCTest : public BaseTest {
  public:
   static void SetUpTestCase() {
     auto benchmark_config = std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config());
-    benchmark_config->cache_binary_tables = false;
     auto table_generator = TPCCTableGenerator{NUM_WAREHOUSES, benchmark_config};
 
     tables = table_generator.generate();

--- a/src/test/tpc/tpcc_test.cpp
+++ b/src/test/tpc/tpcc_test.cpp
@@ -16,6 +16,7 @@ class TPCCTest : public BaseTest {
  public:
   static void SetUpTestCase() {
     auto benchmark_config = std::make_shared<BenchmarkConfig>(BenchmarkConfig::get_default_config());
+    benchmark_config->cache_binary_tables = false;
     auto table_generator = TPCCTableGenerator{NUM_WAREHOUSES, benchmark_config};
 
     tables = table_generator.generate();


### PR DESCRIPTION
The binary dumps have no information if the entire table is sorted. As such, we currently re-sort and re-encode TPC-H tables. By checking if the table is already sorted, we can avoid this step and reduce the benchmark startup time from 0m30.447s to 0m16.147s. This is not the perfect solution and storing the flag in the table would be nicer, but at least this fixes #1864.

Also, this changes the default to cached binary tables, use `--dont_cache_binary_tables` to disable.

Before:
```
- Loading/Generating tables
[...]
-  Loading table "orders" from cached binary "tpch_cached_tables/sf-1.000000/orders.bin" (183 ms 491 µs)
[...]
-  Loading table "lineitem" from cached binary "tpch_cached_tables/sf-1.000000/lineitem.bin" (620 ms 853 µs)
- Loading/Generating tables done (1 s 45 ms)
- Sorting tables
-  Sorting 'lineitem' by 'l_shipdate' (8 s 452 ms)
-  Sorting 'orders' by 'o_orderdate' (1 s 515 ms)
- Sorting tables done (10 s 90 ms)
- Encoding tables if necessary
-  Encoding 'lineitem' - encoding applied (2 s 74 ms)
[...]
-  Encoding 'orders' - encoding applied (456 ms 582 µs)
[...]
- Encoding tables done (2 s 606 ms)
- Writing tables into binary files if necessary
- Writing 'lineitem' into binary file ".bin" (1 s 674 ms)
- Writing 'orders' into binary file ".bin" (1 s 201 ms)
- Writing tables into binary files done (2 s 875 ms)
```

New:
```
- Loading/Generating tables
[...]
-  Loading table "orders" from cached binary "tpch_cached_tables/sf-1.000000/orders.bin" (184 ms 333 µs)
[...]
-  Loading table "lineitem" from cached binary "tpch_cached_tables/sf-1.000000/lineitem.bin" (623 ms 31 µs)
- Loading/Generating tables done (1 s 41 ms)
- Sorting tables
-  Table 'lineitem' is already sorted by 'l_shipdate'
-  Table 'orders' is already sorted by 'o_orderdate'
- Sorting tables done (564 ms 646 µs)
- Encoding tables if necessary
-  Encoding 'lineitem' - no encoding necessary (535 ms 617 µs)
[...]
-  Encoding 'orders' - no encoding necessary (148 ms 3 µs)
[...]
- Encoding tables done (718 ms 586 µs)
- Writing tables into binary files if necessary
- Writing tables into binary files done (6 µs 168 ns)
```