### PR TITLE
Prohibit LQP Modification for Cardinality Estimation

### DIFF
--- a/src/lib/statistics/abstract_cardinality_estimator.hpp
+++ b/src/lib/statistics/abstract_cardinality_estimator.hpp
@@ -26,7 +26,7 @@ class AbstractCardinalityEstimator {
   /**
    * @return the estimated output row count of @param lqp
    */
-  virtual Cardinality estimate_cardinality(const std::shared_ptr<AbstractLQPNode>& lqp) const = 0;
+  virtual Cardinality estimate_cardinality(const std::shared_ptr<const AbstractLQPNode>& lqp) const = 0;
 
   /**
    * For increased cardinality estimation performance:

--- a/src/lib/statistics/cardinality_estimation_cache.hpp
+++ b/src/lib/statistics/cardinality_estimation_cache.hpp
@@ -9,7 +9,7 @@ class CardinalityEstimationCache {
  public:
   std::optional<JoinGraphStatisticsCache> join_graph_statistics_cache;
 
-  using StatisticsByLQP = std::unordered_map<std::shared_ptr<AbstractLQPNode>, std::shared_ptr<TableStatistics>>;
+  using StatisticsByLQP = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, std::shared_ptr<TableStatistics>>;
   std::optional<StatisticsByLQP> statistics_by_lqp;
 };
 

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -75,13 +75,13 @@ std::shared_ptr<AbstractCardinalityEstimator> CardinalityEstimator::new_instance
   return std::make_shared<CardinalityEstimator>();
 }
 
-Cardinality CardinalityEstimator::estimate_cardinality(const std::shared_ptr<AbstractLQPNode>& lqp) const {
+Cardinality CardinalityEstimator::estimate_cardinality(const std::shared_ptr<const AbstractLQPNode>& lqp) const {
   const auto estimated_statistics = estimate_statistics(lqp);
   return estimated_statistics->row_count;
 }
 
 std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
-    const std::shared_ptr<AbstractLQPNode>& lqp) const {
+    const std::shared_ptr<const AbstractLQPNode>& lqp) const {
   /**
    * 1. Try a cache lookup for requested LQP.
    *
@@ -122,39 +122,39 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
 
   switch (lqp->type) {
     case LQPNodeType::Aggregate: {
-      const auto aggregate_node = std::dynamic_pointer_cast<AggregateNode>(lqp);
+      const auto aggregate_node = std::dynamic_pointer_cast<const AggregateNode>(lqp);
       output_table_statistics = estimate_aggregate_node(*aggregate_node, left_input_table_statistics);
     } break;
 
     case LQPNodeType::Alias: {
-      const auto alias_node = std::dynamic_pointer_cast<AliasNode>(lqp);
+      const auto alias_node = std::dynamic_pointer_cast<const AliasNode>(lqp);
       output_table_statistics = estimate_alias_node(*alias_node, left_input_table_statistics);
     } break;
 
     case LQPNodeType::Join: {
-      const auto join_node = std::dynamic_pointer_cast<JoinNode>(lqp);
+      const auto join_node = std::dynamic_pointer_cast<const JoinNode>(lqp);
       output_table_statistics =
           estimate_join_node(*join_node, left_input_table_statistics, right_input_table_statistics);
     } break;
 
     case LQPNodeType::Limit: {
-      const auto limit_node = std::dynamic_pointer_cast<LimitNode>(lqp);
+      const auto limit_node = std::dynamic_pointer_cast<const LimitNode>(lqp);
       output_table_statistics = estimate_limit_node(*limit_node, left_input_table_statistics);
     } break;
 
     case LQPNodeType::Mock: {
-      const auto mock_node = std::dynamic_pointer_cast<MockNode>(lqp);
+      const auto mock_node = std::dynamic_pointer_cast<const MockNode>(lqp);
       Assert(mock_node->table_statistics(), "Cannot return statistics of MockNode that was not assigned statistics");
       output_table_statistics = prune_column_statistics(mock_node->table_statistics(), mock_node->pruned_column_ids());
     } break;
 
     case LQPNodeType::Predicate: {
-      const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(lqp);
+      const auto predicate_node = std::dynamic_pointer_cast<const PredicateNode>(lqp);
       output_table_statistics = estimate_predicate_node(*predicate_node, left_input_table_statistics);
     } break;
 
     case LQPNodeType::Projection: {
-      const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(lqp);
+      const auto projection_node = std::dynamic_pointer_cast<const ProjectionNode>(lqp);
       output_table_statistics = estimate_projection_node(*projection_node, left_input_table_statistics);
     } break;
 
@@ -163,13 +163,13 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
     } break;
 
     case LQPNodeType::StaticTable: {
-      const auto static_table_node = std::dynamic_pointer_cast<StaticTableNode>(lqp);
+      const auto static_table_node = std::dynamic_pointer_cast<const StaticTableNode>(lqp);
       output_table_statistics = static_table_node->table->table_statistics();
       Assert(output_table_statistics, "This StaticTableNode has no statistics");
     } break;
 
     case LQPNodeType::StoredTable: {
-      const auto stored_table_node = std::dynamic_pointer_cast<StoredTableNode>(lqp);
+      const auto stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(lqp);
 
       const auto stored_table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
       Assert(stored_table->table_statistics(), "Stored Table should have cardinality estimation statistics");
@@ -188,12 +188,12 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
     } break;
 
     case LQPNodeType::Validate: {
-      const auto validate_node = std::dynamic_pointer_cast<ValidateNode>(lqp);
+      const auto validate_node = std::dynamic_pointer_cast<const ValidateNode>(lqp);
       output_table_statistics = estimate_validate_node(*validate_node, left_input_table_statistics);
     } break;
 
     case LQPNodeType::Union: {
-      const auto union_node = std::dynamic_pointer_cast<UnionNode>(lqp);
+      const auto union_node = std::dynamic_pointer_cast<const UnionNode>(lqp);
       output_table_statistics =
           estimate_union_node(*union_node, left_input_table_statistics, right_input_table_statistics);
     } break;

--- a/src/lib/statistics/cardinality_estimator.hpp
+++ b/src/lib/statistics/cardinality_estimator.hpp
@@ -32,8 +32,8 @@ class CardinalityEstimator : public AbstractCardinalityEstimator {
  public:
   std::shared_ptr<AbstractCardinalityEstimator> new_instance() const override;
 
-  Cardinality estimate_cardinality(const std::shared_ptr<AbstractLQPNode>& lqp) const override;
-  std::shared_ptr<TableStatistics> estimate_statistics(const std::shared_ptr<AbstractLQPNode>& lqp) const;
+  Cardinality estimate_cardinality(const std::shared_ptr<const AbstractLQPNode>& lqp) const override;
+  std::shared_ptr<TableStatistics> estimate_statistics(const std::shared_ptr<const AbstractLQPNode>& lqp) const;
 
   /**
    * Per-node-type estimation functions

--- a/src/lib/statistics/join_graph_statistics_cache.cpp
+++ b/src/lib/statistics/join_graph_statistics_cache.cpp
@@ -29,7 +29,7 @@ JoinGraphStatisticsCache::JoinGraphStatisticsCache(VertexIndexMap&& vertex_indic
     : _vertex_indices(std::move(vertex_indices)), _predicate_indices(std::move(predicate_indices)) {}
 
 std::optional<JoinGraphStatisticsCache::Bitmask> JoinGraphStatisticsCache::bitmask(
-    const std::shared_ptr<AbstractLQPNode>& lqp) const {
+    const std::shared_ptr<const AbstractLQPNode>& lqp) const {
   auto bitmask = std::optional<Bitmask>{_vertex_indices.size() + _predicate_indices.size()};
 
   visit_lqp(lqp, [&](const auto& node) {
@@ -41,7 +41,7 @@ std::optional<JoinGraphStatisticsCache::Bitmask> JoinGraphStatisticsCache::bitma
       bitmask->set(vertex_iter->second);
       return LQPVisitation::DoNotVisitInputs;
 
-    } else if (const auto join_node = std::dynamic_pointer_cast<JoinNode>(node)) {
+    } else if (const auto join_node = std::dynamic_pointer_cast<const JoinNode>(node)) {
       if (join_node->join_mode == JoinMode::Inner) {
         for (const auto& join_predicate : join_node->join_predicates()) {
           const auto predicate_index_iter = _predicate_indices.find(join_predicate);
@@ -62,7 +62,7 @@ std::optional<JoinGraphStatisticsCache::Bitmask> JoinGraphStatisticsCache::bitma
         return LQPVisitation::DoNotVisitInputs;
       }
 
-    } else if (const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node)) {
+    } else if (const auto predicate_node = std::dynamic_pointer_cast<const PredicateNode>(node)) {
       const auto predicate_index_iter = _predicate_indices.find(predicate_node->predicate());
       if (predicate_index_iter == _predicate_indices.end()) {
         bitmask.reset();

--- a/src/lib/statistics/join_graph_statistics_cache.hpp
+++ b/src/lib/statistics/join_graph_statistics_cache.hpp
@@ -31,7 +31,7 @@ class JoinGraphStatisticsCache {
   using Bitmask = boost::dynamic_bitset<>;
 
   // Maps vertices to their index in the Bitmask
-  using VertexIndexMap = std::unordered_map<std::shared_ptr<AbstractLQPNode>, size_t>;
+  using VertexIndexMap = std::unordered_map<std::shared_ptr<const AbstractLQPNode>, size_t>;
 
   // Maps predicates to their index in the Bitmask
   using PredicateIndexMap = ExpressionUnorderedMap<size_t>;
@@ -47,7 +47,7 @@ class JoinGraphStatisticsCache {
    * Predicates or Vertices not registered in _vertex_indices and _predicate_indices are encountered. The latter can be
    * the case if `lqp` is a suplan of a vertex node.
    */
-  std::optional<Bitmask> bitmask(const std::shared_ptr<AbstractLQPNode>& lqp) const;
+  std::optional<Bitmask> bitmask(const std::shared_ptr<const AbstractLQPNode>& lqp) const;
 
   /**
    * Retrieve the cached statistics associated with @param bitmask. The order of columns in the returned TableStatistics


### PR DESCRIPTION
`AbstractCardinalityEstimator::estimate_cardinality()` requires `const std::shared_ptr<AbstractLQPNode>& lqp` as an argument. As there is no obvious reason to make changes to an LQP while estimating the cardinality of its output, this PR changes the signature to require a shared pointer to a `const` LQP node and adapts the underlying data structures.
This change seems not to have a stable effect on performance (TPC-H, sf 0.01, 60s/query).

```diff
 +--------------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH                | 2905a7817d9d8d62581160431c07ff657e537441-dirty | da616f0adc9d72689dfd3be7b30526ab666d8e27-dirty |
 |  benchmark_mode          | Ordered                                        | Ordered                                        |
 |  build_type              | release                                        | release                                        |
 |  chunk_size              | 65535                                          | 65535                                          |
 |  clients                 | 1                                              | 1                                              |
 |  compiler                | clang 9.0.0                                    | clang 9.0.0                                    |
 |  cores                   | 0                                              | 0                                              |
 |  date                    | 2020-10-02 14:14:31                            | 2020-10-02 14:37:39                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes                 | False                                          | False                                          |
 |  max_duration            | 60000000000                                    | 60000000000                                    |
 |  max_runs                | -1                                             | -1                                             |
 |  scale_factor            | 0.009999999776482582                           | 0.009999999776482582                           |
 |  time_unit               | ns                                             | ns                                             |
 |  use_prepared_statements | False                                          | False                                          |
 |  using_scheduler         | False                                          | False                                          |
 |  verify                  | False                                          | False                                          |
 |  warmup_duration         | 0                                              | 0                                              |
 +--------------------------+------------------------------------------------+------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||     11.2 |    11.0 |   -1%  ||    89.63 |    90.57 |   +1%  |  0.0000 |
 | TPC-H 02 ||      2.4 |     2.4 |   +0%  ||   424.18 |   423.19 |   -0%  |  0.7689 |
 | TPC-H 03 ||      1.9 |     1.9 |   -1%  ||   531.81 |   536.29 |   +1%  |  0.0000 |
 | TPC-H 04 ||      1.2 |     1.2 |   -2%  ||   822.28 |   839.80 |   +2%  |  0.0000 |
 | TPC-H 05 ||      3.1 |     3.1 |   -1%  ||   324.00 |   325.76 |   +1%  |  0.0378 |
-| TPC-H 06 ||      0.3 |     0.3 |   +7%  ||  3041.38 |  2852.73 |   -6%  |  0.0000 |
-| TPC-H 07 ||      4.1 |     4.6 |  +13%  ||   244.28 |   215.72 |  -12%  |  0.0000 |
 | TPC-H 08 ||     25.5 |    26.2 |   +3%  ||    39.23 |    38.19 |   -3%  |  0.0126 |
 | TPC-H 09 ||      5.0 |     5.0 |   -0%  ||   197.86 |   198.79 |   +0%  |  0.2924 |
 | TPC-H 10 ||      2.0 |     2.0 |   -2%  ||   489.27 |   501.08 |   +2%  |  0.0000 |
 | TPC-H 11 ||      1.0 |     1.0 |   +3%  ||   994.54 |   968.36 |   -3%  |  0.0000 |
 | TPC-H 12 ||      1.6 |     1.6 |   -3%  ||   623.91 |   642.45 |   +3%  |  0.0000 |
 | TPC-H 13 ||      4.5 |     4.4 |   -2%  ||   222.66 |   227.21 |   +2%  |  0.0000 |
 | TPC-H 14 ||      0.8 |     0.8 |   +0%  ||  1200.83 |  1195.58 |   -0%  |  0.0000 |
 | TPC-H 15 ||      2.4 |     2.4 |   -0%  ||   410.57 |   412.31 |   +0%  |  0.0000 |
 | TPC-H 16 ||      4.6 |     4.5 |   -1%  ||   218.70 |   220.30 |   +1%  |  0.0000 |
-| TPC-H 17 ||      0.8 |     0.8 |   +6%  ||  1268.01 |  1192.20 |   -6%  |  0.0000 |
 | TPC-H 18 ||      5.9 |     5.9 |   +1%  ||   169.21 |   168.13 |   -1%  |  0.0000 |
-| TPC-H 19 ||     10.6 |    11.1 |   +5%  ||    94.32 |    90.05 |   -5%  |  0.0000 |
+| TPC-H 20 ||      5.6 |     5.2 |   -8%  ||   177.80 |   193.15 |   +9%  |  0.0000 |
 | TPC-H 21 ||     10.7 |    10.2 |   -4%  ||    93.38 |    97.58 |   +4%  |  0.0000 |
 | TPC-H 22 ||      2.9 |     3.0 |   +1%  ||   339.69 |   335.88 |   -1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||    108.1 |   108.7 |   +1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```

For comparison, the same benchmark with 30s/query:
```diff
 +Configuration Overview----+------------------------------------------------+------------------------------------------------+
 | Parameter                | estimator-asis.json                            | estimator-new.json                             |
 +--------------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH                | 2905a7817d9d8d62581160431c07ff657e537441-dirty | da616f0adc9d72689dfd3be7b30526ab666d8e27-dirty |
 |  benchmark_mode          | Ordered                                        | Ordered                                        |
 |  build_type              | release                                        | release                                        |
 |  chunk_size              | 65535                                          | 65535                                          |
 |  clients                 | 1                                              | 1                                              |
 |  compiler                | clang 9.0.0                                    | clang 9.0.0                                    |
 |  cores                   | 0                                              | 0                                              |
 |  date                    | 2020-10-02 13:31:07                            | 2020-10-02 13:43:01                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes                 | False                                          | False                                          |
 |  max_duration            | 30000000000                                    | 30000000000                                    |
 |  max_runs                | -1                                             | -1                                             |
 |  scale_factor            | 0.009999999776482582                           | 0.009999999776482582                           |
 |  time_unit               | ns                                             | ns                                             |
 |  use_prepared_statements | False                                          | False                                          |
 |  using_scheduler         | False                                          | False                                          |
 |  verify                  | False                                          | False                                          |
 |  warmup_duration         | 0                                              | 0                                              |
 +--------------------------+------------------------------------------------+------------------------------------------------+

 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||     11.0 |    10.8 |   -2%  ||    91.11 |    92.94 |   +2%  | (run time too short) |
-| TPC-H 02 ||      2.6 |     2.9 |  +12%  ||   387.92 |   347.02 |  -11%  | (run time too short) |
 | TPC-H 03 ||      1.7 |     1.8 |   +4%  ||   574.52 |   550.95 |   -4%  | (run time too short) |
 | TPC-H 04 ||      1.2 |     1.2 |   -4%  ||   816.01 |   847.88 |   +4%  | (run time too short) |
 | TPC-H 05 ||      3.2 |     3.0 |   -4%  ||   316.00 |   328.84 |   +4%  | (run time too short) |
 | TPC-H 06 ||      0.4 |     0.4 |   +1%  ||  2797.29 |  2784.81 |   -0%  | (run time too short) |
+| TPC-H 07 ||      7.7 |     5.9 |  -23%  ||   130.19 |   168.29 |  +29%  | (run time too short) |
 | TPC-H 08 ||     26.8 |    25.7 |   -4%  ||    37.28 |    38.95 |   +4%  | (run time too short) |
+| TPC-H 09 ||      5.5 |     5.0 |   -9%  ||   182.62 |   200.50 |  +10%  | (run time too short) |
 | TPC-H 10 ||      2.1 |     2.1 |   +0%  ||   476.85 |   474.89 |   -0%  | (run time too short) |
 | TPC-H 11 ||      1.0 |     1.0 |   +0%  ||   974.32 |   970.98 |   -0%  | (run time too short) |
 | TPC-H 12 ||      1.6 |     1.6 |   -1%  ||   617.03 |   621.61 |   +1%  | (run time too short) |
 | TPC-H 13 ||      4.5 |     4.5 |   +0%  ||   222.85 |   222.78 |   -0%  | (run time too short) |
 | TPC-H 14 ||      0.8 |     0.8 |   -1%  ||  1181.64 |  1193.01 |   +1%  | (run time too short) |
 | TPC-H 15 ||      2.6 |     2.5 |   -4%  ||   388.81 |   403.74 |   +4%  | (run time too short) |
 | TPC-H 16 ||      4.6 |     4.7 |   +2%  ||   214.95 |   210.80 |   -2%  | (run time too short) |
 | TPC-H 17 ||      0.9 |     0.8 |   -2%  ||  1162.75 |  1185.67 |   +2%  | (run time too short) |
 | TPC-H 18 ||      5.9 |     5.9 |   +0%  ||   170.02 |   169.99 |   -0%  | (run time too short) |
 | TPC-H 19 ||     10.8 |    10.5 |   -2%  ||    92.94 |    95.17 |   +2%  | (run time too short) |
+| TPC-H 20 ||      5.4 |     5.0 |   -8%  ||   184.45 |   200.28 |   +9%  | (run time too short) |
 | TPC-H 21 ||     11.2 |    11.0 |   -2%  ||    89.14 |    90.83 |   +2%  | (run time too short) |
 | TPC-H 22 ||      2.8 |     2.8 |   +1%  ||   354.49 |   350.52 |   -1%  | (run time too short) |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum      ||    114.2 |   109.9 |   -4%  ||          |          |        |                      |
 | Geomean  ||          |         |        ||          |          |   +2%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```