### PR TITLE
Small changes to segment encoding

### DIFF
--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -9,6 +9,7 @@
 #include "resolve_type.hpp"
 #include "statistics/generate_pruning_statistics.hpp"
 #include "storage/base_encoded_segment.hpp"
+#include "storage/base_segment_encoder.hpp"
 #include "storage/reference_segment.hpp"
 #include "storage/segment_encoding_utils.hpp"
 #include "storage/segment_iterables/any_segment_iterable.hpp"
@@ -73,7 +74,12 @@ std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<
       });
       result = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
     } else {
-      result = encode_and_compress_segment(segment, data_type, encoding_spec);
+      auto encoder = create_encoder(encoding_spec.encoding_type);
+      if (encoding_spec.vector_compression_type) {
+        encoder->set_vector_compression(*encoding_spec.vector_compression_type);
+      }
+
+      result = encoder->encode(segment, data_type);
     }
   });
   return result;

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -27,19 +27,17 @@ namespace opossum {
 std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<BaseSegment>& segment,
                                                           const DataType data_type,
                                                           const SegmentEncodingSpec& encoding_spec) {
+  Assert(!std::dynamic_pointer_cast<const ReferenceSegment>(segment), "Reference segments cannot be encoded.");
+
   std::shared_ptr<BaseSegment> result;
   resolve_data_type(data_type, [&](const auto type) {
     using ColumnDataType = typename decltype(type)::type;
-
-    if (const auto reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(segment)) {
-      Fail("Reference segments cannot be encoded.");
-    }
 
     // TODO(anyone): After #1489, build segment statistics in encode_segment() instead of encode_chunk()
     // and store them within the segment instead of a chunk-owned list of statistics.
 
     // Check if early exit is possible when passed segment is already encoded with requested spec.
-    // If case no vector compression is specified, only the correct encoding type is checked and the current vector
+    // In case no vector compression is specified, only the correct encoding type is checked and the current vector
     // compression type is ignored.
     const auto current_segment_encoding_spec = get_segment_encoding_spec(segment);
     if (current_segment_encoding_spec == encoding_spec ||

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -42,7 +42,9 @@ std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<
     // If case no vector compression is specified, only the correct encoding type is checked and the current vector
     // compression type is ignored.
     const auto current_segment_encoding_spec = get_segment_encoding_spec(segment);
-    if (current_segment_encoding_spec == encoding_spec || (!encoding_spec.vector_compression_type && current_segment_encoding_spec.encoding_type == encoding_spec.encoding_type)) {
+    if (current_segment_encoding_spec == encoding_spec ||
+        (!encoding_spec.vector_compression_type &&
+         current_segment_encoding_spec.encoding_type == encoding_spec.encoding_type)) {
       result = segment;
       return;
     }

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -28,37 +28,23 @@ std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<
                                                           const DataType data_type,
                                                           const SegmentEncodingSpec& encoding_spec) {
   std::shared_ptr<BaseSegment> result;
-  resolve_data_type(data_type, [&](auto type) {
+  resolve_data_type(data_type, [&](const auto type) {
     using ColumnDataType = typename decltype(type)::type;
-
-    // TODO(anyone): After #1489, build segment statistics in encode_segment() instead of encode_chunk()
-    // and store them within the segment instead of a chunk-owned list of statistics.
 
     if (const auto reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(segment)) {
       Fail("Reference segments cannot be encoded.");
     }
 
-    // Check if early exit is possible when passed segment is currently unencoded and the same is requested.
-    const auto unencoded_segment = std::dynamic_pointer_cast<const ValueSegment<ColumnDataType>>(segment);
-    if (unencoded_segment && encoding_spec.encoding_type == EncodingType::Unencoded) {
+    // TODO(anyone): After #1489, build segment statistics in encode_segment() instead of encode_chunk()
+    // and store them within the segment instead of a chunk-owned list of statistics.
+
+    // Check if early exit is possible when passed segment is already encoded with requested spec.
+    // If case no vector compression is specified, only the correct encoding type is checked and the current vector
+    // compression type is ignored.
+    const auto current_segment_encoding_spec = get_segment_encoding_spec(segment);
+    if (current_segment_encoding_spec == encoding_spec || (!encoding_spec.vector_compression_type && current_segment_encoding_spec.encoding_type == encoding_spec.encoding_type)) {
       result = segment;
       return;
-    }
-
-    // Check for early exit, when requested segment encoding is already being used for the passed segment.
-    const auto encoded_segment = std::dynamic_pointer_cast<const BaseEncodedSegment>(segment);
-    if (encoded_segment && encoded_segment->encoding_type() == encoding_spec.encoding_type) {
-      // Encoded segments do not need to be reencoded when the requested encoding is already present and either
-      // (i) no vector compression is given or (ii) the vector encoding is also already present. Hence, with
-      // {EncodingType::Dictionary} being in place, {EncodingType::Dictionary, VectorCompressionType::SimdBp128}
-      // does not reencode the segment.
-      if (!encoding_spec.vector_compression_type ||
-          (encoding_spec.vector_compression_type && encoded_segment->compressed_vector_type() &&
-           *encoding_spec.vector_compression_type ==
-               parent_vector_compression_type(*encoded_segment->compressed_vector_type()))) {
-        result = segment;
-        return;
-      }
     }
 
     // In case of unencoded re-encoding, an AnySegmentIterable iterable is used to manually setup
@@ -69,7 +55,7 @@ std::shared_ptr<BaseSegment> ChunkEncoder::encode_segment(const std::shared_ptr<
       pmr_vector<bool> null_values;
 
       auto iterable = create_any_segment_iterable<ColumnDataType>(*segment);
-      iterable.with_iterators([&](auto it, auto end) {
+      iterable.with_iterators([&](auto it, const auto end) {
         const auto segment_size = std::distance(it, end);
         values.resize(segment_size);
         null_values.resize(segment_size);

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -63,7 +63,8 @@ bool encoding_supports_data_type(EncodingType encoding_type, DataType data_type)
 struct SegmentEncodingSpec {
   constexpr SegmentEncodingSpec() : encoding_type{EncodingType::Dictionary} {}
   constexpr SegmentEncodingSpec(EncodingType encoding_type_) : encoding_type{encoding_type_} {}  // NOLINT
-  constexpr SegmentEncodingSpec(EncodingType encoding_type_, std::optional<VectorCompressionType> vector_compression_type_)
+  constexpr SegmentEncodingSpec(EncodingType encoding_type_,
+                                std::optional<VectorCompressionType> vector_compression_type_)
       : encoding_type{encoding_type_}, vector_compression_type{vector_compression_type_} {}
 
   EncodingType encoding_type;
@@ -71,7 +72,8 @@ struct SegmentEncodingSpec {
 };
 
 inline bool operator==(const SegmentEncodingSpec& lhs, const SegmentEncodingSpec& rhs) {
-  return std::tie(lhs.encoding_type, lhs.vector_compression_type) == std::tie(rhs.encoding_type, rhs.vector_compression_type);
+  return std::tie(lhs.encoding_type, lhs.vector_compression_type) ==
+         std::tie(rhs.encoding_type, rhs.vector_compression_type);
 }
 
 std::ostream& operator<<(std::ostream& stream, const SegmentEncodingSpec& spec);

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -63,12 +63,16 @@ bool encoding_supports_data_type(EncodingType encoding_type, DataType data_type)
 struct SegmentEncodingSpec {
   constexpr SegmentEncodingSpec() : encoding_type{EncodingType::Dictionary} {}
   constexpr SegmentEncodingSpec(EncodingType encoding_type_) : encoding_type{encoding_type_} {}  // NOLINT
-  constexpr SegmentEncodingSpec(EncodingType encoding_type_, VectorCompressionType vector_compression_type_)
+  constexpr SegmentEncodingSpec(EncodingType encoding_type_, std::optional<VectorCompressionType> vector_compression_type_)
       : encoding_type{encoding_type_}, vector_compression_type{vector_compression_type_} {}
 
   EncodingType encoding_type;
   std::optional<VectorCompressionType> vector_compression_type;
 };
+
+inline bool operator==(const SegmentEncodingSpec& lhs, const SegmentEncodingSpec& rhs) {
+  return std::tie(lhs.encoding_type, lhs.vector_compression_type) == std::tie(rhs.encoding_type, rhs.vector_compression_type);
+}
 
 std::ostream& operator<<(std::ostream& stream, const SegmentEncodingSpec& spec);
 

--- a/src/lib/storage/encoding_type.hpp
+++ b/src/lib/storage/encoding_type.hpp
@@ -62,10 +62,10 @@ bool encoding_supports_data_type(EncodingType encoding_type, DataType data_type)
 
 struct SegmentEncodingSpec {
   constexpr SegmentEncodingSpec() : encoding_type{EncodingType::Dictionary} {}
-  constexpr SegmentEncodingSpec(EncodingType encoding_type_) : encoding_type{encoding_type_} {}  // NOLINT
-  constexpr SegmentEncodingSpec(EncodingType encoding_type_,
-                                std::optional<VectorCompressionType> vector_compression_type_)
-      : encoding_type{encoding_type_}, vector_compression_type{vector_compression_type_} {}
+  constexpr SegmentEncodingSpec(EncodingType init_encoding_type) : encoding_type{init_encoding_type} {}  // NOLINT
+  constexpr SegmentEncodingSpec(EncodingType init_encoding_type,
+                                std::optional<VectorCompressionType> init_vector_compression_type)
+      : encoding_type{init_encoding_type}, vector_compression_type{init_vector_compression_type} {}
 
   EncodingType encoding_type;
   std::optional<VectorCompressionType> vector_compression_type;

--- a/src/lib/storage/segment_encoding_utils.cpp
+++ b/src/lib/storage/segment_encoding_utils.cpp
@@ -52,33 +52,21 @@ std::shared_ptr<BaseEncodedSegment> encode_and_compress_segment(const std::share
 }
 
 SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const BaseSegment>& segment) {
-  SegmentEncodingSpec result;
-  resolve_data_type(segment->data_type(), [&](const auto type) {
-    using ColumnDataType = typename decltype(type)::type;
+  Assert(!std::dynamic_pointer_cast<const ReferenceSegment>(segment), "Reference segments cannot be encoded.");
 
-    if (const auto reference_segment = std::dynamic_pointer_cast<const ReferenceSegment>(segment)) {
-      Fail("Reference segments cannot be encoded.");
+  if (std::dynamic_pointer_cast<const BaseValueSegment>(segment)) {
+    return SegmentEncodingSpec{EncodingType::Unencoded};
+  }
+
+  if (const auto encoded_segment = std::dynamic_pointer_cast<const BaseEncodedSegment>(segment)) {
+    std::optional<VectorCompressionType> vector_compression;
+    if (encoded_segment->compressed_vector_type()) {
+      vector_compression = parent_vector_compression_type(*encoded_segment->compressed_vector_type());
     }
+    return SegmentEncodingSpec{encoded_segment->encoding_type(), vector_compression};
+  }
 
-    const auto unencoded_segment = std::dynamic_pointer_cast<const ValueSegment<ColumnDataType>>(segment);
-    if (unencoded_segment) {
-      result = SegmentEncodingSpec{EncodingType::Unencoded};
-      return;
-    }
-
-    const auto encoded_segment = std::dynamic_pointer_cast<const BaseEncodedSegment>(segment);
-    if (encoded_segment) {
-      std::optional<VectorCompressionType> vector_compression = std::nullopt;
-      if (!encoded_segment->compressed_vector_type()) {
-        vector_compression = parent_vector_compression_type(*encoded_segment->compressed_vector_type());
-      }
-      result = SegmentEncodingSpec{encoded_segment->encoding_type(), vector_compression};
-      return;
-    }
-
-    Fail("Unexpected segment encoding found.");
-  });
-  return result;
+  Fail("Unexpected segment encoding found.");
 }
 
 VectorCompressionType parent_vector_compression_type(const CompressedVectorType compressed_vector_type) {

--- a/src/lib/storage/segment_encoding_utils.cpp
+++ b/src/lib/storage/segment_encoding_utils.cpp
@@ -39,18 +39,6 @@ std::unique_ptr<BaseSegmentEncoder> create_encoder(EncodingType encoding_type) {
   return encoder->create_new();
 }
 
-std::shared_ptr<BaseEncodedSegment> encode_and_compress_segment(const std::shared_ptr<const BaseSegment>& segment,
-                                                                const DataType data_type,
-                                                                const SegmentEncodingSpec& encoding_spec) {
-  auto encoder = create_encoder(encoding_spec.encoding_type);
-
-  if (encoding_spec.vector_compression_type) {
-    encoder->set_vector_compression(*encoding_spec.vector_compression_type);
-  }
-
-  return encoder->encode(segment, data_type);
-}
-
 SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const BaseSegment>& segment) {
   Assert(!std::dynamic_pointer_cast<const ReferenceSegment>(segment), "Reference segments cannot be encoded.");
 

--- a/src/lib/storage/segment_encoding_utils.hpp
+++ b/src/lib/storage/segment_encoding_utils.hpp
@@ -20,18 +20,6 @@ class BaseValueSegment;
 std::unique_ptr<BaseSegmentEncoder> create_encoder(EncodingType encoding_type);
 
 /**
- * @brief Encodes a segment by the given encoding specification (i.e., the encoding method and -- when given and
- * applicable -- the vector compression type). In general, do not use this method but rather
- * ChunkEncoder::encode_segment() which supports reencoding to ValueSegments and avoids reencoding with
- * SegmentEncodingSpec already in place.
- *
- * @return encoded segment if data type is supported, otherwise throws exception.
- */
-std::shared_ptr<BaseEncodedSegment> encode_and_compress_segment(const std::shared_ptr<const BaseSegment>& segment,
-                                                                const DataType data_type,
-                                                                const SegmentEncodingSpec& encoding_spec);
-
-/**
  * @return the segment encoding spec for the given segment.
  */
 SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const BaseSegment>& segment);

--- a/src/lib/storage/segment_encoding_utils.hpp
+++ b/src/lib/storage/segment_encoding_utils.hpp
@@ -20,8 +20,10 @@ class BaseValueSegment;
 std::unique_ptr<BaseSegmentEncoder> create_encoder(EncodingType encoding_type);
 
 /**
- * @brief Encodes a segment by the given encoding specification (i.e., the encoding method
- * and -- when given and applicable -- the vector compression type)
+ * @brief Encodes a segment by the given encoding specification (i.e., the encoding method and -- when given and
+ * applicable -- the vector compression type). In general, do not use this method but rather
+ * ChunkEncoder::encode_segment() which supports reencoding to ValueSegments and avoids reencoding with
+ * SegmentEncodingSpec already in place.
  *
  * @return encoded segment if data type is supported, otherwise throws exception.
  */
@@ -29,6 +31,16 @@ std::shared_ptr<BaseEncodedSegment> encode_and_compress_segment(const std::share
                                                                 const DataType data_type,
                                                                 const SegmentEncodingSpec& encoding_spec);
 
+/**
+ * @return the segment encoding spec for thes given segment.
+ */
+SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const BaseSegment>& segment);
+
+/**
+ * @brief Returns the vector compression type for a given compressed vector type.
+ *
+ * For the difference of the two, please take a look at compressed_vector_type.hpp.
+ */
 VectorCompressionType parent_vector_compression_type(const CompressedVectorType compressed_vector_type);
 
 }  // namespace opossum

--- a/src/lib/storage/segment_encoding_utils.hpp
+++ b/src/lib/storage/segment_encoding_utils.hpp
@@ -32,7 +32,7 @@ std::shared_ptr<BaseEncodedSegment> encode_and_compress_segment(const std::share
                                                                 const SegmentEncodingSpec& encoding_spec);
 
 /**
- * @return the segment encoding spec for thes given segment.
+ * @return the segment encoding spec for the given segment.
  */
 SegmentEncodingSpec get_segment_encoding_spec(const std::shared_ptr<const BaseSegment>& segment);
 

--- a/src/test/base_test.cpp
+++ b/src/test/base_test.cpp
@@ -137,6 +137,9 @@ void assert_chunk_encoding(const std::shared_ptr<Chunk>& chunk, const ChunkEncod
     const auto segment = chunk->get_segment(column_id);
     const auto segment_spec = spec.at(column_id);
 
+    ASSERT_EQ(segment_spec.encoding_type, get_segment_encoding_spec(segment).encoding_type);
+    ASSERT_TRUE(!segment_spec.vector_compression_type ||
+                *get_segment_encoding_spec(segment).vector_compression_type == *segment_spec.vector_compression_type);
     if (segment_spec.encoding_type == EncodingType::Unencoded) {
       const auto value_segment = std::dynamic_pointer_cast<const BaseValueSegment>(segment);
       ASSERT_NE(value_segment, nullptr);

--- a/src/test/base_test.cpp
+++ b/src/test/base_test.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<DictionarySegment<T>> create_dict_segment_by_type(DataType data_
   }
 
   const auto& dict_segment =
-      encode_and_compress_segment(value_segment, data_type, SegmentEncodingSpec{EncodingType::Dictionary});
+      ChunkEncoder::encode_segment(value_segment, data_type, SegmentEncodingSpec{EncodingType::Dictionary});
 
   return std::static_pointer_cast<DictionarySegment<T>>(dict_segment);
 }

--- a/src/test/base_test.cpp
+++ b/src/test/base_test.cpp
@@ -139,7 +139,7 @@ void assert_chunk_encoding(const std::shared_ptr<Chunk>& chunk, const ChunkEncod
 
     ASSERT_EQ(segment_spec.encoding_type, get_segment_encoding_spec(segment).encoding_type);
     ASSERT_TRUE(!segment_spec.vector_compression_type ||
-                *get_segment_encoding_spec(segment).vector_compression_type == *segment_spec.vector_compression_type);
+                (*get_segment_encoding_spec(segment).vector_compression_type == *segment_spec.vector_compression_type));
     if (segment_spec.encoding_type == EncodingType::Unencoded) {
       const auto value_segment = std::dynamic_pointer_cast<const BaseValueSegment>(segment);
       ASSERT_NE(value_segment, nullptr);

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -93,6 +93,6 @@ const SegmentEncodingSpec all_segment_encoding_specs[]{
     {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
     {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
     {EncodingType::FrameOfReference},
-    {EncodingType::LZ4, VectorCompressionType::SimdBp128},
+    {EncodingType::LZ4},
     {EncodingType::RunLength}};
 }  // namespace opossum

--- a/src/test/memory/segments_using_allocators_test.cpp
+++ b/src/test/memory/segments_using_allocators_test.cpp
@@ -65,7 +65,7 @@ class SegmentsUsingAllocatorsTest : public BaseTestWithParam<std::tuple<DataType
 TEST_P(SegmentsUsingAllocatorsTest, MigrateSegment) {
   auto encoded_segment = std::static_pointer_cast<BaseSegment>(original_segment);
   if (encoding_spec.encoding_type != EncodingType::Unencoded) {
-    encoded_segment = encode_and_compress_segment(original_segment, data_type, encoding_spec);
+    encoded_segment = ChunkEncoder::encode_segment(original_segment, data_type, encoding_spec);
   }
 
   auto resource = SimpleTrackingMemoryResource{};
@@ -76,7 +76,7 @@ TEST_P(SegmentsUsingAllocatorsTest, MigrateSegment) {
   // retrieve the size of an empty segment for later subtraction.
   auto empty_encoded_segment = std::static_pointer_cast<BaseSegment>(empty_original_segment);
   if (encoding_spec.encoding_type != EncodingType::Unencoded) {
-    empty_encoded_segment = encode_and_compress_segment(empty_original_segment, data_type, encoding_spec);
+    empty_encoded_segment = ChunkEncoder::encode_segment(empty_original_segment, data_type, encoding_spec);
   }
 
   const auto copied_segment_size = copied_segment->memory_usage(MemoryUsageCalculationMode::Full);

--- a/src/test/storage/chunk_test.cpp
+++ b/src/test/storage/chunk_test.cpp
@@ -25,8 +25,8 @@ class StorageChunkTest : public BaseTest {
     vs_str->append("world");
     vs_str->append("!");
 
-    ds_int = encode_and_compress_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
-    ds_str = encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
+    ds_int = ChunkEncoder::encode_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+    ds_str = ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
 
     Segments empty_segments;
     empty_segments.push_back(std::make_shared<ValueSegment<int32_t>>());

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -114,7 +114,7 @@ TEST_P(StorageDictionarySegmentTest, CompressSegmentDouble) {
   vs_double->append(1.1);
 
   auto segment = ChunkEncoder::encode_segment(vs_double, DataType::Double,
-                                             SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
+                                              SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<double>>(segment);
 
   // Test attribute_vector size

--- a/src/test/storage/dictionary_segment_test.cpp
+++ b/src/test/storage/dictionary_segment_test.cpp
@@ -40,7 +40,7 @@ TEST_P(StorageDictionarySegmentTest, LowerUpperBound) {
   for (int i = 0; i <= 10; i += 2) vs_int->append(i);
 
   auto segment =
-      encode_and_compress_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
+      ChunkEncoder::encode_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<int>>(segment);
 
   // Test for AllTypeVariant as parameter
@@ -63,7 +63,7 @@ TEST_P(StorageDictionarySegmentTest, CompressSegmentInt) {
   vs_int->append(3);
 
   auto segment =
-      encode_and_compress_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
+      ChunkEncoder::encode_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<int>>(segment);
 
   // Test attribute_vector size
@@ -88,7 +88,7 @@ TEST_P(StorageDictionarySegmentTest, CompressSegmentString) {
   vs_str->append("Bill");
 
   auto segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<pmr_string>>(segment);
 
   // Test attribute_vector size
@@ -113,7 +113,7 @@ TEST_P(StorageDictionarySegmentTest, CompressSegmentDouble) {
   vs_double->append(0.9);
   vs_double->append(1.1);
 
-  auto segment = encode_and_compress_segment(vs_double, DataType::Double,
+  auto segment = ChunkEncoder::encode_segment(vs_double, DataType::Double,
                                              SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<double>>(segment);
 
@@ -141,7 +141,7 @@ TEST_P(StorageDictionarySegmentTest, CompressNullableSegmentInt) {
   vs_int->append(3);
 
   auto segment =
-      encode_and_compress_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
+      ChunkEncoder::encode_segment(vs_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, GetParam()});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<int>>(segment);
 
   // Test attribute_vector size
@@ -164,7 +164,7 @@ TEST_F(StorageDictionarySegmentTest, FixedSizeByteAlignedVectorSize) {
   vs_int->append(1);
   vs_int->append(2);
 
-  auto segment = encode_and_compress_segment(
+  auto segment = ChunkEncoder::encode_segment(
       vs_int, DataType::Int,
       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
   auto dict_segment = std::dynamic_pointer_cast<DictionarySegment<int>>(segment);
@@ -180,7 +180,7 @@ TEST_F(StorageDictionarySegmentTest, FixedSizeByteAlignedVectorSize) {
     vs_int->append(i);
   }
 
-  segment = encode_and_compress_segment(
+  segment = ChunkEncoder::encode_segment(
       vs_int, DataType::Int,
       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
   dict_segment = std::dynamic_pointer_cast<DictionarySegment<int>>(segment);
@@ -200,7 +200,7 @@ TEST_F(StorageDictionarySegmentTest, FixedSizeByteAlignedMemoryUsageEstimation) 
    */
 
   const auto empty_memory_usage =
-      encode_and_compress_segment(
+      ChunkEncoder::encode_segment(
           vs_int, DataType::Int,
           SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned})
           ->memory_usage(MemoryUsageCalculationMode::Sampled);
@@ -208,7 +208,7 @@ TEST_F(StorageDictionarySegmentTest, FixedSizeByteAlignedMemoryUsageEstimation) 
   vs_int->append(0);
   vs_int->append(1);
   vs_int->append(2);
-  auto compressed_segment = encode_and_compress_segment(
+  auto compressed_segment = ChunkEncoder::encode_segment(
       vs_int, DataType::Int,
       SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
   const auto dictionary_segment = std::dynamic_pointer_cast<DictionarySegment<int>>(compressed_segment);

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -243,6 +243,7 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithShuffledChunkOf
   auto value_segment = create_int_with_null_value_segment();
   auto base_encoded_segment = this->encode_segment(value_segment, DataType::Int);
 
+  EXPECT_EQ(get_segment_encoding_spec(base_encoded_segment), SegmentEncodingSpec{EncodingType::Unencoded});
   EXPECT_EQ(value_segment->size(), base_encoded_segment->size());
 
   auto position_filter = create_random_access_position_filter();
@@ -346,6 +347,7 @@ TEST_F(EncodedSegmentTest, DictionaryAccessCounters) {
   const auto pos_filter = create_random_access_position_filter(row_count);
   auto dictionary_encoded_segment = dynamic_pointer_cast<DictionarySegment<int32_t>>(
       this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary}));
+  EXPECT_EQ(get_segment_encoding_spec(dictionary_encoded_segment), SegmentEncodingSpec{EncodingType::Dictionary});
 
   EXPECT_EQ(0, dictionary_encoded_segment->access_counter[SegmentAccessCounter::AccessType::Dictionary]);
   auto iterable = create_iterable_from_segment(*dictionary_encoded_segment);
@@ -372,12 +374,16 @@ TEST_F(EncodedSegmentTest, SegmentReencoding) {
   auto encoded_segment =
       this->encode_segment(value_segment, DataType::Int,
                            SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
+  EXPECT_EQ(get_segment_encoding_spec(encoded_segment),
+            (SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned}));
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
   encoded_segment = this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
   encoded_segment =
       this->encode_segment(value_segment, DataType::Int,
                            SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128});
+  EXPECT_EQ(get_segment_encoding_spec(encoded_segment),
+            (SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128}));
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
   encoded_segment =
       this->encode_segment(value_segment, DataType::Int,

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -118,7 +118,7 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
   std::shared_ptr<BaseEncodedSegment> encode_segment(const std::shared_ptr<BaseSegment>& base_segment,
                                                      const DataType data_type,
                                                      const SegmentEncodingSpec& segment_encoding_spec) {
-    return encode_and_compress_segment(base_segment, data_type, segment_encoding_spec);
+    return std::dynamic_pointer_cast<BaseEncodedSegment>(ChunkEncoder::encode_segment(base_segment, data_type, segment_encoding_spec));
   }
 };
 

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -243,7 +243,6 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithShuffledChunkOf
   auto value_segment = create_int_with_null_value_segment();
   auto base_encoded_segment = this->encode_segment(value_segment, DataType::Int);
 
-  EXPECT_EQ(get_segment_encoding_spec(base_encoded_segment), SegmentEncodingSpec{EncodingType::Unencoded});
   EXPECT_EQ(value_segment->size(), base_encoded_segment->size());
 
   auto position_filter = create_random_access_position_filter();
@@ -347,7 +346,8 @@ TEST_F(EncodedSegmentTest, DictionaryAccessCounters) {
   const auto pos_filter = create_random_access_position_filter(row_count);
   auto dictionary_encoded_segment = dynamic_pointer_cast<DictionarySegment<int32_t>>(
       this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary}));
-  EXPECT_EQ(get_segment_encoding_spec(dictionary_encoded_segment), SegmentEncodingSpec{EncodingType::Dictionary});
+  EXPECT_EQ(get_segment_encoding_spec(dictionary_encoded_segment),
+            (SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned}));
 
   EXPECT_EQ(0, dictionary_encoded_segment->access_counter[SegmentAccessCounter::AccessType::Dictionary]);
   auto iterable = create_iterable_from_segment(*dictionary_encoded_segment);

--- a/src/test/storage/encoded_segment_test.cpp
+++ b/src/test/storage/encoded_segment_test.cpp
@@ -118,7 +118,8 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
   std::shared_ptr<BaseEncodedSegment> encode_segment(const std::shared_ptr<BaseSegment>& base_segment,
                                                      const DataType data_type,
                                                      const SegmentEncodingSpec& segment_encoding_spec) {
-    return std::dynamic_pointer_cast<BaseEncodedSegment>(ChunkEncoder::encode_segment(base_segment, data_type, segment_encoding_spec));
+    return std::dynamic_pointer_cast<BaseEncodedSegment>(
+        ChunkEncoder::encode_segment(base_segment, data_type, segment_encoding_spec));
   }
 };
 

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -107,7 +107,7 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
   std::shared_ptr<BaseEncodedSegment> encode_segment(const std::shared_ptr<BaseSegment>& base_segment,
                                                      const DataType data_type,
                                                      const SegmentEncodingSpec& segment_encoding_spec) {
-    return encode_and_compress_segment(base_segment, data_type, segment_encoding_spec);
+    return std::dynamic_pointer_cast<BaseEncodedSegment>(ChunkEncoder::encode_segment(base_segment, data_type, segment_encoding_spec));
   }
 };
 

--- a/src/test/storage/encoded_string_segment_test.cpp
+++ b/src/test/storage/encoded_string_segment_test.cpp
@@ -107,7 +107,8 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
   std::shared_ptr<BaseEncodedSegment> encode_segment(const std::shared_ptr<BaseSegment>& base_segment,
                                                      const DataType data_type,
                                                      const SegmentEncodingSpec& segment_encoding_spec) {
-    return std::dynamic_pointer_cast<BaseEncodedSegment>(ChunkEncoder::encode_segment(base_segment, data_type, segment_encoding_spec));
+    return std::dynamic_pointer_cast<BaseEncodedSegment>(
+        ChunkEncoder::encode_segment(base_segment, data_type, segment_encoding_spec));
   }
 };
 

--- a/src/test/storage/fixed_string_dictionary_segment_test.cpp
+++ b/src/test/storage/fixed_string_dictionary_segment_test.cpp
@@ -26,7 +26,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, CompressSegmentString) {
   vs_str->append("Bill");
 
   auto segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   auto dict_segment = std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(segment);
 
   // Test attribute_vector size
@@ -50,7 +50,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, Decode) {
   vs_str->append("Bill");
 
   auto segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   auto dict_segment = std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(segment);
 
   EXPECT_EQ(dict_segment->encoding_type(), EncodingType::FixedStringDictionary);
@@ -68,7 +68,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, LongStrings) {
   vs_str->append("Short");
 
   auto segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   auto dict_segment = std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(segment);
 
   // Test sorting
@@ -87,7 +87,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, LowerUpperBound) {
   vs_str->append("K");
 
   auto segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   auto dict_segment = std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(segment);
 
   // Test for AllTypeVariant as parameter
@@ -109,7 +109,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, NullValues) {
   vs_str->append("E");
 
   auto segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   auto dict_segment = std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(segment);
 
   EXPECT_EQ(dict_segment->null_value_id(), 2u);
@@ -122,7 +122,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, MemoryUsageEstimation) {
    * memory usage estimations
    */
   const auto empty_compressed_segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   const auto empty_dictionary_segment =
       std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(empty_compressed_segment);
   const auto empty_memory_usage = empty_dictionary_segment->memory_usage();
@@ -131,7 +131,7 @@ TEST_F(StorageFixedStringDictionarySegmentTest, MemoryUsageEstimation) {
   vs_str->append("B");
   vs_str->append("C");
   const auto compressed_segment =
-      encode_and_compress_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
+      ChunkEncoder::encode_segment(vs_str, DataType::String, SegmentEncodingSpec{EncodingType::FixedStringDictionary});
   const auto dictionary_segment =
       std::dynamic_pointer_cast<FixedStringDictionarySegment<pmr_string>>(compressed_segment);
 

--- a/src/test/storage/group_key_index_test.cpp
+++ b/src/test/storage/group_key_index_test.cpp
@@ -37,7 +37,7 @@ class GroupKeyIndexTest : public BaseTest {
     value_segment_str->append(NULL_VALUE);  // 11
 
     dict_segment =
-        encode_and_compress_segment(value_segment_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
+        ChunkEncoder::encode_segment(value_segment_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
 
     index = std::make_shared<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseSegment>>({dict_segment}));
 

--- a/src/test/storage/group_key_index_test.cpp
+++ b/src/test/storage/group_key_index_test.cpp
@@ -36,8 +36,8 @@ class GroupKeyIndexTest : public BaseTest {
     value_segment_str->append("inbox");     // 10
     value_segment_str->append(NULL_VALUE);  // 11
 
-    dict_segment =
-        ChunkEncoder::encode_segment(value_segment_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
+    dict_segment = ChunkEncoder::encode_segment(value_segment_str, DataType::String,
+                                                SegmentEncodingSpec{EncodingType::Dictionary});
 
     index = std::make_shared<GroupKeyIndex>(std::vector<std::shared_ptr<const BaseSegment>>({dict_segment}));
 

--- a/src/test/storage/lz4_segment_test.cpp
+++ b/src/test/storage/lz4_segment_test.cpp
@@ -24,7 +24,7 @@ class StorageLZ4SegmentTest : public BaseTest {
 
 template <typename T>
 std::shared_ptr<LZ4Segment<T>> compress(std::shared_ptr<ValueSegment<T>> segment, DataType data_type) {
-  auto encoded_segment = encode_and_compress_segment(segment, data_type, SegmentEncodingSpec{EncodingType::LZ4});
+  auto encoded_segment = ChunkEncoder::encode_segment(segment, data_type, SegmentEncodingSpec{EncodingType::LZ4});
   return std::dynamic_pointer_cast<LZ4Segment<T>>(encoded_segment);
 }
 

--- a/src/test/storage/segment_accessor_test.cpp
+++ b/src/test/storage/segment_accessor_test.cpp
@@ -26,8 +26,8 @@ class SegmentAccessorTest : public BaseTest {
     vc_str->append("!");
     vc_str->append(NULL_VALUE);
 
-    dc_int = encode_and_compress_segment(vc_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
-    dc_str = encode_and_compress_segment(vc_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
+    dc_int = ChunkEncoder::encode_segment(vc_int, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+    dc_str = ChunkEncoder::encode_segment(vc_str, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary});
 
     tbl = std::make_shared<Table>(TableColumnDefinitions{TableColumnDefinition{"vc_int", DataType::Int, false},
                                                          TableColumnDefinition{"dc_str", DataType::String, false}},


### PR DESCRIPTION
This PR mainly introduces a function to the encoding segment utils that allows to receive the segment encoding spec. This function can be used to check if an encoding is really required or if the encoding is already in place (needed for current work on a plugin).

The segment encoding spec has also changed a little bit to make working with it simpler.