### PR TITLE
Rename column_expressions to output_expressions

### DIFF
--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -36,7 +36,7 @@ std::string AggregateExpression::description(const DescriptionMode mode) const {
       stream << "COUNT(*)";
     } else {
       const auto* const column_expression = dynamic_cast<const LQPColumnExpression*>(&*argument());
-      DebugAssert(column_expression, "Expected aggregate argument to be column expression");
+      DebugAssert(column_expression, "Expected aggregate argument to be LQPColumnExpression");
       stream << "COUNT(" << column_expression->original_node.lock() << ".*)";
     }
   } else {

--- a/src/lib/expression/expression_utils.cpp
+++ b/src/lib/expression/expression_utils.cpp
@@ -159,7 +159,7 @@ bool expression_evaluable_on_lqp(const std::shared_ptr<AbstractExpression>& expr
 
     if (AggregateExpression::is_count_star(*sub_expression)) {
       // COUNT(*) needs special treatment. Because its argument is the invalid column id, it is not part of any node's
-      // column_expressions. Check if sub_expression is COUNT(*) - if yes, ignore the INVALID_COLUMN_ID and verify that
+      // output_expressions. Check if sub_expression is COUNT(*) - if yes, ignore the INVALID_COLUMN_ID and verify that
       // its original_node is part of lqp.
       const auto& aggregate_expression = static_cast<const AggregateExpression&>(*sub_expression);
       const auto& lqp_column_expression = static_cast<const LQPColumnExpression&>(*aggregate_expression.argument());

--- a/src/lib/expression/lqp_column_expression.hpp
+++ b/src/lib/expression/lqp_column_expression.hpp
@@ -18,7 +18,7 @@ class LQPColumnExpression : public AbstractExpression {
   bool requires_computation() const override;
 
   // Needs to be weak since nodes can store LQPColumnExpressions referring to themselves (e.g., for
-  // StoredTableNode::column_expressions). If the original_node is not referenced by any shared_ptr anymore, it is
+  // StoredTableNode::output_expressions). If the original_node is not referenced by any shared_ptr anymore, it is
   // deleted. As a result, the weak_ptr expires. It should not be accessed anymore. Thus, if original_node.lock() is
   // a nullptr, the LQP is defective.
   const std::weak_ptr<const AbstractLQPNode> original_node;

--- a/src/lib/expression/lqp_subquery_expression.cpp
+++ b/src/lib/expression/lqp_subquery_expression.cpp
@@ -53,13 +53,13 @@ std::string LQPSubqueryExpression::description(const DescriptionMode mode) const
 }
 
 DataType LQPSubqueryExpression::data_type() const {
-  Assert(lqp->column_expressions().size() == 1,
+  Assert(lqp->output_expressions().size() == 1,
          "Can only determine the DataType of SubqueryExpressions that return exactly one column");
-  return lqp->column_expressions()[0]->data_type();
+  return lqp->output_expressions()[0]->data_type();
 }
 
 bool LQPSubqueryExpression::_on_is_nullable_on_lqp(const AbstractLQPNode&) const {
-  Assert(lqp->column_expressions().size() == 1,
+  Assert(lqp->output_expressions().size() == 1,
          "Can only determine the nullability of SelectExpressions that return exactly one column");
   return lqp->is_column_nullable(ColumnID{0});
 }

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -127,7 +127,10 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   bool shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const;
 
   /**
-   * @return The Expressions defining each column that this node outputs
+   * @return The Expressions defining each "column" that this node outputs. Note: When talking about LQPs, we use the
+   *         term expression, rather than column. A ProjectionNode might output `a + 5`, where a is an
+   *         LQPColumnExpression and `a + 5` is an ArithmeticExpression. Avoid "column expression" if you do not mean
+   *         a column that comes from an actual table.
    */
   virtual std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const;
 

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -129,7 +129,7 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   /**
    * @return The Expressions defining each column that this node outputs
    */
-  virtual std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const;
+  virtual std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const;
 
   /**
    * @return The ColumnID of the @param expression, or std::nullopt if it can't be found. Note that because COUNT(*)

--- a/src/lib/logical_query_plan/abstract_non_query_node.cpp
+++ b/src/lib/logical_query_plan/abstract_non_query_node.cpp
@@ -4,7 +4,7 @@
 
 namespace opossum {
 
-std::vector<std::shared_ptr<AbstractExpression>> AbstractNonQueryNode::column_expressions() const { return {}; }
+std::vector<std::shared_ptr<AbstractExpression>> AbstractNonQueryNode::output_expressions() const { return {}; }
 
 bool AbstractNonQueryNode::is_column_nullable(const ColumnID column_id) const {
   // The majority of non-query nodes output no column (CreateTable, DropTable, ...)

--- a/src/lib/logical_query_plan/abstract_non_query_node.hpp
+++ b/src/lib/logical_query_plan/abstract_non_query_node.hpp
@@ -7,13 +7,13 @@ namespace opossum {
 /**
  * Base class for LQP nodes that do not query data (e.g, DML and DDL nodes) and therefore do not output columns.
  *
- * Helper class that provides a column_expressions() override and contains an empty dummy expression vector
+ * Helper class that provides a output_expressions() override and contains an empty dummy expression vector
  */
 class AbstractNonQueryNode : public AbstractLQPNode {
  public:
   using AbstractLQPNode::AbstractLQPNode;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 };
 

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -65,12 +65,12 @@ std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::output_expressio
 
   for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < output_expressions.size();
        ++expression_idx) {
-    auto& column_expression = output_expressions[expression_idx];
-    DebugAssert(column_expression->type == ExpressionType::Aggregate,
+    auto& output_expression = output_expressions[expression_idx];
+    DebugAssert(output_expression->type == ExpressionType::Aggregate,
                 "Unexpected non-aggregate in list of aggregates.");
-    const auto& aggregate_expression = static_cast<AggregateExpression&>(*column_expression);
+    const auto& aggregate_expression = static_cast<AggregateExpression&>(*output_expression);
     if (aggregate_expression.aggregate_function == AggregateFunction::Any) {
-      column_expression = column_expression->arguments[0];
+      output_expression = output_expression->arguments[0];
     }
   }
 

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -57,15 +57,15 @@ std::string AggregateNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::output_expressions() const {
   // We do not return node_expressions directly here, because we do not want to expose ANY() to the following LQP
   // nodes. This way, we execute ANY() as intended, but do not have to traverse the LQP upwards and adapt nodes
   // that reference the ANY'd column.
-  auto column_expressions = node_expressions;
+  auto output_expressions = node_expressions;
 
-  for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < column_expressions.size();
+  for (auto expression_idx = aggregate_expressions_begin_idx; expression_idx < output_expressions.size();
        ++expression_idx) {
-    auto& column_expression = column_expressions[expression_idx];
+    auto& column_expression = output_expressions[expression_idx];
     DebugAssert(column_expression->type == ExpressionType::Aggregate,
                 "Unexpected non-aggregate in list of aggregates.");
     const auto& aggregate_expression = static_cast<AggregateExpression&>(*column_expression);
@@ -74,7 +74,7 @@ std::vector<std::shared_ptr<AbstractExpression>> AggregateNode::column_expressio
     }
   }
 
-  return column_expressions;
+  return output_expressions;
 }
 
 bool AggregateNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/aggregate_node.hpp
+++ b/src/lib/logical_query_plan/aggregate_node.hpp
@@ -23,7 +23,7 @@ class AggregateNode : public EnableMakeForLQPNode<AggregateNode>, public Abstrac
                 const std::vector<std::shared_ptr<AbstractExpression>>& aggregate_expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   // node_expression contains both the group_by- and the aggregate_expressions in that order.

--- a/src/lib/logical_query_plan/alias_node.cpp
+++ b/src/lib/logical_query_plan/alias_node.cpp
@@ -29,7 +29,7 @@ std::string AliasNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> AliasNode::column_expressions() const { return node_expressions; }
+std::vector<std::shared_ptr<AbstractExpression>> AliasNode::output_expressions() const { return node_expressions; }
 
 size_t AliasNode::_on_shallow_hash() const {
   size_t hash{0};

--- a/src/lib/logical_query_plan/alias_node.hpp
+++ b/src/lib/logical_query_plan/alias_node.hpp
@@ -17,7 +17,7 @@ class AliasNode : public EnableMakeForLQPNode<AliasNode>, public AbstractLQPNode
             const std::vector<std::string>& init_aliases);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
   const std::vector<std::string> aliases;
 

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -15,7 +15,7 @@ std::string DeleteNode::description(const DescriptionMode mode) const { return "
 
 bool DeleteNode::is_column_nullable(const ColumnID column_id) const { Fail("Delete does not output any columns"); }
 
-std::vector<std::shared_ptr<AbstractExpression>> DeleteNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> DeleteNode::output_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -16,7 +16,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractLQPNo
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -14,7 +14,7 @@ DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
 std::string DummyTableNode::description(const DescriptionMode mode) const { return "[DummyTable]"; }
 
-std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::column_expressions() const { return {}; }
+std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::output_expressions() const { return {}; }
 
 bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {
   Fail("DummyTable does not output any columns");

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -18,7 +18,7 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/except_node.cpp
+++ b/src/lib/logical_query_plan/except_node.cpp
@@ -18,8 +18,8 @@ std::string ExceptNode::description(const DescriptionMode mode) const {
   return "[ExceptNode] Mode: " + set_operation_mode_to_string.left.at(set_operation_mode);
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> ExceptNode::column_expressions() const {
-  return left_input()->column_expressions();
+std::vector<std::shared_ptr<AbstractExpression>> ExceptNode::output_expressions() const {
+  return left_input()->output_expressions();
 }
 
 bool ExceptNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/except_node.hpp
+++ b/src/lib/logical_query_plan/except_node.hpp
@@ -17,7 +17,7 @@ class ExceptNode : public EnableMakeForLQPNode<ExceptNode>, public AbstractLQPNo
   explicit ExceptNode(const SetOperationMode init_operation_mode);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const SetOperationMode set_operation_mode;

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -16,12 +16,12 @@ bool FunctionalDependency::operator==(const FunctionalDependency& other) const {
   if (determinants.size() != other.determinants.size() || dependents.size() != other.dependents.size()) return false;
 
   // Compare determinants
-  for (const auto& column_expression : other.determinants) {
-    if (!determinants.contains(column_expression)) return false;
+  for (const auto& expression : other.determinants) {
+    if (!determinants.contains(expression)) return false;
   }
   // Compare dependants
-  for (const auto& column_expression : other.dependents) {
-    if (!dependents.contains(column_expression)) return false;
+  for (const auto& expression : other.dependents) {
+    if (!dependents.contains(expression)) return false;
   }
 
   return true;

--- a/src/lib/logical_query_plan/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/functional_dependency.hpp
@@ -5,8 +5,8 @@
 namespace opossum {
 
 /**
- * Models a functional dependency (FD), which consists out of two sets of column expressions.
- * The left column set (determinants) unambigiously identifies the right column set (dependents):
+ * Models a functional dependency (FD), which consists out of two sets of expressions.
+ * The left set of expressions (determinants) unambigiously identifies the right set (dependents):
  * {Left} => {Right}
  *
  * Example A:
@@ -24,7 +24,7 @@ namespace opossum {
  * Furthermore, knowing an author, we also know his nationality. Hence, we can specify another FD that applies:
  * {Author} => {Author-Nationality}
  *
- * Currently, the determinant column expressions are required to be non-nullable to be involved in FDs.
+ * Currently, the determinant expressions are required to be non-nullable to be involved in FDs.
  * Combining null values and FDs is not trivial. For more reference, see https://arxiv.org/abs/1404.4963.
  */
 struct FunctionalDependency {

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -23,7 +23,7 @@ std::string InsertNode::description(const DescriptionMode mode) const {
 
 bool InsertNode::is_column_nullable(const ColumnID column_id) const { Fail("Insert returns no columns"); }
 
-std::vector<std::shared_ptr<AbstractExpression>> InsertNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> InsertNode::output_expressions() const {
   static std::vector<std::shared_ptr<AbstractExpression>> empty_vector;
   return empty_vector;
 }

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -17,7 +17,7 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractLQPNo
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/logical_query_plan/intersect_node.cpp
+++ b/src/lib/logical_query_plan/intersect_node.cpp
@@ -18,8 +18,8 @@ std::string IntersectNode::description(const DescriptionMode mode) const {
   return "[IntersectNode] Mode: " + set_operation_mode_to_string.left.at(set_operation_mode);
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> IntersectNode::column_expressions() const {
-  return left_input()->column_expressions();
+std::vector<std::shared_ptr<AbstractExpression>> IntersectNode::output_expressions() const {
+  return left_input()->output_expressions();
 }
 
 bool IntersectNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/intersect_node.hpp
+++ b/src/lib/logical_query_plan/intersect_node.hpp
@@ -26,7 +26,7 @@ class IntersectNode : public EnableMakeForLQPNode<IntersectNode>, public Abstrac
   explicit IntersectNode(const SetOperationMode init_operation_mode);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const SetOperationMode set_operation_mode;

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -46,7 +46,7 @@ std::string JoinNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> JoinNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> JoinNode::output_expressions() const {
   Assert(left_input() && right_input(), "Both inputs need to be set to determine a JoinNode's output expressions");
 
   /**
@@ -55,26 +55,26 @@ std::vector<std::shared_ptr<AbstractExpression>> JoinNode::column_expressions() 
    * of feeble code.
    */
 
-  const auto& left_expressions = left_input()->column_expressions();
-  const auto& right_expressions = right_input()->column_expressions();
+  const auto& left_expressions = left_input()->output_expressions();
+  const auto& right_expressions = right_input()->output_expressions();
 
   const auto output_both_inputs =
       join_mode != JoinMode::Semi && join_mode != JoinMode::AntiNullAsTrue && join_mode != JoinMode::AntiNullAsFalse;
 
-  auto column_expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
-  column_expressions.resize(left_expressions.size() + (output_both_inputs ? right_expressions.size() : 0));
+  auto output_expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
+  output_expressions.resize(left_expressions.size() + (output_both_inputs ? right_expressions.size() : 0));
 
-  auto right_begin = std::copy(left_expressions.begin(), left_expressions.end(), column_expressions.begin());
+  auto right_begin = std::copy(left_expressions.begin(), left_expressions.end(), output_expressions.begin());
 
   if (output_both_inputs) std::copy(right_expressions.begin(), right_expressions.end(), right_begin);
 
-  return column_expressions;
+  return output_expressions;
 }
 
 bool JoinNode::is_column_nullable(const ColumnID column_id) const {
   Assert(left_input() && right_input(), "Need both inputs to determine nullability");
 
-  const auto left_input_column_count = left_input()->column_expressions().size();
+  const auto left_input_column_count = left_input()->output_expressions().size();
   const auto column_is_from_left_input = column_id < left_input_column_count;
 
   if (join_mode == JoinMode::Left && !column_is_from_left_input) {

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -28,7 +28,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   JoinNode(const JoinMode init_join_mode, const std::vector<std::shared_ptr<AbstractExpression>>& init_join_predicates);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -265,9 +265,9 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_alias_node(
   const auto input_operator = translate_node(input_node);
 
   auto column_ids = std::vector<ColumnID>();
-  column_ids.reserve(alias_node->column_expressions().size());
+  column_ids.reserve(alias_node->output_expressions().size());
 
-  for (const auto& expression : alias_node->column_expressions()) {
+  for (const auto& expression : alias_node->output_expressions()) {
     column_ids.emplace_back(input_node->get_column_id(*expression));
   }
 
@@ -561,7 +561,7 @@ std::shared_ptr<AbstractExpression> LQPTranslator::_translate_expression(
     // Try to resolve the Expression to a column from the input node
     const auto column_id = node->find_column_id(*expression);
     if (column_id) {
-      const auto referenced_expression = node->column_expressions()[*column_id];
+      const auto referenced_expression = node->output_expressions()[*column_id];
       expression =
           std::make_shared<PQPColumnExpression>(*column_id, referenced_expression->data_type(),
                                                 node->is_column_nullable(node->get_column_id(*referenced_expression)),
@@ -593,7 +593,7 @@ std::shared_ptr<AbstractExpression> LQPTranslator::_translate_expression(
 
       // Only specify a type for the Subquery if it has exactly one column. Otherwise the DataType of the Expression
       // is undefined and obtaining it will result in a runtime error.
-      if (subquery_expression->lqp->column_expressions().size() == 1u) {
+      if (subquery_expression->lqp->output_expressions().size() == 1u) {
         const auto subquery_data_type = subquery_expression->data_type();
         const auto subquery_nullable = subquery_expression->lqp->is_column_nullable(ColumnID{0});
 

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -28,11 +28,11 @@ std::shared_ptr<LQPColumnExpression> MockNode::get_column(const std::string& col
 
 const MockNode::ColumnDefinitions& MockNode::column_definitions() const { return _column_definitions; }
 
-std::vector<std::shared_ptr<AbstractExpression>> MockNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> MockNode::output_expressions() const {
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain that
   // in the constructor
-  if (!_column_expressions) {
-    _column_expressions.emplace(_column_definitions.size() - _pruned_column_ids.size());
+  if (!_output_expressions) {
+    _output_expressions.emplace(_column_definitions.size() - _pruned_column_ids.size());
 
     auto pruned_column_ids_iter = _pruned_column_ids.begin();
 
@@ -44,13 +44,13 @@ std::vector<std::shared_ptr<AbstractExpression>> MockNode::column_expressions() 
         continue;
       }
 
-      (*_column_expressions)[output_column_id] =
+      (*_output_expressions)[output_column_id] =
           std::make_shared<LQPColumnExpression>(shared_from_this(), stored_column_id);
       ++output_column_id;
     }
   }
 
-  return *_column_expressions;
+  return *_output_expressions;
 }
 
 bool MockNode::is_column_nullable(const ColumnID column_id) const {
@@ -72,8 +72,8 @@ void MockNode::set_pruned_column_ids(const std::vector<ColumnID>& pruned_column_
 
   _pruned_column_ids = pruned_column_ids;
 
-  // Rebuilding this lazily the next time `column_expressions()` is called
-  _column_expressions.reset();
+  // Rebuilding this lazily the next time `output_expressions()` is called
+  _output_expressions.reset();
 }
 
 const std::vector<ColumnID>& MockNode::pruned_column_ids() const { return _pruned_column_ids; }

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -30,7 +30,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
   const ColumnDefinitions& column_definitions() const;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   void set_functional_dependencies(const std::vector<FunctionalDependency>& fds);
@@ -58,7 +58,7 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 
  private:
-  mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _column_expressions;
+  mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;
 
   // Constructor args to keep around for deep_copy()
   ColumnDefinitions _column_definitions;

--- a/src/lib/logical_query_plan/projection_node.cpp
+++ b/src/lib/logical_query_plan/projection_node.cpp
@@ -21,7 +21,7 @@ std::string ProjectionNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::column_expressions() const { return node_expressions; }
+std::vector<std::shared_ptr<AbstractExpression>> ProjectionNode::output_expressions() const { return node_expressions; }
 
 bool ProjectionNode::is_column_nullable(const ColumnID column_id) const {
   Assert(column_id < node_expressions.size(), "ColumnID out of range");

--- a/src/lib/logical_query_plan/projection_node.hpp
+++ b/src/lib/logical_query_plan/projection_node.hpp
@@ -12,7 +12,7 @@ class ProjectionNode : public EnableMakeForLQPNode<ProjectionNode>, public Abstr
   explicit ProjectionNode(const std::vector<std::shared_ptr<AbstractExpression>>& expressions);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
  protected:

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -28,18 +28,18 @@ std::string StaticTableNode::description(const DescriptionMode mode) const {
   return stream.str();
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::column_expressions() const {
+std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::output_expressions() const {
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain
   // that in the constructor
-  if (!_column_expressions) {
-    _column_expressions.emplace(table->column_count());
+  if (!_output_expressions) {
+    _output_expressions.emplace(table->column_count());
 
     for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {
-      (*_column_expressions)[column_id] = std::make_shared<LQPColumnExpression>(shared_from_this(), column_id);
+      (*_output_expressions)[column_id] = std::make_shared<LQPColumnExpression>(shared_from_this(), column_id);
     }
   }
 
-  return *_column_expressions;
+  return *_output_expressions;
 }
 
 bool StaticTableNode::is_column_nullable(const ColumnID column_id) const {

--- a/src/lib/logical_query_plan/static_table_node.hpp
+++ b/src/lib/logical_query_plan/static_table_node.hpp
@@ -18,13 +18,13 @@ class StaticTableNode : public EnableMakeForLQPNode<StaticTableNode>, public Abs
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
   const std::shared_ptr<Table> table;
 
  protected:
-  mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _column_expressions;
+  mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;
 
   size_t _on_shallow_hash() const override;
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -39,7 +39,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   std::vector<IndexStatistics> indexes_statistics() const;
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
   std::vector<FunctionalDependency> functional_dependencies() const override;
 
@@ -55,7 +55,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
 
  private:
-  mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _column_expressions;
+  mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;
   std::vector<ChunkID> _pruned_chunk_ids;
   std::vector<ColumnID> _pruned_column_ids;
 };

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -18,10 +18,10 @@ std::string UnionNode::description(const DescriptionMode mode) const {
   return "[UnionNode] Mode: " + set_operation_mode_to_string.left.at(set_operation_mode);
 }
 
-std::vector<std::shared_ptr<AbstractExpression>> UnionNode::column_expressions() const {
-  Assert(expressions_equal(left_input()->column_expressions(), right_input()->column_expressions()),
+std::vector<std::shared_ptr<AbstractExpression>> UnionNode::output_expressions() const {
+  Assert(expressions_equal(left_input()->output_expressions(), right_input()->output_expressions()),
          "Input Expressions must match");
-  return left_input()->column_expressions();
+  return left_input()->output_expressions();
 }
 
 std::vector<FunctionalDependency> UnionNode::functional_dependencies() const {

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -21,7 +21,7 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
   explicit UnionNode(const SetOperationMode init_set_operation_mode);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
   std::vector<FunctionalDependency> functional_dependencies() const override;
 

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& no
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
-std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::column_expressions() const { return {}; }
+std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::output_expressions() const { return {}; }
 
 size_t UpdateNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -19,7 +19,7 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public AbstractNonQu
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
-  std::vector<std::shared_ptr<AbstractExpression>> column_expressions() const override;
+  std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
   const std::string table_name;
 

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -49,7 +49,7 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     if (lqp_node) {
       // LQP is available, use column name from there
       const auto& input_lqp_node = lqp_node->input(from_left ? LQPInputSide::Left : LQPInputSide::Right);
-      return input_lqp_node->column_expressions()[column_id]->as_column_name();
+      return input_lqp_node->output_expressions()[column_id]->as_column_name();
     }
 
     // Fallback - use column ID

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -70,12 +70,12 @@ void AbstractOperator::execute() {
   // Verify that LQP (if set) and PQP match.
   if constexpr (HYRISE_DEBUG) {
     if (lqp_node) {
-      [[maybe_unused]] const auto& lqp_expressions = lqp_node->column_expressions();
+      [[maybe_unused]] const auto& lqp_expressions = lqp_node->output_expressions();
       if (!_output) {
         DebugAssert(lqp_expressions.empty(), "Operator did not produce a result, but the LQP expects it to");
       } else if (std::dynamic_pointer_cast<const AbstractNonQueryNode>(lqp_node) ||
                  std::dynamic_pointer_cast<const DummyTableNode>(lqp_node)) {
-        // AbstractNonQueryNodes do not have any consumable column_expressions, but the corresponding operators return
+        // AbstractNonQueryNodes do not have any consumable output_expressions, but the corresponding operators return
         // 'OK' for better compatibility with the console and the server. We do not assert anything here.
         // Similarly, DummyTableNodes do not produce expressions that are used in the remainder of the LQP and do not
         // need to be tested.

--- a/src/lib/operators/export.cpp
+++ b/src/lib/operators/export.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<const Table> Export::_on_execute() {
       Fail("Export: Exporting file type is not supported.");
   }
 
-  // must match ExportNode::column_expressions
+  // must match ExportNode::output_expressions
   return nullptr;
 }
 

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -56,7 +56,7 @@ std::shared_ptr<const Table> Import::_on_execute() {
 
   Hyrise::get().storage_manager.add_table(_tablename, table);
 
-  // must match ImportNode::column_expressions
+  // must match ImportNode::output_expressions
   return nullptr;
 }
 

--- a/src/lib/optimizer/strategy/between_composition_rule.cpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.cpp
@@ -292,7 +292,7 @@ void BetweenCompositionRule::_replace_predicates(const std::vector<std::shared_p
     lower_bound_value_expression = nullptr;
     upper_bound_value_expression = nullptr;
 
-    // Here, we could also generate BETWEEN expressions for when the lower and upper bounds are column expressions.
+    // Here, we could also generate BETWEEN expressions for when the lower and upper bounds are LQPColumnExpressions.
     // As the table scan does not yet support that and will revert to the ExpressionEvaluator, we don't do this and
     // use two separate predicates instead.
   }

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -106,7 +106,7 @@ std::set<ChunkID> ChunkPruningRule::_compute_exclude_list(const Table& table, co
     }
 
     const auto column_data_type =
-        stored_table_node_without_column_pruning->column_expressions()[operator_predicate.column_id]->data_type();
+        stored_table_node_without_column_pruning->output_expressions()[operator_predicate.column_id]->data_type();
 
     // If `value` cannot be converted losslessly to the column data type, we rather skip pruning than running into
     // errors with lossful casting and pruning Chunks that we shouldn't have pruned.

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
@@ -82,10 +82,10 @@ void DependentGroupByReductionRule::apply_to(const std::shared_ptr<AbstractLQPNo
     if (fds.empty()) return LQPVisitation::VisitInputs;
 
     // --- Preparation ---
-    // Store a copy of the root's column expressions before applying the rule
-    const auto root_column_expressions = root_lqp->column_expressions();
-    // Also store a copy of the aggregate's column expressions to verify the output column order later on.
-    const auto initial_aggregate_column_expressions = aggregate_node.column_expressions();
+    // Store a copy of the root's output expressions before applying the rule
+    const auto root_output_expressions = root_lqp->output_expressions();
+    // Also store a copy of the aggregate's output expressions to verify the output column order later on.
+    const auto initial_aggregate_output_expressions = aggregate_node.output_expressions();
 
     // Gather group-by columns
     const auto fetch_group_by_columns = [&aggregate_node]() {
@@ -121,11 +121,11 @@ void DependentGroupByReductionRule::apply_to(const std::shared_ptr<AbstractLQPNo
     // In case the initial query plan root returned the same columns in the same column order and was not a projection,
     // it is likely that the result of the current aggregate was either the root itself or only operators followed that
     // do not modify the column order (e.g., sort or limit). In this case, we need to restore the initial column order
-    // by adding a projection with the initial column expressions since we changed the column order by moving columns
+    // by adding a projection with the initial output expressions since we changed the column order by moving columns
     // from the group-by list to the aggregations.
-    if (group_by_list_changed && initial_aggregate_column_expressions == root_column_expressions &&
+    if (group_by_list_changed && initial_aggregate_output_expressions == root_output_expressions &&
         root_lqp->type != LQPNodeType::Projection) {
-      const auto projection_node = std::make_shared<ProjectionNode>(root_column_expressions);
+      const auto projection_node = std::make_shared<ProjectionNode>(root_output_expressions);
       lqp_insert_node(root_lqp, LQPInputSide::Left, projection_node);
     }
 

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
@@ -30,8 +30,8 @@ bool remove_dependent_group_by_columns(const FunctionalDependency& fd, const Exp
 
   // To benefit from this rule, the FD's columns have to be part of the group-by list
   if (!std::all_of(fd.determinants.cbegin(), fd.determinants.cend(),
-                   [&group_by_columns](const std::shared_ptr<AbstractExpression>& constraint_column_expression) {
-                     return group_by_columns.contains(constraint_column_expression);
+                   [&group_by_columns](const std::shared_ptr<AbstractExpression>& constraint_expression) {
+                     return group_by_columns.contains(constraint_expression);
                    })) {
     return false;
   }

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -258,7 +258,7 @@ void ExpressionReductionRule::remove_duplicate_aggregate(
   }
 
   // Take a copy of what the aggregate was originally supposed to do
-  const auto original_aggregate_expressions = aggregate_node->column_expressions();
+  const auto original_aggregate_expressions = aggregate_node->output_expressions();
 
   const auto& aggregate_input_node = aggregate_node->left_input();
   auto replacements = ExpressionUnorderedMap<std::shared_ptr<AbstractExpression>>{};
@@ -297,7 +297,7 @@ void ExpressionReductionRule::remove_duplicate_aggregate(
   if (replacements.empty()) return;
 
   // Back up the current column names
-  const auto& root_expressions = root_node->column_expressions();
+  const auto& root_expressions = root_node->output_expressions();
   auto old_column_names = std::vector<std::string>(root_expressions.size());
   for (auto expression_idx = size_t{0}; expression_idx < root_expressions.size(); ++expression_idx) {
     old_column_names[expression_idx] = root_expressions[expression_idx]->as_column_name();
@@ -331,7 +331,7 @@ void ExpressionReductionRule::remove_duplicate_aggregate(
 
   // If there is no upward AliasNode, we need to add one that renames "SUM/COUNT" to "AVG"
   if (!updated_an_alias) {
-    auto root_expressions_replaced = root_node->column_expressions();
+    auto root_expressions_replaced = root_node->output_expressions();
 
     for (auto& expression : root_expressions_replaced) {
       expression_deep_replace(expression, replacements);

--- a/src/lib/optimizer/strategy/join_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.cpp
@@ -23,12 +23,12 @@ void JoinOrderingRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) co
 
   Assert(root->type == LQPNodeType::Root, "JoinOrderingRule needs root to hold onto");
 
-  const auto expected_column_order = root->column_expressions();
+  const auto expected_column_order = root->output_expressions();
 
   auto result_lqp = _perform_join_ordering_recursively(root->left_input());
 
   // Join ordering might change the output column order, let's fix that
-  if (!expressions_equal(expected_column_order, result_lqp->column_expressions())) {
+  if (!expressions_equal(expected_column_order, result_lqp->output_expressions())) {
     result_lqp = ProjectionNode::make(expected_column_order, result_lqp);
   }
 

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -98,7 +98,7 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
     const auto& [left_result, left_cached] = pull_up_correlated_predicates_recursive(
         node->left_input(), parameter_mapping, result_cache, are_inputs_below_aggregate);
     left_input_adapted = left_result.adapted_lqp;
-    result.required_column_expressions = left_result.required_column_expressions;
+    result.required_output_expressions = left_result.required_output_expressions;
     // If the sub-LQP was already visited, its join predicates have already been considered somewhere else and will be
     // part of the final result.
     if (!left_cached) {
@@ -110,11 +110,11 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
     const auto& [right_result, right_cached] = pull_up_correlated_predicates_recursive(
         node->right_input(), parameter_mapping, result_cache, are_inputs_below_aggregate);
     right_input_adapted = right_result.adapted_lqp;
-    for (const auto& column_expression : right_result.required_column_expressions) {
-      const auto find_it = std::find(result.required_column_expressions.cbegin(),
-                                     result.required_column_expressions.cend(), column_expression);
-      if (find_it == result.required_column_expressions.cend()) {
-        result.required_column_expressions.emplace_back(column_expression);
+    for (const auto& column_expression : right_result.required_output_expressions) {
+      const auto find_it = std::find(result.required_output_expressions.cbegin(),
+                                     result.required_output_expressions.cend(), column_expression);
+      if (find_it == result.required_output_expressions.cend()) {
+        result.required_output_expressions.emplace_back(column_expression);
       }
     }
     if (!right_cached) {
@@ -140,10 +140,10 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
         result.join_predicates.insert(result.join_predicates.end(), join_predicates.begin(), join_predicates.end());
         for (const auto& join_predicate : join_predicates) {
           const auto& column_expression = join_predicate->right_operand();
-          auto find_it = std::find(result.required_column_expressions.begin(), result.required_column_expressions.end(),
+          auto find_it = std::find(result.required_output_expressions.begin(), result.required_output_expressions.end(),
                                    column_expression);
-          if (find_it == result.required_column_expressions.end()) {
-            result.required_column_expressions.emplace_back(column_expression);
+          if (find_it == result.required_output_expressions.end()) {
+            result.required_output_expressions.emplace_back(column_expression);
           }
         }
       }
@@ -151,17 +151,17 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
     }
     case LQPNodeType::Aggregate:
       result.adapted_lqp = SubqueryToJoinRule::adapt_aggregate_node(std::static_pointer_cast<AggregateNode>(node),
-                                                                    result.required_column_expressions);
+                                                                    result.required_output_expressions);
       result.adapted_lqp->set_left_input(left_input_adapted);
       break;
     case LQPNodeType::Alias:
       result.adapted_lqp = SubqueryToJoinRule::adapt_alias_node(std::static_pointer_cast<AliasNode>(node),
-                                                                result.required_column_expressions);
+                                                                result.required_output_expressions);
       result.adapted_lqp->set_left_input(left_input_adapted);
       break;
     case LQPNodeType::Projection:
       result.adapted_lqp = SubqueryToJoinRule::adapt_projection_node(std::static_pointer_cast<ProjectionNode>(node),
-                                                                     result.required_column_expressions);
+                                                                     result.required_output_expressions);
       result.adapted_lqp->set_left_input(left_input_adapted);
       break;
     case LQPNodeType::Sort: {
@@ -241,7 +241,7 @@ std::optional<SubqueryToJoinRule::PredicateNodeInfo> SubqueryToJoinRule::is_pred
     result.join_mode = in_expression->is_negated() ? JoinMode::AntiNullAsTrue : JoinMode::Semi;
     // We need to deep_copy the subquery before modifying it as it might be in use somewhere else, too.
     result.subquery = std::static_pointer_cast<LQPSubqueryExpression>(in_expression->set()->deep_copy());
-    result.join_predicate = equals_(in_expression->value(), result.subquery->lqp->column_expressions()[0]);
+    result.join_predicate = equals_(in_expression->value(), result.subquery->lqp->output_expressions()[0]);
 
     // Correlated NOT IN is very weird w.r.t. handling of null values and cannot be turned into a
     // multi-predicate join that treats all its predicates equivalently
@@ -293,13 +293,13 @@ std::optional<SubqueryToJoinRule::PredicateNodeInfo> SubqueryToJoinRule::is_pred
       result.subquery = std::static_pointer_cast<LQPSubqueryExpression>(left_subquery_expression->deep_copy());
       result.join_predicate = std::make_shared<BinaryPredicateExpression>(
           flip_predicate_condition(binary_predicate->predicate_condition), binary_predicate->right_operand(),
-          result.subquery->lqp->column_expressions()[0]);
+          result.subquery->lqp->output_expressions()[0]);
     } else if (const auto right_subquery_expression =
                    std::dynamic_pointer_cast<LQPSubqueryExpression>(binary_predicate->right_operand())) {
       result.subquery = std::static_pointer_cast<LQPSubqueryExpression>(right_subquery_expression->deep_copy());
       result.join_predicate = std::make_shared<BinaryPredicateExpression>(
           binary_predicate->predicate_condition, binary_predicate->left_operand(),
-          result.subquery->lqp->column_expressions()[0]);
+          result.subquery->lqp->output_expressions()[0]);
     } else {
       return std::nullopt;
     }
@@ -417,7 +417,7 @@ SubqueryToJoinRule::try_to_extract_join_predicates(
       continue;
     }
 
-    // Check that one side of the expression is a correlated parameter and the other a column expression of the LQP
+    // Check that one side of the expression is a correlated parameter and the other an expression of the LQP
     // below the predicate node (required for turning it into a join predicate). Also order the left/right operands by
     // the subplans they originate from.
     const auto& binary_predicate_expression = std::static_pointer_cast<BinaryPredicateExpression>(predicate_expression);
@@ -470,13 +470,13 @@ SubqueryToJoinRule::try_to_extract_join_predicates(
 
 std::shared_ptr<AggregateNode> SubqueryToJoinRule::adapt_aggregate_node(
     const std::shared_ptr<AggregateNode>& node,
-    const std::vector<std::shared_ptr<AbstractExpression>>& required_column_expressions) {
+    const std::vector<std::shared_ptr<AbstractExpression>>& required_output_expressions) {
   std::vector<std::shared_ptr<AbstractExpression>> group_by_expressions(
       node->node_expressions.cbegin(), node->node_expressions.cbegin() + node->aggregate_expressions_begin_idx);
   ExpressionUnorderedSet original_group_by_expressions(group_by_expressions.cbegin(), group_by_expressions.cend());
 
   const auto not_found_it = original_group_by_expressions.cend();
-  for (const auto& expression : required_column_expressions) {
+  for (const auto& expression : required_output_expressions) {
     if (original_group_by_expressions.find(expression) == not_found_it) {
       group_by_expressions.emplace_back(expression);
     }
@@ -489,7 +489,7 @@ std::shared_ptr<AggregateNode> SubqueryToJoinRule::adapt_aggregate_node(
 
 std::shared_ptr<AliasNode> SubqueryToJoinRule::adapt_alias_node(
     const std::shared_ptr<AliasNode>& node,
-    const std::vector<std::shared_ptr<AbstractExpression>>& required_column_expressions) {
+    const std::vector<std::shared_ptr<AbstractExpression>>& required_output_expressions) {
   // As with projection nodes, we don't want to add existing columns, but also don't want to deduplicate the existing
   // columns.
   auto expressions = node->node_expressions;
@@ -497,7 +497,7 @@ std::shared_ptr<AliasNode> SubqueryToJoinRule::adapt_alias_node(
   ExpressionUnorderedSet original_expressions(expressions.cbegin(), expressions.cend());
 
   const auto not_found_it = original_expressions.cend();
-  for (const auto& expression : required_column_expressions) {
+  for (const auto& expression : required_output_expressions) {
     if (original_expressions.find(expression) == not_found_it) {
       expressions.emplace_back(expression);
       aliases.emplace_back(expression->as_column_name());
@@ -509,14 +509,14 @@ std::shared_ptr<AliasNode> SubqueryToJoinRule::adapt_alias_node(
 
 std::shared_ptr<ProjectionNode> SubqueryToJoinRule::adapt_projection_node(
     const std::shared_ptr<ProjectionNode>& node,
-    const std::vector<std::shared_ptr<AbstractExpression>>& required_column_expressions) {
+    const std::vector<std::shared_ptr<AbstractExpression>>& required_output_expressions) {
   // We don't want to add columns that are already in the projection node. We also don't want to remove duplicates in
   // the expressions of the projection node, so we can't simply build one set containing all expressions
   auto expressions = node->node_expressions;
   ExpressionUnorderedSet original_expressions(expressions.cbegin(), expressions.cend());
 
   const auto not_found_it = original_expressions.cend();
-  for (const auto& expression : required_column_expressions) {
+  for (const auto& expression : required_output_expressions) {
     if (original_expressions.find(expression) == not_found_it) {
       expressions.emplace_back(expression);
     }

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -110,11 +110,11 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
     const auto& [right_result, right_cached] = pull_up_correlated_predicates_recursive(
         node->right_input(), parameter_mapping, result_cache, are_inputs_below_aggregate);
     right_input_adapted = right_result.adapted_lqp;
-    for (const auto& column_expression : right_result.required_output_expressions) {
+    for (const auto& expression : right_result.required_output_expressions) {
       const auto find_it = std::find(result.required_output_expressions.cbegin(),
-                                     result.required_output_expressions.cend(), column_expression);
+                                     result.required_output_expressions.cend(), expression);
       if (find_it == result.required_output_expressions.cend()) {
-        result.required_output_expressions.emplace_back(column_expression);
+        result.required_output_expressions.emplace_back(expression);
       }
     }
     if (!right_cached) {
@@ -139,11 +139,11 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
         result.pulled_predicate_node_count++;
         result.join_predicates.insert(result.join_predicates.end(), join_predicates.begin(), join_predicates.end());
         for (const auto& join_predicate : join_predicates) {
-          const auto& column_expression = join_predicate->right_operand();
+          const auto& expression = join_predicate->right_operand();
           auto find_it = std::find(result.required_output_expressions.begin(), result.required_output_expressions.end(),
-                                   column_expression);
+                                   expression);
           if (find_it == result.required_output_expressions.end()) {
-            result.required_output_expressions.emplace_back(column_expression);
+            result.required_output_expressions.emplace_back(expression);
           }
         }
       }

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
@@ -54,13 +54,13 @@ class SubqueryToJoinRule : public AbstractRule {
     size_t pulled_predicate_node_count = 0;
 
     /**
-     * Column expressions from the subquery required by the extracted join predicates.
+     * Expressions from the subquery required by the extracted join predicates.
      *
-     * This list contains every column expression only once, even if it is used required by multiple join predicates.
+     * This list contains every expression only once, even if it is used required by multiple join predicates.
      * This is a vector instead of an unordered_set so that tests are reproducible. Since correlation is usually very
      * low there shouldn't be much of a performance difference.
      */
-    std::vector<std::shared_ptr<AbstractExpression>> required_column_expressions = {};
+    std::vector<std::shared_ptr<AbstractExpression>> required_output_expressions = {};
   };
 
   /**
@@ -99,21 +99,21 @@ class SubqueryToJoinRule : public AbstractRule {
    */
   static std::shared_ptr<AggregateNode> adapt_aggregate_node(
       const std::shared_ptr<AggregateNode>& node,
-      const std::vector<std::shared_ptr<AbstractExpression>>& required_column_expressions);
+      const std::vector<std::shared_ptr<AbstractExpression>>& required_output_expressions);
 
   /**
    * Copy an alias node and adapt it to keep all required columns.
    */
   static std::shared_ptr<AliasNode> adapt_alias_node(
       const std::shared_ptr<AliasNode>& node,
-      const std::vector<std::shared_ptr<AbstractExpression>>& required_column_expressions);
+      const std::vector<std::shared_ptr<AbstractExpression>>& required_output_expressions);
 
   /**
    * Copy a projection node and adapt it to keep all required columns.
    */
   static std::shared_ptr<ProjectionNode> adapt_projection_node(
       const std::shared_ptr<ProjectionNode>& node,
-      const std::vector<std::shared_ptr<AbstractExpression>>& required_column_expressions);
+      const std::vector<std::shared_ptr<AbstractExpression>>& required_output_expressions);
 
   /**
    * Walk the subquery LQP, removing all correlated predicate nodes and adapting other nodes as necessary.

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
@@ -56,7 +56,7 @@ class SubqueryToJoinRule : public AbstractRule {
     /**
      * Expressions from the subquery required by the extracted join predicates.
      *
-     * This list contains every expression only once, even if it is used required by multiple join predicates.
+     * This list contains every expression only once, even if it is used (required) by multiple join predicates.
      * This is a vector instead of an unordered_set so that tests are reproducible. Since correlation is usually very
      * low there shouldn't be much of a performance difference.
      */

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -119,7 +119,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
       DebugAssert(plan, "Optimized logical query plan retrieved from cache is empty.");
       // MVCC-enabled and MVCC-disabled LQPs will evict each other
       if (lqp_is_validated(plan) == (_use_mvcc == UseMvcc::Yes)) {
-        // Copy the LQP for reuse as the LQPTranslator might modify mutable fields (e.g., cached column_expressions)
+        // Copy the LQP for reuse as the LQPTranslator might modify mutable fields (e.g., cached output_expressions)
         // and concurrent translations might conflict.
         _optimized_logical_plan = plan->deep_copy();
         return _optimized_logical_plan;

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -586,13 +586,13 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_table_origin(const hsq
         // Add all named columns to the IdentifierContext
         const auto output_expressions = lqp_view->lqp->output_expressions();
         for (auto column_id = ColumnID{0}; column_id < output_expressions.size(); ++column_id) {
-          const auto column_expression = output_expressions[column_id];
+          const auto expression = output_expressions[column_id];
 
           const auto column_name_iter = lqp_view->column_names.find(column_id);
           if (column_name_iter != lqp_view->column_names.end()) {
-            sql_identifier_resolver->add_column_name(column_expression, column_name_iter->second);
+            sql_identifier_resolver->add_column_name(expression, column_name_iter->second);
           }
-          sql_identifier_resolver->set_table_name(column_expression, hsql_table_ref.name);
+          sql_identifier_resolver->set_table_name(expression, hsql_table_ref.name);
         }
 
       } else if (Hyrise::get().storage_manager.has_table(hsql_table_ref.name)) {
@@ -610,13 +610,13 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_table_origin(const hsq
          */
         const auto output_expressions = view->lqp->output_expressions();
         for (auto column_id = ColumnID{0}; column_id < output_expressions.size(); ++column_id) {
-          const auto column_expression = output_expressions[column_id];
+          const auto expression = output_expressions[column_id];
 
           const auto column_name_iter = view->column_names.find(column_id);
           if (column_name_iter != view->column_names.end()) {
-            sql_identifier_resolver->add_column_name(column_expression, column_name_iter->second);
+            sql_identifier_resolver->add_column_name(expression, column_name_iter->second);
           }
-          sql_identifier_resolver->set_table_name(column_expression, hsql_table_ref.name);
+          sql_identifier_resolver->set_table_name(expression, hsql_table_ref.name);
         }
 
         AssertInput(_use_mvcc == (lqp_is_validated(view->lqp) ? UseMvcc::Yes : UseMvcc::No),
@@ -1160,10 +1160,10 @@ void SQLTranslator::_translate_set_operation(const hsql::SetOperation& set_opera
               "Mismatching number of input columns for set operation");
 
   // Check to see if both input LQPs use the same data type for each column
-  for (auto column_expression_idx = size_t{0}; column_expression_idx < left_output_expressions.size();
-       ++column_expression_idx) {
-    const auto& left_expression = left_output_expressions[column_expression_idx];
-    const auto& right_expression = right_output_expressions[column_expression_idx];
+  for (auto expression_idx = size_t{0}; expression_idx < left_output_expressions.size();
+       ++expression_idx) {
+    const auto& left_expression = left_output_expressions[expression_idx];
+    const auto& right_expression = right_output_expressions[expression_idx];
 
     AssertInput(left_expression->data_type() == right_expression->data_type(),
                 "Mismatching input data types for left and right side of set operation");

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
     join_graph_bitmask = cardinality_estimation_cache.join_graph_statistics_cache->bitmask(lqp);
     if (join_graph_bitmask) {
       auto cached_statistics =
-          cardinality_estimation_cache.join_graph_statistics_cache->get(*join_graph_bitmask, lqp->column_expressions());
+          cardinality_estimation_cache.join_graph_statistics_cache->get(*join_graph_bitmask, lqp->output_expressions());
       if (cached_statistics) {
         return cached_statistics;
       }
@@ -230,7 +230,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
    * 3. Store output_table_statistics in cache
    */
   if (join_graph_bitmask) {
-    cardinality_estimation_cache.join_graph_statistics_cache->set(*join_graph_bitmask, lqp->column_expressions(),
+    cardinality_estimation_cache.join_graph_statistics_cache->set(*join_graph_bitmask, lqp->output_expressions(),
                                                                   output_table_statistics);
   }
 
@@ -246,10 +246,10 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_alias_node(
   // For AliasNodes, just reorder/remove AttributeStatistics from the input
 
   auto column_statistics =
-      std::vector<std::shared_ptr<BaseAttributeStatistics>>{alias_node.column_expressions().size()};
+      std::vector<std::shared_ptr<BaseAttributeStatistics>>{alias_node.output_expressions().size()};
 
-  for (size_t expression_idx{0}; expression_idx < alias_node.column_expressions().size(); ++expression_idx) {
-    const auto& expression = *alias_node.column_expressions()[expression_idx];
+  for (size_t expression_idx{0}; expression_idx < alias_node.output_expressions().size(); ++expression_idx) {
+    const auto& expression = *alias_node.output_expressions()[expression_idx];
     const auto input_column_id = alias_node.left_input()->get_column_id(expression);
     column_statistics[expression_idx] = input_table_statistics->column_statistics[input_column_id];
   }
@@ -265,10 +265,10 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_projection_node(
   //               empty AttributeStatistics object is created.
 
   auto column_statistics =
-      std::vector<std::shared_ptr<BaseAttributeStatistics>>{projection_node.column_expressions().size()};
+      std::vector<std::shared_ptr<BaseAttributeStatistics>>{projection_node.output_expressions().size()};
 
-  for (size_t expression_idx{0}; expression_idx < projection_node.column_expressions().size(); ++expression_idx) {
-    const auto& expression = *projection_node.column_expressions()[expression_idx];
+  for (size_t expression_idx{0}; expression_idx < projection_node.output_expressions().size(); ++expression_idx) {
+    const auto& expression = *projection_node.output_expressions()[expression_idx];
     const auto input_column_id = projection_node.left_input()->find_column_id(expression);
     if (input_column_id) {
       column_statistics[expression_idx] = input_table_statistics->column_statistics[*input_column_id];
@@ -289,10 +289,10 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_aggregate_node(
   // dummy statistics are created for now.
 
   auto column_statistics =
-      std::vector<std::shared_ptr<BaseAttributeStatistics>>{aggregate_node.column_expressions().size()};
+      std::vector<std::shared_ptr<BaseAttributeStatistics>>{aggregate_node.output_expressions().size()};
 
-  for (size_t expression_idx{0}; expression_idx < aggregate_node.column_expressions().size(); ++expression_idx) {
-    const auto& expression = *aggregate_node.column_expressions()[expression_idx];
+  for (size_t expression_idx{0}; expression_idx < aggregate_node.output_expressions().size(); ++expression_idx) {
+    const auto& expression = *aggregate_node.output_expressions()[expression_idx];
     const auto input_column_id = aggregate_node.left_input()->find_column_id(expression);
     if (input_column_id) {
       column_statistics[expression_idx] = input_table_statistics->column_statistics[*input_column_id];
@@ -526,7 +526,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_limit_node(
     const auto clamped_row_count = std::min(*row_count, input_table_statistics->row_count);
 
     auto column_statistics =
-        std::vector<std::shared_ptr<BaseAttributeStatistics>>{limit_node.column_expressions().size()};
+        std::vector<std::shared_ptr<BaseAttributeStatistics>>{limit_node.output_expressions().size()};
 
     for (auto column_id = ColumnID{0}; column_id < input_table_statistics->column_statistics.size(); ++column_id) {
       resolve_data_type(input_table_statistics->column_data_type(column_id), [&](const auto data_type_t) {

--- a/src/lib/visualization/pqp_visualizer.cpp
+++ b/src/lib/visualization/pqp_visualizer.cpp
@@ -97,8 +97,8 @@ void PQPVisualizer::_build_subtree(const std::shared_ptr<const AbstractOperator>
   switch (op->type()) {
     case OperatorType::Projection: {
       const auto projection = std::dynamic_pointer_cast<const Projection>(op);
-      for (const auto& column_expression : projection->expressions) {
-        _visualize_subqueries(op, column_expression, visualized_ops);
+      for (const auto& expression : projection->expressions) {
+        _visualize_subqueries(op, expression, visualized_ops);
       }
     } break;
 

--- a/src/test/lib/logical_query_plan/aggregate_node_test.cpp
+++ b/src/test/lib/logical_query_plan/aggregate_node_test.cpp
@@ -36,11 +36,11 @@ class AggregateNodeTest : public BaseTest {
 };
 
 TEST_F(AggregateNodeTest, OutputColumnExpressions) {
-  ASSERT_EQ(_aggregate_node->column_expressions().size(), 4u);
-  EXPECT_EQ(*_aggregate_node->column_expressions().at(0), *_a);
-  EXPECT_EQ(*_aggregate_node->column_expressions().at(1), *_c);
-  EXPECT_EQ(*_aggregate_node->column_expressions().at(2), *sum_(add_(_a, _b)));
-  EXPECT_EQ(*_aggregate_node->column_expressions().at(3), *sum_(add_(_a, _c)));
+  ASSERT_EQ(_aggregate_node->output_expressions().size(), 4u);
+  EXPECT_EQ(*_aggregate_node->output_expressions().at(0), *_a);
+  EXPECT_EQ(*_aggregate_node->output_expressions().at(1), *_c);
+  EXPECT_EQ(*_aggregate_node->output_expressions().at(2), *sum_(add_(_a, _b)));
+  EXPECT_EQ(*_aggregate_node->output_expressions().at(3), *sum_(add_(_a, _c)));
 }
 
 TEST_F(AggregateNodeTest, NodeExpressions) {

--- a/src/test/lib/logical_query_plan/change_meta_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/change_meta_table_node_test.cpp
@@ -35,7 +35,7 @@ TEST_F(ChangeMetaTableNodeTest, HashingAndEqualityCheck) {
 TEST_F(ChangeMetaTableNodeTest, NodeExpressions) { EXPECT_TRUE(_change_meta_table_node->node_expressions.empty()); }
 
 TEST_F(ChangeMetaTableNodeTest, ColumnExpressions) {
-  EXPECT_TRUE(_change_meta_table_node->column_expressions().empty());
+  EXPECT_TRUE(_change_meta_table_node->output_expressions().empty());
 }
 
 TEST_F(ChangeMetaTableNodeTest, Copy) { EXPECT_EQ(*_change_meta_table_node, *_change_meta_table_node->deep_copy()); }

--- a/src/test/lib/logical_query_plan/delete_node_test.cpp
+++ b/src/test/lib/logical_query_plan/delete_node_test.cpp
@@ -25,7 +25,7 @@ TEST_F(DeleteNodeTest, HashingAndEqualityCheck) {
 
 TEST_F(DeleteNodeTest, NodeExpressions) { EXPECT_TRUE(_delete_node->node_expressions.empty()); }
 
-TEST_F(DeleteNodeTest, ColumnExpressions) { EXPECT_TRUE(_delete_node->column_expressions().empty()); }
+TEST_F(DeleteNodeTest, ColumnExpressions) { EXPECT_TRUE(_delete_node->output_expressions().empty()); }
 
 TEST_F(DeleteNodeTest, Copy) { EXPECT_EQ(*_delete_node, *_delete_node->deep_copy()); }
 

--- a/src/test/lib/logical_query_plan/dummy_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/dummy_table_node_test.cpp
@@ -16,7 +16,7 @@ class DummyTableNodeTest : public BaseTest {
 
 TEST_F(DummyTableNodeTest, Description) { EXPECT_EQ(_dummy_table_node->description(), "[DummyTable]"); }
 
-TEST_F(DummyTableNodeTest, OutputColumnExpressions) { EXPECT_EQ(_dummy_table_node->column_expressions().size(), 0u); }
+TEST_F(DummyTableNodeTest, OutputColumnExpressions) { EXPECT_EQ(_dummy_table_node->output_expressions().size(), 0u); }
 
 TEST_F(DummyTableNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_dummy_table_node, *_dummy_table_node);

--- a/src/test/lib/logical_query_plan/except_node_test.cpp
+++ b/src/test/lib/logical_query_plan/except_node_test.cpp
@@ -35,7 +35,7 @@ class ExceptNodeTest : public BaseTest {
 TEST_F(ExceptNodeTest, Description) { EXPECT_EQ(_except_node->description(), "[ExceptNode] Mode: Positions"); }
 
 TEST_F(ExceptNodeTest, OutputColumnExpressions) {
-  EXPECT_TRUE(_except_node->column_expressions() == _mock_node1->column_expressions());
+  EXPECT_TRUE(_except_node->output_expressions() == _mock_node1->output_expressions());
 }
 
 TEST_F(ExceptNodeTest, HashingAndEqualityCheck) {

--- a/src/test/lib/logical_query_plan/export_node_test.cpp
+++ b/src/test/lib/logical_query_plan/export_node_test.cpp
@@ -32,7 +32,7 @@ TEST_F(ExportNodeTest, HashingAndEqualityCheck) {
 
 TEST_F(ExportNodeTest, NodeExpressions) { EXPECT_TRUE(_export_node->node_expressions.empty()); }
 
-TEST_F(ExportNodeTest, ColumnExpressions) { EXPECT_TRUE(_export_node->column_expressions().empty()); }
+TEST_F(ExportNodeTest, ColumnExpressions) { EXPECT_TRUE(_export_node->output_expressions().empty()); }
 
 TEST_F(ExportNodeTest, Copy) { EXPECT_EQ(*_export_node, *_export_node->deep_copy()); }
 

--- a/src/test/lib/logical_query_plan/import_node_test.cpp
+++ b/src/test/lib/logical_query_plan/import_node_test.cpp
@@ -26,7 +26,7 @@ TEST_F(ImportNodeTest, HashingAndEqualityCheck) {
 
 TEST_F(ImportNodeTest, NodeExpressions) { EXPECT_TRUE(_import_node->node_expressions.empty()); }
 
-TEST_F(ImportNodeTest, ColumnExpressions) { EXPECT_TRUE(_import_node->column_expressions().empty()); }
+TEST_F(ImportNodeTest, ColumnExpressions) { EXPECT_TRUE(_import_node->output_expressions().empty()); }
 
 TEST_F(ImportNodeTest, Copy) { EXPECT_EQ(*_import_node, *_import_node->deep_copy()); }
 

--- a/src/test/lib/logical_query_plan/insert_node_test.cpp
+++ b/src/test/lib/logical_query_plan/insert_node_test.cpp
@@ -29,6 +29,6 @@ TEST_F(InsertNodeTest, HashingAndEqualityCheck) {
 
 TEST_F(InsertNodeTest, NodeExpressions) { EXPECT_TRUE(_insert_node->node_expressions.empty()); }
 
-TEST_F(InsertNodeTest, ColumnExpressions) { EXPECT_TRUE(_insert_node->column_expressions().empty()); }
+TEST_F(InsertNodeTest, ColumnExpressions) { EXPECT_TRUE(_insert_node->output_expressions().empty()); }
 
 }  // namespace opossum

--- a/src/test/lib/logical_query_plan/intersect_node_test.cpp
+++ b/src/test/lib/logical_query_plan/intersect_node_test.cpp
@@ -34,7 +34,7 @@ class IntersectNodeTest : public BaseTest {
 TEST_F(IntersectNodeTest, Description) { EXPECT_EQ(_intersect_node->description(), "[IntersectNode] Mode: Positions"); }
 
 TEST_F(IntersectNodeTest, OutputColumnExpressions) {
-  EXPECT_TRUE(_intersect_node->column_expressions() == _mock_node1->column_expressions());
+  EXPECT_TRUE(_intersect_node->output_expressions() == _mock_node1->output_expressions());
 }
 
 TEST_F(IntersectNodeTest, HashingAndEqualityCheck) {

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -60,12 +60,12 @@ TEST_F(JoinNodeTest, DescriptionAntiJoin) {
 }
 
 TEST_F(JoinNodeTest, OutputColumnExpressions) {
-  ASSERT_EQ(_cross_join_node->column_expressions().size(), 5u);
-  EXPECT_EQ(*_cross_join_node->column_expressions().at(1), *_t_a_b);
-  EXPECT_EQ(*_cross_join_node->column_expressions().at(2), *_t_a_c);
-  EXPECT_EQ(*_cross_join_node->column_expressions().at(3), *_t_b_x);
-  EXPECT_EQ(*_cross_join_node->column_expressions().at(4), *_t_b_y);
-  EXPECT_EQ(*_cross_join_node->column_expressions().at(0), *_t_a_a);
+  ASSERT_EQ(_cross_join_node->output_expressions().size(), 5u);
+  EXPECT_EQ(*_cross_join_node->output_expressions().at(1), *_t_a_b);
+  EXPECT_EQ(*_cross_join_node->output_expressions().at(2), *_t_a_c);
+  EXPECT_EQ(*_cross_join_node->output_expressions().at(3), *_t_b_x);
+  EXPECT_EQ(*_cross_join_node->output_expressions().at(4), *_t_b_y);
+  EXPECT_EQ(*_cross_join_node->output_expressions().at(0), *_t_a_a);
 }
 
 TEST_F(JoinNodeTest, HashingAndEqualityCheck) {
@@ -98,17 +98,17 @@ TEST_F(JoinNodeTest, Copy) {
 }
 
 TEST_F(JoinNodeTest, OutputColumnExpressionsSemiJoin) {
-  ASSERT_EQ(_semi_join_node->column_expressions().size(), 3u);
-  EXPECT_EQ(*_semi_join_node->column_expressions().at(0), *_t_a_a);
-  EXPECT_EQ(*_semi_join_node->column_expressions().at(1), *_t_a_b);
-  EXPECT_EQ(*_semi_join_node->column_expressions().at(2), *_t_a_c);
+  ASSERT_EQ(_semi_join_node->output_expressions().size(), 3u);
+  EXPECT_EQ(*_semi_join_node->output_expressions().at(0), *_t_a_a);
+  EXPECT_EQ(*_semi_join_node->output_expressions().at(1), *_t_a_b);
+  EXPECT_EQ(*_semi_join_node->output_expressions().at(2), *_t_a_c);
 }
 
 TEST_F(JoinNodeTest, OutputColumnExpressionsAntiJoin) {
-  ASSERT_EQ(_anti_join_node->column_expressions().size(), 3u);
-  EXPECT_EQ(*_anti_join_node->column_expressions().at(0), *_t_a_a);
-  EXPECT_EQ(*_anti_join_node->column_expressions().at(1), *_t_a_b);
-  EXPECT_EQ(*_anti_join_node->column_expressions().at(2), *_t_a_c);
+  ASSERT_EQ(_anti_join_node->output_expressions().size(), 3u);
+  EXPECT_EQ(*_anti_join_node->output_expressions().at(0), *_t_a_a);
+  EXPECT_EQ(*_anti_join_node->output_expressions().at(1), *_t_a_b);
+  EXPECT_EQ(*_anti_join_node->output_expressions().at(2), *_t_a_c);
 }
 
 TEST_F(JoinNodeTest, NodeExpressions) {

--- a/src/test/lib/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/lib/logical_query_plan/logical_query_plan_test.cpp
@@ -293,7 +293,7 @@ TEST_F(LogicalQueryPlanTest, ComplexGraphReplaceWithLeaf) {
 }
 
 TEST_F(LogicalQueryPlanTest, CreateNodeMapping) {
-  const auto projection_node = ProjectionNode::make(node_int_int->column_expressions(), node_int_int);
+  const auto projection_node = ProjectionNode::make(node_int_int->output_expressions(), node_int_int);
   const auto lqp = projection_node;
 
   const auto copied_lqp = lqp->deep_copy();
@@ -310,7 +310,7 @@ TEST_F(LogicalQueryPlanTest, DeepCopyBasics) {
   const auto expression_a = std::make_shared<LQPColumnExpression>(node_int_int, ColumnID{0});
   const auto expression_b = std::make_shared<LQPColumnExpression>(node_int_int, ColumnID{1});
 
-  const auto projection_node = ProjectionNode::make(node_int_int->column_expressions(), node_int_int);
+  const auto projection_node = ProjectionNode::make(node_int_int->output_expressions(), node_int_int);
   const auto lqp = projection_node;
 
   const auto copied_lqp = lqp->deep_copy();
@@ -417,7 +417,7 @@ TEST_F(LogicalQueryPlanTest, DeepCopySubqueries) {
   const auto copied_predicate_a = std::dynamic_pointer_cast<PredicateNode>(copied_lqp->left_input());
 
   const auto copied_subquery_a =
-      std::dynamic_pointer_cast<LQPSubqueryExpression>(copied_lqp->column_expressions().at(1));
+      std::dynamic_pointer_cast<LQPSubqueryExpression>(copied_lqp->output_expressions().at(1));
   const auto copied_subquery_b =
       std::dynamic_pointer_cast<LQPSubqueryExpression>(copied_predicate_a->predicate()->arguments.at(1));
 

--- a/src/test/lib/logical_query_plan/mock_node_test.cpp
+++ b/src/test/lib/logical_query_plan/mock_node_test.cpp
@@ -34,20 +34,20 @@ TEST_F(MockNodeTest, Description) {
 }
 
 TEST_F(MockNodeTest, OutputColumnExpression) {
-  ASSERT_EQ(_mock_node_a->column_expressions().size(), 4u);
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(0), *lqp_column_(_mock_node_a, ColumnID{0}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(1), *lqp_column_(_mock_node_a, ColumnID{1}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(2), *lqp_column_(_mock_node_a, ColumnID{2}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(3), *lqp_column_(_mock_node_a, ColumnID{3}));
+  ASSERT_EQ(_mock_node_a->output_expressions().size(), 4u);
+  EXPECT_EQ(*_mock_node_a->output_expressions().at(0), *lqp_column_(_mock_node_a, ColumnID{0}));
+  EXPECT_EQ(*_mock_node_a->output_expressions().at(1), *lqp_column_(_mock_node_a, ColumnID{1}));
+  EXPECT_EQ(*_mock_node_a->output_expressions().at(2), *lqp_column_(_mock_node_a, ColumnID{2}));
+  EXPECT_EQ(*_mock_node_a->output_expressions().at(3), *lqp_column_(_mock_node_a, ColumnID{3}));
 
-  ASSERT_EQ(_mock_node_b->column_expressions().size(), 2u);
-  EXPECT_EQ(*_mock_node_b->column_expressions().at(0), *lqp_column_(_mock_node_b, ColumnID{0}));
-  EXPECT_EQ(*_mock_node_b->column_expressions().at(1), *lqp_column_(_mock_node_b, ColumnID{1}));
+  ASSERT_EQ(_mock_node_b->output_expressions().size(), 2u);
+  EXPECT_EQ(*_mock_node_b->output_expressions().at(0), *lqp_column_(_mock_node_b, ColumnID{0}));
+  EXPECT_EQ(*_mock_node_b->output_expressions().at(1), *lqp_column_(_mock_node_b, ColumnID{1}));
 
   _mock_node_a->set_pruned_column_ids({ColumnID{0}, ColumnID{3}});
-  EXPECT_EQ(_mock_node_a->column_expressions().size(), 2u);
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(0), *lqp_column_(_mock_node_a, ColumnID{1}));
-  EXPECT_EQ(*_mock_node_a->column_expressions().at(1), *lqp_column_(_mock_node_a, ColumnID{2}));
+  EXPECT_EQ(_mock_node_a->output_expressions().size(), 2u);
+  EXPECT_EQ(*_mock_node_a->output_expressions().at(0), *lqp_column_(_mock_node_a, ColumnID{1}));
+  EXPECT_EQ(*_mock_node_a->output_expressions().at(1), *lqp_column_(_mock_node_a, ColumnID{2}));
 }
 
 TEST_F(MockNodeTest, HashingAndEqualityCheck) {

--- a/src/test/lib/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/stored_table_node_test.cpp
@@ -65,16 +65,16 @@ TEST_F(StoredTableNodeTest, GetColumn) {
 }
 
 TEST_F(StoredTableNodeTest, ColumnExpressions) {
-  EXPECT_EQ(_stored_table_node->column_expressions().size(), 3u);
-  EXPECT_EQ(*_stored_table_node->column_expressions().at(0u), *_a);
-  EXPECT_EQ(*_stored_table_node->column_expressions().at(1u), *_b);
-  EXPECT_EQ(*_stored_table_node->column_expressions().at(2u), *_c);
+  EXPECT_EQ(_stored_table_node->output_expressions().size(), 3u);
+  EXPECT_EQ(*_stored_table_node->output_expressions().at(0u), *_a);
+  EXPECT_EQ(*_stored_table_node->output_expressions().at(1u), *_b);
+  EXPECT_EQ(*_stored_table_node->output_expressions().at(2u), *_c);
 
   // Column pruning does not interfere with get_column()
   _stored_table_node->set_pruned_column_ids({ColumnID{0}});
-  EXPECT_EQ(_stored_table_node->column_expressions().size(), 2u);
-  EXPECT_EQ(*_stored_table_node->column_expressions().at(0u), *_b);
-  EXPECT_EQ(*_stored_table_node->column_expressions().at(1u), *_c);
+  EXPECT_EQ(_stored_table_node->output_expressions().size(), 2u);
+  EXPECT_EQ(*_stored_table_node->output_expressions().at(0u), *_b);
+  EXPECT_EQ(*_stored_table_node->output_expressions().at(1u), *_c);
 }
 
 TEST_F(StoredTableNodeTest, HashingAndEqualityCheck) {

--- a/src/test/lib/logical_query_plan/union_node_test.cpp
+++ b/src/test/lib/logical_query_plan/union_node_test.cpp
@@ -36,9 +36,9 @@ class UnionNodeTest : public BaseTest {
 TEST_F(UnionNodeTest, Description) { EXPECT_EQ(_union_node->description(), "[UnionNode] Mode: Positions"); }
 
 TEST_F(UnionNodeTest, OutputColumnExpressions) {
-  EXPECT_EQ(*_union_node->column_expressions().at(0), *_mock_node1->column_expressions().at(0));
-  EXPECT_EQ(*_union_node->column_expressions().at(1), *_mock_node1->column_expressions().at(1));
-  EXPECT_EQ(*_union_node->column_expressions().at(2), *_mock_node1->column_expressions().at(2));
+  EXPECT_EQ(*_union_node->output_expressions().at(0), *_mock_node1->output_expressions().at(0));
+  EXPECT_EQ(*_union_node->output_expressions().at(1), *_mock_node1->output_expressions().at(1));
+  EXPECT_EQ(*_union_node->output_expressions().at(2), *_mock_node1->output_expressions().at(2));
 }
 
 TEST_F(UnionNodeTest, HashingAndEqualityCheck) {

--- a/src/test/lib/logical_query_plan/update_node_test.cpp
+++ b/src/test/lib/logical_query_plan/update_node_test.cpp
@@ -55,6 +55,6 @@ TEST_F(UpdateNodeTest, Copy) { EXPECT_EQ(*_update_node->deep_copy(), *_update_no
 
 TEST_F(UpdateNodeTest, NodeExpressions) { ASSERT_TRUE(_update_node->node_expressions.empty()); }
 
-TEST_F(UpdateNodeTest, ColumnExpressions) { EXPECT_TRUE(_update_node->column_expressions().empty()); }
+TEST_F(UpdateNodeTest, ColumnExpressions) { EXPECT_TRUE(_update_node->output_expressions().empty()); }
 
 }  // namespace opossum

--- a/src/test/lib/optimizer/strategy/subquery_to_join_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/subquery_to_join_rule_test.cpp
@@ -202,51 +202,51 @@ TEST_F(SubqueryToJoinRuleTest, AssessCorrelatedParameterUsageReportsUnoptimizabl
 
 TEST_F(SubqueryToJoinRuleTest, AdaptAggregateNode) {
   const auto aggregate_node = AggregateNode::make(expression_vector(a_a), expression_vector());
-  const auto& original_expressions = aggregate_node->column_expressions();
+  const auto& original_expressions = aggregate_node->output_expressions();
 
   // a_a is already group by expression, check it is not added again
   const auto adapted_aggregate_node = SubqueryToJoinRule::adapt_aggregate_node(aggregate_node, {a_a});
-  EXPECT_EQ(adapted_aggregate_node->column_expressions().size(), size_t{1});
+  EXPECT_EQ(adapted_aggregate_node->output_expressions().size(), size_t{1});
 
   // a_b is an additional required group by expression, check it is added
   EXPECT_EQ(std::find(original_expressions.cbegin(), original_expressions.cend(), a_b), original_expressions.cend());
   const auto adapted_aggregate_node_2 = SubqueryToJoinRule::adapt_aggregate_node(aggregate_node, {a_b});
-  const auto& expressions = adapted_aggregate_node_2->column_expressions();
+  const auto& expressions = adapted_aggregate_node_2->output_expressions();
   EXPECT_NE(std::find(expressions.cbegin(), expressions.cend(), a_b), expressions.cend());
 }
 
 TEST_F(SubqueryToJoinRuleTest, AdaptAliasNode) {
   const auto alias_node =
       AliasNode::make(expression_vector(a_a, a_a, a_b), std::vector<std::string>{"a_a", "alias_a_a", "alias_a_b"});
-  const auto& original_expressions = alias_node->column_expressions();
+  const auto& original_expressions = alias_node->output_expressions();
 
   // no added duplicates, preserve multiple names for same column,
   const auto adapted_alias_node = SubqueryToJoinRule::adapt_alias_node(alias_node, {a_a});
-  EXPECT_EQ(adapted_alias_node->column_expressions().size(), size_t{3});
+  EXPECT_EQ(adapted_alias_node->output_expressions().size(), size_t{3});
 
   // no additional aliases
   const auto adapted_alias_node2 = SubqueryToJoinRule::adapt_alias_node(alias_node, {a_b});
-  EXPECT_EQ(adapted_alias_node2->column_expressions().size(), size_t{3});
+  EXPECT_EQ(adapted_alias_node2->output_expressions().size(), size_t{3});
 
   // add if necessary
   EXPECT_EQ(std::find(original_expressions.cbegin(), original_expressions.cend(), a_c), original_expressions.cend());
   const auto adapted_alias_node3 = SubqueryToJoinRule::adapt_alias_node(alias_node, {a_c});
-  const auto& expressions = adapted_alias_node3->column_expressions();
+  const auto& expressions = adapted_alias_node3->output_expressions();
   EXPECT_NE(std::find(expressions.cbegin(), expressions.cend(), a_c), expressions.cend());
 }
 
 TEST_F(SubqueryToJoinRuleTest, AdaptProjectionNode) {
   const auto projection_node = ProjectionNode::make(expression_vector(a_a, a_a));
-  const auto& original_expressions = projection_node->column_expressions();
+  const auto& original_expressions = projection_node->output_expressions();
 
   // no added duplicates, preserve original duplicates
   const auto adapted_projection_node = SubqueryToJoinRule::adapt_projection_node(projection_node, {a_a});
-  EXPECT_EQ(adapted_projection_node->column_expressions().size(), size_t{2});
+  EXPECT_EQ(adapted_projection_node->output_expressions().size(), size_t{2});
 
   // add if necessary
   EXPECT_EQ(std::find(original_expressions.cbegin(), original_expressions.cend(), a_b), original_expressions.cend());
   const auto adapted_projection_node2 = SubqueryToJoinRule::adapt_projection_node(projection_node, {a_b});
-  const auto& expressions = adapted_projection_node2->column_expressions();
+  const auto& expressions = adapted_projection_node2->output_expressions();
   EXPECT_NE(std::find(expressions.cbegin(), expressions.cend(), a_b), expressions.cend());
 }
 


### PR DESCRIPTION
Renames AbstractLQPNode::column_expressions to ::output_expressions

The former sounds too close to LQPColumnExpression. Also, the "column" part is misleading / redundant.

fixes #1893.