### PR TITLE
Properly protect against empty chunks

### DIFF
--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -99,23 +99,7 @@ void AbstractOperator::execute() {
   }
 }
 
-std::shared_ptr<const Table> AbstractOperator::get_output() const {
-  DebugAssert(
-      [&]() {
-        // Check that operators do not return empty chunks
-        if (!_output) return true;
-        if (_output->chunk_count() <= ChunkID{1}) return true;
-        const auto chunk_count = _output->chunk_count();
-        for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
-          const auto chunk = _output->get_chunk(chunk_id);
-          if (chunk && chunk->size() < 1) return false;
-        }
-        return true;
-      }(),
-      "Empty chunk returned from operator " + description());
-
-  return _output;
-}
+std::shared_ptr<const Table> AbstractOperator::get_output() const { return _output; }
 
 void AbstractOperator::clear_output() { _output = nullptr; }
 

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -675,7 +675,9 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
 
   // Write the output
   auto output = std::make_shared<Table>(_output_column_definitions, TableType::Data);
-  output->append_chunk(_output_segments);
+  if (_output_segments.at(0)->size() > 0) {
+    output->append_chunk(_output_segments);
+  }
 
   return output;
 }

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -583,7 +583,9 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
   }
 
   // Append output to result table
-  result_table->append_chunk(_output_segments);
+  if (_output_segments.at(0)->size() > 0) {
+    result_table->append_chunk(_output_segments);
+  }
 
   return result_table;
 }

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -261,7 +261,11 @@ std::shared_ptr<const Table> JoinIndex::_on_execute() {
         " chunks scanned using an index");
   }
 
-  return _build_output_table({std::make_shared<Chunk>(output_segments)});
+  auto chunks = std::vector<std::shared_ptr<Chunk>>{};
+  if (output_segments.at(0)->size() > 0) {
+    chunks.emplace_back(std::make_shared<Chunk>(std::move(output_segments)));
+  }
+  return _build_output_table(std::move(chunks));
 }
 
 void JoinIndex::_fallback_nested_loop(const ChunkID index_chunk_id, const bool track_probe_matches,

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -245,7 +245,11 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
     }
   }
 
-  return _build_output_table({std::make_shared<Chunk>(std::move(segments))});
+  auto chunks = std::vector<std::shared_ptr<Chunk>>{};
+  if (segments.at(0)->size() > 0) {
+    chunks.emplace_back(std::make_shared<Chunk>(std::move(segments)));
+  }
+  return _build_output_table(std::move(chunks));
 }
 
 void JoinNestedLoop::_join_two_untyped_segments(const BaseSegment& base_segment_left,

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -238,6 +238,16 @@ void Table::append_chunk(const Segments& segments, std::shared_ptr<MvccData> mvc
       const auto is_reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment) != nullptr;
       Assert(is_reference_segment == (_type == TableType::References), "Invalid Segment type");
     }
+
+    // Check that existing chunks are not empty
+    const auto chunk_count = _chunks.size();
+    for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+      const auto chunk = get_chunk(chunk_id);
+      if (!chunk) continue;
+
+      // An empty, mutable chunk at the end is fine, but in that case, append_chunk shouldn't have to be called.
+      DebugAssert(chunk->size() > 0, "append_chunk called on a table that has an empty chunk");
+    }
   }
 
   // tbb::concurrent_vector does not guarantee that elements reported by size() are fully initialized yet:

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -47,6 +47,8 @@ Table::Table(const TableColumnDefinitions& column_definitions, const TableType t
     const auto chunk = get_chunk(chunk_id);
     if (!chunk) continue;
 
+    DebugAssert(chunk->size() > 0 || (type == TableType::Data && chunk_id == chunk_count - 1 && chunk->is_mutable()),
+                "Empty chunk other than mutable chunk at the end was found");
     DebugAssert(chunk->has_mvcc_data() == (_use_mvcc == UseMvcc::Yes),
                 "Supply MvccData for Chunks iff Table uses MVCC");
     DebugAssert(chunk->column_count() == column_count(), "Invalid Chunk column count");

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -63,6 +63,8 @@ using Cost = float;
 // different memory sources. These sources are, for example, specific NUMA nodes or non-volatile memory. Without PMR,
 // we would need to explicitly make the allocator part of the class. This would make DRAM and NVM containers type-
 // incompatible. Thanks to PMR, the type is erased and both can co-exist.
+//
+// TODO(anyone): replace this with std::pmr once libc++ supports PMR.
 template <typename T>
 using PolymorphicAllocator = boost::container::pmr::polymorphic_allocator<T>;
 

--- a/src/test/operators/print_test.cpp
+++ b/src/test/operators/print_test.cpp
@@ -311,13 +311,6 @@ TEST_F(OperatorsPrintTest, SegmentType) {
 
 TEST_F(OperatorsPrintTest, EmptyTable) {
   auto tab = Hyrise::get().storage_manager.get_table(_table_name);
-  Segments empty_segments;
-  auto column_1 = std::make_shared<opossum::ValueSegment<int>>();
-  auto column_2 = std::make_shared<opossum::ValueSegment<pmr_string>>();
-  empty_segments.push_back(column_1);
-  empty_segments.push_back(column_2);
-  tab->append_chunk(empty_segments);
-
   auto wrap = std::make_shared<TableWrapper>(tab);
   wrap->execute();
 
@@ -329,9 +322,7 @@ TEST_F(OperatorsPrintTest, EmptyTable) {
       "=== Columns\n"
       "|column_1|column_2|\n"
       "|     int|  string|\n"
-      "|    null|not null|\n"
-      "=== Chunk 0 ===\n"
-      "Empty chunk.\n";
+      "|    null|not null|\n";
 
   EXPECT_EQ(output.str(), expected_output);
   EXPECT_FALSE(wrapper.is_printing_mvcc_information());

--- a/src/test/storage/table_test.cpp
+++ b/src/test/storage/table_test.cpp
@@ -157,7 +157,40 @@ TEST_F(StorageTableTest, EmplaceChunk) {
   auto vs_int = std::make_shared<ValueSegment<int>>();
   auto vs_str = std::make_shared<ValueSegment<pmr_string>>();
 
+  vs_int->append(5);
+  vs_str->append("five");
+
   t->append_chunk({vs_int, vs_str});
+  EXPECT_EQ(t->chunk_count(), 1u);
+}
+
+TEST_F(StorageTableTest, EmplaceEmptyChunk) {
+  EXPECT_EQ(t->chunk_count(), 0u);
+
+  auto vs_int = std::make_shared<ValueSegment<int>>();
+  auto vs_str = std::make_shared<ValueSegment<pmr_string>>();
+
+  t->append_chunk({vs_int, vs_str});
+  EXPECT_EQ(t->chunk_count(), 1u);
+}
+
+TEST_F(StorageTableTest, EmplaceEmptyChunkWhenEmptyExists) {
+  if (!HYRISE_DEBUG) GTEST_SKIP();
+
+  EXPECT_EQ(t->chunk_count(), 0u);
+
+  {
+    auto vs_int = std::make_shared<ValueSegment<int>>();
+    auto vs_str = std::make_shared<ValueSegment<pmr_string>>();
+    t->append_chunk({vs_int, vs_str});
+  }
+
+  {
+    auto vs_int = std::make_shared<ValueSegment<int>>();
+    auto vs_str = std::make_shared<ValueSegment<pmr_string>>();
+    EXPECT_THROW(t->append_chunk({vs_int, vs_str}), std::logic_error);
+  }
+
   EXPECT_EQ(t->chunk_count(), 1u);
 }
 
@@ -182,6 +215,9 @@ TEST_F(StorageTableTest, EmplaceChunkDoesNotReplaceIfNumberOfChunksGreaterOne) {
   {
     auto vs_int = std::make_shared<ValueSegment<int>>();
     auto vs_str = std::make_shared<ValueSegment<pmr_string>>();
+
+    vs_int->append(5);
+    vs_str->append("World!");
 
     t->append_chunk({vs_int, vs_str});
     EXPECT_EQ(t->chunk_count(), 2u);


### PR DESCRIPTION
In #2085, I found that the aggregate operator created empty chunks, which the sort did not handle properly. This tightens the rules for empty chunks, allowing them only as the last, mutable chunk for data tables. It also fixes the operators that were violating this new rule.