### PR TITLE
Reduce cache size in JoinTestRunner

### DIFF
--- a/src/test/tpc/tpch_db_generator_test.cpp
+++ b/src/test/tpc/tpch_db_generator_test.cpp
@@ -49,6 +49,14 @@ TEST_F(TPCHTableGeneratorTest, SmallScaleFactor) {
   EXPECT_TABLE_EQ_ORDERED(table_info_by_name.at("orders").table, load_table(dir_002 + "orders.tbl", chunk_size));
   EXPECT_TABLE_EQ_ORDERED(table_info_by_name.at("nation").table, load_table(dir_002 + "nation.tbl", chunk_size));
   EXPECT_TABLE_EQ_ORDERED(table_info_by_name.at("region").table, load_table(dir_002 + "region.tbl", chunk_size));
+
+  for (const auto& [table_name, table_info] : table_info_by_name) {
+    const auto& table = table_info.table;
+    for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count() - 1; ++chunk_id) {
+      EXPECT_EQ(table->get_chunk(chunk_id)->size(), 1000);
+    }
+    EXPECT_LE(table->last_chunk()->size(), 1000);
+  }
 }
 
 TEST_F(TPCHTableGeneratorTest, RowCountsMediumScaleFactor) {
@@ -56,7 +64,7 @@ TEST_F(TPCHTableGeneratorTest, RowCountsMediumScaleFactor) {
    * Mostly intended to generate coverage and trigger potential leaks in third_party/tpch_dbgen
    */
   const auto scale_factor = 1.0f;
-  const auto table_info_by_name = TPCHTableGenerator(scale_factor, 100).generate();
+  const auto table_info_by_name = TPCHTableGenerator(scale_factor).generate();
 
   EXPECT_EQ(table_info_by_name.at("part").table->row_count(), std::floor(200'000 * scale_factor));
   EXPECT_EQ(table_info_by_name.at("supplier").table->row_count(), std::floor(10'000 * scale_factor));


### PR DESCRIPTION
The JoinTestRunner caches the verification tables as generated by the JoinVerification operator. The key for that cache is the test configuration. As more and more test configurations were added, that cache grew in size, leading to out-of-memory issues with TSAN.

Most of the configuration options, however, are not relevant for the JoinVerification operator. Its results will always be the same independent of, e.g, the chunk size. By leaving the options out of the cached key, we can reduce the size of the cache and fix the current CI issues.

As a welcomed side effect, the number of JoinVerification invocations is down from 2219 to 691, reducing the total runtime from 49975 ms to 41540 ms (debug on Mac).