### PR TITLE
run_benchmarks_over_commit_range.sh: Some Fixes

### DIFF
--- a/scripts/run_benchmarks_over_commit_range.sh
+++ b/scripts/run_benchmarks_over_commit_range.sh
@@ -17,11 +17,11 @@ benchmark=$3
 shift; shift; shift
 benchmark_arguments=$@
 
-# if [[ $(git status --untracked-files=no --porcelain) ]]
-# then
-# 	echo Cowardly refusing to execute on a dirty workspace
-# 	exit 1
-# fi
+if [[ $(git status --untracked-files=no --porcelain) ]]
+then
+	echo Cowardly refusing to execute on a dirty workspace
+	exit 1
+fi
 
 commit_list=$(git rev-list --ancestry-path ${start_commit}^..${end_commit})
 

--- a/scripts/run_benchmarks_over_commit_range.sh
+++ b/scripts/run_benchmarks_over_commit_range.sh
@@ -33,9 +33,9 @@ commit_list=$(echo $commit_list | awk '{for (i=NF; i>1; i--) printf("%s ",$i); p
 output=$(grep 'CMAKE_MAKE_PROGRAM' CMakeCache.txt | grep ninja || true)
 if [ ! -z "$output" ]
 then
-  build_system='ninja'
+	build_system='ninja'
 else
-  build_system='make'
+	build_system='make'
 fi
 
 for commit in $commit_list

--- a/scripts/run_benchmarks_over_commit_range.sh
+++ b/scripts/run_benchmarks_over_commit_range.sh
@@ -17,11 +17,11 @@ benchmark=$3
 shift; shift; shift
 benchmark_arguments=$@
 
-if [[ $(git status --untracked-files=no --porcelain) ]]
-then
-	echo Cowardly refusing to execute on a dirty workspace
-	exit 1
-fi
+# if [[ $(git status --untracked-files=no --porcelain) ]]
+# then
+# 	echo Cowardly refusing to execute on a dirty workspace
+# 	exit 1
+# fi
 
 commit_list=$(git rev-list --ancestry-path ${start_commit}^..${end_commit})
 
@@ -52,6 +52,12 @@ do
 	${build_system} $benchmark -j $((cores / 2)) > /dev/null
 
 	./$benchmark $benchmark_arguments -o auto_${commit}.json
+
+	output=$(grep ${commit} auto_${commit}.json)
+	if [ -z "$output" ]; then
+		echo "Commit Hash ${commit} not found in auto_${commit}.json. It looks like the build failed."
+		exitcode=1
+	fi
 done
 
 for commit in $commit_list


### PR DESCRIPTION
* Use ninja where ninja is used, fixes #2216 
* Check that the SHA-1 hash is part of the json
* Fix output if incomplete hash or other commit reference (e.g., HEAD^) is used