### PR TITLE
Query plan visualization: use of thousands separators

### DIFF
--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -46,6 +46,7 @@ struct VizEdgeInfo {
   std::string arrowhead = "normal";
 };
 
+// Custom facet for creating a custom locale with thousands separator.
 struct SeparateThousands : std::numpunct<char> {
   char_type do_thousands_sep() const override { return ','; }  // separate with commas
   string_type do_grouping() const override { return "\3"; }    // groups of 3 digits

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -48,7 +48,6 @@ struct VizEdgeInfo {
 
 // Custom facet for creating a custom locale with thousands separator.
 struct SeparateThousands : std::numpunct<char> {
-  char_type do_thousands_sep() const override { return ','; }  // separate with commas
   string_type do_grouping() const override { return "\3"; }    // groups of 3 digits
 };
 

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -47,7 +47,7 @@ struct VizEdgeInfo {
 };
 
 // Custom facet for creating a custom locale with thousands separator.
-struct SeparateThousands : std::numpunct<char> {
+struct SeparateThousandsFacet : std::numpunct<char> {
   string_type do_grouping() const override { return "\3"; }    // groups of 3 digits
 };
 

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -46,6 +46,11 @@ struct VizEdgeInfo {
   std::string arrowhead = "normal";
 };
 
+struct SeparateThousands : std::numpunct<char> {
+  char_type do_thousands_sep() const override { return ','; }  // separate with commas
+  string_type do_grouping() const override { return "\3"; }    // groups of 3 digits
+};
+
 template <typename GraphBase>
 class AbstractVisualizer {
   //                                  Edge list    Vertex list   Directed graph

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -115,8 +115,7 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
   std::ostringstream label_stream;
 
   // use a copy of the stream's default locale with thousand separator
-  const auto& separate_thousands_locale =
-      std::locale(label_stream.getloc(), std::make_unique<SeparateThousands>().release());
+  const auto& separate_thousands_locale = std::locale(label_stream.getloc(), new SeparateThousands);
   label_stream.imbue(separate_thousands_locale);
 
   if (!isnan(row_count)) {

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -114,8 +114,11 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
 
   std::ostringstream label_stream;
 
-  // use a copy of the stream's default locale with thousand separator
-  const auto& separate_thousands_locale = std::locale(label_stream.getloc(), new SeparateThousands);
+  // Use a copy of the stream's default locale with thousands separators: Dynamically allocated raw pointers should
+  // be avoided whenever possible. Unfortunately, std::locale stores pointers to the facets and does internal
+  // reference counting. std::locale's destructor destructs the locale and the facets whose reference count becomes
+  // zero. This forces us to use a dynamically allocated raw pointer here.
+  const auto& separate_thousands_locale = std::locale(label_stream.getloc(), new SeparateThousandsFacet);
   label_stream.imbue(separate_thousands_locale);
 
   if (!isnan(row_count)) {

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -113,6 +113,12 @@ void LQPVisualizer::_build_dataflow(const std::shared_ptr<AbstractLQPNode>& from
   }
 
   std::ostringstream label_stream;
+
+  // use a copy of the stream's default locale with thousand separator
+  const auto& separate_thousands_locale =
+      std::locale(label_stream.getloc(), std::make_unique<SeparateThousands>().release());
+  label_stream.imbue(separate_thousands_locale);
+
   if (!isnan(row_count)) {
     label_stream << " " << std::fixed << std::setprecision(1) << row_count << " row(s) | " << row_percentage
                  << "% estd.";

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -145,8 +145,7 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
     std::stringstream stream;
 
     // use a copy of the stream's default locale with thousand separator
-    const auto& separate_thousands_locale =
-        std::locale(stream.getloc(), std::make_unique<SeparateThousands>().release());
+    const auto& separate_thousands_locale = std::locale(stream.getloc(), new SeparateThousands);
     stream.imbue(separate_thousands_locale);
 
     stream << performance_data.output_row_count << " row(s)/";

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -143,8 +143,14 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
   const auto& performance_data = from->performance_data();
   if (performance_data.executed && performance_data.has_output) {
     std::stringstream stream;
-    stream << std::to_string(performance_data.output_row_count) + " row(s)/";
-    stream << std::to_string(performance_data.output_chunk_count) + " chunk(s)";
+
+    // use a copy of the stream's default locale with thousand separator
+    const auto& separate_thousands_locale =
+        std::locale(stream.getloc(), std::make_unique<SeparateThousands>().release());
+    stream.imbue(separate_thousands_locale);
+
+    stream << performance_data.output_row_count << " row(s)/";
+    stream << performance_data.output_chunk_count << " chunk(s)";
     info.label = stream.str();
   }
 

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -144,8 +144,11 @@ void PQPVisualizer::_build_dataflow(const std::shared_ptr<const AbstractOperator
   if (performance_data.executed && performance_data.has_output) {
     std::stringstream stream;
 
-    // use a copy of the stream's default locale with thousand separator
-    const auto& separate_thousands_locale = std::locale(stream.getloc(), new SeparateThousands);
+    // Use a copy of the stream's default locale with thousands separators: Dynamically allocated raw pointers should
+    // be avoided whenever possible. Unfortunately, std::locale stores pointers to the facets and does internal
+    // reference counting. std::locale's destructor destructs the locale and the facets whose reference count becomes
+    // zero. This forces us to use a dynamically allocated raw pointer here.
+    const auto& separate_thousands_locale = std::locale(stream.getloc(), new SeparateThousandsFacet);
     stream.imbue(separate_thousands_locale);
 
     stream << performance_data.output_row_count << " row(s)/";


### PR DESCRIPTION
This PR integrates the usage of thousands separators in the LQP and PQP visualizations for the row (and chunk) count.

LQP example
![TPC-H_07-LQP_excerpt](https://user-images.githubusercontent.com/20044656/81097212-d9369f00-8f07-11ea-9f34-986421f9ba68.png)

PQP example
![TPC-H_07-PQP_excerpt](https://user-images.githubusercontent.com/20044656/81097227-df2c8000-8f07-11ea-9c2e-e910a31fa89d.png)