### PR TITLE
Implement FDs for UnionNode (SetOperationMode::All) & Fix hashing of FDs and LQPUniqueConstraints

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -309,7 +309,7 @@ std::vector<FunctionalDependency> AbstractLQPNode::functional_dependencies() con
   auto trivial_fds = fds_from_unique_constraints(shared_from_this(), unique_constraints);
 
   // (3) Merge and return FDs
-  return merge_fds(non_trivial_fds, trivial_fds);
+  return union_fds(non_trivial_fds, trivial_fds);
 }
 
 std::vector<FunctionalDependency> AbstractLQPNode::non_trivial_functional_dependencies() const {

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -68,7 +68,7 @@ std::unordered_set<FunctionalDependency> inflate_fds(const std::vector<Functiona
   auto inflated_fds = std::unordered_set<FunctionalDependency>();
   inflated_fds.reserve(fds.size());
 
-  for (auto& fd : fds) {
+  for (const auto& fd : fds) {
     if (fd.dependents.size() == 1) {
       inflated_fds.insert(fd);
     } else {
@@ -122,7 +122,6 @@ std::vector<FunctionalDependency> merge_fds(const std::vector<FunctionalDependen
     Assert(fds_a.size() == fds_a_set.size() && fds_b.size() == fds_b_set.size(),
            "Did not expect input vector to contain multiple FDs with the same determinant expressions");
   }
-  if (fds_a.empty() && fds_b.empty()) return {};
   if (fds_a.empty()) return fds_b;
   if (fds_b.empty()) return fds_a;
 

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -32,7 +32,12 @@ bool FunctionalDependency::operator==(const FunctionalDependency& other) const {
 bool FunctionalDependency::operator!=(const FunctionalDependency& other) const { return !(other == *this); }
 
 size_t FunctionalDependency::hash() const {
-  return boost::hash_range(determinants.cbegin(), determinants.cend());
+  size_t hash = 0;
+  for(const auto& expression : determinants) {
+    hash = hash xor expression->hash();
+  }
+
+  return boost::hash_value(hash - determinants.size());
 }
 
 std::ostream& operator<<(std::ostream& stream, const FunctionalDependency& expression) {

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -34,7 +34,7 @@ bool FunctionalDependency::operator!=(const FunctionalDependency& other) const {
 size_t FunctionalDependency::hash() const {
   size_t hash = 0;
   for (const auto& expression : determinants) {
-    // Use commutative XOR operator to combine hashes
+    // To make the hash independent of the expressions' order, we have to use a commutative operator like XOR.
     hash = hash ^ expression->hash();
   }
 

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -33,7 +33,7 @@ bool FunctionalDependency::operator!=(const FunctionalDependency& other) const {
 
 size_t FunctionalDependency::hash() const {
   size_t hash = 0;
-  for(const auto& expression : determinants) {
+  for (const auto& expression : determinants) {
     hash = hash xor expression->hash();
   }
 
@@ -138,7 +138,7 @@ std::vector<FunctionalDependency> intersect_fds(const std::vector<FunctionalDepe
                                                 const std::vector<FunctionalDependency>& fds_b) {
   if (fds_a.empty() || fds_b.empty()) return {};
 
-  const auto& inflated_fds_a = inflate_fds(fds_a); // Continue DEBUG why is a FD lost?
+  const auto& inflated_fds_a = inflate_fds(fds_a);
   const auto& inflated_fds_b = inflate_fds(fds_b);
 
   auto intersected_fds = std::vector<FunctionalDependency>();

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -31,6 +31,10 @@ bool FunctionalDependency::operator==(const FunctionalDependency& other) const {
 
 bool FunctionalDependency::operator!=(const FunctionalDependency& other) const { return !(other == *this); }
 
+size_t FunctionalDependency::hash() const {
+  return boost::hash_range(determinants.cbegin(), determinants.cend());
+}
+
 std::ostream& operator<<(std::ostream& stream, const FunctionalDependency& expression) {
   stream << "{";
   auto determinants_vector =
@@ -129,7 +133,7 @@ std::vector<FunctionalDependency> intersect_fds(const std::vector<FunctionalDepe
                                                 const std::vector<FunctionalDependency>& fds_b) {
   if (fds_a.empty() || fds_b.empty()) return {};
 
-  const auto& inflated_fds_a = inflate_fds(fds_a);
+  const auto& inflated_fds_a = inflate_fds(fds_a); // Continue DEBUG why is a FD lost?
   const auto& inflated_fds_b = inflate_fds(fds_b);
 
   auto intersected_fds = std::vector<FunctionalDependency>();
@@ -149,7 +153,7 @@ std::vector<FunctionalDependency> intersect_fds(const std::vector<FunctionalDepe
 namespace std {
 
 size_t hash<opossum::FunctionalDependency>::operator()(const opossum::FunctionalDependency& fd) const {
-  return boost::hash_range(fd.determinants.cbegin(), fd.determinants.cend());
+  return fd.hash();
 }
 
 }  // namespace std

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -114,7 +114,7 @@ std::vector<FunctionalDependency> deflate_fds(const std::vector<FunctionalDepend
   return deflated_fds;
 }
 
-std::vector<FunctionalDependency> merge_fds(const std::vector<FunctionalDependency>& fds_a,
+std::vector<FunctionalDependency> union_fds(const std::vector<FunctionalDependency>& fds_a,
                                             const std::vector<FunctionalDependency>& fds_b) {
   if constexpr (HYRISE_DEBUG) {
     auto fds_a_set = std::unordered_set<FunctionalDependency>(fds_a.begin(), fds_a.end());
@@ -125,13 +125,13 @@ std::vector<FunctionalDependency> merge_fds(const std::vector<FunctionalDependen
   if (fds_a.empty()) return fds_b;
   if (fds_b.empty()) return fds_a;
 
-  auto fds_merged = std::vector<FunctionalDependency>();
-  fds_merged.reserve(fds_a.size() + fds_b.size());
-  fds_merged.insert(fds_merged.end(), fds_a.begin(), fds_a.end());
-  fds_merged.insert(fds_merged.end(), fds_b.begin(), fds_b.end());
+  auto fds_unified = std::vector<FunctionalDependency>();
+  fds_unified.reserve(fds_a.size() + fds_b.size());
+  fds_unified.insert(fds_unified.end(), fds_a.begin(), fds_a.end());
+  fds_unified.insert(fds_unified.end(), fds_b.begin(), fds_b.end());
 
   // To get rid of potential duplicates, we call deflate before returning.
-  return deflate_fds(fds_merged);
+  return deflate_fds(fds_unified);
 }
 
 std::vector<FunctionalDependency> intersect_fds(const std::vector<FunctionalDependency>& fds_a,

--- a/src/lib/logical_query_plan/functional_dependency.cpp
+++ b/src/lib/logical_query_plan/functional_dependency.cpp
@@ -34,7 +34,8 @@ bool FunctionalDependency::operator!=(const FunctionalDependency& other) const {
 size_t FunctionalDependency::hash() const {
   size_t hash = 0;
   for (const auto& expression : determinants) {
-    hash = hash xor expression->hash();
+    // Use commutative XOR operator to combine hashes
+    hash = hash ^ expression->hash();
   }
 
   return boost::hash_value(hash - determinants.size());

--- a/src/lib/logical_query_plan/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/functional_dependency.hpp
@@ -61,7 +61,7 @@ std::unordered_set<FunctionalDependency> inflate_fds(const std::vector<Functiona
 std::vector<FunctionalDependency> deflate_fds(const std::vector<FunctionalDependency>& fds);
 
 /**
- * @return A merged FD set from the given input @param fds_a and @param fds_b. FDs with the same determinant
+ * @return Unified FDs from the given @param fds_a and @param fds_b vectors. FDs with the same determinant
  *         expressions are merged into single objects by merging their dependent expressions.
  */
 std::vector<FunctionalDependency> union_fds(const std::vector<FunctionalDependency>& fds_a,

--- a/src/lib/logical_query_plan/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/functional_dependency.hpp
@@ -40,11 +40,37 @@ struct FunctionalDependency {
 std::ostream& operator<<(std::ostream& stream, const FunctionalDependency& expression);
 
 /**
+ * @return The given FDs as an unordered set in an inflated form.
+ *         We consider FDs as inflated when they have a single dependent expression only. Therefore, inflating an FD
+ *         works as follows:
+ *                                                      {a} => {b}
+ *                             {a} => {b, c, d}   -->   {a} => {c}
+ *                                                      {a} => {d}
+ */
+std::unordered_set<FunctionalDependency> inflate_fds(const std::vector<FunctionalDependency>& fds);
+
+/**
+ * @return Reduces the given vector of FDs, so that there are no more FD objects with the same determinant expressions.
+ *         As a result, FDs become deflated as follows:
+ *
+ *                             {a} => {b}
+ *                             {a} => {c}         -->   {a} => {b, c, d}
+ *                             {a} => {d}
+ */
+std::vector<FunctionalDependency> deflate_fds(const std::vector<FunctionalDependency>& fds);
+
+/**
  * @return A merged FD set from the given input @param fds_a and @param fds_b. FDs with the same determinant
  *         expressions are merged into single objects by merging their dependent expressions.
  */
 std::vector<FunctionalDependency> merge_fds(const std::vector<FunctionalDependency>& fds_a,
                                             const std::vector<FunctionalDependency>& fds_b);
+
+/**
+ * @return Returns FDs that are included in both of the given vectors.
+ */
+std::vector<FunctionalDependency> intersect_fds(const std::vector<FunctionalDependency>& fds_a,
+                                                const std::vector<FunctionalDependency>& fds_b);
 
 /**
  * Future Work: Transitive FDs

--- a/src/lib/logical_query_plan/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/functional_dependency.hpp
@@ -64,7 +64,7 @@ std::vector<FunctionalDependency> deflate_fds(const std::vector<FunctionalDepend
  * @return A merged FD set from the given input @param fds_a and @param fds_b. FDs with the same determinant
  *         expressions are merged into single objects by merging their dependent expressions.
  */
-std::vector<FunctionalDependency> merge_fds(const std::vector<FunctionalDependency>& fds_a,
+std::vector<FunctionalDependency> union_fds(const std::vector<FunctionalDependency>& fds_a,
                                             const std::vector<FunctionalDependency>& fds_b);
 
 /**

--- a/src/lib/logical_query_plan/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/functional_dependency.hpp
@@ -32,6 +32,7 @@ struct FunctionalDependency {
 
   bool operator==(const FunctionalDependency& other) const;
   bool operator!=(const FunctionalDependency& other) const;
+  size_t hash() const;
 
   ExpressionUnorderedSet determinants;
   ExpressionUnorderedSet dependents;

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -182,7 +182,7 @@ std::vector<FunctionalDependency> JoinNode::non_trivial_functional_dependencies(
   }
 
   // Prevent FDs with duplicate determinant expressions in the output vector
-  auto fds_out = merge_fds(fds_left, fds_right);
+  auto fds_out = union_fds(fds_left, fds_right);
 
   // Outer joins lead to nullable columns, which may invalidate some FDs
   if (!fds_out.empty() &&

--- a/src/lib/logical_query_plan/lqp_unique_constraint.cpp
+++ b/src/lib/logical_query_plan/lqp_unique_constraint.cpp
@@ -18,7 +18,8 @@ bool LQPUniqueConstraint::operator!=(const LQPUniqueConstraint& rhs) const { ret
 size_t LQPUniqueConstraint::hash() const {
   size_t hash = 0;
   for (const auto& expression : expressions) {
-    hash = hash xor expression->hash();
+    // Use commutative XOR operator to combine hashes
+    hash = hash ^ expression->hash();
   }
 
   return boost::hash_value(hash - expressions.size());

--- a/src/lib/logical_query_plan/lqp_unique_constraint.cpp
+++ b/src/lib/logical_query_plan/lqp_unique_constraint.cpp
@@ -18,7 +18,7 @@ bool LQPUniqueConstraint::operator!=(const LQPUniqueConstraint& rhs) const { ret
 size_t LQPUniqueConstraint::hash() const {
   size_t hash = 0;
   for (const auto& expression : expressions) {
-    // Use commutative XOR operator to combine hashes
+    // To make the hash independent of the expressions' order, we have to use a commutative operator like XOR.
     hash = hash ^ expression->hash();
   }
 

--- a/src/lib/logical_query_plan/lqp_unique_constraint.cpp
+++ b/src/lib/logical_query_plan/lqp_unique_constraint.cpp
@@ -17,7 +17,7 @@ bool LQPUniqueConstraint::operator!=(const LQPUniqueConstraint& rhs) const { ret
 
 size_t LQPUniqueConstraint::hash() const {
   size_t hash = 0;
-  for(const auto& expression : expressions) {
+  for (const auto& expression : expressions) {
     hash = hash xor expression->hash();
   }
 

--- a/src/lib/logical_query_plan/lqp_unique_constraint.cpp
+++ b/src/lib/logical_query_plan/lqp_unique_constraint.cpp
@@ -15,12 +15,16 @@ bool LQPUniqueConstraint::operator==(const LQPUniqueConstraint& rhs) const {
 
 bool LQPUniqueConstraint::operator!=(const LQPUniqueConstraint& rhs) const { return !(rhs == *this); }
 
+size_t LQPUniqueConstraint::hash() const {
+  return boost::hash_range(expressions.cbegin(), expressions.cend());
+}
+
 }  // namespace opossum
 
 namespace std {
 
 size_t hash<opossum::LQPUniqueConstraint>::operator()(const opossum::LQPUniqueConstraint& lqp_unique_constraint) const {
-  return boost::hash_range(lqp_unique_constraint.expressions.cbegin(), lqp_unique_constraint.expressions.cend());
+  return lqp_unique_constraint.hash();
 }
 
 }  // namespace std

--- a/src/lib/logical_query_plan/lqp_unique_constraint.cpp
+++ b/src/lib/logical_query_plan/lqp_unique_constraint.cpp
@@ -16,7 +16,12 @@ bool LQPUniqueConstraint::operator==(const LQPUniqueConstraint& rhs) const {
 bool LQPUniqueConstraint::operator!=(const LQPUniqueConstraint& rhs) const { return !(rhs == *this); }
 
 size_t LQPUniqueConstraint::hash() const {
-  return boost::hash_range(expressions.cbegin(), expressions.cend());
+  size_t hash = 0;
+  for(const auto& expression : expressions) {
+    hash = hash xor expression->hash();
+  }
+
+  return boost::hash_value(hash - expressions.size());
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_unique_constraint.hpp
+++ b/src/lib/logical_query_plan/lqp_unique_constraint.hpp
@@ -18,6 +18,7 @@ struct LQPUniqueConstraint final {
 
   bool operator==(const LQPUniqueConstraint& rhs) const;
   bool operator!=(const LQPUniqueConstraint& rhs) const;
+  size_t hash() const;
 
   ExpressionUnorderedSet expressions;
 };

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -429,6 +429,16 @@ void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::
                              return false;
                            }),
             fds.end());
+
+  /**
+   * Future Work: Remove redundant FDs. For example:
+   *               - {a, b} => {c, SUM(d)}
+   *               - {a}    => {b, c}
+   *              Because we already have {a} => {c}, we do not need {a, b} => {c}. Therefore, we should change our set
+   *              of FDs to the following:
+   *               - {a, b} => {SUM(d)}
+   *               - {a}    => {b, c}
+   */
 }
 
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(
     lib/logical_query_plan/logical_query_plan_test.cpp
     lib/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
     lib/logical_query_plan/lqp_translator_test.cpp
+    lib/logical_query_plan/lqp_unique_constraint_test.cpp
     lib/logical_query_plan/lqp_utils_test.cpp
     lib/logical_query_plan/mock_node_test.cpp
     lib/logical_query_plan/predicate_node_test.cpp

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -48,6 +48,7 @@ set(
     lib/logical_query_plan/dummy_table_node_test.cpp
     lib/logical_query_plan/except_node_test.cpp
     lib/logical_query_plan/export_node_test.cpp
+    lib/logical_query_plan/functional_dependency_test.cpp
     lib/logical_query_plan/import_node_test.cpp
     lib/logical_query_plan/insert_node_test.cpp
     lib/logical_query_plan/intersect_node_test.cpp

--- a/src/test/lib/logical_query_plan/functional_dependency_test.cpp
+++ b/src/test/lib/logical_query_plan/functional_dependency_test.cpp
@@ -140,8 +140,8 @@ TEST_F(FunctionalDependencyTest, IntersectFDs) {
 
   const auto& intersected_fds = intersect_fds({fd_a, fd_a_b, fd_x}, {fd_a_b, fd_a_2});
   EXPECT_EQ(intersected_fds.size(), 2);
-  EXPECT_EQ(intersected_fds.at(0), fd_a_2);
-  EXPECT_EQ(intersected_fds.at(1), fd_a_b);
+  EXPECT_EQ(intersected_fds.at(0), fd_a_b);
+  EXPECT_EQ(intersected_fds.at(1), fd_a_2);
 }
 
 }  // namespace opossum

--- a/src/test/lib/logical_query_plan/functional_dependency_test.cpp
+++ b/src/test/lib/logical_query_plan/functional_dependency_test.cpp
@@ -88,39 +88,39 @@ TEST_F(FunctionalDependencyTest, DeflateFDs) {
   EXPECT_EQ(deflated_fds.at(1), fd_b_c);
 }
 
-TEST_F(FunctionalDependencyTest, MergeFDsEmpty) {
+TEST_F(FunctionalDependencyTest, UnionFDsEmpty) {
   const auto fd_a = FunctionalDependency({_a}, {_b, _c});
 
-  EXPECT_TRUE(merge_fds({}, {}).empty());
-  EXPECT_EQ(merge_fds({fd_a}, {}), std::vector<FunctionalDependency>{fd_a});
-  EXPECT_EQ(merge_fds({}, {fd_a}), std::vector<FunctionalDependency>{fd_a});
+  EXPECT_TRUE(union_fds({}, {}).empty());
+  EXPECT_EQ(union_fds({fd_a}, {}), std::vector<FunctionalDependency>{fd_a});
+  EXPECT_EQ(union_fds({}, {fd_a}), std::vector<FunctionalDependency>{fd_a});
 }
 
-TEST_F(FunctionalDependencyTest, MergeFDs) {
+TEST_F(FunctionalDependencyTest, UnionFDs) {
   const auto fd_a = FunctionalDependency({_a}, {_b, _c});
   const auto fd_a_1 = FunctionalDependency({_a}, {_b});
   const auto fd_a_2 = FunctionalDependency({_a}, {_c});
   const auto fd_a_b = FunctionalDependency({_a, _b}, {_c});
   const auto fd_b = FunctionalDependency({_b}, {_c});
 
-  const auto& merged_fds = merge_fds({fd_a_1, fd_a_b, fd_b}, {fd_a_2});
-  const auto& merged_fds_set = std::unordered_set<FunctionalDependency>(merged_fds.begin(), merged_fds.end());
+  const auto& fds_unified = union_fds({fd_a_1, fd_a_b, fd_b}, {fd_a_2});
+  const auto& fds_unified_set = std::unordered_set<FunctionalDependency>(fds_unified.begin(), fds_unified.end());
 
-  EXPECT_EQ(merged_fds_set.size(), 3);
-  EXPECT_TRUE(merged_fds_set.contains(fd_a));
-  EXPECT_TRUE(merged_fds_set.contains(fd_b));
-  EXPECT_TRUE(merged_fds_set.contains(fd_a_b));
+  EXPECT_EQ(fds_unified_set.size(), 3);
+  EXPECT_TRUE(fds_unified_set.contains(fd_a));
+  EXPECT_TRUE(fds_unified_set.contains(fd_b));
+  EXPECT_TRUE(fds_unified_set.contains(fd_a_b));
 }
 
-TEST_F(FunctionalDependencyTest, MergeFDsRemoveDuplicates) {
+TEST_F(FunctionalDependencyTest, UnionFDsRemoveDuplicates) {
   const auto fd_a = FunctionalDependency({_a}, {_b, _c});
   const auto fd_b = FunctionalDependency({_b}, {_c});
 
-  const auto& merged_fds = merge_fds({fd_a, fd_b}, {fd_b});
+  const auto& fds_unified = union_fds({fd_a, fd_b}, {fd_b});
 
-  EXPECT_EQ(merged_fds.size(), 2);
-  EXPECT_EQ(merged_fds.at(0), fd_a);
-  EXPECT_EQ(merged_fds.at(1), fd_b);
+  EXPECT_EQ(fds_unified.size(), 2);
+  EXPECT_EQ(fds_unified.at(0), fd_a);
+  EXPECT_EQ(fds_unified.at(1), fd_b);
 }
 
 TEST_F(FunctionalDependencyTest, IntersectFDsEmpty) {

--- a/src/test/lib/logical_query_plan/functional_dependency_test.cpp
+++ b/src/test/lib/logical_query_plan/functional_dependency_test.cpp
@@ -1,0 +1,99 @@
+#include "base_test.hpp"
+
+#include "logical_query_plan/functional_dependency.hpp"
+
+namespace opossum {
+
+class FunctionalDependencyTest : public BaseTest {
+ public:
+  void SetUp() override {
+    _mock_node_a = MockNode::make(
+        MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::Int, "c"}}, "mock_node_a");
+    _a = _mock_node_a->get_column("a");
+    _b = _mock_node_a->get_column("b");
+    _c = _mock_node_a->get_column("c");
+
+    _mock_node_b =
+        MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}}, "mock_node_b");
+    _x = _mock_node_b->get_column("x");
+    _y = _mock_node_b->get_column("y");
+  }
+
+ protected:
+  std::shared_ptr<MockNode> _mock_node_a, _mock_node_b;
+  std::shared_ptr<LQPColumnExpression> _a, _b, _c, _x, _y;
+};
+
+TEST_F(FunctionalDependencyTest, InflateFDs) {
+  const auto fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto fd_a_1 = FunctionalDependency({_a}, {_b});
+  const auto fd_a_2 = FunctionalDependency({_a}, {_c});
+  const auto fd_a_b = FunctionalDependency({_a, _b}, {_c});
+  const auto fd_x = FunctionalDependency({_x}, {_y});
+
+  const auto& inflated_fds = inflate_fds({fd_a, fd_a_b, fd_x, fd_x});
+  EXPECT_EQ(inflated_fds.size(), 4);
+  EXPECT_FALSE(inflated_fds.contains(fd_a));
+  EXPECT_TRUE(inflated_fds.contains(fd_a_1));
+  EXPECT_TRUE(inflated_fds.contains(fd_a_2));
+  EXPECT_TRUE(inflated_fds.contains(fd_a_b));
+  EXPECT_TRUE(inflated_fds.contains(fd_x));
+}
+
+TEST_F(FunctionalDependencyTest, DeflateFDs) {
+  const auto fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto fd_a_1 = FunctionalDependency({_a}, {_b});
+  const auto fd_a_2 = FunctionalDependency({_a}, {_c});
+  const auto fd_b_c = FunctionalDependency({_b, _c}, {_a});
+
+  const auto& deflated_fds = deflate_fds({fd_a_1, fd_a_2, fd_a_2, fd_b_c});
+  EXPECT_EQ(deflated_fds.size(), 2);
+  EXPECT_EQ(deflated_fds.at(0), fd_a);
+  EXPECT_EQ(deflated_fds.at(1), fd_b_c);
+}
+
+TEST_F(FunctionalDependencyTest, MergeFDsEmpty) {
+  const auto fd_a = FunctionalDependency({_a}, {_b, _c});
+
+  EXPECT_TRUE(merge_fds({}, {}).empty());
+  EXPECT_EQ(merge_fds({fd_a}, {}), std::vector<FunctionalDependency>{fd_a});
+  EXPECT_EQ(merge_fds({}, {fd_a}), std::vector<FunctionalDependency>{fd_a});
+}
+
+TEST_F(FunctionalDependencyTest, MergeFDs) {
+  const auto fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto fd_a_1 = FunctionalDependency({_a}, {_b});
+  const auto fd_a_2 = FunctionalDependency({_a}, {_c});
+  const auto fd_a_b = FunctionalDependency({_a, _b}, {_c});
+  const auto fd_b = FunctionalDependency({_b}, {_c});
+
+  const auto& merged_fds = merge_fds({fd_a_1, fd_b, fd_a_b}, {fd_a_b, fd_a_2});
+
+  EXPECT_EQ(merged_fds.size(), 3);
+  EXPECT_EQ(merged_fds.at(0), fd_a);
+  EXPECT_EQ(merged_fds.at(1), fd_b);
+  EXPECT_EQ(merged_fds.at(2), fd_a_b);
+}
+
+TEST_F(FunctionalDependencyTest, IntersectFDsEmpty) {
+  const auto fd_x = FunctionalDependency({_x}, {_y});
+
+  EXPECT_TRUE(intersect_fds({}, {}).empty());
+  EXPECT_TRUE(intersect_fds({fd_x}, {}).empty());
+  EXPECT_TRUE(intersect_fds({}, {fd_x}).empty());
+}
+
+TEST_F(FunctionalDependencyTest, IntersectFDs) {
+  const auto fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto fd_a_1 = FunctionalDependency({_a}, {_b});
+  const auto fd_a_2 = FunctionalDependency({_a}, {_c});
+  const auto fd_a_b = FunctionalDependency({_a, _b}, {_c});
+  const auto fd_x = FunctionalDependency({_x}, {_y});
+
+  const auto& intersected_fds = intersect_fds({fd_a, fd_a_b, fd_x}, {fd_a_b, fd_a_2});
+  EXPECT_EQ(intersected_fds.size(), 2);
+  EXPECT_EQ(intersected_fds.at(0), fd_a_2);
+  EXPECT_EQ(intersected_fds.at(1), fd_a_b);
+}
+
+}  // namespace opossum

--- a/src/test/lib/logical_query_plan/functional_dependency_test.cpp
+++ b/src/test/lib/logical_query_plan/functional_dependency_test.cpp
@@ -67,12 +67,23 @@ TEST_F(FunctionalDependencyTest, MergeFDs) {
   const auto fd_a_b = FunctionalDependency({_a, _b}, {_c});
   const auto fd_b = FunctionalDependency({_b}, {_c});
 
-  const auto& merged_fds = merge_fds({fd_a_1, fd_b, fd_a_b}, {fd_a_b, fd_a_2});
+  const auto& merged_fds = merge_fds({fd_a_1, fd_a_b, fd_b}, {fd_a_2});
 
   EXPECT_EQ(merged_fds.size(), 3);
   EXPECT_EQ(merged_fds.at(0), fd_a);
   EXPECT_EQ(merged_fds.at(1), fd_b);
   EXPECT_EQ(merged_fds.at(2), fd_a_b);
+}
+
+TEST_F(FunctionalDependencyTest, MergeFDsRemoveDuplicates) {
+  const auto fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto fd_b = FunctionalDependency({_b}, {_c});
+
+  const auto& merged_fds = merge_fds({fd_a, fd_b}, {fd_b});
+
+  EXPECT_EQ(merged_fds.size(), 2);
+  EXPECT_EQ(merged_fds.at(0), fd_a);
+  EXPECT_EQ(merged_fds.at(1), fd_b);
 }
 
 TEST_F(FunctionalDependencyTest, IntersectFDsEmpty) {

--- a/src/test/lib/logical_query_plan/functional_dependency_test.cpp
+++ b/src/test/lib/logical_query_plan/functional_dependency_test.cpp
@@ -84,8 +84,9 @@ TEST_F(FunctionalDependencyTest, DeflateFDs) {
 
   const auto& deflated_fds = deflate_fds({fd_a_1, fd_a_2, fd_a_2, fd_b_c});
   EXPECT_EQ(deflated_fds.size(), 2);
-  EXPECT_EQ(deflated_fds.at(0), fd_a);
-  EXPECT_EQ(deflated_fds.at(1), fd_b_c);
+  const auto deflated_fds_set = std::unordered_set<FunctionalDependency>(deflated_fds.cbegin(), deflated_fds.cend());
+  EXPECT_TRUE(deflated_fds_set.contains(fd_a));
+  EXPECT_TRUE(deflated_fds_set.contains(fd_b_c));
 }
 
 TEST_F(FunctionalDependencyTest, UnionFDsEmpty) {
@@ -119,8 +120,9 @@ TEST_F(FunctionalDependencyTest, UnionFDsRemoveDuplicates) {
   const auto& fds_unified = union_fds({fd_a, fd_b}, {fd_b});
 
   EXPECT_EQ(fds_unified.size(), 2);
-  EXPECT_EQ(fds_unified.at(0), fd_a);
-  EXPECT_EQ(fds_unified.at(1), fd_b);
+  const auto fds_unified_set = std::unordered_set<FunctionalDependency>(fds_unified.cbegin(), fds_unified.cend());
+  EXPECT_TRUE(fds_unified_set.contains(fd_a));
+  EXPECT_TRUE(fds_unified_set.contains(fd_b));
 }
 
 TEST_F(FunctionalDependencyTest, IntersectFDsEmpty) {
@@ -140,8 +142,10 @@ TEST_F(FunctionalDependencyTest, IntersectFDs) {
 
   const auto& intersected_fds = intersect_fds({fd_a, fd_a_b, fd_x}, {fd_a_b, fd_a_2});
   EXPECT_EQ(intersected_fds.size(), 2);
-  EXPECT_EQ(intersected_fds.at(0), fd_a_b);
-  EXPECT_EQ(intersected_fds.at(1), fd_a_2);
+  const auto intersected_fds_set =
+      std::unordered_set<FunctionalDependency>(intersected_fds.cbegin(), intersected_fds.cend());
+  EXPECT_TRUE(intersected_fds_set.contains(fd_a_b));
+  EXPECT_TRUE(intersected_fds_set.contains(fd_a_2));
 }
 
 }  // namespace opossum

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -425,7 +425,7 @@ TEST_F(JoinNodeTest, FunctionalDependenciesDeriveLeftOnly) {
   EXPECT_EQ(join_node->functional_dependencies().at(1), generated_fd_x);
 }
 
-TEST_F(JoinNodeTest, FunctionalDependenciesMerge) {
+TEST_F(JoinNodeTest, FunctionalDependenciesUnify) {
   const auto key_constraint_a_b =
       TableKeyConstraint{{_t_a_a->original_column_id, _t_a_b->original_column_id}, KeyConstraintType::PRIMARY_KEY};
   const auto key_constraint_c = TableKeyConstraint{{_t_a_c->original_column_id}, KeyConstraintType::UNIQUE};
@@ -462,17 +462,17 @@ TEST_F(JoinNodeTest, FunctionalDependenciesMerge) {
   EXPECT_EQ(trivial_fds.at(2), expected_fd_x);
 
   /**
-   * After merging the two FD sets above, we expect three and instead of four FDs since the following FD objects
+   * After unifiying the two FD sets above, we expect three and instead of four FDs since the following FD objects
    *   {a, b} => {c} and
    *   {a, b} => {c, x, y}
    * can be merged into one.
    */
-  const auto merged_fds = merge_fds(non_trivial_fds, trivial_fds);
-  EXPECT_EQ(merged_fds.size(), 3);
-  EXPECT_EQ(merged_fds.at(0), expected_fd_a_b);
-  EXPECT_EQ(merged_fds.at(1), expected_fd_c);
-  EXPECT_EQ(merged_fds.at(2), expected_fd_x);
-  EXPECT_EQ(merged_fds, join_node->functional_dependencies());
+  const auto fds_unified = union_fds(non_trivial_fds, trivial_fds);
+  EXPECT_EQ(fds_unified.size(), 3);
+  EXPECT_EQ(fds_unified.at(0), expected_fd_a_b);
+  EXPECT_EQ(fds_unified.at(1), expected_fd_c);
+  EXPECT_EQ(fds_unified.at(2), expected_fd_x);
+  EXPECT_EQ(fds_unified, join_node->functional_dependencies());
 }
 
 TEST_F(JoinNodeTest, UniqueConstraintsSemiAndAntiJoins) {

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -469,9 +469,10 @@ TEST_F(JoinNodeTest, FunctionalDependenciesUnify) {
    */
   const auto fds_unified = union_fds(non_trivial_fds, trivial_fds);
   EXPECT_EQ(fds_unified.size(), 3);
-  EXPECT_EQ(fds_unified.at(0), expected_fd_a_b);
-  EXPECT_EQ(fds_unified.at(1), expected_fd_c);
-  EXPECT_EQ(fds_unified.at(2), expected_fd_x);
+  const auto fds_unified_set = std::unordered_set<FunctionalDependency>(fds_unified.cbegin(), fds_unified.cend());
+  EXPECT_TRUE(fds_unified_set.contains(expected_fd_a_b));
+  EXPECT_TRUE(fds_unified_set.contains(expected_fd_c));
+  EXPECT_TRUE(fds_unified_set.contains(expected_fd_x));
   EXPECT_EQ(fds_unified, join_node->functional_dependencies());
 }
 

--- a/src/test/lib/logical_query_plan/lqp_unique_constraint_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_unique_constraint_test.cpp
@@ -1,0 +1,61 @@
+#include "base_test.hpp"
+
+#include "logical_query_plan/functional_dependency.hpp"
+#include "logical_query_plan/mock_node.hpp"
+
+namespace opossum {
+
+class LQPUniqueConstraintTest : public BaseTest {
+ public:
+  void SetUp() override {
+    _mock_node_a = MockNode::make(
+        MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::Int, "c"}}, "mock_node_a");
+    _a = _mock_node_a->get_column("a");
+    _b = _mock_node_a->get_column("b");
+    _c = _mock_node_a->get_column("c");
+
+    _mock_node_b =
+        MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "x"}, {DataType::Int, "y"}}, "mock_node_b");
+    _x = _mock_node_b->get_column("x");
+    _y = _mock_node_b->get_column("y");
+  }
+
+ protected:
+  std::shared_ptr<MockNode> _mock_node_a, _mock_node_b;
+  std::shared_ptr<LQPColumnExpression> _a, _b, _c, _x, _y;
+};
+
+TEST_F(LQPUniqueConstraintTest, Equals) {
+  const auto unique_constraint_a = LQPUniqueConstraint({_a});
+  const auto unique_constraint_a_b_c = LQPUniqueConstraint({_a, _b, _c});
+
+  // Equal
+  EXPECT_EQ(unique_constraint_a, LQPUniqueConstraint({_a}));
+  EXPECT_EQ(unique_constraint_a_b_c, LQPUniqueConstraint({_a, _b, _c}));
+  EXPECT_EQ(unique_constraint_a_b_c, LQPUniqueConstraint({_b, _a, _c}));
+  EXPECT_EQ(unique_constraint_a_b_c, LQPUniqueConstraint({_b, _c, _a}));
+  // Not Equal
+  EXPECT_NE(unique_constraint_a, LQPUniqueConstraint({_a, _b}));
+  EXPECT_NE(unique_constraint_a, LQPUniqueConstraint({_b}));
+  EXPECT_NE(unique_constraint_a_b_c, LQPUniqueConstraint({_a, _b}));
+  EXPECT_NE(unique_constraint_a_b_c, LQPUniqueConstraint({_a, _b, _c, _x}));
+}
+
+TEST_F(LQPUniqueConstraintTest, Hash) {
+  const auto unique_constraint_a = LQPUniqueConstraint({_a});
+  const auto unique_constraint_a_b_c = LQPUniqueConstraint({_a, _b, _c});
+
+  // Equal Hash
+  EXPECT_EQ(unique_constraint_a.hash(), LQPUniqueConstraint({_a}).hash());
+  EXPECT_EQ(unique_constraint_a_b_c.hash(), LQPUniqueConstraint({_a, _b, _c}).hash());
+  EXPECT_EQ(unique_constraint_a_b_c.hash(), LQPUniqueConstraint({_c, _a, _b}).hash());
+  EXPECT_EQ(unique_constraint_a_b_c.hash(), LQPUniqueConstraint({_c, _b, _a}).hash());
+
+  // Non-Equal Hash
+  EXPECT_NE(unique_constraint_a.hash(), LQPUniqueConstraint({_a, _b}).hash());
+  EXPECT_NE(unique_constraint_a.hash(), LQPUniqueConstraint({_b}).hash());
+  EXPECT_NE(unique_constraint_a_b_c.hash(), LQPUniqueConstraint({_a, _b}).hash());
+  EXPECT_NE(unique_constraint_a_b_c.hash(), LQPUniqueConstraint({_a, _b, _c, _x}).hash());
+}
+
+}  // namespace opossum

--- a/src/test/lib/logical_query_plan/union_node_test.cpp
+++ b/src/test/lib/logical_query_plan/union_node_test.cpp
@@ -176,6 +176,9 @@ TEST_F(UnionNodeTest, FunctionalDependenciesUnionPositions) {
 }
 
 TEST_F(UnionNodeTest, FunctionalDependenciesUnionPositionsInvalidInput) {
+  // This test verifies a DebugAssert condition. Therefore, we do not want this test to run in release mode.
+  if constexpr (HYRISE_DEBUG) GTEST_SKIP();
+
   const auto trivial_fd_a = FunctionalDependency({_a}, {_b, _c});
   const auto non_trivial_fd_b = FunctionalDependency({_b}, {_a});
 

--- a/src/test/lib/logical_query_plan/union_node_test.cpp
+++ b/src/test/lib/logical_query_plan/union_node_test.cpp
@@ -109,12 +109,12 @@ TEST_F(UnionNodeTest, FunctionalDependenciesUnionAllSimple) {
   // Since all unique constraints become discarded, former trivial FDs become non-trivial:
   EXPECT_EQ(union_node_fds, union_node_non_trivial_fds);
 
+  EXPECT_EQ(union_node_fds.size(), 3);
   const auto& union_node_fds_set =
       std::unordered_set<FunctionalDependency>(union_node_fds.cbegin(), union_node_fds.cend());
-  EXPECT_EQ(union_node_fds_set.size(), 3);
   EXPECT_TRUE(union_node_fds_set.contains(trivial_fd_a));
-  EXPECT_TRUE(union_node_fds_set.contains(non_trivial_fd_c));
   EXPECT_TRUE(union_node_fds_set.contains(non_trivial_fd_b));
+  EXPECT_TRUE(union_node_fds_set.contains(non_trivial_fd_c));
 }
 
 TEST_F(UnionNodeTest, FunctionalDependenciesUnionAllIntersect) {

--- a/src/test/lib/logical_query_plan/union_node_test.cpp
+++ b/src/test/lib/logical_query_plan/union_node_test.cpp
@@ -177,7 +177,7 @@ TEST_F(UnionNodeTest, FunctionalDependenciesUnionPositions) {
 
 TEST_F(UnionNodeTest, FunctionalDependenciesUnionPositionsInvalidInput) {
   // This test verifies a DebugAssert condition. Therefore, we do not want this test to run in release mode.
-  if constexpr (HYRISE_DEBUG) GTEST_SKIP();
+  if constexpr (!HYRISE_DEBUG) GTEST_SKIP();
 
   const auto trivial_fd_a = FunctionalDependency({_a}, {_b, _c});
   const auto non_trivial_fd_b = FunctionalDependency({_b}, {_a});

--- a/src/test/lib/logical_query_plan/union_node_test.cpp
+++ b/src/test/lib/logical_query_plan/union_node_test.cpp
@@ -109,10 +109,12 @@ TEST_F(UnionNodeTest, FunctionalDependenciesUnionAllSimple) {
   // Since all unique constraints become discarded, former trivial FDs become non-trivial:
   EXPECT_EQ(union_node_fds, union_node_non_trivial_fds);
 
-  EXPECT_EQ(union_node_fds.size(), 3);
-  EXPECT_EQ(union_node_fds.at(0), trivial_fd_a);
-  EXPECT_EQ(union_node_fds.at(1), non_trivial_fd_c);
-  EXPECT_EQ(union_node_fds.at(2), non_trivial_fd_b);
+  const auto& union_node_fds_set =
+      std::unordered_set<FunctionalDependency>(union_node_fds.cbegin(), union_node_fds.cend());
+  EXPECT_EQ(union_node_fds_set.size(), 3);
+  EXPECT_TRUE(union_node_fds_set.contains(trivial_fd_a));
+  EXPECT_TRUE(union_node_fds_set.contains(non_trivial_fd_c));
+  EXPECT_TRUE(union_node_fds_set.contains(non_trivial_fd_b));
 }
 
 TEST_F(UnionNodeTest, FunctionalDependenciesUnionAllIntersect) {

--- a/src/test/lib/logical_query_plan/union_node_test.cpp
+++ b/src/test/lib/logical_query_plan/union_node_test.cpp
@@ -15,8 +15,6 @@ class UnionNodeTest : public BaseTest {
   void SetUp() override {
     _mock_node1 = MockNode::make(
         MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::Int, "c"}}, "t_a");
-    _mock_node2 = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "u"}, {DataType::Int, "v"}}, "t_b");
-
     _a = _mock_node1->get_column("a");
     _b = _mock_node1->get_column("b");
     _c = _mock_node1->get_column("c");
@@ -24,6 +22,10 @@ class UnionNodeTest : public BaseTest {
     _union_node = UnionNode::make(SetOperationMode::Positions);
     _union_node->set_left_input(_mock_node1);
     _union_node->set_right_input(_mock_node1);
+
+    _mock_node2 = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "u"}, {DataType::Int, "v"}}, "t_b");
+    _u = _mock_node2->get_column("u");
+    _v = _mock_node2->get_column("v");
   }
 
   std::shared_ptr<MockNode> _mock_node1, _mock_node2;
@@ -31,6 +33,8 @@ class UnionNodeTest : public BaseTest {
   std::shared_ptr<LQPColumnExpression> _a;
   std::shared_ptr<LQPColumnExpression> _b;
   std::shared_ptr<LQPColumnExpression> _c;
+  std::shared_ptr<LQPColumnExpression> _u;
+  std::shared_ptr<LQPColumnExpression> _v;
 };
 
 TEST_F(UnionNodeTest, Description) { EXPECT_EQ(_union_node->description(), "[UnionNode] Mode: Positions"); }
@@ -79,40 +83,144 @@ TEST_F(UnionNodeTest, Copy) { EXPECT_EQ(*_union_node->deep_copy(), *_union_node)
 
 TEST_F(UnionNodeTest, NodeExpressions) { ASSERT_EQ(_union_node->node_expressions.size(), 0u); }
 
-TEST_F(UnionNodeTest, FunctionalDependencies) {
-  // Create StoredTableNode with a single FD
-  const auto table_name = "t_a";
-  Hyrise::get().storage_manager.add_table(table_name, load_table("resources/test_data/tbl/int_int_float.tbl", 1));
-  const auto table = Hyrise::get().storage_manager.get_table(table_name);
-  table->add_soft_key_constraint({{_a->original_column_id}, KeyConstraintType::UNIQUE});
-  const auto stored_table_node = StoredTableNode::make(table_name);
-  EXPECT_EQ(stored_table_node->functional_dependencies().size(), 1);
-  // Create ValidateNode as it is required by UnionPositions
-  auto validate_node = ValidateNode::make(stored_table_node);
-  EXPECT_EQ(validate_node->functional_dependencies().size(), 1);
+TEST_F(UnionNodeTest, FunctionalDependenciesUnionAllSimple) {
+  const auto trivial_fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto non_trivial_fd_b = FunctionalDependency({_b}, {_a});
+  const auto non_trivial_fd_c = FunctionalDependency({_c}, {_b});
 
-  // Test UnionPositions (forward FDs)
-  auto union_positions_node = UnionNode::make(SetOperationMode::All);
-  union_positions_node->set_left_input(validate_node);
-  union_positions_node->set_right_input(validate_node);
+  // Set FDs
+  _mock_node1->set_key_constraints({{{_a->original_column_id}, KeyConstraintType::UNIQUE}});
+  _mock_node1->set_non_trivial_functional_dependencies({non_trivial_fd_b, non_trivial_fd_c});
+  EXPECT_EQ(_mock_node1->functional_dependencies().size(), 3);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(1), non_trivial_fd_c);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(2), trivial_fd_a);
 
-  Hyrise::get().reset();
+  // Create PredicateNodes & UnionPositionsNode
+  const auto& predicate_node_a = PredicateNode::make(greater_than_(_a, 5), _mock_node1);
+  const auto& predicate_node_b = PredicateNode::make(greater_than_(_b, 5), _mock_node1);
+  const auto& union_all_node = UnionNode::make(SetOperationMode::All);
+  union_all_node->set_left_input(predicate_node_a);
+  union_all_node->set_right_input(predicate_node_b);
+
+  // We expect all FDs to be forwarded since both input nodes have the same non-trivial FDs & unique constraints.
+  const auto& union_node_fds = union_all_node->functional_dependencies();
+  const auto& union_node_non_trivial_fds = union_all_node->non_trivial_functional_dependencies();
+  // Since all unique constraints become discarded, former trivial FDs become non-trivial:
+  EXPECT_EQ(union_node_fds, union_node_non_trivial_fds);
+
+  EXPECT_EQ(union_node_fds.size(), 3);
+  EXPECT_EQ(union_node_fds.at(0), trivial_fd_a);
+  EXPECT_EQ(union_node_fds.at(1), non_trivial_fd_c);
+  EXPECT_EQ(union_node_fds.at(2), non_trivial_fd_b);
+}
+
+TEST_F(UnionNodeTest, FunctionalDependenciesUnionAllIntersect) {
+  // Create single non-trivial FD
+  const auto non_trivial_fd_b = FunctionalDependency({_a}, {_b});
+  _mock_node1->set_non_trivial_functional_dependencies({non_trivial_fd_b});
+
+  /**
+   * Create UnionNode
+   * Hack: We use an AggregateNode with a pseudo-aggregate ANY(_c) to
+   *        - receive a new unique constraint and also
+   *        - a new trivial FD {_a, _b} => {_c}
+   */
+  const auto& projection_node_a = ProjectionNode::make(expression_vector(_a, _b, _c), _mock_node1);
+  const auto& aggregate_node = AggregateNode::make(expression_vector(_a, _b), expression_vector(any_(_c)), _mock_node1);
+  const auto& projection_node_b = ProjectionNode::make(expression_vector(_a, _b, _c), aggregate_node);
+
+  const auto& union_all_node = UnionNode::make(SetOperationMode::All);
+  union_all_node->set_left_input(projection_node_a);
+  union_all_node->set_right_input(projection_node_b);
+
+  // Prerequisite: Input nodes have differing FDs
+  const auto& expected_fd_a_b = FunctionalDependency({_a, _b}, {_c});
+  EXPECT_EQ(projection_node_a->functional_dependencies().size(), 1);
+  EXPECT_EQ(projection_node_a->functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(projection_node_b->functional_dependencies().size(), 2);
+  EXPECT_EQ(projection_node_b->functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(projection_node_b->functional_dependencies().at(1), expected_fd_a_b);
+
+  // Test: We expect both input FD-sets to be intersected. Therefore, only one FD should survive.
+  EXPECT_EQ(union_all_node->functional_dependencies().size(), 1);
+  EXPECT_EQ(union_all_node->functional_dependencies().at(0), non_trivial_fd_b);
+}
+
+TEST_F(UnionNodeTest, FunctionalDependenciesUnionPositions) {
+  const auto trivial_fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto non_trivial_fd_b = FunctionalDependency({_b}, {_a});
+
+  // Set FDs
+  _mock_node1->set_key_constraints({{{_a->original_column_id}, KeyConstraintType::UNIQUE}});
+  _mock_node1->set_non_trivial_functional_dependencies({non_trivial_fd_b});
+  EXPECT_EQ(_mock_node1->functional_dependencies().size(), 2);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(1), trivial_fd_a);
+
+  // Create PredicateNodes & UnionPositionsNode
+  const auto& predicate_node_a = PredicateNode::make(greater_than_(_a, 5), _mock_node1);
+  const auto& predicate_node_b = PredicateNode::make(greater_than_(_b, 5), _mock_node1);
+  const auto& union_positions_node = UnionNode::make(SetOperationMode::Positions);
+  union_positions_node->set_left_input(predicate_node_a);
+  union_positions_node->set_right_input(predicate_node_b);
+
+  // Positive Tests
+  EXPECT_EQ(union_positions_node->non_trivial_functional_dependencies().size(), 1);
+  EXPECT_EQ(union_positions_node->non_trivial_functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(union_positions_node->functional_dependencies().size(), 2);
+  EXPECT_EQ(union_positions_node->functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(union_positions_node->functional_dependencies().at(1), trivial_fd_a);
+}
+
+TEST_F(UnionNodeTest, FunctionalDependenciesUnionPositionsInvalidInput) {
+  const auto trivial_fd_a = FunctionalDependency({_a}, {_b, _c});
+  const auto non_trivial_fd_b = FunctionalDependency({_b}, {_a});
+
+  // Set FDs
+  _mock_node1->set_key_constraints({{{_a->original_column_id}, KeyConstraintType::UNIQUE}});
+  _mock_node1->set_non_trivial_functional_dependencies({non_trivial_fd_b});
+  EXPECT_EQ(_mock_node1->functional_dependencies().size(), 2);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(0), non_trivial_fd_b);
+  EXPECT_EQ(_mock_node1->functional_dependencies().at(1), trivial_fd_a);
+
+  // Create PredicateNodes & UnionPositionsNode
+  const auto& predicate_node_a = PredicateNode::make(greater_than_(_a, 5), _mock_node1);
+  const auto& predicate_node_b = PredicateNode::make(greater_than_(_b, 5), _mock_node2);
+  const auto& union_positions_node = UnionNode::make(SetOperationMode::Positions);
+  union_positions_node->set_left_input(predicate_node_a);
+  union_positions_node->set_right_input(predicate_node_b);
+
+  // Negative Tests
+  EXPECT_NE(predicate_node_a->non_trivial_functional_dependencies(),
+            predicate_node_b->non_trivial_functional_dependencies());
+  EXPECT_THROW(union_positions_node->non_trivial_functional_dependencies(), std::logic_error);
+  EXPECT_THROW(union_positions_node->functional_dependencies(), std::logic_error);
 }
 
 TEST_F(UnionNodeTest, UniqueConstraintsUnionPositions) {
   // Add two unique constraints to _mock_node1
   const auto key_constraint_a_b = TableKeyConstraint{{ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY};
   const auto key_constraint_b = TableKeyConstraint{{ColumnID{2}}, KeyConstraintType::UNIQUE};
-  _mock_node1->set_key_constraints(TableKeyConstraints{key_constraint_a_b, key_constraint_b});
+  _mock_node1->set_key_constraints({key_constraint_a_b, key_constraint_b});
   EXPECT_EQ(_mock_node1->unique_constraints()->size(), 2);
 
   // Check whether all unique constraints are forwarded
   EXPECT_TRUE(_union_node->left_input() == _mock_node1 && _union_node->right_input() == _mock_node1);
   EXPECT_EQ(*_union_node->unique_constraints(), *_mock_node1->unique_constraints());
+}
 
-  // Negative test: Input nodes with differing unique constraints should lead to failure
+TEST_F(UnionNodeTest, UniqueConstraintsUnionPositionsInvalidInput) {
+  const auto key_constraint_a_b = TableKeyConstraint{{ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY};
+  const auto key_constraint_b = TableKeyConstraint{{ColumnID{2}}, KeyConstraintType::UNIQUE};
+  _mock_node1->set_key_constraints(TableKeyConstraints{key_constraint_a_b, key_constraint_b});
+
   auto mock_node1_changed = static_pointer_cast<MockNode>(_mock_node1->deep_copy());
-  mock_node1_changed->set_key_constraints(TableKeyConstraints{key_constraint_a_b});
+  mock_node1_changed->set_key_constraints({key_constraint_a_b});
+
+  // Input nodes are not allowed to have differing unique constraints
+  EXPECT_EQ(_mock_node1->unique_constraints()->size(), 2);
+  EXPECT_EQ(mock_node1_changed->unique_constraints()->size(), 1);
   _union_node->set_right_input(mock_node1_changed);
   EXPECT_THROW(_union_node->unique_constraints(), std::logic_error);
 }


### PR DESCRIPTION
This PR adds an implementation and tests for functional dependencies in UnionNode with `SetOperationMode` set to `All`.

In the course of this, various FD-related utility functions have been added as well:

* inflate_fds
* deflate_fds
* intersect_fds

---

Furthermore, the hash functions of LQPUniqueConstraint & FunctionalDependency have been fixed, so that they are no longer dependent on the internal order of elements in its unordered sets. Additional tests that cover the hash-ordering issues have been added as well.