### PR TITLE
Change interface of column_expressions() – No more const-ref

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -218,7 +218,7 @@ bool AbstractLQPNode::shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMa
   return _on_shallow_equals(rhs, node_mapping);
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> AbstractLQPNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> AbstractLQPNode::column_expressions() const {
   Assert(left_input() && !right_input(),
          "Can only forward input expressions iff there is a left input and no right input");
   return left_input()->column_expressions();

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -218,7 +218,7 @@ bool AbstractLQPNode::shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMa
   return _on_shallow_equals(rhs, node_mapping);
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& AbstractLQPNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> AbstractLQPNode::column_expressions() const {
   Assert(left_input() && !right_input(),
          "Can only forward input expressions iff there is a left input and no right input");
   return left_input()->column_expressions();

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -220,7 +220,7 @@ bool AbstractLQPNode::shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMa
 
 std::vector<std::shared_ptr<AbstractExpression>> AbstractLQPNode::column_expressions() const {
   Assert(left_input() && !right_input(),
-         "Can only forward input expressions if there is a left input and no right input");
+         "Can only forward input expressions iff there is a left input and no right input");
   return left_input()->column_expressions();
 }
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -220,7 +220,7 @@ bool AbstractLQPNode::shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMa
 
 std::vector<std::shared_ptr<AbstractExpression>> AbstractLQPNode::column_expressions() const {
   Assert(left_input() && !right_input(),
-         "Can only forward input expressions iff there is a left input and no right input");
+         "Can only forward input expressions if there is a left input and no right input");
   return left_input()->column_expressions();
 }
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -123,7 +123,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   /**
    * @return The Expressions defining each column that this node outputs
    */
-  virtual const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const;
+  virtual const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const;
 
   /**
    * @return The ColumnID of the @param expression, or std::nullopt if it can't be found. Note that because COUNT(*)

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -123,7 +123,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   /**
    * @return The Expressions defining each column that this node outputs
    */
-  virtual const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const;
+  virtual std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const;
 
   /**
    * @return The ColumnID of the @param expression, or std::nullopt if it can't be found. Note that because COUNT(*)

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -57,16 +57,16 @@ std::string AggregateNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& AggregateNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressions() const {
   // We do not return node_expressions directly here, because we do not want to expose ANY() to the following LQP
   // nodes. This way, we execute ANY() as intended, but do not have to traverse the LQP upwards and adapt nodes
   // that reference the ANY'd column.
-  _column_expressions.resize(node_expressions.size());
-  std::copy(node_expressions.begin(), node_expressions.end(), _column_expressions.begin());
+  auto column_expressions = std::vector<std::shared_ptr<AbstractExpression>>(node_expressions.size());
+  std::copy(node_expressions.begin(), node_expressions.end(), column_expressions.begin());
 
-  for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < _column_expressions.size();
+  for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < column_expressions.size();
        ++expression_idx) {
-    auto& column_expression = _column_expressions[expression_idx];
+    auto& column_expression = column_expressions[expression_idx];
     DebugAssert(column_expression->type == ExpressionType::Aggregate,
                 "Unexpected non-aggregate in list of aggregates.");
     if (column_expression->type == ExpressionType::Aggregate) {
@@ -77,7 +77,7 @@ const std::vector<std::shared_ptr<AbstractExpression>>& AggregateNode::column_ex
     }
   }
 
-  return _column_expressions;
+  return column_expressions;
 }
 
 bool AggregateNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -57,7 +57,7 @@ std::string AggregateNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressions() const {
   // We do not return node_expressions directly here, because we do not want to expose ANY() to the following LQP
   // nodes. This way, we execute ANY() as intended, but do not have to traverse the LQP upwards and adapt nodes
   // that reference the ANY'd column.

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -61,8 +61,7 @@ std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressio
   // We do not return node_expressions directly here, because we do not want to expose ANY() to the following LQP
   // nodes. This way, we execute ANY() as intended, but do not have to traverse the LQP upwards and adapt nodes
   // that reference the ANY'd column.
-  auto column_expressions = std::vector<std::shared_ptr<AbstractExpression>>(node_expressions.size());
-  std::copy(node_expressions.begin(), node_expressions.end(), column_expressions.begin());
+  auto column_expressions = node_expressions;
 
   for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < column_expressions.size();
        ++expression_idx) {

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -24,7 +24,7 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
                 const std::vector<std::shared_ptr<AbstractExpression>>& aggregate_expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   // node_expression contains both the group_by- and the aggregate_expressions in that order.

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -24,7 +24,7 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
                 const std::vector<std::shared_ptr<AbstractExpression>>& aggregate_expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   // node_expression contains both the group_by- and the aggregate_expressions in that order.
@@ -34,9 +34,6 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
   size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
-
- private:
-  mutable std::vector<std::shared_ptr<AbstractExpression>> _column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -29,8 +29,6 @@ std::string AliasNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> AliasNode::column_expressions() const { return node_expressions; }
-
 size_t AliasNode::_on_shallow_hash() const {
   size_t hash{0};
   for (const auto& alias : aliases) {

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -29,7 +29,7 @@ std::string AliasNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& AliasNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> AliasNode::column_expressions() const {
   return node_expressions;
 }
 

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -29,6 +29,8 @@ std::string AliasNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
+std::vector<std::shared_ptr<AbstractExpression>> AliasNode::column_expressions() const { return node_expressions; }
+
 size_t AliasNode::_on_shallow_hash() const {
   size_t hash{0};
   for (const auto& alias : aliases) {

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -29,9 +29,7 @@ std::string AliasNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> AliasNode::column_expressions() const {
-  return node_expressions;
-}
+std::vector<std::shared_ptr<AbstractExpression>> AliasNode::column_expressions() const { return node_expressions; }
 
 size_t AliasNode::_on_shallow_hash() const {
   size_t hash{0};

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -17,7 +17,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
             const std::vector<std::string>& aliases);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::vector<std::string> aliases;
 

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -17,7 +17,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
             const std::vector<std::string>& aliases);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return node_expressions; }
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::vector<std::string> aliases;
 

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -17,7 +17,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
             const std::vector<std::string>& aliases);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::vector<std::string> aliases;
 

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -17,7 +17,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
             const std::vector<std::string>& aliases);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return node_expressions; }
 
   const std::vector<std::string> aliases;
 

--- a/src/lib/logical_query_plan/base_non_query_node.cpp
+++ b/src/lib/logical_query_plan/base_non_query_node.cpp
@@ -4,8 +4,8 @@
 
 namespace opossum {
 
-const std::vector<std::shared_ptr<AbstractExpression>>& BaseNonQueryNode::column_expressions() const {
-  return _column_expressions_dummy;
+const std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const {
+  return {};
 }
 
 bool BaseNonQueryNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/base_non_query_node.cpp
+++ b/src/lib/logical_query_plan/base_non_query_node.cpp
@@ -4,9 +4,7 @@
 
 namespace opossum {
 
-const std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const {
-  return {};
-}
+const std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const { return {}; }
 
 bool BaseNonQueryNode::is_column_nullable(const ColumnID column_id) const {
   // The majority of non-query nodes output no column (CreateTable, DropTable, ...)

--- a/src/lib/logical_query_plan/base_non_query_node.cpp
+++ b/src/lib/logical_query_plan/base_non_query_node.cpp
@@ -4,8 +4,6 @@
 
 namespace opossum {
 
-std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const { return {}; }
-
 bool BaseNonQueryNode::is_column_nullable(const ColumnID column_id) const {
   // The majority of non-query nodes output no column (CreateTable, DropTable, ...)
   // Non-query nodes that do return columns (ShowColumns, ...) need to override this function

--- a/src/lib/logical_query_plan/base_non_query_node.cpp
+++ b/src/lib/logical_query_plan/base_non_query_node.cpp
@@ -4,7 +4,7 @@
 
 namespace opossum {
 
-const std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const { return {}; }
+std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const { return {}; }
 
 bool BaseNonQueryNode::is_column_nullable(const ColumnID column_id) const {
   // The majority of non-query nodes output no column (CreateTable, DropTable, ...)

--- a/src/lib/logical_query_plan/base_non_query_node.cpp
+++ b/src/lib/logical_query_plan/base_non_query_node.cpp
@@ -4,6 +4,8 @@
 
 namespace opossum {
 
+std::vector<std::shared_ptr<AbstractExpression>> BaseNonQueryNode::column_expressions() const { return {}; }
+
 bool BaseNonQueryNode::is_column_nullable(const ColumnID column_id) const {
   // The majority of non-query nodes output no column (CreateTable, DropTable, ...)
   // Non-query nodes that do return columns (ShowColumns, ...) need to override this function

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -13,7 +13,7 @@ class BaseNonQueryNode : public AbstractLQPNode {
  public:
   using AbstractLQPNode::AbstractLQPNode;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return {}; }
   bool is_column_nullable(const ColumnID column_id) const override;
 };
 

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -13,7 +13,7 @@ class BaseNonQueryNode : public AbstractLQPNode {
  public:
   using AbstractLQPNode::AbstractLQPNode;
 
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 };
 

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -13,7 +13,7 @@ class BaseNonQueryNode : public AbstractLQPNode {
  public:
   using AbstractLQPNode::AbstractLQPNode;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return {}; }
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 };
 

--- a/src/lib/logical_query_plan/base_non_query_node.hpp
+++ b/src/lib/logical_query_plan/base_non_query_node.hpp
@@ -13,11 +13,8 @@ class BaseNonQueryNode : public AbstractLQPNode {
  public:
   using AbstractLQPNode::AbstractLQPNode;
 
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-
- private:
-  const std::vector<std::shared_ptr<AbstractExpression>> _column_expressions_dummy{};  // always empty
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -15,7 +15,7 @@ std::string DeleteNode::description(const DescriptionMode mode) const { return "
 
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 
-const std::vector<std::shared_ptr<AbstractExpression>> DeleteNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> DeleteNode::column_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -15,7 +15,7 @@ std::string DeleteNode::description(const DescriptionMode mode) const { return "
 
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& DeleteNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> DeleteNode::column_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -16,7 +16,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -16,7 +16,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -14,7 +14,7 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
 std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
-const std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const { return {}; }
+std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const { return {}; }
 
 bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {
   Fail("DummyTable does not output any columns");

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -14,6 +14,8 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
 std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
+std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const { return {}; }
+
 bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {
   Fail("DummyTable does not output any columns");
 }

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -14,8 +14,6 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
 std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
-std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const { return {}; }
-
 bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {
   Fail("DummyTable does not output any columns");
 }

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -14,9 +14,7 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
 std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
-const std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const {
-  return {};
-}
+const std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const { return {}; }
 
 bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {
   Fail("DummyTable does not output any columns");

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -14,8 +14,8 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
 std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& DummyTableNode::column_expressions() const {
-  return _column_expressions;
+const std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const {
+  return {};
 }
 
 bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -18,7 +18,7 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -18,15 +18,12 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
-
- private:
-  std::vector<std::shared_ptr<AbstractExpression>> _column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -18,7 +18,7 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return {}; }
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -18,7 +18,7 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return {}; }
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -22,7 +22,7 @@ std::string InsertNode::description(const DescriptionMode mode) const {
 
 bool InsertNode::is_column_nullable(const ColumnID column_id) const { Fail("Insert returns no columns"); }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& InsertNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> InsertNode::column_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -22,7 +22,7 @@ std::string InsertNode::description(const DescriptionMode mode) const {
 
 bool InsertNode::is_column_nullable(const ColumnID column_id) const { Fail("Insert returns no columns"); }
 
-const std::vector<std::shared_ptr<AbstractExpression>> InsertNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> InsertNode::column_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -17,7 +17,7 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -17,7 +17,7 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -45,7 +45,7 @@ std::string JoinNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> JoinNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> JoinNode::column_expressions() const {
   Assert(left_input() && right_input(), "Both inputs need to be set to determine a JoinNode's output expressions");
 
   /**

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -45,7 +45,7 @@ std::string JoinNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> JoinNode::column_expressions() const {
   Assert(left_input() && right_input(), "Both inputs need to be set to determine a JoinNode's output expressions");
 
   /**
@@ -60,13 +60,14 @@ const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::column_express
   const auto output_both_inputs =
       join_mode != JoinMode::Semi && join_mode != JoinMode::AntiNullAsTrue && join_mode != JoinMode::AntiNullAsFalse;
 
-  _column_expressions.resize(left_expressions.size() + (output_both_inputs ? right_expressions.size() : 0));
+  auto column_expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
+  column_expressions.resize(left_expressions.size() + (output_both_inputs ? right_expressions.size() : 0));
 
-  auto right_begin = std::copy(left_expressions.begin(), left_expressions.end(), _column_expressions.begin());
+  auto right_begin = std::copy(left_expressions.begin(), left_expressions.end(), column_expressions.begin());
 
   if (output_both_inputs) std::copy(right_expressions.begin(), right_expressions.end(), right_begin);
 
-  return _column_expressions;
+  return column_expressions;
 }
 
 bool JoinNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -29,7 +29,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   JoinNode(const JoinMode join_mode, const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;
@@ -40,9 +40,6 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
-
- private:
-  mutable std::vector<std::shared_ptr<AbstractExpression>> _column_expressions;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -29,7 +29,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   JoinNode(const JoinMode join_mode, const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -26,7 +26,7 @@ LQPColumnReference MockNode::get_column(const std::string& column_name) const {
 
 const MockNode::ColumnDefinitions& MockNode::column_definitions() const { return _column_definitions; }
 
-const std::vector<std::shared_ptr<AbstractExpression>> MockNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> MockNode::column_expressions() const {
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain that
   // in the constructor
   if (!_column_expressions) {

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -26,7 +26,7 @@ LQPColumnReference MockNode::get_column(const std::string& column_name) const {
 
 const MockNode::ColumnDefinitions& MockNode::column_definitions() const { return _column_definitions; }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& MockNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> MockNode::column_expressions() const {
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain that
   // in the constructor
   if (!_column_expressions) {

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -30,7 +30,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
   const ColumnDefinitions& column_definitions() const;
 
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   /**

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -30,7 +30,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
   const ColumnDefinitions& column_definitions() const;
 
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   /**

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -21,9 +21,7 @@ std::string ProjectionNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::column_expressions() const {
-  return node_expressions;
-}
+std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::column_expressions() const { return node_expressions; }
 
 bool ProjectionNode::is_column_nullable(const ColumnID column_id) const {
   Assert(column_id < node_expressions.size(), "ColumnID out of range");

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -21,6 +21,8 @@ std::string ProjectionNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
+std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::column_expressions() const { return node_expressions; }
+
 bool ProjectionNode::is_column_nullable(const ColumnID column_id) const {
   Assert(column_id < node_expressions.size(), "ColumnID out of range");
   Assert(left_input(), "Need left input to determine nullability");

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -21,8 +21,6 @@ std::string ProjectionNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::column_expressions() const { return node_expressions; }
-
 bool ProjectionNode::is_column_nullable(const ColumnID column_id) const {
   Assert(column_id < node_expressions.size(), "ColumnID out of range");
   Assert(left_input(), "Need left input to determine nullability");

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -21,7 +21,7 @@ std::string ProjectionNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& ProjectionNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::column_expressions() const {
   return node_expressions;
 }
 

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -12,7 +12,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
   explicit ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -12,7 +12,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
   explicit ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return node_expressions; }
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -12,7 +12,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
   explicit ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -12,7 +12,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
   explicit ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return node_expressions; }
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -28,7 +28,7 @@ std::string StaticTableNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& StaticTableNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::column_expressions() const {
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain
   // that in the constructor
   if (!_column_expressions) {

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -28,7 +28,7 @@ std::string StaticTableNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::column_expressions() const {
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain
   // that in the constructor
   if (!_column_expressions) {

--- a/src/lib/logical_query_plan/static_table_node.hpp
+++ b/src/lib/logical_query_plan/static_table_node.hpp
@@ -17,7 +17,7 @@ class StaticTableNode : public EnableMakeForLQPNode<StaticTableNode>, public Bas
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::shared_ptr<Table> table;

--- a/src/lib/logical_query_plan/static_table_node.hpp
+++ b/src/lib/logical_query_plan/static_table_node.hpp
@@ -17,7 +17,7 @@ class StaticTableNode : public EnableMakeForLQPNode<StaticTableNode>, public Bas
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::shared_ptr<Table> table;

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -60,7 +60,7 @@ std::string StoredTableNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> StoredTableNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> StoredTableNode::column_expressions() const {
   // Need to initialize the expressions lazily because (a) they will have a weak_ptr to this node and we can't obtain
   // that in the constructor and (b) because we don't have column pruning information in the constructor
   if (!_column_expressions) {

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -60,7 +60,7 @@ std::string StoredTableNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& StoredTableNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> StoredTableNode::column_expressions() const {
   // Need to initialize the expressions lazily because (a) they will have a weak_ptr to this node and we can't obtain
   // that in the constructor and (b) because we don't have column pruning information in the constructor
   if (!_column_expressions) {

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -40,7 +40,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   std::vector<IndexStatistics> indexes_statistics() const;
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::string table_name;

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -40,7 +40,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   std::vector<IndexStatistics> indexes_statistics() const;
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::string table_name;

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -17,7 +17,7 @@ std::string UnionNode::description(const DescriptionMode mode) const {
   return "[UnionNode] Mode: " + union_mode_to_string.left.at(union_mode);
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>> UnionNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> UnionNode::column_expressions() const {
   Assert(expressions_equal(left_input()->column_expressions(), right_input()->column_expressions()),
          "Input Expressions must match");
   return left_input()->column_expressions();

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -17,7 +17,7 @@ std::string UnionNode::description(const DescriptionMode mode) const {
   return "[UnionNode] Mode: " + union_mode_to_string.left.at(union_mode);
 }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& UnionNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> UnionNode::column_expressions() const {
   Assert(expressions_equal(left_input()->column_expressions(), right_input()->column_expressions()),
          "Input Expressions must match");
   return left_input()->column_expressions();

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -14,7 +14,7 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
   explicit UnionNode(const UnionMode union_mode);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const UnionMode union_mode;

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -14,7 +14,7 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
   explicit UnionNode(const UnionMode union_mode);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const UnionMode union_mode;

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -26,6 +26,11 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
+std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const {
+  static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
+  return empty_vector;
+}
+
 size_t UpdateNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
-const std::vector<std::shared_ptr<AbstractExpression>>& UpdateNode::column_expressions() const {
+const std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
-const std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -26,11 +26,6 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
-std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const {
-  static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
-  return empty_vector;
-}
-
 size_t UpdateNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -26,10 +26,7 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
-std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const {
-  static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
-  return empty_vector;
-}
+std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const { return {}; }
 
 size_t UpdateNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,7 +19,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return {}; }
 
   const std::string table_name;
 

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,7 +19,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override { return {}; }
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,7 +19,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const override;
+  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,7 +19,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public BaseNonQueryN
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  const std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -312,7 +312,8 @@ void ColumnPruningRule::apply_to(const std::shared_ptr<AbstractLQPNode>& lqp) co
   std::unordered_map<std::shared_ptr<AbstractLQPNode>, ExpressionUnorderedSet> required_expressions_by_node;
 
   // Add top-level columns that need to be included as they are the actual output
-  required_expressions_by_node[lqp].insert(lqp->column_expressions().begin(), lqp->column_expressions().end());
+  const auto column_expressions = lqp->column_expressions();
+  required_expressions_by_node[lqp].insert(column_expressions.cbegin(), column_expressions.cend());
 
   // Recursively walk through the LQP. We cannot use visit_lqp as we explicitly need to take each path through the LQP.
   // The right side of a diamond might require additional columns - if we only visited each node once, we might miss

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -575,7 +575,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_table_origin(const hsq
              "There have to be as many identifier lists as column expressions");
       for (auto select_list_element_idx = size_t{0}; select_list_element_idx < lqp->column_expressions().size();
            ++select_list_element_idx) {
-        const auto& subquery_expression = lqp->column_expressions()[select_list_element_idx];
+        const auto subquery_expression = lqp->column_expressions()[select_list_element_idx];
 
         // Make sure each column from the Subquery has a name
         if (identifiers.empty()) {

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1287,8 +1287,9 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_add_expressions_if_unavailable(
   // If all requested expressions are available, no need to create a projection
   if (projection_expressions.empty()) return node;
 
-  projection_expressions.insert(projection_expressions.end(), node->column_expressions().begin(),
-                                node->column_expressions().end());
+  const auto column_expressions = node->column_expressions();
+  projection_expressions.insert(projection_expressions.end(), column_expressions.cbegin(),
+                                column_expressions.cend());
 
   return ProjectionNode::make(projection_expressions, node);
 }

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1288,8 +1288,7 @@ std::shared_ptr<AbstractLQPNode> SQLTranslator::_add_expressions_if_unavailable(
   if (projection_expressions.empty()) return node;
 
   const auto column_expressions = node->column_expressions();
-  projection_expressions.insert(projection_expressions.end(), column_expressions.cbegin(),
-                                column_expressions.cend());
+  projection_expressions.insert(projection_expressions.end(), column_expressions.cbegin(), column_expressions.cend());
 
   return ProjectionNode::make(projection_expressions, node);
 }


### PR DESCRIPTION
`AbtractLQPNode` defines the following interface for `column_expressions()`:

```cpp
  /**
   * @return The Expressions defining each column that this node outputs
   */
  virtual const std::vector<std::shared_ptr<AbstractExpression>>& column_expressions() const;
```

Currently, subclasses have to declare a local member to fulfill the const-ref return value requirement. E.g.:
```cpp
 private:
  mutable std::vector<std::shared_ptr<AbstractExpression>> _column_expressions;
```
Some classes like `StoredTableNode` use it for caching purposes. Other classes like `AggregateNode` do not profit from it in any way. 

This PR removes the const-ref requirement to streamline the code of classes such as `AggregateNode`. 
Caching is still possible and there do not seem to be any drawbacks.

**TPC-H** with `-s 0.1` on Sidon VM:
```
+----------------+--------------------+------+---------------------+------+------------+---------+
| Benchmark      | prev. iter/s       | runs | new iter/s          | runs | change [%] | p-value |
+----------------+--------------------+------+---------------------+------+------------+---------+
| TPC-H 01       | 0.1919398009777069 | 12   | 0.21470250189304352 | 13   | +12%       |  0.0000 |
| TPC-H 02       | 5.541507720947266  | 333  | 5.7285332679748535  | 344  | +3%        |  0.0479 |
| TPC-H 03       | 2.16111421585083   | 130  | 2.2413113117218018  | 135  | +4%        |  0.0000 |
| TPC-H 04       | 2.067389488220215  | 125  | 2.217461347579956   | 134  | +7%        |  0.0000 |
| TPC-H 05       | 1.3617089986801147 | 82   | 1.4238612651824951  | 86   | +5%        |  0.0861 |
| TPC-H 06       | 12.958759307861328 | 778  | 12.887876510620117  | 774  | -1%        |  0.5960 |
| TPC-H 07       | 1.4620112180709839 | 88   | 1.5445239543914795  | 93   | +6%        |  0.0284 |
| TPC-H 08       | 1.1984443664550781 | 72   | 1.2623604536056519  | 76   | +5%        |  0.0000 |
| TPC-H 09       | 0.6259207129478455 | 38   | 0.6591220498085022  | 40   | +5%        |  0.0035 |
| TPC-H 10       | 1.5203663110733032 | 92   | 1.545432686805725   | 93   | +2%        |  0.0187 |
| TPC-H 11       | 7.922471523284912  | 476  | 8.654515266418457   | 520  | +9%        |  0.0000 |
| TPC-H 12       | 2.965729236602783  | 178  | 2.9513394832611084  | 178  | -0%        |  0.6144 |
| TPC-H 13       | 1.712074875831604  | 103  | 1.6667110919952393  | 101  | -3%        |  0.0000 |
| TPC-H 14       | 11.962322235107422 | 718  | 11.898499488830566  | 714  | -1%        |  0.2440 |
| TPC-H 15       | 9.244974136352539  | 555  | 9.662525177001953   | 580  | +5%        |  0.0000 |
| TPC-H 16       | 2.3166229724884033 | 140  | 2.306548833847046   | 139  | -0%        |  0.4230 |
| TPC-H 17       | 1.292288064956665  | 78   | 1.4241784811019897  | 86   | +10%       |  0.0000 |
| TPC-H 18       | 0.6974138021469116 | 42   | 0.7035350799560547  | 43   | +1%        |  0.0061 |
| TPC-H 19       | 1.8945655822753906 | 114  | 2.0330302715301514  | 122  | +7%        |  0.0000 |
| TPC-H 20       | 3.7615299224853516 | 226  | 3.9770662784576416  | 239  | +6%        |  0.0000 |
| TPC-H 21       | 0.5316105484962463 | 32   | 0.5749118328094482  | 35   | +8%        |  0.0000 |
| TPC-H 22       | 4.31493616104126   | 259  | 4.272810459136963   | 257  | -1%        |  0.0000 |
| geometric mean |                    |      |                     |      | +4%        |         |
+----------------+--------------------+------+---------------------+------+------------+---------+
```




