### PR TITLE
Fix explanation in hash join

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -127,7 +127,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
    * JoinMode::Inner        The smaller relation becomes the build side, the bigger the probe side
    * JoinMode::Left/Right   The outer relation becomes the probe side, the inner relation becomes the build side
    * JoinMode::FullOuter    Not supported by JoinHash
-   * JoinMode::Semi/Anti*   The left relation becomes the build side, the right relation becomes the probe side
+   * JoinMode::Semi/Anti*   The left relation becomes the probe side, the right relation becomes the build side
    */
   const auto build_hash_table_for_right_input =
       _mode == JoinMode::Left || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse ||


### PR DESCRIPTION
When discussing and analyzing Hyrise's semi joins for TPC-H, @aloeser  stumpled upon the following explanation:
`* JoinMode::Semi/Anti*   The left relation becomes the build side, the right relation becomes the probe side`

Just below that, we determine to build the hash table on the right side when `const auto 
      _mode == JoinMode::Left || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse ||
      _mode == JoinMode::Semi`

Since we want to iterate all the values of the left semi side and check them for existing partner, the left side should be the probe side.

This PR fixes the comment.