### PR TITLE
Store row count in performance data, don't keep temporaries

### DIFF
--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -225,7 +225,7 @@ BENCHMARK_F(TPCHDataMicroBenchmarkFixture, BM_TPCHQ4WithExistsSubquery)(benchmar
 
   for (auto _ : state) {
     const auto pqp = LQPTranslator{}.translate_node(lqp);
-    const auto tasks = OperatorTask::make_tasks_from_operator(pqp, CleanupTemporaries::Yes);
+    const auto tasks = OperatorTask::make_tasks_from_operator(pqp);
     Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
   }
 }
@@ -243,7 +243,7 @@ BENCHMARK_F(TPCHDataMicroBenchmarkFixture, BM_TPCHQ4WithUnnestedSemiJoin)(benchm
 
   for (auto _ : state) {
     const auto pqp = LQPTranslator{}.translate_node(lqp);
-    const auto tasks = OperatorTask::make_tasks_from_operator(pqp, CleanupTemporaries::Yes);
+    const auto tasks = OperatorTask::make_tasks_from_operator(pqp);
     Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
   }
 }

--- a/src/benchmarklib/benchmark_sql_executor.cpp
+++ b/src/benchmarklib/benchmark_sql_executor.cpp
@@ -21,7 +21,6 @@ BenchmarkSQLExecutor::BenchmarkSQLExecutor(const std::shared_ptr<SQLiteWrapper>&
 std::pair<SQLPipelineStatus, std::shared_ptr<const Table>> BenchmarkSQLExecutor::execute(
     const std::string& sql, const std::shared_ptr<const Table>& expected_result_table) {
   auto pipeline_builder = SQLPipelineBuilder{sql};
-  if (_visualize_prefix) pipeline_builder.dont_cleanup_temporaries();
   if (transaction_context) pipeline_builder.with_transaction_context(transaction_context);
 
   auto pipeline = pipeline_builder.create_pipeline();

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -250,8 +250,7 @@ bool Console::_initialize_pipeline(const std::string& sql) {
   try {
     auto builder = SQLPipelineBuilder{sql}
                        .with_lqp_cache(_lqp_cache)
-                       .with_pqp_cache(_pqp_cache)
-                       .dont_cleanup_temporaries();  // keep tables for debugging and visualization
+                       .with_pqp_cache(_pqp_cache);
     if (_explicitly_created_transaction_context) {
       builder.with_transaction_context(_explicitly_created_transaction_context);
     }

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -977,7 +977,7 @@ std::shared_ptr<const Table> ExpressionEvaluator::_evaluate_subquery_expression_
   auto row_pqp = expression.pqp->deep_copy();
   row_pqp->set_parameters(parameters);
 
-  const auto tasks = OperatorTask::make_tasks_from_operator(row_pqp, CleanupTemporaries::Yes);
+  const auto tasks = OperatorTask::make_tasks_from_operator(row_pqp);
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
 
   return row_pqp->get_output();

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -38,23 +38,35 @@ const std::vector<OperatorJoinPredicate>& AbstractJoinOperator::secondary_predic
 }
 
 std::string AbstractJoinOperator::description(DescriptionMode description_mode) const {
-  const auto column_name = [](const auto& table, const auto column_id) {
-    return table ? table->column_name(column_id) : "Column #"s + std::to_string(column_id);
+  const auto column_name = [&](const auto from_left, const auto column_id) {
+    const auto& input_table = from_left ? _input_left->get_output() : _input_right->get_output();
+    if (input_table) {
+      // Input table is still available, use name from there
+      return input_table->column_name(column_id);
+    }
+
+    if (lqp_node) {
+      // LQP is available, use column name from there
+      const auto& input_lqp_node = lqp_node->input(from_left ? LQPInputSide::Left : LQPInputSide::Right);
+      return input_lqp_node->column_expressions()[column_id]->as_column_name();
+    }
+
+    // Fallback - use column ID
+    return (from_left ? "Left"s : "Right"s) + " Column #"s + std::to_string(column_id);
   };
 
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
 
   std::stringstream stream;
   stream << name() << separator << "(" << _mode << " Join where "
-         << column_name(input_table_left(), _primary_predicate.column_ids.first) << " "
-         << _primary_predicate.predicate_condition << " "
-         << column_name(input_table_right(), _primary_predicate.column_ids.second);
+         << column_name(true, _primary_predicate.column_ids.first) << " " << _primary_predicate.predicate_condition
+         << " " << column_name(false, _primary_predicate.column_ids.second);
 
   // add information about secondary join predicates
   for (const auto& secondary_predicate : _secondary_predicates) {
-    stream << " AND " << column_name(input_table_left(), secondary_predicate.column_ids.first) << " "
+    stream << " AND " << column_name(true, secondary_predicate.column_ids.first) << " "
            << secondary_predicate.predicate_condition << " "
-           << column_name(input_table_right(), secondary_predicate.column_ids.second);
+           << column_name(false, secondary_predicate.column_ids.second);
   }
 
   stream << ")";

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -53,7 +53,7 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     }
 
     // Fallback - use column ID
-    return (from_left ? "Left"s : "Right"s) + " Column #"s + std::to_string(column_id);
+    return "Column #"s + std::to_string(column_id);
   };
 
   const auto separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 
 #include "constant_mappings.hpp"
+#include "logical_query_plan/abstract_lqp_node.hpp"
 
 using namespace std::string_literals;  // NOLINT
 

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -30,7 +30,7 @@ void AbstractOperator::execute() {
   DTRACE_PROBE1(HYRISE, OPERATOR_STARTED, name().c_str());
   DebugAssert(!_input_left || _input_left->get_output(), "Left input has not yet been executed");
   DebugAssert(!_input_right || _input_right->get_output(), "Right input has not yet been executed");
-  DebugAssert(_performance_data->walltime.count() == 0, "Operator has already been executed");
+  DebugAssert(!_performance_data->executed, "Operator has already been executed");
 
   Timer performance_timer;
 
@@ -56,6 +56,9 @@ void AbstractOperator::execute() {
   _on_cleanup();
 
   _performance_data->walltime = performance_timer.lap();
+  _performance_data->executed = true;
+  _performance_data->output_row_count = _output->row_count();
+  _performance_data->output_chunk_count = _output->chunk_count();
 
   DTRACE_PROBE5(HYRISE, OPERATOR_EXECUTED, name().c_str(), _performance_data->walltime.count(),
                 _output ? _output->row_count() : 0, _output ? _output->chunk_count() : 0,

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -57,8 +57,10 @@ void AbstractOperator::execute() {
 
   _performance_data->walltime = performance_timer.lap();
   _performance_data->executed = true;
-  _performance_data->output_row_count = _output->row_count();
-  _performance_data->output_chunk_count = _output->chunk_count();
+  if (_output) {
+    _performance_data->output_row_count = _output->row_count();
+    _performance_data->output_chunk_count = _output->chunk_count();
+  }
 
   DTRACE_PROBE5(HYRISE, OPERATOR_EXECUTED, name().c_str(), _performance_data->walltime.count(),
                 _output ? _output->row_count() : 0, _output ? _output->chunk_count() : 0,

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -58,6 +58,7 @@ void AbstractOperator::execute() {
   _performance_data->walltime = performance_timer.lap();
   _performance_data->executed = true;
   if (_output) {
+    _performance_data->has_output = true;
     _performance_data->output_row_count = _output->row_count();
     _performance_data->output_chunk_count = _output->chunk_count();
   }

--- a/src/lib/operators/operator_performance_data.cpp
+++ b/src/lib/operators/operator_performance_data.cpp
@@ -7,7 +7,13 @@
 namespace opossum {
 
 void OperatorPerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
-  stream << format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
+  if (executed) {
+    stream << output_row_count << " row(s) in ";
+    stream << output_chunk_count << " chunk(s), ";
+    stream << format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
+  } else {
+    stream << "not executed";
+  }
 }
 
 std::ostream& operator<<(std::ostream& stream, const OperatorPerformanceData& performance_data) {

--- a/src/lib/operators/operator_performance_data.cpp
+++ b/src/lib/operators/operator_performance_data.cpp
@@ -7,13 +7,18 @@
 namespace opossum {
 
 void OperatorPerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
-  if (executed) {
-    stream << output_row_count << " row(s) in ";
-    stream << output_chunk_count << " chunk(s), ";
-    stream << format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
-  } else {
+  if (!executed) {
     stream << "not executed";
+    return;
   }
+
+  if (!has_output) {
+    stream << "executed, but no output";
+  }
+
+  stream << output_row_count << " row(s) in ";
+  stream << output_chunk_count << " chunk(s), ";
+  stream << format_duration(std::chrono::duration_cast<std::chrono::nanoseconds>(walltime));
 }
 
 std::ostream& operator<<(std::ostream& stream, const OperatorPerformanceData& performance_data) {

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -13,7 +13,10 @@ namespace opossum {
 struct OperatorPerformanceData : public Noncopyable {
   virtual ~OperatorPerformanceData() = default;
 
+  bool executed{false};
   std::chrono::nanoseconds walltime{0};
+  uint64_t output_row_count{0};
+  uint64_t output_chunk_count{0};
 
   virtual void output_to_stream(std::ostream& stream,
                                 DescriptionMode description_mode = DescriptionMode::SingleLine) const;

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -15,6 +15,10 @@ struct OperatorPerformanceData : public Noncopyable {
 
   bool executed{false};
   std::chrono::nanoseconds walltime{0};
+
+  // Some operators do not return a table (e.g., Insert).
+  // Note: The operator returning an empty table will be expressed as has_output == true, output_row_count == 0
+  bool has_output{false};
   uint64_t output_row_count{0};
   uint64_t output_chunk_count{0};
 

--- a/src/lib/scheduler/operator_task.cpp
+++ b/src/lib/scheduler/operator_task.cpp
@@ -12,8 +12,7 @@
 #include "utils/tracing/probes.hpp"
 
 namespace opossum {
-OperatorTask::OperatorTask(std::shared_ptr<AbstractOperator> op,
-                           SchedulePriority priority, bool stealable)
+OperatorTask::OperatorTask(std::shared_ptr<AbstractOperator> op, SchedulePriority priority, bool stealable)
     : AbstractTask(priority, stealable), _op(std::move(op)) {}
 
 std::string OperatorTask::description() const {
@@ -98,7 +97,7 @@ void OperatorTask::_on_execute() {
   // root (i.e., the final result)
   for (const auto& weak_predecessor : predecessors()) {
     const auto predecessor = std::dynamic_pointer_cast<OperatorTask>(weak_predecessor.lock());
-    DebugAssert(predecessor, "predecessor of OperatorTask is not an OperatorTask itself");
+    DebugAssert(predecessor, "Predecessor of OperatorTask is not an OperatorTask itself");
     auto previous_operator_still_needed = false;
 
     for (const auto& successor : predecessor->successors()) {

--- a/src/lib/scheduler/operator_task.cpp
+++ b/src/lib/scheduler/operator_task.cpp
@@ -12,39 +12,38 @@
 #include "utils/tracing/probes.hpp"
 
 namespace opossum {
-OperatorTask::OperatorTask(std::shared_ptr<AbstractOperator> op, CleanupTemporaries cleanup_temporaries,
+OperatorTask::OperatorTask(std::shared_ptr<AbstractOperator> op,
                            SchedulePriority priority, bool stealable)
-    : AbstractTask(priority, stealable), _op(std::move(op)), _cleanup_temporaries(cleanup_temporaries) {}
+    : AbstractTask(priority, stealable), _op(std::move(op)) {}
 
 std::string OperatorTask::description() const {
   return "OperatorTask with id: " + std::to_string(id()) + " for op: " + _op->description();
 }
 
 std::vector<std::shared_ptr<OperatorTask>> OperatorTask::make_tasks_from_operator(
-    const std::shared_ptr<AbstractOperator>& op, CleanupTemporaries cleanup_temporaries) {
+    const std::shared_ptr<AbstractOperator>& op) {
   std::vector<std::shared_ptr<OperatorTask>> tasks;
   std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>> task_by_op;
-  _add_tasks_from_operator(op, tasks, task_by_op, cleanup_temporaries);
+  _add_tasks_from_operator(op, tasks, task_by_op);
   return tasks;
 }
 
 std::shared_ptr<OperatorTask> OperatorTask::_add_tasks_from_operator(
     const std::shared_ptr<AbstractOperator>& op, std::vector<std::shared_ptr<OperatorTask>>& tasks,
-    std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>>& task_by_op,
-    CleanupTemporaries cleanup_temporaries) {
+    std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>>& task_by_op) {
   const auto task_by_op_it = task_by_op.find(op);
   if (task_by_op_it != task_by_op.end()) return task_by_op_it->second;
 
-  const auto task = std::make_shared<OperatorTask>(op, cleanup_temporaries);
+  const auto task = std::make_shared<OperatorTask>(op);
   task_by_op.emplace(op, task);
 
   if (auto left = op->mutable_input_left()) {
-    auto subtree_root = _add_tasks_from_operator(left, tasks, task_by_op, cleanup_temporaries);
+    auto subtree_root = _add_tasks_from_operator(left, tasks, task_by_op);
     subtree_root->set_as_predecessor_of(task);
   }
 
   if (auto right = op->mutable_input_right()) {
-    auto subtree_root = _add_tasks_from_operator(right, tasks, task_by_op, cleanup_temporaries);
+    auto subtree_root = _add_tasks_from_operator(right, tasks, task_by_op);
     subtree_root->set_as_predecessor_of(task);
   }
 
@@ -97,21 +96,19 @@ void OperatorTask::_on_execute() {
   // Get rid of temporary tables that are not needed anymore
   // Because `clear_output` is only called by the successive OperatorTasks, we can be sure that no one cleans up the
   // root (i.e., the final result)
-  if (_cleanup_temporaries == CleanupTemporaries::Yes) {
-    for (const auto& weak_predecessor : predecessors()) {
-      const auto predecessor = std::dynamic_pointer_cast<OperatorTask>(weak_predecessor.lock());
-      DebugAssert(predecessor, "predecessor of OperatorTask is not an OperatorTask itself");
-      auto previous_operator_still_needed = false;
+  for (const auto& weak_predecessor : predecessors()) {
+    const auto predecessor = std::dynamic_pointer_cast<OperatorTask>(weak_predecessor.lock());
+    DebugAssert(predecessor, "predecessor of OperatorTask is not an OperatorTask itself");
+    auto previous_operator_still_needed = false;
 
-      for (const auto& successor : predecessor->successors()) {
-        if (successor.get() != this && !successor->is_done()) {
-          previous_operator_still_needed = true;
-        }
+    for (const auto& successor : predecessor->successors()) {
+      if (successor.get() != this && !successor->is_done()) {
+        previous_operator_still_needed = true;
       }
-      // If someone else still holds a shared_ptr to the table (e.g., a ReferenceSegment pointing to a materialized
-      // temporary table), it will not yet get deleted
-      if (!previous_operator_still_needed) predecessor->get_operator()->clear_output();
     }
+    // If someone else still holds a shared_ptr to the table (e.g., a ReferenceSegment pointing to a materialized
+    // temporary table), it will not yet get deleted
+    if (!previous_operator_still_needed) predecessor->get_operator()->clear_output();
   }
 }
 }  // namespace opossum

--- a/src/lib/scheduler/operator_task.hpp
+++ b/src/lib/scheduler/operator_task.hpp
@@ -16,14 +16,14 @@ class AbstractOperator;
 class OperatorTask : public AbstractTask {
  public:
   // We don't like abbreviations, but "operator" is a keyword
-  OperatorTask(std::shared_ptr<AbstractOperator> op, CleanupTemporaries cleanup_temporaries,
+  OperatorTask(std::shared_ptr<AbstractOperator> op,
                SchedulePriority priority = SchedulePriority::Default, bool stealable = true);
 
   /**
    * Create tasks recursively from result operator and set task dependencies automatically.
    */
   static std::vector<std::shared_ptr<OperatorTask>> make_tasks_from_operator(
-      const std::shared_ptr<AbstractOperator>& op, CleanupTemporaries cleanup_temporaries);
+      const std::shared_ptr<AbstractOperator>& op);
 
   const std::shared_ptr<AbstractOperator>& get_operator() const;
 
@@ -38,11 +38,9 @@ class OperatorTask : public AbstractTask {
    */
   static std::shared_ptr<OperatorTask> _add_tasks_from_operator(
       const std::shared_ptr<AbstractOperator>& op, std::vector<std::shared_ptr<OperatorTask>>& tasks,
-      std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>>& task_by_op,
-      CleanupTemporaries cleanup_temporaries);
+      std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>>& task_by_op);
 
  private:
   std::shared_ptr<AbstractOperator> _op;
-  CleanupTemporaries _cleanup_temporaries;
 };
 }  // namespace opossum

--- a/src/lib/server/query_handler.cpp
+++ b/src/lib/server/query_handler.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<AbstractOperator> QueryHandler::bind_prepared_plan(const Prepare
 
 std::shared_ptr<const Table> QueryHandler::execute_prepared_plan(
     const std::shared_ptr<AbstractOperator>& physical_plan) {
-  const auto tasks = OperatorTask::make_tasks_from_operator(physical_plan, CleanupTemporaries::Yes);
+  const auto tasks = OperatorTask::make_tasks_from_operator(physical_plan);
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
   return tasks.back()->get_operator()->get_output();
 }

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -17,8 +17,7 @@ namespace opossum {
 SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<TransactionContext>& transaction_context,
                          const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
                          const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
-                         const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache,
-                         const CleanupTemporaries cleanup_temporaries)
+                         const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache)
     : pqp_cache(init_pqp_cache),
       lqp_cache(init_lqp_cache),
       _sql(sql),
@@ -82,7 +81,7 @@ SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Transacti
 
     auto pipeline_statement = std::make_shared<SQLPipelineStatement>(statement_string, std::move(parsed_statement),
                                                                      use_mvcc, transaction_context, optimizer,
-                                                                     pqp_cache, lqp_cache, cleanup_temporaries);
+                                                                     pqp_cache, lqp_cache);
     _sql_pipeline_statements.push_back(std::move(pipeline_statement));
   }
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -36,7 +36,7 @@ class SQLPipeline : public Noncopyable {
   SQLPipeline(const std::string& sql, const std::shared_ptr<TransactionContext>& transaction_context,
               const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
               const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
-              const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache, const CleanupTemporaries cleanup_temporaries);
+              const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache);
 
   // Returns the original SQL string
   const std::string& get_sql() const;

--- a/src/lib/sql/sql_pipeline_builder.cpp
+++ b/src/lib/sql/sql_pipeline_builder.cpp
@@ -37,16 +37,11 @@ SQLPipelineBuilder& SQLPipelineBuilder::with_lqp_cache(const std::shared_ptr<SQL
 
 SQLPipelineBuilder& SQLPipelineBuilder::disable_mvcc() { return with_mvcc(UseMvcc::No); }
 
-SQLPipelineBuilder& SQLPipelineBuilder::dont_cleanup_temporaries() {
-  _cleanup_temporaries = CleanupTemporaries::No;
-  return *this;
-}
-
 SQLPipeline SQLPipelineBuilder::create_pipeline() const {
   DTRACE_PROBE1(HYRISE, CREATE_PIPELINE, reinterpret_cast<uintptr_t>(this));
   auto optimizer = _optimizer ? _optimizer : Optimizer::create_default_optimizer();
   auto pipeline =
-      SQLPipeline(_sql, _transaction_context, _use_mvcc, optimizer, _pqp_cache, _lqp_cache, _cleanup_temporaries);
+      SQLPipeline(_sql, _transaction_context, _use_mvcc, optimizer, _pqp_cache, _lqp_cache);
   DTRACE_PROBE3(HYRISE, PIPELINE_CREATION_DONE, pipeline.get_sql_per_statement().size(), _sql.c_str(),
                 reinterpret_cast<uintptr_t>(this));
   return pipeline;
@@ -57,7 +52,7 @@ SQLPipelineStatement SQLPipelineBuilder::create_pipeline_statement(
   auto optimizer = _optimizer ? _optimizer : Optimizer::create_default_optimizer();
 
   return {_sql,       std::move(parsed_sql), _use_mvcc, _transaction_context, optimizer, _pqp_cache,
-          _lqp_cache, _cleanup_temporaries};
+          _lqp_cache};
 }
 
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline_builder.hpp
+++ b/src/lib/sql/sql_pipeline_builder.hpp
@@ -48,11 +48,6 @@ class SQLPipelineBuilder final {
    */
   SQLPipelineBuilder& disable_mvcc();
 
-  /*
-   * Keep temporary tables in the middle of the query plan for visualization and debugging
-   */
-  SQLPipelineBuilder& dont_cleanup_temporaries();
-
   SQLPipeline create_pipeline() const;
 
   /**
@@ -69,7 +64,6 @@ class SQLPipelineBuilder final {
   std::shared_ptr<Optimizer> _optimizer;
   std::shared_ptr<SQLPhysicalPlanCache> _pqp_cache;
   std::shared_ptr<SQLLogicalPlanCache> _lqp_cache;
-  CleanupTemporaries _cleanup_temporaries{true};
 };
 
 }  // namespace opossum

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -32,8 +32,7 @@ SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, std::shared_p
                                            const std::shared_ptr<TransactionContext>& transaction_context,
                                            const std::shared_ptr<Optimizer>& optimizer,
                                            const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
-                                           const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache,
-                                           const CleanupTemporaries cleanup_temporaries)
+                                           const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache)
     : pqp_cache(init_pqp_cache),
       lqp_cache(init_lqp_cache),
       _sql_string(sql),
@@ -42,8 +41,7 @@ SQLPipelineStatement::SQLPipelineStatement(const std::string& sql, std::shared_p
       _transaction_context(transaction_context),
       _optimizer(optimizer),
       _parsed_sql_statement(std::move(parsed_sql)),
-      _metrics(std::make_shared<SQLPipelineStatementMetrics>()),
-      _cleanup_temporaries(cleanup_temporaries) {
+      _metrics(std::make_shared<SQLPipelineStatementMetrics>()) {
   Assert(!_parsed_sql_statement || _parsed_sql_statement->size() == 1,
          "SQLPipelineStatement must hold exactly one SQL statement");
   DebugAssert(!_sql_string.empty(), "An SQLPipelineStatement should always contain a SQL statement string for caching");
@@ -197,7 +195,7 @@ const std::vector<std::shared_ptr<OperatorTask>>& SQLPipelineStatement::get_task
     return _tasks;
   }
 
-  _tasks = OperatorTask::make_tasks_from_operator(get_physical_plan(), _cleanup_temporaries);
+  _tasks = OperatorTask::make_tasks_from_operator(get_physical_plan());
   return _tasks;
 }
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -52,8 +52,7 @@ class SQLPipelineStatement : public Noncopyable {
                        const UseMvcc use_mvcc, const std::shared_ptr<TransactionContext>& transaction_context,
                        const std::shared_ptr<Optimizer>& optimizer,
                        const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
-                       const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache,
-                       const CleanupTemporaries cleanup_temporaries);
+                       const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache);
 
   // Returns the raw SQL string.
   const std::string& get_sql_string();
@@ -122,9 +121,6 @@ class SQLPipelineStatement : public Noncopyable {
   TranslationInfo _translation_info;
 
   std::shared_ptr<SQLPipelineStatementMetrics> _metrics;
-
-  // Delete temporary tables
-  const CleanupTemporaries _cleanup_temporaries;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -164,7 +164,7 @@ uint64_t Table::row_count() const {
 
   if (_type == TableType::References) {
     // After being created, reference tables should never be changed again.
-    DebugAssert(row_count == *_cached_row_count, "Size of reference table has changed");
+    DebugAssert(!_cached_row_count || row_count == *_cached_row_count, "Size of reference table has changed");
     _cached_row_count = row_count;
   }
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -165,6 +165,9 @@ uint64_t Table::row_count() const {
   if (_type == TableType::References) {
     // After being created, reference tables should never be changed again.
     DebugAssert(!_cached_row_count || row_count == *_cached_row_count, "Size of reference table has changed");
+
+    // row_count() is called by AbstractOperator after the operator has finished to fill the performance data. As such,
+    // no synchronization is necessary.
     _cached_row_count = row_count;
   }
 

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -151,13 +151,24 @@ void Table::append_mutable_chunk() {
 }
 
 uint64_t Table::row_count() const {
-  uint64_t ret = 0;
+  if (_type == TableType::References && _cached_row_count && !HYRISE_DEBUG) {
+    return *_cached_row_count;
+  }
+
+  uint64_t row_count = 0;
   const auto chunk_count = _chunks.size();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk = get_chunk(chunk_id);
-    if (chunk) ret += chunk->size();
+    if (chunk) row_count += chunk->size();
   }
-  return ret;
+
+  if (_type == TableType::References) {
+    // After being created, reference tables should never be changed again.
+    DebugAssert(row_count == *_cached_row_count, "Size of reference table has changed");
+    _cached_row_count = row_count;
+  }
+
+  return row_count;
 }
 
 bool Table::empty() const { return row_count() == 0u; }

--- a/src/lib/storage/table.hpp
+++ b/src/lib/storage/table.hpp
@@ -227,5 +227,9 @@ class Table : private Noncopyable {
   std::shared_ptr<TableStatistics> _table_statistics;
   std::unique_ptr<std::mutex> _append_mutex;
   std::vector<IndexStatistics> _indexes;
+
+  // For tables with _type==Reference, the row count will not vary. As such, there is no need to iterate over all
+  // chunks more than once.
+  mutable std::optional<uint64_t> _cached_row_count;
 };
 }  // namespace opossum

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -216,8 +216,6 @@ enum class DescriptionMode { SingleLine, MultiLine };
 
 enum class UseMvcc : bool { Yes = true, No = false };
 
-enum class CleanupTemporaries : bool { Yes = true, No = false };
-
 enum class MemoryUsageCalculationMode { Sampled, Full };
 
 enum class EraseReferencedSegmentType : bool { Yes = true, No = false };

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -126,16 +126,18 @@ class AbstractVisualizer {
       for (auto iter = iter_pair.first; iter != iter_pair.second; ++iter) {
         max_unnormalized_width = std::max(max_unnormalized_width, std::log(_graph[*iter].pen_width) / log_base);
       }
-      if (max_unnormalized_width == 0.0) {
-        // All widths are the same, don't do anything
-        return;
-      }
 
       double offset = max_unnormalized_width - (max_normalized_width - 1.0);
 
       for (auto iter = iter_pair.first; iter != iter_pair.second; ++iter) {
         auto& pen_width = _graph[*iter].pen_width;
-        pen_width = 1.0 + std::max(0.0, std::log(pen_width) / log_base - offset);
+        if (max_unnormalized_width == 0.0) {
+          // All widths are the same, set pen width to 1
+          pen_width = 1.0;
+        } else {
+          // Set normalized pen width
+          pen_width = 1.0 + std::max(0.0, std::log(pen_width) / log_base - offset);
+        }
       }
 #pragma GCC diagnostic pop
     };

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -164,6 +164,8 @@ void PQPVisualizer::_add_operator(const std::shared_ptr<const AbstractOperator>&
     auto total = performance_data.walltime;
     label += "\n\n" + format_duration(total);
     info.pen_width = total.count();
+  } else {
+    info.pen_width = 1;
   }
 
   _duration_by_operator_name[op->name()] += performance_data.walltime;

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -140,7 +140,7 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
   VizEdgeInfo info = _default_edge;
 
   const auto& performance_data = from->performance_data();
-  if (performance_data.executed) {
+  if (performance_data.executed && performance_data.has_output) {
     std::stringstream stream;
     stream << std::to_string(performance_data.output_row_count) + " row(s)/";
     stream << std::to_string(performance_data.output_chunk_count) + " chunk(s)";

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -139,19 +139,17 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
                                     const std::shared_ptr<const AbstractOperator>& to, const InputSide side) {
   VizEdgeInfo info = _default_edge;
 
-  if (const auto& output = from->get_output()) {
+  const auto& performance_data = from->performance_data();
+  if (performance_data.executed) {
     std::stringstream stream;
-
-    stream << std::to_string(output->row_count()) + " row(s)/";
-    stream << std::to_string(output->chunk_count()) + " chunk(s)/";
-    stream << format_bytes(output->memory_usage(MemoryUsageCalculationMode::Sampled));
-
+    stream << std::to_string(performance_data.output_row_count) + " row(s)/";
+    stream << std::to_string(performance_data.output_chunk_count) + " chunk(s)";
     info.label = stream.str();
+  }
 
-    info.pen_width = output->row_count();
-    if (to->input_right() != nullptr) {
-      info.arrowhead = side == InputSide::Left ? "lnormal" : "rnormal";
-    }
+  info.pen_width = performance_data.output_row_count;
+  if (to->input_right() != nullptr) {
+    info.arrowhead = side == InputSide::Left ? "lnormal" : "rnormal";
   }
 
   _add_edge(from, to, info);
@@ -161,13 +159,14 @@ void PQPVisualizer::_add_operator(const std::shared_ptr<const AbstractOperator>&
   VizVertexInfo info = _default_vertex;
   auto label = op->description(DescriptionMode::MultiLine);
 
-  if (op->get_output()) {
-    auto total = op->performance_data().walltime;
+  const auto& performance_data = op->performance_data();
+  if (performance_data.executed) {
+    auto total = performance_data.walltime;
     label += "\n\n" + format_duration(total);
     info.pen_width = total.count();
   }
 
-  _duration_by_operator_name[op->name()] += op->performance_data().walltime;
+  _duration_by_operator_name[op->name()] += performance_data.walltime;
 
   info.label = label;
   _add_vertex(op, info);

--- a/src/test/operators/delete_test.cpp
+++ b/src/test/operators/delete_test.cpp
@@ -114,6 +114,20 @@ TEST_F(OperatorsDeleteTest, DetectDirtyWrite) {
   EXPECT_FALSE(delete_op1->execute_failed());
   EXPECT_TRUE(delete_op2->execute_failed());
 
+  // Sneaking in a test for the OperatorPerformanceData here, which doesn't really make sense to be tested without an
+  // operator:
+  {
+    const auto& performance_data_1 = delete_op1->performance_data();
+    EXPECT_TRUE(performance_data_1.executed);
+    EXPECT_GT(performance_data_1.walltime.count(), 0);
+    EXPECT_FALSE(performance_data_1.has_output);
+
+    const auto& performance_data_2 = delete_op2->performance_data();
+    EXPECT_TRUE(performance_data_2.executed);
+    EXPECT_GT(performance_data_2.walltime.count(), 0);
+    EXPECT_FALSE(performance_data_2.has_output);
+  }
+
   // MVCC commit.
   t1_context->commit();
   t2_context->rollback();

--- a/src/test/operators/operator_deep_copy_test.cpp
+++ b/src/test/operators/operator_deep_copy_test.cpp
@@ -202,7 +202,7 @@ TEST_F(OperatorDeepCopyTest, Subquery) {
   SQLPipelineBuilder{"INSERT INTO table_3int VALUES (11, 11, 11)"}.create_pipeline_statement().get_result_table();
 
   const auto copied_plan = sql_pipeline.get_physical_plan()->deep_copy();
-  const auto tasks = OperatorTask::make_tasks_from_operator(copied_plan, CleanupTemporaries::Yes);
+  const auto tasks = OperatorTask::make_tasks_from_operator(copied_plan);
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
 
   const auto copied_result = tasks.back()->get_operator()->get_output();

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -277,14 +277,33 @@ TEST_P(OperatorsTableScanTest, DoubleScan) {
   scan_2->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(scan_2->get_output(), expected_result);
+
+  // Sneaking in a test for the OperatorPerformanceData here, which doesn't really make sense to be tested without an
+  // operator:
+  const auto& performance_data = scan_2->performance_data();
+  EXPECT_TRUE(performance_data.executed);
+  EXPECT_GT(performance_data.walltime.count(), 0);
+  EXPECT_TRUE(performance_data.has_output);
+  EXPECT_EQ(performance_data.output_row_count, 1);
+  EXPECT_EQ(performance_data.output_chunk_count, 1);
 }
 
 TEST_P(OperatorsTableScanTest, EmptyResultScan) {
   auto scan_1 = create_table_scan(get_int_float_op(), ColumnID{0}, PredicateCondition::GreaterThan, 90000);
   scan_1->execute();
 
-  for (auto i = ChunkID{0}; i < scan_1->get_output()->chunk_count(); i++)
+  for (auto i = ChunkID{0}; i < scan_1->get_output()->chunk_count(); i++) {
     EXPECT_EQ(scan_1->get_output()->get_chunk(i)->column_count(), 2u);
+  }
+
+  // Sneaking in a test for the OperatorPerformanceData here, which doesn't really make sense to be tested without an
+  // operator:
+  const auto& performance_data = scan_1->performance_data();
+  EXPECT_TRUE(performance_data.executed);
+  EXPECT_GT(performance_data.walltime.count(), 0);
+  EXPECT_TRUE(performance_data.has_output);
+  EXPECT_EQ(performance_data.output_row_count, 0);
+  EXPECT_EQ(performance_data.output_chunk_count, 0);
 }
 
 TEST_P(OperatorsTableScanTest, SingleScan) {

--- a/src/test/scheduler/scheduler_test.cpp
+++ b/src/test/scheduler/scheduler_test.cpp
@@ -199,8 +199,8 @@ TEST_F(SchedulerTest, MultipleOperators) {
   auto a = PQPColumnExpression::from_table(*test_table, ColumnID{0});
   auto ts = std::make_shared<TableScan>(gt, greater_than_equals_(a, 1234));
 
-  auto gt_task = std::make_shared<OperatorTask>(gt, CleanupTemporaries::Yes);
-  auto ts_task = std::make_shared<OperatorTask>(ts, CleanupTemporaries::Yes);
+  auto gt_task = std::make_shared<OperatorTask>(gt);
+  auto ts_task = std::make_shared<OperatorTask>(ts);
   gt_task->set_as_predecessor_of(ts_task);
 
   gt_task->schedule();

--- a/src/test/sql/sql_pipeline_test.cpp
+++ b/src/test/sql/sql_pipeline_test.cpp
@@ -400,19 +400,6 @@ TEST_F(SQLPipelineTest, CleanupWithScheduler) {
   }
 }
 
-TEST_F(SQLPipelineTest, DisabledCleanupWithScheduler) {
-  auto sql_pipeline = SQLPipelineBuilder{_join_query}.dont_cleanup_temporaries().create_pipeline();
-
-  Hyrise::get().topology.use_fake_numa_topology(8, 4);
-  Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
-  sql_pipeline.get_result_table();
-
-  for (auto task_it = sql_pipeline.get_tasks()[0].cbegin(); task_it != sql_pipeline.get_tasks()[0].cend() - 1;
-       ++task_it) {
-    EXPECT_NE(std::dynamic_pointer_cast<OperatorTask>(*task_it)->get_operator()->get_output(), nullptr);
-  }
-}
-
 TEST_F(SQLPipelineTest, GetResultTableBadQuery) {
   auto sql = "SELECT a + not_a_column FROM table_a";
   auto sql_pipeline = SQLPipelineBuilder{sql}.create_pipeline();

--- a/src/test/tasks/operator_task_test.cpp
+++ b/src/test/tasks/operator_task_test.cpp
@@ -33,7 +33,7 @@ class OperatorTaskTest : public BaseTest {
 
 TEST_F(OperatorTaskTest, BasicTasksFromOperatorTest) {
   auto gt = std::make_shared<GetTable>("table_a");
-  auto tasks = OperatorTask::make_tasks_from_operator(gt, CleanupTemporaries::Yes);
+  auto tasks = OperatorTask::make_tasks_from_operator(gt);
 
   auto result_task = tasks.back();
   result_task->schedule();
@@ -46,7 +46,7 @@ TEST_F(OperatorTaskTest, SingleDependencyTasksFromOperatorTest) {
   auto a = PQPColumnExpression::from_table(*_test_table_a, "a");
   auto ts = std::make_shared<TableScan>(gt, equals_(a, 1234));
 
-  auto tasks = OperatorTask::make_tasks_from_operator(ts, CleanupTemporaries::Yes);
+  auto tasks = OperatorTask::make_tasks_from_operator(ts);
   for (auto& task : tasks) {
     task->schedule();
     // We don't have to wait here, because we are running the task tests without a scheduler
@@ -66,7 +66,7 @@ TEST_F(OperatorTaskTest, DoubleDependencyTasksFromOperatorTest) {
       gt_a, gt_b, JoinMode::Inner,
       OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
 
-  auto tasks = OperatorTask::make_tasks_from_operator(join, CleanupTemporaries::Yes);
+  auto tasks = OperatorTask::make_tasks_from_operator(join);
   for (auto& task : tasks) {
     task->schedule();
     // We don't have to wait here, because we are running the task tests without a scheduler
@@ -89,7 +89,7 @@ TEST_F(OperatorTaskTest, MakeDiamondShape) {
   auto scan_c = std::make_shared<TableScan>(scan_a, greater_than_(b, 2000));
   auto union_positions = std::make_shared<UnionPositions>(scan_b, scan_c);
 
-  auto tasks = OperatorTask::make_tasks_from_operator(union_positions, CleanupTemporaries::Yes);
+  auto tasks = OperatorTask::make_tasks_from_operator(union_positions);
 
   ASSERT_EQ(tasks.size(), 5u);
   EXPECT_EQ(tasks[0]->get_operator(), gt_a);


### PR DESCRIPTION
* For each operator, this stores the resulting chunk and row count in OperatorPerformanceData
* As a result, we don't need the result table anymore to visualize the plan (fixes #1646)
* As a result of that, we don't need CleanupTemporaries anymore.
* To reduce the impact of having to calculate the row_count, we now cache the row count for reference tables.

```diff
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | Benchmark      | prev. iter/s       | runs  | new iter/s         | runs  | change [%] | p-value |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | TPC-H 01       | 1.2954007387161255 | 78    | 1.2995855808258057 | 78    | +0%        |  0.4136 |
+| TPC-H 02       | 79.22210693359375  | 4754  | 84.02629089355469  | 5042  | +6%        |  0.0000 |
 | TPC-H 03       | 8.796109199523926  | 528   | 9.104130744934082  | 547   | +4%        |  0.0000 |
 | TPC-H 04       | 7.861326694488525  | 472   | 8.128789901733398  | 488   | +3%        |  0.0000 |
 | TPC-H 05       | 4.098977565765381  | 246   | 4.150041103363037  | 250   | +1%        |  0.0360 |
 | TPC-H 06       | 262.84381103515625 | 15771 | 270.1571044921875  | 16210 | +3%        |  0.0000 |
 | TPC-H 07       | 9.691267967224121  | 582   | 9.99113655090332   | 600   | +3%        |  0.0000 |
 | TPC-H 08       | 7.426480293273926  | 446   | 7.6607770919799805 | 460   | +3%        |  0.0000 |
 | TPC-H 09       | 1.749589204788208  | 105   | 1.7984514236450195 | 108   | +3%        |  0.0000 |
 | TPC-H 10       | 3.3428919315338135 | 201   | 3.394002914428711  | 204   | +2%        |  0.1044 |
+| TPC-H 11       | 37.64109420776367  | 2259  | 39.703086853027344 | 2383  | +5%        |  0.0000 |
 | TPC-H 12       | 14.899829864501953 | 894   | 15.280900001525879 | 917   | +3%        |  0.0000 |
+| TPC-H 13       | 2.3008885383605957 | 139   | 2.657020330429077  | 160   | +15%       |  0.0000 |
 | TPC-H 14       | 43.536373138427734 | 2613  | 42.64398956298828  | 2559  | -2%        |  0.0000 |
 | TPC-H 15       | 118.18135833740234 | 7091  | 117.94392395019531 | 7077  | -0%        |  0.0031 |
 | TPC-H 16       | 9.004341125488281  | 541   | 9.330336570739746  | 560   | +4%        |  0.0000 |
 | TPC-H 17       | 5.367760181427002  | 323   | 5.577611923217773  | 335   | +4%        |  0.0000 |
 | TPC-H 18       | 1.2562159299850464 | 76    | 1.2815972566604614 | 77    | +2%        |  0.0019 |
 | TPC-H 19       | 9.865779876708984  | 592   | 10.181819915771484 | 612   | +3%        |  0.0000 |
+| TPC-H 20       | 31.38033676147461  | 1883  | 33.14265060424805  | 1989  | +6%        |  0.0000 |
 | TPC-H 21       | 1.3725528717041016 | 83    | 1.4100109338760376 | 85    | +3%        |  0.0000 |
 | TPC-H 22       | 18.62116813659668  | 1118  | 18.42943572998047  | 1106  | -1%        |  0.0000 |
 | geometric mean |                    |       |                    |       | +3%        |         |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
```

Not sure if the changes, e.g., in Q13 are really caused by this. At least we don't break anything.