### PR TITLE
Reduce test times

### DIFF
--- a/scripts/analyze_gtest_runtime.py
+++ b/scripts/analyze_gtest_runtime.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+# Takes the JSON output of googletest and prints information about the longest tests and test suites
+
+import json
+import sys
+from terminaltables import AsciiTable
+
+if len(sys.argv) != 2:
+  print('Usage: (1) Run googletest with --gtest_output="json:output.json"')
+  print('       (2) " + sys.argv[0] + " output.json')
+  sys.exit(1)
+
+with open(sys.argv[1]) as f:
+  data = json.load(f)
+
+testsuites = {}
+tests = {}
+
+for testsuite in data['testsuites']:
+  testsuites[testsuite['name']] = float(testsuite['time'].replace('s', ''))
+  for test in testsuite['testsuite']:
+    tests[testsuite['name'] + '.' + test['name']] = float(test['time'].replace('s', ''))
+
+
+testsuites_sorted = list({k: v for k, v in sorted(testsuites.items(), key=lambda item: -item[1])}.items())
+tests_sorted = list({k: v for k, v in sorted(tests.items(), key=lambda item: -item[1])}.items())
+
+NUM = 20
+table = []
+table += [[str(NUM) + ' most expensive test suites', 's', str(NUM) + ' most expensive tests', 's']]
+
+for i in range(NUM):
+  table += [[testsuites_sorted[i][0], testsuites_sorted[i][1], tests_sorted[i][0], tests_sorted[i][1]]]
+
+print(AsciiTable(table).table)

--- a/scripts/analyze_gtest_runtime.py
+++ b/scripts/analyze_gtest_runtime.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Takes the JSON output of googletest and prints information about the longest tests and test suites
+# Takes the JSON output of googletest and prints information about the longest running tests and test suites
 
 import json
 import sys
@@ -26,11 +26,11 @@ for testsuite in data['testsuites']:
 testsuites_sorted = list({k: v for k, v in sorted(testsuites.items(), key=lambda item: -item[1])}.items())
 tests_sorted = list({k: v for k, v in sorted(tests.items(), key=lambda item: -item[1])}.items())
 
-NUM = 20
+ENTRIES_SHOWN = 20
 table = []
-table += [[str(NUM) + ' most expensive test suites', 's', str(NUM) + ' most expensive tests', 's']]
+table += [[str(ENTRIES_SHOWN) + ' most expensive test suites', 's', str(ENTRIES_SHOWN) + ' most expensive tests', 's']]
 
-for i in range(NUM):
+for i in range(ENTRIES_SHOWN):
   table += [[testsuites_sorted[i][0], testsuites_sorted[i][1], tests_sorted[i][0], tests_sorted[i][1]]]
 
 print(AsciiTable(table).table)

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -46,18 +46,26 @@ namespace opossum {
 
 class SQLTranslatorTest : public BaseTest {
  public:
-  void SetUp() override {
-    Hyrise::get().storage_manager.add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
-    Hyrise::get().storage_manager.add_table("int_string", load_table("resources/test_data/tbl/int_string.tbl"));
-    Hyrise::get().storage_manager.add_table("int_float2", load_table("resources/test_data/tbl/int_float2.tbl"));
-    Hyrise::get().storage_manager.add_table("int_float5", load_table("resources/test_data/tbl/int_float5.tbl"));
-    Hyrise::get().storage_manager.add_table("int_int_int", load_table("resources/test_data/tbl/int_int_int.tbl"));
+  static void SetUpTestSuite() {
+    int_float = load_table("resources/test_data/tbl/int_float.tbl");
+    int_string = load_table("resources/test_data/tbl/int_string.tbl");
+    int_float2 = load_table("resources/test_data/tbl/int_float2.tbl");
+    int_float5 = load_table("resources/test_data/tbl/int_float5.tbl");
+    int_int_int = load_table("resources/test_data/tbl/int_int_int.tbl");
+  }
 
+  void SetUp() override {
     stored_table_node_int_float = StoredTableNode::make("int_float");
     stored_table_node_int_string = StoredTableNode::make("int_string");
     stored_table_node_int_float2 = StoredTableNode::make("int_float2");
     stored_table_node_int_float5 = StoredTableNode::make("int_float5");
     stored_table_node_int_int_int = StoredTableNode::make("int_int_int");
+
+    Hyrise::get().storage_manager.add_table("int_float", int_float);
+    Hyrise::get().storage_manager.add_table("int_string", int_string);
+    Hyrise::get().storage_manager.add_table("int_float2", int_float2);
+    Hyrise::get().storage_manager.add_table("int_float5", int_float5);
+    Hyrise::get().storage_manager.add_table("int_int_int", int_int_int);
 
     int_float_a = stored_table_node_int_float->get_column("a");
     int_float_b = stored_table_node_int_float->get_column("b");
@@ -98,11 +106,9 @@ class SQLTranslatorTest : public BaseTest {
     return {lqps.at(0), translation_result.translation_info.parameter_ids_of_value_placeholders};
   }
 
-  std::shared_ptr<StoredTableNode> stored_table_node_int_float;
-  std::shared_ptr<StoredTableNode> stored_table_node_int_string;
-  std::shared_ptr<StoredTableNode> stored_table_node_int_float2;
-  std::shared_ptr<StoredTableNode> stored_table_node_int_float5;
-  std::shared_ptr<StoredTableNode> stored_table_node_int_int_int;
+  static inline std::shared_ptr<Table> int_float, int_string, int_float2, int_float5, int_int_int;
+  static inline std::shared_ptr<StoredTableNode> stored_table_node_int_float, stored_table_node_int_string,
+      stored_table_node_int_float2, stored_table_node_int_float5, stored_table_node_int_int_int;
   LQPColumnReference int_float_a, int_float_b, int_string_a, int_string_b, int_float5_a, int_float5_d, int_float2_a,
       int_float2_b, int_int_int_a, int_int_int_b, int_int_int_c;
 };


### PR DESCRIPTION
fixes #2083, adds a new script to list the most expensive tests:

```
[:~/Projekte/Opossum/Git/build] mrks/test_times(+30/-17)+* ± ../scripts/analyze_gtest_runtime.py old.json
+----------------------------------------------------+--------+---------------------------------------------------------------------------------+-------+
| 20 most expensive test suites                      | s      | 20 most expensive tests                                                         | s     |
+----------------------------------------------------+--------+---------------------------------------------------------------------------------+-------+
| JoinNestedLoop/JoinTestRunner                      | 17.265 | BinaryWriterTest.LZ4MultipleBlocks                                              | 0.596 |
| JoinSortMerge/JoinTestRunner                       | 11.251 | JoinNestedLoop/JoinTestRunner.TestJoin/678                                      | 0.52  |
| SQLiteTestRunnerUnencoded/SQLiteTestRunner         | 10.768 | JoinNestedLoop/JoinTestRunner.TestJoin/800                                      | 0.487 |
| SQLTranslatorTest                                  | 9.753  | JoinNestedLoop/JoinTestRunner.TestJoin/670                                      | 0.482 |
| TableScanBetweenTestInstances/TableScanBetweenTest | 5.239  | JoinNestedLoop/JoinTestRunner.TestJoin/682                                      | 0.463 |
| LQPTranslatorTest                                  | 2.174  | JoinNestedLoop/JoinTestRunner.TestJoin/548                                      | 0.459 |
| PredicatePlacementRuleTest                         | 1.863  | JoinNestedLoop/JoinTestRunner.TestJoin/796                                      | 0.453 |
| EncodingTypes/OperatorsTableScanTest               | 1.749  | JoinNestedLoop/JoinTestRunner.TestJoin/804                                      | 0.444 |
| ExpressionEvaluatorToValuesTest                    | 1.492  | SQLiteTestRunnerUnencoded/SQLiteTestRunner.CompareToSQLite/Line202WithUnencoded | 0.434 |
| JoinHash/JoinTestRunner                            | 1.435  | JoinNestedLoop/JoinTestRunner.TestJoin/792                                      | 0.422 |
| SegmentEncoding/EncodedSegmentIterablesTest        | 1.256  | JoinNestedLoop/JoinTestRunner.TestJoin/686                                      | 0.416 |
| SegmentEncodingSpecs/EncodedStringSegmentTest      | 0.83   | JoinNestedLoop/JoinTestRunner.TestJoin/674                                      | 0.41  |
| SegmentEncoding/EncodedStringSegmentIterablesTest  | 0.633  | JoinSortMerge/JoinTestRunner.TestJoin/599                                       | 0.393 |
| BinaryWriterTest                                   | 0.612  | SQLiteTestRunnerUnencoded/SQLiteTestRunner.CompareToSQLite/Line207WithUnencoded | 0.39  |
| SegmentEncodingSpecs/EncodedSegmentTest            | 0.529  | JoinSortMerge/JoinTestRunner.TestJoin/477                                       | 0.388 |
| MetaTable/MultiMetaTablesTest                      | 0.49   | JoinSortMerge/JoinTestRunner.TestJoin/355                                       | 0.387 |
| StorageLZ4SegmentTest                              | 0.459  | JoinNestedLoop/JoinTestRunner.TestJoin/556                                      | 0.385 |
| LogicalQueryPlanTest                               | 0.459  | JoinSortMerge/JoinTestRunner.TestJoin/603                                       | 0.363 |
| MaterializeTestInstances/MaterializeTest           | 0.437  | JoinNestedLoop/JoinTestRunner.TestJoin/808                                      | 0.362 |
| BinaryParserTest                                   | 0.358  | BinaryParserTest.LZ4MultipleBlocks                                              | 0.353 |
+----------------------------------------------------+--------+---------------------------------------------------------------------------------+-------+
[:~/Projekte/Opossum/Git/build] mrks/test_times(+30/-17)+* ± ../scripts/analyze_gtest_runtime.py new.json
+----------------------------------------------------+--------+---------------------------------------------------------------------------------+-------+
| 20 most expensive test suites                      | s      | 20 most expensive tests                                                         | s     |
+----------------------------------------------------+--------+---------------------------------------------------------------------------------+-------+
| JoinNestedLoop/JoinTestRunner                      | 14.267 | BinaryWriterTest.LZ4MultipleBlocks                                              | 0.551 |
| JoinSortMerge/JoinTestRunner                       | 9.833  | JoinNestedLoop/JoinTestRunner.TestJoin/678                                      | 0.462 |
| SQLiteTestRunnerUnencoded/SQLiteTestRunner         | 8.725  | JoinNestedLoop/JoinTestRunner.TestJoin/800                                      | 0.461 |
| LQPTranslatorTest                                  | 2.228  | JoinNestedLoop/JoinTestRunner.TestJoin/804                                      | 0.435 |
| TableScanBetweenTestInstances/TableScanBetweenTest | 2.045  | JoinNestedLoop/JoinTestRunner.TestJoin/682                                      | 0.424 |
| PredicatePlacementRuleTest                         | 1.786  | JoinNestedLoop/JoinTestRunner.TestJoin/796                                      | 0.419 |
| ExpressionEvaluatorToValuesTest                    | 1.475  | JoinNestedLoop/JoinTestRunner.TestJoin/674                                      | 0.407 |
| EncodingTypes/OperatorsTableScanTest               | 1.138  | JoinNestedLoop/JoinTestRunner.TestJoin/670                                      | 0.404 |
| SegmentEncoding/EncodedSegmentIterablesTest        | 1.098  | JoinNestedLoop/JoinTestRunner.TestJoin/792                                      | 0.397 |
| JoinHash/JoinTestRunner                            | 1.062  | JoinSortMerge/JoinTestRunner.TestJoin/355                                       | 0.396 |
| SegmentEncodingSpecs/EncodedStringSegmentTest      | 0.724  | SQLiteTestRunnerUnencoded/SQLiteTestRunner.CompareToSQLite/Line202WithUnencoded | 0.391 |
| BinaryWriterTest                                   | 0.567  | JoinSortMerge/JoinTestRunner.TestJoin/599                                       | 0.378 |
| SegmentEncoding/EncodedStringSegmentIterablesTest  | 0.542  | JoinSortMerge/JoinTestRunner.TestJoin/477                                       | 0.372 |
| SegmentEncodingSpecs/EncodedSegmentTest            | 0.401  | SQLiteTestRunnerUnencoded/SQLiteTestRunner.CompareToSQLite/Line207WithUnencoded | 0.358 |
| MetaTable/MultiMetaTablesTest                      | 0.396  | JoinNestedLoop/JoinTestRunner.TestJoin/686                                      | 0.358 |
| SQLPipelineStatementTest                           | 0.39   | JoinNestedLoop/JoinTestRunner.TestJoin/556                                      | 0.356 |
| SQLTranslatorTest                                  | 0.386  | JoinNestedLoop/JoinTestRunner.TestJoin/808                                      | 0.354 |
| LogicalQueryPlanTest                               | 0.366  | JoinSortMerge/JoinTestRunner.TestJoin/603                                       | 0.331 |
| StorageLZ4SegmentTest                              | 0.332  | JoinSortMerge/JoinTestRunner.TestJoin/481                                       | 0.329 |
| BinaryParserTest                                   | 0.289  | JoinSortMerge/JoinTestRunner.TestJoin/359                                       | 0.326 |
+----------------------------------------------------+--------+---------------------------------------------------------------------------------+-------+
```