### PR TITLE
Shallow clone for third party module nlohmann

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,7 @@
 [submodule "third_party/nlohmann_json"]
 	path = third_party/nlohmann_json
 	url = https://github.com/nlohmann/json.git
+	shallow = true
 [submodule "third_party/sql-parser"]
 	path = third_party/sql-parser
 	url = https://github.com/hyrise/sql-parser


### PR DESCRIPTION
Our third party module `nlohmann_json` has recently deleted its test files and shrunk from ~260 MB to ~20 MB.
This PR uses the shallow submodule flag to only pull the most recent version (same as a clone with `--depth 1`).

```
$ git clone --single-branch --branch master --recursive https://github.com/hyrise/hyrise.git master_clone
$ git clone --single-branch --branch martin/shallow_nlohmann_submodule --recursive https://github.com/hyrise/hyrise.git shallow_branch_clone
$ du -h -d1
679M	./master_clone
408M	./shallow_branch_clone
```