### PR TITLE
Aggregate: Write ANY as part of grouping, not as pseudo aggregate function

### DIFF
--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_0agg/result_any_null.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_0agg/result_any_null.tbl
@@ -1,4 +1,4 @@
-b|ANY(a)
+b|a
 float_null|int_null
 456.7|12345
 457.7|12345

--- a/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/any_filtered.tbl
+++ b/resources/test_data/tbl/aggregateoperator/groupby_int_1gb_1agg/any_filtered.tbl
@@ -1,3 +1,3 @@
-a|ANY(b)
-int|float_null
+a|b
+int|float
 12|350.7

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -3,8 +3,8 @@
 #include <iterator>
 #include <type_traits>
 
-#include "boost/lexical_cast.hpp"
-#include "boost/variant/apply_visitor.hpp"
+#include <boost/lexical_cast.hpp>
+#include <boost/variant/apply_visitor.hpp>
 
 #include "all_parameter_variant.hpp"
 #include "expression/abstract_expression.hpp"

--- a/src/lib/operators/abstract_aggregate_operator.hpp
+++ b/src/lib/operators/abstract_aggregate_operator.hpp
@@ -124,20 +124,6 @@ class AggregateFunctionBuilder<ColumnDataType, AggregateType, AggregateFunction:
 };
 
 template <typename ColumnDataType, typename AggregateType>
-class AggregateFunctionBuilder<ColumnDataType, AggregateType, AggregateFunction::Any> {
- public:
-  auto get_aggregate_function() {
-    return [](const ColumnDataType& new_value, std::optional<AggregateType>& current_primary_aggregate,
-              std::vector<AggregateType>& current_secondary_aggregates) {
-      // ANY() is expected to be only executed on groups whose values are all equal.
-      DebugAssert(!current_primary_aggregate || *current_primary_aggregate == new_value,
-                  "ANY() expects all values in the group to be equal.");
-      current_primary_aggregate = new_value;
-    };
-  }
-};
-
-template <typename ColumnDataType, typename AggregateType>
 class AggregateFunctionBuilder<ColumnDataType, AggregateType, AggregateFunction::Count> {
  public:
   auto get_aggregate_function() {

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -617,8 +617,8 @@ void AggregateHash::_aggregate() {
                   chunk_id, aggregate_idx, *abstract_segment, keys_per_chunk);
               break;
             case AggregateFunction::Any:
-              _aggregate_segment<ColumnDataType, AggregateFunction::Any, AggregateKey>(
-                  chunk_id, aggregate_idx, *abstract_segment, keys_per_chunk);
+              //  ANY is a pseudo-function and is handled by _write_groupby_output
+              break;
           }
         });
 
@@ -651,8 +651,9 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
       break;
   }
 
-  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
-  Timer timer;  // _aggregate above has its own, internal timer. Start measuring once _aggregate is done.
+  const auto num_output_columns = _groupby_column_ids.size() + _aggregates.size();
+  _output_column_definitions.resize(num_output_columns);
+  _output_segments.resize(num_output_columns);
 
   /**
    * Write group-by columns.
@@ -672,7 +673,9 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
     }
     _write_groupby_output(pos_list);
   }
-  step_performance_data.set_step_runtime(OperatorSteps::GroupByColumnsWriting, timer.lap());
+
+  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
+  Timer timer;  // _aggregate and _write_groupby_output have their own, internal timer. Start measuring once they are done.
 
   /*
   Write the aggregated columns to the output
@@ -816,15 +819,39 @@ write_aggregate_values(pmr_vector<AggregateType>& values, pmr_vector<bool>& null
 }
 
 void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
+  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
+  Timer timer;  // _aggregate above has its own, internal timer. Start measuring once _aggregate is done.
+
   auto input_table = left_input_table();
 
-  // For each GROUP BY column, resolve its type, iterate over its values, and add them to a new output ValueSegment
-  for (const auto& column_id : _groupby_column_ids) {
-    _output_column_definitions.emplace_back(input_table->column_name(column_id),
-                                            input_table->column_data_type(column_id),
-                                            input_table->column_is_nullable(column_id));
+  auto unaggregated_columns = std::vector<std::pair<ColumnID, ColumnID>>{};
+  {
+    auto output_column_id = ColumnID{0};
+    for (const auto& input_column_id : _groupby_column_ids) {
+      unaggregated_columns.emplace_back(input_column_id, output_column_id);
+      ++output_column_id;
+    }
+    for (auto aggregate : _aggregates) {
+      if (aggregate->aggregate_function == AggregateFunction::Any) {
+        const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
+        const auto input_column_id = pqp_column.column_id;
+        unaggregated_columns.emplace_back(input_column_id, output_column_id);
+      }
+      ++output_column_id;
+    }
+  }
 
-    resolve_data_type(input_table->column_data_type(column_id), [&](const auto typed_value) {
+  // For each GROUP BY column, resolve its type, iterate over its values, and add them to a new output ValueSegment
+  for (const auto& unaggregated_column : unaggregated_columns) {
+    // Structured bindings do not work with the capture below :/
+    const auto input_column_id = unaggregated_column.first;
+    const auto output_column_id = unaggregated_column.second;
+
+    _output_column_definitions[output_column_id] = TableColumnDefinition{input_table->column_name(input_column_id),
+                                            input_table->column_data_type(input_column_id),
+                                            input_table->column_is_nullable(input_column_id)};
+
+    resolve_data_type(input_table->column_data_type(input_column_id), [&](const auto typed_value) {
       using ColumnDataType = typename decltype(typed_value)::type;
 
       auto values = pmr_vector<ColumnDataType>(pos_list.size());
@@ -841,7 +868,7 @@ void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
         auto& accessor = accessors[row_id.chunk_id];
         if (!accessor) {
           accessor =
-              create_segment_accessor<ColumnDataType>(input_table->get_chunk(row_id.chunk_id)->get_segment(column_id));
+              create_segment_accessor<ColumnDataType>(input_table->get_chunk(row_id.chunk_id)->get_segment(input_column_id));
         }
 
         const auto& optional_value = accessor->access(row_id.chunk_offset);
@@ -854,9 +881,11 @@ void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
       }
 
       auto value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
-      _output_segments.push_back(value_segment);
+      _output_segments[output_column_id] = value_segment;
     });
   }
+
+  step_performance_data.set_step_runtime(OperatorSteps::GroupByColumnsWriting, timer.lap());
 }
 
 template <typename ColumnDataType>
@@ -885,18 +914,18 @@ void AggregateHash::_write_aggregate_output(boost::hana::basic_type<ColumnDataTy
       write_aggregate_output<ColumnDataType, AggregateFunction::StandardDeviationSample>(column_index);
       break;
     case AggregateFunction::Any:
-      write_aggregate_output<ColumnDataType, AggregateFunction::Any>(column_index);
+      // write_aggregate_output<ColumnDataType, AggregateFunction::Any>(column_index);
       break;
   }
 }
 
 template <typename ColumnDataType, AggregateFunction function>
-void AggregateHash::write_aggregate_output(ColumnID column_index) {
+void AggregateHash::write_aggregate_output(ColumnID aggregate_index) {
   // retrieve type information from the aggregation traits
   typename AggregateTraits<ColumnDataType, function>::AggregateType aggregate_type;
   auto aggregate_data_type = AggregateTraits<ColumnDataType, function>::AGGREGATE_DATA_TYPE;
 
-  const auto& aggregate = _aggregates[column_index];
+  const auto& aggregate = _aggregates[aggregate_index];
 
   const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
   const auto input_column_id = pqp_column.column_id;
@@ -907,12 +936,12 @@ void AggregateHash::write_aggregate_output(ColumnID column_index) {
   }
 
   auto context = std::static_pointer_cast<AggregateResultContext<ColumnDataType, decltype(aggregate_type)>>(
-      _contexts_per_column[column_index]);
+      _contexts_per_column[aggregate_index]);
 
   const auto& results = context->results;
 
   // Before writing the first aggregate column, write all group keys into the respective columns
-  if (column_index == 0) {
+  if (aggregate_index == 0) {
     auto pos_list = RowIDPosList(context->results.size());
     auto chunk_offset = ChunkOffset{0};
     for (auto& result : context->results) {
@@ -941,7 +970,8 @@ void AggregateHash::write_aggregate_output(ColumnID column_index) {
   }
 
   DebugAssert(NEEDS_NULL || null_values.empty(), "write_aggregate_values unexpectedly wrote NULL values");
-  _output_column_definitions.emplace_back(aggregate->as_column_name(), aggregate_data_type, NEEDS_NULL);
+  const auto output_column_id = _groupby_column_ids.size() + aggregate_index;
+  _output_column_definitions[output_column_id] = TableColumnDefinition{aggregate->as_column_name(), aggregate_data_type, NEEDS_NULL};
 
   auto output_segment = std::shared_ptr<ValueSegment<decltype(aggregate_type)>>{};
   if (!NEEDS_NULL) {
@@ -950,7 +980,7 @@ void AggregateHash::write_aggregate_output(ColumnID column_index) {
     output_segment =
         std::make_shared<ValueSegment<decltype(aggregate_type)>>(std::move(values), std::move(null_values));
   }
-  _output_segments.push_back(output_segment);
+  _output_segments[output_column_id] = output_segment;
 }
 
 template <typename AggregateKey>

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -675,9 +675,9 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
     _write_groupby_output(pos_list);
   }
 
+  // _aggregate and _write_groupby_output have their own, internal timer. Start measuring once they are done.
   auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
-  Timer
-      timer;  // _aggregate and _write_groupby_output have their own, internal timer. Start measuring once they are done.
+  Timer timer;
 
   /*
   Write the aggregated columns to the output

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -662,6 +662,8 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
 
   /**
    * If only GROUP BY columns (including ANY pseudo-aggregates) are written, we need to call _write_groupby_output.
+   *   Example: SELECT c_custkey, c_name FROM customer GROUP BY c_custkey, c_name (same as SELECT DISTINCT), which
+   *            is rewritten to group only on c_custkey and collect c_name as an ANY pseudo-aggregate.
    * Otherwise, it is called by the first call to _write_aggregate_output.
    **/
   if (!_has_aggregate_functions) {

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -833,7 +833,7 @@ void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
       unaggregated_columns.emplace_back(input_column_id, output_column_id);
       ++output_column_id;
     }
-    for (auto aggregate : _aggregates) {
+    for (const auto& aggregate : _aggregates) {
       if (aggregate->aggregate_function == AggregateFunction::Any) {
         const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
         const auto input_column_id = pqp_column.column_id;

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -147,6 +147,7 @@ class AggregateHash : public AbstractAggregateOperator {
 
   std::vector<std::shared_ptr<BaseValueSegment>> _groupby_segments;
   std::vector<std::shared_ptr<SegmentVisitorContext>> _contexts_per_column;
+  bool _has_aggregate_functions;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -104,7 +104,7 @@ class AggregateHash : public AbstractAggregateOperator {
 
   // write the aggregated output for a given aggregate column
   template <typename ColumnDataType, AggregateFunction function>
-  void write_aggregate_output(ColumnID column_index);
+  void write_aggregate_output(ColumnID aggregate_index);
 
   enum class OperatorSteps : uint8_t {
     GroupByKeyPartitioning,

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -676,7 +676,8 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
           break;
         }
         case AggregateFunction::Any: {
-          write_groupby_column(input_column_id, ColumnID{static_cast<ColumnID::base_type>(aggregate_index + _groupby_column_ids.size())});
+          write_groupby_column(input_column_id, ColumnID{static_cast<ColumnID::base_type>(aggregate_index +
+                                                                                          _groupby_column_ids.size())});
           break;
         }
       }
@@ -767,7 +768,11 @@ void AggregateSort::create_aggregate_column_definitions(ColumnID column_index) {
     aggregate_data_type = left_input_table()->column_data_type(input_column_id);
   }
 
-  constexpr bool NEEDS_NULL = (function != AggregateFunction::Count && function != AggregateFunction::CountDistinct);
-  _output_column_definitions.emplace_back(aggregate->as_column_name(), aggregate_data_type, NEEDS_NULL);
+  const auto nullable = (function != AggregateFunction::Count && function != AggregateFunction::CountDistinct &&
+                         function != AggregateFunction::Any) ||
+                        (function == AggregateFunction::Any && left_input_table()->column_is_nullable(input_column_id));
+  const auto column_name = aggregate->aggregate_function == AggregateFunction::Any ? pqp_column.as_column_name()
+                                                                                   : aggregate->as_column_name();
+  _output_column_definitions.emplace_back(column_name, aggregate_data_type, nullable);
 }
 }  // namespace opossum

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -553,10 +553,9 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
    *     output the column value at the start of the group (it is per definition the same in the whole group)
    * Write outputted values into the result table
    */
-  size_t groupby_index = 0;
-  for (const auto& column_id : _groupby_column_ids) {
+  const auto write_groupby_column = [&](const ColumnID input_column_id, const ColumnID output_column_id) {
     auto group_boundary_iter = group_boundaries.cbegin();
-    auto data_type = input_table->column_data_type(column_id);
+    auto data_type = input_table->column_data_type(input_column_id);
     resolve_data_type(data_type, [&](auto type) {
       using ColumnDataType = typename decltype(type)::type;
       auto values = pmr_vector<ColumnDataType>(group_boundaries.size() + 1);
@@ -573,7 +572,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
         }
 
         const auto chunk = sorted_table->get_chunk(group_start.chunk_id);
-        const auto& segment = chunk->get_segment(column_id);
+        const auto& segment = chunk->get_segment(input_column_id);
 
         /*
          * We are aware that operator[] and AllTypeVariant are known to be inefficient.
@@ -592,10 +591,15 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
       }
 
       // Write group by segments
-      _output_segments[groupby_index] =
+      _output_segments[output_column_id] =
           std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
     });
-    groupby_index++;
+  };
+
+  auto groupby_output_column_id = ColumnID{0};
+  for (const auto& input_column_id : _groupby_column_ids) {
+    write_groupby_column(input_column_id, groupby_output_column_id);
+    ++groupby_output_column_id;
   }
 
   // Call _aggregate_values for each aggregate
@@ -672,9 +676,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
           break;
         }
         case AggregateFunction::Any: {
-          using AggregateType = typename AggregateTraits<ColumnDataType, AggregateFunction::Any>::AggregateType;
-          _aggregate_values<ColumnDataType, AggregateType, AggregateFunction::Any>(group_boundaries, aggregate_index,
-                                                                                   sorted_table);
+          write_groupby_column(input_column_id, ColumnID{static_cast<ColumnID::base_type>(aggregate_index + _groupby_column_ids.size())});
           break;
         }
       }

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -94,8 +94,6 @@ namespace opossum {
 std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   auto optimizer = std::make_shared<Optimizer>();
 
-  optimizer->add_rule(std::make_unique<DependentGroupByReductionRule>());
-
   optimizer->add_rule(std::make_unique<ExpressionReductionRule>());
 
   // Run before the JoinOrderingRule so that the latter has simple (non-conjunctive) predicates. However, as the
@@ -106,6 +104,11 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   // case we are out of luck and the join ordering will be sub-optimal) but many of them are also introduced by the
   // SubqueryToJoinRule. As such, we run the JoinOrderingRule before the SubqueryToJoinRule.
   optimizer->add_rule(std::make_unique<JoinOrderingRule>());
+
+  // Run Group-By Reduction after the JoinOrderingRule ran. The actual join order is not important, but the matching
+  // of cross joins with predicates that is done by that rule is needed to create some of the functional dependencies
+  // (FDs) used by the DependentGroupByReductionRule.
+  optimizer->add_rule(std::make_unique<DependentGroupByReductionRule>());
 
   optimizer->add_rule(std::make_unique<BetweenCompositionRule>());
 

--- a/src/test/lib/operators/aggregate_test.cpp
+++ b/src/test/lib/operators/aggregate_test.cpp
@@ -233,25 +233,6 @@ TYPED_TEST(OperatorsAggregateTest, AnyOnGroupWithMultipleEntries) {
   EXPECT_EQ(aggregate->get_output()->template get_value<int>(ColumnID{2}, 0u), 20);
 }
 
-// For debug builds, we DebugAssert that all values are the same within a group.
-TYPED_TEST(OperatorsAggregateTest, FailAnyOnNonDependentColumn) {
-  if (!HYRISE_DEBUG) GTEST_SKIP();
-
-  auto filtered = std::make_shared<TableScan>(
-      this->_table_wrapper_2_2, equals_(get_column_expression(this->_table_wrapper_2_2, ColumnID{0}), 123));
-  filtered->execute();
-
-  // Column 3 stores different values for the tuples of the remaining group.
-  const auto table = this->_table_wrapper_2_2->get_output();
-  const auto aggregate_expressions = std::vector<std::shared_ptr<AggregateExpression>>{
-      any_(pqp_column_(ColumnID{3}, table->column_data_type(ColumnID{3}), table->column_is_nullable(ColumnID{3}),
-                       table->column_name(ColumnID{3})))};
-
-  auto aggregate =
-      std::make_shared<TypeParam>(filtered, aggregate_expressions, std::vector<ColumnID>{ColumnID{0}, ColumnID{1}});
-  EXPECT_THROW(aggregate->execute(), std::logic_error);
-}
-
 // Use ANY() on a column with NULL values.
 TYPED_TEST(OperatorsAggregateTest, AnyAndNulls) {
   test_output<TypeParam>(this->_table_wrapper_1_0_null, {{ColumnID{0}, AggregateFunction::Any}}, {ColumnID{1}},


### PR DESCRIPTION
Currently we treat ANY as a regular aggregate function, which means that we look at each value individually. By writing it as if it was a group-by column (but not using it for grouping), we gain quite a bit:

```diff
 +Configuration Overview----+------------------------------------------------+------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/master_node1.json        | agg.json                                       |
 +--------------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH                | ae811a4f022d58a54c40c8b49eeb2146fb01e9db-dirty | e228c01d829714a3027a484a903c8bbba7550023-dirty |
 |  benchmark_mode          | Ordered                                        | Ordered                                        |
 |  build_type              | release                                        | release                                        |
 |  chunk_size              | 65535                                          | 65535                                          |
 |  clients                 | 1                                              | 1                                              |
 |  compiler                | gcc 9.2                                        | gcc 9.2                                        |
 |  cores                   | 0                                              | 0                                              |
 |  date                    | 2020-09-16 13:04:38                            | 2020-09-16 12:15:33                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes                 | False                                          | False                                          |
 |  max_duration            | 60000000000                                    | 60000000000                                    |
 |  max_runs                | -1                                             | -1                                             |
 |  scale_factor            | 1.0                                            | 1.0                                            |
 |  time_unit               | ns                                             | ns                                             |
 |  use_prepared_statements | False                                          | False                                          |
 |  using_scheduler         | False                                          | False                                          |
 |  verify                  | False                                          | False                                          |
 |  warmup_duration         | 0                                              | 0                                              |
 +--------------------------+------------------------------------------------+------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    822.9 |   822.4 |   -0%  ||     1.22 |     1.22 |   +0%  |  0.9315 |
 | TPC-H 02 ||      4.5 |     4.6 |   +2%  ||   220.20 |   215.56 |   -2%  |  0.0069 |
 | TPC-H 03 ||     80.9 |    81.3 |   +1%  ||    12.36 |    12.29 |   -1%  |  0.0001 |
 | TPC-H 04 ||     65.3 |    65.7 |   +1%  ||    15.32 |    15.22 |   -1%  |  0.0000 |
 | TPC-H 05 ||    222.1 |   225.6 |   +2%  ||     4.50 |     4.43 |   -2%  |  0.0003 |
 | TPC-H 06 ||      3.2 |     3.2 |   +0%  ||   313.27 |   312.78 |   -0%  |  0.1279 |
 | TPC-H 07 ||     56.8 |    57.1 |   +0%  ||    17.59 |    17.53 |   -0%  |  0.7006 |
 | TPC-H 08 ||     72.0 |    72.9 |   +1%  ||    13.90 |    13.71 |   -1%  |  0.0063 |
 | TPC-H 09 ||    502.3 |   510.8 |   +2%  ||     1.99 |     1.96 |   -2%  |  0.0000 |
+| TPC-H 10 ||    252.7 |   164.9 |  -35%  ||     3.96 |     6.06 |  +53%  |  0.0000 |
 | TPC-H 11 ||      8.2 |     8.2 |   +1%  ||   122.33 |   121.29 |   -1%  |  0.0000 |
 | TPC-H 12 ||     42.2 |    43.0 |   +2%  ||    23.71 |    23.26 |   -2%  |  0.0000 |
 | TPC-H 13 ||    351.1 |   357.7 |   +2%  ||     2.85 |     2.80 |   -2%  |  0.0000 |
 | TPC-H 14 ||     21.0 |    21.3 |   +1%  ||    47.63 |    46.96 |   -1%  |  0.0000 |
 | TPC-H 15 ||      7.7 |     7.8 |   +2%  ||   130.42 |   127.50 |   -2%  |  0.0000 |
 | TPC-H 16 ||     89.9 |    91.3 |   +2%  ||    11.12 |    10.95 |   -2%  |  0.0000 |
 | TPC-H 17 ||     16.3 |    16.5 |   +1%  ||    61.21 |    60.62 |   -1%  |  0.0000 |
 | TPC-H 18 ||    726.7 |   727.7 |   +0%  ||     1.38 |     1.37 |   -0%  |  0.8958 |
 | TPC-H 19 ||     27.8 |    28.2 |   +2%  ||    36.02 |    35.47 |   -2%  |  0.0000 |
 | TPC-H 20 ||     15.6 |    15.6 |   +0%  ||    63.97 |    63.92 |   -0%  |  0.7599 |
 | TPC-H 21 ||    410.2 |   413.3 |   +1%  ||     2.44 |     2.42 |   -1%  |  0.1112 |
 | TPC-H 22 ||     49.5 |    49.7 |   +0%  ||    20.22 |    20.13 |   -0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3848.8 |  3789.0 |   -2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```