### PR TITLE
Table Scan: Improve all-rows-match shortcut

### DIFF
--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -170,7 +170,10 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
         matches_out->guarantee_single_chunk();
 
         // If the entire chunk is matched, create a EntireChunkPosList instead
-        const auto output_pos_list = matches_out->size() == chunk_in->size() ? static_cast<std::shared_ptr<AbstractPosList>>(std::make_shared<EntireChunkPosList>(chunk_id, chunk_in->size())) : static_cast<std::shared_ptr<AbstractPosList>>(matches_out);
+        const auto output_pos_list = matches_out->size() == chunk_in->size()
+                                         ? static_cast<std::shared_ptr<AbstractPosList>>(
+                                               std::make_shared<EntireChunkPosList>(chunk_id, chunk_in->size()))
+                                         : static_cast<std::shared_ptr<AbstractPosList>>(matches_out);
 
         for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
           auto ref_segment_out = std::make_shared<ReferenceSegment>(in_table, column_id, output_pos_list);

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -162,7 +162,8 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
               }
             }
 
-            const auto ref_segment_out = std::make_shared<ReferenceSegment>(table_out, column_id_out, filtered_pos_list);
+            const auto ref_segment_out =
+                std::make_shared<ReferenceSegment>(table_out, column_id_out, filtered_pos_list);
             out_segments.push_back(ref_segment_out);
           }
         }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -149,8 +149,8 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
               } else {
                 // When segments reference multiple chunks, we do not keep the sort order of the input chunk. The main
                 // reason is that several table scan implementations split the pos lists by chunks (see
-                // AbstractDereferencedColumnTableScanImpl::_scan_reference_segment) and thus shuffle the data. While this
-                // does not affect all scan implementations, we chose the safe and defensive path for now.
+                // AbstractDereferencedColumnTableScanImpl::_scan_reference_segment) and thus shuffle the data. While
+                // this does not affect all scan implementations, we chose the safe and defensive path for now.
                 keep_chunk_sort_order = false;
               }
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -107,6 +107,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
       if (matches_out->empty()) return;
 
       Segments out_segments;
+      out_segments.reserve(in_table->column_count());
 
       /**
        * matches_out contains a list of row IDs into this chunk. If this is not a reference table, we can directly use
@@ -119,48 +120,60 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
        */
       auto keep_chunk_sort_order = true;
       if (in_table->type() == TableType::References) {
-        auto filtered_pos_lists = std::map<std::shared_ptr<const AbstractPosList>, std::shared_ptr<RowIDPosList>>{};
-
-        for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
-          auto segment_in = chunk_in->get_segment(column_id);
-
-          auto ref_segment_in = std::dynamic_pointer_cast<const ReferenceSegment>(segment_in);
-          DebugAssert(ref_segment_in, "All segments should be of type ReferenceSegment.");
-
-          const auto pos_list_in = ref_segment_in->pos_list();
-
-          const auto table_out = ref_segment_in->referenced_table();
-          const auto column_id_out = ref_segment_in->referenced_column_id();
-
-          auto& filtered_pos_list = filtered_pos_lists[pos_list_in];
-
-          if (!filtered_pos_list) {
-            filtered_pos_list = std::make_shared<RowIDPosList>(matches_out->size());
-            if (pos_list_in->references_single_chunk()) {
-              filtered_pos_list->guarantee_single_chunk();
-            } else {
-              // When segments reference multiple chunks, we do not keep the sort order of the input chunk. The main
-              // reason is that several table scan implementations split the pos lists by chunks (see
-              // AbstractDereferencedColumnTableScanImpl::_scan_reference_segment) and thus shuffle the data. While this
-              // does not affect all scan implementations, we chose the safe and defensive path for now.
-              keep_chunk_sort_order = false;
-            }
-
-            size_t offset = 0;
-            for (const auto& match : *matches_out) {
-              const auto row_id = (*pos_list_in)[match.chunk_offset];
-              (*filtered_pos_list)[offset] = row_id;
-              ++offset;
-            }
+        if (matches_out->size() == chunk_in->size()) {
+          // Shortcut - the entire input reference segment matches, so we can simply forward that chunk
+          for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
+            auto segment_in = chunk_in->get_segment(column_id);
+            out_segments.emplace_back(segment_in);
           }
+        } else {
+          auto filtered_pos_lists = std::map<std::shared_ptr<const AbstractPosList>, std::shared_ptr<RowIDPosList>>{};
 
-          auto ref_segment_out = std::make_shared<ReferenceSegment>(table_out, column_id_out, filtered_pos_list);
-          out_segments.push_back(ref_segment_out);
+          for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
+            auto segment_in = chunk_in->get_segment(column_id);
+
+            auto ref_segment_in = std::dynamic_pointer_cast<const ReferenceSegment>(segment_in);
+            DebugAssert(ref_segment_in, "All segments should be of type ReferenceSegment.");
+
+            const auto pos_list_in = ref_segment_in->pos_list();
+
+            const auto table_out = ref_segment_in->referenced_table();
+            const auto column_id_out = ref_segment_in->referenced_column_id();
+
+            auto& filtered_pos_list = filtered_pos_lists[pos_list_in];
+
+            if (!filtered_pos_list) {
+              filtered_pos_list = std::make_shared<RowIDPosList>(matches_out->size());
+              if (pos_list_in->references_single_chunk()) {
+                filtered_pos_list->guarantee_single_chunk();
+              } else {
+                // When segments reference multiple chunks, we do not keep the sort order of the input chunk. The main
+                // reason is that several table scan implementations split the pos lists by chunks (see
+                // AbstractDereferencedColumnTableScanImpl::_scan_reference_segment) and thus shuffle the data. While this
+                // does not affect all scan implementations, we chose the safe and defensive path for now.
+                keep_chunk_sort_order = false;
+              }
+
+              size_t offset = 0;
+              for (const auto& match : *matches_out) {
+                const auto row_id = (*pos_list_in)[match.chunk_offset];
+                (*filtered_pos_list)[offset] = row_id;
+                ++offset;
+              }
+            }
+
+            auto ref_segment_out = std::make_shared<ReferenceSegment>(table_out, column_id_out, filtered_pos_list);
+            out_segments.push_back(ref_segment_out);
+          }
         }
       } else {
         matches_out->guarantee_single_chunk();
+
+        // If the entire chunk is matched, create a EntireChunkPosList instead
+        const auto output_pos_list = matches_out->size() == chunk_in->size() ? static_cast<std::shared_ptr<AbstractPosList>>(std::make_shared<EntireChunkPosList>(chunk_id, chunk_in->size())) : static_cast<std::shared_ptr<AbstractPosList>>(matches_out);
+
         for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
-          auto ref_segment_out = std::make_shared<ReferenceSegment>(in_table, column_id, matches_out);
+          auto ref_segment_out = std::make_shared<ReferenceSegment>(in_table, column_id, output_pos_list);
           out_segments.push_back(ref_segment_out);
         }
       }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -123,14 +123,14 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
         if (matches_out->size() == chunk_in->size()) {
           // Shortcut - the entire input reference segment matches, so we can simply forward that chunk
           for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
-            auto segment_in = chunk_in->get_segment(column_id);
+            const auto segment_in = chunk_in->get_segment(column_id);
             out_segments.emplace_back(segment_in);
           }
         } else {
           auto filtered_pos_lists = std::map<std::shared_ptr<const AbstractPosList>, std::shared_ptr<RowIDPosList>>{};
 
           for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
-            auto segment_in = chunk_in->get_segment(column_id);
+            const auto segment_in = chunk_in->get_segment(column_id);
 
             auto ref_segment_in = std::dynamic_pointer_cast<const ReferenceSegment>(segment_in);
             DebugAssert(ref_segment_in, "All segments should be of type ReferenceSegment.");
@@ -162,7 +162,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
               }
             }
 
-            auto ref_segment_out = std::make_shared<ReferenceSegment>(table_out, column_id_out, filtered_pos_list);
+            const auto ref_segment_out = std::make_shared<ReferenceSegment>(table_out, column_id_out, filtered_pos_list);
             out_segments.push_back(ref_segment_out);
           }
         }
@@ -175,8 +175,8 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
                                                std::make_shared<EntireChunkPosList>(chunk_id, chunk_in->size()))
                                          : static_cast<std::shared_ptr<AbstractPosList>>(matches_out);
 
-        for (ColumnID column_id{0u}; column_id < in_table->column_count(); ++column_id) {
-          auto ref_segment_out = std::make_shared<ReferenceSegment>(in_table, column_id, output_pos_list);
+        for (auto column_id = ColumnID{0u}; column_id < in_table->column_count(); ++column_id) {
+          const auto ref_segment_out = std::make_shared<ReferenceSegment>(in_table, column_id, output_pos_list);
           out_segments.push_back(ref_segment_out);
         }
       }

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
@@ -124,8 +124,14 @@ void ColumnBetweenTableScanImpl::_scan_dictionary_segment(
       const auto output_size = position_filter ? position_filter->size() : segment.size();
       const auto output_start_offset = matches.size();
       matches.resize(matches.size() + output_size);
+
+      // Make the compiler try harder to vectorize the trivial loop below.
+      // This empty block is used to convince clang-format to keep the pragma indented.
+      // NOLINTNEXTLINE
+      {}  // clang-format off
       #pragma omp simd
-      for (auto chunk_offset = ChunkOffset{0}; chunk_offset < output_size; ++chunk_offset) {
+      // clang-format on
+      for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(output_size); ++chunk_offset) {
         matches[output_start_offset + chunk_offset] = RowID{chunk_id, chunk_offset};
       }
     }

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
@@ -109,14 +109,26 @@ void ColumnBetweenTableScanImpl::_scan_dictionary_segment(
   auto attribute_vector_iterable = create_iterable_from_attribute_vector(segment);
 
   /**
-   * Early out: All entries (except NULLs) match
+   * Early out: All entries (possibly except NULLs) match
    */
   // NOLINTNEXTLINE - cpplint is drunk
   if (lower_bound_value_id == ValueID{0} && upper_bound_value_id == INVALID_VALUE_ID) {
-    attribute_vector_iterable.with_iterators(position_filter, [&](auto left_it, auto left_end) {
-      static const auto always_true = [](const auto&) { return true; };
-      _scan_with_iterators<true>(always_true, left_it, left_end, chunk_id, matches);
-    });
+    if (_column_is_nullable) {
+      // We still have to check for NULLs
+      attribute_vector_iterable.with_iterators(position_filter, [&](auto left_it, auto left_end) {
+        static const auto always_true = [](const auto&) { return true; };
+        _scan_with_iterators<true>(always_true, left_it, left_end, chunk_id, matches);
+      });
+    } else {
+      // No NULLs, all entries match.
+      const auto output_size = position_filter ? position_filter->size() : segment.size();
+      const auto output_start_offset = matches.size();
+      matches.resize(matches.size() + output_size);
+      #pragma omp simd
+      for (auto chunk_offset = ChunkOffset{0}; chunk_offset < output_size; ++chunk_offset) {
+        matches[output_start_offset + chunk_offset] = RowID{chunk_id, chunk_offset};
+      }
+    }
 
     return;
   }

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
@@ -132,6 +132,8 @@ void ColumnBetweenTableScanImpl::_scan_dictionary_segment(
       #pragma omp simd
       // clang-format on
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(output_size); ++chunk_offset) {
+        // `matches` might already contain entries if it is called multiple times by
+        // AbstractDereferencedColumnTableScanImpl::_scan_reference_segment.
         matches[output_start_offset + chunk_offset] = RowID{chunk_id, chunk_offset};
       }
     }

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -132,6 +132,8 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(
       #pragma omp simd
       // clang-format on
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(output_size); ++chunk_offset) {
+        // `matches` might already contain entries if it is called multiple times by
+        // AbstractDereferencedColumnTableScanImpl::_scan_reference_segment.
         matches[output_start_offset + chunk_offset] = RowID{chunk_id, chunk_offset};
       }
     }

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -113,11 +113,21 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(
   auto iterable = create_iterable_from_attribute_vector(segment);
 
   if (_value_matches_all(segment, search_value_id)) {
-    iterable.with_iterators(position_filter, [&](auto it, auto end) {
-      static const auto always_true = [](const auto&) { return true; };
-      // Matches all, so include all rows except those with NULLs in the result.
-      _scan_with_iterators<true>(always_true, it, end, chunk_id, matches);
-    });
+    if (_column_is_nullable) {
+      // We still have to check for NULLs
+      iterable.with_iterators(position_filter, [&](auto it, auto end) {
+        static const auto always_true = [](const auto&) { return true; };
+        _scan_with_iterators<true>(always_true, it, end, chunk_id, matches);
+      });
+    } else {
+      // No NULLs, all rows match.
+      const auto output_size = position_filter ? position_filter->size() : segment.size();
+      const auto output_start_offset = matches.size();
+      matches.resize(matches.size() + output_size);
+      for (auto chunk_offset = ChunkOffset{0}; chunk_offset < output_size; ++chunk_offset) {
+        matches[output_start_offset + chunk_offset] = RowID{chunk_id, chunk_offset};
+      }      
+    }
 
     return;
   }

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -111,8 +111,8 @@ std::pair<SubqueryToJoinRule::PredicatePullUpResult, bool> pull_up_correlated_pr
         node->right_input(), parameter_mapping, result_cache, are_inputs_below_aggregate);
     right_input_adapted = right_result.adapted_lqp;
     for (const auto& expression : right_result.required_output_expressions) {
-      const auto find_it = std::find(result.required_output_expressions.cbegin(),
-                                     result.required_output_expressions.cend(), expression);
+      const auto find_it =
+          std::find(result.required_output_expressions.cbegin(), result.required_output_expressions.cend(), expression);
       if (find_it == result.required_output_expressions.cend()) {
         result.required_output_expressions.emplace_back(expression);
       }


### PR DESCRIPTION
If the dictionary lookup shows that all values in the chunk match, we still need to make sure not to return any NULL rows. With this PR, we use the NULLable flag to skip this check where possible.

Additionally, this adds a shortcut in the generation of the output chunks if the entire chunk matches: Instead of creating a new ReferenceSegment (and potentially rebuilding the mapping), we simply forward the input chunk. This part is easier to review with whitespace changes hidden.

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 1  |
| numactl | membind: 1  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 6a043ce6c | 26.08.2020 11:52 | Implement FDs for UnionNode (SetOperationMode::All) & Fix hashing of FDs and LQPUniqueConstraints (#2192) | real 284.02 user 2425.89 sys 137.99|
| 2376397ee | 26.08.2020 12:54 | bla | real 282.53 user 2421.01 sys 138.32|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +2%
</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_6a043ce6c12946a09907b625f3b2db7d152b9cd0_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_2376397eeaec77b65e2df4b3ec93de3273d1ea06_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                         | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-08-26 12:59:53                                                                                                                    | 2020-08-26 19:11:55                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    820.8 |   814.8 |   -1%  ||     1.22 |     1.23 |   +1%  |  0.2470 |
 | TPC-H 02 ||      4.7 |     4.7 |   -1%  ||   210.81 |   213.31 |   +1%  |  0.1288 |
 | TPC-H 03 ||     83.2 |    82.0 |   -1%  ||    12.02 |    12.20 |   +1%  |  0.0000 |
 | TPC-H 04 ||     67.9 |    67.3 |   -1%  ||    14.73 |    14.86 |   +1%  |  0.0000 |
+| TPC-H 05 ||    223.9 |   212.0 |   -5%  ||     4.47 |     4.72 |   +6%  |  0.0000 |
+| TPC-H 06 ||      3.6 |     3.2 |  -12%  ||   277.25 |   313.52 |  +13%  |  0.0000 |
 | TPC-H 07 ||     59.3 |    58.3 |   -2%  ||    16.86 |    17.16 |   +2%  |  0.0668 |
 | TPC-H 08 ||     65.9 |    65.8 |   -0%  ||    15.16 |    15.19 |   +0%  |  0.7943 |
 | TPC-H 09 ||    516.9 |   511.9 |   -1%  ||     1.93 |     1.95 |   +1%  |  0.0054 |
 | TPC-H 10 ||    254.3 |   250.1 |   -2%  ||     3.93 |     4.00 |   +2%  |  0.1059 |
 | TPC-H 11 ||      8.6 |     8.6 |   -0%  ||   116.15 |   116.57 |   +0%  |  0.0017 |
 | TPC-H 12 ||     45.0 |    43.6 |   -3%  ||    22.23 |    22.96 |   +3%  |  0.0000 |
 | TPC-H 13 ||    359.2 |   349.6 |   -3%  ||     2.78 |     2.86 |   +3%  |  0.0000 |
 | TPC-H 14 ||     21.3 |    20.9 |   -2%  ||    46.87 |    47.79 |   +2%  |  0.0000 |
 | TPC-H 15 ||      7.9 |     8.0 |   +1%  ||   126.26 |   124.92 |   -1%  |  0.0000 |
 | TPC-H 16 ||     93.7 |    90.8 |   -3%  ||    10.67 |    11.01 |   +3%  |  0.0000 |
 | TPC-H 17 ||     21.7 |    21.4 |   -1%  ||    46.13 |    46.78 |   +1%  |  0.0000 |
+| TPC-H 18 ||    736.3 |   672.7 |   -9%  ||     1.36 |     1.49 |   +9%  |  0.0000 |
 | TPC-H 19 ||     33.5 |    32.9 |   -2%  ||    29.87 |    30.37 |   +2%  |  0.0000 |
 | TPC-H 20 ||     17.7 |    16.9 |   -4%  ||    56.52 |    59.07 |   +5%  |  0.0000 |
 | TPC-H 21 ||    417.3 |   416.7 |   -0%  ||     2.40 |     2.40 |   +0%  |  0.7268 |
 | TPC-H 22 ||     52.1 |    52.0 |   -0%  ||    19.18 |    19.22 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3914.9 |  3804.2 |   -3%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +5%
</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_6a043ce6c12946a09907b625f3b2db7d152b9cd0_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_2376397eeaec77b65e2df4b3ec93de3273d1ea06_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                         | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-08-26 13:22:12                                                                                                                    | 2020-08-26 19:34:14                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                          | [0, 56, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   2494.9 |  2314.7 |   -7%  ||    19.36 |    21.03 |   +9%  |  0.0001 |
 | TPC-H 02 ||     21.3 |    20.9 |   -2%  ||  1937.86 |  1963.99 |   +1%  |  0.0000 |
+| TPC-H 03 ||    449.2 |   420.3 |   -6%  ||   108.55 |   115.95 |   +7%  |  0.0000 |
 | TPC-H 04 ||    241.3 |   241.1 |   -0%  ||   198.99 |   199.17 |   +0%  |  0.9562 |
 | TPC-H 05 ||   1211.3 |  1203.9 |   -1%  ||    40.28 |    40.48 |   +0%  |  0.8250 |
+| TPC-H 06 ||     22.6 |    18.2 |  -20%  ||  1675.90 |  2309.89 |  +38%  |  0.0000 |
 | TPC-H 07 ||    228.7 |   224.3 |   -2%  ||   211.10 |   215.08 |   +2%  |  0.0914 |
 | TPC-H 08 ||    370.3 |   365.4 |   -1%  ||   126.58 |   128.18 |   +1%  |  0.3052 |
 | TPC-H 09 ||   2449.3 |  2454.2 |   +0%  ||    19.46 |    19.52 |   +0%  |  0.9496 |
 | TPC-H 10 ||   1423.1 |  1423.1 |   +0%  ||    34.43 |    34.56 |   +0%  |  0.9987 |
 | TPC-H 11 ||     61.9 |    62.1 |   +0%  ||   749.85 |   748.00 |   -0%  |  0.5761 |
+| TPC-H 12 ||    123.7 |   115.9 |   -6%  ||   364.32 |   389.09 |   +7%  |  0.0000 |
 | TPC-H 13 ||   2065.1 |  2045.0 |   -1%  ||    23.67 |    23.75 |   +0%  |  0.6947 |
 | TPC-H 14 ||    128.8 |   127.4 |   -1%  ||   373.63 |   377.36 |   +1%  |  0.0313 |
+| TPC-H 15 ||     54.1 |    48.6 |  -10%  ||   848.71 |   936.69 |  +10%  |  0.0000 |
 | TPC-H 16 ||    424.8 |   415.9 |   -2%  ||   115.76 |   118.01 |   +2%  |  0.0348 |
 | TPC-H 17 ||    165.8 |   158.2 |   -5%  ||   206.27 |   214.95 |   +4%  |  0.0000 |
 | TPC-H 18 ||   5874.9 |  5886.6 |   +0%  ||     8.18 |     8.00 |   -2%  |  0.9473 |
+| TPC-H 19 ||    215.8 |   198.6 |   -8%  ||   213.65 |   232.22 |   +9%  |  0.0000 |
+| TPC-H 20 ||     61.9 |    53.1 |  -14%  ||   745.16 |   860.06 |  +15%  |  0.0000 |
 | TPC-H 21 ||   2223.6 |  2229.6 |   +0%  ||    21.43 |    21.55 |   +1%  |  0.9430 |
 | TPC-H 22 ||    610.9 |   614.3 |   +1%  ||    79.06 |    79.27 |   +0%  |  0.8140 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  20923.3 | 20641.3 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +5%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_6a043ce6c12946a09907b625f3b2db7d152b9cd0_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_2376397eeaec77b65e2df4b3ec93de3273d1ea06_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                          | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-08-26 13:44:44                                                                                                                     | 2020-08-26 19:56:42                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+

 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     30.7 |    30.6 |   -0%  ||    32.59 |    32.67 |   +0%  |  0.0350 |
 | 03      ||      6.6 |     6.6 |   +0%  ||   152.54 |   152.01 |   -0%  |  0.0000 |
 | 06      ||     20.2 |    20.3 |   +0%  ||    49.42 |    49.18 |   -0%  |  0.0000 |
 | 07      ||     56.7 |    56.4 |   -1%  ||    17.63 |    17.72 |   +1%  |  0.0000 |
 | 09      ||    106.6 |   106.9 |   +0%  ||     9.38 |     9.36 |   -0%  |  0.0001 |
 | 10      ||     19.8 |    19.8 |   +0%  ||    50.53 |    50.52 |   -0%  |  0.7650 |
+| 13      ||    134.2 |   121.3 |  -10%  ||     7.45 |     8.25 |  +11%  |  0.0000 |
 | 15      ||     12.1 |    11.9 |   -2%  ||    82.71 |    84.01 |   +2%  |  0.0000 |
 | 17      ||     31.0 |    30.6 |   -1%  ||    32.25 |    32.69 |   +1%  |  0.0361 |
 | 19      ||     11.3 |    11.3 |   -1%  ||    88.39 |    88.87 |   +1%  |  0.0000 |
 | 25      ||     18.0 |    18.1 |   +0%  ||    55.40 |    55.24 |   -0%  |  0.6337 |
 | 26      ||     29.3 |    29.0 |   -1%  ||    34.08 |    34.49 |   +1%  |  0.0000 |
 | 28      ||     93.8 |    91.6 |   -2%  ||    10.66 |    10.92 |   +2%  |  0.0000 |
 | 29      ||     30.8 |    30.6 |   -1%  ||    32.46 |    32.66 |   +1%  |  0.3532 |
 | 31      ||    129.3 |   129.3 |   +0%  ||     7.73 |     7.73 |   -0%  |  0.7642 |
 | 34      ||     29.0 |    28.9 |   -0%  ||    34.47 |    34.55 |   +0%  |  0.0000 |
 | 35      ||     99.9 |   101.0 |   +1%  ||    10.01 |     9.91 |   -1%  |  0.0000 |
 | 39a     ||    208.0 |   207.5 |   -0%  ||     4.81 |     4.82 |   +0%  |  0.0537 |
 | 39b     ||    207.4 |   206.9 |   -0%  ||     4.82 |     4.83 |   +0%  |  0.0044 |
 | 41      ||     26.3 |    26.4 |   +0%  ||    37.98 |    37.92 |   -0%  |  0.0050 |
 | 42      ||      7.6 |     7.6 |   -0%  ||   131.65 |   132.07 |   +0%  |  0.0000 |
 | 43      ||    246.4 |   247.1 |   +0%  ||     4.06 |     4.05 |   -0%  |  0.0000 |
 | 45      ||     10.5 |    10.5 |   -0%  ||    95.30 |    95.42 |   +0%  |  0.0185 |
 | 48      ||     98.8 |    94.5 |   -4%  ||    10.12 |    10.59 |   +5%  |  0.0000 |
 | 50      ||     12.3 |    12.3 |   +0%  ||    81.54 |    81.30 |   -0%  |  0.0001 |
 | 52      ||      7.7 |     7.7 |   -0%  ||   129.53 |   129.53 |   +0%  |  0.8315 |
 | 55      ||      7.6 |     7.6 |   -0%  ||   131.54 |   131.72 |   +0%  |  0.0000 |
 | 62      ||     78.9 |    78.8 |   -0%  ||    12.68 |    12.69 |   +0%  |  0.0020 |
 | 65      ||     72.9 |    73.5 |   +1%  ||    13.71 |    13.60 |   -1%  |  0.0000 |
 | 69      ||     24.9 |    24.8 |   -0%  ||    40.19 |    40.33 |   +0%  |  0.0000 |
 | 73      ||     18.6 |    18.6 |   -0%  ||    53.64 |    53.81 |   +0%  |  0.0000 |
 | 79      ||     51.6 |    51.6 |   +0%  ||    19.37 |    19.36 |   -0%  |  0.3924 |
 | 81      ||     20.0 |    19.9 |   -0%  ||    50.06 |    50.26 |   +0%  |  0.0000 |
 | 83      ||      9.9 |     9.8 |   -0%  ||   101.45 |   101.63 |   +0%  |  0.0000 |
+| 85      ||     62.1 |    57.6 |   -7%  ||    16.09 |    17.35 |   +8%  |  0.0003 |
 | 88      ||    107.6 |   107.6 |   +0%  ||     9.29 |     9.29 |   -0%  |  0.9927 |
+| 91      ||     21.1 |    19.5 |   -7%  ||    47.43 |    51.16 |   +8%  |  0.0000 |
 | 93      ||    260.7 |   260.5 |   -0%  ||     3.84 |     3.84 |   +0%  |  0.7194 |
 | 96      ||      9.9 |     9.9 |   -0%  ||   100.97 |   100.98 |   +0%  |  0.6989 |
 | 97      ||    397.9 |   396.1 |   -0%  ||     2.51 |     2.52 |   +0%  |  0.4542 |
 | 99      ||    160.8 |   158.3 |   -2%  ||     6.22 |     6.32 |   +2%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   2988.8 |  2958.9 |   -1%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_6a043ce6c12946a09907b625f3b2db7d152b9cd0_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_2376397eeaec77b65e2df4b3ec93de3273d1ea06_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                          | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-08-26 14:25:51                                                                                                                     | 2020-08-26 20:37:49                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                           | [0, 56, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+

 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    198.2 |   197.9 |   -0%  ||   245.57 |   245.93 |   +0%  |  0.8547 |
-| 03      ||     95.8 |   108.8 |  +14%  ||   445.56 |   392.02 |  -12%  |  0.0000 |
 | 06      ||    122.7 |   122.2 |   -0%  ||   390.49 |   391.86 |   +0%  |  0.5969 |
 | 07      ||    418.6 |   418.0 |   -0%  ||   113.11 |   113.18 |   +0%  |  0.9087 |
 | 09      ||    524.7 |   531.7 |   +1%  ||    93.15 |    90.98 |   -2%  |  0.6607 |
 | 10      ||     89.7 |    89.1 |   -1%  ||   521.55 |   524.39 |   +1%  |  0.4168 |
+| 13      ||    432.2 |   387.0 |  -10%  ||   113.82 |   126.64 |  +11%  |  0.0000 |
 | 15      ||     70.0 |    69.4 |   -1%  ||   667.46 |   673.38 |   +1%  |  0.1079 |
 | 17      ||    158.2 |   157.8 |   -0%  ||   292.23 |   293.47 |   +0%  |  0.7563 |
-| 19      ||    222.9 |   254.8 |  +14%  ||   190.29 |   164.15 |  -14%  |  0.0000 |
-| 25      ||    230.5 |   269.4 |  +17%  ||   192.72 |   164.46 |  -15%  |  0.0000 |
 | 26      ||    258.6 |   259.4 |   +0%  ||   188.53 |   188.12 |   -0%  |  0.7806 |
 | 28      ||    191.1 |   173.6 |   -9%  ||   225.92 |   236.73 |   +5%  |  0.0000 |
 | 29      ||    171.6 |   170.9 |   -0%  ||   275.46 |   276.45 |   +0%  |  0.6913 |
 | 31      ||    706.3 |   700.7 |   -1%  ||    68.67 |    69.15 |   +1%  |  0.7672 |
 | 34      ||    133.6 |   133.4 |   -0%  ||   356.09 |   356.73 |   +0%  |  0.8279 |
 | 35      ||    864.0 |   859.4 |   -1%  ||    56.88 |    56.96 |   +0%  |  0.7973 |
 | 39a     ||   1506.2 |  1512.2 |   +0%  ||    32.17 |    32.31 |   +0%  |  0.8763 |
 | 39b     ||   1514.0 |  1480.2 |   -2%  ||    32.20 |    32.39 |   +1%  |  0.3902 |
-| 41      ||   1302.8 |  1445.7 |  +11%  ||    33.38 |    31.45 |   -6%  |  0.1745 |
-| 42      ||     95.4 |   110.7 |  +16%  ||   420.51 |   363.86 |  -13%  |  0.0000 |
 | 43      ||    744.7 |   734.9 |   -1%  ||    66.16 |    66.79 |   +1%  |  0.2942 |
 | 45      ||     53.4 |    53.3 |   -0%  ||   853.80 |   854.19 |   +0%  |  0.8631 |
 | 48      ||    467.1 |   469.7 |   +1%  ||   103.27 |   103.61 |   +0%  |  0.7398 |
 | 50      ||    140.1 |   142.9 |   +2%  ||   308.17 |   299.60 |   -3%  |  0.0116 |
 | 52      ||     96.4 |    97.1 |   +1%  ||   419.54 |   418.22 |   -0%  |  0.3149 |
 | 55      ||     96.4 |    97.1 |   +1%  ||   421.34 |   418.65 |   -1%  |  0.2434 |
 | 62      ||    305.9 |   305.2 |   -0%  ||   160.25 |   160.66 |   +0%  |  0.7783 |
 | 65      ||    607.3 |   605.3 |   -0%  ||    81.12 |    81.38 |   +0%  |  0.7744 |
 | 69      ||    151.3 |   150.5 |   -1%  ||   309.70 |   310.71 |   +0%  |  0.5809 |
 | 73      ||     98.2 |    98.0 |   -0%  ||   478.54 |   479.11 |   +0%  |  0.8103 |
 | 79      ||    238.7 |   237.5 |   -0%  ||   203.48 |   204.41 |   +0%  |  0.5808 |
 | 81      ||    134.9 |   133.9 |   -1%  ||   356.58 |   359.51 |   +1%  |  0.2587 |
 | 83      ||     68.1 |    68.5 |   +1%  ||   685.99 |   682.01 |   -1%  |  0.3856 |
 | 85      ||    256.3 |   252.7 |   -1%  ||   190.12 |   192.72 |   +1%  |  0.2719 |
 | 88      ||    739.8 |   726.9 |   -2%  ||    49.12 |    48.75 |   -1%  |  0.3244 |
+| 91      ||     86.0 |    77.9 |   -9%  ||   551.29 |   605.31 |  +10%  |  0.0000 |
 | 93      ||   1203.3 |  1205.5 |   +0%  ||    40.51 |    40.46 |   -0%  |  0.9459 |
 | 96      ||    134.3 |   135.5 |   +1%  ||   343.29 |   340.43 |   -1%  |  0.2333 |
 | 97      ||   3379.2 |  3439.9 |   +2%  ||    13.98 |    14.00 |   +0%  |  0.5425 |
 | 99      ||    785.3 |   780.9 |   -1%  ||    62.56 |    62.85 |   +0%  |  0.6974 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  19093.8 | 19265.8 |   +1%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +6%
 ||
Geometric mean of throughput changes: -4%
</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_6a043ce6c12946a09907b625f3b2db7d152b9cd0_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_2376397eeaec77b65e2df4b3ec93de3273d1ea06_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                         | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-08-26 15:07:09                                                                                                                    | 2020-08-26 21:19:06                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     64.9 |    67.8 |   +4%  ||     2.05 |     1.95 |   -5%  | (run time too short) |
 | New-Order    ||     28.7 |    29.8 |   +4%  ||    22.76 |    21.87 |   -4%  | (run time too short) |
 | Order-Status ||      1.5 |     1.5 |   +1%  ||     2.00 |     1.93 |   -3%  | (run time too short) |
 | Payment      ||      3.3 |     3.4 |   +3%  ||    21.73 |    20.84 |   -4%  | (run time too short) |
-| Stock-Level  ||     67.2 |    72.7 |   +8%  ||     2.03 |     1.93 |   -5%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    165.7 |   175.3 |   +6%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -4%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: -2%
</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_6a043ce6c12946a09907b625f3b2db7d152b9cd0_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_2376397eeaec77b65e2df4b3ec93de3273d1ea06_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                         | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-08-26 15:08:13                                                                                                                    | 2020-08-26 21:20:11                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                          | [0, 56, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
+| Delivery     ||    343.6 |   324.8 |   -5%  ||     2.82 |     2.97 |   +5%  | (run time too short) |
 |    unsucc.:  ||      4.8 |     4.7 |   -3%  ||    92.12 |    91.28 |   -1%  |                      |
 | New-Order    ||    140.8 |   149.6 |   +6%  ||    60.30 |    57.54 |   -5%  |               0.0000 |
 |    unsucc.:  ||      6.3 |     6.1 |   -3%  ||  1007.87 |  1003.10 |   -0%  |                      |
 | Order-Status ||      8.3 |     8.3 |   +1%  ||    94.99 |    94.29 |   -1%  | (run time too short) |
-| Payment      ||     18.6 |    18.4 |   -1%  ||     6.56 |     6.03 |   -8%  | (run time too short) |
 |    unsucc.:  ||      5.0 |     4.9 |   -1%  ||  1014.18 |  1007.53 |   -1%  |                      |
 | Stock-Level  ||    113.0 |   117.0 |   +4%  ||    94.77 |    94.09 |   -1%  |               0.0000 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    624.2 |   618.1 |   -1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +1%
</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_6a043ce6c12946a09907b625f3b2db7d152b9cd0_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2376397eeaec77b65e2df4b3ec93de3273d1ea06_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                              | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-08-26 15:09:19                                                                                                                         | 2020-08-26 21:21:16                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+

 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    347.8 |    348.1 |   +0%  ||     2.88 |     2.87 |   -0%  |  0.7396 |
 | 10b     ||    349.5 |    348.8 |   -0%  ||     2.86 |     2.87 |   +0%  |  0.3529 |
 | 10c     ||   1159.7 |   1163.8 |   +0%  ||     0.86 |     0.86 |   -0%  |  0.4414 |
 | 11a     ||    150.5 |    149.2 |   -1%  ||     6.64 |     6.70 |   +1%  |  0.3675 |
 | 11b     ||    140.0 |    139.2 |   -1%  ||     7.14 |     7.18 |   +1%  |  0.5693 |
+| 11c     ||    544.8 |    517.5 |   -5%  ||     1.84 |     1.93 |   +5%  |  0.0000 |
+| 11d     ||   5227.7 |   4712.5 |  -10%  ||     0.19 |     0.21 |  +11%  |  0.0000 |
 | 12a     ||    364.4 |    364.4 |   +0%  ||     2.74 |     2.74 |   -0%  |  0.9971 |
 | 12b     ||    623.0 |    624.9 |   +0%  ||     1.61 |     1.60 |   -0%  |  0.7414 |
 | 12c     ||   3696.1 |   3718.1 |   +1%  ||     0.27 |     0.27 |   -1%  |  0.5463 |
 | 13a     ||    170.5 |    171.1 |   +0%  ||     5.86 |     5.84 |   -0%  |  0.0047 |
+| 13b     ||    273.9 |    248.9 |   -9%  ||     3.65 |     4.02 |  +10%  |  0.0000 |
+| 13c     ||    154.0 |    135.2 |  -12%  ||     6.49 |     7.39 |  +14%  |  0.0000 |
 | 13d     ||    170.5 |    170.8 |   +0%  ||     5.87 |     5.85 |   -0%  |  0.0496 |
 | 14a     ||   4037.3 |   4044.5 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.8516 |
 | 14b     ||   4655.2 |   4677.0 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.6148 |
 | 14c     ||   4031.7 |   4043.7 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.7496 |
 | 15a     ||    224.8 |    224.3 |   -0%  ||     4.45 |     4.46 |   +0%  |  0.7120 |
 | 15b     ||    214.6 |    214.8 |   +0%  ||     4.66 |     4.65 |   -0%  |  0.7860 |
 | 15c     ||    154.8 |    151.0 |   -2%  ||     6.46 |     6.62 |   +3%  |  0.0000 |
+| 15d     ||    509.5 |    466.8 |   -8%  ||     1.96 |     2.14 |   +9%  |  0.0000 |
+| 16a     ||   5051.1 |   4707.0 |   -7%  ||     0.20 |     0.21 |   +7%  |  0.0013 |
+| 16b     ||   6769.8 |   6167.7 |   -9%  ||     0.15 |     0.16 |  +10%  |       ˅ |
+| 16c     ||   5233.6 |   4812.5 |   -8%  ||     0.19 |     0.21 |   +9%  |  0.0000 |
+| 16d     ||   5257.0 |   4814.7 |   -8%  ||     0.19 |     0.21 |   +9%  |  0.0000 |
 | 17a     ||   1012.2 |    977.4 |   -3%  ||     0.99 |     1.02 |   +4%  |  0.0000 |
 | 17b     ||    772.7 |    772.0 |   -0%  ||     1.29 |     1.30 |   +0%  |  0.8670 |
 | 17c     ||    726.7 |    726.7 |   +0%  ||     1.38 |     1.38 |   -0%  |  0.9912 |
 | 17d     ||    838.0 |    839.5 |   +0%  ||     1.19 |     1.19 |   -0%  |  0.7509 |
+| 17e     ||   3166.3 |   2923.9 |   -8%  ||     0.32 |     0.34 |   +8%  |  0.0000 |
+| 17f     ||   1670.0 |   1581.0 |   -5%  ||     0.60 |     0.63 |   +6%  |  0.0000 |
 | 18a     ||    673.2 |    671.5 |   -0%  ||     1.49 |     1.49 |   +0%  |  0.6210 |
 | 18b     ||    246.1 |    245.6 |   -0%  ||     4.06 |     4.07 |   +0%  |  0.6864 |
 | 18c     ||   3735.7 |   3752.8 |   +0%  ||     0.27 |     0.27 |   -0%  |  0.4073 |
 | 19a     ||   7756.1 |   7706.3 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | 19b     ||   4622.5 |   4623.6 |   +0%  ||     0.22 |     0.22 |   -0%  |  0.9424 |
 | 19c     ||   7500.7 |   7480.5 |   -0%  ||     0.13 |     0.13 |   +0%  |       ˅ |
+| 19d     ||   6072.3 |   5698.5 |   -6%  ||     0.16 |     0.18 |   +7%  |  0.0000 |
 | 1a      ||     60.2 |     59.6 |   -1%  ||    16.61 |    16.79 |   +1%  |  0.0000 |
 | 1b      ||     22.8 |     22.7 |   -1%  ||    43.82 |    44.06 |   +1%  |  0.0000 |
 | 1c      ||     22.7 |     22.6 |   -0%  ||    43.98 |    44.16 |   +0%  |  0.0000 |
 | 1d      ||     22.4 |     22.5 |   +0%  ||    44.55 |    44.51 |   -0%  |  0.0082 |
 | 20a     ||   1312.8 |   1269.9 |   -3%  ||     0.76 |     0.79 |   +3%  |  0.0000 |
 | 20b     ||   1130.4 |   1109.3 |   -2%  ||     0.88 |     0.90 |   +2%  |  0.0000 |
 | 20c     ||   1178.3 |   1134.0 |   -4%  ||     0.85 |     0.88 |   +4%  |  0.0000 |
 | 21a     ||   3821.0 |   3827.9 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.5535 |
 | 21b     ||    257.7 |    255.7 |   -1%  ||     3.88 |     3.91 |   +1%  |  0.0038 |
 | 21c     ||   3943.2 |   3950.1 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.5653 |
 | 22a     ||   3455.3 |   3478.7 |   +1%  ||     0.29 |     0.29 |   -1%  |  0.4400 |
 | 22b     ||   3452.0 |   3479.0 |   +1%  ||     0.29 |     0.29 |   -1%  |  0.3709 |
 | 22c     ||   4052.7 |   4066.6 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.6519 |
 | 22d     ||   4075.4 |   4087.9 |   +0%  ||     0.25 |     0.24 |   -0%  |  0.6795 |
 | 23a     ||    153.7 |    152.1 |   -1%  ||     6.51 |     6.57 |   +1%  |  0.0144 |
 | 23b     ||    117.3 |    117.6 |   +0%  ||     8.53 |     8.50 |   -0%  |  0.3521 |
 | 23c     ||    175.3 |    172.1 |   -2%  ||     5.71 |     5.81 |   +2%  |  0.0000 |
 | 24a     ||   4759.2 |   4687.3 |   -2%  ||     0.21 |     0.21 |   +2%  |  0.0343 |
 | 24b     ||   4691.6 |   4625.9 |   -1%  ||     0.21 |     0.22 |   +1%  |  0.3541 |
 | 25a     ||    247.3 |    247.0 |   -0%  ||     4.04 |     4.05 |   +0%  |  0.7705 |
 | 25b     ||    254.5 |    255.3 |   +0%  ||     3.93 |     3.92 |   -0%  |  0.3404 |
 | 25c     ||   3746.6 |   3763.3 |   +0%  ||     0.27 |     0.27 |   -0%  |  0.3664 |
 | 26a     ||   1006.5 |    984.8 |   -2%  ||     0.99 |     1.02 |   +2%  |  0.0000 |
 | 26b     ||    999.8 |    977.4 |   -2%  ||     1.00 |     1.02 |   +2%  |  0.0009 |
 | 26c     ||   1008.2 |    984.6 |   -2%  ||     0.99 |     1.02 |   +2%  |  0.0000 |
 | 27a     ||   3465.1 |   3495.1 |   +1%  ||     0.29 |     0.29 |   -1%  |  0.1077 |
 | 27b     ||   3427.0 |   3456.6 |   +1%  ||     0.29 |     0.29 |   -1%  |  0.1146 |
 | 27c     ||    200.3 |    197.2 |   -2%  ||     4.99 |     5.07 |   +2%  |  0.0468 |
 | 28a     ||   4093.3 |   4107.2 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8837 |
 | 28b     ||   3362.9 |   3394.3 |   +1%  ||     0.30 |     0.29 |   -1%  |  0.7413 |
 | 28c     ||   4089.9 |   4109.0 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8373 |
 | 29a     ||   4678.3 |   4598.0 |   -2%  ||     0.21 |     0.22 |   +2%  |  0.5810 |
 | 29b     ||    191.6 |    191.8 |   +0%  ||     5.22 |     5.21 |   -0%  |  0.9839 |
 | 29c     ||   4758.1 |   4682.7 |   -2%  ||     0.21 |     0.21 |   +2%  |  0.6288 |
 | 2a      ||    104.2 |    104.0 |   -0%  ||     9.60 |     9.62 |   +0%  |  0.0003 |
 | 2b      ||     80.8 |     80.9 |   +0%  ||    12.38 |    12.37 |   -0%  |  0.2108 |
 | 2c      ||     51.8 |     51.8 |   -0%  ||    19.29 |    19.31 |   +0%  |  0.0207 |
 | 2d      ||    130.8 |    130.4 |   -0%  ||     7.64 |     7.67 |   +0%  |  0.0000 |
 | 30a     ||    261.8 |    261.4 |   -0%  ||     3.82 |     3.82 |   +0%  |  0.9395 |
 | 30b     ||   1101.0 |   1102.4 |   +0%  ||     0.91 |     0.91 |   -0%  |  0.9488 |
 | 30c     ||   3768.2 |   3788.4 |   +1%  ||     0.27 |     0.26 |   -1%  |  0.8052 |
 | 31a     ||    291.5 |    291.0 |   -0%  ||     3.43 |     3.44 |   +0%  |  0.8380 |
 | 31b     ||   1126.0 |   1125.0 |   -0%  ||     0.89 |     0.89 |   +0%  |  0.9407 |
 | 31c     ||    295.6 |    295.2 |   -0%  ||     3.38 |     3.39 |   +0%  |  0.8973 |
 | 32a     ||     37.3 |     36.9 |   -1%  ||    26.82 |    27.10 |   +1%  |  0.0000 |
 | 32b     ||    281.5 |    283.1 |   +1%  ||     3.55 |     3.53 |   -1%  |  0.0000 |
 | 33a     ||     70.9 |     70.9 |   +0%  ||    14.10 |    14.10 |   -0%  |  0.9856 |
 | 33b     ||     69.6 |     69.8 |   +0%  ||    14.36 |    14.33 |   -0%  |  0.7301 |
 | 33c     ||     85.0 |     84.8 |   -0%  ||    11.76 |    11.79 |   +0%  |  0.7469 |
 | 3a      ||   3930.9 |   3946.7 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.0000 |
 | 3b      ||     34.8 |     34.3 |   -2%  ||    28.72 |    29.19 |   +2%  |  0.0000 |
 | 3c      ||   5012.4 |   5033.1 |   +0%  ||     0.20 |     0.20 |   -0%  |  0.0541 |
 | 4a      ||    127.6 |    127.5 |   -0%  ||     7.83 |     7.84 |   +0%  |  0.2065 |
 | 4b      ||     26.2 |     26.2 |   -0%  ||    38.10 |    38.13 |   +0%  |  0.0940 |
 | 4c      ||    144.4 |    144.3 |   -0%  ||     6.93 |     6.93 |   +0%  |  0.6492 |
 | 5a      ||   3757.0 |   3771.8 |   +0%  ||     0.27 |     0.27 |   -0%  |  0.0000 |
 | 5b      ||    276.8 |    275.8 |   -0%  ||     3.61 |     3.63 |   +0%  |  0.0031 |
 | 5c      ||   4357.5 |   4376.0 |   +0%  ||     0.23 |     0.23 |   -0%  |  0.0000 |
 | 6a      ||    243.3 |    243.8 |   +0%  ||     4.11 |     4.10 |   -0%  |  0.0095 |
 | 6b      ||    955.0 |    954.1 |   -0%  ||     1.05 |     1.05 |   +0%  |  0.6844 |
 | 6c      ||    243.8 |    243.6 |   -0%  ||     4.10 |     4.11 |   +0%  |  0.2181 |
 | 6d      ||    956.9 |    954.0 |   -0%  ||     1.04 |     1.05 |   +0%  |  0.0187 |
 | 6e      ||    244.3 |    243.8 |   -0%  ||     4.09 |     4.10 |   +0%  |  0.0021 |
 | 6f      ||   1526.9 |   1504.8 |   -1%  ||     0.65 |     0.66 |   +1%  |  0.0000 |
+| 7a      ||    271.9 |    249.8 |   -8%  ||     3.68 |     4.00 |   +9%  |  0.0000 |
 | 7b      ||    123.0 |    123.0 |   -0%  ||     8.13 |     8.13 |   +0%  |  0.9926 |
+| 7c      ||  12123.8 |  10831.2 |  -11%  ||     0.08 |     0.09 |  +12%  |       ˅ |
 | 8a      ||    110.1 |    107.3 |   -3%  ||     9.08 |     9.32 |   +3%  |  0.0000 |
 | 8b      ||    163.4 |    161.5 |   -1%  ||     6.12 |     6.19 |   +1%  |  0.0001 |
 | 8c      ||   4603.6 |   4395.2 |   -5%  ||     0.22 |     0.23 |   +5%  |  0.0000 |
 | 8d      ||   1579.9 |   1568.0 |   -1%  ||     0.63 |     0.64 |   +1%  |  0.0038 |
 | 9a      ||   3480.2 |   3462.1 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.3013 |
 | 9b      ||    337.3 |    330.9 |   -2%  ||     2.96 |     3.02 |   +2%  |  0.0002 |
 | 9c      ||   3498.1 |   3494.0 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.8186 |
 | 9d      ||   4134.2 |   4099.4 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.1346 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 220557.1 | 215599.8 |   -2%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -9%
 ||
Geometric mean of throughput changes: +6%
</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_6a043ce6c12946a09907b625f3b2db7d152b9cd0_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2376397eeaec77b65e2df4b3ec93de3273d1ea06_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 6a043ce6c12946a09907b625f3b2db7d152b9cd0-dirty                                                                                              | 2376397eeaec77b65e2df4b3ec93de3273d1ea06-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-08-26 17:04:58                                                                                                                         | 2020-08-26 23:17:05                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                               | [0, 56, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+

 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)     | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |       new |        ||      old |      new |        |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
+| 10a     ||    2433.1 |    2317.2 |   -5%  ||    14.75 |    16.43 |  +11%  |  0.0996 |
+| 10b     ||    1849.2 |    1640.9 |  -11%  ||    18.25 |    21.50 |  +18%  |  0.0000 |
 | 10c     ||    8412.4 |    8430.5 |   +0%  ||     4.78 |     4.65 |   -3%  |  0.9747 |
 | 11a     ||     825.1 |     786.1 |   -5%  ||    46.53 |    48.79 |   +5%  |  0.0068 |
+| 11b     ||     735.3 |     715.5 |   -3%  ||    47.93 |    50.88 |   +6%  |  0.0927 |
+| 11c     ||    2867.9 |    2276.2 |  -21%  ||    16.57 |    21.01 |  +27%  |  0.0000 |
+| 11d     ||   34287.6 |   23419.1 |  -32%  ||     0.95 |     1.53 |  +61%  |  0.0000 |
 | 12a     ||    3569.5 |    3595.0 |   +1%  ||    13.31 |    13.18 |   -1%  |  0.8850 |
 | 12b     ||    1341.4 |    1315.5 |   -2%  ||    31.78 |    31.75 |   -0%  |  0.4157 |
 | 12c     ||   18058.6 |   19591.1 |   +8%  ||     1.88 |     1.92 |   +2%  |  0.3223 |
 | 13a     ||    1090.3 |    1074.9 |   -1%  ||    40.00 |    40.63 |   +2%  |  0.5373 |
+| 13b     ||    1648.2 |    1213.3 |  -26%  ||    24.18 |    33.55 |  +39%  |  0.0000 |
+| 13c     ||    1586.2 |    1185.0 |  -25%  ||    23.96 |    34.28 |  +43%  |  0.0000 |
 | 13d     ||    1096.0 |    1081.3 |   -1%  ||    39.61 |    40.18 |   +1%  |  0.5915 |
 | 14a     ||   17843.8 |   17083.1 |   -4%  ||     2.22 |     2.18 |   -2%  |  0.4662 |
 | 14b     ||   17837.1 |   16858.6 |   -5%  ||     2.08 |     2.12 |   +2%  |  0.3847 |
-| 14c     ||   16726.3 |   16611.6 |   -1%  ||     2.30 |     2.18 |   -5%  |  0.9161 |
+| 15a     ||    1841.8 |    1732.8 |   -6%  ||    23.88 |    25.77 |   +8%  |  0.0124 |
 | 15b     ||    1380.1 |    1334.1 |   -3%  ||    32.43 |    33.56 |   +3%  |  0.1143 |
+| 15c     ||     766.8 |     727.0 |   -5%  ||    60.11 |    63.68 |   +6%  |  0.0072 |
+| 15d     ||    2696.4 |    2269.5 |  -16%  ||    16.73 |    20.22 |  +21%  |  0.0000 |
+| 16a     ||   38028.8 |   29180.2 |  -23%  ||     0.73 |     1.03 |  +41%  |  0.0002 |
+| 16b     ||   48807.7 |   36309.6 |  -26%  ||     0.55 |     0.78 |  +42%  |  0.0000 |
+| 16c     ||   39893.2 |   27212.3 |  -32%  ||     0.63 |     0.92 |  +45%  |  0.0000 |
+| 16d     ||   37111.9 |   30737.9 |  -17%  ||     0.68 |     0.90 |  +32%  |  0.0047 |
 | 17a     ||    6816.5 |    8539.2 |  +25%  ||     4.57 |     4.75 |   +4%  |  0.0014 |
+| 17b     ||    8074.0 |    7776.4 |   -4%  ||     4.38 |     4.78 |   +9%  |  0.4874 |
 | 17c     ||    8051.3 |    8062.6 |   +0%  ||     4.40 |     4.58 |   +4%  |  0.9770 |
 | 17d     ||    8390.9 |    8355.8 |   -0%  ||     4.23 |     4.27 |   +1%  |  0.9354 |
+| 17e     ||   16689.1 |   11670.2 |  -30%  ||     2.32 |     3.20 |  +38%  |  0.0000 |
 | 17f     ||   13001.5 |   12158.1 |   -6%  ||     2.88 |     2.92 |   +1%  |  0.3634 |
 | 18a     ||    4227.1 |    4437.2 |   +5%  ||    10.25 |    10.22 |   -0%  |  0.3611 |
+| 18b     ||    2352.3 |    2062.5 |  -12%  ||    18.95 |    21.00 |  +11%  |  0.0003 |
 | 18c     ||   16654.0 |   16377.6 |   -2%  ||     2.20 |     2.25 |   +2%  |  0.7512 |
 | 19a     ||   33587.6 |   31352.4 |   -7%  ||     0.93 |     0.92 |   -2%  |  0.3198 |
 | 19b     ||    9877.9 |   11487.0 |  +16%  ||     3.35 |     3.43 |   +2%  |  0.0295 |
 | 19c     ||   33409.3 |   31632.4 |   -5%  ||     0.92 |     0.92 |   +0%  |  0.3671 |
+| 19d     ||   44533.4 |   31609.3 |  -29%  ||     0.57 |     1.03 |  +82%  |  0.0000 |
 | 1a      ||     301.9 |     305.5 |   +1%  ||   154.81 |   153.03 |   -1%  |  0.3966 |
 | 1b      ||      67.3 |      67.4 |   +0%  ||   614.59 |   615.99 |   +0%  |  0.8376 |
 | 1c      ||      73.9 |      73.9 |   +0%  ||   602.45 |   601.99 |   -0%  |  0.9744 |
 | 1d      ||      67.1 |      67.2 |   +0%  ||   619.82 |   617.36 |   -0%  |  0.8645 |
 | 20a     ||    8955.6 |    8659.9 |   -3%  ||     4.42 |     4.45 |   +1%  |  0.5104 |
+| 20b     ||    9112.5 |    8438.2 |   -7%  ||     4.35 |     4.80 |  +10%  |  0.0784 |
 | 20c     ||    9786.1 |    8763.6 |  -10%  ||     3.85 |     3.78 |   -2%  |  0.0380 |
 | 21a     ||   14413.0 |   14121.7 |   -2%  ||     2.65 |     2.73 |   +3%  |  0.7263 |
 | 21b     ||     981.9 |     986.0 |   +0%  ||    48.97 |    49.35 |   +1%  |  0.8909 |
+| 21c     ||   14533.5 |   14331.9 |   -1%  ||     2.42 |     2.63 |   +9%  |  0.8007 |
 | 22a     ||   16346.0 |   15990.3 |   -2%  ||     2.38 |     2.28 |   -4%  |  0.7494 |
 | 22b     ||   16233.3 |   15591.9 |   -4%  ||     2.25 |     2.25 |   +0%  |  0.5860 |
 | 22c     ||   16487.1 |   15900.0 |   -4%  ||     2.28 |     2.25 |   -1%  |  0.5503 |
 | 22d     ||   16179.1 |   17056.0 |   +5%  ||     2.23 |     2.20 |   -1%  |  0.4434 |
 | 23a     ||     498.3 |     497.0 |   -0%  ||    93.85 |    94.37 |   +1%  |  0.8774 |
+| 23b     ||    2180.9 |    1994.6 |   -9%  ||    18.30 |    19.98 |   +9%  |  0.0046 |
 | 23c     ||     536.4 |     523.8 |   -2%  ||    87.46 |    90.25 |   +3%  |  0.1833 |
+| 24a     ||   14164.6 |   12590.3 |  -11%  ||     2.62 |     2.92 |  +11%  |  0.0229 |
+| 24b     ||   12238.5 |   10898.4 |  -11%  ||     3.23 |     3.40 |   +5%  |  0.0485 |
+| 25a     ||    2542.3 |    2196.9 |  -14%  ||    17.05 |    19.95 |  +17%  |  0.0000 |
+| 25b     ||    2469.4 |    2033.4 |  -18%  ||    14.93 |    17.28 |  +16%  |  0.0000 |
+| 25c     ||   16871.6 |   16059.8 |   -5%  ||     2.13 |     2.42 |  +13%  |  0.3499 |
+| 26a     ||    3009.8 |    2776.5 |   -8%  ||    12.12 |    13.23 |   +9%  |  0.0063 |
+| 26b     ||    3561.2 |    3029.5 |  -15%  ||    11.65 |    13.85 |  +19%  |  0.0000 |
+| 26c     ||    3012.3 |    2613.8 |  -13%  ||    10.92 |    12.63 |  +16%  |  0.0000 |
 | 27a     ||   14336.3 |   16300.7 |  +14%  ||     2.42 |     2.40 |   -1%  |  0.0510 |
 | 27b     ||   16201.4 |   14682.2 |   -9%  ||     2.43 |     2.43 |   +0%  |  0.2044 |
 | 27c     ||    2148.5 |    2141.0 |   -0%  ||    17.97 |    17.93 |   -0%  |  0.8986 |
 | 28a     ||   16638.6 |   17412.6 |   +5%  ||     2.25 |     2.25 |   +0%  |  0.5038 |
 | 28b     ||   15557.5 |   15831.9 |   +2%  ||     2.53 |     2.53 |   -0%  |  0.8099 |
 | 28c     ||   16267.2 |   15798.7 |   -3%  ||     2.13 |     2.15 |   +1%  |  0.6644 |
+| 29a     ||   11498.0 |   10513.9 |   -9%  ||     2.93 |     3.58 |  +22%  |  0.2481 |
+| 29b     ||    2820.1 |    2614.4 |   -7%  ||    16.43 |    17.36 |   +6%  |  0.0936 |
+| 29c     ||   15387.8 |   14675.3 |   -5%  ||     2.35 |     2.67 |  +13%  |  0.4091 |
 | 2a      ||     879.4 |     863.5 |   -2%  ||    50.60 |    51.58 |   +2%  |  0.5157 |
 | 2b      ||     985.0 |     944.2 |   -4%  ||    43.78 |    44.95 |   +3%  |  0.0728 |
 | 2c      ||     470.9 |     451.3 |   -4%  ||    64.99 |    67.56 |   +4%  |  0.0001 |
 | 2d      ||     840.9 |     832.1 |   -1%  ||    53.08 |    53.78 |   +1%  |  0.6810 |
+| 30a     ||    2413.4 |    2211.5 |   -8%  ||    18.15 |    19.68 |   +8%  |  0.0191 |
 | 30b     ||    3033.5 |    2928.4 |   -3%  ||    13.93 |    14.31 |   +3%  |  0.3376 |
 | 30c     ||   17110.0 |   16757.4 |   -2%  ||     2.08 |     2.07 |   -1%  |  0.7662 |
+| 31a     ||    2411.4 |    2381.1 |   -1%  ||    12.61 |    13.33 |   +6%  |  0.6316 |
 | 31b     ||    3066.4 |    3018.9 |   -2%  ||    11.08 |    11.35 |   +2%  |  0.5056 |
+| 31c     ||    2749.3 |    2530.3 |   -8%  ||    13.65 |    14.35 |   +5%  |  0.0069 |
 | 32a     ||      68.8 |      70.0 |   +2%  ||   405.47 |   405.58 |   +0%  |  0.0000 |
 | 32b     ||    1121.7 |    1147.5 |   +2%  ||    41.85 |    40.88 |   -2%  |  0.3072 |
 | 33a     ||     416.1 |     405.3 |   -3%  ||   111.70 |   114.98 |   +3%  |  0.0823 |
 | 33b     ||     324.1 |     317.2 |   -2%  ||   145.26 |   148.87 |   +2%  |  0.1130 |
 | 33c     ||     384.2 |     383.8 |   -0%  ||   120.89 |   121.45 |   +0%  |  0.9374 |
 | 3a      ||   15738.2 |   13991.6 |  -11%  ||     2.22 |     2.22 |   -0%  |  0.1348 |
 | 3b      ||     623.9 |     601.0 |   -4%  ||    70.43 |    72.14 |   +2%  |  0.0021 |
-| 3c      ||   29937.8 |   29604.7 |   -1%  ||     1.13 |     0.98 |  -13%  |  0.8658 |
 | 4a      ||     921.2 |     925.4 |   +0%  ||    52.64 |    52.66 |   +0%  |  0.8597 |
 | 4b      ||     239.4 |     229.5 |   -4%  ||   165.45 |   173.03 |   +5%  |  0.0001 |
 | 4c      ||    1114.0 |    1121.1 |   +1%  ||    43.03 |    43.28 |   +1%  |  0.8316 |
 | 5a      ||   12851.5 |   14949.6 |  +16%  ||     2.55 |     2.67 |   +5%  |  0.0090 |
 | 5b      ||    1073.5 |    1082.1 |   +1%  ||    36.62 |    36.63 |   +0%  |  0.6783 |
 | 5c      ||   18325.5 |   18801.9 |   +3%  ||     1.98 |     2.07 |   +4%  |  0.7259 |
 | 6a      ||    4662.7 |    4366.6 |   -6%  ||     7.82 |     8.15 |   +4%  |  0.1102 |
+| 6b      ||    6598.1 |    6290.8 |   -5%  ||     5.10 |     5.37 |   +5%  |  0.3312 |
 | 6c      ||    4371.4 |    4711.3 |   +8%  ||     8.07 |     8.23 |   +2%  |  0.0746 |
 | 6d      ||    6497.2 |    6939.3 |   +7%  ||     5.45 |     5.45 |   -0%  |  0.1344 |
 | 6e      ||    4496.2 |    4119.9 |   -8%  ||     7.97 |     7.95 |   -0%  |  0.0153 |
 | 6f      ||    7271.6 |    7220.8 |   -1%  ||     5.42 |     5.50 |   +2%  |  0.9020 |
 | 7a      ||    2464.9 |    2270.6 |   -8%  ||    15.68 |    16.03 |   +2%  |  0.0069 |
 | 7b      ||    1836.9 |    1789.5 |   -3%  ||    24.55 |    24.92 |   +1%  |  0.3495 |
+| 7c      ||   50598.0 |   41662.8 |  -18%  ||     0.15 |     0.17 |  +11%  |       ˅ |
+| 8a      ||    2222.5 |    2107.0 |   -5%  ||    19.52 |    20.65 |   +6%  |  0.0689 |
 | 8b      ||    1765.0 |    1777.5 |   +1%  ||    24.46 |    24.40 |   -0%  |  0.8051 |
+| 8c      ||   25093.4 |   23934.1 |   -5%  ||     1.13 |     1.30 |  +15%  |  0.5397 |
 | 8d      ||   10898.4 |   10237.8 |   -6%  ||     3.90 |     3.83 |   -2%  |  0.3710 |
-| 9a      ||   20792.2 |   21027.5 |   +1%  ||     1.78 |     1.58 |  -11%  |  0.8336 |
 | 9b      ||    3410.3 |    3400.5 |   -0%  ||    12.42 |    12.37 |   -0%  |  0.9498 |
 | 9c      ||   20875.8 |   22407.1 |   +7%  ||     1.52 |     1.50 |   -1%  |  0.3932 |
 | 9d      ||   23635.4 |   21186.1 |  -10%  ||     1.60 |     1.62 |   +1%  |  0.1461 |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Sum     || 1118469.1 | 1021755.8 |   -9%  ||          |          |        |         |
+| Geomean ||           |           |        ||          |          |   +6%  |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                    |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
```
</details>