### PR TITLE
Finalize operator results

### DIFF
--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -103,6 +103,15 @@ std::shared_ptr<Table> AbstractJoinOperator::_build_output_table(std::vector<std
     }
   }
 
+  const auto chunk_count = chunks.size();
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
+    // Mark all created chunks as immutable. Since certain joins need to finalize() themselves (e.g., to set sort
+    // orders when applicable), we need to check that a chunk is not already marked as immutable.
+    if (chunks[chunk_id]->is_mutable()) {
+      chunks[chunk_id]->finalize();
+    }
+  }
+
   return std::make_shared<Table>(output_column_definitions, table_type, std::move(chunks));
 }
 

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -70,8 +70,8 @@ void AbstractOperator::execute() {
   // Chunks from operators other than GetTable should be immutable
   if constexpr (HYRISE_DEBUG) {
     // We exclude the TableWrapper (heavily used in tests with arbitrary tables) and modifiying operators.
-    if (const auto ro_operator = std::dynamic_pointer_cast<const AbstractReadOnlyOperator>(_input_left) &&
-                                 _input_left->type() != OperatorType::TableWrapper) {
+    if (std::dynamic_pointer_cast<const AbstractReadOnlyOperator>(_input_left) &&
+        _input_left->type() != OperatorType::TableWrapper) {
       const auto check_input_table = [&](const std::shared_ptr<const Table>& input_table) {
         const auto chunk_count = input_table->chunk_count();
         for (auto chunk_id = ChunkID{0u}; chunk_id < chunk_count; ++chunk_id) {

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -677,6 +677,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
   auto output = std::make_shared<Table>(_output_column_definitions, TableType::Data);
   if (_output_segments.at(0)->size() > 0) {
     output->append_chunk(_output_segments);
+    output->last_chunk()->finalize();
   }
 
   return output;

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -216,10 +216,10 @@ std::shared_ptr<const Table> GetTable::_on_execute() {
       *output_chunks_iter = std::make_shared<Chunk>(std::move(output_segments), stored_chunk->mvcc_data(),
                                                     stored_chunk->get_allocator(), std::move(output_indexes));
 
+      // Pruned chunks are always marked as immutable as they are (as of now) only consumed by read-only operators.
+      (*output_chunks_iter)->finalize();
+
       if (output_chunk_sorted_by) {
-        // Finalizing the output chunk here is safe because this path is only taken for
-        // a sorted chunk. Chunks should never be sorted when they are still mutable
-        (*output_chunks_iter)->finalize();
         (*output_chunks_iter)->set_sorted_by(*output_chunk_sorted_by);
       }
 

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -217,7 +217,10 @@ std::shared_ptr<const Table> GetTable::_on_execute() {
                                                     stored_chunk->get_allocator(), std::move(output_indexes));
 
       // Pruned chunks are always marked as immutable as they are (as of now) only consumed by read-only operators.
-      (*output_chunks_iter)->finalize();
+      // Test by Martin:
+      if (!stored_chunk->is_mutable()) {
+        (*output_chunks_iter)->finalize();
+      }
 
       if (output_chunk_sorted_by) {
         (*output_chunks_iter)->set_sorted_by(*output_chunk_sorted_by);

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -91,6 +91,7 @@ std::shared_ptr<AbstractTask> IndexScan::_create_job_and_schedule(const ChunkID 
 
     std::lock_guard<std::mutex> lock(output_mutex);
     _out_table->append_chunk(segments, nullptr, chunk->get_allocator());
+    _out_table->last_chunk()->finalize();
   });
 
   job_task->schedule();

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -117,6 +117,7 @@ void Product::_add_product_of_two_chunks(const std::shared_ptr<Table>& output, C
   }
 
   output->append_chunk(output_segments);
+  output->last_chunk()->finalize();
 }
 
 std::shared_ptr<AbstractOperator> Product::_on_deep_copy(

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -46,6 +46,7 @@ std::shared_ptr<const Table> UnionAll::_on_execute() {
 
       // adding newly filled chunk to the output table
       output_chunks[output_chunk_idx] = std::make_shared<Chunk>(output_segments);
+      output_chunks[output_chunk_idx]->finalize();
       ++output_chunk_idx;
     }
   }

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -141,6 +141,7 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
     }
 
     out_table->append_chunk(output_segments);
+    out_table->last_chunk()->finalize();
   };
 
   /**

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -149,7 +149,9 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& in_table, co
     const auto chunk_in = in_table->get_chunk(chunk_id);
     Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
+    const auto column_count = chunk_in->column_count();
     Segments output_segments;
+    output_segments.reserve(column_count);
     std::shared_ptr<const AbstractPosList> pos_list_out = std::make_shared<const RowIDPosList>();
     auto referenced_table = std::shared_ptr<const Table>();
     const auto ref_segment_in = std::dynamic_pointer_cast<const ReferenceSegment>(chunk_in->get_segment(ColumnID{0}));
@@ -197,7 +199,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& in_table, co
       }
 
       // Construct the actual ReferenceSegment objects and add them to the chunk.
-      for (ColumnID column_id{0}; column_id < chunk_in->column_count(); ++column_id) {
+      for (ColumnID column_id{0}; column_id < column_count; ++column_id) {
         const auto reference_segment =
             std::static_pointer_cast<const ReferenceSegment>(chunk_in->get_segment(column_id));
         const auto referenced_column_id = reference_segment->referenced_column_id();
@@ -228,7 +230,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& in_table, co
       }
 
       // Create actual ReferenceSegment objects.
-      for (ColumnID column_id{0}; column_id < chunk_in->column_count(); ++column_id) {
+      for (ColumnID column_id{0}; column_id < column_count; ++column_id) {
         auto ref_segment_out = std::make_shared<ReferenceSegment>(referenced_table, column_id, pos_list_out);
         output_segments.push_back(ref_segment_out);
       }


### PR DESCRIPTION
To set sort orders and table clustering in #2000, several operators needed to first finalize their results. With that we realized that all read-only operators should always `finalize()` their results and these are immutable.

This PR adds the last few `finalize()` calls to operators and adds a DebugAssert in `abstract_operators.cpp` to check for it.

Fixes #2131