### PR TITLE
Consider pruned chunk ids in LQPTranslator for index scans

### DIFF
--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -210,7 +210,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
   const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node->left_input());
   const auto pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
 
-  DebugAssert(std::is_sorted(pruned_chunk_ids.begin(), pruned_chunk_ids.end()),
+  DebugAssert(std::is_sorted(pruned_chunk_ids.cbegin(), pruned_chunk_ids.cend()),
     "Expected sorted vector of ColumnIDs");
 
   const auto table_name = stored_table_node->table_name;
@@ -218,13 +218,13 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
   std::vector<ChunkID> indexed_chunks;
 
   auto pruned_table_chunk_id = ChunkID{0};
-  auto pruned_chunk_ids_iter = pruned_chunk_ids.begin();
+  auto pruned_chunk_ids_iter = pruned_chunk_ids.cbegin();
 
-  // Create a vector of chunk ids that have a GroupKey index and are not prunned.
+  // Create a vector of chunk ids that have a GroupKey index and are not pruned.
   const auto chunk_count = table->chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     // Check if chunk is pruned
-    if (pruned_chunk_ids_iter <= pruned_chunk_ids.end() && chunk_id == *pruned_chunk_ids_iter) {
+    if (pruned_chunk_ids_iter != pruned_chunk_ids.cend() && chunk_id == *pruned_chunk_ids_iter) {
       ++pruned_chunk_ids_iter;
       continue;
     }

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -208,15 +208,31 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
   if (value2_variant) right_values2.emplace_back(*value2_variant);
 
   const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node->left_input());
+  const auto pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
+  
   const auto table_name = stored_table_node->table_name;
   const auto table = Hyrise::get().storage_manager.get_table(table_name);
   std::vector<ChunkID> indexed_chunks;
 
+  auto pruned_table_chunk_id = 0;
+  auto pruned_vector_id = 0; 
+
+  // Create a vector of chunk ids that have a GroupKey index and are not prunned. 
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0u}; chunk_id < chunk_count; ++chunk_id) {
-    const auto chunk = table->get_chunk(chunk_id);
-    if (chunk && chunk->get_index(SegmentIndexType::GroupKey, column_ids)) {
-      indexed_chunks.emplace_back(chunk_id);
+    Assert(std::is_sorted(pruned_chunk_ids.begin(), pruned_chunk_ids.end()), 
+      "Expected sorted vector of ColumnIDs");
+    // Check if chunk is pruned
+    if (pruned_vector_id < static_cast<int>(pruned_chunk_ids.size()) && 
+      chunk_id == pruned_chunk_ids[pruned_vector_id]) {
+      ++pruned_vector_id;
+    } else {
+      // Check if chunk has GroupKey index
+      const auto chunk = table->get_chunk(chunk_id);
+      if (chunk && chunk->get_index(SegmentIndexType::GroupKey, column_ids)) {
+        indexed_chunks.emplace_back(pruned_table_chunk_id);
+      }
+      ++pruned_table_chunk_id;
     }
   }
 

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -222,7 +222,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
 
   // Create a vector of chunk ids that have a GroupKey index and are not prunned.
   const auto chunk_count = table->chunk_count();
-  for (ChunkID chunk_id{0u}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     // Check if chunk is pruned
     if (pruned_chunk_ids_iter <= pruned_chunk_ids.end() && chunk_id == *pruned_chunk_ids_iter) {
       ++pruned_chunk_ids_iter;

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -209,21 +209,21 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
 
   const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node->left_input());
   const auto pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
-  
+
   const auto table_name = stored_table_node->table_name;
   const auto table = Hyrise::get().storage_manager.get_table(table_name);
   std::vector<ChunkID> indexed_chunks;
 
   auto pruned_table_chunk_id = 0;
-  auto pruned_vector_id = 0; 
+  auto pruned_vector_id = 0;
 
-  // Create a vector of chunk ids that have a GroupKey index and are not prunned. 
+  // Create a vector of chunk ids that have a GroupKey index and are not prunned.
   const auto chunk_count = table->chunk_count();
   for (ChunkID chunk_id{0u}; chunk_id < chunk_count; ++chunk_id) {
-    Assert(std::is_sorted(pruned_chunk_ids.begin(), pruned_chunk_ids.end()), 
+    Assert(std::is_sorted(pruned_chunk_ids.begin(), pruned_chunk_ids.end()),
       "Expected sorted vector of ColumnIDs");
     // Check if chunk is pruned
-    if (pruned_vector_id < static_cast<int>(pruned_chunk_ids.size()) && 
+    if (pruned_vector_id < static_cast<int>(pruned_chunk_ids.size()) &&
       chunk_id == pruned_chunk_ids[pruned_vector_id]) {
       ++pruned_vector_id;
     } else {

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -208,7 +208,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
   if (value2_variant) right_values2.emplace_back(*value2_variant);
 
   const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(node->left_input());
-  const auto pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
+  const auto& pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
 
   DebugAssert(std::is_sorted(pruned_chunk_ids.cbegin(), pruned_chunk_ids.cend()),
     "Expected sorted vector of ColumnIDs");

--- a/src/test/lib/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_translator_test.cpp
@@ -488,6 +488,52 @@ TEST_F(LQPTranslatorTest, PredicateNodeIndexScan) {
   EXPECT_EQ(table_scan_op->lqp_node, predicate_node);
 }
 
+TEST_F(LQPTranslatorTest, PredicateNodePrunedIndexScan) {
+  /**
+   * Build LQP and translate to PQP
+   */
+  const auto stored_table_node = StoredTableNode::make("int_float_chunked");
+
+  const auto table = Hyrise::get().storage_manager.get_table("int_float_chunked");
+  std::vector<ColumnID> index_column_ids = {ColumnID{1}};
+  std::vector<ChunkID> index_chunk_ids = {ChunkID{0}, ChunkID{2}};
+  std::vector<ChunkID> pruned_chunk_ids = {ChunkID{0}};
+  table->get_chunk(index_chunk_ids[0])->create_index<GroupKeyIndex>(index_column_ids);
+  table->get_chunk(index_chunk_ids[1])->create_index<GroupKeyIndex>(index_column_ids);
+
+  stored_table_node->set_pruned_chunk_ids(pruned_chunk_ids);
+  auto predicate_node = PredicateNode::make(equals_(stored_table_node->get_column("b"), 42));
+  predicate_node->set_left_input(stored_table_node);
+  predicate_node->scan_type = ScanType::IndexScan;
+  const auto op = LQPTranslator{}.translate_node(predicate_node);
+
+  // As the vector of indexed chunks contain the chunk ids {0, 2} and the vector of pruned chunks 
+  // contains the chunk id {0}, the first indexed chunk is pruned. Correspondingly, the ids of the 
+  // indexed chunks have to be adopted, so that the index chunk with the id 2 has now the id 1. 
+  std::vector<ChunkID> index_scan_chunk_ids = {ChunkID{1}};
+
+  /**
+   * Check PQP
+   */
+  const auto union_op = std::dynamic_pointer_cast<UnionAll>(op);
+  ASSERT_TRUE(union_op);
+
+  const auto index_scan_op = std::dynamic_pointer_cast<const IndexScan>(op->left_input());
+  ASSERT_TRUE(index_scan_op);
+  EXPECT_EQ(index_scan_op->included_chunk_ids, index_scan_chunk_ids);
+
+  const auto table_scan_op = std::dynamic_pointer_cast<const TableScan>(op->right_input());
+  const auto b = PQPColumnExpression::from_table(*table, "b");
+  ASSERT_TRUE(table_scan_op);
+  EXPECT_EQ(table_scan_op->excluded_chunk_ids, index_scan_chunk_ids);
+  EXPECT_EQ(*table_scan_op->predicate(), *equals_(b, 42));
+
+  // Check the setting of LQP nodes for index scans
+  EXPECT_EQ(union_op->lqp_node, predicate_node);
+  EXPECT_EQ(index_scan_op->lqp_node, predicate_node);
+  EXPECT_EQ(table_scan_op->lqp_node, predicate_node);
+}
+
 TEST_F(LQPTranslatorTest, PredicateNodeBinaryIndexScan) {
   /**
    * Build LQP and translate to PQP

--- a/src/test/lib/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_translator_test.cpp
@@ -495,9 +495,9 @@ TEST_F(LQPTranslatorTest, PredicateNodePrunedIndexScan) {
   const auto stored_table_node = StoredTableNode::make("int_float_chunked");
 
   const auto table = Hyrise::get().storage_manager.get_table("int_float_chunked");
-  std::vector<ColumnID> index_column_ids = {ColumnID{1}};
-  std::vector<ChunkID> index_chunk_ids = {ChunkID{0}, ChunkID{2}};
-  std::vector<ChunkID> pruned_chunk_ids = {ChunkID{0}};
+  auto index_column_ids = std::vector{ColumnID{1}};
+  auto index_chunk_ids = std::vector{ChunkID{0}, ChunkID{2}};
+  auto pruned_chunk_ids = std::vector{ChunkID{0}};
   table->get_chunk(index_chunk_ids[0])->create_index<GroupKeyIndex>(index_column_ids);
   table->get_chunk(index_chunk_ids[1])->create_index<GroupKeyIndex>(index_column_ids);
 
@@ -507,9 +507,9 @@ TEST_F(LQPTranslatorTest, PredicateNodePrunedIndexScan) {
   predicate_node->scan_type = ScanType::IndexScan;
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
-  // As the vector of indexed chunks contain the chunk ids {0, 2} and the vector of pruned chunks
+  // As the vector of indexed chunks contains the chunk ids {0, 2} and the vector of pruned chunks
   // contains the chunk id {0}, the first indexed chunk is pruned. Correspondingly, the ids of the
-  // indexed chunks have to be adopted, so that the index chunk with the id 2 has now the id 1.
+  // indexed chunks have to be adapted, so that the indexed chunk with the id 2 now has the id 1.
   std::vector<ChunkID> index_scan_chunk_ids = {ChunkID{1}};
 
   /**

--- a/src/test/lib/logical_query_plan/lqp_translator_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_translator_test.cpp
@@ -507,9 +507,9 @@ TEST_F(LQPTranslatorTest, PredicateNodePrunedIndexScan) {
   predicate_node->scan_type = ScanType::IndexScan;
   const auto op = LQPTranslator{}.translate_node(predicate_node);
 
-  // As the vector of indexed chunks contain the chunk ids {0, 2} and the vector of pruned chunks 
-  // contains the chunk id {0}, the first indexed chunk is pruned. Correspondingly, the ids of the 
-  // indexed chunks have to be adopted, so that the index chunk with the id 2 has now the id 1. 
+  // As the vector of indexed chunks contain the chunk ids {0, 2} and the vector of pruned chunks
+  // contains the chunk id {0}, the first indexed chunk is pruned. Correspondingly, the ids of the
+  // indexed chunks have to be adopted, so that the index chunk with the id 2 has now the id 1.
   std::vector<ChunkID> index_scan_chunk_ids = {ChunkID{1}};
 
   /**


### PR DESCRIPTION
The translation of predicates node to index scans checks if a GroupKey index exists and creates the corresponding included_chunk_ids and excluded_chunk_ids vectors to specify for which chunks the index scan can be used and for which chunks the table scan should be used as a fallback.    

During the creation of the include/exclude chunk id vector, information about pruned chunks are not considered at the moment. For that reason, the pull request adds an id mapping, which removes pruned chunks and adopts the chunk ids correspondingly. 