### PR TITLE
Hash Join: Merge output chunks <500 rows

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -547,25 +547,39 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     output_chunks.reserve(expected_output_chunk_count);
 
     // For every partition, create a reference segment.
-    for (size_t partition_id = 0, output_chunk_id{0}; partition_id < build_side_pos_lists.size(); ++partition_id) {
+    auto partition_id = size_t{0};
+    auto output_chunk_id = size_t{0};
+    while (partition_id < build_side_pos_lists.size()) {
       // Moving the values into a shared pos list saves us some work in write_output_segments. We know that
       // build_pos_lists and probe_side_pos_lists will not be used again.
       auto build_side_pos_list = std::make_shared<RowIDPosList>(std::move(build_side_pos_lists[partition_id]));
       auto probe_side_pos_list = std::make_shared<RowIDPosList>(std::move(probe_side_pos_lists[partition_id]));
 
       if (build_side_pos_list->empty() && probe_side_pos_list->empty()) {
+        ++partition_id;
         continue;
       }
 
-      const auto MIN_SIZE = 500;
-      const auto MAX_SIZE = MIN_SIZE * 2;
+      // If the input is heavily pre-filtered or the join results in very few matches, we might end up with a high
+      // number of chunks that contain only few rows. If a PosList is smaller than MIN_SIZE, we merge it with the
+      // following PosList(s) until a size between MIN_SIZE and MAX_SIZE is reached. This involves a trade-off:
+      // A lower number of output chunks reduces the overhead, especially when multi-threading is used. However,
+      // merging chunks destroys a potential references_single_chunk property of the PosList that would have been
+      // emitted otherwise.
+      constexpr auto MIN_SIZE = 500;
+      constexpr auto MAX_SIZE = MIN_SIZE * 2;
       build_side_pos_list->reserve(MAX_SIZE);
       probe_side_pos_list->reserve(MAX_SIZE);
-      while (partition_id + 1 < probe_side_pos_lists.size() && probe_side_pos_list->size() < MIN_SIZE && probe_side_pos_list->size() + probe_side_pos_lists[partition_id + 1].size() < MAX_SIZE) {
-        std::copy(build_side_pos_lists[partition_id + 1].begin(), build_side_pos_lists[partition_id + 1].end(), std::back_inserter(*build_side_pos_list));
+      while (partition_id + 1 < probe_side_pos_lists.size() && probe_side_pos_list->size() < MIN_SIZE &&
+             probe_side_pos_list->size() + probe_side_pos_lists[partition_id + 1].size() < MAX_SIZE) {
+        // Copy entries from following PosList into the current working set (build_side_pos_list) and free the memory
+        // used for the merged PosList.
+        std::copy(build_side_pos_lists[partition_id + 1].begin(), build_side_pos_lists[partition_id + 1].end(),
+                  std::back_inserter(*build_side_pos_list));
         build_side_pos_lists[partition_id + 1] = {};
 
-        std::copy(probe_side_pos_lists[partition_id + 1].begin(), probe_side_pos_lists[partition_id + 1].end(), std::back_inserter(*probe_side_pos_list));
+        std::copy(probe_side_pos_lists[partition_id + 1].begin(), probe_side_pos_lists[partition_id + 1].end(),
+                  std::back_inserter(*probe_side_pos_list));
         probe_side_pos_lists[partition_id + 1] = {};
 
         ++partition_id;
@@ -596,6 +610,7 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       }
 
       output_chunks.emplace_back(std::make_shared<Chunk>(std::move(output_segments)));
+      ++partition_id;
       ++output_chunk_id;
     }
     _performance.set_step_runtime(OperatorSteps::OutputWriting, timer_output_writing.lap());

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -565,11 +565,14 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
       // following PosList(s) until a size between MIN_SIZE and MAX_SIZE is reached. This involves a trade-off:
       // A lower number of output chunks reduces the overhead, especially when multi-threading is used. However,
       // merging chunks destroys a potential references_single_chunk property of the PosList that would have been
-      // emitted otherwise.
+      // emitted otherwise. Search for guarantee_single_chunk in join_hash_steps.hpp for details.
       constexpr auto MIN_SIZE = 500;
       constexpr auto MAX_SIZE = MIN_SIZE * 2;
       build_side_pos_list->reserve(MAX_SIZE);
       probe_side_pos_list->reserve(MAX_SIZE);
+
+      // Checking the probe side's PosLists is sufficient. The PosLists from the build side have either the same
+      // size or are empty (in case of semi/anti joins).
       while (partition_id + 1 < probe_side_pos_lists.size() && probe_side_pos_list->size() < MIN_SIZE &&
              probe_side_pos_list->size() + probe_side_pos_lists[partition_id + 1].size() < MAX_SIZE) {
         // Copy entries from following PosList into the current working set (build_side_pos_list) and free the memory

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -913,6 +913,10 @@ inline void write_output_segments(Segments& output_segments, const std::shared_p
             ++new_pos_list_iter;
           }
           if (common_chunk_id && *common_chunk_id != INVALID_CHUNK_ID) {
+            // Track the occuring chunk ids and set the single chunk guarantee if possible. Generally, this is the case
+            // if both of the following are true: (1) The probe side input already had this guarantee and (2) no radix
+            // partitioning was used. If multiple small PosLists were merged (see MIN_SIZE in join_hash.cpp), this
+            // guarantee cannot be given.
             new_pos_list->guarantee_single_chunk();
           }
 
@@ -936,7 +940,8 @@ inline void write_output_segments(Segments& output_segments, const std::shared_p
       // radix partitioning, and so on. Also, actually checking for this property instead of simply forwarding it may
       // allows us to set guarantee_single_chunk in more cases. In cases where more than one chunk is referenced, this
       // should be cheap. In the other cases, the cost of iterating through the PosList are likely to be amortized in
-      // following operators.
+      // following operators. See the comment at the previous call of guarantee_single_chunk to understand when this
+      // guarantee might not be given.
       // This is not part of PosList as other operators should have a better understanding of how they emit references.
       auto common_chunk_id = std::optional<ChunkID>{};
       for (const auto& row : *pos_list) {


### PR DESCRIPTION
If a hash join's input is heavily pre-filtered or the join results in very few matches, we might end up with a high number of chunks that contain only few rows. This involves a trade-off: A lower number of output chunks reduces the overhead, especially when multi-threading is used. However, merging chunks destroys a potential references_single_chunk property of the PosList that would have been emitted otherwise.

@mweisgut - Did we already talk about the impact of chunk sizes on the efficiency of multi-threading? This popped up when I was looking at MT for my thesis, so I wrote a quick fix for it. `500` is a number that seems to work well for TPC-H, but that is just an educated guess. I suspect that there is more to the chunk+MT discussion than just this.

---------------

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.0TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| f8e4cd4f8 | 27.08.2020 18:18 | Table Scan: Improve all-rows-match shortcut (#2194) | real 282.58 user 2451.64 sys 142.82|
| 9ae936be1 | 28.08.2020 17:31 | Hash Join: Merge output chunks <500 rows | real 282.50 user 2449.63 sys 142.54|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -1%
</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_9ae936be1ed8740d379b1743cff2540bd24559cd_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                         | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-08-28 17:36:28                                                                                                                    | 2020-08-28 23:46:27                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    822.5 |   818.5 |   -0%  ||     1.22 |     1.22 |   +0%  |  0.4390 |
-| TPC-H 02 ||      4.7 |     5.1 |   +9%  ||   211.65 |   194.25 |   -8%  |  0.0000 |
 | TPC-H 03 ||     82.3 |    84.9 |   +3%  ||    12.15 |    11.78 |   -3%  |  0.0000 |
 | TPC-H 04 ||     67.9 |    70.0 |   +3%  ||    14.72 |    14.28 |   -3%  |  0.0000 |
 | TPC-H 05 ||    227.4 |   228.6 |   +1%  ||     4.40 |     4.37 |   -1%  |  0.1168 |
 | TPC-H 06 ||      3.2 |     3.2 |   +1%  ||   311.28 |   309.50 |   -1%  |  0.0000 |
 | TPC-H 07 ||     59.6 |    59.4 |   -0%  ||    16.78 |    16.83 |   +0%  |  0.7665 |
-| TPC-H 08 ||     67.2 |    78.1 |  +16%  ||    14.88 |    12.80 |  -14%  |  0.0000 |
 | TPC-H 09 ||    530.3 |   524.4 |   -1%  ||     1.89 |     1.91 |   +1%  |  0.0324 |
 | TPC-H 10 ||    255.3 |   259.9 |   +2%  ||     3.92 |     3.85 |   -2%  |  0.1063 |
 | TPC-H 11 ||      8.7 |     9.1 |   +4%  ||   114.72 |   110.37 |   -4%  |  0.0000 |
 | TPC-H 12 ||     44.1 |    44.0 |   -0%  ||    22.69 |    22.73 |   +0%  |  0.1466 |
 | TPC-H 13 ||    361.3 |   359.2 |   -1%  ||     2.77 |     2.78 |   +1%  |  0.0023 |
 | TPC-H 14 ||     21.3 |    21.1 |   -1%  ||    46.87 |    47.45 |   +1%  |  0.0000 |
 | TPC-H 15 ||      8.1 |     8.1 |   -0%  ||   122.66 |   123.04 |   +0%  |  0.0000 |
 | TPC-H 16 ||     91.9 |    91.7 |   -0%  ||    10.88 |    10.90 |   +0%  |  0.3739 |
+| TPC-H 17 ||     21.9 |    19.7 |  -10%  ||    45.67 |    50.81 |  +11%  |  0.0000 |
 | TPC-H 18 ||    680.4 |   678.3 |   -0%  ||     1.47 |     1.47 |   +0%  |  0.6995 |
+| TPC-H 19 ||     33.5 |    31.3 |   -7%  ||    29.82 |    31.96 |   +7%  |  0.0000 |
 | TPC-H 20 ||     17.4 |    17.4 |   +0%  ||    57.59 |    57.50 |   -0%  |  0.5826 |
 | TPC-H 21 ||    420.3 |   426.6 |   +2%  ||     2.38 |     2.34 |   -1%  |  0.0019 |
 | TPC-H 22 ||     53.1 |    51.6 |   -3%  ||    18.84 |    19.38 |   +3%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3882.6 |  3890.4 |   +0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +12%
</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_9ae936be1ed8740d379b1743cff2540bd24559cd_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                         | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-08-28 17:58:46                                                                                                                    | 2020-08-29 00:08:46                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2332.9 |  2318.5 |   -1%  ||    20.76 |    21.08 |   +2%  |  0.7492 |
+| TPC-H 02 ||     22.2 |    17.3 |  -22%  ||  1899.65 |  2356.59 |  +24%  |  0.0000 |
 | TPC-H 03 ||    475.5 |   475.4 |   -0%  ||   103.44 |   103.34 |   -0%  |  0.9900 |
 | TPC-H 04 ||    274.3 |   274.1 |   -0%  ||   177.43 |   178.34 |   +1%  |  0.9453 |
 | TPC-H 05 ||   1340.5 |  1313.8 |   -2%  ||    36.21 |    36.38 |   +0%  |  0.4978 |
 | TPC-H 06 ||     21.3 |    21.2 |   -1%  ||  1867.09 |  1895.27 |   +2%  |  0.0000 |
 | TPC-H 07 ||    256.5 |   256.8 |   +0%  ||   190.47 |   190.16 |   -0%  |  0.9214 |
+| TPC-H 08 ||    384.2 |   218.8 |  -43%  ||   127.80 |   223.15 |  +75%  |  0.0000 |
 | TPC-H 09 ||   2744.2 |  2741.8 |   -0%  ||    17.60 |    17.30 |   -2%  |  0.9849 |
 | TPC-H 10 ||   1540.4 |  1536.3 |   -0%  ||    31.83 |    31.90 |   +0%  |  0.8816 |
 | TPC-H 11 ||     67.6 |    68.0 |   +1%  ||   691.39 |   688.56 |   -0%  |  0.3117 |
 | TPC-H 12 ||    133.9 |   134.0 |   +0%  ||   359.51 |   359.37 |   -0%  |  0.9355 |
 | TPC-H 13 ||   2289.0 |  2276.4 |   -1%  ||    21.15 |    21.13 |   -0%  |  0.8296 |
 | TPC-H 14 ||    140.3 |   140.0 |   -0%  ||   343.63 |   344.63 |   +0%  |  0.6569 |
 | TPC-H 15 ||     54.1 |    54.3 |   +0%  ||   849.64 |   847.10 |   -0%  |  0.2192 |
 | TPC-H 16 ||    452.6 |   453.7 |   +0%  ||   108.72 |   108.34 |   -0%  |  0.8189 |
+| TPC-H 17 ||    203.1 |    60.7 |  -70%  ||   239.37 |   766.75 | +220%  |  0.0000 |
 | TPC-H 18 ||   6030.6 |  5958.3 |   -1%  ||     7.77 |     7.83 |   +1%  |  0.6872 |
+| TPC-H 19 ||    151.8 |    92.9 |  -39%  ||   318.07 |   512.17 |  +61%  |  0.0000 |
 | TPC-H 20 ||     56.3 |    56.5 |   +0%  ||   818.24 |   815.44 |   -0%  |  0.5333 |
 | TPC-H 21 ||   2257.0 |  2276.2 |   +1%  ||    21.07 |    21.08 |   +0%  |  0.8275 |
 | TPC-H 22 ||    676.9 |   678.9 |   +0%  ||    71.96 |    71.43 |   -1%  |  0.9183 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  21905.5 | 21423.7 |   -2%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |  +12%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -1%
</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_9ae936be1ed8740d379b1743cff2540bd24559cd_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                          | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-08-28 18:21:18                                                                                                                     | 2020-08-29 00:31:17                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+

 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     30.8 |    30.6 |   -1%  ||    32.49 |    32.72 |   +1%  |  0.0000 |
-| 03      ||      6.6 |     7.2 |   +9%  ||   152.05 |   138.98 |   -9%  |  0.0000 |
-| 06      ||     20.3 |    21.3 |   +5%  ||    49.36 |    47.05 |   -5%  |  0.0000 |
 | 07      ||     56.7 |    57.9 |   +2%  ||    17.63 |    17.27 |   -2%  |  0.0000 |
 | 09      ||    107.2 |   107.4 |   +0%  ||     9.33 |     9.31 |   -0%  |  0.0003 |
-| 10      ||     19.9 |    21.0 |   +5%  ||    50.16 |    47.63 |   -5%  |  0.0000 |
 | 13      ||    121.8 |   122.2 |   +0%  ||     8.21 |     8.18 |   -0%  |  0.7950 |
 | 15      ||     11.9 |    11.5 |   -4%  ||    83.81 |    87.29 |   +4%  |  0.0000 |
 | 17      ||     30.8 |    31.2 |   +1%  ||    32.47 |    32.03 |   -1%  |  0.0340 |
+| 19      ||     11.3 |    10.5 |   -7%  ||    88.42 |    95.56 |   +8%  |  0.0000 |
 | 25      ||     18.2 |    18.1 |   -0%  ||    55.03 |    55.12 |   +0%  |  0.7935 |
 | 26      ||     29.2 |    28.6 |   -2%  ||    34.27 |    34.94 |   +2%  |  0.0000 |
 | 28      ||     92.2 |    91.5 |   -1%  ||    10.85 |    10.93 |   +1%  |  0.0000 |
 | 29      ||     31.0 |    32.3 |   +4%  ||    32.27 |    30.94 |   -4%  |  0.0000 |
 | 31      ||    130.2 |   133.9 |   +3%  ||     7.68 |     7.47 |   -3%  |  0.0000 |
 | 34      ||     28.9 |    30.0 |   +4%  ||    34.57 |    33.29 |   -4%  |  0.0000 |
 | 35      ||    100.4 |   101.1 |   +1%  ||     9.96 |     9.89 |   -1%  |  0.0000 |
 | 39a     ||    208.3 |   200.6 |   -4%  ||     4.80 |     4.99 |   +4%  |  0.0000 |
+| 39b     ||    207.0 |   198.0 |   -4%  ||     4.83 |     5.05 |   +5%  |  0.0000 |
 | 41      ||     26.2 |    26.2 |   -0%  ||    38.13 |    38.15 |   +0%  |  0.5411 |
-| 42      ||      7.6 |     8.2 |   +7%  ||   131.65 |   122.58 |   -7%  |  0.0000 |
 | 43      ||    247.8 |   248.0 |   +0%  ||     4.04 |     4.03 |   -0%  |  0.1042 |
 | 45      ||     10.6 |    10.7 |   +1%  ||    94.66 |    93.76 |   -1%  |  0.0000 |
 | 48      ||     94.5 |    96.1 |   +2%  ||    10.58 |    10.40 |   -2%  |  0.0000 |
 | 50      ||     12.4 |    12.1 |   -2%  ||    80.92 |    82.85 |   +2%  |  0.0000 |
-| 52      ||      7.7 |     8.3 |   +7%  ||   129.09 |   120.81 |   -6%  |  0.0000 |
-| 55      ||      7.6 |     8.2 |   +8%  ||   131.26 |   121.55 |   -7%  |  0.0000 |
 | 62      ||     78.9 |    79.2 |   +0%  ||    12.67 |    12.62 |   -0%  |  0.0000 |
 | 65      ||     73.4 |    74.3 |   +1%  ||    13.62 |    13.46 |   -1%  |  0.0000 |
-| 69      ||     24.9 |    27.4 |  +10%  ||    40.11 |    36.45 |   -9%  |  0.0000 |
 | 73      ||     18.6 |    19.4 |   +4%  ||    53.76 |    51.56 |   -4%  |  0.0000 |
 | 79      ||     51.6 |    52.5 |   +2%  ||    19.39 |    19.03 |   -2%  |  0.0000 |
 | 81      ||     20.0 |    19.9 |   -0%  ||    49.96 |    50.13 |   +0%  |  0.0000 |
 | 83      ||      9.9 |     9.9 |   -0%  ||   100.73 |   101.15 |   +0%  |  0.0000 |
 | 85      ||     57.9 |    58.8 |   +2%  ||    17.28 |    17.01 |   -2%  |  0.4398 |
+| 88      ||    107.9 |   102.4 |   -5%  ||     9.27 |     9.76 |   +5%  |  0.0000 |
 | 91      ||     19.7 |    19.8 |   +1%  ||    50.88 |    50.41 |   -1%  |  0.0000 |
 | 93      ||    265.9 |   266.3 |   +0%  ||     3.76 |     3.76 |   -0%  |  0.3855 |
+| 96      ||     10.0 |     9.2 |   -8%  ||   100.44 |   108.61 |   +8%  |  0.0000 |
 | 97      ||    399.8 |   405.7 |   +1%  ||     2.50 |     2.47 |   -1%  |  0.0361 |
 | 99      ||    159.1 |   158.1 |   -1%  ||     6.28 |     6.33 |   +1%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   2974.6 |  2975.6 |   +0%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -7%
 ||
Geometric mean of throughput changes: +25%
</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_9ae936be1ed8740d379b1743cff2540bd24559cd_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                          | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-08-28 19:02:25                                                                                                                     | 2020-08-29 01:12:24                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+

 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    228.2 |   229.8 |   +1%  ||   213.85 |   212.41 |   -1%  |  0.3554 |
+| 03      ||    107.7 |    31.4 |  -71%  ||   443.29 |  1413.56 | +219%  |  0.0000 |
 | 06      ||    143.2 |   143.8 |   +0%  ||   337.28 |   335.36 |   -1%  |  0.6442 |
 | 07      ||    513.7 |   511.9 |   -0%  ||    95.73 |    95.98 |   +0%  |  0.8255 |
 | 09      ||    545.2 |   544.9 |   -0%  ||    89.87 |    89.05 |   -1%  |  0.9827 |
 | 10      ||    102.4 |   100.8 |   -2%  ||   467.66 |   473.70 |   +1%  |  0.0790 |
 | 13      ||    423.5 |   423.4 |   -0%  ||   115.95 |   116.06 |   +0%  |  0.9803 |
 | 15      ||     80.0 |    80.1 |   +0%  ||   590.04 |   588.76 |   -0%  |  0.7010 |
 | 17      ||    186.6 |   179.0 |   -4%  ||   260.37 |   270.82 |   +4%  |  0.0002 |
+| 19      ||    263.3 |    49.9 |  -81%  ||   185.47 |   919.97 | +396%  |  0.0000 |
+| 25      ||    265.3 |   100.7 |  -62%  ||   184.10 |   474.57 | +158%  |  0.0000 |
 | 26      ||    297.8 |   296.1 |   -1%  ||   164.67 |   165.57 |   +1%  |  0.6278 |
 | 28      ||    213.0 |   212.7 |   -0%  ||   228.49 |   228.77 |   +0%  |  0.9187 |
 | 29      ||    196.8 |   196.4 |   -0%  ||   246.97 |   247.37 |   +0%  |  0.8612 |
 | 31      ||    826.7 |   800.8 |   -3%  ||    59.23 |    59.33 |   +0%  |  0.3068 |
 | 34      ||    149.2 |   148.7 |   -0%  ||   323.36 |   324.83 |   +0%  |  0.6721 |
 | 35      ||    984.7 |   990.3 |   +1%  ||    49.35 |    49.36 |   +0%  |  0.8066 |
 | 39a     ||   1683.7 |  1678.1 |   -0%  ||    29.18 |    29.05 |   -0%  |  0.9052 |
 | 39b     ||   1678.6 |  1675.5 |   -0%  ||    29.13 |    28.98 |   -1%  |  0.9512 |
 | 41      ||   1430.4 |  1362.4 |   -5%  ||    32.56 |    33.86 |   +4%  |  0.5163 |
+| 42      ||    118.1 |    38.5 |  -67%  ||   405.47 |  1165.86 | +188%  |  0.0000 |
 | 43      ||    778.0 |   782.5 |   +1%  ||    63.38 |    63.01 |   -1%  |  0.6727 |
 | 45      ||     61.2 |    60.8 |   -1%  ||   756.16 |   761.11 |   +1%  |  0.2333 |
 | 48      ||    537.8 |   539.9 |   +0%  ||    90.44 |    90.73 |   +0%  |  0.8551 |
+| 50      ||    159.7 |   128.0 |  -20%  ||   302.50 |   375.41 |  +24%  |  0.0000 |
+| 52      ||    118.4 |    39.2 |  -67%  ||   404.48 |  1146.33 | +183%  |  0.0000 |
+| 55      ||    118.4 |    38.6 |  -67%  ||   404.43 |  1158.68 | +186%  |  0.0000 |
 | 62      ||    354.1 |   355.7 |   +0%  ||   138.44 |   137.95 |   -0%  |  0.6658 |
 | 65      ||    687.2 |   686.7 |   -0%  ||    71.60 |    71.73 |   +0%  |  0.9601 |
 | 69      ||    180.1 |   180.5 |   +0%  ||   269.28 |   268.29 |   -0%  |  0.8694 |
 | 73      ||    109.4 |   106.4 |   -3%  ||   437.03 |   448.18 |   +3%  |  0.0000 |
 | 79      ||    270.5 |   271.1 |   +0%  ||   180.96 |   180.62 |   -0%  |  0.8270 |
 | 81      ||    153.7 |   152.5 |   -1%  ||   314.69 |   316.94 |   +1%  |  0.2841 |
 | 83      ||     73.9 |    74.2 |   +1%  ||   635.58 |   632.30 |   -1%  |  0.4559 |
 | 85      ||    285.6 |   285.5 |   -0%  ||   171.14 |   171.43 |   +0%  |  0.9755 |
+| 88      ||    998.9 |   432.0 |  -57%  ||    47.31 |   112.73 | +138%  |  0.0000 |
 | 91      ||     83.3 |    83.1 |   -0%  ||   569.44 |   570.41 |   +0%  |  0.6970 |
 | 93      ||   1318.9 |  1327.1 |   +1%  ||    36.86 |    36.79 |   -0%  |  0.8330 |
+| 96      ||    143.4 |    40.3 |  -72%  ||   336.21 |  1124.76 | +235%  |  0.0000 |
 | 97      ||   3685.5 |  3646.8 |   -1%  ||    12.97 |    13.00 |   +0%  |  0.7495 |
 | 99      ||    849.1 |   846.4 |   -0%  ||    57.93 |    57.99 |   +0%  |  0.8481 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||  21405.2 | 19872.2 |   -7%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |  +25%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_9ae936be1ed8740d379b1743cff2540bd24559cd_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                         | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-08-28 19:43:42                                                                                                                    | 2020-08-29 01:53:41                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     67.4 |    67.5 |   +0%  ||     1.93 |     1.97 |   +2%  | (run time too short) |
 | New-Order    ||     29.7 |    29.4 |   -1%  ||    21.88 |    22.08 |   +1%  | (run time too short) |
 | Order-Status ||      1.5 |     1.5 |   +0%  ||     1.93 |     1.97 |   +2%  | (run time too short) |
 | Payment      ||      3.4 |     3.5 |   +1%  ||    20.88 |    21.07 |   +1%  | (run time too short) |
 | Stock-Level  ||     73.4 |    71.0 |   -3%  ||     1.97 |     1.98 |   +1%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    175.4 |   172.9 |   -1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +1%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_9ae936be1ed8740d379b1743cff2540bd24559cd_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                         | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-08-28 19:44:47                                                                                                                    | 2020-08-29 01:54:46                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+

 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    329.4 |   347.4 |   +5%  ||     2.92 |     2.79 |   -4%  | (run time too short) |
 |    unsucc.:  ||      3.8 |     4.3 |  +13%  ||    90.14 |    92.09 |   +2%  |                      |
 | New-Order    ||    146.0 |   145.2 |   -0%  ||    58.83 |    59.64 |   +1%  |               0.7332 |
 |    unsucc.:  ||      5.5 |     5.5 |   -0%  ||   988.17 |  1007.93 |   +2%  |                      |
 | Order-Status ||      7.8 |     8.2 |   +4%  ||    93.09 |    94.94 |   +2%  | (run time too short) |
 | Payment      ||     17.1 |    15.8 |   -7%  ||     6.34 |     6.07 |   -4%  | (run time too short) |
 |    unsucc.:  ||      4.7 |     4.6 |   -1%  ||   994.29 |  1014.26 |   +2%  |                      |
 | Stock-Level  ||    123.2 |   116.1 |   -6%  ||    92.92 |    94.70 |   +2%  |               0.0000 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    623.6 |   632.7 |   +1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -1%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: -1%
</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_9ae936be1ed8740d379b1743cff2540bd24559cd_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                              | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-08-28 19:45:52                                                                                                                         | 2020-08-29 01:55:51                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+

 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
-| 10a     ||    353.0 |    381.4 |   +8%  ||     2.83 |     2.62 |   -7%  |  0.0000 |
-| 10b     ||    352.9 |    375.8 |   +6%  ||     2.83 |     2.66 |   -6%  |  0.0000 |
 | 10c     ||   1165.8 |   1161.4 |   -0%  ||     0.86 |     0.86 |   +0%  |  0.3749 |
 | 11a     ||    151.0 |    151.6 |   +0%  ||     6.62 |     6.59 |   -0%  |  0.6415 |
 | 11b     ||    141.1 |    142.3 |   +1%  ||     7.09 |     7.03 |   -1%  |  0.3972 |
 | 11c     ||    518.2 |    525.3 |   +1%  ||     1.93 |     1.90 |   -1%  |  0.1744 |
 | 11d     ||   4733.6 |   4753.9 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.8119 |
 | 12a     ||    364.1 |    366.6 |   +1%  ||     2.75 |     2.73 |   -1%  |  0.4684 |
 | 12b     ||    624.8 |    624.5 |   -0%  ||     1.60 |     1.60 |   +0%  |  0.9644 |
 | 12c     ||   3726.1 |   3704.4 |   -1%  ||     0.27 |     0.27 |   +1%  |  0.5330 |
-| 13a     ||    171.0 |    181.8 |   +6%  ||     5.85 |     5.50 |   -6%  |  0.0000 |
 | 13b     ||    249.2 |    256.3 |   +3%  ||     4.01 |     3.90 |   -3%  |  0.0000 |
-| 13c     ||    135.8 |    142.8 |   +5%  ||     7.36 |     7.00 |   -5%  |  0.0000 |
-| 13d     ||    171.1 |    181.5 |   +6%  ||     5.85 |     5.51 |   -6%  |  0.0000 |
 | 14a     ||   4054.8 |   4033.6 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.5648 |
 | 14b     ||   4680.2 |   4641.9 |   -1%  ||     0.21 |     0.22 |   +1%  |  0.3910 |
 | 14c     ||   4055.7 |   4031.2 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.5181 |
 | 15a     ||    223.7 |    224.6 |   +0%  ||     4.47 |     4.45 |   -0%  |  0.5509 |
 | 15b     ||    209.0 |    217.9 |   +4%  ||     4.78 |     4.59 |   -4%  |  0.0000 |
 | 15c     ||    152.3 |    153.3 |   +1%  ||     6.56 |     6.52 |   -1%  |  0.0659 |
 | 15d     ||    463.0 |    463.7 |   +0%  ||     2.16 |     2.16 |   -0%  |  0.7291 |
 | 16a     ||   4722.3 |   4688.5 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.6982 |
 | 16b     ||   6203.1 |   6200.0 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.9695 |
 | 16c     ||   4809.3 |   4830.6 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.7600 |
 | 16d     ||   4799.9 |   4791.3 |   -0%  ||     0.21 |     0.21 |   +0%  |  0.8975 |
 | 17a     ||    977.6 |    984.2 |   +1%  ||     1.02 |     1.02 |   -1%  |  0.2760 |
 | 17b     ||    775.2 |    787.3 |   +2%  ||     1.29 |     1.27 |   -2%  |  0.0056 |
 | 17c     ||    729.4 |    744.2 |   +2%  ||     1.37 |     1.34 |   -2%  |  0.0003 |
 | 17d     ||    843.6 |    853.9 |   +1%  ||     1.19 |     1.17 |   -1%  |  0.0282 |
 | 17e     ||   2930.0 |   2932.9 |   +0%  ||     0.34 |     0.34 |   -0%  |  0.8687 |
 | 17f     ||   1584.8 |   1560.3 |   -2%  ||     0.63 |     0.64 |   +2%  |  0.0550 |
 | 18a     ||    674.1 |    680.3 |   +1%  ||     1.48 |     1.47 |   -1%  |  0.0680 |
 | 18b     ||    248.4 |    252.0 |   +1%  ||     4.03 |     3.97 |   -1%  |  0.0073 |
 | 18c     ||   3763.1 |   3745.7 |   -0%  ||     0.27 |     0.27 |   +0%  |  0.4027 |
 | 19a     ||   7729.9 |   7655.7 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | 19b     ||   4633.8 |   4555.0 |   -2%  ||     0.22 |     0.22 |   +2%  |  0.0000 |
 | 19c     ||   7517.1 |   7432.4 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | 19d     ||   5683.8 |   5677.2 |   -0%  ||     0.18 |     0.18 |   +0%  |  0.8890 |
 | 1a      ||     60.0 |     59.3 |   -1%  ||    16.66 |    16.85 |   +1%  |  0.0000 |
 | 1b      ||     22.9 |     23.5 |   +3%  ||    43.68 |    42.54 |   -3%  |  0.0000 |
 | 1c      ||     22.9 |     23.5 |   +3%  ||    43.71 |    42.54 |   -3%  |  0.0000 |
 | 1d      ||     22.6 |     23.3 |   +3%  ||    44.19 |    42.96 |   -3%  |  0.0000 |
 | 20a     ||   1273.8 |   1290.9 |   +1%  ||     0.79 |     0.77 |   -1%  |  0.0000 |
 | 20b     ||   1114.1 |   1105.8 |   -1%  ||     0.90 |     0.90 |   +1%  |  0.0000 |
 | 20c     ||   1142.6 |   1126.4 |   -1%  ||     0.88 |     0.89 |   +1%  |  0.0000 |
 | 21a     ||   3828.8 |   3811.0 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.1423 |
 | 21b     ||    255.8 |    258.4 |   +1%  ||     3.91 |     3.87 |   -1%  |  0.0003 |
 | 21c     ||   3953.2 |   3930.6 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.0650 |
 | 22a     ||   3475.2 |   3461.6 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.6582 |
 | 22b     ||   3479.0 |   3460.7 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.5528 |
 | 22c     ||   4074.9 |   4053.2 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.5083 |
 | 22d     ||   4094.2 |   4075.5 |   -0%  ||     0.24 |     0.25 |   +0%  |  0.5563 |
 | 23a     ||    153.4 |    155.9 |   +2%  ||     6.52 |     6.41 |   -2%  |  0.0001 |
 | 23b     ||    118.7 |    123.6 |   +4%  ||     8.43 |     8.09 |   -4%  |  0.0000 |
 | 23c     ||    173.9 |    175.2 |   +1%  ||     5.75 |     5.71 |   -1%  |  0.0777 |
 | 24a     ||   4722.5 |   4649.4 |   -2%  ||     0.21 |     0.22 |   +2%  |  0.0335 |
 | 24b     ||   4666.6 |   4593.2 |   -2%  ||     0.21 |     0.22 |   +2%  |  0.2828 |
 | 25a     ||    250.7 |    256.5 |   +2%  ||     3.99 |     3.90 |   -2%  |  0.0000 |
-| 25b     ||    258.1 |    270.6 |   +5%  ||     3.88 |     3.70 |   -5%  |  0.0000 |
 | 25c     ||   3778.8 |   3761.0 |   -0%  ||     0.26 |     0.27 |   +0%  |  0.3597 |
 | 26a     ||    991.4 |   1000.0 |   +1%  ||     1.01 |     1.00 |   -1%  |  0.0280 |
 | 26b     ||    984.7 |    989.1 |   +0%  ||     1.02 |     1.01 |   -0%  |  0.5083 |
 | 26c     ||    992.1 |   1000.4 |   +1%  ||     1.01 |     1.00 |   -1%  |  0.1027 |
 | 27a     ||   3492.5 |   3469.9 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2311 |
 | 27b     ||   3456.8 |   3437.0 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2955 |
 | 27c     ||    199.2 |    202.5 |   +2%  ||     5.02 |     4.94 |   -2%  |  0.0372 |
 | 28a     ||   4118.6 |   4092.5 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.7917 |
 | 28b     ||   3393.9 |   3371.3 |   -1%  ||     0.29 |     0.30 |   +1%  |  0.8170 |
 | 28c     ||   4116.4 |   4094.1 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.8186 |
 | 29a     ||   4595.0 |   4526.5 |   -1%  ||     0.22 |     0.22 |   +2%  |  0.6307 |
-| 29b     ||    192.3 |    207.9 |   +8%  ||     5.20 |     4.81 |   -7%  |  0.1270 |
 | 29c     ||   4726.7 |   4640.6 |   -2%  ||     0.21 |     0.22 |   +2%  |  0.5845 |
-| 2a      ||    104.9 |    111.6 |   +6%  ||     9.53 |     8.96 |   -6%  |  0.0000 |
-| 2b      ||     81.8 |     88.0 |   +8%  ||    12.22 |    11.36 |   -7%  |  0.0000 |
-| 2c      ||     52.7 |     58.5 |  +11%  ||    18.97 |    17.10 |  -10%  |  0.0000 |
 | 2d      ||    131.0 |    137.1 |   +5%  ||     7.63 |     7.30 |   -4%  |  0.0000 |
 | 30a     ||    265.0 |    272.0 |   +3%  ||     3.77 |     3.68 |   -3%  |  0.1737 |
 | 30b     ||   1106.8 |   1097.5 |   -1%  ||     0.90 |     0.91 |   +1%  |  0.6717 |
 | 30c     ||   3800.8 |   3787.0 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.8700 |
-| 31a     ||    293.8 |    310.4 |   +6%  ||     3.40 |     3.22 |   -5%  |  0.0000 |
 | 31b     ||   1128.9 |   1128.0 |   -0%  ||     0.89 |     0.89 |   +0%  |  0.9441 |
-| 31c     ||    298.2 |    313.9 |   +5%  ||     3.35 |     3.19 |   -5%  |  0.0000 |
 | 32a     ||     37.4 |     38.4 |   +3%  ||    26.76 |    26.01 |   -3%  |  0.0000 |
 | 32b     ||    284.7 |    290.4 |   +2%  ||     3.51 |     3.44 |   -2%  |  0.0000 |
 | 33a     ||     71.5 |     73.6 |   +3%  ||    13.98 |    13.58 |   -3%  |  0.0000 |
 | 33b     ||     70.3 |     72.6 |   +3%  ||    14.22 |    13.77 |   -3%  |  0.0000 |
 | 33c     ||     85.6 |     89.0 |   +4%  ||    11.68 |    11.24 |   -4%  |  0.0000 |
 | 3a      ||   3942.0 |   3927.5 |   -0%  ||     0.25 |     0.25 |   +0%  |  0.0000 |
-| 3b      ||     34.7 |     37.1 |   +7%  ||    28.86 |    26.94 |   -7%  |  0.0000 |
 | 3c      ||   5040.9 |   5030.4 |   -0%  ||     0.20 |     0.20 |   +0%  |  0.3399 |
 | 4a      ||    128.0 |    130.0 |   +2%  ||     7.81 |     7.69 |   -2%  |  0.0000 |
-| 4b      ||     26.4 |     28.0 |   +6%  ||    37.82 |    35.70 |   -6%  |  0.0000 |
 | 4c      ||    145.1 |    147.1 |   +1%  ||     6.89 |     6.80 |   -1%  |  0.0000 |
 | 5a      ||   3771.0 |   3750.3 |   -1%  ||     0.27 |     0.27 |   +1%  |  0.0000 |
 | 5b      ||    277.5 |    274.8 |   -1%  ||     3.60 |     3.64 |   +1%  |  0.0000 |
 | 5c      ||   4384.0 |   4350.2 |   -1%  ||     0.23 |     0.23 |   +1%  |  0.0000 |
 | 6a      ||    247.5 |    248.7 |   +0%  ||     4.04 |     4.02 |   -0%  |  0.0000 |
 | 6b      ||    961.2 |    969.7 |   +1%  ||     1.04 |     1.03 |   -1%  |  0.0003 |
 | 6c      ||    247.6 |    248.5 |   +0%  ||     4.04 |     4.02 |   -0%  |  0.0000 |
 | 6d      ||    959.9 |    970.3 |   +1%  ||     1.04 |     1.03 |   -1%  |  0.0000 |
 | 6e      ||    247.4 |    248.7 |   +1%  ||     4.04 |     4.02 |   -1%  |  0.0000 |
 | 6f      ||   1508.7 |   1514.9 |   +0%  ||     0.66 |     0.66 |   -0%  |  0.0000 |
-| 7a      ||    251.6 |    265.5 |   +6%  ||     3.97 |     3.77 |   -5%  |  0.0000 |
-| 7b      ||    123.3 |    138.8 |  +13%  ||     8.11 |     7.20 |  -11%  |  0.0000 |
 | 7c      ||  10879.7 |  10834.5 |   -0%  ||     0.09 |     0.09 |   +0%  |       ˅ |
-| 8a      ||    107.9 |    115.9 |   +7%  ||     9.27 |     8.63 |   -7%  |  0.0000 |
 | 8b      ||    162.8 |    165.9 |   +2%  ||     6.14 |     6.03 |   -2%  |  0.0000 |
 | 8c      ||   4402.9 |   4366.7 |   -1%  ||     0.23 |     0.23 |   +1%  |  0.2301 |
 | 8d      ||   1574.7 |   1543.9 |   -2%  ||     0.64 |     0.65 |   +2%  |  0.0000 |
 | 9a      ||   3472.1 |   3454.6 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.3339 |
 | 9b      ||    332.5 |    331.0 |   -0%  ||     3.01 |     3.02 |   +0%  |  0.4043 |
 | 9c      ||   3501.4 |   3487.7 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.4412 |
 | 9d      ||   4098.0 |   4074.2 |   -1%  ||     0.24 |     0.25 |   +1%  |  0.2822 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 216166.6 | 215331.2 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +22%
</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_9ae936be1ed8740d379b1743cff2540bd24559cd_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | f8e4cd4f8c9426864a00a5a7ef2eda42a6c5bd1f-dirty                                                                                              | 9ae936be1ed8740d379b1743cff2540bd24559cd-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-08-28 21:41:43                                                                                                                         | 2020-08-29 03:51:43                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+

 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)     | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |       new |        ||      old |      new |        |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
+| 10a     ||    3450.1 |    2189.6 |  -37%  ||    13.57 |    21.73 |  +60%  |  0.0000 |
+| 10b     ||    2781.9 |    1454.1 |  -48%  ||    16.80 |    33.17 |  +97%  |  0.0000 |
 | 10c     ||    9330.7 |    8124.3 |  -13%  ||     4.72 |     4.57 |   -3%  |  0.0371 |
+| 11a     ||     912.6 |     453.0 |  -50%  ||    53.51 |   107.23 | +100%  |  0.0000 |
+| 11b     ||     868.9 |     422.4 |  -51%  ||    55.87 |   115.53 | +107%  |  0.0000 |
 | 11c     ||    2382.3 |    2358.6 |   -1%  ||    20.40 |    20.42 |   +0%  |  0.8058 |
+| 11d     ||   22889.7 |   22626.2 |   -1%  ||     1.57 |     1.68 |   +7%  |  0.8391 |
 | 12a     ||    3653.6 |    3439.2 |   -6%  ||    12.97 |    13.18 |   +2%  |  0.2400 |
 | 12b     ||    1421.8 |    1382.6 |   -3%  ||    34.11 |    34.35 |   +1%  |  0.4821 |
 | 12c     ||   16352.3 |   19933.4 |  +22%  ||     1.85 |     1.82 |   -2%  |  0.0220 |
 | 13a     ||    1118.6 |    1086.4 |   -3%  ||    43.56 |    44.88 |   +3%  |  0.3639 |
 | 13b     ||    1341.1 |    1315.4 |   -2%  ||    35.90 |    36.83 |   +3%  |  0.6381 |
 | 13c     ||    1344.2 |    1310.4 |   -3%  ||    35.96 |    36.82 |   +2%  |  0.4863 |
+| 13d     ||    1147.5 |    1106.9 |   -4%  ||    42.30 |    44.36 |   +5%  |  0.3189 |
 | 14a     ||   18436.8 |   16266.5 |  -12%  ||     2.13 |     2.10 |   -2%  |  0.1107 |
 | 14b     ||   16520.6 |   18024.9 |   +9%  ||     1.95 |     2.00 |   +3%  |  0.2735 |
 | 14c     ||   17192.2 |   16928.8 |   -2%  ||     2.08 |     2.13 |   +2%  |  0.8438 |
+| 15a     ||    1896.1 |    1039.7 |  -45%  ||    25.38 |    46.33 |  +83%  |  0.0000 |
+| 15b     ||    1579.1 |    1024.3 |  -35%  ||    30.16 |    47.33 |  +57%  |  0.0000 |
+| 15c     ||     616.5 |     423.2 |  -31%  ||    79.57 |   115.91 |  +46%  |  0.0000 |
+| 15d     ||    2514.4 |    2351.0 |   -7%  ||    18.90 |    20.56 |   +9%  |  0.0675 |
 | 16a     ||   25117.1 |   26096.3 |   +4%  ||     1.08 |     1.08 |   -0%  |  0.6284 |
 | 16b     ||   33886.7 |   33831.8 |   -0%  ||     0.92 |     0.93 |   +2%  |  0.9790 |
 | 16c     ||   30234.7 |   28545.1 |   -6%  ||     0.97 |     1.00 |   +3%  |  0.4381 |
+| 16d     ||   30511.2 |   28763.3 |   -6%  ||     1.03 |     1.10 |   +6%  |  0.4515 |
+| 17a     ||    8524.9 |    7791.5 |   -9%  ||     4.60 |     5.17 |  +12%  |  0.1918 |
+| 17b     ||    8211.5 |    7647.5 |   -7%  ||     4.73 |     5.17 |   +9%  |  0.2773 |
+| 17c     ||    8385.9 |    8565.2 |   +2%  ||     4.72 |     5.13 |   +9%  |  0.7523 |
+| 17d     ||    8904.4 |    8058.5 |  -10%  ||     4.25 |     5.35 |  +26%  |  0.1621 |
 | 17e     ||   11381.2 |   12688.8 |  +11%  ||     3.23 |     3.37 |   +4%  |  0.1045 |
+| 17f     ||   13251.1 |    9907.3 |  -25%  ||     2.92 |     4.13 |  +42%  |  0.0001 |
 | 18a     ||    4443.1 |    4279.6 |   -4%  ||    10.48 |    10.42 |   -1%  |  0.5610 |
+| 18b     ||    2236.9 |    2212.4 |   -1%  ||    18.97 |    21.60 |  +14%  |  0.8172 |
 | 18c     ||   16809.1 |   17002.9 |   +1%  ||     2.15 |     2.17 |   +1%  |  0.8794 |
+| 19a     ||   35430.5 |   33927.2 |   -4%  ||     0.85 |     0.92 |   +8%  |  0.5427 |
 | 19b     ||   11044.4 |    9913.4 |  -10%  ||     3.35 |     3.40 |   +1%  |  0.1822 |
+| 19c     ||   31105.8 |   33950.4 |   +9%  ||     0.90 |     0.95 |   +6%  |  0.2492 |
-| 19d     ||   32195.1 |   31239.5 |   -3%  ||     0.95 |     0.87 |   -9%  |  0.6678 |
 | 1a      ||     322.9 |     322.3 |   -0%  ||   151.69 |   152.08 |   +0%  |  0.9170 |
 | 1b      ||      73.1 |      72.2 |   -1%  ||   639.10 |   647.00 |   +1%  |  0.1105 |
 | 1c      ||      76.8 |      75.7 |   -1%  ||   613.27 |   620.39 |   +1%  |  0.0866 |
 | 1d      ||      73.1 |      72.2 |   -1%  ||   639.91 |   646.43 |   +1%  |  0.1430 |
+| 20a     ||    7818.0 |    5042.0 |  -36%  ||     4.87 |     8.37 |  +72%  |  0.0000 |
+| 20b     ||    8012.8 |    3706.8 |  -54%  ||     4.87 |    10.90 | +124%  |  0.0000 |
+| 20c     ||    9751.5 |    4014.4 |  -59%  ||     4.08 |    11.55 | +183%  |  0.0000 |
 | 21a     ||   14928.5 |   15557.9 |   +4%  ||     2.28 |     2.33 |   +2%  |  0.6183 |
 | 21b     ||    1016.5 |     973.1 |   -4%  ||    47.98 |    48.86 |   +2%  |  0.1518 |
+| 21c     ||   16581.3 |   14555.1 |  -12%  ||     2.22 |     2.38 |   +8%  |  0.1192 |
 | 22a     ||   16024.4 |   16949.6 |   +6%  ||     2.20 |     2.18 |   -1%  |  0.4699 |
 | 22b     ||   15801.3 |   16362.7 |   +4%  ||     2.18 |     2.18 |   -0%  |  0.6703 |
 | 22c     ||   17396.2 |   15318.9 |  -12%  ||     2.10 |     2.12 |   +1%  |  0.1226 |
 | 22d     ||   16904.4 |   18291.7 |   +8%  ||     2.07 |     2.10 |   +2%  |  0.3075 |
+| 23a     ||     501.9 |     453.2 |  -10%  ||    97.86 |   108.45 |  +11%  |  0.0000 |
+| 23b     ||    2432.0 |     946.0 |  -61%  ||    19.46 |    51.67 | +165%  |  0.0000 |
+| 23c     ||     553.8 |     528.2 |   -5%  ||    88.25 |    92.97 |   +5%  |  0.0433 |
+| 24a     ||   11786.3 |   10902.7 |   -7%  ||     2.78 |     3.48 |  +25%  |  0.3484 |
+| 24b     ||   11469.9 |   10876.2 |   -5%  ||     3.45 |     3.72 |   +8%  |  0.4633 |
+| 25a     ||    2516.4 |    2307.9 |   -8%  ||    18.62 |    20.90 |  +12%  |  0.0592 |
+| 25b     ||    2987.1 |    2786.5 |   -7%  ||    15.33 |    16.21 |   +6%  |  0.2441 |
 | 25c     ||   18056.0 |   17016.5 |   -6%  ||     2.10 |     2.07 |   -2%  |  0.4727 |
+| 26a     ||    3062.6 |    2919.3 |   -5%  ||    14.98 |    16.53 |  +10%  |  0.3738 |
+| 26b     ||    2919.9 |    2746.4 |   -6%  ||    15.53 |    16.85 |   +8%  |  0.2618 |
+| 26c     ||    3090.7 |    2839.7 |   -8%  ||    15.27 |    16.38 |   +7%  |  0.0905 |
 | 27a     ||   16530.2 |   16100.0 |   -3%  ||     2.22 |     2.30 |   +4%  |  0.7353 |
 | 27b     ||   15861.2 |   16169.8 |   +2%  ||     2.35 |     2.38 |   +1%  |  0.8048 |
+| 27c     ||    2699.3 |     916.0 |  -66%  ||    17.53 |    53.38 | +204%  |  0.0000 |
 | 28a     ||   17687.1 |   18354.9 |   +4%  ||     2.03 |     2.03 |   -0%  |  0.6412 |
 | 28b     ||   16466.4 |   16262.2 |   -1%  ||     2.32 |     2.35 |   +1%  |  0.8826 |
 | 28c     ||   16531.7 |   16237.8 |   -2%  ||     2.03 |     2.03 |   -0%  |  0.8346 |
 | 29a     ||   10346.8 |   11250.6 |   +9%  ||     3.48 |     3.63 |   +4%  |  0.3190 |
+| 29b     ||    2892.5 |    2507.4 |  -13%  ||    16.15 |    19.05 |  +18%  |  0.0121 |
+| 29c     ||   15388.4 |   11096.5 |  -28%  ||     2.70 |     3.37 |  +25%  |  0.0001 |
+| 2a      ||    1058.9 |     599.6 |  -43%  ||    45.34 |    81.86 |  +81%  |  0.0000 |
+| 2b      ||    1188.3 |     637.5 |  -46%  ||    40.63 |    76.43 |  +88%  |  0.0000 |
+| 2c      ||     806.7 |     543.7 |  -33%  ||    60.80 |    90.33 |  +49%  |  0.0000 |
+| 2d      ||    1006.7 |     689.8 |  -31%  ||    48.23 |    71.07 |  +47%  |  0.0000 |
+| 30a     ||    2649.2 |    2452.4 |   -7%  ||    17.78 |    19.11 |   +7%  |  0.1278 |
 | 30b     ||    2893.3 |    2890.5 |   -0%  ||    15.83 |    16.35 |   +3%  |  0.9857 |
 | 30c     ||   17044.6 |   16239.6 |   -5%  ||     2.00 |     2.03 |   +2%  |  0.5427 |
+| 31a     ||    3751.3 |    3048.7 |  -19%  ||    12.08 |    14.68 |  +22%  |  0.0002 |
+| 31b     ||    3489.6 |    3251.2 |   -7%  ||    13.63 |    14.27 |   +5%  |  0.2189 |
+| 31c     ||    3578.9 |    2926.6 |  -18%  ||    13.15 |    16.30 |  +24%  |  0.0002 |
 | 32a     ||     137.7 |     132.3 |   -4%  ||   349.73 |   363.23 |   +4%  |  0.0003 |
+| 32b     ||    1556.3 |    1139.9 |  -27%  ||    31.33 |    42.81 |  +37%  |  0.0000 |
+| 33a     ||     388.4 |     282.7 |  -27%  ||   126.34 |   172.66 |  +37%  |  0.0000 |
+| 33b     ||     324.1 |     280.9 |  -13%  ||   150.98 |   174.06 |  +15%  |  0.0000 |
+| 33c     ||     406.3 |     367.8 |   -9%  ||   120.79 |   133.17 |  +10%  |  0.0000 |
 | 3a      ||   17104.3 |   15065.6 |  -12%  ||     2.07 |     2.05 |   -1%  |  0.1288 |
+| 3b      ||     803.1 |     326.5 |  -59%  ||    60.90 |   150.11 | +147%  |  0.0000 |
-| 3c      ||   27763.8 |   31361.9 |  +13%  ||     1.05 |     0.97 |   -8%  |  0.1536 |
 | 4a      ||     944.6 |     945.8 |   +0%  ||    51.78 |    51.90 |   +0%  |  0.9645 |
+| 4b      ||     282.6 |     103.0 |  -64%  ||   172.66 |   463.47 | +168%  |  0.0000 |
 | 4c      ||    1156.3 |    1154.8 |   -0%  ||    42.29 |    42.27 |   -0%  |  0.9711 |
 | 5a      ||   13919.1 |   13856.6 |   -0%  ||     2.32 |     2.33 |   +1%  |  0.9540 |
 | 5b      ||    1378.3 |    1391.9 |   +1%  ||    34.86 |    34.86 |   -0%  |  0.7928 |
 | 5c      ||   18989.3 |   19445.5 |   +2%  ||     1.97 |     1.93 |   -2%  |  0.7624 |
+| 6a      ||    5501.3 |    1943.9 |  -65%  ||     7.18 |    24.36 | +239%  |  0.0000 |
+| 6b      ||    7622.1 |    6777.2 |  -11%  ||     5.48 |     5.88 |   +7%  |  0.1345 |
+| 6c      ||    6032.1 |    1897.8 |  -69%  ||     7.12 |    25.36 | +256%  |  0.0000 |
+| 6d      ||    6965.3 |    7086.1 |   +2%  ||     5.50 |     6.15 |  +12%  |  0.8120 |
+| 6e      ||    6243.4 |    1884.0 |  -70%  ||     7.28 |    25.72 | +253%  |  0.0000 |
+| 6f      ||    7311.5 |    6851.4 |   -6%  ||     5.87 |     6.40 |   +9%  |  0.2772 |
+| 7a      ||    3168.3 |    1500.2 |  -53%  ||    14.65 |    32.36 | +121%  |  0.0000 |
+| 7b      ||    1837.6 |    1589.5 |  -14%  ||    26.13 |    30.07 |  +15%  |  0.0001 |
-| 7c      ||   42267.5 |   42628.7 |   +1%  ||     0.18 |     0.12 |  -36%  |       ˅ |
+| 8a      ||    2843.1 |    1531.0 |  -46%  ||    16.43 |    31.03 |  +89%  |  0.0000 |
+| 8b      ||    2253.8 |    1511.5 |  -33%  ||    20.17 |    32.26 |  +60%  |  0.0000 |
+| 8c      ||   22068.4 |   24340.5 |  +10%  ||     1.28 |     1.37 |   +6%  |  0.2147 |
 | 8d      ||    9550.0 |   10604.4 |  +11%  ||     3.82 |     3.83 |   +0%  |  0.1360 |
 | 9a      ||   20127.1 |   20792.3 |   +3%  ||     1.52 |     1.52 |   -0%  |  0.7146 |
+| 9b      ||    4099.6 |    3189.0 |  -22%  ||    10.98 |    14.92 |  +36%  |  0.0000 |
 | 9c      ||   22694.9 |   23112.9 |   +2%  ||     1.48 |     1.48 |   +0%  |  0.8232 |
-| 9d      ||   23661.0 |   23170.6 |   -2%  ||     1.63 |     1.40 |  -14%  |  0.7540 |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
+| Sum     || 1054854.4 | 1001759.7 |   -5%  ||          |          |        |         |
+| Geomean ||           |           |        ||          |          |  +22%  |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                    |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
```
</details>