### PR TITLE
Create chunk pruning statistics in StorageManager::AddTable

### DIFF
--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -201,9 +201,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
     // get added chunk, mark it as immutable and add statistics
     const auto& added_chunk = table->last_chunk();
     added_chunk->finalize();
-    if (!added_chunk->pruning_statistics()) {
-      generate_chunk_pruning_statistics(added_chunk);
-    }
+    generate_chunk_pruning_statistics(added_chunk);
   }
 
   Hyrise::get().scheduler()->wait_for_all_tasks();

--- a/src/lib/statistics/generate_pruning_statistics.cpp
+++ b/src/lib/statistics/generate_pruning_statistics.cpp
@@ -89,7 +89,9 @@ void generate_chunk_pruning_statistics(const std::shared_ptr<Table>& table) {
       continue;
     }
 
-    generate_chunk_pruning_statistics(chunk);
+    if (!chunk->pruning_statistics()) {
+      generate_chunk_pruning_statistics(chunk);
+    }
   }
 }
 

--- a/src/lib/statistics/generate_pruning_statistics.cpp
+++ b/src/lib/statistics/generate_pruning_statistics.cpp
@@ -43,6 +43,12 @@ void create_pruning_statistics_for_segment(AttributeStatistics<T>& segment_stati
 namespace opossum {
 
 void generate_chunk_pruning_statistics(const std::shared_ptr<Chunk>& chunk) {
+  if (chunk->pruning_statistics()) {
+    // Pruning statistics should be stable no matter what encoding or sort order is used. Hence, when they are present
+    // they are up to date and we can skip the recreation.
+    return;
+  }
+
   auto chunk_statistics = ChunkPruningStatistics{chunk->column_count()};
 
   for (auto column_id = ColumnID{0}; column_id < chunk->column_count(); ++column_id) {
@@ -89,9 +95,7 @@ void generate_chunk_pruning_statistics(const std::shared_ptr<Table>& table) {
       continue;
     }
 
-    if (!chunk->pruning_statistics()) {
-      generate_chunk_pruning_statistics(chunk);
-    }
+    generate_chunk_pruning_statistics(chunk);
   }
 }
 

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -112,9 +112,7 @@ void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::
     chunk->replace_segment(column_id, encoded_segment);
   }
 
-  if (!chunk->pruning_statistics()) {
-    generate_chunk_pruning_statistics(chunk);
-  }
+  generate_chunk_pruning_statistics(chunk);
 }
 
 void ChunkEncoder::encode_chunk(const std::shared_ptr<Chunk>& chunk, const std::vector<DataType>& column_data_types,

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -30,6 +30,7 @@ void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> t
   }
 
   table->set_table_statistics(TableStatistics::from_table(*table));
+  generate_chunk_pruning_statistics(table);
   _tables.emplace(name, std::move(table));
 }
 

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -29,8 +29,10 @@ void StorageManager::add_table(const std::string& name, std::shared_ptr<Table> t
     Assert(table->get_chunk(chunk_id)->has_mvcc_data(), "Table must have MVCC data.");
   }
 
+  // Create table statistics and chunk pruning statistics for added table.
   table->set_table_statistics(TableStatistics::from_table(*table));
   generate_chunk_pruning_statistics(table);
+
   _tables.emplace(name, std::move(table));
 }
 

--- a/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -130,6 +130,8 @@ TEST_F(ChunkPruningRuleTest, BetweenPruningTest) {
 TEST_F(ChunkPruningRuleTest, NoStatisticsAvailable) {
   auto table = Hyrise::get().storage_manager.get_table("uncompressed");
   auto chunk = table->get_chunk(ChunkID(0));
+  EXPECT_TRUE(chunk->pruning_statistics());
+  chunk->set_pruning_statistics(std::nullopt);
   EXPECT_FALSE(chunk->pruning_statistics());
 
   auto stored_table_node = std::make_shared<StoredTableNode>("uncompressed");

--- a/src/test/storage/storage_manager_test.cpp
+++ b/src/test/storage/storage_manager_test.cpp
@@ -41,6 +41,18 @@ TEST_F(StorageManagerTest, AddTableTwice) {
                std::exception);
 }
 
+TEST_F(StorageManagerTest, StatisticCreationOnAddTable) {
+  auto& sm = Hyrise::get().storage_manager;
+  sm.add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
+
+  const auto table = sm.get_table("int_float");
+  EXPECT_EQ(table->table_statistics()->row_count, 3.0f);
+  const auto chunk = table->get_chunk(ChunkID{0});
+  EXPECT_TRUE(chunk->pruning_statistics().has_value());
+  EXPECT_EQ(chunk->pruning_statistics()->at(0)->data_type, DataType::Int);
+  EXPECT_EQ(chunk->pruning_statistics()->at(1)->data_type, DataType::Float);
+}
+
 TEST_F(StorageManagerTest, GetTable) {
   auto& sm = Hyrise::get().storage_manager;
   auto t3 = sm.get_table("first_table");


### PR DESCRIPTION
This PR create `ChunkPruningStatistics` whenever tables are added to the storage manager.

When tables are added to the storage manager, currently only table statistics are created but no chunk pruning statistics. That leads to cases when data is loaded and no chunk pruning takes place, because the `ChunkPruningRule` cannot find any chunk pruning statistics.

Currently, chunk pruning statistics are generated when data is encoded. Hence, the case of no pruning statistics usually does not happen in our benchmarks.

Moreover, we currently might create the statistics several times as `generate_chunk_pruning_statistics(table)` did not check for their presence. This leads to a reduce encoding times for TPC-H SF 1:
 * Dictionary: from `3 s 857 ms` to `3 s 184 ms` (statistics creation is optimized here using the dictionaries, subtle difference)
 * RLE: from `16 s 743 ms` to `3 s 421 ms`
 * LZ4: from `1 min 3 s` to `45 s 673 ms`

The reason for the clear improvement with RLE is that the first creation is done in parallel during encoding while the second iteration is sequential.