### PR TITLE
CsvParser: Finalize chunks of parsed table

### DIFF
--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -92,9 +92,8 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const Chunk
     DebugAssert(!segments.empty(), "Empty chunks shouldn't occur when importing CSV");
     const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
     table->append_chunk(segments, mvcc_data);
+    table->last_chunk()->finalize();
   }
-
-  table->last_chunk()->finalize();
 
   return table;
 }

--- a/src/test/lib/import_export/csv/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv/csv_parser_test.cpp
@@ -289,4 +289,15 @@ TEST_F(CsvParserTest, WithScheduler) {
   Hyrise::get().set_scheduler(scheduler);
 }
 
+TEST_F(CsvParserTest, FinalizedChunks) {
+  auto table = CsvParser::parse("resources/test_data/csv/float_int_large.csv", ChunkOffset{40});
+  // parsed table has 100 rows
+  EXPECT_EQ(table->chunk_count(), 3U);
+
+  // check if all chunks are finalized
+  EXPECT_FALSE(table->get_chunk(ChunkID{0})->is_mutable());
+  EXPECT_FALSE(table->get_chunk(ChunkID{1})->is_mutable());
+  EXPECT_FALSE(table->get_chunk(ChunkID{2})->is_mutable());
+}
+
 }  // namespace opossum

--- a/src/test/lib/import_export/csv/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv/csv_parser_test.cpp
@@ -290,7 +290,7 @@ TEST_F(CsvParserTest, WithScheduler) {
 }
 
 TEST_F(CsvParserTest, FinalizedChunks) {
-  auto table = CsvParser::parse("resources/test_data/csv/float_int_large.csv", ChunkOffset{40});
+  const auto table = CsvParser::parse("resources/test_data/csv/float_int_large.csv", ChunkOffset{40});
 
   EXPECT_EQ(table->chunk_count(), 3U);
 

--- a/src/test/lib/import_export/csv/csv_parser_test.cpp
+++ b/src/test/lib/import_export/csv/csv_parser_test.cpp
@@ -291,7 +291,7 @@ TEST_F(CsvParserTest, WithScheduler) {
 
 TEST_F(CsvParserTest, FinalizedChunks) {
   auto table = CsvParser::parse("resources/test_data/csv/float_int_large.csv", ChunkOffset{40});
-  // parsed table has 100 rows
+
   EXPECT_EQ(table->chunk_count(), 3U);
 
   // check if all chunks are finalized


### PR DESCRIPTION
With this PR, all chunks of a table created by `CsvParser::parse` are finalized and thus immutable.