### PR TITLE
Benchmark: fix NULL detection

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -65,6 +65,8 @@ void AbstractTableGenerator::generate_and_store() {
                   is_sorted = false;
                   break;
                 }
+
+                ++it;
                 continue;
               }
 
@@ -158,8 +160,8 @@ void AbstractTableGenerator::generate_and_store() {
     std::cout << " (" << per_table_timer.lap_formatted() << ")" << std::endl;
   }
   metrics.encoding_duration = timer.lap();
-  std::cout << "- Encoding tables and generating pruning statistic done ("
-            << format_duration(metrics.encoding_duration) << ")" << std::endl;
+  std::cout << "- Encoding tables and generating pruning statistic done (" << format_duration(metrics.encoding_duration)
+            << ")" << std::endl;
 
   /**
    * Write the Tables into binary files if required


### PR DESCRIPTION
Some benchmarks define sort orders, e.g. lineitem is sorted by l_shipdate. To avoid unnecessary sorting, the AbstractTableGenerator performs a check whether the table is already sorted. This led to an endless loop, if the first value of the sorting column is NULL.

fixes #2079, thanks @aloeser 