### PR TITLE
Catch duplicate aggregate functions

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -257,6 +257,9 @@ SELECT COUNT(*) FROM mixed;
 SELECT COUNT(*) + 1 FROM mixed;
 SELECT COUNT(*) FROM mixed GROUP BY a;
 SELECT a, COUNT(*) FROM mixed GROUP BY a;
+SELECT a, COUNT(*) FROM mixed GROUP BY a ORDER BY a desc;
+SELECT a, COUNT(*) FROM mixed GROUP BY a ORDER BY COUNT(*) desc;
+SELECT a, COUNT(*) FROM mixed GROUP BY a ORDER BY 100 - COUNT(*) desc;
 SELECT COUNT(*), SUM(a + b) FROM id_int_int_int_100;
 SELECT COUNT(*) FROM mixed AS L, mixed AS R WHERE L.a = R.a;
 SELECT COUNT(*) FROM id_int_int_int_50, id_int_int_int_100;
@@ -266,7 +269,9 @@ SELECT COUNT(*) FROM mixed, id_int_int_int_100;
 -- COUNT(expr)
 SELECT COUNT(1) FROM mixed;
 SELECT COUNT(b + 1) FROM mixed;
+SELECT COUNT(b) + 1 FROM mixed;
 SELECT COUNT(1 + 2) FROM mixed;
+SELECT COUNT(b + c) FROM mixed;
 SELECT a, COUNT(1) FROM mixed GROUP BY a;
 SELECT b + 1, COUNT(c + 1) FROM mixed GROUP BY b+1;
 
@@ -278,6 +283,7 @@ sELEcT Sum(b + b) AS sum_b_b from mixed;
 
 -- Aggregates with NULL
 SELECT a, MAX(b) FROM mixed_null GROUP BY a;
+SELECT a, MAX(b) FROM mixed_null GROUP BY a ORDER BY MAX(b) DESC;
 SELECT a, MIN(b) FROM mixed_null GROUP BY a;
 SELECT a, SUM(b) FROM mixed_null GROUP BY a;
 SELECT a, AVG(b) FROM mixed_null GROUP BY a;
@@ -286,6 +292,7 @@ SELECT a, COUNT(*) FROM mixed_null GROUP BY a;
 
 -- Checks that output of Aggregate can be worked with correctly.
 SELECT b, sub.min_c, max_b FROM (SELECT a, b, MAX(b) AS max_b, MIN(c) AS min_c FROM mixed GROUP BY a, b) as sub WHERE b BETWEEN 20 AND 50 AND min_c > 15;
+SELECT a, b FROM (SELECT a, COUNT(a) AS b FROM mixed GROUP BY a) t
 
 -- HAVING
 SELECT a, b, MAX(b), AVG(c) FROM mixed GROUP BY a, b HAVING MAX(b) >= 10 AND MAX(b) < 40;

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -1,3 +1,7 @@
+-- The queries in this file are automatically executed by the SQLiteTestRunner as part of hyriseTest.
+-- Their result is then compared to that of SQLite.
+-- Tables are loaded from sqlite_testrunner.tables.
+
 -- Select entire table
 SELECT * FROM mixed;
 SELECT * FROM mixed_null;

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -68,11 +68,9 @@ std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressio
     auto& column_expression = column_expressions[expression_idx];
     DebugAssert(column_expression->type == ExpressionType::Aggregate,
                 "Unexpected non-aggregate in list of aggregates.");
-    if (column_expression->type == ExpressionType::Aggregate) {
-      const auto& aggregate_expression = static_cast<AggregateExpression&>(*column_expression);
-      if (aggregate_expression.aggregate_function == AggregateFunction::Any) {
-        column_expression = column_expression->arguments[0];
-      }
+    const auto& aggregate_expression = static_cast<AggregateExpression&>(*column_expression);
+    if (aggregate_expression.aggregate_function == AggregateFunction::Any) {
+      column_expression = column_expression->arguments[0];
     }
   }
 

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1507,7 +1507,7 @@ std::shared_ptr<AbstractExpression> SQLTranslator::_translate_hsql_expr(
                                  [&aggregate_expression](const auto input_expression) {
                                    return *input_expression == *aggregate_expression;
                                  }),
-                    "Hyrise cannot handle repeated aggregate expressions, see code #1902 for details.");
+                    "Hyrise cannot handle repeated aggregate expressions, see #1902 for details.");
 
         return aggregate_expression;
       }

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -470,7 +470,8 @@ TEST_F(SQLTranslatorTest, RepeatingAggregates) {
 
   EXPECT_THROW(compile_query("SELECT COUNT(a) FROM (SELECT a, COUNT(a) FROM t GROUP BY a) t2"), InvalidInputException);
 
-  EXPECT_THROW(compile_query("SELECT COUNT(a) FROM (SELECT a, COUNT(a) AS b FROM t GROUP BY a) t2"), InvalidInputException);
+  EXPECT_THROW(compile_query("SELECT COUNT(a) FROM (SELECT a, COUNT(a) AS b FROM t GROUP BY a) t2"),
+               InvalidInputException);
 
   EXPECT_THROW(compile_query("SELECT AVG(a) FROM (SELECT a, AVG(a) FROM t GROUP BY a) t3"), InvalidInputException);
 }

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -470,6 +470,8 @@ TEST_F(SQLTranslatorTest, RepeatingAggregates) {
 
   EXPECT_THROW(compile_query("SELECT COUNT(a) FROM (SELECT a, COUNT(a) FROM t GROUP BY a) t2"), InvalidInputException);
 
+  EXPECT_THROW(compile_query("SELECT COUNT(a) FROM (SELECT a, COUNT(a) AS b FROM t GROUP BY a) t2"), InvalidInputException);
+
   EXPECT_THROW(compile_query("SELECT AVG(a) FROM (SELECT a, AVG(a) FROM t GROUP BY a) t3"), InvalidInputException);
 }
 

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -461,6 +461,18 @@ TEST_F(SQLTranslatorTest, SelectListAliasesDifferentForSimilarAggregatesInSubque
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(SQLTranslatorTest, RepeatingAggregates) {
+  // See #1902. Optimally, these queries would produce correct results. Until then, at least make sure they don't
+  // produce any wrong ones.
+
+  EXPECT_THROW(compile_query("SELECT COUNT(*) FROM (SELECT COUNT(*) FROM t WHERE a <= 1234) t2"),
+               InvalidInputException);
+
+  EXPECT_THROW(compile_query("SELECT COUNT(a) FROM (SELECT a, COUNT(a) FROM t GROUP BY a) t2"), InvalidInputException);
+
+  EXPECT_THROW(compile_query("SELECT AVG(a) FROM (SELECT a, AVG(a) FROM t GROUP BY a) t3"), InvalidInputException);
+}
+
 TEST_F(SQLTranslatorTest, SelectAggregate) {
   const auto actual_lqp = compile_query("SELECT COUNT(*) FROM int_float");
 


### PR DESCRIPTION
These queries are currently broken because the SQLTranslator incorrectly identifies the aggregate function as having already been calculated (see #1902):

```
SELECT COUNT(*) FROM (SELECT COUNT(*) FROM t WHERE a <= 1234) t2
SELECT COUNT(a) FROM (SELECT a, COUNT(a) FROM t GROUP BY a) t2
SELECT AVG(a) FROM (SELECT a, AVG(a) FROM t GROUP BY a) t3
```

As long as this (1) does not produce wrong results and (2) does not get in the way of experiments or benchmarks, it feels more like a cosmetic issue. This PR introduces a check for these cases.