### PR TITLE
Fix problems with flake8 linter and E203

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -96,7 +96,7 @@ if [[ ${output} ]]; then
 fi
 
 # Python linting
-output=$(flake8 --max-line-length 120 scripts)
+output=$(flake8 --max-line-length 120 --extend-ignore=E203 scripts)
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1


### PR DESCRIPTION
E203 is broken and it is recommended to ignored it (see https://github.com/psf/black/issues/280).
Currently, `black` correctly adds spaces around colons in some cases and `flake8` marks them as errors due to the broken E203.

This PR extends the ignore list by adding E203 (note, the default settings of `flake8` already ignore several warnings).

Resolves #2200.