### PR TITLE
Fix PMR in FixedStringDictionarySegments, include in tests

### DIFF
--- a/src/lib/storage/dictionary_segment/dictionary_encoder.hpp
+++ b/src/lib/storage/dictionary_segment/dictionary_encoder.hpp
@@ -90,7 +90,7 @@ class DictionaryEncoder : public SegmentEncoder<DictionaryEncoder<Encoding>> {
     if constexpr (Encoding == EncodingType::FixedStringDictionary) {
       // Encode a segment with a FixedStringVector as dictionary. pmr_string is the only supported type
       auto fixed_string_dictionary =
-          std::make_shared<FixedStringVector>(dictionary->cbegin(), dictionary->cend(), max_string_length);
+          std::make_shared<FixedStringVector>(dictionary->cbegin(), dictionary->cend(), max_string_length, allocator);
       return std::make_shared<FixedStringDictionarySegment<T>>(fixed_string_dictionary, compressed_attribute_vector);
     } else {
       // Encode a segment with a pmr_vector<T> as dictionary

--- a/src/lib/storage/fixed_string_dictionary_segment.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment.cpp
@@ -56,8 +56,8 @@ ChunkOffset FixedStringDictionarySegment<T>::size() const {
 template <typename T>
 std::shared_ptr<BaseSegment> FixedStringDictionarySegment<T>::copy_using_allocator(
     const PolymorphicAllocator<size_t>& alloc) const {
+  auto new_dictionary = std::make_shared<FixedStringVector>(*_dictionary, alloc);
   auto new_attribute_vector = _attribute_vector->copy_using_allocator(alloc);
-  auto new_dictionary = std::make_shared<FixedStringVector>(*_dictionary);
   return std::make_shared<FixedStringDictionarySegment<T>>(new_dictionary, std::move(new_attribute_vector));
 }
 

--- a/src/lib/storage/fixed_string_dictionary_segment.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment.cpp
@@ -58,7 +58,12 @@ std::shared_ptr<BaseSegment> FixedStringDictionarySegment<T>::copy_using_allocat
     const PolymorphicAllocator<size_t>& alloc) const {
   auto new_dictionary = std::make_shared<FixedStringVector>(*_dictionary, alloc);
   auto new_attribute_vector = _attribute_vector->copy_using_allocator(alloc);
-  return std::make_shared<FixedStringDictionarySegment<T>>(new_dictionary, std::move(new_attribute_vector));
+
+  auto copy = std::make_shared<FixedStringDictionarySegment<T>>(new_dictionary, std::move(new_attribute_vector));
+
+  copy->access_counter = access_counter;
+
+  return copy;
 }
 
 template <typename T>

--- a/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
@@ -11,6 +11,12 @@
 
 namespace opossum {
 
+FixedStringVector::FixedStringVector(const FixedStringVector& other, PolymorphicAllocator<char> allocator)
+    : _string_length(other._string_length), _chars(other._chars, allocator), _size(other._size) {
+  // We need to set `_chars` in the initializer list. Otherwise, it would be first created with the default allocator
+  // and the assignment operator would not exchange the allocator.
+}
+
 void FixedStringVector::push_back(const pmr_string& string) {
   Assert(string.size() <= _string_length, "Inserted string is too long to insert in FixedStringVector");
   const auto pos = _chars.size();
@@ -99,6 +105,6 @@ PolymorphicAllocator<FixedString> FixedStringVector::get_allocator() { return _c
 
 void FixedStringVector::reserve(const size_t n) { _chars.reserve(n * _string_length); }
 
-size_t FixedStringVector::data_size() const { return sizeof(*this) + _chars.size(); }
+size_t FixedStringVector::data_size() const { return sizeof(*this) + _chars.capacity(); }
 
 }  // namespace opossum

--- a/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
@@ -11,7 +11,7 @@
 
 namespace opossum {
 
-FixedStringVector::FixedStringVector(const FixedStringVector& other, PolymorphicAllocator<char> allocator)
+FixedStringVector::FixedStringVector(const FixedStringVector& other, const PolymorphicAllocator<char>& allocator)
     : _string_length(other._string_length), _chars(other._chars, allocator), _size(other._size) {
   // We need to set `_chars` in the initializer list. Otherwise, it would be first created with the default allocator
   // and the assignment operator would not exchange the allocator.

--- a/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
@@ -13,8 +13,8 @@ namespace opossum {
 
 FixedStringVector::FixedStringVector(const FixedStringVector& other, const PolymorphicAllocator<char>& allocator)
     : _string_length(other._string_length), _chars(other._chars, allocator), _size(other._size) {
-  // We need to set `_chars` in the initializer list. Otherwise, it would be first created with the default allocator
-  // and the assignment operator would not exchange the allocator.
+  // For pmr_vectors, operator= does not change the allocator. As such, we need to set _chars in the initializer list.
+  // Otherwise, it would be created using the default allocator and ignore the passed-in allocator.
 }
 
 void FixedStringVector::push_back(const pmr_string& string) {

--- a/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.hpp
+++ b/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.hpp
@@ -18,11 +18,12 @@ namespace opossum {
 class FixedStringVector {
  public:
   // Create a FixedStringVector of FixedStrings with given values
-  FixedStringVector(const FixedStringVector& other) = default;
+  FixedStringVector(const FixedStringVector& other, PolymorphicAllocator<char> allocator = {});
 
   // Create a FixedStringVector of FixedStrings with given values by iterating over other container
-  template <class Iter>
-  FixedStringVector(Iter first, Iter last, const size_t string_length) : _string_length(string_length) {
+  template <typename Iter>
+  FixedStringVector(Iter first, Iter last, const size_t string_length, PolymorphicAllocator<char> allocator = {})
+      : _string_length(string_length), _chars(allocator) {
     const auto value_count = std::distance(first, last);
     // If string_length equals 0 we would not have any elements in the vector. Hence, we would have to deal with null
     // pointers. In order to avoid this, we insert a null terminator to the vector by using resize.
@@ -31,7 +32,10 @@ class FixedStringVector {
       _size = value_count;
     } else {
       _chars.reserve(_string_length * value_count);
-      _iterator_push_back(first, last);
+      while (first != last) {
+        push_back(*first);
+        ++first;
+      }
     }
   }
 
@@ -85,14 +89,6 @@ class FixedStringVector {
   const size_t _string_length;
   pmr_vector<char> _chars;
   size_t _size = 0;
-
-  template <class Iter>
-  void _iterator_push_back(Iter first, Iter last) {
-    while (first != last) {
-      push_back(*first);
-      ++first;
-    }
-  }
 };
 
 }  // namespace opossum

--- a/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.hpp
+++ b/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.hpp
@@ -18,11 +18,11 @@ namespace opossum {
 class FixedStringVector {
  public:
   // Create a FixedStringVector of FixedStrings with given values
-  FixedStringVector(const FixedStringVector& other, PolymorphicAllocator<char> allocator = {});
+  FixedStringVector(const FixedStringVector& other, const PolymorphicAllocator<char>& allocator = {});
 
   // Create a FixedStringVector of FixedStrings with given values by iterating over other container
   template <typename Iter>
-  FixedStringVector(Iter first, Iter last, const size_t string_length, PolymorphicAllocator<char> allocator = {})
+  FixedStringVector(Iter first, Iter last, const size_t string_length, const PolymorphicAllocator<char>& allocator = {})
       : _string_length(string_length), _chars(allocator) {
     const auto value_count = std::distance(first, last);
     // If string_length equals 0 we would not have any elements in the vector. Hence, we would have to deal with null

--- a/src/lib/storage/frame_of_reference_segment.cpp
+++ b/src/lib/storage/frame_of_reference_segment.cpp
@@ -55,8 +55,12 @@ std::shared_ptr<BaseSegment> FrameOfReferenceSegment<T, U>::copy_using_allocator
   auto new_null_values = pmr_vector<bool>{_null_values, alloc};
   auto new_offset_values = _offset_values->copy_using_allocator(alloc);
 
-  return std::make_shared<FrameOfReferenceSegment>(std::move(new_block_minima), std::move(new_null_values),
-                                                   std::move(new_offset_values));
+  auto copy = std::make_shared<FrameOfReferenceSegment>(std::move(new_block_minima), std::move(new_null_values),
+                                                        std::move(new_offset_values));
+
+  copy->access_counter = access_counter;
+
+  return copy;
 }
 
 template <typename T, typename U>

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -429,16 +429,22 @@ std::shared_ptr<BaseSegment> LZ4Segment<T>::copy_using_allocator(const Polymorph
       _null_values ? std::optional<pmr_vector<bool>>{pmr_vector<bool>{*_null_values, alloc}} : std::nullopt;
   auto new_dictionary = pmr_vector<char>{_dictionary, alloc};
 
+  auto copy = std::shared_ptr<LZ4Segment<T>>{};
+
   if (_string_offsets) {
     auto new_string_offsets = *_string_offsets ? (*_string_offsets)->copy_using_allocator(alloc) : nullptr;
-    return std::make_shared<LZ4Segment>(std::move(new_lz4_blocks), std::move(new_null_values),
-                                        std::move(new_dictionary), std::move(new_string_offsets), _block_size,
-                                        _last_block_size, _compressed_size, _num_elements);
+    copy = std::make_shared<LZ4Segment<T>>(std::move(new_lz4_blocks), std::move(new_null_values),
+                                           std::move(new_dictionary), std::move(new_string_offsets), _block_size,
+                                           _last_block_size, _compressed_size, _num_elements);
   } else {
-    return std::make_shared<LZ4Segment>(std::move(new_lz4_blocks), std::move(new_null_values),
-                                        std::move(new_dictionary), _block_size, _last_block_size, _compressed_size,
-                                        _num_elements);
+    copy = std::make_shared<LZ4Segment<T>>(std::move(new_lz4_blocks), std::move(new_null_values),
+                                           std::move(new_dictionary), _block_size, _last_block_size, _compressed_size,
+                                           _num_elements);
   }
+
+  copy->access_counter = access_counter;
+
+  return copy;
 }
 
 template <typename T>

--- a/src/lib/storage/resolve_encoded_segment_type.hpp
+++ b/src/lib/storage/resolve_encoded_segment_type.hpp
@@ -35,6 +35,7 @@ constexpr auto encoded_segment_for_type = hana::make_map(
                     template_c<FixedStringDictionarySegment>),
     hana::make_pair(enum_c<EncodingType, EncodingType::FrameOfReference>, template_c<FrameOfReferenceSegment>),
     hana::make_pair(enum_c<EncodingType, EncodingType::LZ4>, template_c<LZ4Segment>));
+// When adding something here, please also append all_segment_encoding_specs in the BaseTest class.
 
 /**
  * @brief Resolves the type of an encoded segment.

--- a/src/lib/storage/run_length_segment.cpp
+++ b/src/lib/storage/run_length_segment.cpp
@@ -56,7 +56,11 @@ std::shared_ptr<BaseSegment> RunLengthSegment<T>::copy_using_allocator(
   auto new_null_values = std::make_shared<pmr_vector<bool>>(*_null_values, alloc);
   auto new_end_positions = std::make_shared<pmr_vector<ChunkOffset>>(*_end_positions, alloc);
 
-  return std::make_shared<RunLengthSegment<T>>(new_values, new_null_values, new_end_positions);
+  auto copy = std::make_shared<RunLengthSegment<T>>(new_values, new_null_values, new_end_positions);
+
+  copy->access_counter = access_counter;
+
+  return copy;
 }
 
 template <typename T>

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -119,7 +119,6 @@ template <typename T>
 void ValueSegment<T>::resize(const size_t size) {
   DebugAssert(size > _values.size() && size <= _values.capacity(),
               "ValueSegments should not be shrunk or resized beyond their original capacity");
-  access_counter[SegmentAccessCounter::AccessType::Sequential] += _values.size();
   _values.resize(size);
   if (is_nullable()) {
     _null_values->resize(size);

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -92,6 +92,8 @@ const SegmentEncodingSpec all_segment_encoding_specs[]{
     {EncodingType::Unencoded},
     {EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned},
     {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+    {EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned},
+    {EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128},
     {EncodingType::FrameOfReference},
     {EncodingType::LZ4},
     {EncodingType::RunLength}};


### PR DESCRIPTION
While working on something else, I noticed that 
* FixedStringDictionarySegments did not correctly implement copy_using_allocator (related to #623),
* this was not tested because the FixedStringDictionary was not included in the list of encodings to test, and
* the existing tests did not use external memory for pmr_strings.

All should be fixed now.

Also, this fixes and tests that segment access counters are persistent across migrations.