### PR TITLE
Export meta table support for the console

### DIFF
--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -11,7 +11,7 @@ import subprocess
 # ANSI-colored text turned out to be too cumbersome.
 def assert_latency_equals(item_count, runtimes, latency_string):
     if item_count == 0:
-        assert 'nan' in latency_string
+        assert "nan" in latency_string
         return
     avg_latency = sum(runtimes) / item_count / 1_000_000
     assert str(round(avg_latency, 1)) in latency_string

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -609,7 +609,7 @@ int Console::_export_table(const std::string& args) {
   const auto& meta_table_manager = Hyrise::get().meta_table_manager;
 
   std::shared_ptr<AbstractOperator> table_operator = nullptr;
-  if (meta_table_manager.is_meta_table_name(tablename)) {
+  if (MetaTableManager::is_meta_table_name(tablename)) {
     if (!meta_table_manager.has_table(tablename)) {
       out("Error: MetaTable does not exist in MetaTableManager\n");
       return ReturnCode::Error;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -15,7 +15,6 @@
 #include <memory>
 #include <regex>
 #include <string>
-#include <string_view>
 #include <vector>
 
 #include <boost/algorithm/string/join.hpp>
@@ -610,7 +609,7 @@ int Console::_export_table(const std::string& args) {
   const auto& meta_table_manager = Hyrise::get().meta_table_manager;
 
   std::shared_ptr<AbstractOperator> table_operator = nullptr;
-  if (std::string_view(tablename).starts_with(MetaTableManager::META_PREFIX)) {
+  if (meta_table_manager.is_meta_table_name(tablename)) {
     if (!meta_table_manager.has_table(tablename)) {
       out("Error: MetaTable does not exist in MetaTableManager\n");
       return ReturnCode::Error;
@@ -624,8 +623,8 @@ int Console::_export_table(const std::string& args) {
     table_operator = std::make_shared<GetTable>(tablename);
   }
 
-  out("Exporting \"" + tablename + "\" into \"" + filepath + "\" ...\n");
   table_operator->execute();
+  out("Exporting \"" + tablename + "\" into \"" + filepath + "\" ...\n");
 
   try {
     auto exporter = std::make_shared<Export>(table_operator, filepath);

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include <boost/algorithm/string/join.hpp>
@@ -30,6 +31,7 @@
 #include "operators/get_table.hpp"
 #include "operators/import.hpp"
 #include "operators/print.hpp"
+#include "operators/table_wrapper.hpp"
 #include "optimizer/join_ordering/join_graph.hpp"
 #include "optimizer/optimizer.hpp"
 #include "pagination.hpp"
@@ -45,6 +47,7 @@
 #include "tpch/tpch_table_generator.hpp"
 #include "utils/invalid_input_exception.hpp"
 #include "utils/load_table.hpp"
+#include "utils/meta_table_manager.hpp"
 #include "utils/string_utils.hpp"
 #include "visualization/join_graph_visualizer.hpp"
 #include "visualization/lqp_visualizer.hpp"
@@ -604,17 +607,28 @@ int Console::_export_table(const std::string& args) {
   const std::string& filepath = arguments.at(1);
 
   const auto& storage_manager = Hyrise::get().storage_manager;
-  if (!storage_manager.has_table(tablename)) {
-    out("Error: Table does not exist in StorageManager\n");
-    return ReturnCode::Error;
+  const auto& meta_table_manager = Hyrise::get().meta_table_manager;
+
+  std::shared_ptr<AbstractOperator> table_operator = nullptr;
+  if (std::string_view(tablename).starts_with(MetaTableManager::META_PREFIX)) {
+    if (!meta_table_manager.has_table(tablename)) {
+      out("Error: MetaTable does not exist in MetaTableManager\n");
+      return ReturnCode::Error;
+    }
+    table_operator = std::make_shared<TableWrapper>(meta_table_manager.generate_table(tablename));
+  } else {
+    if (!storage_manager.has_table(tablename)) {
+      out("Error: Table does not exist in StorageManager\n");
+      return ReturnCode::Error;
+    }
+    table_operator = std::make_shared<GetTable>(tablename);
   }
 
   out("Exporting \"" + tablename + "\" into \"" + filepath + "\" ...\n");
-  auto get_table = std::make_shared<GetTable>(tablename);
-  get_table->execute();
+  table_operator->execute();
 
   try {
-    auto exporter = std::make_shared<Export>(get_table, filepath);
+    auto exporter = std::make_shared<Export>(table_operator, filepath);
     exporter->execute();
   } catch (const std::exception& exception) {
     out("Error: Exception thrown while exporting:\n  " + std::string(exception.what()) + "\n");


### PR DESCRIPTION
With this PR, metatables can be exported from the console.
Example: `export meta_system_utilization sys_util.csv`

Additionally, this PR introduces minor format changes in `compareBenchmarkScriptTest.py`, performed by our format script.