### PR TITLE
Fix two expression issues

### DIFF
--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -81,7 +81,7 @@ SELECT * FROM id_int_int_int_100 WHERE 91 > a AND 20 <= a;
 SELECT * FROM id_int_int_int_100 WHERE 91 >= a AND 20 < a;
 SELECT * FROM id_int_int_int_100 WHERE 91 > a AND 20 < a;
 
--- Scans with BETWEEN that cannot be handled by ColumnBetweenTableScanImpl
+-- Scans with BETWEEN that cannot be handled by ColumnBetweenTableScanImpl, which supports scalar predicates only
 SELECT * FROM mixed WHERE 10 BETWEEN b AND 40
 SELECT * FROM mixed WHERE c BETWEEN b AND 100
 SELECT * FROM mixed WHERE b + 10 BETWEEN b AND c

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -81,6 +81,11 @@ SELECT * FROM id_int_int_int_100 WHERE 91 > a AND 20 <= a;
 SELECT * FROM id_int_int_int_100 WHERE 91 >= a AND 20 < a;
 SELECT * FROM id_int_int_int_100 WHERE 91 > a AND 20 < a;
 
+-- Scans with BETWEEN that cannot be handled by ColumnBetweenTableScanImpl
+SELECT * FROM mixed WHERE 10 BETWEEN b AND 40
+SELECT * FROM mixed WHERE c BETWEEN b AND 100
+SELECT * FROM mixed WHERE b + 10 BETWEEN b AND c
+
 -- Scans with potential for predicate pruning
 SELECT * FROM id_int_int_int_100 WHERE a >= 20 AND a <= 40 OR b >= 50 AND b <= 95;
 SELECT * FROM id_int_int_int_100 WHERE a >= 20 AND a <= 40 AND c <= 35 AND b >= 49 AND a >= 21 AND b <= 95 AND c <= 40 AND c >= 23;

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -300,8 +300,8 @@ std::unique_ptr<AbstractTableScanImpl> TableScan::create_impl() const {
 
     auto lower_bound_value = expression_get_value_or_parameter(*between_expression->lower_bound());
     if (lower_bound_value) {
-      const auto adjusted_predicate_and_value =
-          lossless_predicate_variant_cast(lower_condition, *lower_bound_value, left_column->data_type());
+      const auto adjusted_predicate_and_value = lossless_predicate_variant_cast(
+          lower_condition, *lower_bound_value, between_expression->value()->data_type());
       if (adjusted_predicate_and_value) {
         lower_condition = adjusted_predicate_and_value->first;
         lower_bound_value = adjusted_predicate_and_value->second;
@@ -312,8 +312,8 @@ std::unique_ptr<AbstractTableScanImpl> TableScan::create_impl() const {
 
     auto upper_bound_value = expression_get_value_or_parameter(*between_expression->upper_bound());
     if (upper_bound_value) {
-      const auto adjusted_predicate_and_value =
-          lossless_predicate_variant_cast(upper_condition, *upper_bound_value, left_column->data_type());
+      const auto adjusted_predicate_and_value = lossless_predicate_variant_cast(
+          upper_condition, *upper_bound_value, between_expression->value()->data_type());
       if (adjusted_predicate_and_value) {
         upper_condition = adjusted_predicate_and_value->first;
         upper_bound_value = adjusted_predicate_and_value->second;

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -209,6 +209,11 @@ std::unique_ptr<AbstractTableScanImpl> TableScan::create_impl() const {
   /**
    * Select the scanning implementation (`_impl`) to use based on the kind of the expression. For this we have to
    * closely examine the predicate expression.
+   *
+   * Many implementations require the comparison values to be of the same column type. If we were to cast the values
+   * to the column type, `int_column = 16.25` would turn into `int_column = 16`, which is obviously wrong. As such, we
+   * use lossless casts to guarantee safe type conversions. This was introduced by #1550.
+   *
    * Use the ExpressionEvaluator as a powerful, but slower fallback if no dedicated scanning implementation exists for
    * an expression.
    */

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -1027,6 +1027,13 @@ TEST_P(OperatorsTableScanTest, GetImpl) {
     // Cannot use ColumnBetweenTableScanImpl as lower bound is not a value
   }
 
+  {
+    const auto abstract_impl = TableScan{get_int_float_op(), between_exclusive_(column_a, 3, column_b)}.create_impl();
+    const auto impl = dynamic_cast<ExpressionEvaluatorTableScanImpl*>(abstract_impl.get());
+    ASSERT_TRUE(impl);
+    // Cannot use ColumnBetweenTableScanImpl as upper bound is not a value
+  }
+
   // clang-format on
 }
 

--- a/src/test/operators/table_scan_test.cpp
+++ b/src/test/operators/table_scan_test.cpp
@@ -1020,6 +1020,13 @@ TEST_P(OperatorsTableScanTest, GetImpl) {
     EXPECT_EQ(impl->right_value, AllTypeVariant{4.099999904632568359375f});
   }
 
+  {
+    const auto abstract_impl = TableScan{get_int_float_op(), between_exclusive_(column_a, column_b, 3.1)}.create_impl();
+    const auto impl = dynamic_cast<ExpressionEvaluatorTableScanImpl*>(abstract_impl.get());
+    ASSERT_TRUE(impl);
+    // Cannot use ColumnBetweenTableScanImpl as lower bound is not a value
+  }
+
   // clang-format on
 }
 

--- a/src/test/sql/sql_translator_test.cpp
+++ b/src/test/sql/sql_translator_test.cpp
@@ -2473,6 +2473,8 @@ TEST_F(SQLTranslatorTest, CatchInputErrors) {
   EXPECT_THROW(compile_query("SELECT no_such_function(5+3);"), InvalidInputException);
   EXPECT_THROW(compile_query("SELECT no_such_column FROM int_float;"), InvalidInputException);
   EXPECT_THROW(compile_query("SELECT * FROM no_such_table;"), InvalidInputException);
+  EXPECT_THROW(compile_query("SELECT SUM(b) FROM int_string;"), InvalidInputException);
+  EXPECT_THROW(compile_query("SELECT a FROM int_string GROUP BY a HAVING SUM(b) > 2;"), InvalidInputException);
   EXPECT_THROW(compile_query("SELECT b, SUM(b) AS s FROM table_a GROUP BY a;"), InvalidInputException);
   EXPECT_THROW(compile_query("SELECT * FROM int_float GROUP BY a;"), InvalidInputException);
   EXPECT_THROW(compile_query("SELECT t1.*, t2.*, SUM(t2.b) FROM int_float t1, int_float t2 GROUP BY t1.a, t1.b, t2.a"),


### PR DESCRIPTION
* For BETWEEN expressions where one of the bounds is not a column, we correctly fall back to the ExpressionEvaluator. Before this PR, we still expected both to be PQPColumnExpressions in one place.
* When trying to `SUM(string_column)`, a non-descript exception was thrown later on. We now catch this in the SQLTranslator.