### PR TITLE
Get rid of benchmarks' JSON config

### DIFF
--- a/src/benchmark/file_based_benchmark.cpp
+++ b/src/benchmark/file_based_benchmark.cpp
@@ -28,27 +28,16 @@ int main(int argc, char* argv[]) {
   // Comma-separated query names or "all"
   std::string queries_str;
 
-  if (CLIConfigParser::cli_has_json_config(argc, argv)) {
-    // JSON config file was passed in
-    const auto json_config = CLIConfigParser::parse_json_config_file(argv[1]);
-    table_path = json_config.value("table_path", "");
-    query_path = json_config.value("query_path", "");
-    queries_str = json_config.value("queries", "all");
+  // Parse command line args
+  const auto cli_parse_result = cli_options.parse(argc, argv);
 
-    benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_options_json_config(json_config));
+  if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
 
-  } else {
-    // Parse regular command line args
-    const auto cli_parse_result = cli_options.parse(argc, argv);
+  query_path = cli_parse_result["query_path"].as<std::string>();
+  table_path = cli_parse_result["table_path"].as<std::string>();
+  queries_str = cli_parse_result["queries"].as<std::string>();
 
-    if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
-
-    query_path = cli_parse_result["query_path"].as<std::string>();
-    table_path = cli_parse_result["table_path"].as<std::string>();
-    queries_str = cli_parse_result["queries"].as<std::string>();
-
-    benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
-  }
+  benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
 
   // Check that the options "query_path" and "table_path" were specified
   if (query_path.empty() || table_path.empty()) {

--- a/src/benchmark/join_order_benchmark.cpp
+++ b/src/benchmark/join_order_benchmark.cpp
@@ -40,27 +40,16 @@ int main(int argc, char* argv[]) {
   // Comma-separated query names or "all"
   std::string queries_str;
 
-  if (CLIConfigParser::cli_has_json_config(argc, argv)) {
-    // JSON config file was passed in
-    const auto json_config = CLIConfigParser::parse_json_config_file(argv[1]);
-    table_path = json_config.value("table_path", DEFAULT_TABLE_PATH);
-    query_path = json_config.value("query_path", DEFAULT_QUERY_PATH);
-    queries_str = json_config.value("queries", "all");
+  // Parse command line args
+  const auto cli_parse_result = cli_options.parse(argc, argv);
 
-    benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_options_json_config(json_config));
+  if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
 
-  } else {
-    // Parse regular command line args
-    const auto cli_parse_result = cli_options.parse(argc, argv);
+  query_path = cli_parse_result["query_path"].as<std::string>();
+  table_path = cli_parse_result["table_path"].as<std::string>();
+  queries_str = cli_parse_result["queries"].as<std::string>();
 
-    if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
-
-    query_path = cli_parse_result["query_path"].as<std::string>();
-    table_path = cli_parse_result["table_path"].as<std::string>();
-    queries_str = cli_parse_result["queries"].as<std::string>();
-
-    benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
-  }
+  benchmark_config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
 
   // Check that the options "query_path" and "table_path" were specified
   if (query_path.empty() || table_path.empty()) {

--- a/src/benchmark/tpcc_benchmark.cpp
+++ b/src/benchmark/tpcc_benchmark.cpp
@@ -48,24 +48,15 @@ int main(int argc, char* argv[]) {
   size_t num_warehouses;
   bool consistency_checks;
 
-  if (CLIConfigParser::cli_has_json_config(argc, argv)) {
-    // JSON config file was passed in
-    const auto json_config = CLIConfigParser::parse_json_config_file(argv[1]);
-    num_warehouses = json_config.value("scale", 1);
-    consistency_checks = json_config.value("consistency_checks", false);
+  // Parse command line args
+  const auto cli_parse_result = cli_options.parse(argc, argv);
 
-    config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_options_json_config(json_config));
-  } else {
-    // Parse regular command line args
-    const auto cli_parse_result = cli_options.parse(argc, argv);
+  if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
 
-    if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
+  num_warehouses = cli_parse_result["scale"].as<size_t>();
+  consistency_checks = cli_parse_result["consistency_checks"].as<bool>();
 
-    num_warehouses = cli_parse_result["scale"].as<size_t>();
-    consistency_checks = cli_parse_result["consistency_checks"].as<bool>();
-
-    config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
-  }
+  config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
 
   // As TPC-C procedures may run into conflicts on both the Hyrise and the SQLite side, we cannot guarantee that the
   // two databases stay in sync.

--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -44,24 +44,16 @@ int main(int argc, char* argv[]) {
 
   auto config = std::shared_ptr<opossum::BenchmarkConfig>{};
   auto scale_factor = int32_t{};
-  if (opossum::CLIConfigParser::cli_has_json_config(argc, argv)) {
-    // JSON config file was passed in
-    const auto json_config = opossum::CLIConfigParser::parse_json_config_file(argv[1]);
-    scale_factor = json_config.value("scale", 1);
-    config = std::make_shared<opossum::BenchmarkConfig>(
-        opossum::CLIConfigParser::parse_basic_options_json_config(json_config));
-  } else {
-    // Parse regular command line args
-    const auto cli_parse_result = cli_options.parse(argc, argv);
 
-    if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) {
-      return 0;
-    }
-    scale_factor = cli_parse_result["scale"].as<int32_t>();
+  // Parse command line args
+  const auto cli_parse_result = cli_options.parse(argc, argv);
 
-    config =
-        std::make_shared<opossum::BenchmarkConfig>(opossum::CLIConfigParser::parse_basic_cli_options(cli_parse_result));
+  if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) {
+    return 0;
   }
+  scale_factor = cli_parse_result["scale"].as<int32_t>();
+
+  config = std::make_shared<opossum::BenchmarkConfig>(opossum::CLIConfigParser::parse_cli_options(cli_parse_result));
 
   const auto valid_scale_factors = std::array{1, 1000, 3000, 10000, 30000, 100000};
 

--- a/src/benchmark/tpch_benchmark.cpp
+++ b/src/benchmark/tpch_benchmark.cpp
@@ -46,31 +46,20 @@ int main(int argc, char* argv[]) {
   float scale_factor;
   bool use_prepared_statements;
 
-  if (CLIConfigParser::cli_has_json_config(argc, argv)) {
-    // JSON config file was passed in
-    const auto json_config = CLIConfigParser::parse_json_config_file(argv[1]);
-    scale_factor = json_config.value("scale", 1.f);
-    comma_separated_queries = json_config.value("queries", std::string(""));
+  // Parse command line args
+  const auto cli_parse_result = cli_options.parse(argc, argv);
 
-    config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_options_json_config(json_config));
+  if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
 
-    use_prepared_statements = json_config.value("use_prepared_statements", false);
-  } else {
-    // Parse regular command line args
-    const auto cli_parse_result = cli_options.parse(argc, argv);
-
-    if (CLIConfigParser::print_help_if_requested(cli_options, cli_parse_result)) return 0;
-
-    if (cli_parse_result.count("queries")) {
-      comma_separated_queries = cli_parse_result["queries"].as<std::string>();
-    }
-
-    scale_factor = cli_parse_result["scale"].as<float>();
-
-    config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_basic_cli_options(cli_parse_result));
-
-    use_prepared_statements = cli_parse_result["use_prepared_statements"].as<bool>();
+  if (cli_parse_result.count("queries")) {
+    comma_separated_queries = cli_parse_result["queries"].as<std::string>();
   }
+
+  scale_factor = cli_parse_result["scale"].as<float>();
+
+  config = std::make_shared<BenchmarkConfig>(CLIConfigParser::parse_cli_options(cli_parse_result));
+
+  use_prepared_statements = cli_parse_result["use_prepared_statements"].as<bool>();
 
   std::vector<BenchmarkItemID> item_ids;
 

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -26,26 +26,4 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode benchmark_mode, const Chunk
 
 BenchmarkConfig BenchmarkConfig::get_default_config() { return BenchmarkConfig(); }
 
-// This is intentionally limited to 80 chars per line, as cxxopts does this too and it looks bad otherwise.
-const char* BenchmarkConfig::description = R"(
-============================
-Benchmark Configuration JSON
-============================
-All options can also be provided as a JSON config file. This must be the only
-argument passed in. The options are identical to and behave like the CLI options.
-Example:
-{
-  "scheduler": true,
-  "time": 5
-}
-
-The JSON config can also include benchmark-specific options (e.g. TPCH's scale
-option). They will be parsed like the
-CLI options.
-
-{
-  "scale": 0.1
-}
-)";
-
 }  // namespace opossum

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -16,7 +16,6 @@ enum class BenchmarkMode { Ordered, Shuffled };
 using Duration = std::chrono::high_resolution_clock::duration;
 using TimePoint = std::chrono::high_resolution_clock::time_point;
 
-// View BenchmarkConfig::description to see format of the JSON-version
 class BenchmarkConfig {
  public:
   BenchmarkConfig(const BenchmarkMode benchmark_mode, const ChunkOffset chunk_size,
@@ -43,8 +42,6 @@ class BenchmarkConfig {
   bool verify = false;
   bool cache_binary_tables = false;  // Defaults to false for internal use, but the CLI sets it to true by default
   bool sql_metrics = false;
-
-  static const char* description;
 
  private:
   BenchmarkConfig() = default;

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -404,8 +404,6 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
   // TPC-C does not support binary caching
   const auto default_dont_cache_binary_tables = (benchmark_name == "TPC-C Benchmark" ? "true" : "false");
 
-  // If you add a new option here, make sure to edit CLIConfigParser::basic_cli_options_to_json() so it contains the
-  // newest options. Sadly, there is no way to to get all option keys to do this automatically.
   // clang-format off
   cli_options.add_options()
     ("help", "print a summary of CLI options")

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -410,16 +410,16 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("full_help", "print more detailed information about configuration options")
     ("r,runs", "Maximum number of runs per item, negative values mean infinity", cxxopts::value<int64_t>()->default_value("-1")) // NOLINT
     ("c,chunk_size", "Chunk size", cxxopts::value<ChunkOffset>()->default_value(std::to_string(Chunk::DEFAULT_SIZE))) // NOLINT
-    ("t,time", "Runtime - per item for Ordered, total for Shuffled", cxxopts::value<size_t>()->default_value("60")) // NOLINT
-    ("w,warmup", "Number of seconds that each item is run for warm up", cxxopts::value<size_t>()->default_value("0")) // NOLINT
+    ("t,time", "Runtime - per item for Ordered, total for Shuffled", cxxopts::value<uint64_t>()->default_value("60")) // NOLINT
+    ("w,warmup", "Number of seconds that each item is run for warm up", cxxopts::value<uint64_t>()->default_value("0")) // NOLINT
     ("o,output", "JSON file to output results to, don't specify for stdout", cxxopts::value<std::string>()->default_value("")) // NOLINT
     ("m,mode", "Ordered or Shuffled", cxxopts::value<std::string>()->default_value(default_mode)) // NOLINT
     ("e,encoding", "Specify Chunk encoding as a string or as a JSON config file (for more detailed configuration, see --full_help). String options: " + encoding_strings_option, cxxopts::value<std::string>()->default_value("Dictionary"))  // NOLINT
     ("compression", "Specify vector compression as a string. Options: " + compression_strings_option, cxxopts::value<std::string>()->default_value(""))  // NOLINT
     ("indexes", "Create indexes (where defined by benchmark)", cxxopts::value<bool>()->default_value("false"))  // NOLINT
     ("scheduler", "Enable or disable the scheduler", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("cores", "Specify the number of cores used by the scheduler (if active). 0 means all available cores", cxxopts::value<uint>()->default_value("0")) // NOLINT
-    ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint>()->default_value("1")) // NOLINT
+    ("cores", "Specify the number of cores used by the scheduler (if active). 0 means all available cores", cxxopts::value<uint32_t>()->default_value("0")) // NOLINT
+    ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint32_t>()->default_value("1")) // NOLINT
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value(default_dont_cache_binary_tables)) // NOLINT

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -11,44 +11,25 @@
 
 namespace opossum {
 
-bool CLIConfigParser::cli_has_json_config(const int argc, char** argv) {
-  const auto has_json = argc > 1 && boost::algorithm::ends_with(argv[1], ".json");
-  if (has_json && argc > 2) {
-    std::cout << "Passed multiple args with a json config. All CLI args will be ignored...";
-  }
-
-  return has_json;
-}
-
-nlohmann::json CLIConfigParser::parse_json_config_file(const std::string& json_file_str) {
-  Assert(std::filesystem::is_regular_file(json_file_str), "No such file: " + json_file_str);
-
-  nlohmann::json json_config;
-  std::ifstream json_file{json_file_str};
-  json_file >> json_config;
-
-  return json_config;
-}
-
-BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann::json& json_config) {
+BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& parse_result) {
   const auto default_config = BenchmarkConfig::get_default_config();
 
   // Display info about output destination
   std::optional<std::string> output_file_path;
-  const auto output_file_string = json_config.value("output", "");
+  const auto output_file_string = parse_result["output"].as<std::string>();
   if (!output_file_string.empty()) {
     output_file_path = output_file_string;
     std::cout << "- Writing benchmark results to '" << *output_file_path << "'" << std::endl;
   }
 
-  const auto enable_scheduler = json_config.value("scheduler", default_config.enable_scheduler);
-  const auto cores = json_config.value("cores", default_config.cores);
+  const auto enable_scheduler = parse_result["scheduler"].as<bool>();
+  const auto cores = parse_result["cores"].as<uint>();
   const auto number_of_cores_str = (cores == 0) ? "all available" : std::to_string(cores);
   const auto core_info = enable_scheduler ? " using " + number_of_cores_str + " cores" : "";
   std::cout << "- Running in " + std::string(enable_scheduler ? "multi" : "single") + "-threaded mode" << core_info
             << std::endl;
 
-  const auto clients = json_config.value("clients", default_config.clients);
+  const auto clients = parse_result["clients"].as<uint>();
   std::cout << "- " + std::to_string(clients) + " simulated clients are scheduling items in parallel" << std::endl;
 
   if (cores != default_config.cores || clients != default_config.clients) {
@@ -66,7 +47,7 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
   }
 
   // Determine benchmark and display it
-  const auto benchmark_mode_str = json_config.value("mode", "Ordered");
+  const auto benchmark_mode_str = parse_result["mode"].as<std::string>();
   auto benchmark_mode = BenchmarkMode::Ordered;  // Just to init it deterministically
   if (benchmark_mode_str == "Ordered") {
     benchmark_mode = BenchmarkMode::Ordered;
@@ -77,7 +58,7 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
   }
   std::cout << "- Running benchmark in '" << benchmark_mode_str << "' mode" << std::endl;
 
-  const auto enable_visualization = json_config.value("visualize", default_config.enable_visualization);
+  const auto enable_visualization = parse_result["visualize"].as<bool>();
   if (enable_visualization) {
     Assert(clients == 1, "Cannot visualize plans with multiple clients as files may be overwritten");
     std::cout << "- Visualizing the plans into SVG files. This will make the performance numbers invalid." << std::endl;
@@ -85,8 +66,8 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
 
   // Get the specified encoding type
   std::unique_ptr<EncodingConfig> encoding_config{};
-  const auto encoding_type_str = json_config.value("encoding", "Dictionary");
-  const auto compression_type_str = json_config.value("compression", "");
+  const auto encoding_type_str = parse_result["encoding"].as<std::string>();
+  const auto compression_type_str = parse_result["compression"].as<std::string>();
   if (boost::algorithm::ends_with(encoding_type_str, ".json")) {
     // Use encoding file instead of default type
     encoding_config = std::make_unique<EncodingConfig>(parse_encoding_config(encoding_type_str));
@@ -99,27 +80,25 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
     std::cout << "- Encoding is '" << encoding_type_str << "'" << std::endl;
   }
 
-  const auto indexes = json_config.value("indexes", default_config.indexes);
+  const auto indexes = parse_result["indexes"].as<bool>();
   if (indexes) {
     std::cout << "- Creating indexes (as defined by the benchmark)" << std::endl;
   }
 
   // Get all other variables
-  const auto chunk_size = json_config.value("chunk_size", default_config.chunk_size);
+  const auto chunk_size = parse_result["chunk_size"].as<ChunkOffset>();
   std::cout << "- Chunk size is " << chunk_size << std::endl;
 
-  const auto max_runs = json_config.value("runs", default_config.max_runs);
+  const auto max_runs = parse_result["runs"].as<int64_t>();
   if (max_runs >= 0) {
     std::cout << "- Max runs per item is " << max_runs << std::endl;
   }
 
-  const auto default_duration_seconds = std::chrono::duration_cast<std::chrono::seconds>(default_config.max_duration);
-  const auto max_duration = json_config.value("time", default_duration_seconds.count());
+  const auto max_duration = parse_result["time"].as<size_t>();
   std::cout << "- Max duration per item is " << max_duration << " seconds" << std::endl;
   const Duration timeout_duration = std::chrono::duration_cast<opossum::Duration>(std::chrono::seconds{max_duration});
 
-  const auto default_warmup_seconds = std::chrono::duration_cast<std::chrono::seconds>(default_config.warmup_duration);
-  const auto warmup = json_config.value("warmup", default_warmup_seconds.count());
+  const auto warmup = parse_result["warmup"].as<size_t>();
   if (warmup > 0) {
     std::cout << "- Warmup duration per item is " << warmup << " seconds" << std::endl;
   } else {
@@ -127,20 +106,20 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
   }
   const Duration warmup_duration = std::chrono::duration_cast<opossum::Duration>(std::chrono::seconds{warmup});
 
-  const auto verify = json_config.value("verify", default_config.verify);
+  const auto verify = parse_result["verify"].as<bool>();
   if (verify) {
     std::cout << "- Automatically verifying results with SQLite. This will make the performance numbers invalid."
               << std::endl;
   }
 
-  const auto cache_binary_tables = json_config.value("cache_binary_tables", false);
+  const auto cache_binary_tables = !parse_result["dont_cache_binary_tables"].as<bool>();
   if (cache_binary_tables) {
     std::cout << "- Caching tables as binary files" << std::endl;
   } else {
     std::cout << "- Not caching tables as binary files" << std::endl;
   }
 
-  const auto sql_metrics = json_config.value("sql_metrics", false);
+  const auto sql_metrics = parse_result["sql_metrics"].as<bool>();
   if (sql_metrics) {
     Assert(!output_file_string.empty(), "--sql_metrics only makes sense when an output file is set.");
     std::cout << "- Tracking SQL metrics" << std::endl;
@@ -152,33 +131,6 @@ BenchmarkConfig CLIConfigParser::parse_basic_options_json_config(const nlohmann:
       benchmark_mode,  chunk_size,          *encoding_config, indexes, max_runs, timeout_duration,
       warmup_duration, output_file_path,    enable_scheduler, cores,   clients,  enable_visualization,
       verify,          cache_binary_tables, sql_metrics};
-}
-
-BenchmarkConfig CLIConfigParser::parse_basic_cli_options(const cxxopts::ParseResult& parse_result) {
-  return parse_basic_options_json_config(basic_cli_options_to_json(parse_result));
-}
-
-nlohmann::json CLIConfigParser::basic_cli_options_to_json(const cxxopts::ParseResult& parse_result) {
-  nlohmann::json json_config;
-
-  json_config.emplace("runs", parse_result["runs"].as<int64_t>());
-  json_config.emplace("chunk_size", parse_result["chunk_size"].as<ChunkOffset>());
-  json_config.emplace("time", parse_result["time"].as<size_t>());
-  json_config.emplace("warmup", parse_result["warmup"].as<size_t>());
-  json_config.emplace("mode", parse_result["mode"].as<std::string>());
-  json_config.emplace("encoding", parse_result["encoding"].as<std::string>());
-  json_config.emplace("compression", parse_result["compression"].as<std::string>());
-  json_config.emplace("indexes", parse_result["indexes"].as<bool>());
-  json_config.emplace("scheduler", parse_result["scheduler"].as<bool>());
-  json_config.emplace("cores", parse_result["cores"].as<uint>());
-  json_config.emplace("clients", parse_result["clients"].as<uint>());
-  json_config.emplace("visualize", parse_result["visualize"].as<bool>());
-  json_config.emplace("output", parse_result["output"].as<std::string>());
-  json_config.emplace("verify", parse_result["verify"].as<bool>());
-  json_config.emplace("cache_binary_tables", !parse_result["dont_cache_binary_tables"].as<bool>());
-  json_config.emplace("sql_metrics", parse_result["sql_metrics"].as<bool>());
-
-  return json_config;
 }
 
 EncodingConfig CLIConfigParser::parse_encoding_config(const std::string& encoding_file_str) {
@@ -253,7 +205,6 @@ bool CLIConfigParser::print_help_if_requested(const cxxopts::Options& options,
   std::cout << options.help() << std::endl;
 
   if (parse_result.count("full_help")) {
-    std::cout << BenchmarkConfig::description << std::endl;
     std::cout << EncodingConfig::description << std::endl;
   } else {
     std::cout << "Use --full_help for more configuration options" << std::endl << std::endl;

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -23,13 +23,13 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
   }
 
   const auto enable_scheduler = parse_result["scheduler"].as<bool>();
-  const auto cores = parse_result["cores"].as<uint>();
+  const auto cores = parse_result["cores"].as<uint32_t>();
   const auto number_of_cores_str = (cores == 0) ? "all available" : std::to_string(cores);
   const auto core_info = enable_scheduler ? " using " + number_of_cores_str + " cores" : "";
   std::cout << "- Running in " + std::string(enable_scheduler ? "multi" : "single") + "-threaded mode" << core_info
             << std::endl;
 
-  const auto clients = parse_result["clients"].as<uint>();
+  const auto clients = parse_result["clients"].as<uint32_t>();
   std::cout << "- " + std::to_string(clients) + " simulated clients are scheduling items in parallel" << std::endl;
 
   if (cores != default_config.cores || clients != default_config.clients) {
@@ -92,13 +92,15 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
   const auto max_runs = parse_result["runs"].as<int64_t>();
   if (max_runs >= 0) {
     std::cout << "- Max runs per item is " << max_runs << std::endl;
+  } else {
+    std::cout << "- Executing items until max duration is up:" << std::endl;
   }
 
-  const auto max_duration = parse_result["time"].as<size_t>();
+  const auto max_duration = parse_result["time"].as<uint64_t>();
   std::cout << "- Max duration per item is " << max_duration << " seconds" << std::endl;
   const Duration timeout_duration = std::chrono::duration_cast<opossum::Duration>(std::chrono::seconds{max_duration});
 
-  const auto warmup = parse_result["warmup"].as<size_t>();
+  const auto warmup = parse_result["warmup"].as<uint64_t>();
   if (warmup > 0) {
     std::cout << "- Warmup duration per item is " << warmup << " seconds" << std::endl;
   } else {

--- a/src/benchmarklib/cli_config_parser.hpp
+++ b/src/benchmarklib/cli_config_parser.hpp
@@ -12,15 +12,7 @@ namespace opossum {
 
 class CLIConfigParser {
  public:
-  static bool cli_has_json_config(const int argc, char** argv);
-
-  static nlohmann::json parse_json_config_file(const std::string& json_file_str);
-
-  static nlohmann::json basic_cli_options_to_json(const cxxopts::ParseResult& parse_result);
-
-  static BenchmarkConfig parse_basic_options_json_config(const nlohmann::json& json_config);
-
-  static BenchmarkConfig parse_basic_cli_options(const cxxopts::ParseResult& parse_result);
+  static BenchmarkConfig parse_cli_options(const cxxopts::ParseResult& parse_result);
 
   static EncodingConfig parse_encoding_config(const std::string& encoding_file_str);
 


### PR DESCRIPTION
fixes #1926 

*Deleted code is bug-free code.*

The diff is easier to read if you enable "Hide whitespace changes".