### PR TITLE
Expression: faster equals and hash

### DIFF
--- a/src/test/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/logical_query_plan/aggregate_node_test.cpp
@@ -81,7 +81,9 @@ TEST_F(AggregateNodeTest, HashingAndEqualityCheck) {
   EXPECT_NE(*_aggregate_node, *different_aggregate_node_d);
 
   EXPECT_NE(_aggregate_node->hash(), different_aggregate_node_a->hash());
-  EXPECT_NE(_aggregate_node->hash(), different_aggregate_node_b->hash());
+  // _aggregate_node and different_aggregate_node_b are known to conflict because we do not recurse deep enough to
+  // identify the difference in the aggregate expressions. That is acceptable, as long as the comparison identifies
+  // the two nodes as non-equal.
   EXPECT_NE(_aggregate_node->hash(), different_aggregate_node_c->hash());
   EXPECT_NE(_aggregate_node->hash(), different_aggregate_node_d->hash());
 }


### PR DESCRIPTION
For `operator==` on an expression, it makes sense to first compare the expression itself before recursing into the inputs.

When hashing, we do not need to consider each and every part of the expression tree. As a hash comparison is always followed by a call to `operator==`, we will have to recurse anyway and while `operator==` can use early outs once it detected a difference, `hash` cannot.

Benchmark numbers for SF 0.01 (which places more load on the optimizer and has more complex LQPs than TPC-C):

```diff
 +----------------+--------------------+--------+--------------------+--------+------------+---------+
 | Benchmark      | prev. iter/s       | runs   | new iter/s         | runs   | change [%] | p-value |
 +----------------+--------------------+--------+--------------------+--------+------------+---------+
+| TPC-H 01       | 131.44422912597656 | 7887   | 142.7306365966797  | 8564   | +9%        |  0.0000 |
 | TPC-H 02       | 1688.8310546875    | 101330 | 1765.0733642578125 | 105905 | +5%        |  0.0000 |
+| TPC-H 03       | 658.1688842773438  | 39491  | 700.1943969726562  | 42012  | +6%        |  0.0000 |
 | TPC-H 04       | 939.4557495117188  | 56368  | 980.3738403320312  | 58823  | +4%        |  0.0000 |
 | TPC-H 05       | 572.7870483398438  | 34368  | 596.810546875      | 35809  | +4%        |  0.0000 |
 | TPC-H 06       | 9269.5751953125    | 556175 | 9375.779296875     | 562547 | +1%        |  0.0000 |
+| TPC-H 07       | 461.1575012207031  | 27670  | 494.9696044921875  | 29699  | +7%        |  0.0000 |
 | TPC-H 08       | 61.11573028564453  | 3668   | 62.22343063354492  | 3734   | +2%        |  0.0170 |
 | TPC-H 09       | 299.5536193847656  | 17974  | 306.5870056152344  | 18396  | +2%        |  0.0000 |
 | TPC-H 10       | 454.503173828125   | 27271  | 468.79730224609375 | 28128  | +3%        |  0.0000 |
+| TPC-H 11       | 2772.150634765625  | 166330 | 2925.06005859375   | 175504 | +6%        |  0.0000 |
 | TPC-H 12       | 1295.4189453125    | 77726  | 1325.53955078125   | 79533  | +2%        |  0.0000 |
+| TPC-H 13       | 414.93011474609375 | 24896  | 441.9283142089844  | 26516  | +7%        |  0.0000 |
 | TPC-H 14       | 2831.969482421875  | 169919 | 2879.275390625     | 172757 | +2%        |  0.0000 |
+| TPC-H 15       | 741.4963989257812  | 44490  | 788.024169921875   | 47282  | +6%        |  0.0000 |
 | TPC-H 16       | 429.308349609375   | 25759  | 436.68914794921875 | 26202  | +2%        |  0.0000 |
+| TPC-H 17       | 1093.38818359375   | 65604  | 1231.50146484375   | 73891  | +13%       |  0.0000 |
 | TPC-H 18       | 360.6149597167969  | 21637  | 354.37762451171875 | 21263  | -2%        |  0.0000 |
 | TPC-H 19       | 164.68177795410156 | 9881   | 169.15576171875    | 10150  | +3%        |  0.0000 |
 | TPC-H 20       | 312.91632080078125 | 18775  | 320.8516845703125  | 19252  | +3%        |  0.0000 |
+| TPC-H 21       | 231.15927124023438 | 13870  | 244.774169921875   | 14687  | +6%        |  0.0000 |
 | TPC-H 22       | 589.9743041992188  | 35399  | 591.46337890625    | 35488  | +0%        |  0.0000 |
 | geometric mean |                    |        |                    |        | +4%        |         |
 +----------------+--------------------+--------+--------------------+--------+------------+---------+
```

closes #1803 