### PR TITLE
Fix missing constructors for AbstractTableConstraint

### DIFF
--- a/src/lib/storage/constraints/abstract_table_constraint.hpp
+++ b/src/lib/storage/constraints/abstract_table_constraint.hpp
@@ -14,6 +14,12 @@ namespace opossum {
 class AbstractTableConstraint {
  public:
   explicit AbstractTableConstraint(std::unordered_set<ColumnID> init_columns);
+
+  AbstractTableConstraint(const AbstractTableConstraint&) = default;
+  AbstractTableConstraint(AbstractTableConstraint&&) = default;
+  AbstractTableConstraint& operator=(const AbstractTableConstraint&) = default;
+  AbstractTableConstraint& operator=(AbstractTableConstraint&&) = default;
+
   virtual ~AbstractTableConstraint() = default;
 
   const std::unordered_set<ColumnID>& columns() const;


### PR DESCRIPTION
This might not be the best solution to resolve #2165, but at least it compiles.