### PR TITLE
Reduce compile time impact of static PosList polymorphism

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -322,11 +322,13 @@ try {
     }
   }
 
-  stage("Notify") {
-    script {
-      githubNotify context: 'CI Pipeline', status: 'SUCCESS'
-      if (env.BRANCH_NAME == 'master' || full_ci) {
-        githubNotify context: 'Full CI', status: 'SUCCESS'
+  node {
+    stage("Notify") {
+      script {
+        githubNotify context: 'CI Pipeline', status: 'SUCCESS'
+        if (env.BRANCH_NAME == 'master' || full_ci) {
+          githubNotify context: 'Full CI', status: 'SUCCESS'
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,41 +4,39 @@ full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TpcdsTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
 try {
-  node('master') {
-    stage ("Start") {
-      // Check if the user who opened the PR is a known collaborator (i.e., has been added to a hyrise/hyrise team)
-      if (env.CHANGE_ID) {
-        try {
-          withCredentials([usernamePassword(credentialsId: '5fe8ede9-bbdb-4803-a307-6924d4b4d9b5', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN')]) {
-            env.PR_CREATED_BY = pullRequest.createdBy
-            sh '''
-              curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY} | head -n 1 | grep "HTTP/1.1 204 No Content"
-            '''
-          }
-        } catch (error) {
-          stage ("User unknown") {
-            script {
-              githubNotify context: 'CI Pipeline', status: 'FAILURE', description: 'User is not a collaborator'
-            }
-          }
-          throw error
+  stage ("Start") {
+    // Check if the user who opened the PR is a known collaborator (i.e., has been added to a hyrise/hyrise team)
+    if (env.CHANGE_ID) {
+      try {
+        withCredentials([usernamePassword(credentialsId: '5fe8ede9-bbdb-4803-a307-6924d4b4d9b5', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN')]) {
+          env.PR_CREATED_BY = pullRequest.createdBy
+          sh '''
+            curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY} | head -n 1 | grep "HTTP/1.1 204 No Content"
+          '''
         }
-      }
-
-      script {
-        githubNotify context: 'CI Pipeline', status: 'PENDING'
-
-        // Cancel previous builds
-        if (env.BRANCH_NAME != 'master') {
-          def jobname = env.JOB_NAME
-          def buildnum = env.BUILD_NUMBER.toInteger()
-          def job = Jenkins.instance.getItemByFullName(jobname)
-          for (build in job.builds) {
-            if (!build.isBuilding()) { continue; }
-            if (buildnum == build.getNumber().toInteger()) { continue; }
-            echo "Cancelling previous build " + build.getNumber().toString()
-            build.doStop();
+      } catch (error) {
+        stage ("User unknown") {
+          script {
+            githubNotify context: 'CI Pipeline', status: 'FAILURE', description: 'User is not a collaborator'
           }
+        }
+        throw error
+      }
+    }
+
+    script {
+      githubNotify context: 'CI Pipeline', status: 'PENDING'
+
+      // Cancel previous builds
+      if (env.BRANCH_NAME != 'master') {
+        def jobname = env.JOB_NAME
+        def buildnum = env.BUILD_NUMBER.toInteger()
+        def job = Jenkins.instance.getItemByFullName(jobname)
+        for (build in job.builds) {
+          if (!build.isBuilding()) { continue; }
+          if (buildnum == build.getNumber().toInteger()) { continue; }
+          echo "Cancelling previous build " + build.getNumber().toString()
+          build.doStop();
         }
       }
     }

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -140,7 +140,9 @@ void AggregateHash::_aggregate_segment(ChunkID chunk_id, ColumnID column_index, 
 
   ChunkOffset chunk_offset{0};
 
-  segment_iterate<ColumnDataType>(base_segment, [&](const auto& position) {
+  // Looking up the result in the hash map is way more expensive than dereferencing the iterator. To reduce the compile
+  // time, we erase the iterators here.
+  segment_iterate<ColumnDataType, EraseTypes::Always>(base_segment, [&](const auto& position) {
     auto& result =
         get_or_add_result(result_ids, results, get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
                           RowID{chunk_id, chunk_offset});
@@ -287,16 +289,17 @@ void AggregateHash::_aggregate() {
               const auto chunk_in = input_table->get_chunk(chunk_id);
               const auto base_segment = chunk_in->get_segment(groupby_column_id);
               ChunkOffset chunk_offset{0};
-              segment_iterate<ColumnDataType>(*base_segment, [&](const auto& position) {
-                const auto int_to_uint = [](const int32_t value) {
-                  // We need to convert a potentially negative int32_t value into the uint64_t space. We do not care
-                  // about preserving the value, just its uniqueness. Subtract the minimum value in int32_t (which is
-                  // negative itself) to get a positive number.
-                  const auto shifted_value = static_cast<int64_t>(value) - std::numeric_limits<int32_t>::min();
-                  DebugAssert(shifted_value >= 0, "Type conversion failed");
-                  return static_cast<uint64_t>(shifted_value);
-                };
 
+              const auto int_to_uint = [](const int32_t value) {
+                // We need to convert a potentially negative int32_t value into the uint64_t space. We do not care
+                // about preserving the value, just its uniqueness. Subtract the minimum value in int32_t (which is
+                // negative itself) to get a positive number.
+                const auto shifted_value = static_cast<int64_t>(value) - std::numeric_limits<int32_t>::min();
+                DebugAssert(shifted_value >= 0, "Type conversion failed");
+                return static_cast<uint64_t>(shifted_value);
+              };
+
+              segment_iterate<ColumnDataType>(*base_segment, [&](const auto& position) {
                 if constexpr (std::is_same_v<AggregateKey, AggregateKeyEntry>) {
                   if (position.is_null()) {
                     keys_per_chunk[chunk_id][chunk_offset] = 0;

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -645,7 +645,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
   if (_aggregates.empty()) {
     auto context = std::static_pointer_cast<AggregateResultContext<DistinctColumnType, DistinctAggregateType>>(
         _contexts_per_column[0]);
-    auto pos_list = PosList();
+    auto pos_list = RowIDPosList();
     pos_list.reserve(context->results.size());
     for (const auto& result : context->results) {
       pos_list.push_back(result.row_id);
@@ -809,7 +809,7 @@ write_aggregate_values(std::shared_ptr<ValueSegment<AggregateType>> segment,
   Fail("Invalid aggregate");
 }
 
-void AggregateHash::_write_groupby_output(PosList& pos_list) {
+void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
   auto input_table = input_table_left();
 
   // For each GROUP BY column, resolve its type, iterate over its values, and add them to a new output ValueSegment
@@ -907,7 +907,7 @@ void AggregateHash::write_aggregate_output(ColumnID column_index) {
 
   // Before writing the first aggregate column, write all group keys into the respective columns
   if (column_index == 0) {
-    auto pos_list = PosList(context->results.size());
+    auto pos_list = RowIDPosList(context->results.size());
     auto chunk_offset = ChunkOffset{0};
     for (auto& result : context->results) {
       pos_list[chunk_offset] = (result.row_id);

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -140,9 +140,7 @@ void AggregateHash::_aggregate_segment(ChunkID chunk_id, ColumnID column_index, 
 
   ChunkOffset chunk_offset{0};
 
-  // Looking up the result in the hash map is way more expensive than dereferencing the iterator. To reduce the compile
-  // time, we erase the iterators here.
-  segment_iterate<ColumnDataType, EraseTypes::Always>(base_segment, [&](const auto& position) {
+  segment_iterate<ColumnDataType>(base_segment, [&](const auto& position) {
     auto& result =
         get_or_add_result(result_ids, results, get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
                           RowID{chunk_id, chunk_offset});

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -50,7 +50,8 @@ class AbstractTableScanImpl {
     // For a description of the SIMD code, have a look at the comments in that method.
     // To reduce compile time, SIMD scanning is not used for for ColumnVsColumnScans. Also, string comparisons are more
     // expensive than the scan itself, so we disable SIMD for these, too.
-    if constexpr (std::is_same_v<RightIterator, std::false_type> && !std::is_same_v<std::decay_t<decltype(left_it->value())>, pmr_string>) {
+    if constexpr (std::is_same_v<RightIterator, std::false_type> &&
+                  !std::is_same_v<std::decay_t<decltype(left_it->value())>, pmr_string>) {
       _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
     }
 

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -48,9 +48,13 @@ class AbstractTableScanImpl {
                        const ChunkID chunk_id, RowIDPosList& matches_out, [[maybe_unused]] RightIterator right_it) {
     // The major part of the table is scanned using SIMD. Only the remainder is handled in this method.
     // For a description of the SIMD code, have a look at the comments in that method.
-    _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
+    // To reduce compile time, SIMD scanning is not used for for ColumnVsColumnScans. Also, string comparisons are more
+    // expensive than the scan itself, so we disable SIMD for these, too.
+    if constexpr (std::is_same_v<RightIterator, std::false_type> && !std::is_same_v<std::decay_t<decltype(left_it->value())>, pmr_string>) {
+      _simd_scan_with_iterators<CheckForNull>(func, left_it, left_end, chunk_id, matches_out, right_it);
+    }
 
-    // Do the remainder the easy way. If we did not use the optimization above, left_it was not yet touched, so we
+    // Do the remainder the easy way. If we did not use the SIMD optimization above, left_it was not yet touched, so we
     // iterate over the entire input data.
     for (; left_it != left_end; ++left_it) {
       const auto left = *left_it;

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -98,18 +98,23 @@ std::shared_ptr<RowIDPosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID ch
    * SLOW PATH
    * ...in which the left and right segment iterables are erased into AnySegmentIterables<T>
    */
-  resolve_data_type(left_segment->data_type(), [&](const auto left_data_type_t) {
-    using LeftColumnDataType = typename decltype(left_data_type_t)::type;
+  resolve_data_type(left_segment->data_type(), [&](const auto left_data_type) {
+    using LeftColumnDataType = typename decltype(left_data_type)::type;
 
     auto left_iterable = create_any_segment_iterable<LeftColumnDataType>(*left_segment);
 
     resolve_data_type(right_segment->data_type(), [&](const auto right_data_type_t) {
       using RightColumnDataType = typename decltype(right_data_type_t)::type;
 
-      auto right_iterable = create_any_segment_iterable<RightColumnDataType>(*right_segment);
+      // C++ cannot compare strings and non-strings out of the box:
+      if constexpr (std::is_same_v<LeftColumnDataType, pmr_string> == std::is_same_v<RightColumnDataType, pmr_string>) {
+        auto right_iterable = create_any_segment_iterable<RightColumnDataType>(*right_segment);
 
-      PerformanceWarning("ColumnVsColumnTableScan using type-erased iterators");
-      result = _typed_scan_chunk_with_iterables<EraseTypes::Always>(chunk_id, left_iterable, right_iterable);
+        PerformanceWarning("ColumnVsColumnTableScan using type-erased iterators");
+        result = _typed_scan_chunk_with_iterables<EraseTypes::Always>(chunk_id, left_iterable, right_iterable);
+      } else {
+        Fail("Trying to compare strings and non-strings");
+      }
     });
   });
 
@@ -137,50 +142,40 @@ std::shared_ptr<RowIDPosList> __attribute__((noinline))
 ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterators(ChunkID chunk_id, LeftIterator& left_it,
                                                               const LeftIterator& left_end, RightIterator& right_it,
                                                               const RightIterator& right_end) const {
-  const auto chunk = _in_table->get_chunk(chunk_id);
-
   auto matches_out = std::make_shared<RowIDPosList>();
 
-  using LeftType = typename LeftIterator::ValueType;
-  using RightType = typename RightIterator::ValueType;
+  bool condition_was_flipped = false;
+  auto maybe_flipped_condition = _predicate_condition;
+  if (maybe_flipped_condition == PredicateCondition::GreaterThan ||
+      maybe_flipped_condition == PredicateCondition::GreaterThanEquals) {
+    maybe_flipped_condition = flip_predicate_condition(maybe_flipped_condition);
+    condition_was_flipped = true;
+  }
 
-  // C++ cannot compare strings and non-strings out of the box:
-  if constexpr (std::is_same_v<LeftType, pmr_string> == std::is_same_v<RightType, pmr_string>) {
-    bool condition_was_flipped = false;
-    auto maybe_flipped_condition = _predicate_condition;
-    if (maybe_flipped_condition == PredicateCondition::GreaterThan ||
-        maybe_flipped_condition == PredicateCondition::GreaterThanEquals) {
-      maybe_flipped_condition = flip_predicate_condition(maybe_flipped_condition);
-      condition_was_flipped = true;
+  auto conditionally_erase_comparator_type = [](auto comparator, const auto& it1, const auto& it2) {
+    if constexpr (erase_comparator_type == EraseTypes::OnlyInDebugBuild) {
+      return comparator;
+    } else {
+      return std::function<bool(const AbstractSegmentPosition<std::decay_t<decltype(it1->value())>>&,
+                                const AbstractSegmentPosition<std::decay_t<decltype(it2->value())>>&)>{comparator};
     }
+  };
 
-    auto conditionally_erase_comparator_type = [](auto comparator, const auto& it1, const auto& it2) {
-      if constexpr (erase_comparator_type == EraseTypes::OnlyInDebugBuild) {
-        return comparator;
-      } else {
-        return std::function<bool(const AbstractSegmentPosition<std::decay_t<decltype(it1->value())>>&,
-                                  const AbstractSegmentPosition<std::decay_t<decltype(it2->value())>>&)>{comparator};
-      }
+  with_comparator_light(maybe_flipped_condition, [&](auto predicate_comparator) {
+    const auto comparator = [predicate_comparator](const auto& left, const auto& right) {
+      return predicate_comparator(left.value(), right.value());
     };
 
-    with_comparator_light(maybe_flipped_condition, [&](auto predicate_comparator) {
-      const auto comparator = [predicate_comparator](const auto& left, const auto& right) {
-        return predicate_comparator(left.value(), right.value());
-      };
-
-      if (condition_was_flipped) {
-        const auto erased_comparator = conditionally_erase_comparator_type(comparator, right_it, left_it);
-        AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id,
-                                                          *matches_out, left_it);
-      } else {
-        const auto erased_comparator = conditionally_erase_comparator_type(comparator, left_it, right_it);
-        AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it, left_end, chunk_id, *matches_out,
-                                                          right_it);
-      }
-    });
-  } else {
-    Fail("Trying to compare strings and non-strings");
-  }
+    if (condition_was_flipped) {
+      const auto erased_comparator = conditionally_erase_comparator_type(comparator, right_it, left_it);
+      AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id,
+                                                        *matches_out, left_it);
+    } else {
+      const auto erased_comparator = conditionally_erase_comparator_type(comparator, left_it, right_it);
+      AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it, left_end, chunk_id, *matches_out,
+                                                        right_it);
+    }
+  });
 
   return matches_out;
 }

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -168,8 +168,8 @@ ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterators(ChunkID chunk_id, 
 
     if (condition_was_flipped) {
       const auto erased_comparator = conditionally_erase_comparator_type(comparator, right_it, left_it);
-      AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id,
-                                                        *matches_out, left_it);
+      AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, right_it, right_end, chunk_id, *matches_out,
+                                                        left_it);
     } else {
       const auto erased_comparator = conditionally_erase_comparator_type(comparator, left_it, right_it);
       AbstractTableScanImpl::_scan_with_iterators<true>(erased_comparator, left_it, left_end, chunk_id, *matches_out,

--- a/src/lib/resolve_type.hpp
+++ b/src/lib/resolve_type.hpp
@@ -113,7 +113,7 @@ std::shared_ptr<Base> make_shared_by_data_type(DataType data_type, ConstructorAr
  * Resolves a data type by passing a hana::type object on to a generic lambda
  *
  * @param data_type is an enum value of any of the supported column types
- * @param func is a generic lambda or similar accepting a hana::type object
+ * @param functor is a generic lambda or similar accepting a hana::type object
  *
  *
  * Note on hana::type (taken from Boost.Hana documentation):
@@ -159,13 +159,13 @@ std::shared_ptr<Base> make_shared_by_data_type(DataType data_type, ConstructorAr
  *   });
  */
 template <typename Functor>
-void resolve_data_type(DataType data_type, const Functor& func) {
+void resolve_data_type(DataType data_type, const Functor& functor) {
   DebugAssert(data_type != DataType::Null, "data_type cannot be null.");
 
   hana::for_each(data_type_pairs, [&](auto x) {
     if (hana::first(x) == data_type) {
       // The + before hana::second - which returns a reference - converts its return value into a value
-      func(+hana::second(x));
+      functor(+hana::second(x));
       return;
     }
   });
@@ -174,7 +174,7 @@ void resolve_data_type(DataType data_type, const Functor& func) {
 /**
  * Given a BaseSegment and its known column type, resolve the segment implementation and call the lambda
  *
- * @param func is a generic lambda or similar accepting a reference to a specialized segment (value, dictionary,
+ * @param functor is a generic lambda or similar accepting a reference to a specialized segment (value, dictionary,
  * reference)
  *
  *
@@ -198,17 +198,17 @@ using ConstOutIfConstIn = std::conditional_t<std::is_const_v<In>, const Out, Out
 template <typename ColumnDataType, typename BaseSegmentType, typename Functor>
 // BaseSegmentType allows segment to be const and non-const
 std::enable_if_t<std::is_same_v<BaseSegment, std::remove_const_t<BaseSegmentType>>>
-/*void*/ resolve_segment_type(BaseSegmentType& segment, const Functor& func) {
+/*void*/ resolve_segment_type(BaseSegmentType& segment, const Functor& functor) {
   using ValueSegmentPtr = ConstOutIfConstIn<BaseSegmentType, ValueSegment<ColumnDataType>>*;
   using ReferenceSegmentPtr = ConstOutIfConstIn<BaseSegmentType, ReferenceSegment>*;
   using EncodedSegmentPtr = ConstOutIfConstIn<BaseSegmentType, BaseEncodedSegment>*;
 
   if (auto value_segment = dynamic_cast<ValueSegmentPtr>(&segment)) {
-    func(*value_segment);
+    functor(*value_segment);
   } else if (auto ref_segment = dynamic_cast<ReferenceSegmentPtr>(&segment)) {
-    func(*ref_segment);
+    functor(*ref_segment);
   } else if (auto encoded_segment = dynamic_cast<EncodedSegmentPtr>(&segment)) {
-    resolve_encoded_segment_type<ColumnDataType>(*encoded_segment, func);
+    resolve_encoded_segment_type<ColumnDataType>(*encoded_segment, functor);
   } else {
     Fail("Unrecognized column type encountered.");
   }
@@ -220,19 +220,17 @@ std::enable_if_t<std::is_same_v<BaseSegment, std::remove_const_t<BaseSegmentType
 enum class ErasePosListType { OnlyInDebugBuild, Always };
 
 template <ErasePosListType erase_pos_list_type = ErasePosListType::OnlyInDebugBuild, typename Functor>
-void resolve_pos_list_type(const std::shared_ptr<const AbstractPosList>& untyped_pos_list, const Functor& func) {
+void resolve_pos_list_type(const std::shared_ptr<const AbstractPosList>& untyped_pos_list, const Functor& functor) {
   if constexpr (HYRISE_DEBUG || erase_pos_list_type == ErasePosListType::Always) {
-    func(untyped_pos_list);
+    functor(untyped_pos_list);
   } else {
-    if (!untyped_pos_list) {
-      func(untyped_pos_list);
-      return;
-    }
-
-    if (auto rowid_pos_list = std::dynamic_pointer_cast<const RowIDPosList>(untyped_pos_list)) {
-      func(rowid_pos_list);
+    if (auto row_id_pos_list = std::dynamic_pointer_cast<const RowIDPosList>(untyped_pos_list); !untyped_pos_list || row_id_pos_list) {
+      // We also use this branch for nullptr instead of calling the functor with the untyped_pos_list. This way, we
+      // avoid an initialization of functor with AbstractPosList. The first thing the functor has to do is to check
+      // for nullptr anyway, and for that check it does not matter "which" nullptr we pass in.
+      functor(row_id_pos_list);
     } else if (auto entire_chunk_pos_list = std::dynamic_pointer_cast<const EntireChunkPosList>(untyped_pos_list)) {
-      func(entire_chunk_pos_list);
+      functor(entire_chunk_pos_list);
     } else {
       Fail("Unrecognized PosList type encountered");
     }
@@ -243,7 +241,7 @@ void resolve_pos_list_type(const std::shared_ptr<const AbstractPosList>& untyped
  * Resolves a data type by passing a hana::type object and the downcasted segment on to a generic lambda
  *
  * @param data_type is an enum value of any of the supported column types
- * @param func is a generic lambda or similar accepting two parameters: a hana::type object and
+ * @param functor is a generic lambda or similar accepting two parameters: a hana::type object and
  *   a reference to a specialized segment (value, dictionary, reference)
  *
  *
@@ -264,11 +262,11 @@ void resolve_pos_list_type(const std::shared_ptr<const AbstractPosList>& untyped
  */
 template <typename Functor, typename BaseSegmentType>  // BaseSegmentType allows segment to be const and non-const
 std::enable_if_t<std::is_same_v<BaseSegment, std::remove_const_t<BaseSegmentType>>>
-/*void*/ resolve_data_and_segment_type(BaseSegmentType& segment, const Functor& func) {
+/*void*/ resolve_data_and_segment_type(BaseSegmentType& segment, const Functor& functor) {
   resolve_data_type(segment.data_type(), [&](auto type) {
     using ColumnDataType = typename decltype(type)::type;
 
-    resolve_segment_type<ColumnDataType>(segment, [&](auto& typed_segment) { func(type, typed_segment); });
+    resolve_segment_type<ColumnDataType>(segment, [&](auto& typed_segment) { functor(type, typed_segment); });
   });
 }
 

--- a/src/lib/resolve_type.hpp
+++ b/src/lib/resolve_type.hpp
@@ -227,8 +227,8 @@ void resolve_pos_list_type(const std::shared_ptr<const AbstractPosList>& untyped
     if (auto row_id_pos_list = std::dynamic_pointer_cast<const RowIDPosList>(untyped_pos_list);
         !untyped_pos_list || row_id_pos_list) {
       // We also use this branch for nullptr instead of calling the functor with the untyped_pos_list. This way, we
-      // avoid initializing the functor with AbstractPosList. The first thing the functor has to do is to check for
-      // ullptr anyway, and for that check it does not matter "which" nullptr we pass in.
+      // avoid initializing the functor template with AbstractPosList. The first thing the functor has to do is to
+      // check for nullptr anyway, and for that check it does not matter "which" nullptr we pass in.
       functor(row_id_pos_list);
     } else if (auto entire_chunk_pos_list = std::dynamic_pointer_cast<const EntireChunkPosList>(untyped_pos_list)) {
       functor(entire_chunk_pos_list);

--- a/src/lib/resolve_type.hpp
+++ b/src/lib/resolve_type.hpp
@@ -216,7 +216,7 @@ std::enable_if_t<std::is_same_v<BaseSegment, std::remove_const_t<BaseSegmentType
 
 // Used as a template parameter that is passed whenever we conditionally erase the type of the position list. This is
 // done to reduce the compile time at the cost of the runtime performance. We do not re-use EraseTypes here, as it
-// might confuse readers who could think that erase all types within the functor.
+// might confuse readers who could think that the setting erases all types within the functor.
 enum class ErasePosListType { OnlyInDebugBuild, Always };
 
 template <ErasePosListType erase_pos_list_type = ErasePosListType::OnlyInDebugBuild, typename Functor>
@@ -224,10 +224,11 @@ void resolve_pos_list_type(const std::shared_ptr<const AbstractPosList>& untyped
   if constexpr (HYRISE_DEBUG || erase_pos_list_type == ErasePosListType::Always) {
     functor(untyped_pos_list);
   } else {
-    if (auto row_id_pos_list = std::dynamic_pointer_cast<const RowIDPosList>(untyped_pos_list); !untyped_pos_list || row_id_pos_list) {
+    if (auto row_id_pos_list = std::dynamic_pointer_cast<const RowIDPosList>(untyped_pos_list);
+        !untyped_pos_list || row_id_pos_list) {
       // We also use this branch for nullptr instead of calling the functor with the untyped_pos_list. This way, we
-      // avoid an initialization of functor with AbstractPosList. The first thing the functor has to do is to check
-      // for nullptr anyway, and for that check it does not matter "which" nullptr we pass in.
+      // avoid initializing the functor with AbstractPosList. The first thing the functor has to do is to check for
+      // ullptr anyway, and for that check it does not matter "which" nullptr we pass in.
       functor(row_id_pos_list);
     } else if (auto entire_chunk_pos_list = std::dynamic_pointer_cast<const EntireChunkPosList>(untyped_pos_list)) {
       functor(entire_chunk_pos_list);

--- a/src/lib/storage/pos_lists/entire_chunk_pos_list.cpp
+++ b/src/lib/storage/pos_lists/entire_chunk_pos_list.cpp
@@ -4,10 +4,7 @@ namespace opossum {
 
 bool EntireChunkPosList::references_single_chunk() const { return true; }
 
-ChunkID EntireChunkPosList::common_chunk_id() const {
-  DebugAssert(_common_chunk_id != INVALID_CHUNK_ID, "common_chunk_id called on invalid chunk id");
-  return _common_chunk_id;
-}
+ChunkID EntireChunkPosList::common_chunk_id() const { return _common_chunk_id; }
 
 bool EntireChunkPosList::empty() const { return size() == 0; }
 

--- a/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
+++ b/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
@@ -16,8 +16,6 @@ class EntireChunkPosList : public AbstractPosList {
     DebugAssert(_common_chunk_id != INVALID_CHUNK_ID, "Cannot create EntireChunkPosList for INVALID_CHUNK_ID");
   }
 
-  EntireChunkPosList& operator=(EntireChunkPosList&& other) = default;
-
   bool references_single_chunk() const final;
   ChunkID common_chunk_id() const final;
 

--- a/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
+++ b/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
@@ -12,14 +12,16 @@ class EntireChunkPosList : public AbstractPosList {
   // _before_ doing the checks that all elements should match. This way, you prevent the race
   // condition of an element being added in between doing the checks and getting the size.
   explicit EntireChunkPosList(const ChunkID common_chunk_id, const ChunkOffset common_chunk_size)
-      : _common_chunk_id(common_chunk_id), _common_chunk_size(common_chunk_size) {}
+      : _common_chunk_id(common_chunk_id), _common_chunk_size(common_chunk_size) {
+    DebugAssert(_common_chunk_id != INVALID_CHUNK_ID, "Cannot create EntireChunkPosList for INVALID_CHUNK_ID");
+  }
 
   EntireChunkPosList& operator=(EntireChunkPosList&& other) = default;
 
   bool references_single_chunk() const final;
   ChunkID common_chunk_id() const final;
 
-  // implemented here to assure compiler optimization without LTO (PosListIterator uses this a lot)
+  // Implemented in hpp for performance reasons (to allow inlining)
   RowID operator[](const size_t index) const final {
     DebugAssert(_common_chunk_id != INVALID_CHUNK_ID, "operator[] called on invalid chunk id");
     return RowID{_common_chunk_id, static_cast<ChunkOffset>(index)};
@@ -35,12 +37,12 @@ class EntireChunkPosList : public AbstractPosList {
   PosListIterator<EntireChunkPosList, RowID> cend() const;
 
  private:
-  ChunkID _common_chunk_id;
+  const ChunkID _common_chunk_id;
 
   // If tuples are added to the chunk _after_ we create the pos list, we do not want to automatically contain these
   // (MVCC correctness).  To do that, we store the size of the chunk when constructing an object. The end() methods
   // can then use this to give a correct end iterator, even if new values were added to the chunk in between.
-  ChunkOffset _common_chunk_size;
+  const ChunkOffset _common_chunk_size;
 };
 
 }  // namespace opossum

--- a/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
+++ b/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
@@ -21,7 +21,6 @@ class EntireChunkPosList : public AbstractPosList {
 
   // Implemented in hpp for performance reasons (to allow inlining)
   RowID operator[](const size_t index) const final {
-    DebugAssert(_common_chunk_id != INVALID_CHUNK_ID, "operator[] called on invalid chunk id");
     return RowID{_common_chunk_id, static_cast<ChunkOffset>(index)};
   }
 

--- a/src/lib/storage/pos_lists/rowid_pos_list.hpp
+++ b/src/lib/storage/pos_lists/rowid_pos_list.hpp
@@ -11,7 +11,7 @@ namespace opossum {
 
 // The RowIDPosList is the most generic type of PosList. It holds a list of RowIDs where ChunkID and ChunkOffset can
 // vary freely. Not only can it point to different chunks, but it can also contain NULLs (as, e.g., produced by an
-// outer join). This comes at the cost of an higher memory usage than more specialized types of PosList have.
+// outer join). This comes at the cost of a higher memory usage than more specialized types of PosLists have.
 // Inheriting from std::vector is generally not encouraged, because the STL containers are not prepared for
 // inheritance. By making the inheritance private and this class final, we can assure that the problems that come with
 // a non-virtual destructor do not occur.

--- a/src/lib/storage/pos_lists/rowid_pos_list.hpp
+++ b/src/lib/storage/pos_lists/rowid_pos_list.hpp
@@ -9,10 +9,9 @@
 
 namespace opossum {
 
-// TODO update
-// For a long time, PosList was just a pmr_vector<RowID>. With this class, we want to add functionality to that vector,
-// more specifically, flags that give us some guarantees about its contents. If we know, e.g., that all entries point
-// into the same chunk, we can simplify things in split_pos_list_by_chunk_id.
+// The RowIDPosList is the most generic type of PosList. It holds a list of RowIDs where ChunkID and ChunkOffset can
+// vary freely. Not only can it point to different chunks, but it can also contain NULLs (as, e.g., produced by an
+// outer join). This comes at the cost of an higher memory usage than more specialized types of PosList have.
 // Inheriting from std::vector is generally not encouraged, because the STL containers are not prepared for
 // inheritance. By making the inheritance private and this class final, we can assure that the problems that come with
 // a non-virtual destructor do not occur.

--- a/src/lib/storage/pos_lists/rowid_pos_list.hpp
+++ b/src/lib/storage/pos_lists/rowid_pos_list.hpp
@@ -9,6 +9,7 @@
 
 namespace opossum {
 
+// TODO update
 // For a long time, PosList was just a pmr_vector<RowID>. With this class, we want to add functionality to that vector,
 // more specifically, flags that give us some guarantees about its contents. If we know, e.g., that all entries point
 // into the same chunk, we can simplify things in split_pos_list_by_chunk_id.

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -33,9 +33,8 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
     const auto& position_filter = _segment.pos_list();
 
     // If we are guaranteed that the reference segment refers to a single non-NULL chunk, we can do some
-    // optimizations. For example, we can use a single, non-virtual segment accessor instead of having
-    // to keep multiple and using virtual method calls. If begin_it is NULL, chunk_id will be INVALID_CHUNK_ID.
-    // Therefore, we skip this case.
+    // optimizations. For example, we can use a filtered iterator instead of having to create segments accessors
+    // and using virtual method calls.
 
     if (position_filter->references_single_chunk() && position_filter->size() > 0) {
       // If a single chunk is referenced, we use the PosList as a filter for the referenced segment iterable.
@@ -44,7 +43,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
       // PosList has no NULL values. However, once we have a `has_null_values` flag in a smarter PosList, we should
       // use it here.
 
-      auto referenced_segment =
+      const auto referenced_segment =
           referenced_table->get_chunk(position_filter->common_chunk_id())->get_segment(referenced_column_id);
 
       bool functor_was_called = false;

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -43,7 +43,8 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
       // PosList has no NULL values. However, once we have a `has_null_values` flag in a smarter PosList, we should
       // use it here.
 
-      auto referenced_segment = referenced_table->get_chunk(position_filter->common_chunk_id())->get_segment(referenced_column_id);
+      auto referenced_segment =
+          referenced_table->get_chunk(position_filter->common_chunk_id())->get_segment(referenced_column_id);
 
       bool functor_was_called = false;
 

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -31,91 +31,92 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
 
     const auto& position_filter = _segment.pos_list();
 
-    resolve_pos_list_type(position_filter, [&functor, &referenced_table, &referenced_column_id](auto pos_list) {
-      const auto begin_it = pos_list->begin();
-      const auto end_it = pos_list->end();
+    // If we are guaranteed that the reference segment refers to a single non-NULL chunk, we can do some
+    // optimizations. For example, we can use a single, non-virtual segment accessor instead of having
+    // to keep multiple and using virtual method calls. If begin_it is NULL, chunk_id will be INVALID_CHUNK_ID.
+    // Therefore, we skip this case.
 
-      // If we are guaranteed that the reference segment refers to a single non-NULL chunk, we can do some
-      // optimizations. For example, we can use a single, non-virtual segment accessor instead of having
-      // to keep multiple and using virtual method calls. If begin_it is NULL, chunk_id will be INVALID_CHUNK_ID.
-      // Therefore, we skip this case.
+    if (position_filter->references_single_chunk() && position_filter->size() > 0) {
+      // If a single chunk is referenced, we use the PosList as a filter for the referenced segment iterable.
+      // This assumes that the PosList itself does not contain any NULL values. As NULL-producing operators
+      // (Join, Aggregate, Projection) do not emit a PosList with references_single_chunk, we can assume that the
+      // PosList has no NULL values. However, once we have a `has_null_values` flag in a smarter PosList, we should
+      // use it here.
 
-      if (pos_list->references_single_chunk() && pos_list->size() > 0 && !begin_it->is_null()) {
-        // If a single chunk is referenced, we use the PosList as a filter for the referenced segment iterable.
-        // This assumes that the PosList itself does not contain any NULL values. As NULL-producing operators
-        // (Join, Aggregate, Projection) do not emit a PosList with references_single_chunk, we can assume that the
-        // PosList has no NULL values. However, once we have a `has_null_values` flag in a smarter PosList, we should
-        // use it here.
+      auto referenced_segment = referenced_table->get_chunk(position_filter->common_chunk_id())->get_segment(referenced_column_id);
 
-        auto referenced_segment = referenced_table->get_chunk(begin_it->chunk_id)->get_segment(referenced_column_id);
+      bool functor_was_called = false;
 
-        bool functor_was_called = false;
+      if constexpr (erase_reference_segment_type == EraseReferencedSegmentType::No) {
+        resolve_segment_type<T>(*referenced_segment, [&](const auto& typed_segment) {
+          using SegmentType = std::decay_t<decltype(typed_segment)>;
 
-        if constexpr (erase_reference_segment_type == EraseReferencedSegmentType::No) {
-          resolve_segment_type<T>(*referenced_segment, [&](const auto& typed_segment) {
-            using SegmentType = std::decay_t<decltype(typed_segment)>;
-
-            // This is ugly, but it allows us to define segment types that we are not interested in and save a lot of
-            // compile time during development. While new segment types should be added here,
+          // This is ugly, but it allows us to define segment types that we are not interested in and save a lot of
+          // compile time during development. While new segment types should be added here,
 #ifdef HYRISE_ERASE_DICTIONARY
-            if constexpr (std::is_same_v<SegmentType, DictionarySegment<T>>) return;
+          if constexpr (std::is_same_v<SegmentType, DictionarySegment<T>>) return;
 #endif
 
 #ifdef HYRISE_ERASE_RUNLENGTH
-            if constexpr (std::is_same_v<SegmentType, RunLengthSegment<T>>) return;
+          if constexpr (std::is_same_v<SegmentType, RunLengthSegment<T>>) return;
 #endif
 
 #ifdef HYRISE_ERASE_FIXEDSTRINGDICTIONARY
-            if constexpr (std::is_same_v<SegmentType, FixedStringDictionarySegment<T>>) return;
+          if constexpr (std::is_same_v<SegmentType, FixedStringDictionarySegment<T>>) return;
 #endif
 
 #ifdef HYRISE_ERASE_FRAMEOFREFERENCE
-            if constexpr (std::is_same_v<T, int32_t>) {
-              if constexpr (std::is_same_v<SegmentType, FrameOfReferenceSegment<T>>) return;
-            }
+          if constexpr (std::is_same_v<T, int32_t>) {
+            if constexpr (std::is_same_v<SegmentType, FrameOfReferenceSegment<T>>) return;
+          }
 #endif
 
-            // Always erase LZ4Segment accessors
-            if constexpr (std::is_same_v<SegmentType, LZ4Segment<T>>) return;
+          // Always erase LZ4Segment accessors
+          if constexpr (std::is_same_v<SegmentType, LZ4Segment<T>>) return;
 
-            if constexpr (!std::is_same_v<SegmentType, ReferenceSegment>) {
-              const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
-              segment_iterable.with_iterators(pos_list, functor);
+          if constexpr (!std::is_same_v<SegmentType, ReferenceSegment>) {
+            const auto segment_iterable = create_iterable_from_segment<T>(typed_segment);
+            segment_iterable.with_iterators(position_filter, functor);
 
-              functor_was_called = true;
-            } else {
-              Fail("Found ReferenceSegment pointing to ReferenceSegment");
-            }
-          });
-
-          if (!functor_was_called) {
-            PerformanceWarning("ReferenceSegmentIterable for referenced segment type erased by compile-time setting");
+            functor_was_called = true;
+          } else {
+            Fail("Found ReferenceSegment pointing to ReferenceSegment");
           }
+        });
 
-        } else {
-          PerformanceWarning("Using type-erased accessor as the ReferenceSegmentIterable is type-erased itself");
+        if (!functor_was_called) {
+          PerformanceWarning("ReferenceSegmentIterable for referenced segment type erased by compile-time setting");
         }
 
-        if (functor_was_called) return;
-
-        // The functor was not called yet, because we did not instantiate specialized code for the segment type.
-
-        const auto segment_iterable = create_any_segment_iterable<T>(*referenced_segment);
-        segment_iterable.with_iterators(pos_list, functor);
       } else {
-        using Accessors = std::vector<std::shared_ptr<AbstractSegmentAccessor<T>>>;
+        PerformanceWarning("Using type-erased accessor as the ReferenceSegmentIterable is type-erased itself");
+      }
 
-        auto accessors = std::make_shared<Accessors>(referenced_table->chunk_count());
+      if (functor_was_called) return;
 
-        using PosListIteratorType = std::decay_t<decltype(begin_it)>;
+      // The functor was not called yet, because we did not instantiate specialized code for the segment type.
+
+      const auto segment_iterable = create_any_segment_iterable<T>(*referenced_segment);
+      segment_iterable.with_iterators(position_filter, functor);
+    } else {
+      using Accessors = std::vector<std::shared_ptr<AbstractSegmentAccessor<T>>>;
+
+      auto accessors = std::make_shared<Accessors>(referenced_table->chunk_count());
+
+      resolve_pos_list_type(position_filter, [&](auto resolved_position_filter) {
+        const auto position_begin_it = resolved_position_filter->begin();
+        const auto position_end_it = resolved_position_filter->end();
+
+        using PosListIteratorType = std::decay_t<decltype(position_begin_it)>;
+
         auto begin = MultipleChunkIterator<PosListIteratorType>{referenced_table, referenced_column_id, accessors,
-                                                                begin_it, begin_it};
+                                                                position_begin_it, position_begin_it};
         auto end = MultipleChunkIterator<PosListIteratorType>{referenced_table, referenced_column_id, accessors,
-                                                              begin_it, end_it};
+                                                              position_begin_it, position_end_it};
 
         functor(begin, end);
-      }
-    });
+      });
+    }
   }
 
   size_t _on_size() const { return _segment.size(); }

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "resolve_type.hpp"
 #include "storage/create_iterable_from_segment.hpp"
 #include "storage/dictionary_segment.hpp"
 #include "storage/fixed_string_dictionary_segment.hpp"

--- a/src/lib/storage/segment_iterables.hpp
+++ b/src/lib/storage/segment_iterables.hpp
@@ -3,6 +3,7 @@
 #include <type_traits>
 
 #include "storage/segment_iterables/base_segment_iterators.hpp"
+#include "resolve_type.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
 

--- a/src/lib/storage/segment_iterables.hpp
+++ b/src/lib/storage/segment_iterables.hpp
@@ -156,7 +156,7 @@ class PointAccessibleSegmentIterable : public SegmentIterable<Derived> {
       DebugAssert(position_filter->references_single_chunk(), "Expected PosList to reference single chunk");
 
       resolve_pos_list_type<erase_pos_list_type>(position_filter,
-                            [&functor, this](auto& pos_list) { _self()._on_with_iterators(pos_list, functor); });
+                            [&functor, this](auto& resolved_position_filter) { _self()._on_with_iterators(resolved_position_filter, functor); });
     }
   }
 

--- a/src/lib/storage/segment_iterables/any_segment_iterable.hpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.hpp
@@ -76,7 +76,9 @@ class AnySegmentIterableWrapper : public BaseAnySegmentIterableWrapper<ValueType
                       const AnySegmentIterableFunctorWrapper<ValueType>& functor_wrapper) const override {
     if (position_filter) {
       if constexpr (is_point_accessible_segment_iterable_v<UnerasedIterable>) {
-        // Since the iterator type is erased, there is no reason to resolve the PosList
+        // Since we are in AnySegmentIterable, where we erase the segment types as far as possible, there is no reason
+        // to resolve the PosList. This further reduces the compile time at the cost of run time performance (which we
+        // have already sacrificed when we chose the AnySegmentIterable in the first place).
         iterable.template with_iterators<ErasePosListType::Always>(position_filter, [&](auto begin, const auto end) {
           const auto any_segment_iterator_begin = AnySegmentIterator<ValueType>(begin);
           const auto any_segment_iterator_end = AnySegmentIterator<ValueType>(end);

--- a/src/lib/storage/segment_iterables/any_segment_iterable.hpp
+++ b/src/lib/storage/segment_iterables/any_segment_iterable.hpp
@@ -21,14 +21,14 @@ class BaseSegment;
  *
  * Returns iterable if it has already been wrapped
  */
-template <typename IterableT>
-auto erase_type_from_iterable(const IterableT& iterable);
+template <typename UnerasedIterable>
+auto erase_type_from_iterable(const UnerasedIterable& iterable);
 
 /**
  * @brief Wraps passed segment iterable in an AnySegmentIterable in debug mode
  */
-template <typename IterableT>
-decltype(auto) erase_type_from_iterable_if_debug(const IterableT& iterable);
+template <typename UnerasedIterable>
+decltype(auto) erase_type_from_iterable_if_debug(const UnerasedIterable& iterable);
 
 /**
  * @defgroup AnySegmentIterable Traits
@@ -41,8 +41,8 @@ struct is_any_segment_iterable : std::false_type {};
 template <typename T>
 struct is_any_segment_iterable<AnySegmentIterable<T>> : std::true_type {};
 
-template <typename IterableT>
-constexpr auto is_any_segment_iterable_v = is_any_segment_iterable<IterableT>::value;
+template <typename UnerasedIterable>
+constexpr auto is_any_segment_iterable_v = is_any_segment_iterable<UnerasedIterable>::value;
 /**@}*/
 
 template <typename ValueType>
@@ -59,10 +59,10 @@ class BaseAnySegmentIterableWrapper {
   virtual size_t size() const = 0;
 };
 
-template <typename ValueType, typename IterableT>
+template <typename ValueType, typename UnerasedIterable>
 class AnySegmentIterableWrapper : public BaseAnySegmentIterableWrapper<ValueType> {
  public:
-  explicit AnySegmentIterableWrapper(const IterableT& init_iterable) : iterable(init_iterable) {}
+  explicit AnySegmentIterableWrapper(const UnerasedIterable& init_iterable) : iterable(init_iterable) {}
 
   void with_iterators(const AnySegmentIterableFunctorWrapper<ValueType>& functor_wrapper) const override {
     iterable.with_iterators([&](auto begin, const auto end) {
@@ -75,8 +75,9 @@ class AnySegmentIterableWrapper : public BaseAnySegmentIterableWrapper<ValueType
   void with_iterators(const std::shared_ptr<const AbstractPosList>& position_filter,
                       const AnySegmentIterableFunctorWrapper<ValueType>& functor_wrapper) const override {
     if (position_filter) {
-      if constexpr (is_point_accessible_segment_iterable_v<IterableT>) {
-        iterable.with_iterators(position_filter, [&](auto begin, const auto end) {
+      if constexpr (is_point_accessible_segment_iterable_v<UnerasedIterable>) {
+        // Since the iterator type is erased, there is no reason to resolve the PosList
+        iterable.template with_iterators<ErasePosListType::Always>(position_filter, [&](auto begin, const auto end) {
           const auto any_segment_iterator_begin = AnySegmentIterator<ValueType>(begin);
           const auto any_segment_iterator_end = AnySegmentIterator<ValueType>(end);
           functor_wrapper(any_segment_iterator_begin, any_segment_iterator_end);
@@ -91,7 +92,7 @@ class AnySegmentIterableWrapper : public BaseAnySegmentIterableWrapper<ValueType
 
   size_t size() const override { return iterable._on_size(); }
 
-  IterableT iterable;
+  UnerasedIterable iterable;
 };
 
 /**
@@ -111,10 +112,10 @@ class AnySegmentIterable : public PointAccessibleSegmentIterable<AnySegmentItera
  public:
   using ValueType = T;
 
-  template <typename IterableT>
-  explicit AnySegmentIterable(const IterableT& iterable)
-      : _iterable_wrapper{std::make_shared<AnySegmentIterableWrapper<T, IterableT>>(iterable)} {
-    static_assert(!is_any_segment_iterable_v<IterableT>, "Iterables should not be wrapped twice.");
+  template <typename UnerasedIterable>
+  explicit AnySegmentIterable(const UnerasedIterable& iterable)
+      : _iterable_wrapper{std::make_shared<AnySegmentIterableWrapper<T, UnerasedIterable>>(iterable)} {
+    static_assert(!is_any_segment_iterable_v<UnerasedIterable>, "Iterables should not be wrapped twice.");
   }
 
   AnySegmentIterable(const AnySegmentIterable&) = default;
@@ -138,19 +139,19 @@ class AnySegmentIterable : public PointAccessibleSegmentIterable<AnySegmentItera
   std::shared_ptr<BaseAnySegmentIterableWrapper<ValueType>> _iterable_wrapper;
 };
 
-template <typename IterableT>
-auto erase_type_from_iterable(const IterableT& iterable) {
+template <typename UnerasedIterable>
+auto erase_type_from_iterable(const UnerasedIterable& iterable) {
   // clang-format off
-  if constexpr(is_any_segment_iterable_v<IterableT>) {
+  if constexpr(is_any_segment_iterable_v<UnerasedIterable>) {
     return iterable;
   } else {
-    return AnySegmentIterable<typename IterableT::ValueType>{iterable};
+    return AnySegmentIterable<typename UnerasedIterable::ValueType>{iterable};
   }
   // clang-format on
 }
 
-template <typename IterableT>
-decltype(auto) erase_type_from_iterable_if_debug(const IterableT& iterable) {
+template <typename UnerasedIterable>
+decltype(auto) erase_type_from_iterable_if_debug(const UnerasedIterable& iterable) {
 #if HYRISE_DEBUG
   return erase_type_from_iterable(iterable);
 #else

--- a/src/lib/utils/load_table.cpp
+++ b/src/lib/utils/load_table.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<Table> load_table(const std::string& file_name, size_t chunk_siz
   }
 
   // All other chunks have been finalized by Table::append() when they reached their capacity.
-  if (!table->empty() && static_cast<bool>(finalize_last_chunk)) {
+  if (!table->empty() && finalize_last_chunk == FinalizeLastChunk::Yes) {
     table->last_chunk()->finalize();
   }
 


### PR DESCRIPTION
```
ninja clean; time ninja hyriseBenchmarkTPCH
nemea, single node          Macbook 16"
gcc                         clang

master before PR commit
  debug (with unity)
    real  1m29.816s         1m47.360s
    user  10m7.729s         14m0.838s
  release (no unity)
    real  3m36.696s         6m2.243s
    user  31m29.549s        59m31.819s

master with PR commit
  debug
    real  1m30.820s         1m47.463s
    user  10m30.046s        14m17.649s
  release
    real  6m27.217s         10m4.363s
    user  43m37.977s        77m10.721s

now (dffdabaae4d35123a9080d3c86f0ec82df841c5d)
  debug
    real  1m30.643s         1m47.410s
    user  10m12.337s        14m2.814s
  release
    real  3m11.059s         7m2.953s
    user  34m10.579s        67m41.654s
```

I ran a couple of benchmarks. Unfortunately, they are not super-conclusive. The only thing I can say is that this PR doesn't reduce the overall performance. I benchmarked parts of the modifications and the changes did not necessarily reflect the code that was touched. Vex not thou the compiler's mind; For thou canst not fathom it.

TPC-H:
```diff
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | Benchmark      | prev. iter/s       | runs  | new iter/s         | runs  | change [%] | p-value |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | TPC-H 01       | 1.2424206733703613 | 75    | 1.2369002103805542 | 75    | -0%        |  0.2482 |
 | TPC-H 02       | 84.00621795654297  | 5041  | 84.3220443725586   | 5060  | +0%        |  0.5895 |
 | TPC-H 03       | 9.212895393371582  | 553   | 9.044968605041504  | 543   | -2%        |  0.0000 |
 | TPC-H 04       | 8.77935791015625   | 527   | 8.742874145507812  | 525   | -0%        |  0.0000 |
 | TPC-H 05       | 4.252862930297852  | 256   | 4.2294087409973145 | 254   | -1%        |  0.0285 |
 | TPC-H 06       | 276.4041748046875  | 16585 | 273.35736083984375 | 16402 | -1%        |  0.0000 |
 | TPC-H 07       | 10.154862403869629 | 610   | 10.075932502746582 | 605   | -1%        |  0.2784 |
 | TPC-H 08       | 7.904600620269775  | 475   | 7.850379467010498  | 472   | -1%        |  0.0659 |
 | TPC-H 09       | 1.775230884552002  | 107   | 1.7471566200256348 | 105   | -2%        |  0.0000 |
 | TPC-H 10       | 3.2888612747192383 | 198   | 3.3170411586761475 | 200   | +1%        |  0.4067 |
 | TPC-H 11       | 41.566429138183594 | 2495  | 41.365455627441406 | 2482  | -0%        |  0.0000 |
 | TPC-H 12       | 17.449411392211914 | 1047  | 17.608848571777344 | 1057  | +1%        |  0.0000 |
+| TPC-H 13       | 2.589919328689575  | 156   | 2.8019068241119385 | 169   | +8%        |  0.0000 |
 | TPC-H 14       | 43.932186126708984 | 2636  | 42.90464401245117  | 2575  | -2%        |  0.0000 |
 | TPC-H 15       | 124.5029067993164  | 7471  | 126.02437591552734 | 7562  | +1%        |  0.0000 |
 | TPC-H 16       | 9.007349967956543  | 541   | 9.201645851135254  | 553   | +2%        |  0.0000 |
 | TPC-H 17       | 5.811931133270264  | 349   | 5.861619472503662  | 352   | +1%        |  0.0004 |
+| TPC-H 18       | 1.310404896736145  | 79    | 1.3818061351776123 | 83    | +5%        |  0.0000 |
 | TPC-H 19       | 10.675104141235352 | 641   | 10.697976112365723 | 642   | +0%        |  0.6584 |
 | TPC-H 20       | 33.400760650634766 | 2005  | 33.64235305786133  | 2019  | +1%        |  0.0001 |
 | TPC-H 21       | 1.4243228435516357 | 86    | 1.4187384843826294 | 86    | -0%        |  0.3724 |
 | TPC-H 22       | 19.187511444091797 | 1152  | 19.07138442993164  | 1145  | -1%        |  0.0000 |
 | geometric mean |                    |       |                    |       | +0%        |         |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
```

TPC-DS:
```diff
 +----------------+--------------------+------+--------------------+------+------------+---------+
 | Benchmark      | prev. iter/s       | runs | new iter/s         | runs | change [%] | p-value |
 +----------------+--------------------+------+--------------------+------+------------+---------+
 | 01             | 28.218875885009766 | 1694 | 27.086042404174805 | 1626 | -4%        |  0.0000 |
 | 03             | 29.546478271484375 | 1773 | 29.530975341796875 | 1772 | -0%        |  0.2766 |
 | 06             | 30.412189483642578 | 1825 | 29.75090980529785  | 1786 | -2%        |  0.0000 |
-| 07             | 15.294437408447266 | 918  | 14.033504486083984 | 843  | -8%        |  0.0000 |
 | 09             | 9.366772651672363  | 563  | 8.933613777160645  | 537  | -5%        |  0.0000 |
 | 10             | 18.072948455810547 | 1085 | 18.090551376342773 | 1086 | +0%        |  0.2904 |
+| 13             | 7.269359111785889  | 437  | 8.439867973327637  | 507  | +16%       |  0.0000 |
 | 15             | 58.949851989746094 | 3537 | 57.205501556396484 | 3433 | -3%        |  0.0000 |
 | 17             | 19.26760482788086  | 1157 | 18.550561904907227 | 1114 | -4%        |  0.0000 |
 | 19             | 40.22402572631836  | 2414 | 39.60765075683594  | 2377 | -2%        |  0.0000 |
 | 25             | 26.431297302246094 | 1586 | 25.90554428100586  | 1555 | -2%        |  0.0016 |
-| 26             | 30.59981346130371  | 1836 | 28.0986270904541   | 1686 | -8%        |  0.0000 |
 | 28             | 10.661736488342285 | 640  | 10.672459602355957 | 641  | +0%        |  0.0107 |
 | 29             | 19.775850296020508 | 1187 | 18.95545768737793  | 1138 | -4%        |  0.0000 |
 | 31             | 5.9138007164001465 | 355  | 5.6597137451171875 | 340  | -4%        |  0.0000 |
-| 34             | 26.60393524169922  | 1597 | 23.51320457458496  | 1411 | -12%       |  0.0000 |
 | 35             | 6.815205097198486  | 409  | 6.657992362976074  | 400  | -2%        |  0.0000 |
 | 39a            | 3.2534592151641846 | 196  | 3.3446762561798096 | 201  | +3%        |  0.0000 |
 | 39b            | 3.4317963123321533 | 206  | 3.3506011962890625 | 202  | -2%        |  0.0000 |
 | 41             | 41.74595642089844  | 2505 | 41.86216735839844  | 2512 | +0%        |  0.0000 |
 | 42             | 50.84732437133789  | 3051 | 50.32358932495117  | 3020 | -1%        |  0.0000 |
 | 43             | 4.856598377227783  | 292  | 4.871105194091797  | 293  | +0%        |  0.0000 |
 | 45             | 61.88260269165039  | 3713 | 59.95973205566406  | 3598 | -3%        |  0.0000 |
 | 48             | 8.826986312866211  | 530  | 9.111830711364746  | 547  | +3%        |  0.0000 |
 | 50             | 34.94005584716797  | 2097 | 34.006065368652344 | 2041 | -3%        |  0.0000 |
 | 52             | 50.44255065917969  | 3027 | 49.830806732177734 | 2990 | -1%        |  0.0000 |
 | 55             | 50.87740707397461  | 3053 | 50.356990814208984 | 3022 | -1%        |  0.0000 |
 | 62             | 12.423343658447266 | 746  | 12.067952156066895 | 725  | -3%        |  0.0000 |
-| 65             | 12.451356887817383 | 748  | 11.704113006591797 | 703  | -6%        |  0.0000 |
 | 69             | 15.767358779907227 | 947  | 15.640191078186035 | 939  | -1%        |  0.0000 |
-| 73             | 32.862457275390625 | 1972 | 30.96516227722168  | 1858 | -6%        |  0.0000 |
 | 79             | 14.311079978942871 | 859  | 13.802621841430664 | 829  | -4%        |  0.0000 |
 | 81             | 39.686180114746094 | 2382 | 38.897865295410156 | 2334 | -2%        |  0.0000 |
-| 83             | 52.37228012084961  | 3143 | 49.03268051147461  | 2942 | -6%        |  0.0000 |
+| 85             | 11.475872039794922 | 689  | 12.368303298950195 | 743  | +8%        |  0.0004 |
-| 88             | 5.219685077667236  | 314  | 4.9330973625183105 | 296  | -5%        |  0.0000 |
+| 91             | 38.433902740478516 | 2307 | 43.99463653564453  | 2640 | +14%       |  0.0000 |
 | 93             | 3.6486079692840576 | 219  | 3.656942367553711  | 220  | +0%        |  0.1643 |
 | 96             | 48.176368713378906 | 2891 | 46.73023986816406  | 2804 | -3%        |  0.0000 |
+| 97             | 2.2179489135742188 | 134  | 2.4570960998535156 | 148  | +11%       |  0.0000 |
 | 99             | 6.164465427398682  | 370  | 5.97387170791626   | 359  | -3%        |  0.0000 |
 | geometric mean |                    |      |                    |      | -1%        |         |
 +----------------+--------------------+------+--------------------+------+------------+---------+
```