### PR TITLE
Fix pruning of PredicateNodes with multiple outputs

### DIFF
--- a/resources/test_data/tbl/meta_tables/meta_segments_accurate_libcpp_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_accurate_libcpp_updated.tbl
@@ -3,7 +3,7 @@ string|int|int|string|string|long|string_null|string_null|long|long|long|long|lo
 int_int|0|0|a|int|2|null|null|200|3|8|0|0
 int_int|0|1|b|int|2|null|null|200|3|6|0|0
 int_int|1|0|a|int|1|null|null|200|1|4|0|0
-int_int|1|1|b|int|1|null|null|200|1|3|0|0
+int_int|1|1|b|int|1|null|null|200|1|2|0|0
 int_int|2|0|a|int|1|null|null|200|0|1|0|0
 int_int|2|1|b|int|1|null|null|200|0|1|0|0
 int_int_int_null|0|0|a|int|2|RunLength|null|144|0|12|0|0

--- a/resources/test_data/tbl/meta_tables/meta_segments_accurate_libcpp_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_accurate_libcpp_updated.tbl
@@ -2,8 +2,8 @@ table_name|chunk_id|column_id|column_name|column_data_type|distinct_value_count|
 string|int|int|string|string|long|string_null|string_null|long|long|long|long|long
 int_int|0|0|a|int|2|null|null|200|3|8|0|0
 int_int|0|1|b|int|2|null|null|200|3|6|0|0
-int_int|1|0|a|int|1|null|null|200|1|4|0|0
-int_int|1|1|b|int|1|null|null|200|1|2|0|0
+int_int|1|0|a|int|1|null|null|200|1|3|0|0
+int_int|1|1|b|int|1|null|null|200|1|3|0|0
 int_int|2|0|a|int|1|null|null|200|0|1|0|0
 int_int|2|1|b|int|1|null|null|200|0|1|0|0
 int_int_int_null|0|0|a|int|2|RunLength|null|144|0|12|0|0

--- a/resources/test_data/tbl/meta_tables/meta_segments_accurate_libstdcpp_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_accurate_libstdcpp_updated.tbl
@@ -2,8 +2,8 @@ table_name|chunk_id|column_id|column_name|column_data_type|distinct_value_count|
 string|int|int|string|string|long|string_null|string_null|long|long|long|long|long
 int_int|0|0|a|int|2|null|null|192|3|8|0|0
 int_int|0|1|b|int|2|null|null|192|3|6|0|0
-int_int|1|0|a|int|1|null|null|192|1|4|0|0
-int_int|1|1|b|int|1|null|null|192|1|2|0|0
+int_int|1|0|a|int|1|null|null|192|1|3|0|0
+int_int|1|1|b|int|1|null|null|192|1|3|0|0
 int_int|2|0|a|int|1|null|null|192|0|1|0|0
 int_int|2|1|b|int|1|null|null|192|0|1|0|0
 int_int_int_null|0|0|a|int|2|RunLength|null|144|0|12|0|0

--- a/resources/test_data/tbl/meta_tables/meta_segments_accurate_libstdcpp_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_accurate_libstdcpp_updated.tbl
@@ -3,7 +3,7 @@ string|int|int|string|string|long|string_null|string_null|long|long|long|long|lo
 int_int|0|0|a|int|2|null|null|192|3|8|0|0
 int_int|0|1|b|int|2|null|null|192|3|6|0|0
 int_int|1|0|a|int|1|null|null|192|1|4|0|0
-int_int|1|1|b|int|1|null|null|192|1|3|0|0
+int_int|1|1|b|int|1|null|null|192|1|2|0|0
 int_int|2|0|a|int|1|null|null|192|0|1|0|0
 int_int|2|1|b|int|1|null|null|192|0|1|0|0
 int_int_int_null|0|0|a|int|2|RunLength|null|144|0|12|0|0

--- a/resources/test_data/tbl/meta_tables/meta_segments_libcpp_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_libcpp_updated.tbl
@@ -2,7 +2,7 @@ table_name|chunk_id|column_id|column_name|column_data_type|encoding_type|vector_
 string|int|int|string|string|string_null|string_null|long|long|long|long|long
 int_int|0|0|a|int|null|null|200|3|6|0|0
 int_int|0|1|b|int|null|null|200|3|4|0|0
-int_int|1|0|a|int|null|null|200|1|3|0|0
+int_int|1|0|a|int|null|null|200|1|2|0|0
 int_int|1|1|b|int|null|null|200|1|2|0|0
 int_int|2|0|a|int|null|null|200|0|0|0|0
 int_int|2|1|b|int|null|null|200|0|0|0|0

--- a/resources/test_data/tbl/meta_tables/meta_segments_libstdcpp_updated.tbl
+++ b/resources/test_data/tbl/meta_tables/meta_segments_libstdcpp_updated.tbl
@@ -2,7 +2,7 @@ table_name|chunk_id|column_id|column_name|column_data_type|encoding_type|vector_
 string|int|int|string|string|string_null|string_null|long|long|long|long|long
 int_int|0|0|a|int|null|null|192|3|6|0|0
 int_int|0|1|b|int|null|null|192|3|4|0|0
-int_int|1|0|a|int|null|null|192|1|3|0|0
+int_int|1|0|a|int|null|null|192|1|2|0|0
 int_int|1|1|b|int|null|null|192|1|2|0|0
 int_int|2|0|a|int|null|null|192|0|0|0|0
 int_int|2|1|b|int|null|null|192|0|0|0|0

--- a/src/test/lib/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -126,11 +126,11 @@ TEST_F(ChunkPruningRuleTest, MultipleOutputs1) {
   const auto b = lqp_column_(stored_table_node, ColumnID{1});
 
   // clang-format off
-  auto common = 
+  auto common =
     PredicateNode::make(greater_than_(b, 700),    // allows for pruning of chunk 0
       PredicateNode::make(greater_than_(a, 123),  // allows for pruning of chunk 2
         stored_table_node));
-  auto lqp = 
+  auto lqp =
     UnionNode::make(SetOperationMode::All,
       PredicateNode::make(less_than_(b, 850),     // would allow for pruning of chunk 3
         common),
@@ -153,10 +153,10 @@ TEST_F(ChunkPruningRuleTest, MultipleOutputs2) {
   const auto b = lqp_column_(stored_table_node, ColumnID{1});
 
   // clang-format off
-  auto common = 
+  auto common =
     PredicateNode::make(greater_than_(a, 123),  // allows for pruning of chunk 2
       stored_table_node);
-  auto lqp = 
+  auto lqp =
     UnionNode::make(SetOperationMode::All,
       PredicateNode::make(greater_than_(b, 700),    // would allow for pruning of chunk 0
         PredicateNode::make(less_than_(b, 850),     // would allow for pruning of chunk 3


### PR DESCRIPTION
Currently, if a PredicateNode has multiple outputs, it is not considered for chunk pruning. You can see the effects in TPC-H Q4, where the predicate on the orders table is not used because the between predicate has multiple outputs at the time where the rule is run.

While we must not use predicates that are on a branch of the query, using the one on the fork is fine.

No impact on TPC-H, as the affected cases profit from being able to use a binary search and the scan is quite cheap anyway. Might still be interesting for @aloeser (and @krichly?).