### PR TITLE
Fix segfault when requesting vector compression of LZ4 segment of an empty string column

### DIFF
--- a/src/lib/import_export/binary/binary_writer.cpp
+++ b/src/lib/import_export/binary/binary_writer.cpp
@@ -305,15 +305,15 @@ void BinaryWriter::_write_segment(const LZ4Segment<T>& lz4_segment, std::ofstrea
   // Write dictionary
   export_values(ofstream, lz4_segment.dictionary());
 
-  if (lz4_segment.string_offsets() && *lz4_segment.string_offsets()) {
+  if (lz4_segment.string_offsets()) {
     // Write string_offset size
-    export_value(ofstream, static_cast<uint32_t>((*lz4_segment.string_offsets())->size()));
+    export_value(ofstream, static_cast<uint32_t>(lz4_segment.string_offsets()->size()));
     // Write string_offset data_size
     export_value(ofstream,
                  static_cast<uint32_t>(
-                     dynamic_cast<const SimdBp128Vector&>(*lz4_segment.string_offsets().value()).data().size()));
+                     dynamic_cast<const SimdBp128Vector&>(*lz4_segment.string_offsets()).data().size()));
     // Write string offsets
-    _export_compressed_vector(ofstream, *lz4_segment.compressed_vector_type(), *lz4_segment.string_offsets().value());
+    _export_compressed_vector(ofstream, *lz4_segment.compressed_vector_type(), *(lz4_segment.string_offsets()));
   } else {
     // Write string_offset size = 0
     export_value(ofstream, uint32_t{0});

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -23,7 +23,7 @@ LZ4Segment<T>::LZ4Segment(pmr_vector<pmr_vector<char>>&& lz4_blocks, std::option
       _lz4_blocks{std::move(lz4_blocks)},
       _null_values{std::move(null_values)},
       _dictionary{std::move(dictionary)},
-      _string_offsets{std::nullopt},
+      _string_offsets{nullptr},
       _block_size{block_size},
       _last_block_size{last_block_size},
       _compressed_size{compressed_size},
@@ -71,11 +71,11 @@ const std::optional<pmr_vector<bool>>& LZ4Segment<T>::null_values() const {
 }
 
 template <typename T>
-std::optional<std::unique_ptr<BaseVectorDecompressor>> LZ4Segment<T>::string_offset_decompressor() const {
-  if (_string_offsets && *_string_offsets) {
-    return (*_string_offsets)->create_base_decompressor();
+std::unique_ptr<BaseVectorDecompressor> LZ4Segment<T>::string_offset_decompressor() const {
+  if (_string_offsets) {
+    return _string_offsets->create_base_decompressor();
   } else {
-    return std::nullopt;
+    return nullptr;
   }
 }
 
@@ -105,7 +105,7 @@ size_t LZ4Segment<T>::last_block_size() const {
 }
 
 template <typename T>
-const std::optional<std::unique_ptr<const BaseCompressedVector>>& LZ4Segment<T>::string_offsets() const {
+const std::unique_ptr<const BaseCompressedVector>& LZ4Segment<T>::string_offsets() const {
   return _string_offsets;
 }
 
@@ -153,7 +153,7 @@ std::vector<pmr_string> LZ4Segment<pmr_string>::decompress() const {
    * indicated by the end of the data vector.
    * The offsets are stored in a compressed vector and accessed via the vector decompression interface.
    */
-  auto offset_decompressor = (*_string_offsets)->create_base_decompressor();
+  auto offset_decompressor = _string_offsets->create_base_decompressor();
   auto decompressed_strings = std::vector<pmr_string>();
   for (auto offset_index = size_t{0u}; offset_index < offset_decompressor->size(); ++offset_index) {
     auto start_char_offset = offset_decompressor->get(offset_index);
@@ -304,7 +304,7 @@ std::pair<pmr_string, size_t> LZ4Segment<pmr_string>::decompress(const ChunkOffs
    * blocks need to be decompressed.
    * The offsets are stored in a compressed vector and accessed via the vector decompression interface.
    */
-  auto offset_decompressor = (*_string_offsets)->create_base_decompressor();
+  auto offset_decompressor = _string_offsets->create_base_decompressor();
   auto start_offset = offset_decompressor->get(chunk_offset);
   size_t end_offset;
   if (chunk_offset + 1 == offset_decompressor->size()) {
@@ -432,7 +432,7 @@ std::shared_ptr<AbstractSegment> LZ4Segment<T>::copy_using_allocator(const Polym
   auto copy = std::shared_ptr<LZ4Segment<T>>{};
 
   if (_string_offsets) {
-    auto new_string_offsets = *_string_offsets ? (*_string_offsets)->copy_using_allocator(alloc) : nullptr;
+    auto new_string_offsets = _string_offsets ? _string_offsets->copy_using_allocator(alloc) : nullptr;
     copy = std::make_shared<LZ4Segment<T>>(std::move(new_lz4_blocks), std::move(new_null_values),
                                            std::move(new_dictionary), std::move(new_string_offsets), _block_size,
                                            _last_block_size, _compressed_size, _num_elements);
@@ -466,8 +466,8 @@ size_t LZ4Segment<T>::memory_usage(const MemoryUsageCalculationMode) const {
    * (i.e., no rows or only rows with empty strings).
    */
   auto offset_size = size_t{0};
-  if (_string_offsets && *_string_offsets) {
-    offset_size = (*_string_offsets)->data_size();
+  if (_string_offsets) {
+    offset_size = _string_offsets->data_size();
   }
   return sizeof(*this) + _compressed_size + null_value_vector_size + offset_size + _dictionary.size() +
          block_vector_size;
@@ -488,8 +488,8 @@ std::optional<CompressedVectorType> LZ4Segment<T>::compressed_vector_type() cons
 template <>
 std::optional<CompressedVectorType> LZ4Segment<pmr_string>::compressed_vector_type() const {
   std::optional<CompressedVectorType> type;
-  if (_string_offsets && *_string_offsets) {
-    return (*_string_offsets)->type();
+  if (_string_offsets) {
+    return _string_offsets->type();
   }
   return type;
 }

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -488,8 +488,8 @@ std::optional<CompressedVectorType> LZ4Segment<T>::compressed_vector_type() cons
 template <>
 std::optional<CompressedVectorType> LZ4Segment<pmr_string>::compressed_vector_type() const {
   std::optional<CompressedVectorType> type;
-  if (_string_offsets) {
-    resolve_compressed_vector_type(*(*_string_offsets), [&](const auto& vector) { type = vector.type(); });
+  if (_string_offsets && *_string_offsets) {
+    return (*_string_offsets)->type();
   }
   return type;
 }

--- a/src/lib/storage/lz4_segment.hpp
+++ b/src/lib/storage/lz4_segment.hpp
@@ -73,7 +73,7 @@ class LZ4Segment : public AbstractEncodedSegment {
    *                   a single block, the passed dictionary will be empty since it is not needed for independent
    *                   decompression.
    * @param string_offsets These offsets are only needed if this segment is not a pmr_string segment.
-   *                       Otherwise, this is set to a std::nullopt (see the other constructor).
+   *                       Otherwise, this is set to nullptr (see the other constructor).
    *                       It contains the offsets for the compressed strings. The offset at position 0 is the
    *                       character index of the string at index 0. Its (exclusive) end is at the offset at position 1.
    *                       The last string ends at the end of the compressed data (since there is an offset after it
@@ -96,12 +96,12 @@ class LZ4Segment : public AbstractEncodedSegment {
                       const size_t num_elements);
 
   const std::optional<pmr_vector<bool>>& null_values() const;
-  std::optional<std::unique_ptr<BaseVectorDecompressor>> string_offset_decompressor() const;
+  std::unique_ptr<BaseVectorDecompressor> string_offset_decompressor() const;
   const pmr_vector<char>& dictionary() const;
   const pmr_vector<pmr_vector<char>>& lz4_blocks() const;
   size_t block_size() const;
   size_t last_block_size() const;
-  const std::optional<std::unique_ptr<const BaseCompressedVector>>& string_offsets() const;
+  const std::unique_ptr<const BaseCompressedVector>& string_offsets() const;
 
   /**
    * @defgroup AbstractSegment interface
@@ -173,7 +173,7 @@ class LZ4Segment : public AbstractEncodedSegment {
   const pmr_vector<pmr_vector<char>> _lz4_blocks;
   const std::optional<pmr_vector<bool>> _null_values;
   const pmr_vector<char> _dictionary;
-  const std::optional<std::unique_ptr<const BaseCompressedVector>> _string_offsets;
+  const std::unique_ptr<const BaseCompressedVector> _string_offsets;
   const size_t _block_size;
   const size_t _last_block_size;
   const size_t _compressed_size;

--- a/src/test/lib/storage/lz4_segment_test.cpp
+++ b/src/test/lib/storage/lz4_segment_test.cpp
@@ -41,7 +41,7 @@ TEST_F(StorageLZ4SegmentTest, HandleOptionalOffsetsAndNullValues) {
   vs_str->append("Peter");
   auto str_segment = compress(vs_str, DataType::String);
   EXPECT_TRUE(str_segment->string_offset_decompressor());
-  EXPECT_NE(*(str_segment->string_offset_decompressor()), nullptr);
+  EXPECT_NE(str_segment->string_offset_decompressor(), nullptr);
   EXPECT_FALSE(str_segment->null_values());
 }
 
@@ -88,7 +88,7 @@ TEST_F(StorageLZ4SegmentTest, CompressNullableStringSegment) {
 
   const auto offset_decompressor = lz4_segment->string_offset_decompressor();
   EXPECT_TRUE(offset_decompressor);
-  EXPECT_EQ((*offset_decompressor)->size(), 6u);
+  EXPECT_EQ(offset_decompressor->size(), 6u);
 
   auto expected_offsets = std::vector<size_t>{0, 4, 9, 13, 17, 17};
   for (auto index = size_t{0u}; index < lz4_segment->size(); ++index) {
@@ -96,7 +96,7 @@ TEST_F(StorageLZ4SegmentTest, CompressNullableStringSegment) {
     EXPECT_TRUE((*null_values)[index] == expected_null_values[index]);
 
     // Test offsets
-    EXPECT_TRUE((*offset_decompressor)->get(index) == expected_offsets[index]);
+    EXPECT_TRUE(offset_decompressor->get(index) == expected_offsets[index]);
   }
 }
 
@@ -120,7 +120,7 @@ TEST_F(StorageLZ4SegmentTest, CompressNullableAndEmptyStringSegment) {
 
   const auto offset_decompressor = lz4_segment->string_offset_decompressor();
   EXPECT_TRUE(offset_decompressor);
-  EXPECT_EQ((*offset_decompressor)->size(), 6u);
+  EXPECT_EQ(offset_decompressor->size(), 6u);
 
   auto expected_offsets = std::vector<size_t>{0, 4, 9, 13, 13, 13};
   for (auto index = size_t{0u}; index < lz4_segment->size(); ++index) {
@@ -128,7 +128,7 @@ TEST_F(StorageLZ4SegmentTest, CompressNullableAndEmptyStringSegment) {
     EXPECT_TRUE((*null_values)[index] == expected_null_values[index]);
 
     // Test offsets
-    EXPECT_TRUE((*offset_decompressor)->get(index) == expected_offsets[index]);
+    EXPECT_TRUE(offset_decompressor->get(index) == expected_offsets[index]);
   }
 }
 
@@ -147,20 +147,20 @@ TEST_F(StorageLZ4SegmentTest, CompressSingleCharStringSegment) {
 
   const auto offset_decompressor = lz4_segment->string_offset_decompressor();
   EXPECT_TRUE(offset_decompressor);
-  EXPECT_EQ((*offset_decompressor)->size(), row_count + 1);
+  EXPECT_EQ(offset_decompressor->size(), row_count + 1);
 
   for (auto index = size_t{0u}; index < lz4_segment->size() - 1; ++index) {
     // Test compressed values
     EXPECT_EQ(decompressed_data[index], "");
 
     // Test offsets
-    EXPECT_EQ((*offset_decompressor)->get(index), 0);
+    EXPECT_EQ(offset_decompressor->get(index), 0);
   }
 
   // Test last element
   EXPECT_EQ(decompressed_data[row_count], "a");
   // This offset is also 0 since the elements before it don't have any content
-  EXPECT_EQ((*offset_decompressor)->get(row_count), 0);
+  EXPECT_EQ(offset_decompressor->get(row_count), 0);
 }
 
 TEST_F(StorageLZ4SegmentTest, CompressZeroOneStringSegment) {


### PR DESCRIPTION
For empty string columns (not the case for TPC-H, but for TPC-DS), LZ4 does not store the string vector offsets as every query is of length 0.
When requesting the vector compression type, a check was missing and Hyrise crashed when the vector compression type was requested for an empty string column.

I thought about testing it, but empty string columns are tested and would be needed is now testing the return value of the compressed vector type. I am not sure if that test makes sense.
In case anybody likes to see a test, I'll add one.