### PR TITLE
Let server sessions finish before exiting

### DIFF
--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -32,7 +32,7 @@ void Server::_accept_new_session() {
 void Server::_start_session(const std::shared_ptr<Session>& new_session, const boost::system::error_code& error) {
   Assert(!error, error.message());
 
-  std::thread session_thread([session=new_session, &num_running_sessions = this->_num_running_sessions] () mutable {
+  std::thread session_thread([session = new_session, &num_running_sessions = this->_num_running_sessions]() mutable {
     const std::string thread_name = "server_p_" + std::to_string(session->socket()->remote_endpoint().port());
 #ifdef __APPLE__
     pthread_setname_np(thread_name.c_str());

--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -42,6 +42,9 @@ void Server::_start_session(const std::shared_ptr<Session>& new_session, const b
 
     ++num_running_sessions;
     new_session->run();
+
+    // Call session's destructor before releasing num_running_sessions so that we finish before the server is shut down
+    new_session.reset();
     --num_running_sessions;
   });
 

--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -42,9 +42,6 @@ void Server::_start_session(const std::shared_ptr<Session>& new_session, const b
 
     ++num_running_sessions;
     new_session->run();
-
-    // Call session's destructor before releasing num_running_sessions so that we finish before the server is shut down
-    new_session.reset();
     --num_running_sessions;
   });
 

--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -61,6 +61,10 @@ void Server::_start_session(const std::shared_ptr<Session>& new_session, const b
     --num_running_sessions;
   });
 
+  // We ensure that all threads are completed before the server is shut down by tracking the number of running threads
+  // in _num_running_sessions. The alternative would be to store the std::thread objects in some kind of data structure
+  // and call join() on all of them before shutting down the server. This would result in a growing number of completed
+  // threads waiting to be joined and the need for a cleanup procedure.
   session_thread.detach();
   _accept_new_session();
 }

--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -32,7 +32,7 @@ void Server::_accept_new_session() {
 void Server::_start_session(const std::shared_ptr<Session>& new_session, const boost::system::error_code& error) {
   Assert(!error, error.message());
 
-  std::thread session_thread([new_session, &num_running_sessions=this->_num_running_sessions] {
+  std::thread session_thread([new_session, &num_running_sessions = this->_num_running_sessions] {
     const std::string thread_name = "server_p_" + std::to_string(new_session->socket()->remote_endpoint().port());
 #ifdef __APPLE__
     pthread_setname_np(thread_name.c_str());
@@ -54,7 +54,10 @@ boost::asio::ip::address Server::server_address() const { return _acceptor.local
 uint16_t Server::server_port() const { return _acceptor.local_endpoint().port(); }
 
 void Server::shutdown() {
-  while (_num_running_sessions > 0) {}
+  while (_num_running_sessions > 0) {
+    // This busy wait might be inefficient, but as this is only to guarantee a clean shutdown, it's good enough.
+    std::this_thread::yield();
+  }
   _io_service.stop();
 }
 

--- a/src/lib/server/server.hpp
+++ b/src/lib/server/server.hpp
@@ -48,6 +48,7 @@ class Server {
 
   void _start_session(const std::shared_ptr<Session>& new_session, const boost::system::error_code& error);
 
+  std::atomic<uint64_t> _num_running_sessions{0};
   boost::asio::io_service _io_service;
   boost::asio::ip::tcp::acceptor _acceptor;
   const SendExecutionInfo _send_execution_info;

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -249,13 +249,9 @@ TEST_F(ServerTestRunner, TestShutdownDuringExecution) {
   }
 
   // These should run for a while, one should finish earlier
-  std::thread([&transaction] {
-    transaction.exec("SELECT * FROM table_a t1, table_a t2");
-  }).detach();
+  std::thread([&transaction] { transaction.exec("SELECT * FROM table_a t1, table_a t2"); }).detach();
 
-  std::thread([&transaction] {
-    transaction.exec("SELECT * FROM table_a t1, table_a t2 WHERE t1.a = 123");
-  }).detach();
+  std::thread([&transaction] { transaction.exec("SELECT * FROM table_a t1, table_a t2 WHERE t1.a = 123"); }).detach();
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -32,7 +32,7 @@ class ServerTestRunner : public BaseTest {
     std::remove(_export_filename.c_str());
 
     // Wait to run the server and set the scheduler
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 
   void TearDown() override {

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -42,9 +42,6 @@ class ServerTestRunner : public BaseTest {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     _server_thread->join();
 
-    _server.reset();
-    _server_thread.reset();
-
     std::remove(_export_filename.c_str());
   }
 


### PR DESCRIPTION
#1977 showed issues with the server stopping before all sessions are closed. To quote from the new test:

> Test that open sessions are allowed to finish before the server is destroyed. This is more relevant for tests than for the actual execution. In "real-life", i.e., during our experiments, we usually simply kill the server. In tests however, the server finishing while sessions might not be completely finished could lead to issues like #1977.

Benchmark:
```
echo 'CREATE TABLE t (a INT)' | psql -h localhost -p 1241
echo 'SELECT * FROM t;' > test
pgbench -h localhost -p 1241 -f test -n -c 100 -j 100 -T 10
```

old:
> tps = 151788.790109 (including connections establishing)
> tps = 152061.524404 (excluding connections establishing)

new:
> tps = 152625.496717 (including connections establishing)
> tps = 152822.493136 (excluding connections establishing)

Thus, the atomic does not seem to make any noteworthy difference.

This should fix #1977 (which I haven't seen since January and cannot be found in any non-purged Jenkins logs) by making sure that the io_service outlives the sessions.