### PR TITLE
Allow recognizing flipped JoinOperatorPredicates

### DIFF
--- a/src/lib/operators/operator_join_predicate.cpp
+++ b/src/lib/operators/operator_join_predicate.cpp
@@ -26,9 +26,9 @@ std::optional<OperatorJoinPredicate> OperatorJoinPredicate::from_expression(cons
 
   Assert(abstract_predicate_expression->arguments.size() == 2u, "Expected two arguments");
 
-  // It is possible that a join with the left input A and right input B has a join predicate in the form of B.x = A.x
-  // To avoid having the join implementations handle such situations, we check if the predicates sides match. If not,
-  // the columns IDs and the predicate are flipped.
+  // It is possible that a join with left input A and right input B has a join predicate in the form of B.x = A.x. To
+  // avoid having the join implementations handle such situations we check if the predicate sides match. If not, the
+  // column IDs and the predicates are flipped.
   const auto left_in_left = left_input.find_column_id(*abstract_predicate_expression->arguments[0]);
   const auto left_in_right = right_input.find_column_id(*abstract_predicate_expression->arguments[0]);
   const auto right_in_left = left_input.find_column_id(*abstract_predicate_expression->arguments[1]);

--- a/src/lib/operators/operator_join_predicate.cpp
+++ b/src/lib/operators/operator_join_predicate.cpp
@@ -26,6 +26,9 @@ std::optional<OperatorJoinPredicate> OperatorJoinPredicate::from_expression(cons
 
   Assert(abstract_predicate_expression->arguments.size() == 2u, "Expected two arguments");
 
+  // It is possible that a join with the left input A and right input B has a join predicate in the form of B.x = A.x
+  // To avoid having the join implementations handle such situations, we check if the predicates sides match. If not,
+  // the columns IDs and the predicate are flipped.
   const auto left_in_left = left_input.find_column_id(*abstract_predicate_expression->arguments[0]);
   const auto left_in_right = right_input.find_column_id(*abstract_predicate_expression->arguments[0]);
   const auto right_in_left = left_input.find_column_id(*abstract_predicate_expression->arguments[1]);
@@ -37,9 +40,7 @@ std::optional<OperatorJoinPredicate> OperatorJoinPredicate::from_expression(cons
   }
 
   if (right_in_left && left_in_right) {
-    std::cout << "Flipped" << std::endl;
-    // Use the left column in found in the right table and vice versa. Flip after construction to avoid code
-    //duplication.
+    // Use the left column found in the right table and vice versa. Flip after construction to avoid code duplication.
     auto join_predicate = OperatorJoinPredicate{{*left_in_right, *right_in_left}, predicate_condition};
     join_predicate.flip();
     return join_predicate;

--- a/src/lib/operators/operator_join_predicate.hpp
+++ b/src/lib/operators/operator_join_predicate.hpp
@@ -26,11 +26,17 @@ struct OperatorJoinPredicate {
    */
   void flip();
 
+  /**
+   * Returns whether OperatorJoinPredicate has been flipped or not.
+   */
+  bool is_flipped() const;
+
   OperatorJoinPredicate(const ColumnIDPair& init_column_ids, const PredicateCondition init_predicate_condition);
 
   // `.first` is the Column in the left input, `.second` is the column in the right input
   ColumnIDPair column_ids;
   PredicateCondition predicate_condition;
+  bool flipped = false;
 };
 
 // For gtest

--- a/src/test/operators/operator_join_predicate_test.cpp
+++ b/src/test/operators/operator_join_predicate_test.cpp
@@ -31,12 +31,14 @@ TEST_F(OperatorJoinPredicateTest, FromExpression) {
   EXPECT_EQ(predicate_a->column_ids.first, ColumnID{0});
   EXPECT_EQ(predicate_a->column_ids.second, ColumnID{1});
   EXPECT_EQ(predicate_a->predicate_condition, PredicateCondition::Equals);
+  EXPECT_FALSE(predicate_a->is_flipped());
 
   const auto predicate_b = OperatorJoinPredicate::from_expression(*less_than_(b_a, a_b), *node_a, *node_b);
   ASSERT_TRUE(predicate_b);
   EXPECT_EQ(predicate_b->column_ids.first, ColumnID{1});
   EXPECT_EQ(predicate_b->column_ids.second, ColumnID{0});
   EXPECT_EQ(predicate_b->predicate_condition, PredicateCondition::GreaterThan);
+  EXPECT_TRUE(predicate_b->is_flipped());
 }
 
 TEST_F(OperatorJoinPredicateTest, FromExpressionImpossible) {


### PR DESCRIPTION
When analyzing PQPs, the order of predicates might differ between LQP and PQP (e.g., LQP with `A.x = B.x` and a PQP with `B.x = A.x`). This PR adds a simple bool and method to later check if sides have been flipped.