### PR TITLE
JoinHash: Move branch out of loop

### DIFF
--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -267,9 +267,10 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
       auto& elements = radix_container[chunk_id].elements;
       auto& null_values = radix_container[chunk_id].null_values;
 
-      elements.resize(chunk_in->size());
+      const auto num_rows = chunk_in->size();
+      elements.resize(num_rows);
       if constexpr (keep_null_values) {
-        null_values.resize(chunk_in->size());
+        null_values.resize(num_rows);
       }
 
       auto elements_iter = elements.begin();
@@ -281,8 +282,17 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
       auto reference_chunk_offset = ChunkOffset{0};
 
       const auto segment = chunk_in->get_segment(column_id);
-      segment_with_iterators<T>(*segment, [&](auto it, const auto end) {
+      segment_with_iterators<T>(*segment, [&](auto it, auto end) {
         using IterableType = typename decltype(it)::IterableType;
+
+        if constexpr (!is_reference_segment_iterable_v<IterableType>) {
+          while (end - it > num_rows) {
+            // The last chunk has changed its size since we allocated elements. This is due to a concurrent insert
+            // into that chunk. In any case, those inserts will not be visible to our current transaction, so we can
+            // ignore them.
+            --end;
+          }
+        }
 
         while (it != end) {
           const auto& value = *it;
@@ -336,19 +346,13 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
           }
 
           ++it;
-
-          if (elements_iter == elements.end()) {
-            // The last chunk has changed its size since we allocated elements. This is due to a concurrent insert
-            // into that chunk. In any case, those inserts will not be visible to our current transaction, so we can
-            // ignore them.
-            break;
-          }
         }
       });
 
       // elements was allocated with the size of the chunk. As we might have skipped NULL values, we need to resize the
       // vector to the number of values actually written.
       elements.resize(std::distance(elements.begin(), elements_iter));
+      null_values.resize(std::distance(null_values.begin(), null_values_iter));
 
       histograms[chunk_id] = std::move(histogram);
 

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -286,12 +286,11 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
         using IterableType = typename decltype(it)::IterableType;
 
         if constexpr (!is_reference_segment_iterable_v<IterableType>) {
-          while (end - it > num_rows) {
-            // The last chunk has changed its size since we allocated elements. This is due to a concurrent insert
-            // into that chunk. In any case, those inserts will not be visible to our current transaction, so we can
-            // ignore them.
-            --end;
-          }
+          // The last chunk might have changed its size since we allocated elements. This would be due to concurrent
+          // inserts into that chunk. In any case, those inserts will not be visible to our current transaction, so we
+          // can ignore them.
+          const auto inserted_rows = (end - it) - num_rows;
+          end -= inserted_rows;
         }
 
         while (it != end) {


### PR DESCRIPTION
There is a check in the hash join that we only need to do once. This moves it out of the loop.

Benchmarks are running. It appears that we are triggering another binary alignment change (Q6 is not supposed to change), so I am not sure how conclusive they are. In any case, I believe that the code change is sensible.