### PR TITLE
Import cached binary tables: fail for inconsistent chunk sizes

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -298,7 +298,7 @@ for (placeholder, final) in [
             unit_column = header_strings[column_id + 1]
             previous_length = len(title_column) + len(unit_column) + 1
             new_title = f" {final} ".ljust(previous_length, " ")
-            lines[1] = "|".join(header_strings[:column_id] + [new_title] + header_strings[column_id + 2:])
+            lines[1] = "|".join(header_strings[:column_id] + [new_title] + header_strings[column_id + 2 :])
 
 
 # Swap second line of header with automatically added separator. Terminaltables does not support multi-line headers. So
@@ -340,9 +340,9 @@ if github_format:
     table_string_reformatted = "```diff\n"
     table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "\n"
     for line in table_string.splitlines():
-        if (green_control_sequence + "+" in line) or ('| Sum ' in line and green_control_sequence in line):
+        if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):
             table_string_reformatted += "+"
-        elif (red_control_sequence + "-" in line) or ('| Sum ' in line and red_control_sequence in line):
+        elif (red_control_sequence + "-" in line) or ("| Sum " in line and red_control_sequence in line):
             table_string_reformatted += "-"
         else:
             table_string_reformatted += " "

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -177,7 +177,8 @@ void AbstractTableGenerator::generate_and_store() {
       const auto& table = table_info.table;
       if (table->chunk_count() > 1 && table->get_chunk(ChunkID{0})->size() != _benchmark_config->chunk_size) {
         Fail("Table '" + table_name + "' was loaded from binary, but has a mismatching chunk size of " +
-             std::to_string(table->get_chunk(ChunkID{0})->size()));
+             std::to_string(table->get_chunk(ChunkID{0})->size()) +
+             ". Delete cached files or use '--dont_cache_binary_tables'.");
       }
     }
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -176,8 +176,8 @@ void AbstractTableGenerator::generate_and_store() {
     for (auto& [table_name, table_info] : table_info_by_name) {
       const auto& table = table_info.table;
       if (table->chunk_count() > 1 && table->get_chunk(ChunkID{0})->size() != _benchmark_config->chunk_size) {
-        std::cout << "- WARNING: " << table_name << " was loaded from binary, but has a mismatching chunk size of "
-                  << table->get_chunk(ChunkID{0})->size() << std::endl;
+        Fail("Table '" + table_name + "' was loaded from binary, but has a mismatching chunk size of " +
+             std::to_string(table->get_chunk(ChunkID{0})->size()));
       }
     }
 


### PR DESCRIPTION
With this PR, the table generator fails if an imported cached binary table has a different chunk size than the one defined in the benchmark configuration.

Additionally, this PR introduces minor format changes in `compare_benchmarks.py`, performed by our format script.