### PR TITLE
JoinIndex: Support Semi and Anti* joins with IndexSide::Left

### DIFF
--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -41,16 +41,7 @@ bool JoinIndex::supports(const JoinConfiguration config) {
       return false;  // non-inner index joins on reference tables are not supported
     }
 
-    if (config.secondary_predicates) {
-      return false;  // multi predicate index joins are not supported
-    }
-
-    const auto is_semi_or_anti_join = config.join_mode == JoinMode::Semi ||
-                                      config.join_mode == JoinMode::AntiNullAsFalse ||
-                                      config.join_mode == JoinMode::AntiNullAsTrue;
-    // if a Semi or Anti* join is executed, the left side is outputted by definition. Choosing the index join when
-    // indexes are not available for the right table would not be beneficial.
-    return !(is_semi_or_anti_join && config.index_side == IndexSide::Left);
+    return !config.secondary_predicates;  // multi predicate index joins are not supported
   }
 }
 
@@ -427,14 +418,8 @@ void JoinIndex::_append_matches(const AbstractIndex::Iterator& range_begin, cons
   const auto is_semi_or_anti_join =
       _mode == JoinMode::Semi || _mode == JoinMode::AntiNullAsFalse || _mode == JoinMode::AntiNullAsTrue;
 
-  if (is_semi_or_anti_join) {
-    Assert(_index_side == IndexSide::Right,
-           "For Semi or Anti* joins, the left side is the probe side, so the index needs to be on the right.");
-  }
-
   // Remember the matches for non-inner joins
-  if (is_semi_or_anti_join || (_mode == JoinMode::Left && _index_side == IndexSide::Right) ||
-      (_mode == JoinMode::Right && _index_side == IndexSide::Left) ||
+  if (((is_semi_or_anti_join || _mode == JoinMode::Left) && _index_side == IndexSide::Right) ||
       (_mode == JoinMode::Right && _index_side == IndexSide::Left) || _mode == JoinMode::FullOuter) {
     _probe_matches[probe_chunk_id][probe_chunk_offset] = true;
   }
@@ -505,15 +490,30 @@ void JoinIndex::_append_matches_non_inner(const bool is_semi_or_anti_join) {
   // We use `_probe_matches` to determine whether a tuple from the probe side found a match.
   if (is_semi_or_anti_join) {
     const auto invert = _mode == JoinMode::AntiNullAsFalse || _mode == JoinMode::AntiNullAsTrue;
-    const auto chunk_count = _probe_input_table->chunk_count();
-    for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
-      const auto chunk = _probe_input_table->get_chunk(chunk_id);
-      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
+    if (_index_side == IndexSide::Right) {
+      const auto chunk_count = _probe_input_table->chunk_count();
+      for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+        const auto chunk = _probe_input_table->get_chunk(chunk_id);
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
-      const auto chunk_size = chunk->size();
-      for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
-        if (_probe_matches[chunk_id][chunk_offset] ^ invert) {
-          _probe_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+        const auto chunk_size = chunk->size();
+        for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
+          if (_probe_matches[chunk_id][chunk_offset] ^ invert) {
+            _probe_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+          }
+        }
+      }
+    } else {  // INDEX SIDE LEFT
+      const auto chunk_count = _index_input_table->chunk_count();
+      for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+        const auto chunk = _index_input_table->get_chunk(chunk_id);
+        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
+
+        const auto chunk_size = chunk->size();
+        for (ChunkOffset chunk_offset{0}; chunk_offset < chunk_size; ++chunk_offset) {
+          if (_index_matches[chunk_id][chunk_offset] ^ invert) {
+            _index_pos_list->emplace_back(RowID{chunk_id, chunk_offset});
+          }
         }
       }
     }


### PR DESCRIPTION
With this PR, the `JoinIndex` supports Semi and Anti* joins where the left input table is indexed. Even if by definition the tuples of the left input table are outputted, using indexes of the left table's chunks can be beneficial when the number of tuples of the right table is very small.

Fixes #2119