### PR TITLE
Fix: order information can be corrupt when columns are pruned

### DIFF
--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -191,9 +191,9 @@ std::shared_ptr<const Table> GetTable::_on_execute() {
         }
 
         if (current_chunk_order && current_chunk_order->first == stored_column_id) {
-          adapted_chunk_order = {
-              ColumnID{static_cast<uint16_t>(std::distance(_pruned_column_ids.begin(), pruned_column_ids_iter))},
-              current_chunk_order->second};
+          const auto pruned_column_count = std::distance(_pruned_column_ids.begin(), pruned_column_ids_iter);
+          adapted_chunk_order = {ColumnID{static_cast<uint16_t>(stored_column_id - pruned_column_count)},
+                                 current_chunk_order->second};
         }
 
         *output_segments_iter = stored_chunk->get_segment(stored_column_id);

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -191,8 +191,8 @@ std::shared_ptr<const Table> GetTable::_on_execute() {
         }
 
         if (current_chunk_order && current_chunk_order->first == stored_column_id) {
-          const auto pruned_column_count = std::distance(_pruned_column_ids.begin(), pruned_column_ids_iter);
-          adapted_chunk_order = {ColumnID{static_cast<uint16_t>(stored_column_id - pruned_column_count)},
+          const auto columns_pruned_so_far = std::distance(_pruned_column_ids.begin(), pruned_column_ids_iter);
+          adapted_chunk_order = {ColumnID{static_cast<uint16_t>(stored_column_id - columns_pruned_so_far)},
                                  current_chunk_order->second};
         }
 


### PR DESCRIPTION
This PR fixes a wrong order information of chunks which gets corrupted when columns are pruned.

For the pruned `order` table in the TPC-H benchmark, rather by luck, the correct sorting information was kept after column pruning (used in queries 3, 4, 5, and 10, but almost no effect on overall running time). For the `lineitem` table, the order information was not properly set for queries 1, 6, 14, and 15. After this PR, these are now correctly using sorted scans.

Benchmarks are **without** the iterator fix.

**Clang:**
```diff
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | Benchmark      | prev. iter/s       | runs  | new iter/s         | runs  | change [%] | p-value |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | TPC-H 01       | 1.5868635177612305 | 96    | 1.657425045967102  | 100   | +4%        |  0.0000 |
 | TPC-H 02       | 68.18059539794922  | 4091  | 67.726806640625    | 4064  | -1%        |  0.3403 |
 | TPC-H 03       | 7.365335941314697  | 443   | 7.244886875152588  | 435   | -2%        |  0.0041 |
 | TPC-H 04       | 6.094265937805176  | 366   | 6.182038307189941  | 372   | +1%        |  0.0297 |
-| TPC-H 05       | 3.4249560832977295 | 206   | 3.230015277862549  | 194   | -6%        |  0.0000 |
 | TPC-H 06       | 279.67462158203125 | 16781 | 277.9426574707031  | 16677 | -1%        |  0.0000 |
 | TPC-H 07       | 7.40938138961792   | 445   | 7.347842693328857  | 441   | -1%        |  0.1945 |
+| TPC-H 08       | 5.061038970947266  | 304   | 5.776637077331543  | 347   | +14%       |  0.0000 |
 | TPC-H 09       | 1.644068956375122  | 99    | 1.651640772819519  | 100   | +0%        |  0.3090 |
 | TPC-H 10       | 3.2626090049743652 | 196   | 3.307302713394165  | 199   | +1%        |  0.0472 |
 | TPC-H 11       | 27.693269729614258 | 1662  | 27.718461990356445 | 1664  | +0%        |  0.4749 |
 | TPC-H 12       | 13.64775276184082  | 819   | 13.551064491271973 | 814   | -1%        |  0.0000 |
 | TPC-H 13       | 3.0233631134033203 | 182   | 3.0279600620269775 | 182   | +0%        |  0.4399 |
 | TPC-H 14       | 47.99119186401367  | 2880  | 48.82837677001953  | 2930  | +2%        |  0.0000 |
 | TPC-H 15       | 111.2303695678711  | 6674  | 116.45787811279297 | 6988  | +5%        |  0.0000 |
 | TPC-H 16       | 8.66276741027832   | 520   | 8.65756607055664   | 520   | -0%        |  0.6826 |
 | TPC-H 17       | 4.0730814933776855 | 245   | 4.136162281036377  | 249   | +2%        |  0.0414 |
+| TPC-H 18       | 1.050811529159546  | 64    | 1.2530944347381592 | 76    | +19%       |  0.0000 |
 | TPC-H 19       | 8.49098014831543   | 510   | 8.83651065826416   | 531   | +4%        |  0.0000 |
 | TPC-H 20       | 25.511146545410156 | 1531  | 25.511865615844727 | 1531  | +0%        |  0.9908 |
 | TPC-H 21       | 1.088209867477417  | 66    | 1.0494625568389893 | 63    | -4%        |  0.0013 |
 | TPC-H 22       | 15.042771339416504 | 903   | 15.133134841918945 | 909   | +1%        |  0.0060 |
 | geometric mean |                    |       |                    |       | +2%        |         |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
```

**GCC:**
```diff
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | Benchmark      | prev. iter/s       | runs  | new iter/s         | runs  | change [%] | p-value |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | TPC-H 01       | 1.3078560829162598 | 79    | 1.3199772834777832 | 80    | +1%        |  0.0399 |
 | TPC-H 02       | 81.14222717285156  | 4869  | 80.77617645263672  | 4847  | -0%        |  0.5075 |
 | TPC-H 03       | 8.012537002563477  | 482   | 8.19926929473877   | 492   | +2%        |  0.0000 |
 | TPC-H 04       | 7.0284247398376465 | 422   | 7.053976535797119  | 424   | +0%        |  0.4517 |
+| TPC-H 05       | 3.759524345397949  | 226   | 3.9664297103881836 | 238   | +6%        |  0.0000 |
 | TPC-H 06       | 269.40924072265625 | 16165 | 267.3199462890625  | 16040 | -1%        |  0.0000 |
 | TPC-H 07       | 8.090940475463867  | 486   | 7.820286750793457  | 470   | -3%        |  0.0000 |
 | TPC-H 08       | 6.398609638214111  | 384   | 6.27178955078125   | 377   | -2%        |  0.0056 |
 | TPC-H 09       | 1.671049952507019  | 101   | 1.6650798320770264 | 100   | -0%        |  0.3895 |
 | TPC-H 10       | 3.3558731079101562 | 202   | 3.3736934661865234 | 203   | +1%        |  0.3725 |
 | TPC-H 11       | 31.096588134765625 | 1866  | 30.899898529052734 | 1854  | -1%        |  0.0000 |
 | TPC-H 12       | 14.514853477478027 | 871   | 14.586938858032227 | 876   | +0%        |  0.0011 |
 | TPC-H 13       | 2.895000457763672  | 174   | 2.8595242500305176 | 172   | -1%        |  0.0000 |
 | TPC-H 14       | 50.54335021972656  | 3033  | 51.11309814453125  | 3067  | +1%        |  0.0000 |
 | TPC-H 15       | 115.3832778930664  | 6923  | 118.39179992675781 | 7104  | +3%        |  0.0000 |
 | TPC-H 16       | 8.160351753234863  | 490   | 8.162007331848145  | 490   | +0%        |  0.9345 |
 | TPC-H 17       | 4.714223861694336  | 283   | 4.5161848068237305 | 272   | -4%        |  0.0000 |
-| TPC-H 18       | 1.2485154867172241 | 75    | 1.0898767709732056 | 66    | -13%       |  0.0000 |
 | TPC-H 19       | 9.558914184570312  | 574   | 9.744610786437988  | 585   | +2%        |  0.0187 |
 | TPC-H 20       | 29.0145206451416   | 1741  | 28.895187377929688 | 1734  | -0%        |  0.0339 |
 | TPC-H 21       | 1.1764694452285767 | 71    | 1.2161873579025269 | 73    | +3%        |  0.0031 |
 | TPC-H 22       | 17.389968872070312 | 1044  | 17.111196517944336 | 1027  | -2%        |  0.0000 |
 | geometric mean |                    |       |                    |       | -0%        |         |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
```

The degrading query 18 is not changed and Q5 spends only a few percent of runtime in the scan. So I consider both to be noise. Q15 looks good and "as expected" but I cannot rule out that this is noise as well.