### PR TITLE
Add OperatorSteps to Projection

### DIFF
--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -445,7 +445,7 @@ void AggregateHash::_aggregate() {
   // Check for invalid aggregates
   _validate_aggregates();
 
-  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
+  auto& step_performance_data = dynamic_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
   Timer timer;
 
   /**
@@ -651,7 +651,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
       break;
   }
 
-  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
+  auto& step_performance_data = dynamic_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
   Timer timer;  // _aggregate above has its own, internal timer. Start measuring once _aggregate is done.
 
   /**

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -206,7 +206,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
         _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(
             *this, build_input_table, probe_input_table, _mode, adjusted_column_ids,
             _primary_predicate.predicate_condition, output_column_order, *_radix_bits,
-            static_cast<OperatorPerformanceData<JoinHash::OperatorSteps>&>(*performance_data),
+            dynamic_cast<OperatorPerformanceData<JoinHash::OperatorSteps>&>(*performance_data),
             std::move(adjusted_secondary_predicates));
       } else {
         Fail("Cannot join String with non-String column");

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -25,6 +25,13 @@ class Projection : public AbstractReadOnlyOperator {
 
   const std::string& name() const override;
 
+  enum class OperatorSteps : uint8_t {
+    UncorrelatedSubqueries,
+    ForwardUnmodifiedColumns,
+    EvaluateNewColumns,
+    BuildOutput
+  };
+
   /**
    * The dummy table is used for literal projections that have no input table.
    * This was introduce to allow queries like INSERT INTO tbl VALUES (1, 2, 3);


### PR DESCRIPTION
Adds the following steps to the projection operator: `UncorrelatedSubqueries, ForwardUnmodifiedColumns, EvaluateNewColumns, BuildOutput`.

This helps us in understanding the performance of queries.

Also changes some casts to dynamic_casts that fail if the data structure was not properly initialized.