### PR TITLE
Make code clang-10 ready

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,12 +41,15 @@ endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 20)
 
+# Hotfix for boost bug (https://github.com/boostorg/asio/issues/312):
+add_compile_options(-DBOOST_ASIO_DISABLE_CONCEPTS)
+
 # When generating a dtrace header file, symbols containing dollar-signs are created This file needs to be compiled as well.
 # Hence, the `-Wno-dollar-in-identifier-extension` flag is required.
 add_compile_options(-pthread -Wall -Wextra -pedantic -Werror -Wno-unused-parameter -Wno-dollar-in-identifier-extension -Wno-unknown-pragmas -Wno-subobject-linkage)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene)
+    add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories)
 endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/TargetLinkLibrariesSystem.cmake)

--- a/src/benchmark/operators/table_scan_sorted_benchmark.cpp
+++ b/src/benchmark/operators/table_scan_sorted_benchmark.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<TableWrapper> create_table(const DataType data_type, const int t
 
     pmr_vector<bool> null_values(value_vector.size(), false);
     // setting 10% of the values NULL
-    auto null_elements = static_cast<int>(std::round(value_vector.size() * 0.1));
+    auto null_elements = static_cast<int>(std::round(static_cast<double>(value_vector.size()) * 0.1));
     std::fill(null_values.begin(), null_values.begin() + null_elements, true);
     if (mode == "Shuffled") {
       std::shuffle(null_values.begin(), null_values.end(), generator);

--- a/src/benchmark/operators/union_positions_benchmark.cpp
+++ b/src/benchmark/operators/union_positions_benchmark.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<Table> create_reference_table(std::shared_ptr<Table> referenced_
        * of (num_rows * 0.2f) * REFERENCED_TABLE_CHUNK_COUNT rows - i.e. twice as many rows as the referencing table
        * we're creating. So when creating TWO referencing tables, there should be a fair amount of overlap.
        */
-      auto pos_list = generate_pos_list(num_rows * 0.2f, num_rows_per_chunk);
+      auto pos_list = generate_pos_list(static_cast<float>(num_rows) * 0.2f, num_rows_per_chunk);
       segments.push_back(std::make_shared<ReferenceSegment>(referenced_table, column_idx, pos_list));
     }
     table->append_chunk(segments);
@@ -117,8 +117,8 @@ BENCHMARK(BM_UnionPositions);
 void BM_UnionPositionsBaseLine(::benchmark::State& state) {  // NOLINT
   auto num_table_rows = 500000;
 
-  auto pos_list_left = generate_pos_list(num_table_rows * 0.2f, num_table_rows);
-  auto pos_list_right = generate_pos_list(num_table_rows * 0.2f, num_table_rows);
+  auto pos_list_left = generate_pos_list(static_cast<float>(num_table_rows) * 0.2f, num_table_rows);
+  auto pos_list_right = generate_pos_list(static_cast<float>(num_table_rows) * 0.2f, num_table_rows);
 
   for (auto _ : state) {
     // Create copies, this would need to be done the UnionPositions Operator as well

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -224,7 +224,7 @@ void BenchmarkRunner::_benchmark_ordered() {
     const auto items_per_second = static_cast<float>(result.successful_runs.size()) / duration_seconds;
     const auto num_successful_runs = result.successful_runs.size();
     const auto duration_per_item =
-        num_successful_runs > 0 ? static_cast<float>(duration_seconds) / num_successful_runs : NAN;
+        num_successful_runs > 0 ? static_cast<float>(duration_seconds) / static_cast<float>(num_successful_runs) : NAN;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds ("
@@ -361,8 +361,9 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     // The field items_per_second is relied upon by a number of visualization scripts. Carefully consider if you really
     // want to touch this and potentially break the comparability across commits.
     benchmark["items_per_second"] = items_per_second;
-    const auto time_per_item =
-        !result.successful_runs.empty() ? reported_item_duration_ns / result.successful_runs.size() : std::nanf("");
+    const auto time_per_item = !result.successful_runs.empty()
+                                   ? reported_item_duration_ns / static_cast<float>(result.successful_runs.size())
+                                   : std::nanf("");
     benchmark["avg_real_time_per_iteration"] = time_per_item;
 
     benchmarks.push_back(benchmark);

--- a/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
@@ -169,7 +169,7 @@ bool TPCCNewOrder::_on_execute() {
     }
 
     // Calculate price of line item (OL_AMOUNT)
-    const auto ol_amount = order_line.ol_quantity * i_price;
+    const auto ol_amount = static_cast<float>(order_line.ol_quantity) * i_price;
 
     // Add to ORDER_LINE
     // TODO(anyone): This can be made faster if we interpret "For each O_OL_CNT item on the order" less strictly and

--- a/src/benchmarklib/tpcc/procedures/tpcc_order_status.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_order_status.cpp
@@ -46,8 +46,9 @@ bool TPCCOrderStatus::_on_execute() {
     Assert(customer_table->row_count() >= 1, "Did not find customer by name");
 
     // Calculate ceil(n/2)
-    auto customer_offset = static_cast<size_t>(
-        std::min(std::ceil(customer_table->row_count() / 2.0), static_cast<double>(customer_table->row_count() - 1)));
+    auto customer_offset =
+        static_cast<size_t>(std::min(std::ceil(static_cast<double>(customer_table->row_count()) / 2.0),
+                                     static_cast<double>(customer_table->row_count() - 1)));
     customer_id = *customer_table->get_value<int32_t>(ColumnID{0}, customer_offset);
   }
 

--- a/src/benchmarklib/tpcc/procedures/tpcc_payment.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_payment.cpp
@@ -103,7 +103,7 @@ bool TPCCPayment::_on_execute() {
 
     // Calculate ceil(n/2)
     customer_offset =
-        static_cast<size_t>(std::max(0.0, std::min(std::ceil(customer_table->row_count() / 2.0),
+        static_cast<size_t>(std::max(0.0, std::min(std::ceil(static_cast<double>(customer_table->row_count()) / 2.0),
                                                    static_cast<double>(customer_table->row_count() - 1))));
     c_id = *customer_table->get_value<int32_t>(ColumnID{0}, customer_offset);
   }

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -44,8 +44,9 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_item_table() {
                        [&](std::vector<size_t>) { return _random_gen.random_number(1, 10000); });
   _add_column<pmr_string>(segments_by_chunk, column_definitions, "I_NAME", cardinalities,
                           [&](std::vector<size_t>) { return pmr_string{_random_gen.astring(14, 24)}; });
-  _add_column<float>(segments_by_chunk, column_definitions, "I_PRICE", cardinalities,
-                     [&](std::vector<size_t>) { return _random_gen.random_number(100, 10000) / 100.f; });
+  _add_column<float>(segments_by_chunk, column_definitions, "I_PRICE", cardinalities, [&](std::vector<size_t>) {
+    return static_cast<float>(_random_gen.random_number(100, 10000)) / 100.f;
+  });
   _add_column<pmr_string>(
       segments_by_chunk, column_definitions, "I_DATA", cardinalities, [&](std::vector<size_t> indices) {
         std::string data = _random_gen.astring(26, 50);
@@ -92,8 +93,9 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_warehouse_table() {
 
   _add_column<pmr_string>(segments_by_chunk, column_definitions, "W_ZIP", cardinalities,
                           [&](std::vector<size_t>) { return pmr_string{_random_gen.zip_code()}; });
-  _add_column<float>(segments_by_chunk, column_definitions, "W_TAX", cardinalities,
-                     [&](std::vector<size_t>) { return _random_gen.random_number(0, 2000) / 10000.f; });
+  _add_column<float>(segments_by_chunk, column_definitions, "W_TAX", cardinalities, [&](std::vector<size_t>) {
+    return static_cast<float>(_random_gen.random_number(0, 2000)) / 10000.f;
+  });
   _add_column<float>(segments_by_chunk, column_definitions, "W_YTD", cardinalities, [&](std::vector<size_t>) {
     return CUSTOMER_YTD * NUM_CUSTOMERS_PER_DISTRICT * NUM_DISTRICTS_PER_WAREHOUSE;
   });
@@ -189,8 +191,9 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_district_table() {
 
   _add_column<pmr_string>(segments_by_chunk, column_definitions, "D_ZIP", cardinalities,
                           [&](std::vector<size_t>) { return pmr_string{_random_gen.zip_code()}; });
-  _add_column<float>(segments_by_chunk, column_definitions, "D_TAX", cardinalities,
-                     [&](std::vector<size_t>) { return _random_gen.random_number(0, 2000) / 10000.f; });
+  _add_column<float>(segments_by_chunk, column_definitions, "D_TAX", cardinalities, [&](std::vector<size_t>) {
+    return static_cast<float>(_random_gen.random_number(0, 2000)) / 10000.f;
+  });
   _add_column<float>(segments_by_chunk, column_definitions, "D_YTD", cardinalities,
                      [&](std::vector<size_t>) { return CUSTOMER_YTD * NUM_CUSTOMERS_PER_DISTRICT; });
   _add_column<int32_t>(segments_by_chunk, column_definitions, "D_NEXT_O_ID", cardinalities,
@@ -253,8 +256,9 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_customer_table() {
                           });
   _add_column<float>(segments_by_chunk, column_definitions, "C_CREDIT_LIM", cardinalities,
                      [&](std::vector<size_t>) { return 50000; });
-  _add_column<float>(segments_by_chunk, column_definitions, "C_DISCOUNT", cardinalities,
-                     [&](std::vector<size_t>) { return _random_gen.random_number(0, 5000) / 10000.f; });
+  _add_column<float>(segments_by_chunk, column_definitions, "C_DISCOUNT", cardinalities, [&](std::vector<size_t>) {
+    return static_cast<float>(_random_gen.random_number(0, 5000)) / 10000.f;
+  });
   _add_column<float>(segments_by_chunk, column_definitions, "C_BALANCE", cardinalities,
                      [&](std::vector<size_t>) { return -CUSTOMER_YTD; });
   _add_column<float>(segments_by_chunk, column_definitions, "C_YTD_PAYMENT", cardinalities,
@@ -455,7 +459,7 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_order_line_table(
                                 [&](std::vector<size_t> indices) {
                                   return indices[2] < NUM_ORDERS_PER_DISTRICT - NUM_NEW_ORDERS_PER_DISTRICT
                                              ? 0.f
-                                             : _random_gen.random_number(1, 999999) / 100.f;
+                                             : static_cast<float>(_random_gen.random_number(1, 999999)) / 100.f;
                                 });
   _add_order_line_column<pmr_string>(segments_by_chunk, column_definitions, "OL_DIST_INFO", cardinalities,
                                      order_line_counts,

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
@@ -209,7 +209,7 @@ std::string TPCHBenchmarkItemRunner::_build_query(const BenchmarkItemID item_id)
       const auto end_date = calculate_date(boost::gregorian::date{1993, 01, 01}, (diff + 1) * 12);
 
       static std::uniform_int_distribution<> discount_dist{2, 9};
-      const auto discount = 0.01f * discount_dist(random_engine);
+      const auto discount = 0.01f * static_cast<float>(discount_dist(random_engine));
 
       std::uniform_int_distribution<> quantity_dist{24, 25};
       const auto quantity = quantity_dist(random_engine);

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -79,7 +79,7 @@ DSSType call_dbgen_mk(size_t idx, MKRetType (*mk_fn)(DSS_HUGE, DSSType* val, Arg
 float convert_money(DSS_HUGE cents) {
   const auto dollars = cents / 100;
   cents %= 100;
-  return dollars + (static_cast<float>(cents)) / 100.0f;
+  return static_cast<float>(dollars) + (static_cast<float>(cents)) / 100.0f;
 }
 
 /**

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -72,7 +72,7 @@ class GDFSCache : public AbstractCacheImpl<Key, Value> {
       entry.value = value;
       entry.size = size;
       entry.frequency++;
-      entry.priority = _inflation + entry.frequency / entry.size;
+      entry.priority = _inflation + static_cast<double>(entry.frequency) / entry.size;
       _queue.update(handle);
 
       return;
@@ -89,7 +89,7 @@ class GDFSCache : public AbstractCacheImpl<Key, Value> {
 
     // Insert new item in cache.
     GDFSCacheEntry entry{key, value, 1, size, 0.0};
-    entry.priority = _inflation + entry.frequency / entry.size;
+    entry.priority = _inflation + static_cast<double>(entry.frequency) / entry.size;
     Handle handle = _queue.push(entry);
     _map[key] = handle;
   }
@@ -100,7 +100,7 @@ class GDFSCache : public AbstractCacheImpl<Key, Value> {
     Handle handle = it->second;
     GDFSCacheEntry& entry = (*handle);
     entry.frequency++;
-    entry.priority = _inflation + entry.frequency / entry.size;
+    entry.priority = _inflation + static_cast<double>(entry.frequency) / entry.size;
     _queue.update(handle);
     return entry.value;
   }

--- a/src/lib/expression/evaluation/expression_functors.hpp
+++ b/src/lib/expression/evaluation/expression_functors.hpp
@@ -94,7 +94,8 @@ struct STLComparisonFunctorWrapper {
     if constexpr (std::is_same_v<NullValue, ArgA> || std::is_same_v<NullValue, ArgB>) {
       result = Result{};
     } else {
-      result = static_cast<Result>(Functor<std::common_type_t<ArgA, ArgB>>{}(a, b));
+      result = static_cast<Result>(Functor<std::common_type_t<ArgA, ArgB>>{}(
+          static_cast<std::common_type_t<ArgA, ArgB>>(a), static_cast<std::common_type_t<ArgA, ArgB>>(b)));
     }
   }
 };
@@ -122,7 +123,8 @@ struct STLArithmeticFunctorWrapper {
                   std::is_same_v<NullValue, ArgB>) {
       result = Result{};
     } else {
-      result = static_cast<Result>(Functor<std::common_type_t<ArgA, ArgB>>{}(a, b));
+      result = static_cast<Result>(Functor<std::common_type_t<ArgA, ArgB>>{}(
+          static_cast<std::common_type_t<ArgA, ArgB>>(a), static_cast<std::common_type_t<ArgA, ArgB>>(b)));
     }
   }
 };
@@ -183,7 +185,7 @@ struct DivisionEvaluator {
       if (b_value == 0) {
         result_null = true;
       } else {
-        result_value = static_cast<Result>(a_value / b_value);
+        result_value = static_cast<Result>(static_cast<Result>(a_value) / static_cast<Result>(b_value));
       }
     }
   }

--- a/src/lib/lossy_cast.hpp
+++ b/src/lib/lossy_cast.hpp
@@ -35,10 +35,13 @@ std::optional<Target> lossy_variant_cast(const AllTypeVariant& source) {
       result = boost::get<SourceDataType>(source);
     } else {
       if constexpr (std::is_same_v<pmr_string, SourceDataType> == std::is_same_v<pmr_string, Target>) {
+        using CommonDataType = std::common_type_t<SourceDataType, Target>;
         const auto source_value = boost::get<SourceDataType>(source);
-        if (source_value > std::numeric_limits<Target>::max()) {
+        if (static_cast<CommonDataType>(source_value) >
+            static_cast<CommonDataType>(std::numeric_limits<Target>::max())) {
           result = std::numeric_limits<Target>::max();
-        } else if (source_value < std::numeric_limits<Target>::lowest()) {
+        } else if (static_cast<CommonDataType>(source_value) <
+                   static_cast<CommonDataType>(std::numeric_limits<Target>::lowest())) {
           result = std::numeric_limits<Target>::lowest();
         } else {
           result = static_cast<Target>(boost::get<SourceDataType>(source));

--- a/src/lib/operators/abstract_aggregate_operator.hpp
+++ b/src/lib/operators/abstract_aggregate_operator.hpp
@@ -55,7 +55,7 @@ class AggregateFunctionBuilder<ColumnDataType, AggregateType, AggregateFunction:
               std::vector<AggregateType>& current_secondary_aggregates) {
       // add new value to sum
       if (current_primary_aggregate) {
-        *current_primary_aggregate += new_value;
+        *current_primary_aggregate += static_cast<AggregateType>(new_value);
       } else {
         current_primary_aggregate = new_value;
       }
@@ -104,9 +104,9 @@ class AggregateFunctionBuilder<ColumnDataType, AggregateType, AggregateFunction:
 
         // update values
         ++count;
-        const double delta = new_value - mean;
+        const double delta = static_cast<double>(new_value) - mean;
         mean += delta / count;
-        const double delta2 = new_value - mean;
+        const double delta2 = static_cast<double>(new_value) - mean;
         squared_distance_from_mean += delta * delta2;
 
         if (count > 1) {

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -211,7 +211,8 @@ void AggregateHash::_aggregate() {
       size_t needed_size = aligned_size<KeysPerChunk<AggregateKey>>() +
                            chunk_count * aligned_size<AggregateKeys<AggregateKey>>() +
                            input_table->row_count() * needed_size_per_aggregate_key;
-      needed_size = static_cast<size_t>(needed_size * 1.1);  // Give it a little bit more, just in case
+      needed_size =
+          static_cast<size_t>(static_cast<double>(needed_size) * 1.1);  // Give it a little bit more, just in case
 
       auto temp_buffer = boost::container::pmr::monotonic_buffer_resource(needed_size);
       auto allocator = AggregateKeysAllocator{PolymorphicAllocator<AggregateKeys<AggregateKey>>{&temp_buffer}};

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -232,7 +232,7 @@ void AggregateSort::_set_and_write_aggregate_value(
       current_primary_aggregate = std::optional<AggregateType>();
     } else {
       // normal average calculation
-      current_primary_aggregate = *current_primary_aggregate / value_count;
+      current_primary_aggregate = *current_primary_aggregate / static_cast<AggregateType>(value_count);
     }
   }
   if constexpr (function == AggregateFunction::StandardDeviationSample &&

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -194,7 +194,8 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
         // to avoid large build partitions, this should never happen. Nonetheless, we better
         // assert since the effects of overflows will probably hard to debug.
         const auto max_partition_size = std::numeric_limits<uint32_t>::max() * 0.5;
-        Assert(static_cast<size_t>(build_input_table->row_count() / std::pow(2, *_radix_bits)) < max_partition_size,
+        Assert(static_cast<uint32_t>(static_cast<double>(build_input_table->row_count()) / std::pow(2, *_radix_bits)) <
+                   max_partition_size,
                "Partition count too small (potential overflows in hash map offsetting).");
 
         _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -223,7 +223,7 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const
 
   std::vector<std::shared_ptr<BaseAttributeStatistics>> column_statistics(column_count);
 
-  const auto scale = 1 - (num_rows_pruned / old_statistics.row_count);
+  const auto scale = 1 - (static_cast<float>(num_rows_pruned) / old_statistics.row_count);
   for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     if (column_id == predicate.column_id) {
       column_statistics[column_id] = old_statistics.column_statistics[column_id]->pruned(
@@ -235,7 +235,8 @@ std::shared_ptr<TableStatistics> ChunkPruningRule::_prune_table_statistics(const
     }
   }
 
-  return std::make_shared<TableStatistics>(std::move(column_statistics), old_statistics.row_count - num_rows_pruned);
+  return std::make_shared<TableStatistics>(std::move(column_statistics),
+                                           old_statistics.row_count - static_cast<float>(num_rows_pruned));
 }
 
 }  // namespace opossum

--- a/src/lib/statistics/statistics_objects/abstract_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/abstract_histogram.cpp
@@ -150,7 +150,7 @@ float AbstractHistogram<T>::bin_ratio_less_than(const BinID bin_id, const T& val
     const auto value_repr = _domain.string_to_number(in_domain_value);
     const auto min_repr = _domain.string_to_number(bin_min.substr(common_prefix_length));
     const auto max_repr = _domain.string_to_number(bin_max.substr(common_prefix_length));
-    const auto bin_ratio = static_cast<float>(value_repr - min_repr) / (max_repr - min_repr + 1);
+    const auto bin_ratio = static_cast<float>(value_repr - min_repr) / static_cast<float>(max_repr - min_repr + 1);
 
     return bin_ratio;
   }
@@ -186,7 +186,7 @@ float AbstractHistogram<T>::bin_ratio_less_than_equals(const BinID bin_id, const
     const auto value_repr = _domain.string_to_number(in_domain_value) + 1;
     const auto min_repr = _domain.string_to_number(bin_min.substr(common_prefix_length));
     const auto max_repr = _domain.string_to_number(bin_max.substr(common_prefix_length));
-    const auto bin_ratio = static_cast<float>(value_repr - min_repr) / (max_repr - min_repr + 1);
+    const auto bin_ratio = static_cast<float>(value_repr - min_repr) / static_cast<float>(max_repr - min_repr + 1);
 
     return bin_ratio;
   }

--- a/src/lib/statistics/statistics_objects/counting_quotient_filter.cpp
+++ b/src/lib/statistics/statistics_objects/counting_quotient_filter.cpp
@@ -110,8 +110,11 @@ size_t CountingQuotientFilter<ElementType>::memory_consumption() const {
 template <typename ElementType>
 float CountingQuotientFilter<ElementType>::load_factor() const {
   auto load_factor = 0.f;
-  std::visit([&](auto& filter) { load_factor = filter.noccupied_slots / static_cast<float>(filter.nslots); },
-             _quotient_filter);
+  std::visit(
+      [&](auto& filter) {
+        load_factor = static_cast<float>(filter.noccupied_slots) / static_cast<float>(filter.nslots);
+      },
+      _quotient_filter);
   return load_factor;
 }
 

--- a/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
@@ -83,8 +83,8 @@ EqualDistinctCountHistogram<T>::EqualDistinctCountHistogram(std::vector<T>&& bin
   AbstractHistogram<T>::_assert_bin_validity();
 
   _total_count = std::accumulate(_bin_heights.cbegin(), _bin_heights.cend(), HistogramCountType{0});
-  _total_distinct_count =
-      static_cast<HistogramCountType>(_distinct_count_per_bin * bin_count() + _bin_count_with_extra_value);
+  _total_distinct_count = _distinct_count_per_bin * static_cast<HistogramCountType>(bin_count()) +
+                          static_cast<HistogramCountType>(_bin_count_with_extra_value);
 }
 
 template <typename T>

--- a/src/lib/statistics/statistics_objects/histogram_domain.cpp
+++ b/src/lib/statistics/statistics_objects/histogram_domain.cpp
@@ -24,7 +24,8 @@ size_t HistogramDomain<pmr_string>::character_range_width() const {
 HistogramDomain<pmr_string>::IntegralType HistogramDomain<pmr_string>::string_to_number(
     const pmr_string& string_value) const {
   // The prefix length must not overflow for the number of supported characters when representing strings as numbers.
-  DebugAssert(prefix_length < std::log(std::numeric_limits<uint64_t>::max()) / std::log(character_range_width() + 1),
+  DebugAssert(prefix_length <= static_cast<size_t>(std::log(std::numeric_limits<uint64_t>::max()) /
+                                                   std::log(character_range_width() + 1)),
               "String prefix too long");
   if (!contains(string_value)) {
     return string_to_number(string_to_domain(string_value));

--- a/src/lib/statistics/table_statistics.cpp
+++ b/src/lib/statistics/table_statistics.cpp
@@ -50,8 +50,9 @@ std::shared_ptr<TableStatistics> TableStatistics::from_table(const Table& table)
             // Use the insight that the histogram will only contain non-null values to generate the NullValueRatio
             // property
             const auto null_value_ratio =
-                table.row_count() == 0 ? 0.0f
-                                       : 1.0f - (static_cast<float>(histogram->total_count()) / table.row_count());
+                table.row_count() == 0
+                    ? 0.0f
+                    : 1.0f - (static_cast<float>(histogram->total_count()) / static_cast<float>(table.row_count()));
             output_column_statistics->set_statistics_object(
                 std::make_shared<NullValueRatioStatistics>(null_value_ratio));
           } else {

--- a/src/lib/storage/run_length_segment/run_length_segment_iterable.hpp
+++ b/src/lib/storage/run_length_segment/run_length_segment_iterable.hpp
@@ -78,7 +78,7 @@ class RunLengthSegmentIterable : public PointAccessibleSegmentIterable<RunLength
     const auto chunk_size = end_positions->back();
     const auto run_count = end_positions->size();
 
-    const auto avg_elements_per_run = static_cast<float>(chunk_size) / run_count;
+    const auto avg_elements_per_run = static_cast<float>(chunk_size) / static_cast<float>(run_count);
     return static_cast<ChunkOffset>(LINEAR_SEARCH_VECTOR_DISTANCE_THRESHOLD * std::ceil(avg_elements_per_run));
   }
 

--- a/src/lib/strong_typedef.hpp
+++ b/src/lib/strong_typedef.hpp
@@ -20,7 +20,7 @@
 
 #define STRONG_TYPEDEF(T, D)                                                                                      \
   namespace opossum {                                                                                             \
-  struct D : boost::totally_ordered1<D, boost::totally_ordered2<D, T>> {                                          \
+  struct D : boost::totally_ordered1<D> {                                                                         \
     typedef T base_type;                                                                                          \
     T t;                                                                                                          \
     constexpr explicit D(const T& t_) BOOST_NOEXCEPT_IF(boost::has_nothrow_copy_constructor<T>::value) : t(t_) {} \

--- a/src/lib/utils/size_estimation_utils.hpp
+++ b/src/lib/utils/size_estimation_utils.hpp
@@ -49,7 +49,7 @@ size_t string_vector_memory_usage(const V& string_vector, const MemoryUsageCalcu
   constexpr auto min_rows = size_t{10};
 
   const auto samples_to_draw =
-      std::max(min_rows, static_cast<size_t>(std::ceil(sampling_factor * string_vector.size())));
+      std::max(min_rows, static_cast<size_t>(std::ceil(sampling_factor * static_cast<float>(string_vector.size()))));
 
   if (mode == MemoryUsageCalculationMode::Full || samples_to_draw >= string_vector.size()) {
     // Run the (expensive) calculation of aggregating the whole vector's string sizes when full estimation is desired
@@ -84,10 +84,10 @@ size_t string_vector_memory_usage(const V& string_vector, const MemoryUsageCalcu
     elements_size += string_heap_size(string_vector[sample_position]);
   }
 
-  const auto actual_sampling_factor = static_cast<float>(samples_to_draw) / string_vector.size();
-  return base_size +
-         static_cast<size_t>(std::ceil(static_cast<float>(elements_size) / static_cast<float>(actual_sampling_factor)) +
-                             (string_vector.capacity() - string_vector.size()) * sizeof(StringType));
+  const auto actual_sampling_factor = static_cast<float>(samples_to_draw) / static_cast<float>(string_vector.size());
+  return base_size + static_cast<size_t>(
+                         std::ceil(static_cast<float>(elements_size) / static_cast<float>(actual_sampling_factor)) +
+                         static_cast<float>((string_vector.capacity() - string_vector.size()) * sizeof(StringType)));
 }
 
 }  // namespace opossum

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -58,7 +58,8 @@ void PQPVisualizer::_build_graph(const std::vector<std::shared_ptr<AbstractOpera
     // Print third column (relative operator duration)
     operator_breakdown_stream << "|";
     for (const auto& [_, nanoseconds] : sorted_duration_by_operator_name) {
-      operator_breakdown_stream << round(static_cast<double>(nanoseconds.count()) / total_nanoseconds.count() * 100)
+      operator_breakdown_stream << round(static_cast<double>(nanoseconds.count()) /
+                                         static_cast<double>(total_nanoseconds.count()) * 100)
                                 << " %\\l";
     }
     operator_breakdown_stream << " \\l";
@@ -147,7 +148,7 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
     info.label = stream.str();
   }
 
-  info.pen_width = performance_data.output_row_count;
+  info.pen_width = static_cast<double>(performance_data.output_row_count);
   if (to->input_right() != nullptr) {
     info.arrowhead = side == InputSide::Left ? "lnormal" : "rnormal";
   }
@@ -163,9 +164,9 @@ void PQPVisualizer::_add_operator(const std::shared_ptr<const AbstractOperator>&
   if (performance_data.executed) {
     auto total = performance_data.walltime;
     label += "\n\n" + format_duration(total);
-    info.pen_width = total.count();
+    info.pen_width = static_cast<double>(total.count());
   } else {
-    info.pen_width = 1;
+    info.pen_width = 1.0;
   }
 
   _duration_by_operator_name[op->name()] += performance_data.walltime;

--- a/src/test/lib/all_type_variant_test.cpp
+++ b/src/test/lib/all_type_variant_test.cpp
@@ -12,8 +12,8 @@ namespace opossum {
 template <typename T>
 class AllTypeVariantTest : public BaseTest {};
 
-using DataTypes = ::testing::Types<int32_t, int64_t, float, double, pmr_string>;
-TYPED_TEST_SUITE(AllTypeVariantTest, DataTypes, );  // NOLINT(whitespace/parens)
+using AllTypeVariantTestDataTypes = ::testing::Types<int32_t, int64_t, float, double, pmr_string>;
+TYPED_TEST_SUITE(AllTypeVariantTest, AllTypeVariantTestDataTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(AllTypeVariantTest, GetExtractsExactNumericalValue) {
   auto values = std::vector<TypeParam>{};

--- a/src/test/lib/all_type_variant_test.cpp
+++ b/src/test/lib/all_type_variant_test.cpp
@@ -9,34 +9,29 @@
 
 namespace opossum {
 
+template <typename T>
 class AllTypeVariantTest : public BaseTest {};
 
-TEST_F(AllTypeVariantTest, GetExtractsExactNumericalValue) {
-  {
-    const auto value_in = static_cast<float>(std::rand()) / RAND_MAX;
-    const auto variant = AllTypeVariant{value_in};
-    const auto value_out = boost::get<float>(variant);
+using DataTypes = ::testing::Types<int32_t, int64_t, float, double, pmr_string>;
+TYPED_TEST_SUITE(AllTypeVariantTest, DataTypes, );  // NOLINT(whitespace/parens)
 
-    ASSERT_EQ(value_in, value_out);
+TYPED_TEST(AllTypeVariantTest, GetExtractsExactNumericalValue) {
+  auto values = std::vector<TypeParam>{};
+  if constexpr (std::is_same_v<TypeParam, pmr_string>) {
+    values.emplace_back(pmr_string{});
+    values.emplace_back(pmr_string{"shortstring"});
+    values.emplace_back(pmr_string{"reallyreallylongstringthatcantbestoredusingsso"});
+  } else {
+    values.emplace_back(std::numeric_limits<TypeParam>::min());
+    values.emplace_back(std::numeric_limits<TypeParam>::lowest());
+    values.emplace_back(std::numeric_limits<TypeParam>::max());
+    values.emplace_back(TypeParam{0});
+    values.emplace_back(TypeParam{17});
   }
-  {
-    const auto value_in = static_cast<double>(std::rand()) / RAND_MAX;
-    const auto variant = AllTypeVariant{value_in};
-    const auto value_out = boost::get<double>(variant);
 
-    ASSERT_EQ(value_in, value_out);
-  }
-  {
-    const auto value_in = static_cast<int32_t>(std::rand());
+  for (auto value_in : values) {
     const auto variant = AllTypeVariant{value_in};
-    const auto value_out = boost::get<int32_t>(variant);
-
-    ASSERT_EQ(value_in, value_out);
-  }
-  {
-    const auto value_in = static_cast<int64_t>(std::rand());
-    const auto variant = AllTypeVariant{value_in};
-    const auto value_out = boost::get<int64_t>(variant);
+    const auto value_out = boost::get<TypeParam>(variant);
 
     ASSERT_EQ(value_in, value_out);
   }

--- a/src/test/operators/join_hash_types_test.cpp
+++ b/src/test/operators/join_hash_types_test.cpp
@@ -46,8 +46,8 @@ void test_hash_map(const std::vector<T>& values) {
   }
 }
 
-using DataTypes = ::testing::Types<int, float, double>;
-TYPED_TEST_SUITE(JoinHashTypesTest, DataTypes, );  // NOLINT(whitespace/parens)
+using JoinHashTypesTestDataTypes = ::testing::Types<int, float, double>;
+TYPED_TEST_SUITE(JoinHashTypesTest, JoinHashTypesTestDataTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(JoinHashTypesTest, BuildSingleValueLargePosList) {
   int test_item_count = 500;

--- a/src/test/server/server_test_runner.cpp
+++ b/src/test/server/server_test_runner.cpp
@@ -431,7 +431,7 @@ TEST_F(ServerTestRunner, TestTransactionConflicts) {
   EXPECT_GE(conflicted_increments, 1);
 
   EXPECT_EQ(successful_increments + conflicted_increments, num_threads * iterations_per_thread);
-  EXPECT_FLOAT_EQ(final_sum - initial_sum, successful_increments);
+  EXPECT_EQ(final_sum - initial_sum, successful_increments);
 }
 
 }  // namespace opossum

--- a/src/test/statistics/attribute_statistics_test.cpp
+++ b/src/test/statistics/attribute_statistics_test.cpp
@@ -60,8 +60,8 @@ TEST_F(AttributeStatisticsTest, Scaled) {
   EXPECT_EQ(scaled_attribute_statistics->min_max_filter->min, 0);
   EXPECT_EQ(scaled_attribute_statistics->min_max_filter->max, 100);
 
-  EXPECT_FLOAT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).first, 0);
-  EXPECT_FLOAT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).second, 100);
+  EXPECT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).first, 0);
+  EXPECT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).second, 100);
 
   EXPECT_FLOAT_EQ(attribute_statistics.null_value_ratio->ratio, 0.2f);
 }
@@ -90,8 +90,8 @@ TEST_F(AttributeStatisticsTest, Sliced) {
   EXPECT_EQ(scaled_attribute_statistics->min_max_filter->min, 51);
   EXPECT_EQ(scaled_attribute_statistics->min_max_filter->max, 100);
 
-  EXPECT_FLOAT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).first, 51);
-  EXPECT_FLOAT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).second, 100);
+  EXPECT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).first, 51);
+  EXPECT_EQ(scaled_attribute_statistics->range_filter->ranges.at(0).second, 100);
 
   EXPECT_FLOAT_EQ(attribute_statistics.null_value_ratio->ratio, 0.2f);
 }

--- a/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
@@ -121,8 +121,8 @@ class CountingQuotientFilterTypedTest : public BaseTest {
   }
 };
 
-using Types = ::testing::Types<int32_t, int64_t, pmr_string>;
-TYPED_TEST_SUITE(CountingQuotientFilterTypedTest, Types, );  // NOLINT(whitespace/parens)
+using CountingQuitenFilterTestTypes = ::testing::Types<int32_t, int64_t, pmr_string>;
+TYPED_TEST_SUITE(CountingQuotientFilterTypedTest, CountingQuitenFilterTestTypes, );  // NOLINT(whitespace/parens)
 
 TYPED_TEST(CountingQuotientFilterTypedTest, ValueCounts) {
   this->test_value_counts(this->cqf2);

--- a/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
+++ b/src/test/statistics/statistics_objects/counting_quotient_filter_test.cpp
@@ -116,7 +116,7 @@ class CountingQuotientFilterTypedTest : public BaseTest {
         ++false_positives;
       }
     }
-    const auto false_positive_rate = false_positives / static_cast<float>(runs);
+    const auto false_positive_rate = static_cast<float>(false_positives) / static_cast<float>(runs);
     EXPECT_LT(false_positive_rate, 0.4f);
   }
 };

--- a/src/test/statistics/statistics_objects/generic_histogram_test.cpp
+++ b/src/test/statistics/statistics_objects/generic_histogram_test.cpp
@@ -207,10 +207,10 @@ TEST_F(GenericHistogramTest, StringLessThan) {
                            24 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 25 * (ipow(26, 1) + ipow(26, 0)) + 1 +
                            25 * (ipow(26, 0)) + 1;
 
-  const auto bin_1_width = (bin_1_upper - bin_1_lower + 1.f);
-  const auto bin_2_width = (bin_2_upper - bin_2_lower + 1.f);
-  const auto bin_3_width = (bin_3_upper - bin_3_lower + 1.f);
-  const auto bin_4_width = (bin_4_upper - bin_4_lower + 1.f);
+  const auto bin_1_width = (static_cast<float>(bin_1_upper - bin_1_lower) + 1.f);
+  const auto bin_2_width = (static_cast<float>(bin_2_upper - bin_2_lower) + 1.f);
+  const auto bin_3_width = (static_cast<float>(bin_3_upper - bin_3_lower) + 1.f);
+  const auto bin_4_width = (static_cast<float>(bin_4_upper - bin_4_lower) + 1.f);
 
   constexpr auto bin_1_count = 4.f;
   constexpr auto bin_2_count = 6.f;
@@ -226,17 +226,17 @@ TEST_F(GenericHistogramTest, StringLessThan) {
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "abcf"), 2 / bin_1_width * bin_1_count);
 
-  EXPECT_FLOAT_EQ(
-      histogram.estimate_cardinality(PredicateCondition::LessThan, "cccc"),
-      (2 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 2 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) +
-       1 + 2 * (ipow(26, 1) + ipow(26, 0)) + 1 + 2 * (ipow(26, 0)) + 1 - bin_1_lower) /
-          bin_1_width * bin_1_count);
+  EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "cccc"),
+                  static_cast<float>(2 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     2 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     2 * (ipow(26, 1) + ipow(26, 0)) + 1 + 2 * (ipow(26, 0)) + 1 - bin_1_lower) /
+                      bin_1_width * bin_1_count);
 
-  EXPECT_FLOAT_EQ(
-      histogram.estimate_cardinality(PredicateCondition::LessThan, "dddd"),
-      (3 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 3 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) +
-       1 + 3 * (ipow(26, 1) + ipow(26, 0)) + 1 + 3 * (ipow(26, 0)) + 1 - bin_1_lower) /
-          bin_1_width * bin_1_count);
+  EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "dddd"),
+                  static_cast<float>(3 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     3 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     3 * (ipow(26, 1) + ipow(26, 0)) + 1 + 3 * (ipow(26, 0)) + 1 - bin_1_lower) /
+                      bin_1_width * bin_1_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "efgg"),
                   (bin_1_width - 2) / bin_1_width * bin_1_count);
@@ -252,24 +252,24 @@ TEST_F(GenericHistogramTest, StringLessThan) {
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "ijkn"),
                   2 / bin_2_width * bin_2_count + bin_1_count);
 
-  EXPECT_FLOAT_EQ(
-      histogram.estimate_cardinality(PredicateCondition::LessThan, "jjjj"),
-      (9 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 9 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) +
-       1 + 9 * (ipow(26, 1) + ipow(26, 0)) + 1 + 9 * (ipow(26, 0)) + 1 - bin_2_lower) /
-              bin_2_width * bin_2_count +
-          bin_1_count);
+  EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "jjjj"),
+                  static_cast<float>(9 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     9 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     9 * (ipow(26, 1) + ipow(26, 0)) + 1 + 9 * (ipow(26, 0)) + 1 - bin_2_lower) /
+                          bin_2_width * bin_2_count +
+                      bin_1_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "kkkk"),
-                  (10 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   10 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 10 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   10 * (ipow(26, 0)) + 1 - bin_2_lower) /
+                  static_cast<float>(10 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     10 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     10 * (ipow(26, 1) + ipow(26, 0)) + 1 + 10 * (ipow(26, 0)) + 1 - bin_2_lower) /
                           bin_2_width * bin_2_count +
                       bin_1_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "lzzz"),
-                  (11 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   25 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 25 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   25 * (ipow(26, 0)) + 1 - bin_2_lower) /
+                  static_cast<float>(11 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     25 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     25 * (ipow(26, 1) + ipow(26, 0)) + 1 + 25 * (ipow(26, 0)) + 1 - bin_2_lower) /
                           bin_2_width * bin_2_count +
                       bin_1_count);
 
@@ -288,23 +288,23 @@ TEST_F(GenericHistogramTest, StringLessThan) {
                   2 / bin_3_width * bin_3_count + bin_1_count + bin_2_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "pppp"),
-                  (15 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   15 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 15 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   15 * (ipow(26, 0)) + 1 - bin_3_lower) /
+                  static_cast<float>(15 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     15 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     15 * (ipow(26, 1) + ipow(26, 0)) + 1 + 15 * (ipow(26, 0)) + 1 - bin_3_lower) /
                           bin_3_width * bin_3_count +
                       bin_1_count + bin_2_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "qqqq"),
-                  (16 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   16 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 16 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   16 * (ipow(26, 0)) + 1 - bin_3_lower) /
+                  static_cast<float>(16 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     16 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     16 * (ipow(26, 1) + ipow(26, 0)) + 1 + 16 * (ipow(26, 0)) + 1 - bin_3_lower) /
                           bin_3_width * bin_3_count +
                       bin_1_count + bin_2_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "qllo"),
-                  (16 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   11 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 11 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   14 * (ipow(26, 0)) + 1 - bin_3_lower) /
+                  static_cast<float>(16 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     11 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     11 * (ipow(26, 1) + ipow(26, 0)) + 1 + 14 * (ipow(26, 0)) + 1 - bin_3_lower) /
                           bin_3_width * bin_3_count +
                       bin_1_count + bin_2_count);
 
@@ -327,23 +327,23 @@ TEST_F(GenericHistogramTest, StringLessThan) {
                   2 / bin_4_width * bin_4_count + bin_1_count + bin_2_count + bin_3_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "vvvv"),
-                  (21 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   21 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 21 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   21 * (ipow(26, 0)) + 1 - bin_4_lower) /
+                  static_cast<float>(21 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     21 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     21 * (ipow(26, 1) + ipow(26, 0)) + 1 + 21 * (ipow(26, 0)) + 1 - bin_4_lower) /
                           bin_4_width * bin_4_count +
                       bin_1_count + bin_2_count + bin_3_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "xxxx"),
-                  (23 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   23 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 23 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   23 * (ipow(26, 0)) + 1 - bin_4_lower) /
+                  static_cast<float>(23 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     23 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     23 * (ipow(26, 1) + ipow(26, 0)) + 1 + 23 * (ipow(26, 0)) + 1 - bin_4_lower) /
                           bin_4_width * bin_4_count +
                       bin_1_count + bin_2_count + bin_3_count);
 
   EXPECT_FLOAT_EQ(histogram.estimate_cardinality(PredicateCondition::LessThan, "ycip"),
-                  (24 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
-                   2 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 + 8 * (ipow(26, 1) + ipow(26, 0)) + 1 +
-                   15 * (ipow(26, 0)) + 1 - bin_4_lower) /
+                  static_cast<float>(24 * (ipow(26, 3) + ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     2 * (ipow(26, 2) + ipow(26, 1) + ipow(26, 0)) + 1 +
+                                     8 * (ipow(26, 1) + ipow(26, 0)) + 1 + 15 * (ipow(26, 0)) + 1 - bin_4_lower) /
                           bin_4_width * bin_4_count +
                       bin_1_count + bin_2_count + bin_3_count);
 

--- a/src/test/tpc/tpcc_test.cpp
+++ b/src/test/tpc/tpcc_test.cpp
@@ -300,7 +300,7 @@ TEST_F(TPCCTest, NewOrder) {
       EXPECT_EQ(table->row_count(), 1);
       const auto i_price = *table->get_value<float>("I_PRICE", 0);
 
-      const auto expected_ol_amount = i_price * order_lines[line_idx].ol_quantity;
+      const auto expected_ol_amount = i_price * static_cast<float>(order_lines[line_idx].ol_quantity);
       EXPECT_EQ(order_line_row[8], AllTypeVariant{expected_ol_amount});  // OL_AMOUNT
     }
 
@@ -404,7 +404,7 @@ TEST_F(TPCCTest, PaymentCustomerByName) {
     // Customers start with C_BALANCE = -10, C_YTD_PAYMENT = 10, C_PAYMENT_CNT = 1
     EXPECT_FLOAT_EQ(*table->get_value<float>("C_BALANCE", 0), -10.0f - payment.h_amount);
     EXPECT_FLOAT_EQ(*table->get_value<float>("C_YTD_PAYMENT", 0), 10.0f + payment.h_amount);
-    EXPECT_FLOAT_EQ(*table->get_value<int32_t>("C_PAYMENT_CNT", 0), 2);
+    EXPECT_EQ(*table->get_value<int32_t>("C_PAYMENT_CNT", 0), 2);
   }
 
   // We do not test for C_DATA


### PR DESCRIPTION
I locally installed clang-10 on one of my laptops. Mostly, clang now warns about implicit int to float conversions. While adding static_casts makes the code more verbose, I think that this might make people more aware of potentially lossy casts.

clang-10 support is not yet part of CI, so for now, this is a one time change with (hopefully) no visible effects.