### PR TITLE
Fix division by zero in compare benchmark test

### DIFF
--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -10,6 +10,9 @@ import subprocess
 # The next two functions check for string matches instead of using math.isclose() since extracting values from
 # ANSI-colored text turned out to be too cumbersome.
 def assert_latency_equals(item_count, runtimes, latency_string):
+    if item_count == 0:
+        assert 'nan' in latency_string
+        return
     avg_latency = sum(runtimes) / item_count / 1_000_000
     assert str(round(avg_latency, 1)) in latency_string
 


### PR DESCRIPTION
Checking for edge case, when there has been not a single successful run (apparently happens in the CI).
There is no error when the throughput is calculated on an empty set of runs.

Resolves #2196.