### PR TITLE
Fix: missing includes

### DIFF
--- a/src/lib/utils/meta_tables/abstract_meta_table.hpp
+++ b/src/lib/utils/meta_tables/abstract_meta_table.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "all_type_variant.hpp"
+#include "storage/table.hpp"
 #include "storage/table_column_definition.hpp"
 
 namespace opossum {

--- a/src/lib/utils/meta_tables/segment_meta_data.cpp
+++ b/src/lib/utils/meta_tables/segment_meta_data.cpp
@@ -1,6 +1,11 @@
 #include "segment_meta_data.hpp"
 
 #include "hyrise.hpp"
+#include "resolve_type.hpp"
+#include "storage/base_encoded_segment.hpp"
+#include "storage/create_iterable_from_segment.hpp"
+#include "storage/dictionary_segment.hpp"
+#include "storage/fixed_string_dictionary_segment.hpp"
 
 namespace opossum {
 

--- a/src/lib/utils/settings/abstract_setting.hpp
+++ b/src/lib/utils/settings/abstract_setting.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "types.hpp"
+
 namespace opossum {
 
 /**


### PR DESCRIPTION
When not using pre-compile headers, the last master commit introduces some problems due to missing includes.

This PR adds the missing includes (forwarding declaration was not sufficient).