### PR TITLE
Initialize accesses variable with zero

### DIFF
--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -115,7 +115,7 @@ class SingleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor
   }
 
  protected:
-  mutable uint64_t _accesses{0};   // TODO: block überfrühten Merge
+  mutable uint64_t _accesses{0};
   const PosList& _pos_list;
   const ChunkID _chunk_id;
   const Segment& _segment;

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -115,7 +115,7 @@ class SingleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor
   }
 
  protected:
-  mutable uint64_t _accesses{0};
+  mutable uint64_t _accesses{0};   // TODO: block überfrühten Merge
   const PosList& _pos_list;
   const ChunkID _chunk_id;
   const Segment& _segment;

--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -53,7 +53,7 @@ class SegmentAccessor final : public AbstractSegmentAccessor<T> {
   ~SegmentAccessor() { _segment.access_counter[SegmentAccessCounter::AccessType::Random] += _accesses; }
 
  protected:
-  mutable uint64_t _accesses;
+  mutable uint64_t _accesses{0};
   const SegmentType& _segment;
 };
 
@@ -115,7 +115,7 @@ class SingleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor
   }
 
  protected:
-  mutable uint64_t _accesses;
+  mutable uint64_t _accesses{0};
   const PosList& _pos_list;
   const ChunkID _chunk_id;
   const Segment& _segment;

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -114,4 +114,20 @@ TEST_F(SegmentAccessorTest, TestReferenceSegmentToDictionarySegmentString) {
   EXPECT_FALSE(rc_str_accessor->access(ChunkOffset{4}));
 }
 
+TEST_F(SegmentAccessorTest, TestSegmentAccessCounterIncrementing) {
+  const auto& access_counter = vc_int->access_counter;
+  EXPECT_EQ(access_counter[SegmentAccessCounter::AccessType::Random], 0ul);
+
+  // Create segment accessor in a new scope to ensure its destructor, which writes the access counters, is called.
+  {
+    auto vc_int_base_accessor = create_segment_accessor<int>(vc_int);
+
+    EXPECT_EQ(vc_int_base_accessor->access(ChunkOffset{0}), 4);
+    EXPECT_EQ(vc_int_base_accessor->access(ChunkOffset{1}), 6);
+    EXPECT_EQ(vc_int_base_accessor->access(ChunkOffset{2}), 3);
+  }
+
+  EXPECT_EQ(access_counter[SegmentAccessCounter::AccessType::Random], 3ul);
+}
+
 }  // namespace opossum


### PR DESCRIPTION
When working on the segment accessors, I stumpled upon an arbitrary values for the member `_accesses`. This PR simply initializes the variable.