### PR TITLE
Size estimation utils: make seed static

### DIFF
--- a/src/lib/utils/size_estimation_utils.hpp
+++ b/src/lib/utils/size_estimation_utils.hpp
@@ -65,7 +65,7 @@ size_t string_vector_memory_usage(const V& string_vector, const MemoryUsageCalcu
   // Since we want an ordered position list (this potentially increases the performance when accessing the segment), we
   // can directly use std::set to generate distinct sample positions. std::set is slightly faster than
   // std::unordered_set + sorting for small sample sizes.
-  std::default_random_engine generator{std::random_device{}()};
+  std::default_random_engine generator{17};
   std::uniform_int_distribution<size_t> distribution(0ul, samples_to_draw);
   std::set<size_t> sample_set;
   while (sample_set.size() < samples_to_draw) {


### PR DESCRIPTION
This mini PR changes the seed to be static in the size estimation utils.

The size estimation utils are used to determine the size of string segments, for which random sampling is used. Currently, the seed is random with the effect of steadily changing values for the size of a segment. Since the segments don't change, the size should not change as well.
This effect is especially obvious when the memory usage is steadily requested and visualized (e.g., in the bachelor's project's cockpit).

The potential short comings of this approach are only theoretical in my opinion as the meta table is not meant to be requested multiple times in order to capture a more accurate estimate.
If this would be the case, we could add another Sampling Enum value (SampledStatic, SampledRandom), but I don't see the necessity right now. If anybody sees that, I'll add it.