### PR TITLE
Removal of random values in tests

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -42,6 +42,13 @@ if [ ! -z "$output" ]; then
 	exitcode=1
 fi
 
+# Tests should not include any type of random behavior, see #1321.
+output=$(grep -rEn '#include <random>|std::random|std::[a-z_]+_engine|std::[a-z_]+_distribution' src/test | grep -v std::random_access_iterator_tag | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Tests should not include any type of random behavior, see #1321./')
+if [ ! -z "$output" ]; then
+	echo "$output"
+	exitcode=1
+fi
+
 # Check for included cpp files. You would think that this is not necessary, but history proves you wrong.
 regex='#include .*\.cpp'
 namecheck=$(find src \( -iname "*.cpp" -o -iname "*.hpp" \) -print0 | xargs -0 grep -rn "$regex" | grep -v NOLINT)

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -211,7 +211,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_predicate_node_to_in
   const auto& pruned_chunk_ids = stored_table_node->pruned_chunk_ids();
 
   DebugAssert(std::is_sorted(pruned_chunk_ids.cbegin(), pruned_chunk_ids.cend()),
-    "Expected sorted vector of ColumnIDs");
+              "Expected sorted vector of ColumnIDs");
 
   const auto table_name = stored_table_node->table_name;
   const auto table = Hyrise::get().storage_manager.get_table(table_name);

--- a/src/test/lib/storage/any_segment_iterable_test.cpp
+++ b/src/test/lib/storage/any_segment_iterable_test.cpp
@@ -1,5 +1,4 @@
 #include <memory>
-#include <random>
 #include <utility>
 #include <vector>
 

--- a/src/test/lib/storage/encoded_segment_test.cpp
+++ b/src/test/lib/storage/encoded_segment_test.cpp
@@ -97,6 +97,7 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     auto list = _create_sequential_position_filter(row_count);
 
     auto skewed_list = std::make_shared<RowIDPosList>();
+    skewed_list->guarantee_single_chunk();
     skewed_list->reserve(list->size());
     // Let one iterator run from the beginning and one from the end of the list in each other's direction. Add the
     // iterators' elements alternately to the skewed list.

--- a/src/test/lib/storage/encoded_segment_test.cpp
+++ b/src/test/lib/storage/encoded_segment_test.cpp
@@ -1,6 +1,5 @@
 #include <cctype>
 #include <memory>
-#include <random>
 #include <sstream>
 
 #include "base_test.hpp"
@@ -20,15 +19,19 @@ namespace opossum {
 
 class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
  protected:
-  static constexpr auto max_value = 1'024;
+  static constexpr auto _max_value = 1'024;
+
+  // 0, 1, the maximum value and 20 randomly generated int32_t values from the interval [0, _max_value]
+  const std::array<int32_t, 23> _generated_value_pool{0,   1,  _max_value, 600,  679, 212, 559, 439, 620, 910, 831, 662,
+                                                      389, 97, 530,        1013, 460, 138, 697, 861, 35,  329, 476};
 
  protected:
-  size_t row_count() {
+  size_t _row_count() {
     const auto encoding_spec = GetParam();
-    return row_count(encoding_spec.encoding_type);
+    return _row_count(encoding_spec.encoding_type);
   }
 
-  size_t row_count(EncodingType encoding_type) {
+  size_t _row_count(EncodingType encoding_type) {
     static constexpr auto default_row_count = size_t{1u} << 10;
 
     switch (encoding_type) {
@@ -40,54 +43,45 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     }
   }
 
-  std::shared_ptr<ValueSegment<int32_t>> create_int_value_segment() { return create_int_value_segment(row_count()); }
+  std::shared_ptr<ValueSegment<int32_t>> _create_int_value_segment() { return _create_int_value_segment(_row_count()); }
 
-  std::shared_ptr<ValueSegment<int32_t>> create_int_value_segment(size_t row_count) {
+  std::shared_ptr<ValueSegment<int32_t>> _create_int_value_segment(size_t row_count) {
     auto values = pmr_vector<int32_t>(row_count);
 
-    std::default_random_engine engine{};
-    std::uniform_int_distribution<int32_t> dist{0u, max_value};
-
+    auto counter = 0u;
     for (auto& elem : values) {
-      elem = dist(engine);
+      elem = _generated_value_pool[counter % _generated_value_pool.size()];
     }
 
     return std::make_shared<ValueSegment<int32_t>>(std::move(values));
   }
 
-  std::shared_ptr<ValueSegment<int32_t>> create_int_with_null_value_segment() {
-    return create_int_with_null_value_segment(row_count());
+  std::shared_ptr<ValueSegment<int32_t>> _create_int_with_null_value_segment() {
+    return _create_int_with_null_value_segment(_row_count());
   }
 
-  std::shared_ptr<ValueSegment<int32_t>> create_int_with_null_value_segment(size_t row_count) {
+  std::shared_ptr<ValueSegment<int32_t>> _create_int_with_null_value_segment(size_t row_count) {
     auto values = pmr_vector<int32_t>(row_count);
     auto null_values = pmr_vector<bool>(row_count);
 
-    std::default_random_engine engine{};
-    std::uniform_int_distribution<int32_t> dist{0u, max_value};
-    std::bernoulli_distribution bernoulli_dist{0.3};
-
     for (auto i = 0u; i < row_count; ++i) {
-      values[i] = dist(engine);
-      null_values[i] = bernoulli_dist(engine);
+      values[i] = _generated_value_pool[i % _generated_value_pool.size()];
+      null_values[i] = (i % 3) == 0;
     }
 
     return std::make_shared<ValueSegment<int32_t>>(std::move(values), std::move(null_values));
   }
 
-  std::shared_ptr<RowIDPosList> create_sequential_position_filter() {
-    return create_sequential_position_filter(row_count());
+  std::shared_ptr<RowIDPosList> _create_sequential_position_filter() {
+    return _create_sequential_position_filter(_row_count());
   }
 
-  static std::shared_ptr<RowIDPosList> create_sequential_position_filter(size_t row_count) {
+  static std::shared_ptr<RowIDPosList> _create_sequential_position_filter(size_t row_count) {
     auto list = std::make_shared<RowIDPosList>();
     list->guarantee_single_chunk();
 
-    std::default_random_engine engine{};
-    std::bernoulli_distribution bernoulli_dist{0.5};
-
     for (auto offset_in_referenced_chunk = 0u; offset_in_referenced_chunk < row_count; ++offset_in_referenced_chunk) {
-      if (bernoulli_dist(engine)) {
+      if (offset_in_referenced_chunk % 2) {
         list->push_back(RowID{ChunkID{0}, offset_in_referenced_chunk});
       }
     }
@@ -95,29 +89,42 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     return list;
   }
 
-  std::shared_ptr<RowIDPosList> create_random_access_position_filter() {
-    return create_random_access_position_filter(row_count());
+  std::shared_ptr<RowIDPosList> _create_random_access_position_filter() {
+    return _create_random_access_position_filter(_row_count());
   }
 
-  static std::shared_ptr<RowIDPosList> create_random_access_position_filter(size_t row_count) {
-    auto list = create_sequential_position_filter(row_count);
+  static std::shared_ptr<RowIDPosList> _create_random_access_position_filter(size_t row_count) {
+    auto list = _create_sequential_position_filter(row_count);
 
-    auto random_device = std::random_device{};
-    std::default_random_engine engine{random_device()};
-    std::shuffle(list->begin(), list->end(), engine);
+    auto skewed_list = std::make_shared<RowIDPosList>();
+    skewed_list->reserve(list->size());
+    // Let one iterator run from the beginning and one from the end of the list in each other's direction. Add the
+    // iterators' elements alternately to the skewed list.
+    auto front_iter = list->cbegin();
+    auto back_iter = list->cend() - 1;
+    const auto half_list_size = list->size() / 2;
+    for (auto counter = 0u; counter < half_list_size; ++counter) {
+      skewed_list->emplace_back(std::move(*front_iter));
+      skewed_list->emplace_back(std::move(*back_iter));
+      ++front_iter;
+      --back_iter;
+    }
+    if (front_iter == back_iter) {  // odd number of list elements
+      skewed_list->emplace_back(std::move(*front_iter));
+    }
 
-    return list;
+    return skewed_list;
   }
 
-  std::shared_ptr<AbstractEncodedSegment> encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
-                                                         const DataType data_type) {
+  std::shared_ptr<AbstractEncodedSegment> _encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
+                                                          const DataType data_type) {
     auto segment_encoding_spec = GetParam();
-    return this->encode_segment(abstract_segment, data_type, segment_encoding_spec);
+    return this->_encode_segment(abstract_segment, data_type, segment_encoding_spec);
   }
 
-  std::shared_ptr<AbstractEncodedSegment> encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
-                                                         const DataType data_type,
-                                                         const SegmentEncodingSpec& segment_encoding_spec) {
+  std::shared_ptr<AbstractEncodedSegment> _encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
+                                                          const DataType data_type,
+                                                          const SegmentEncodingSpec& segment_encoding_spec) {
     return std::dynamic_pointer_cast<AbstractEncodedSegment>(
         ChunkEncoder::encode_segment(abstract_segment, data_type, segment_encoding_spec));
   }
@@ -144,7 +151,7 @@ INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedSegmentTest,
 
 TEST_P(EncodedSegmentTest, EncodeEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_vector<int32_t>{});
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -162,8 +169,8 @@ TEST_P(EncodedSegmentTest, EncodeEmptyIntSegment) {
 }
 
 TEST_P(EncodedSegmentTest, SequentiallyReadNotNullableIntSegment) {
-  auto value_segment = create_int_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto value_segment = _create_int_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -182,8 +189,8 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNotNullableIntSegment) {
 }
 
 TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegment) {
-  auto value_segment = create_int_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto value_segment = _create_int_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -215,12 +222,12 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegment) {
 }
 
 TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithChunkOffsetsList) {
-  auto value_segment = create_int_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto value_segment = _create_int_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
-  auto position_filter = create_sequential_position_filter();
+  auto position_filter = _create_sequential_position_filter();
 
   resolve_encoded_segment_type<int32_t>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto value_segment_iterable = create_iterable_from_segment(*value_segment);
@@ -241,12 +248,12 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithChunkOffsetsLis
 }
 
 TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithShuffledChunkOffsetsList) {
-  auto value_segment = create_int_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto value_segment = _create_int_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
-  auto position_filter = create_random_access_position_filter();
+  auto position_filter = _create_random_access_position_filter();
 
   resolve_encoded_segment_type<int32_t>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto value_segment_iterable = create_iterable_from_segment(*value_segment);
@@ -268,7 +275,7 @@ TEST_P(EncodedSegmentTest, SequentiallyReadNullableIntSegmentWithShuffledChunkOf
 
 TEST_P(EncodedSegmentTest, SequentiallyReadEmptyIntSegment) {
   auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_vector<int32_t>{});
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -285,7 +292,7 @@ TEST_P(EncodedSegmentTest, SequentiallyReadEmptyIntSegment) {
 
 TEST_F(EncodedSegmentTest, SeqIncreasingAccessValueSegmentCounters) {
   const auto row_count = 666u;
-  auto value_segment = create_int_value_segment(row_count);
+  auto value_segment = _create_int_value_segment(row_count);
 
   auto iterable = create_iterable_from_segment(*value_segment);
   EXPECT_EQ(0, value_segment->access_counter[SegmentAccessCounter::AccessType::Sequential]);
@@ -294,8 +301,8 @@ TEST_F(EncodedSegmentTest, SeqIncreasingAccessValueSegmentCounters) {
 }
 
 TEST_P(EncodedSegmentTest, SeqIncreasingAccessSegmentCounters) {
-  auto value_segment = create_int_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto value_segment = _create_int_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
 
   resolve_encoded_segment_type<int32_t>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto iterable = create_iterable_from_segment(encoded_segment);
@@ -306,15 +313,15 @@ TEST_P(EncodedSegmentTest, SeqIncreasingAccessSegmentCounters) {
 }
 
 TEST_P(EncodedSegmentTest, IncreasingSegmentAccessCountersWithPosList) {
-  auto value_segment = create_int_value_segment();
-  const auto pos_filter = create_sequential_position_filter();
+  auto value_segment = _create_int_value_segment();
+  const auto pos_filter = _create_sequential_position_filter();
 
   auto value_segment_iterable = create_iterable_from_segment(*value_segment);
   EXPECT_EQ(0, value_segment->access_counter[SegmentAccessCounter::AccessType::Monotonic]);
   value_segment_iterable.for_each(pos_filter, [](const auto) {});
   EXPECT_EQ(pos_filter->size(), value_segment->access_counter[SegmentAccessCounter::AccessType::Monotonic]);
 
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
   resolve_encoded_segment_type<int32_t>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto abstract_encoded_segment_iterable = create_iterable_from_segment(encoded_segment);
     EXPECT_EQ(0, encoded_segment.access_counter[SegmentAccessCounter::AccessType::Monotonic]);
@@ -324,15 +331,15 @@ TEST_P(EncodedSegmentTest, IncreasingSegmentAccessCountersWithPosList) {
 }
 
 TEST_P(EncodedSegmentTest, RandomSegmentAccessCountersWithPosList) {
-  auto value_segment = create_int_value_segment();
-  const auto pos_filter = create_random_access_position_filter();
+  auto value_segment = _create_int_value_segment();
+  const auto pos_filter = _create_random_access_position_filter();
 
   auto value_segment_iterable = create_iterable_from_segment(*value_segment);
   EXPECT_EQ(0, value_segment->access_counter[SegmentAccessCounter::AccessType::Random]);
   value_segment_iterable.for_each(pos_filter, [](const auto) {});
   EXPECT_EQ(pos_filter->size(), value_segment->access_counter[SegmentAccessCounter::AccessType::Random]);
 
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::Int);
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::Int);
   resolve_encoded_segment_type<int32_t>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto abstract_encoded_segment_iterable = create_iterable_from_segment(encoded_segment);
     EXPECT_EQ(0, encoded_segment.access_counter[SegmentAccessCounter::AccessType::Random]);
@@ -343,10 +350,10 @@ TEST_P(EncodedSegmentTest, RandomSegmentAccessCountersWithPosList) {
 
 TEST_F(EncodedSegmentTest, DictionaryAccessCounters) {
   const auto row_count = 666u;
-  auto value_segment = create_int_value_segment(row_count);
-  const auto pos_filter = create_random_access_position_filter(row_count);
+  auto value_segment = _create_int_value_segment(row_count);
+  const auto pos_filter = _create_random_access_position_filter(row_count);
   auto dictionary_encoded_segment = dynamic_pointer_cast<DictionarySegment<int32_t>>(
-      this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary}));
+      this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary}));
   EXPECT_EQ(get_segment_encoding_spec(dictionary_encoded_segment),
             (SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned}));
 
@@ -370,35 +377,35 @@ TEST_F(EncodedSegmentTest, DictionaryAccessCounters) {
 
 TEST_F(EncodedSegmentTest, SegmentReencoding) {
   // Use the row_count used for frame of reference segments.
-  auto value_segment = create_int_with_null_value_segment(row_count(EncodingType::FrameOfReference));
+  auto value_segment = _create_int_with_null_value_segment(_row_count(EncodingType::FrameOfReference));
 
   auto encoded_segment =
-      this->encode_segment(value_segment, DataType::Int,
-                           SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
+      this->_encode_segment(value_segment, DataType::Int,
+                            SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
   EXPECT_EQ(get_segment_encoding_spec(encoded_segment),
             (SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned}));
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
-  encoded_segment = this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
+  encoded_segment = this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
   encoded_segment =
-      this->encode_segment(value_segment, DataType::Int,
-                           SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128});
+      this->_encode_segment(value_segment, DataType::Int,
+                            SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128});
   EXPECT_EQ(get_segment_encoding_spec(encoded_segment),
             (SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::SimdBp128}));
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
   encoded_segment =
-      this->encode_segment(value_segment, DataType::Int,
-                           SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned});
+      this->_encode_segment(value_segment, DataType::Int,
+                            SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::FixedSizeByteAligned});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
-  encoded_segment = this->encode_segment(
+  encoded_segment = this->_encode_segment(
       value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
-  encoded_segment = this->encode_segment(
+  encoded_segment = this->_encode_segment(
       value_segment, DataType::Int,
       SegmentEncodingSpec{EncodingType::FrameOfReference, VectorCompressionType::FixedSizeByteAligned});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
-  encoded_segment = this->encode_segment(value_segment, DataType::Int,
-                                         SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128});
+  encoded_segment = this->_encode_segment(value_segment, DataType::Int,
+                                          SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
 }
 
@@ -413,7 +420,7 @@ TEST_F(EncodedSegmentTest, RunLengthEncodingMonotonicallyIncreasing) {
 
   const auto value_segment = std::make_shared<ValueSegment<int32_t>>(std::move(values));
   const auto encoded_segment =
-      this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
+      this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
 
   const auto run_length_segment = std::dynamic_pointer_cast<const RunLengthSegment<int32_t>>(encoded_segment);
   ASSERT_TRUE(run_length_segment);
@@ -455,7 +462,7 @@ TEST_F(EncodedSegmentTest, RunLengthEncodingVaryingRuns) {
 
   const auto value_segment = std::make_shared<ValueSegment<int32_t>>(std::move(values));
   const auto encoded_segment =
-      this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
+      this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
 
   const auto run_length_segment = std::dynamic_pointer_cast<const RunLengthSegment<int32_t>>(encoded_segment);
   ASSERT_TRUE(run_length_segment);
@@ -519,7 +526,7 @@ TEST_F(EncodedSegmentTest, RunLengthEncodingNullValues) {
 
   const auto value_segment = std::make_shared<ValueSegment<int32_t>>(std::move(values), std::move(null_values));
   const auto encoded_segment =
-      this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
+      this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
 
   const auto run_length_segment = std::dynamic_pointer_cast<const RunLengthSegment<int32_t>>(encoded_segment);
   ASSERT_TRUE(run_length_segment);
@@ -579,7 +586,7 @@ TEST_F(EncodedSegmentTest, RunLengthEncodingNullValuesInRun) {
 
   const auto value_segment = std::make_shared<ValueSegment<int32_t>>(std::move(values), std::move(null_values));
   const auto encoded_segment =
-      this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
+      this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::RunLength});
 
   const auto run_length_segment = std::dynamic_pointer_cast<const RunLengthSegment<int32_t>>(encoded_segment);
   ASSERT_TRUE(run_length_segment);
@@ -623,7 +630,7 @@ TEST_F(EncodedSegmentTest, FrameOfReference) {
   auto null_values_copy = null_values;
   const auto value_segment = std::make_shared<ValueSegment<int32_t>>(std::move(values), std::move(null_values));
   const auto encoded_segment =
-      this->encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::FrameOfReference});
+      this->_encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::FrameOfReference});
 
   const auto for_segment = std::dynamic_pointer_cast<const FrameOfReferenceSegment<int32_t>>(encoded_segment);
   ASSERT_TRUE(for_segment);
@@ -654,7 +661,7 @@ TEST_F(EncodedSegmentTest, FrameOfReference) {
   // Check that NULLs are not stored for FoR segment that does not contain any NULLs
   const auto value_segment_no_nulls = std::make_shared<ValueSegment<int32_t>>(std::move(values_copy));
   const auto encoded_segment_no_nulls =
-      this->encode_segment(value_segment_no_nulls, DataType::Int, SegmentEncodingSpec{EncodingType::FrameOfReference});
+      this->_encode_segment(value_segment_no_nulls, DataType::Int, SegmentEncodingSpec{EncodingType::FrameOfReference});
 
   const auto for_segment_no_nulls =
       std::dynamic_pointer_cast<const FrameOfReferenceSegment<int32_t>>(encoded_segment_no_nulls);

--- a/src/test/lib/storage/encoded_segment_test.cpp
+++ b/src/test/lib/storage/encoded_segment_test.cpp
@@ -21,9 +21,11 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
  protected:
   static constexpr auto _max_value = 1'024;
 
-  // 0, 1, the maximum value and 20 randomly generated int32_t values from the interval [0, _max_value]
-  const std::array<int32_t, 23> _generated_value_pool{0,   1,  _max_value, 600,  679, 212, 559, 439, 620, 910, 831, 662,
-                                                      389, 97, 530,        1013, 460, 138, 697, 861, 35,  329, 476};
+  // 0, 1, -1, _max_value, -_max_value and 20 randomly generated int32_t values from the interval
+  // [-_max_value, _max_value]
+  const std::array<int32_t, 25> _generated_value_pool{0,   1,    -1,   _max_value, -_max_value, 750, -978, -350, -885,
+                                                      738, -234, 582,  269,        -485,        893, -630, 528,  -122,
+                                                      551, 544,  -106, 194,        415,         954, -608};
 
  protected:
   size_t _row_count() {

--- a/src/test/lib/storage/encoded_string_segment_test.cpp
+++ b/src/test/lib/storage/encoded_string_segment_test.cpp
@@ -18,29 +18,28 @@ namespace opossum {
 
 class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
  protected:
-  static constexpr auto max_length = 32;
-  static constexpr auto row_count = size_t{1u} << 10;
+  static constexpr auto _row_count = size_t{1u} << 10;
 
-  std::shared_ptr<ValueSegment<pmr_string>> create_empty_string_value_segment() {
-    auto values = pmr_vector<pmr_string>(row_count);
+  std::shared_ptr<ValueSegment<pmr_string>> _create_empty_string_value_segment() {
+    auto values = pmr_vector<pmr_string>(_row_count);
     return std::make_shared<ValueSegment<pmr_string>>(std::move(values));
   }
 
-  std::shared_ptr<ValueSegment<pmr_string>> create_empty_string_with_null_value_segment() {
-    auto values = pmr_vector<pmr_string>(row_count);
-    auto null_values = pmr_vector<bool>(row_count);
+  std::shared_ptr<ValueSegment<pmr_string>> _create_empty_string_with_null_value_segment() {
+    auto values = pmr_vector<pmr_string>(_row_count);
+    auto null_values = pmr_vector<bool>(_row_count);
 
-    for (auto index = size_t{0u}; index < row_count; ++index) {
+    for (auto index = size_t{0u}; index < _row_count; ++index) {
       null_values[index] = index % 4 == 0;
     }
 
     return std::make_shared<ValueSegment<pmr_string>>(std::move(values), std::move(null_values));
   }
 
-  std::shared_ptr<ValueSegment<pmr_string>> create_string_value_segment() {
-    auto values = pmr_vector<pmr_string>(row_count);
+  std::shared_ptr<ValueSegment<pmr_string>> _create_string_value_segment() {
+    auto values = pmr_vector<pmr_string>(_row_count);
 
-    for (auto index = size_t{0u}; index < row_count; ++index) {
+    for (auto index = size_t{0u}; index < _row_count; ++index) {
       if (index % 3 == 0) {
         values[index] = "Hello world!!1!12345";
       } else if (index % 3 == 1) {
@@ -53,11 +52,11 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     return std::make_shared<ValueSegment<pmr_string>>(std::move(values));
   }
 
-  std::shared_ptr<ValueSegment<pmr_string>> create_string_with_null_value_segment() {
-    auto values = pmr_vector<pmr_string>(row_count);
-    auto null_values = pmr_vector<bool>(row_count);
+  std::shared_ptr<ValueSegment<pmr_string>> _create_string_with_null_value_segment() {
+    auto values = pmr_vector<pmr_string>(_row_count);
+    auto null_values = pmr_vector<bool>(_row_count);
 
-    for (auto index = 0u; index < row_count; ++index) {
+    for (auto index = 0u; index < _row_count; ++index) {
       null_values[index] = index % 4 == 0;
       if (index % 3 == 0) {
         values[index] = "Hello world!!1!12345";
@@ -71,12 +70,12 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     return std::make_shared<ValueSegment<pmr_string>>(std::move(values), std::move(null_values));
   }
 
-  std::shared_ptr<RowIDPosList> create_sequential_position_filter() {
+  std::shared_ptr<RowIDPosList> _create_sequential_position_filter() {
     auto list = std::make_shared<RowIDPosList>();
     list->guarantee_single_chunk();
 
-    for (auto offset_in_referenced_chunk = 0u; offset_in_referenced_chunk < row_count; ++offset_in_referenced_chunk) {
-      if (!(offset_in_referenced_chunk % 2)) {
+    for (auto offset_in_referenced_chunk = 0u; offset_in_referenced_chunk < _row_count; ++offset_in_referenced_chunk) {
+      if (offset_in_referenced_chunk % 2) {
         list->push_back(RowID{ChunkID{0}, offset_in_referenced_chunk});
       }
     }
@@ -84,8 +83,8 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     return list;
   }
 
-  std::shared_ptr<RowIDPosList> create_random_access_position_filter() {
-    auto list = create_sequential_position_filter();
+  std::shared_ptr<RowIDPosList> _create_random_access_position_filter() {
+    auto list = _create_sequential_position_filter();
 
     auto skewed_list = std::make_shared<RowIDPosList>();
     skewed_list->reserve(list->size());
@@ -95,27 +94,27 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     auto back_iter = list->cend() - 1;
     const auto half_list_size = list->size() / 2;
     for (auto counter = 0u; counter < half_list_size; ++counter) {
-      skewed_list->emplace_back(*front_iter);
-      skewed_list->emplace_back(*back_iter);
+      skewed_list->emplace_back(std::move(*front_iter));
+      skewed_list->emplace_back(std::move(*back_iter));
       ++front_iter;
       --back_iter;
     }
     if (front_iter == back_iter) {  // odd number of list elements
-      skewed_list->emplace_back(*front_iter);
+      skewed_list->emplace_back(std::move(*front_iter));
     }
 
     return skewed_list;
   }
 
-  std::shared_ptr<AbstractEncodedSegment> encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
-                                                         const DataType data_type) {
+  std::shared_ptr<AbstractEncodedSegment> _encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
+                                                          const DataType data_type) {
     auto segment_encoding_spec = GetParam();
-    return this->encode_segment(abstract_segment, data_type, segment_encoding_spec);
+    return this->_encode_segment(abstract_segment, data_type, segment_encoding_spec);
   }
 
-  std::shared_ptr<AbstractEncodedSegment> encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
-                                                         const DataType data_type,
-                                                         const SegmentEncodingSpec& segment_encoding_spec) {
+  std::shared_ptr<AbstractEncodedSegment> _encode_segment(const std::shared_ptr<AbstractSegment>& abstract_segment,
+                                                          const DataType data_type,
+                                                          const SegmentEncodingSpec& segment_encoding_spec) {
     return std::dynamic_pointer_cast<AbstractEncodedSegment>(
         ChunkEncoder::encode_segment(abstract_segment, data_type, segment_encoding_spec));
   }
@@ -141,8 +140,8 @@ INSTANTIATE_TEST_SUITE_P(SegmentEncodingSpecs, EncodedStringSegmentTest,
                          encoded_string_segment_test_formatter);
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableEmptyStringSegment) {
-  auto value_segment = create_empty_string_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::String);
+  auto value_segment = _create_empty_string_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::String);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -161,8 +160,8 @@ TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableEmptyStringSegment) 
 }
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableEmptyStringSegment) {
-  auto value_segment = create_empty_string_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::String);
+  auto value_segment = _create_empty_string_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::String);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -194,8 +193,8 @@ TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableEmptyStringSegment) {
 }
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableStringSegment) {
-  auto value_segment = create_string_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::String);
+  auto value_segment = _create_string_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::String);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -214,8 +213,8 @@ TEST_P(EncodedStringSegmentTest, SequentiallyReadNotNullableStringSegment) {
 }
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableStringSegment) {
-  auto value_segment = create_string_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::String);
+  auto value_segment = _create_string_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::String);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
@@ -247,12 +246,12 @@ TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableStringSegment) {
 }
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableStringSegmentWithChunkOffsetsList) {
-  auto value_segment = create_string_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::String);
+  auto value_segment = _create_string_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::String);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
-  auto position_filter = create_sequential_position_filter();
+  auto position_filter = _create_sequential_position_filter();
 
   resolve_encoded_segment_type<pmr_string>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto value_segment_iterable = create_iterable_from_segment(*value_segment);
@@ -273,12 +272,12 @@ TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableStringSegmentWithChunkO
 }
 
 TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableStringSegmentWithShuffledChunkOffsetsList) {
-  auto value_segment = create_string_with_null_value_segment();
-  auto abstract_encoded_segment = this->encode_segment(value_segment, DataType::String);
+  auto value_segment = _create_string_with_null_value_segment();
+  auto abstract_encoded_segment = this->_encode_segment(value_segment, DataType::String);
 
   EXPECT_EQ(value_segment->size(), abstract_encoded_segment->size());
 
-  auto position_filter = create_random_access_position_filter();
+  auto position_filter = _create_random_access_position_filter();
 
   resolve_encoded_segment_type<pmr_string>(*abstract_encoded_segment, [&](const auto& encoded_segment) {
     auto value_segment_iterable = create_iterable_from_segment(*value_segment);
@@ -299,32 +298,33 @@ TEST_P(EncodedStringSegmentTest, SequentiallyReadNullableStringSegmentWithShuffl
 }
 
 TEST_F(EncodedStringSegmentTest, SegmentReencoding) {
-  auto value_segment = create_string_with_null_value_segment();
+  auto value_segment = _create_string_with_null_value_segment();
 
   auto encoded_segment =
-      this->encode_segment(value_segment, DataType::String,
-                           SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
-  EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
-
-  encoded_segment = this->encode_segment(value_segment, DataType::String, SegmentEncodingSpec{EncodingType::RunLength});
+      this->_encode_segment(value_segment, DataType::String,
+                            SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::FixedSizeByteAligned});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
 
   encoded_segment =
-      this->encode_segment(value_segment, DataType::String,
-                           SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128});
+      this->_encode_segment(value_segment, DataType::String, SegmentEncodingSpec{EncodingType::RunLength});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
 
-  encoded_segment = this->encode_segment(
+  encoded_segment =
+      this->_encode_segment(value_segment, DataType::String,
+                            SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::SimdBp128});
+  EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
+
+  encoded_segment = this->_encode_segment(
       value_segment, DataType::String, SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
 
-  encoded_segment = this->encode_segment(
+  encoded_segment = this->_encode_segment(
       value_segment, DataType::String,
       SegmentEncodingSpec{EncodingType::FixedStringDictionary, VectorCompressionType::FixedSizeByteAligned});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
 
-  encoded_segment = this->encode_segment(value_segment, DataType::String,
-                                         SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128});
+  encoded_segment = this->_encode_segment(value_segment, DataType::String,
+                                          SegmentEncodingSpec{EncodingType::LZ4, VectorCompressionType::SimdBp128});
   EXPECT_SEGMENT_EQ_ORDERED(value_segment, encoded_segment);
 }
 

--- a/src/test/lib/storage/encoded_string_segment_test.cpp
+++ b/src/test/lib/storage/encoded_string_segment_test.cpp
@@ -87,6 +87,7 @@ class EncodedStringSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     auto list = _create_sequential_position_filter();
 
     auto skewed_list = std::make_shared<RowIDPosList>();
+    skewed_list->guarantee_single_chunk();
     skewed_list->reserve(list->size());
     // Let one iterator run from the beginning and one from the end of the list in each other's direction. Add the
     // iterators' elements alternately to the skewed list.

--- a/src/test/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index_test.cpp
+++ b/src/test/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index_test.cpp
@@ -62,7 +62,7 @@ class AdaptiveRadixTreeIndexTest : public BaseTest {
     // and the second value (additional_values[1]). The first value increases, the second value decreases over time.
     std::set<std::optional<int32_t>> search_values = distinct_values;
     while (search_values.size() < distinct_values.size() * 2) {
-      auto value_index = search_values.size() % 2;
+      const auto value_index = search_values.size() % 2;
       auto& value = additional_values[value_index];
       search_values.insert(value);
 
@@ -312,7 +312,7 @@ TEST_F(AdaptiveRadixTreeIndexTest, DenseVectorOfInts) {
     }
   }
 
-  DebugAssert(values.size(), overall_value_counter);
+  DebugAssert(values.size() == overall_value_counter, "Number of generated values is incorrect.");
 
   _search_elements(values);
 }


### PR DESCRIPTION
fixes #1321:
- removal of random value generation in tests
- extension of the lint script so that using random values in tests will be reported as errors (taken from @mrks)
- renaming (leading underscore for private/protected variables/functions)
- formatting