### PR TITLE
Fix performance regression in ColumnPruningRule

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -59,9 +59,8 @@ AbstractLQPNode::AbstractLQPNode(LQPNodeType node_type,
     : type(node_type), node_expressions(init_node_expressions) {}
 
 AbstractLQPNode::~AbstractLQPNode() {
-  Assert(
-      _outputs.empty(),
-      "Bug detected. There are outputs that should still reference to this node. Thus this node shouldn't get deleted");
+  Assert(_outputs.empty(),
+         "There are outputs that should still reference this node. Thus this node shouldn't get deleted");
 
   // We're in the destructor, thus we must make sure we're not calling any virtual methods - so we're doing the removal
   // directly instead of calling set_input_left/right(nullptr)

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -196,14 +196,12 @@ TEST_F(ColumnPruningRuleTest, Diamond) {
   // Create deep copy so we can set pruned ColumnIDs on node_a below without manipulating the input LQP
   lqp = lqp->deep_copy();
 
-  // While column c is used in a projection, the result of that projection is removed later on.
+  // Column c should be removed even below the UnionNode
   const auto pruned_node_a = pruned(node_a, {ColumnID{2}});
   const auto pruned_a = pruned_node_a->get_column("a");
   const auto pruned_b = pruned_node_a->get_column("b");
-  const auto pruned_c = pruned_node_a->get_column("c");
 
-  const auto expected_sub_lqp = ProjectionNode::make(expression_vector(add_(pruned_a, 2), add_(pruned_b, 3),
-                                                     add_(pruned_c, 4)), pruned_node_a);
+  const auto expected_sub_lqp = ProjectionNode::make(expression_vector(add_(pruned_a, 2), add_(pruned_b, 3)), pruned_node_a);
 
   const auto actual_lqp = apply_rule(rule, lqp);
 

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -182,7 +182,7 @@ TEST_F(ColumnPruningRuleTest, Diamond) {
   auto lqp = std::shared_ptr<AbstractLQPNode>{};
 
   // clang-format off
-  const auto sub_lqp = 
+  const auto sub_lqp =
   ProjectionNode::make(expression_vector(add_(a, 2), add_(b, 3), add_(c, 4)),
     node_a);
 

--- a/src/test/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/optimizer/strategy/column_pruning_rule_test.cpp
@@ -182,8 +182,9 @@ TEST_F(ColumnPruningRuleTest, Diamond) {
   auto lqp = std::shared_ptr<AbstractLQPNode>{};
 
   // clang-format off
-  const auto sub_lqp = ProjectionNode::make(expression_vector(add_(a, 2), add_(b, 3), add_(c, 4)),
-        node_a);
+  const auto sub_lqp = 
+  ProjectionNode::make(expression_vector(add_(a, 2), add_(b, 3), add_(c, 4)),
+    node_a);
 
   lqp =
   ProjectionNode::make(expression_vector(add_(a, 2), add_(b, 3)),
@@ -201,7 +202,9 @@ TEST_F(ColumnPruningRuleTest, Diamond) {
   const auto pruned_a = pruned_node_a->get_column("a");
   const auto pruned_b = pruned_node_a->get_column("b");
 
-  const auto expected_sub_lqp = ProjectionNode::make(expression_vector(add_(pruned_a, 2), add_(pruned_b, 3)), pruned_node_a);
+  const auto expected_sub_lqp =
+  ProjectionNode::make(expression_vector(add_(pruned_a, 2), add_(pruned_b, 3)),
+    pruned_node_a);
 
   const auto actual_lqp = apply_rule(rule, lqp);
 


### PR DESCRIPTION
#2011 prepared Hyrise for set operations. As part of that, the ColumnPruningRule was changed. This halved the performance of Q19. For the Positions mode in the UnionNode, this change is definitely not necessary. Skipping the additions of the column_expressions fixes the performance regression. For the other, upcoming modes, I am not sure. I removed it for now.

fixes #2115 (won't fix the other issue mentioned there)

```diff
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | Benchmark      | prev. iter/s       | runs  | new iter/s         | runs  | change [%] | p-value |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+
 | TPC-H 01       | 1.2329988479614258 | 74    | 1.2363585233688354 | 75    | +0%        |  0.5374 |
 | TPC-H 02       | 195.8797149658203  | 11753 | 191.20858764648438 | 11473 | -2%        |  0.0019 |
 | TPC-H 03       | 11.939603805541992 | 717   | 11.90280532836914  | 715   | -0%        |  0.0231 |
 | TPC-H 04       | 14.691651344299316 | 882   | 14.64279842376709  | 879   | -0%        |  0.0000 |
 | TPC-H 05       | 4.469067096710205  | 269   | 4.390355587005615  | 264   | -2%        |  0.0000 |
 | TPC-H 06       | 272.80853271484375 | 16369 | 278.51544189453125 | 16711 | +2%        |  0.0000 |
+| TPC-H 07       | 14.06118106842041  | 844   | 16.81814956665039  | 1010  | +20%       |  0.0000 |
 | TPC-H 08       | 14.612746238708496 | 877   | 15.095235824584961 | 906   | +3%        |  0.0000 |
 | TPC-H 09       | 1.8807814121246338 | 113   | 1.9384243488311768 | 117   | +3%        |  0.0000 |
 | TPC-H 10       | 3.889920711517334  | 234   | 3.896395206451416  | 234   | +0%        |  0.8684 |
 | TPC-H 11       | 107.89323425292969 | 6474  | 109.90555572509766 | 6595  | +2%        |  0.0000 |
 | TPC-H 12       | 22.232572555541992 | 1334  | 22.21855926513672  | 1334  | -0%        |  0.6204 |
 | TPC-H 13       | 2.8134889602661133 | 169   | 2.8078033924102783 | 169   | -0%        |  0.2162 |
 | TPC-H 14       | 47.13869094848633  | 2829  | 47.24376678466797  | 2835  | +0%        |  0.0468 |
 | TPC-H 15       | 126.5372085571289  | 7593  | 123.48709106445312 | 7410  | -2%        |  0.0000 |
 | TPC-H 16       | 10.98271656036377  | 659   | 11.014805793762207 | 661   | +0%        |  0.2886 |
 | TPC-H 17       | 27.565385818481445 | 1654  | 27.287858963012695 | 1638  | -1%        |  0.0000 |
 | TPC-H 18       | 1.4278912544250488 | 86    | 1.4168144464492798 | 86    | -1%        |  0.5368 |
+| TPC-H 19       | 15.487592697143555 | 930   | 29.467113494873047 | 1769  | +90%       |  0.0000 |
 | TPC-H 20       | 56.01963424682617  | 3362  | 55.41490173339844  | 3325  | -1%        |  0.0000 |
 | TPC-H 21       | 1.7175447940826416 | 104   | 1.7218716144561768 | 104   | +0%        |  0.6123 |
 | TPC-H 22       | 19.26909637451172  | 1157  | 19.052671432495117 | 1144  | -1%        |  0.0000 |
 | geometric mean |                    |       |                    |       | +4%        |         |
 +----------------+--------------------+-------+--------------------+-------+------------+---------+