### PR TITLE
StoredTableColumnAlignmentRule

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -317,6 +317,8 @@ set(
     optimizer/strategy/predicate_split_up_rule.hpp
     optimizer/strategy/semi_join_reduction_rule.cpp
     optimizer/strategy/semi_join_reduction_rule.hpp
+    optimizer/strategy/stored_table_column_alignment_rule.cpp
+    optimizer/strategy/stored_table_column_alignment_rule.hpp
     optimizer/strategy/subquery_to_join_rule.cpp
     optimizer/strategy/subquery_to_join_rule.hpp
     resolve_type.hpp

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   // StoredTableNode as possible where the ChunkPruningRule can work with them.
   optimizer->add_rule(std::make_unique<ChunkPruningRule>());
 
-  // This is an optimization for the PQP sub plan memoization which is sensitive to the a StoredTableNode's table name,
+  // This is an optimization for the PQP sub-plan memoization which is sensitive to the a StoredTableNode's table name,
   // set of pruned chunks and set of pruned columns. Since this rule depends on pruning information, it has to be
   // executed after the ColumnPruningRule and ChunkPruningRule.
   optimizer->add_rule(std::make_unique<StoredTableColumnAlignmentRule>());

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -21,6 +21,7 @@
 #include "strategy/predicate_reordering_rule.hpp"
 #include "strategy/predicate_split_up_rule.hpp"
 #include "strategy/semi_join_reduction_rule.hpp"
+#include "strategy/stored_table_column_alignment_rule.hpp"
 #include "strategy/subquery_to_join_rule.hpp"
 
 /**
@@ -130,6 +131,8 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   // `a BETWEEN 5 and 7` is. Also, run it after the PredicatePlacementRule, so that predicates are as close to the
   // StoredTableNode as possible where the ChunkPruningRule can work with them.
   optimizer->add_rule(std::make_unique<ChunkPruningRule>());
+
+  optimizer->add_rule(std::make_unique<StoredTableColumnAlignmentRule>());
 
   // Bring predicates into the desired order once the PredicatePlacementRule has positioned them as desired
   optimizer->add_rule(std::make_unique<PredicateReorderingRule>());

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -132,6 +132,9 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   // StoredTableNode as possible where the ChunkPruningRule can work with them.
   optimizer->add_rule(std::make_unique<ChunkPruningRule>());
 
+  // This is an optimization for the PQP sub plan memoization which is sensitive to the a StoredTableNode's table name,
+  // set of pruned chunks and set of pruned columns. Since this rule depends on pruning information, it has to be
+  // executed after the ColumnPruningRule and ChunkPruningRule.
   optimizer->add_rule(std::make_unique<StoredTableColumnAlignmentRule>());
 
   // Bring predicates into the desired order once the PredicatePlacementRule has positioned them as desired

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -8,81 +8,57 @@
 namespace opossum {
 
 void StoredTableColumnAlignmentRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
-  std::cout << "APPLY TO\n";
   StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>> gathered_stored_table_nodes_for_node;
   StoredTableNodeUnorderedMap<std::vector<ColumnID>> aligned_pruned_column_ids_for_node;
-  recursively_gather_stored_table_nodes(root, gathered_stored_table_nodes_for_node,
-  	aligned_pruned_column_ids_for_node);
-  
-  for (const auto& kv : gathered_stored_table_nodes_for_node) {
-  	std::cout << "StoredTableNode: " << kv.first->table_name << "\n";
-  	for (const auto& chunk_id : kv.first->pruned_chunk_ids()) {
-  		std::cout << "  " << chunk_id << "\n";
-  	}
-  	for (const auto& stored_table_node : kv.second) {
-  		std::cout << "pruned columns: " << "\n";
-  		for (const auto& column_id : stored_table_node->pruned_column_ids()) {
-  			std::cout << column_id << " ";
-  		}
-  		std::cout << "\n";
-  	}
-  }
-
-  // iterate over groups of StoredTableNode and set the minimum superset of columns for each StoredTableNode in each
-  // group
+  recursively_gather_stored_table_nodes(root, gathered_stored_table_nodes_for_node, aligned_pruned_column_ids_for_node);
+  // iterate over groups of StoredTableNode and set the maximum superset of columns for each StoredTableNode in each
+  // StoredTableNode group. A group is characterized by the table name and the pruned chunk ids.
   for (const auto& node_nodes_pair : gathered_stored_table_nodes_for_node) {
- 	for (const auto& stored_table_node : node_nodes_pair.second) {
-  		stored_table_node->set_pruned_column_ids(aligned_pruned_column_ids_for_node[stored_table_node]);
-  	}
-  }
-
-  std::cout << "after update" << "\n";
-  for (const auto& kv : gathered_stored_table_nodes_for_node) {
-  	std::cout << "StoredTableNode: " << kv.first->table_name << "\n";
-  	for (const auto& chunk_id : kv.first->pruned_chunk_ids()) {
-  		std::cout << "  " << chunk_id << "\n";
-  	}
-  	for (const auto& stored_table_node : kv.second) {
-  		std::cout << "pruned columns: " << "\n";
-  		for (const auto& column_id : stored_table_node->pruned_column_ids()) {
-  			std::cout << column_id << " ";
-  		}
-  		std::cout << "\n";
-  	}
+    for (const auto& stored_table_node : node_nodes_pair.second) {
+      stored_table_node->set_pruned_column_ids(aligned_pruned_column_ids_for_node[stored_table_node]);
+    }
   }
 }
 
-void StoredTableColumnAlignmentRule::recursively_gather_stored_table_nodes(const std::shared_ptr<AbstractLQPNode>& node,
-  StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
-  StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const {
+void StoredTableColumnAlignmentRule::recursively_gather_stored_table_nodes(
+    const std::shared_ptr<AbstractLQPNode>& node,
+    StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
+    StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const {
   const auto& left_input = node->left_input();
   const auto& right_input = node->right_input();
 
   if (left_input) {
-  	recursively_gather_stored_table_nodes(left_input, gathered_stored_table_nodes_for_node,
-  		aligned_pruned_column_ids_for_node);
+    recursively_gather_stored_table_nodes(left_input, gathered_stored_table_nodes_for_node,
+                                          aligned_pruned_column_ids_for_node);
   }
   if (right_input) {
     recursively_gather_stored_table_nodes(right_input, gathered_stored_table_nodes_for_node,
-    	aligned_pruned_column_ids_for_node);	
+                                          aligned_pruned_column_ids_for_node);
   }
   if (node->type == LQPNodeType::StoredTable) {
-  	const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node);
-  	
-  	auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
-  	gathered_stored_table_nodes.emplace_back(stored_table_node);
+    const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node);
 
-  	// update minimum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
-  	// pruned chunk ids
-  	auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
-  	std::vector<ColumnID> updated_pruned_column_ids{};
-  	updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
-  		stored_table_node->pruned_column_ids().size());
-  	std::set_union(aligned_pruned_column_ids.begin(), aligned_pruned_column_ids.end(),
-  		stored_table_node->pruned_column_ids().begin(), stored_table_node->pruned_column_ids().end(),
-  		std::back_inserter(updated_pruned_column_ids));
-  	updated_pruned_column_ids.shrink_to_fit();
-  	aligned_pruned_column_ids_for_node[stored_table_node] = updated_pruned_column_ids;
+    auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
+    gathered_stored_table_nodes.emplace_back(stored_table_node);
+
+    // update minimum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
+    // pruned chunk ids
+    if (aligned_pruned_column_ids_for_node.contains(stored_table_node)) {
+      auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
+      if (aligned_pruned_column_ids.empty()) {
+      }
+      std::vector<ColumnID> updated_pruned_column_ids{};
+      updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
+                                        stored_table_node->pruned_column_ids().size());
+      std::set_intersection(aligned_pruned_column_ids.begin(), aligned_pruned_column_ids.end(),
+                            stored_table_node->pruned_column_ids().begin(),
+                            stored_table_node->pruned_column_ids().end(),
+                            std::back_inserter(updated_pruned_column_ids));
+      updated_pruned_column_ids.shrink_to_fit();
+      aligned_pruned_column_ids_for_node[stored_table_node] = updated_pruned_column_ids;
+    } else {
+      aligned_pruned_column_ids_for_node[stored_table_node] = stored_table_node->pruned_column_ids();
+    }
   }
 }
 

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -4,58 +4,77 @@
 #include <memory>
 
 #include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
+
+namespace {
+// Modified hash code generation for StoredTableNodes where column pruning information is omitted. Struct is used to
+// enable hash-based containers containing std::shared_ptr<StoredTableNode>.
+struct StoredTableNodeSharedPtrHash final {
+  size_t operator()(const std::shared_ptr<opossum::StoredTableNode>& node) const {
+    size_t hash{0};
+    boost::hash_combine(hash, node->table_name);
+    for (const auto& pruned_chunk_id : node->pruned_chunk_ids()) {
+      boost::hash_combine(hash, static_cast<size_t>(pruned_chunk_id));
+    }
+    return hash;
+  }
+};
+
+// Modified equals evaluation code for StoredTableNodes where column pruning information is omitted. Struct is used to
+// enable hash-based containers containing std::shared_ptr<StoredTableNode>.
+struct StoredTableNodeSharedPtrEqual final {
+  size_t operator()(const std::shared_ptr<opossum::StoredTableNode>& lhs,
+                    const std::shared_ptr<opossum::StoredTableNode>& rhs) const {
+    return lhs == rhs || (lhs->table_name == rhs->table_name && lhs->pruned_chunk_ids() == rhs->pruned_chunk_ids());
+  }
+};
+
+template <typename Value>
+using ColumnPruningAgnosticStoredTableNodeMap =
+    std::unordered_map<std::shared_ptr<opossum::StoredTableNode>, Value, StoredTableNodeSharedPtrHash,
+                       StoredTableNodeSharedPtrEqual>;
+}  // namespace
 
 namespace opossum {
 
 void StoredTableColumnAlignmentRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
-  StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>> gathered_stored_table_nodes_for_node;
-  StoredTableNodeUnorderedMap<std::vector<ColumnID>> aligned_pruned_column_ids_for_node;
-  recursively_gather_stored_table_nodes(root, gathered_stored_table_nodes_for_node, aligned_pruned_column_ids_for_node);
+  ColumnPruningAgnosticStoredTableNodeMap<std::vector<std::shared_ptr<StoredTableNode>>>
+      gathered_stored_table_nodes_for_node;
+  ColumnPruningAgnosticStoredTableNodeMap<std::vector<ColumnID>> aligned_pruned_column_ids_for_node;
+
+  visit_lqp(root, [&](const auto& node) {
+    if (node->type == LQPNodeType::StoredTable) {
+      const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node);
+
+      auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
+      gathered_stored_table_nodes.emplace_back(stored_table_node);
+
+      // update maximum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
+      // pruned chunk ids
+      if (aligned_pruned_column_ids_for_node.contains(stored_table_node)) {
+        auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
+        std::vector<ColumnID> updated_pruned_column_ids{};
+        updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
+                                          stored_table_node->pruned_column_ids().size());
+        // sortedness of input containers is guaranteed by set_pruned_column_ids
+        std::set_intersection(aligned_pruned_column_ids.begin(), aligned_pruned_column_ids.end(),
+                              stored_table_node->pruned_column_ids().begin(),
+                              stored_table_node->pruned_column_ids().end(),
+                              std::back_inserter(updated_pruned_column_ids));
+        updated_pruned_column_ids.shrink_to_fit();
+        aligned_pruned_column_ids_for_node[stored_table_node] = updated_pruned_column_ids;
+      } else {
+        aligned_pruned_column_ids_for_node[stored_table_node] = stored_table_node->pruned_column_ids();
+      }
+    }
+    return LQPVisitation::VisitInputs;
+  });
+
   // iterate over groups of StoredTableNode and set the maximum superset of columns for each StoredTableNode in each
   // StoredTableNode group. A group is characterized by the table name and the pruned chunk ids.
   for (const auto& node_nodes_pair : gathered_stored_table_nodes_for_node) {
     for (const auto& stored_table_node : node_nodes_pair.second) {
       stored_table_node->set_pruned_column_ids(aligned_pruned_column_ids_for_node[stored_table_node]);
-    }
-  }
-}
-
-void StoredTableColumnAlignmentRule::recursively_gather_stored_table_nodes(
-    const std::shared_ptr<AbstractLQPNode>& node,
-    StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
-    StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const {
-  const auto& left_input = node->left_input();
-  const auto& right_input = node->right_input();
-
-  if (left_input) {
-    recursively_gather_stored_table_nodes(left_input, gathered_stored_table_nodes_for_node,
-                                          aligned_pruned_column_ids_for_node);
-  }
-  if (right_input) {
-    recursively_gather_stored_table_nodes(right_input, gathered_stored_table_nodes_for_node,
-                                          aligned_pruned_column_ids_for_node);
-  }
-  if (node->type == LQPNodeType::StoredTable) {
-    const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node);
-
-    auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
-    gathered_stored_table_nodes.emplace_back(stored_table_node);
-
-    // update maximum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
-    // pruned chunk ids
-    if (aligned_pruned_column_ids_for_node.contains(stored_table_node)) {
-      auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
-      std::vector<ColumnID> updated_pruned_column_ids{};
-      updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
-                                        stored_table_node->pruned_column_ids().size());
-      std::set_intersection(aligned_pruned_column_ids.begin(), aligned_pruned_column_ids.end(),
-                            stored_table_node->pruned_column_ids().begin(),
-                            stored_table_node->pruned_column_ids().end(),
-                            std::back_inserter(updated_pruned_column_ids));
-      updated_pruned_column_ids.shrink_to_fit();
-      aligned_pruned_column_ids_for_node[stored_table_node] = updated_pruned_column_ids;
-    } else {
-      aligned_pruned_column_ids_for_node[stored_table_node] = stored_table_node->pruned_column_ids();
     }
   }
 }

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -66,7 +66,7 @@ void StoredTableColumnAlignmentRule::apply_to(const std::shared_ptr<AbstractLQPN
   // column ids and (2) iterate over the nodes and set the aligned pruned column ids.
   for (const auto& group_representative : group_representatives) {
     std::optional<std::vector<ColumnID>> aligned_pruned_column_ids;
-    auto group_range = grouped_stored_table_nodes.equal_range(group_representative);
+    const auto& group_range = grouped_stored_table_nodes.equal_range(group_representative);
     for (auto group_iter = group_range.first; group_iter != group_range.second; ++group_iter) {
       const auto& stored_table_node = *group_iter;
       if (!aligned_pruned_column_ids) {

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -41,7 +41,7 @@ void StoredTableColumnAlignmentRule::recursively_gather_stored_table_nodes(
     auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
     gathered_stored_table_nodes.emplace_back(stored_table_node);
 
-    // update minimum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
+    // update maximum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
     // pruned chunk ids
     if (aligned_pruned_column_ids_for_node.contains(stored_table_node)) {
       auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -1,0 +1,89 @@
+#include "optimizer/strategy/stored_table_column_alignment_rule.hpp"
+
+#include <algorithm>
+#include <memory>
+
+#include "logical_query_plan/abstract_lqp_node.hpp"
+
+namespace opossum {
+
+void StoredTableColumnAlignmentRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
+  std::cout << "APPLY TO\n";
+  StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>> gathered_stored_table_nodes_for_node;
+  StoredTableNodeUnorderedMap<std::vector<ColumnID>> aligned_pruned_column_ids_for_node;
+  recursively_gather_stored_table_nodes(root, gathered_stored_table_nodes_for_node,
+  	aligned_pruned_column_ids_for_node);
+  
+  for (const auto& kv : gathered_stored_table_nodes_for_node) {
+  	std::cout << "StoredTableNode: " << kv.first->table_name << "\n";
+  	for (const auto& chunk_id : kv.first->pruned_chunk_ids()) {
+  		std::cout << "  " << chunk_id << "\n";
+  	}
+  	for (const auto& stored_table_node : kv.second) {
+  		std::cout << "pruned columns: " << "\n";
+  		for (const auto& column_id : stored_table_node->pruned_column_ids()) {
+  			std::cout << column_id << " ";
+  		}
+  		std::cout << "\n";
+  	}
+  }
+
+  // iterate over groups of StoredTableNode and set the minimum superset of columns for each StoredTableNode in each
+  // group
+  for (const auto& node_nodes_pair : gathered_stored_table_nodes_for_node) {
+ 	for (const auto& stored_table_node : node_nodes_pair.second) {
+  		stored_table_node->set_pruned_column_ids(aligned_pruned_column_ids_for_node[stored_table_node]);
+  	}
+  }
+
+  std::cout << "after update" << "\n";
+  for (const auto& kv : gathered_stored_table_nodes_for_node) {
+  	std::cout << "StoredTableNode: " << kv.first->table_name << "\n";
+  	for (const auto& chunk_id : kv.first->pruned_chunk_ids()) {
+  		std::cout << "  " << chunk_id << "\n";
+  	}
+  	for (const auto& stored_table_node : kv.second) {
+  		std::cout << "pruned columns: " << "\n";
+  		for (const auto& column_id : stored_table_node->pruned_column_ids()) {
+  			std::cout << column_id << " ";
+  		}
+  		std::cout << "\n";
+  	}
+  }
+}
+
+void StoredTableColumnAlignmentRule::recursively_gather_stored_table_nodes(const std::shared_ptr<AbstractLQPNode>& node,
+  StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
+  StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const {
+  const auto& left_input = node->left_input();
+  const auto& right_input = node->right_input();
+
+  if (left_input) {
+  	recursively_gather_stored_table_nodes(left_input, gathered_stored_table_nodes_for_node,
+  		aligned_pruned_column_ids_for_node);
+  }
+  if (right_input) {
+    recursively_gather_stored_table_nodes(right_input, gathered_stored_table_nodes_for_node,
+    	aligned_pruned_column_ids_for_node);	
+  }
+  if (node->type == LQPNodeType::StoredTable) {
+  	const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node);
+  	
+  	auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
+  	gathered_stored_table_nodes.emplace_back(stored_table_node);
+
+  	// update minimum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
+  	// pruned chunk ids
+  	auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
+  	std::vector<ColumnID> updated_pruned_column_ids{};
+  	updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
+  		stored_table_node->pruned_column_ids().size());
+  	std::set_union(aligned_pruned_column_ids.begin(), aligned_pruned_column_ids.end(),
+  		stored_table_node->pruned_column_ids().begin(), stored_table_node->pruned_column_ids().end(),
+  		std::back_inserter(updated_pruned_column_ids));
+  	updated_pruned_column_ids.shrink_to_fit();
+  	aligned_pruned_column_ids_for_node[stored_table_node] = updated_pruned_column_ids;
+  }
+}
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -45,8 +45,6 @@ void StoredTableColumnAlignmentRule::recursively_gather_stored_table_nodes(
     // pruned chunk ids
     if (aligned_pruned_column_ids_for_node.contains(stored_table_node)) {
       auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
-      if (aligned_pruned_column_ids.empty()) {
-      }
       std::vector<ColumnID> updated_pruned_column_ids{};
       updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
                                         stored_table_node->pruned_column_ids().size());

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
+#include <unordered_set>
+#include <vector>
 
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
@@ -29,52 +32,56 @@ struct StoredTableNodeSharedPtrEqual final {
   }
 };
 
-template <typename Value>
-using ColumnPruningAgnosticStoredTableNodeMap =
-    std::unordered_map<std::shared_ptr<opossum::StoredTableNode>, Value, StoredTableNodeSharedPtrHash,
-                       StoredTableNodeSharedPtrEqual>;
+using ColumnPruningAgnosticSet = std::unordered_set<std::shared_ptr<opossum::StoredTableNode>,
+                                                    StoredTableNodeSharedPtrHash, StoredTableNodeSharedPtrEqual>;
+
+using ColumnPruningAgnosticMultiSet =
+    std::unordered_multiset<std::shared_ptr<opossum::StoredTableNode>, StoredTableNodeSharedPtrHash,
+                            StoredTableNodeSharedPtrEqual>;
 }  // namespace
 
 namespace opossum {
 
 void StoredTableColumnAlignmentRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
-  ColumnPruningAgnosticStoredTableNodeMap<std::vector<std::shared_ptr<StoredTableNode>>>
-      gathered_stored_table_nodes_for_node;
-  ColumnPruningAgnosticStoredTableNodeMap<std::vector<ColumnID>> aligned_pruned_column_ids_for_node;
+  // stores exactly one representative for each StoredTableNode group. Members of the same StoredTableNode group
+  // have the same table name and pruned chunks.
+  auto group_representatives = ColumnPruningAgnosticSet{};
 
+  // stores all StoredTableNodes grouped by key.
+  auto grouped_stored_table_nodes = ColumnPruningAgnosticMultiSet{};
+
+  // iterate over the LQP and store all StoredTableNodes in multiple sets/groups: nodes of the same set/group have the
+  // same table name and the same pruned chunks.
   visit_lqp(root, [&](const auto& node) {
     if (node->type == LQPNodeType::StoredTable) {
       const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node);
-
-      auto& gathered_stored_table_nodes = gathered_stored_table_nodes_for_node[stored_table_node];
-      gathered_stored_table_nodes.emplace_back(stored_table_node);
-
-      // update maximum superset of pruned column ids for a StoredTableNodes with the same table name and same set of
-      // pruned chunk ids
-      if (aligned_pruned_column_ids_for_node.contains(stored_table_node)) {
-        auto& aligned_pruned_column_ids = aligned_pruned_column_ids_for_node[stored_table_node];
-        std::vector<ColumnID> updated_pruned_column_ids{};
-        updated_pruned_column_ids.reserve(aligned_pruned_column_ids.size() +
-                                          stored_table_node->pruned_column_ids().size());
-        // sortedness of input containers is guaranteed by set_pruned_column_ids
-        std::set_intersection(aligned_pruned_column_ids.begin(), aligned_pruned_column_ids.end(),
-                              stored_table_node->pruned_column_ids().begin(),
-                              stored_table_node->pruned_column_ids().end(),
-                              std::back_inserter(updated_pruned_column_ids));
-        updated_pruned_column_ids.shrink_to_fit();
-        aligned_pruned_column_ids_for_node[stored_table_node] = updated_pruned_column_ids;
-      } else {
-        aligned_pruned_column_ids_for_node[stored_table_node] = stored_table_node->pruned_column_ids();
-      }
+      DebugAssert(stored_table_node, "LQPNode with type 'StoredTable' could not be casted to a StoredTableNode.");
+      group_representatives.emplace(stored_table_node);
+      grouped_stored_table_nodes.emplace(stored_table_node);
     }
     return LQPVisitation::VisitInputs;
   });
 
-  // iterate over groups of StoredTableNode and set the maximum superset of columns for each StoredTableNode in each
-  // StoredTableNode group. A group is characterized by the table name and the pruned chunk ids.
-  for (const auto& node_nodes_pair : gathered_stored_table_nodes_for_node) {
-    for (const auto& stored_table_node : node_nodes_pair.second) {
-      stored_table_node->set_pruned_column_ids(aligned_pruned_column_ids_for_node[stored_table_node]);
+  // for each group of StoredTableNodes, (1) iterate over the nodes and calculate the set intersection of pruned
+  // column ids and (2) iterate over the nodes and set the aligned pruned column ids.
+  for (const auto& group_representative : group_representatives) {
+    std::optional<std::vector<ColumnID>> aligned_pruned_column_ids;
+    auto group_range = grouped_stored_table_nodes.equal_range(group_representative);
+    for (auto iter = group_range.first; iter != group_range.second; ++iter) {
+      const auto& stored_table_node = *iter;
+      if (!aligned_pruned_column_ids) {
+        aligned_pruned_column_ids = stored_table_node->pruned_column_ids();
+      } else {
+        std::vector<ColumnID> updated_pruned_column_ids{};
+        std::set_intersection(aligned_pruned_column_ids->begin(), aligned_pruned_column_ids->end(),
+                              stored_table_node->pruned_column_ids().begin(),
+                              stored_table_node->pruned_column_ids().end(),
+                              std::back_inserter(updated_pruned_column_ids));
+        aligned_pruned_column_ids = std::move(updated_pruned_column_ids);
+      }
+    }
+    for (auto iter = group_range.first; iter != group_range.second; ++iter) {
+      (*iter)->set_pruned_column_ids(*aligned_pruned_column_ids);
     }
   }
 }

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -9,15 +9,53 @@
 namespace opossum {
 
 // The PQP sub plan memoization for StoredTableNodes is sensitive to the node's table name, set of pruned chunks and
-// set of pruned columns. Consequently, for multiple nodes with the same table name, chunk and column pruning, only one
-// GetTable operator is created and executed. In some queries, the ColumnPruningRule and ChunkPruningRule provide an
-// LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are equal but the sets of pruned
-// columns are different. This leads to the creation and execution of different GetTable operators.
-// TODO(Marcel) add an example, see github review feedback
+// set of pruned columns. Consequently, for multiple nodes with the same table name, same pruned chunks and same pruned
+// columns, only one GetTable operator is created and executed. In some queries, the ColumnPruningRule and
+// ChunkPruningRule provide an LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are
+// equal but the sets of pruned columns are different. This leads to the creation and execution of different GetTable
+// operators instead of only one operator.
 //
 // This rule identifies StoredTableNodes that differ only in the pruned columns. It then intersects the lists of pruned
 // columns. While this means that some columns are left unpruned, it makes the job easier for the memoization in the
 // LQPTranslator. In our experiments, this has led to significant performance improvements and negligible reductions.
+//
+// Example: LQP sub plan before executing the StoredTableColumnAlignmentRule
+//
+//                      +------------------------+
+//                      | Join (1)               |
+//                      | Mode: Inner            |
+//                      | predicate: Li_a = Pa_a |
+//                      +------------------------+
+//                         /                \
+//       +------------------------+     +------------------------+
+//       | Join (2)               |     | Join (3)               |
+//       | Mode: Semi             |     | Mode: Semi             |
+//       | predicate: Li_a = Pa_a |     | predicate: Li_a = Pa_a |
+//       +------------------------+     +------------------------+
+//                   /          \           /           \
+// +---------------------+  +-----------------------+  +-----------------------+
+// | StoredTable (1)     |  | StoredTable (2)       |  | StoredTable (3)       |
+// | table name:     Li  |  | table name:     Pa    |  | table name:     Li    |
+// | pruned chunks:  { } |  | pruned chunks:  {1,2} |  | pruned chunks:  { }   |
+// | pruned columns: {3} |  | pruned columns: { }   |  | pruned columns: {3,4} |
+// +---------------------+  +-----------------------+  +-----------------------+
+//
+// Join (2) and Join (3) in the above sub plan have the same join mode and the same join predicate. Both use the same
+// input tables (Li and Pa). However, the input StoredTable (1) and (3) for the table Li are different since the set of
+// pruned columns are not equal. When an LQPNode n1 is translated, the PQP sub plan memoization reuses an operator that
+// was already created for another LQPNode n2 that is semantically equal to n1. The equality comparison of StoredTable
+// nodes is sensitive to the table name, pruned chunks and pruned columns. Consequently, Stored Table nodes (1) and (3)
+// unequal and two different GetTable operators would be created in the PQP. For LQPNode equality comparisons, the
+// input nodes are generally relevant. Joins (2) and (3) are not semantically equal since they have semantically
+// unequal input StoredTable nodes for table "Li". As a result, the LQPTranslator would create two Join operators.
+//
+// In order to create and execute less operators and therefore to reduce the execution time of the resulting PQP, this
+// rule would align the pruned columns of StoredTableNode (3): The pruned columns {3,4} are a super set of the set of
+// pruned columns for StoredTable node (1). Reducing the set of pruned columns to {3} would:
+// - still guarantee that all necessary columns for nodes on higher levels in the overall LQP are still available and
+// - make StoredTable node (1) and StoredTable node (3) semantically equal. Therefore only one GetTable operator for
+//   both nodes would be created and executed. Additionally, Join (2) and Join (3) would also be semantically equal
+//   and only one Join operator for both nodes would be created and executed.
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -33,6 +33,15 @@ template <typename Value>
 using StoredTableNodeUnorderedMap = std::unordered_map<std::shared_ptr<StoredTableNode>, Value,
                                                        StoredTableNodeSharedPtrHash, StoredTableNodeSharedPtrEqual>;
 
+// The PQP sub plan memoization for StoredTableNodes is sensitive to the node's table name, set of pruned chunks and
+// set of pruned columns. Consequently, for multiple nodes with the same table name, chunk and column pruning, only one
+// GetTable operator is created and executed. In some queries, the ColumnPruningRule and ChunkPruningRule provide an
+// LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are equal but the sets of pruned
+// columns are different. This leads to the creation and execution of different GetTable operators.
+//
+// This rule identifies StoredTableNodes with equal table names and sets of pruned chunks and aligns the pruned columns
+// so that the sets of pruned columns are equal which means that the PQP sub plan memoization is effective for theses
+// StoredTableNodes and only one GetTable operator is created.
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -6,56 +6,59 @@
 #include "abstract_rule.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 
+/*
+ The PQP sub plan memoization for StoredTableNodes is sensitive to the node's table name, set of pruned chunks and
+ set of pruned columns. Consequently, for multiple nodes with the same table name, same pruned chunks and same pruned
+ columns, only one GetTable operator is created and executed. In some queries, the ColumnPruningRule and
+ ChunkPruningRule provide an LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are
+ equal but the sets of pruned columns are different. This leads to the creation and execution of different GetTable
+ operators instead of only one operator.
+
+ This rule identifies StoredTableNodes that differ only in the pruned columns. It then intersects the lists of pruned
+ columns. While this means that some columns are left unpruned, it makes the job easier for the memoization in the
+ LQPTranslator. In our experiments, this has led to significant performance improvements and negligible reductions.
+
+ Example: LQP sub plan before executing the StoredTableColumnAlignmentRule
+
+                      +------------------------+
+                      | Join (1)               |
+                      | Mode: Inner            |
+                      | predicate: Li_a = Pa_a |
+                      +------------------------+
+                         /                \
+       +------------------------+     +------------------------+
+       | Join (2)               |     | Join (3)               |
+       | Mode: Semi             |     | Mode: Semi             |
+       | predicate: Li_a = Pa_a |     | predicate: Li_a = Pa_a |
+       +------------------------+     +------------------------+
+                   /          \           /           \
+ +---------------------+  +-----------------------+  +-----------------------+
+ | StoredTable (1)     |  | StoredTable (2)       |  | StoredTable (3)       |
+ | table name:     Li  |  | table name:     Pa    |  | table name:     Li    |
+ | pruned chunks:  { } |  | pruned chunks:  {1,2} |  | pruned chunks:  { }   |
+ | pruned columns: {3} |  | pruned columns: { }   |  | pruned columns: {3,4} |
+ +---------------------+  +-----------------------+  +-----------------------+
+
+ Join (2) and Join (3) in the above sub plan have the same join mode and the same join predicate. Both use the same
+ input tables (Li and Pa). However, the input StoredTable (1) and (3) for the table Li are different since the set of
+ pruned columns are not equal. When an LQPNode n1 is translated, the PQP sub plan memoization reuses an operator that
+ was already created for another LQPNode n2 that is semantically equal to n1. The equality comparison of StoredTable
+ nodes is sensitive to the table name, pruned chunks and pruned columns. Consequently, Stored Table nodes (1) and (3)
+ unequal and two different GetTable operators would be created in the PQP. For LQPNode equality comparisons, the
+ input nodes are generally relevant. Joins (2) and (3) are not semantically equal since they have semantically
+ unequal input StoredTable nodes for table "Li". As a result, the LQPTranslator would create two Join operators.
+
+ In order to create and execute less operators and therefore to reduce the execution time of the resulting PQP, this
+ rule would align the pruned columns of StoredTableNode (3): The pruned columns {3,4} are a super set of the set of
+ pruned columns for StoredTable node (1). Reducing the set of pruned columns to {3} would:
+ - still guarantee that all necessary columns for nodes on higher levels in the overall LQP are still available and
+ - make StoredTable node (1) and StoredTable node (3) semantically equal. Therefore only one GetTable operator for
+   both nodes would be created and executed. Additionally, Join (2) and Join (3) would also be semantically equal
+   and only one Join operator for both nodes would be created and executed.
+*/
+
 namespace opossum {
 
-// The PQP sub plan memoization for StoredTableNodes is sensitive to the node's table name, set of pruned chunks and
-// set of pruned columns. Consequently, for multiple nodes with the same table name, same pruned chunks and same pruned
-// columns, only one GetTable operator is created and executed. In some queries, the ColumnPruningRule and
-// ChunkPruningRule provide an LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are
-// equal but the sets of pruned columns are different. This leads to the creation and execution of different GetTable
-// operators instead of only one operator.
-//
-// This rule identifies StoredTableNodes that differ only in the pruned columns. It then intersects the lists of pruned
-// columns. While this means that some columns are left unpruned, it makes the job easier for the memoization in the
-// LQPTranslator. In our experiments, this has led to significant performance improvements and negligible reductions.
-//
-// Example: LQP sub plan before executing the StoredTableColumnAlignmentRule
-//
-//                      +------------------------+
-//                      | Join (1)               |
-//                      | Mode: Inner            |
-//                      | predicate: Li_a = Pa_a |
-//                      +------------------------+
-//                         /                \
-//       +------------------------+     +------------------------+
-//       | Join (2)               |     | Join (3)               |
-//       | Mode: Semi             |     | Mode: Semi             |
-//       | predicate: Li_a = Pa_a |     | predicate: Li_a = Pa_a |
-//       +------------------------+     +------------------------+
-//                   /          \           /           \
-// +---------------------+  +-----------------------+  +-----------------------+
-// | StoredTable (1)     |  | StoredTable (2)       |  | StoredTable (3)       |
-// | table name:     Li  |  | table name:     Pa    |  | table name:     Li    |
-// | pruned chunks:  { } |  | pruned chunks:  {1,2} |  | pruned chunks:  { }   |
-// | pruned columns: {3} |  | pruned columns: { }   |  | pruned columns: {3,4} |
-// +---------------------+  +-----------------------+  +-----------------------+
-//
-// Join (2) and Join (3) in the above sub plan have the same join mode and the same join predicate. Both use the same
-// input tables (Li and Pa). However, the input StoredTable (1) and (3) for the table Li are different since the set of
-// pruned columns are not equal. When an LQPNode n1 is translated, the PQP sub plan memoization reuses an operator that
-// was already created for another LQPNode n2 that is semantically equal to n1. The equality comparison of StoredTable
-// nodes is sensitive to the table name, pruned chunks and pruned columns. Consequently, Stored Table nodes (1) and (3)
-// unequal and two different GetTable operators would be created in the PQP. For LQPNode equality comparisons, the
-// input nodes are generally relevant. Joins (2) and (3) are not semantically equal since they have semantically
-// unequal input StoredTable nodes for table "Li". As a result, the LQPTranslator would create two Join operators.
-//
-// In order to create and execute less operators and therefore to reduce the execution time of the resulting PQP, this
-// rule would align the pruned columns of StoredTableNode (3): The pruned columns {3,4} are a super set of the set of
-// pruned columns for StoredTable node (1). Reducing the set of pruned columns to {3} would:
-// - still guarantee that all necessary columns for nodes on higher levels in the overall LQP are still available and
-// - make StoredTable node (1) and StoredTable node (3) semantically equal. Therefore only one GetTable operator for
-//   both nodes would be created and executed. Additionally, Join (2) and Join (3) would also be semantically equal
-//   and only one Join operator for both nodes would be created and executed.
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -13,10 +13,11 @@ namespace opossum {
 // GetTable operator is created and executed. In some queries, the ColumnPruningRule and ChunkPruningRule provide an
 // LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are equal but the sets of pruned
 // columns are different. This leads to the creation and execution of different GetTable operators.
+// TODO(Marcel) add an example, see github review feedback
 //
-// This rule identifies StoredTableNodes with equal table names and sets of pruned chunks and aligns the pruned columns
-// so that the sets of pruned columns are equal which means that the PQP sub plan memoization is effective for theses
-// StoredTableNodes and only one GetTable operator is created.
+// This rule identifies StoredTableNodes that differ only in the pruned columns. It then intersects the lists of pruned
+// columns. While this means that some columns are left unpruned, it makes the job easier for the memoization in the
+// LQPTranslator. In our experiments, this has led to significant performance improvements and negligible reductions.
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -12,12 +12,12 @@ namespace opossum {
 // enable hash based containers containing std::shared_ptr<StoredTableNode>.
 struct StoredTableNodeSharedPtrHash final {
   size_t operator()(const std::shared_ptr<StoredTableNode>& node) const {
-  	size_t hash{0};
-	boost::hash_combine(hash, node->table_name);
-	for (const auto& pruned_chunk_id : node->pruned_chunk_ids()) {
-	  boost::hash_combine(hash, static_cast<size_t>(pruned_chunk_id));
-	}
-	return hash;
+    size_t hash{0};
+    boost::hash_combine(hash, node->table_name);
+    for (const auto& pruned_chunk_id : node->pruned_chunk_ids()) {
+      boost::hash_combine(hash, static_cast<size_t>(pruned_chunk_id));
+    }
+    return hash;
   }
 };
 
@@ -30,16 +30,16 @@ struct StoredTableNodeSharedPtrEqual final {
 };
 
 template <typename Value>
-using StoredTableNodeUnorderedMap =
-  std::unordered_map<std::shared_ptr<StoredTableNode>, Value, StoredTableNodeSharedPtrHash,
-  StoredTableNodeSharedPtrEqual>;
+using StoredTableNodeUnorderedMap = std::unordered_map<std::shared_ptr<StoredTableNode>, Value,
+                                                       StoredTableNodeSharedPtrHash, StoredTableNodeSharedPtrEqual>;
 
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
-  void recursively_gather_stored_table_nodes(const std::shared_ptr<AbstractLQPNode>& node,
-  	StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
-  	StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const;
+  void recursively_gather_stored_table_nodes(
+      const std::shared_ptr<AbstractLQPNode>& node,
+      StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
+      StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include "abstract_rule.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+
+namespace opossum {
+
+// Modified hash code generation for StoredTableNodes where column pruning information is omitted. Struct is used to
+// enable hash based containers containing std::shared_ptr<StoredTableNode>.
+struct StoredTableNodeSharedPtrHash final {
+  size_t operator()(const std::shared_ptr<StoredTableNode>& node) const {
+  	size_t hash{0};
+	boost::hash_combine(hash, node->table_name);
+	for (const auto& pruned_chunk_id : node->pruned_chunk_ids()) {
+	  boost::hash_combine(hash, static_cast<size_t>(pruned_chunk_id));
+	}
+	return hash;
+  }
+};
+
+// Modified equals evaluation code for StoredTableNodes where column pruning information is omitted. Struct is used to
+// enable hash based containers containing std::shared_ptr<StoredTableNode>.
+struct StoredTableNodeSharedPtrEqual final {
+  size_t operator()(const std::shared_ptr<StoredTableNode>& lhs, const std::shared_ptr<StoredTableNode>& rhs) const {
+    return lhs == rhs || (lhs->table_name == rhs->table_name && lhs->pruned_chunk_ids() == rhs->pruned_chunk_ids());
+  }
+};
+
+template <typename Value>
+using StoredTableNodeUnorderedMap =
+  std::unordered_map<std::shared_ptr<StoredTableNode>, Value, StoredTableNodeSharedPtrHash,
+  StoredTableNodeSharedPtrEqual>;
+
+class StoredTableColumnAlignmentRule : public AbstractRule {
+ public:
+  void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
+  void recursively_gather_stored_table_nodes(const std::shared_ptr<AbstractLQPNode>& node,
+  	StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
+  	StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const;
+};
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -8,31 +8,6 @@
 
 namespace opossum {
 
-// Modified hash code generation for StoredTableNodes where column pruning information is omitted. Struct is used to
-// enable hash based containers containing std::shared_ptr<StoredTableNode>.
-struct StoredTableNodeSharedPtrHash final {
-  size_t operator()(const std::shared_ptr<StoredTableNode>& node) const {
-    size_t hash{0};
-    boost::hash_combine(hash, node->table_name);
-    for (const auto& pruned_chunk_id : node->pruned_chunk_ids()) {
-      boost::hash_combine(hash, static_cast<size_t>(pruned_chunk_id));
-    }
-    return hash;
-  }
-};
-
-// Modified equals evaluation code for StoredTableNodes where column pruning information is omitted. Struct is used to
-// enable hash based containers containing std::shared_ptr<StoredTableNode>.
-struct StoredTableNodeSharedPtrEqual final {
-  size_t operator()(const std::shared_ptr<StoredTableNode>& lhs, const std::shared_ptr<StoredTableNode>& rhs) const {
-    return lhs == rhs || (lhs->table_name == rhs->table_name && lhs->pruned_chunk_ids() == rhs->pruned_chunk_ids());
-  }
-};
-
-template <typename Value>
-using StoredTableNodeUnorderedMap = std::unordered_map<std::shared_ptr<StoredTableNode>, Value,
-                                                       StoredTableNodeSharedPtrHash, StoredTableNodeSharedPtrEqual>;
-
 // The PQP sub plan memoization for StoredTableNodes is sensitive to the node's table name, set of pruned chunks and
 // set of pruned columns. Consequently, for multiple nodes with the same table name, chunk and column pruning, only one
 // GetTable operator is created and executed. In some queries, the ColumnPruningRule and ChunkPruningRule provide an
@@ -45,10 +20,6 @@ using StoredTableNodeUnorderedMap = std::unordered_map<std::shared_ptr<StoredTab
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
-  void recursively_gather_stored_table_nodes(
-      const std::shared_ptr<AbstractLQPNode>& node,
-      StoredTableNodeUnorderedMap<std::vector<std::shared_ptr<StoredTableNode>>>& gathered_stored_table_nodes_for_node,
-      StoredTableNodeUnorderedMap<std::vector<ColumnID>>& aligned_pruned_column_ids_for_node) const;
 };
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -7,7 +7,7 @@
 #include "logical_query_plan/stored_table_node.hpp"
 
 /*
- The PQP sub plan memoization (see LQPTranslator::_operator_by_lqp_node) for StoredTableNodes is sensitive to the node's
+ The PQP sub-plan memoization (see LQPTranslator::_operator_by_lqp_node) for StoredTableNodes is sensitive to the node's
  table name, set of pruned chunks and set of pruned columns. Consequently, for multiple nodes with the same table name,
  same pruned chunks and same pruned columns, only one GetTable operator is created and executed. In some queries, the
  ColumnPruningRule and ChunkPruningRule provide an LQP with multiple StoredTableNodes where the table names and sets of
@@ -19,7 +19,7 @@
  columns. While this means that some columns are left unpruned, it makes the job easier for the memoization in the
  LQPTranslator. In our experiments, this has led to significant performance improvements and negligible reductions.
 
- Example: LQP sub plan before executing the StoredTableColumnAlignmentRule
+ Example: LQP sub-plan before executing the StoredTableColumnAlignmentRule
 
                       +------------------------+
                       | Join (1)               |

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -138,6 +138,7 @@ set(
     optimizer/strategy/predicate_split_up_rule_test.cpp
     optimizer/strategy/semi_join_reduction_rule_test.cpp
     optimizer/strategy/strategy_base_test.cpp
+    optimizer/strategy/stored_table_column_alignment_rule_test.cpp
     optimizer/strategy/strategy_base_test.hpp
     optimizer/strategy/subquery_to_join_rule_test.cpp
     plugins/mvcc_delete_plugin_test.cpp

--- a/src/test/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
+++ b/src/test/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
@@ -39,6 +39,8 @@ TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableEqualChunksEqualColumns) {
 
   EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
   EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}}));
+  EXPECT_EQ(_stored_table_node_left->hash(), _stored_table_node_right->hash());
+  EXPECT_EQ(*_stored_table_node_left, *_stored_table_node_right);
 }
 
 TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableEqualChunksDifferentColumns) {
@@ -49,6 +51,8 @@ TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableEqualChunksDifferentColumns
 
   EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
   EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}}));
+  EXPECT_EQ(_stored_table_node_left->hash(), _stored_table_node_right->hash());
+  EXPECT_EQ(*_stored_table_node_left, *_stored_table_node_right);
 }
 
 TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableDifferentChunksDifferentColumns) {
@@ -60,6 +64,8 @@ TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableDifferentChunksDifferentCol
 
   EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
   EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}, ColumnID{1}}));
+  EXPECT_NE(_stored_table_node_left->hash(), _stored_table_node_right->hash());
+  EXPECT_NE(*_stored_table_node_left, *_stored_table_node_right);
 }
 
 TEST_F(StoredTableColumnAlignmentRuleTest, DifferentTableEqualChunksDifferentColumns) {
@@ -72,6 +78,8 @@ TEST_F(StoredTableColumnAlignmentRuleTest, DifferentTableEqualChunksDifferentCol
 
   EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
   EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}, ColumnID{1}}));
+  EXPECT_NE(_stored_table_node_left->hash(), _stored_table_node_right->hash());
+  EXPECT_NE(*_stored_table_node_left, *_stored_table_node_right);
 }
 
 }  // namespace opossum

--- a/src/test/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
+++ b/src/test/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
@@ -1,0 +1,77 @@
+#include <vector>
+
+#include "logical_query_plan/stored_table_node.hpp"
+#include "logical_query_plan/union_node.hpp"
+#include "optimizer/strategy/stored_table_column_alignment_rule.hpp"
+#include "strategy_base_test.hpp"
+
+namespace opossum {
+
+class StoredTableColumnAlignmentRuleTest : public StrategyBaseTest {
+ public:
+  void SetUp() override {
+    Hyrise::get().storage_manager.add_table("t_a", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
+    Hyrise::get().storage_manager.add_table("t_b", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
+
+    _stored_table_node_left = StoredTableNode::make("t_a");
+    _stored_table_node_right = StoredTableNode::make("t_a");
+
+    _stored_table_node_left->set_pruned_chunk_ids({ChunkID{2}});
+    _stored_table_node_right->set_pruned_chunk_ids({ChunkID{2}});
+
+    _stored_table_node_left->set_pruned_column_ids({ColumnID{0}});
+    _stored_table_node_right->set_pruned_column_ids({ColumnID{0}});
+
+    _union_node = UnionNode::make(SetOperationMode::All);
+    _union_node->set_left_input(_stored_table_node_left);
+    _union_node->set_right_input(_stored_table_node_right);
+
+    _rule = std::make_shared<StoredTableColumnAlignmentRule>();
+  }
+
+  std::shared_ptr<StoredTableColumnAlignmentRule> _rule;
+  std::shared_ptr<UnionNode> _union_node;
+  std::shared_ptr<StoredTableNode> _stored_table_node_left, _stored_table_node_right;
+};
+
+TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableEqualChunksEqualColumns) {
+  apply_rule(_rule, _union_node);
+
+  EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
+  EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}}));
+}
+
+TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableEqualChunksDifferentColumns) {
+  _stored_table_node_right->set_pruned_column_ids({ColumnID{0}, ColumnID{1}});
+  _union_node->set_right_input(_stored_table_node_right);
+
+  apply_rule(_rule, _union_node);
+
+  EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
+  EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}}));
+}
+
+TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableDifferentChunksDifferentColumns) {
+  _stored_table_node_right->set_pruned_chunk_ids({ChunkID{2}, ChunkID{3}});
+  _stored_table_node_right->set_pruned_column_ids({ColumnID{0}, ColumnID{1}});
+  _union_node->set_right_input(_stored_table_node_right);
+
+  apply_rule(_rule, _union_node);
+
+  EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
+  EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}, ColumnID{1}}));
+}
+
+TEST_F(StoredTableColumnAlignmentRuleTest, DifferentTableEqualChunksDifferentColumns) {
+  _stored_table_node_right = StoredTableNode::make("t_b");
+  _stored_table_node_right->set_pruned_chunk_ids({ChunkID{2}});
+  _stored_table_node_right->set_pruned_column_ids({ColumnID{0}, ColumnID{1}});
+  _union_node->set_right_input(_stored_table_node_right);
+
+  apply_rule(_rule, _union_node);
+
+  EXPECT_EQ(_stored_table_node_left->pruned_column_ids(), (std::vector{ColumnID{0}}));
+  EXPECT_EQ(_stored_table_node_right->pruned_column_ids(), (std::vector{ColumnID{0}, ColumnID{1}}));
+}
+
+}  // namespace opossum


### PR DESCRIPTION
## Description
The PQP sub plan memoization for StoredTableNodes is sensitive to the node's table name, set of pruned chunks and set of pruned columns. Consequently, for multiple nodes with the same table name, same pruned chunks and same pruned columns, only one GetTable operator is created and executed. In some queries, the ColumnPruningRule and ChunkPruningRule provide an LQP with multiple StoredTableNodes where the table names and sets of pruned chunks are equal but the sets of pruned columns are different. This leads to the creation and execution of different GetTable operators instead of only one operator.

This rule identifies StoredTableNodes that differ only in the pruned columns. It then intersects the lists of pruned columns. While this means that some columns are left unpruned, it makes the job easier for the memoization in the LQPTranslator. In our experiments, this has led to significant performance improvements and negligible reductions.

## Benchmark Comparison
comparison: d43fb623d vs f7d6246ec
executed on pella, NUMA node 1
build: RelWithDebInfo

### TPC-H
`./hyriseBenchmarkTPCH -s 1 -r 30`
```
+----------------+----------------+------+----------------+------+------------+----------------------+
| Benchmark      | prev. iter/s   | runs | new iter/s     | runs | change [%] |              p-value |
+----------------+----------------+------+----------------+------+------------+----------------------+
| TPC-H 01       | 0.808261215687 | 30   | 0.775613844395 | 30   | -4%        | (run time too short) |
| TPC-H 02       | 39.4202270508  | 30   | 40.5404472351  | 30   | +3%        | (run time too short) |
| TPC-H 03       | 5.11661243439  | 30   | 5.16426706314  | 30   | +1%        | (run time too short) |
| TPC-H 04       | 6.22300100327  | 30   | 6.11033773422  | 30   | -2%        | (run time too short) |
| TPC-H 05       | 1.98856902122  | 30   | 1.98523318768  | 30   | -0%        | (run time too short) |
| TPC-H 06       | 92.9693603516  | 30   | 93.6799240112  | 30   | +1%        | (run time too short) |
| TPC-H 07       | 7.18500375748  | 30   | 7.23907995224  | 30   | +1%        | (run time too short) |
| TPC-H 08       | 7.44914722443  | 30   | 7.46293115616  | 30   | +0%        | (run time too short) |
| TPC-H 09       | 1.05010020733  | 30   | 1.04464066029  | 30   | -1%        | (run time too short) |
| TPC-H 10       | 1.95173037052  | 30   | 1.94143795967  | 30   | -1%        | (run time too short) |
| TPC-H 11       | 51.842124939   | 30   | 51.6629066467  | 30   | -0%        | (run time too short) |
| TPC-H 12       | 10.4508676529  | 30   | 9.9458770752   | 30   | -5%        | (run time too short) |
| TPC-H 13       | 1.52068531513  | 30   | 1.51268649101  | 30   | -1%        | (run time too short) |
| TPC-H 14       | 25.84806633    | 30   | 25.5330581665  | 30   | -1%        | (run time too short) |
| TPC-H 15       | 56.921875      | 30   | 57.5614852905  | 30   | +1%        | (run time too short) |
| TPC-H 16       | 5.95111179352  | 30   | 6.00333356857  | 30   | +1%        | (run time too short) |
| TPC-H 17       | 9.75971412659  | 30   | 16.4921894073  | 30   | +69%       | (run time too short) |
| TPC-H 18       | 0.735659241676 | 30   | 0.73869240284  | 30   | +0%        | (run time too short) |
| TPC-H 19       | 12.1287403107  | 30   | 12.2900209427  | 30   | +1%        | (run time too short) |
| TPC-H 20       | 28.2435932159  | 30   | 28.4328689575  | 30   | +1%        | (run time too short) |
| TPC-H 21       | 0.821533858776 | 30   | 1.16572213173  | 30   | +42%       | (run time too short) |
| TPC-H 22       | 7.78854417801  | 30   | 7.86301755905  | 30   | +1%        | (run time too short) |
| geometric mean |                |      |                |      | +4%        |                      |
+----------------+----------------+------+----------------+------+------------+----------------------+
```

### TPC-DS
`./hyriseBenchmarkTPCDS -s 1 -r 30`
```
+----------------+---------------+------+---------------+------+------------+----------------------+
| Benchmark      | prev. iter/s  | runs | new iter/s    | runs | change [%] |              p-value |
+----------------+---------------+------+---------------+------+------------+----------------------+
| 01             | 14.8473272324 | 30   | 15.1353216171 | 30   | +2%        | (run time too short) |
| 03             | 57.7059631348 | 30   | 57.7753639221 | 30   | +0%        | (run time too short) |
| 06             | 20.8637065887 | 30   | 20.9599342346 | 30   | +0%        | (run time too short) |
| 07             | 6.79859972    | 30   | 6.51345396042 | 30   | -4%        | (run time too short) |
| 09             | 4.04866456985 | 30   | 4.03576564789 | 30   | -0%        | (run time too short) |
| 10             | 20.539100647  | 30   | 20.6436004639 | 30   | +1%        | (run time too short) |
| 13             | 5.34782171249 | 30   | 5.38502931595 | 30   | +1%        | (run time too short) |
| 15             | 41.746547699  | 30   | 41.9188842773 | 30   | +0%        | (run time too short) |
| 17             | 12.4100160599 | 30   | 12.5039396286 | 30   | +1%        | (run time too short) |
| 19             | 40.1315536499 | 30   | 40.2961769104 | 30   | +0%        | (run time too short) |
| 25             | 18.6570549011 | 30   | 18.9375076294 | 30   | +2%        | (run time too short) |
| 26             | 15.309504509  | 30   | 15.1728496552 | 30   | -1%        | (run time too short) |
| 28             | 7.99202489853 | 30   | 7.92670726776 | 30   | -1%        | (run time too short) |
| 29             | 12.2146492004 | 30   | 12.3524341583 | 30   | +1%        | (run time too short) |
| 31             | 3.84116411209 | 30   | 3.83518838882 | 30   | -0%        | (run time too short) |
| 34             | 17.777009964  | 30   | 17.8109416962 | 30   | +0%        | (run time too short) |
| 35             | 4.74193954468 | 30   | 4.78170204163 | 30   | +1%        | (run time too short) |
| 39a            | 2.4887316227  | 30   | 2.48633623123 | 30   | -0%        | (run time too short) |
| 39b            | 2.48768496513 | 30   | 2.49046421051 | 30   | +0%        | (run time too short) |
| 41             | 17.5549736023 | 30   | 16.9735965729 | 30   | -3%        | (run time too short) |
| 42             | 61.6618843079 | 30   | 61.7899055481 | 30   | +0%        | (run time too short) |
| 43             | 2.19654202461 | 30   | 2.19479179382 | 30   | -0%        | (run time too short) |
| 45             | 43.8250770569 | 30   | 43.9056663513 | 30   | +0%        | (run time too short) |
| 48             | 5.65509653091 | 30   | 5.6732635498  | 30   | +0%        | (run time too short) |
| 50             | 36.4451217651 | 30   | 36.749332428  | 30   | +1%        | (run time too short) |
| 52             | 60.7162437439 | 30   | 60.817199707  | 30   | +0%        | (run time too short) |
| 55             | 62.1214942932 | 30   | 62.0861740112 | 30   | -0%        | (run time too short) |
| 62             | 6.91570949554 | 30   | 6.84029006958 | 30   | -1%        | (run time too short) |
| 65             | 7.27852344513 | 30   | 7.18192815781 | 30   | -1%        | (run time too short) |
| 69             | 16.3616542816 | 30   | 16.3075428009 | 30   | -0%        | (run time too short) |
| 73             | 26.6281795502 | 30   | 26.4427642822 | 30   | -1%        | (run time too short) |
| 79             | 9.3133058548  | 30   | 9.25420951843 | 30   | -1%        | (run time too short) |
| 81             | 28.1001358032 | 30   | 28.116689682  | 30   | +0%        | (run time too short) |
| 83             | 51.9071273804 | 30   | 52.4082145691 | 30   | +1%        | (run time too short) |
| 85             | 6.56966876984 | 30   | 6.73189687729 | 30   | +2%        | (run time too short) |
| 88             | 4.78254747391 | 30   | 4.78843021393 | 30   | +0%        | (run time too short) |
| 91             | 30.44049263   | 30   | 30.6110363007 | 30   | +1%        | (run time too short) |
| 93             | 2.13753294945 | 30   | 2.11107897758 | 30   | -1%        | (run time too short) |
| 96             | 49.883934021  | 30   | 49.6257514954 | 30   | -1%        | (run time too short) |
| 97             | 1.30872070789 | 30   | 1.31454968452 | 30   | +0%        | (run time too short) |
| 99             | 3.34695076942 | 30   | 3.33235883713 | 30   | -0%        | (run time too short) |
| geometric mean |               |      |               |      | -0%        |                      |
+----------------+---------------+------+---------------+------+------------+----------------------+
```

### Testing
- [x] `./hyriseBenchmarkTPCH -s 0.01 -r 1 --verify` (f7d6246ec)
- [x] `./hyriseBenchmarkTPCDS -s 1 -r 1 --verify` (460d187)
- [x] `hyriseTest` (f7d6246ec)

### Query Plan Example: TPC-H Q17

Old LQP
![TPC-H_17-LQP_old](https://user-images.githubusercontent.com/20044656/82287557-bf359b80-99a0-11ea-8194-740d6c589722.png)

Old PQP
![TPC-H_17-PQP_old](https://user-images.githubusercontent.com/20044656/82287561-c3fa4f80-99a0-11ea-9208-1cb971e722c6.png)

New LQP
![TPC-H_17-LQP_new](https://user-images.githubusercontent.com/20044656/82287587-cb215d80-99a0-11ea-9257-782d0c09df7b.png)

New PQP
![TPC-H_17-PQP_new](https://user-images.githubusercontent.com/20044656/82287596-d1173e80-99a0-11ea-9d38-01d0bb9c0b84.png)