### PR TITLE
Clarify benchmark information text

### DIFF
--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -29,7 +29,7 @@ def main():
 
   benchmark.expect_exact("Writing benchmark results to 'json_output.txt'")
   benchmark.expect_exact("Running in single-threaded mode")
-  benchmark.expect_exact("1 simulated clients is scheduling items")
+  benchmark.expect_exact("1 simulated client is scheduling items")
   benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
   benchmark.expect_exact("Encoding is 'Unencoded'")
   benchmark.expect_exact("Max runs per item is 100")

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -29,7 +29,7 @@ def main():
 
   benchmark.expect_exact("Writing benchmark results to 'json_output.txt'")
   benchmark.expect_exact("Running in single-threaded mode")
-  benchmark.expect_exact("1 simulated clients are scheduling items in parallel")
+  benchmark.expect_exact("1 simulated clients is scheduling items")
   benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
   benchmark.expect_exact("Encoding is 'Unencoded'")
   benchmark.expect_exact("Max runs per item is 100")

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -28,7 +28,7 @@ def main():
 
   benchmark.expect_exact("Writing benchmark results to 'json_output.txt'")
   benchmark.expect_exact("Running in single-threaded mode")
-  benchmark.expect_exact("1 simulated clients are scheduling items in parallel")
+  benchmark.expect_exact("1 simulated client is scheduling items")
   benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
   benchmark.expect_exact("Encoding is 'Unencoded'")
   benchmark.expect_exact("Max runs per item is 100")

--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -30,7 +30,7 @@ def main():
 
   benchmark.expect_exact("Writing benchmark results to 'json_output.txt'")
   benchmark.expect_exact("Running in single-threaded mode")
-  benchmark.expect_exact("1 simulated clients are scheduling items in parallel")
+  benchmark.expect_exact("1 simulated client is scheduling items")
   benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
   benchmark.expect_exact("Encoding is 'Dictionary'")
   benchmark.expect_exact("Max duration per item is 10 seconds")

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -30,7 +30,9 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
             << std::endl;
 
   const auto clients = parse_result["clients"].as<uint32_t>();
-  std::cout << "- " + std::to_string(clients) + " simulated clients are scheduling items in parallel" << std::endl;
+  std::cout << "- " + std::to_string(clients) + " simulated ";
+  std::cout << (clients == 1 ? "client is " : "clients are ") << "scheduling items";
+  std::cout << (clients > 1 ? " in parallel" : "") << std::endl;
 
   if (cores != default_config.cores || clients != default_config.clients) {
     if (!enable_scheduler) {


### PR DESCRIPTION
When using 1 client, the benchmark states "1 simulated clients is scheduling items in parallel".

For one client, it's now "1 simulated client is scheduling items".