### PR TITLE
Change ValueExpression long suffix to upper case

### DIFF
--- a/src/lib/expression/value_expression.cpp
+++ b/src/lib/expression/value_expression.cpp
@@ -26,9 +26,9 @@ std::string ValueExpression::description(const DescriptionMode mode) const {
   }
 
   if (value.type() == typeid(int64_t)) {
-    stream << "l";
+    stream << "L";
   } else if (value.type() == typeid(float)) {
-    stream << "f";
+    stream << "F";
   }
 
   return stream.str();


### PR DESCRIPTION
Turns out #2134 was a false alarm. The 'l' indicating a long value just looks awfully similar to a '1'. Let's use upper case suffixes instead.

fixes #2134 