### PR TITLE
Improve --github output of compare_benchmarks.py 

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -341,8 +341,8 @@ if github_format:
                                "<summary>Configuration Overview - click to expand</summary>\n\n" + \
                                "```diff\n" + \
                                create_context_overview(old_data, new_data, github_format) + \
-                               "```\n + \ " + \
-                               "</details>\n" + \
+                               "```\n" + \
+                               "</details>\n\n" + \
                                "```diff\n"
     for line in table_string.splitlines():
         if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -337,7 +337,7 @@ if github_format:
     green_control_sequence = colored("", "green")[0:5]
     red_control_sequence = colored("", "red")[0:5]
 
-    table_string_reformatted = "<details>\n<summary>Benchmark Configuration - click to expand</summary>\n```diff\n"
+    table_string_reformatted = "<details>\n<summary>Configuration Overview - click to expand</summary>\n```diff\n"
     table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "```</details>\n```diff"
     for line in table_string.splitlines():
         if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -337,8 +337,8 @@ if github_format:
     green_control_sequence = colored("", "green")[0:5]
     red_control_sequence = colored("", "red")[0:5]
 
-    table_string_reformatted = "```diff\n"
-    table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "\n"
+    table_string_reformatted = "<details>\n<summary>Benchmark Configuration - click to expand</summary>\n```diff\n"
+    table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "```</details>\n```diff"
     for line in table_string.splitlines():
         if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):
             table_string_reformatted += "+"

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -337,8 +337,13 @@ if github_format:
     green_control_sequence = colored("", "green")[0:5]
     red_control_sequence = colored("", "red")[0:5]
 
-    table_string_reformatted = "<details>\n<summary>Configuration Overview - click to expand</summary>\n\n```diff\n"
-    table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "```\n</details>\n```diff"
+    table_string_reformatted = "<details>\n" + \
+                               "<summary>Configuration Overview - click to expand</summary>\n\n" + \
+                               "```diff\n" + \
+                               create_context_overview(old_data, new_data, github_format) + \
+                               "```\n + \ " + \
+                               "</details>\n" + \
+                               "```diff\n"
     for line in table_string.splitlines():
         if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):
             table_string_reformatted += "+"

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -337,8 +337,8 @@ if github_format:
     green_control_sequence = colored("", "green")[0:5]
     red_control_sequence = colored("", "red")[0:5]
 
-    table_string_reformatted = "<details>\n<summary>Configuration Overview - click to expand</summary>\n```diff\n"
-    table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "```</details>\n```diff"
+    table_string_reformatted = "<details>\n<summary>Configuration Overview - click to expand</summary>\n\n```diff\n"
+    table_string_reformatted += create_context_overview(old_data, new_data, github_format) + "```\n</details>\n```diff"
     for line in table_string.splitlines():
         if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):
             table_string_reformatted += "+"


### PR DESCRIPTION
Makes the "Configuration Overview" section collapsable when using the `--github` flag.

**Example Output**:

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------------------------------------------+------------------------------------------------+
 | Parameter        | results_master.json                            | results_constraints.json                       |
 +------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH        | 2905a7817d9d8d62581160431c07ff657e537441-dirty | c0e706da1384d8c0bfd54f8e5590c63b1956bc61-dirty |
 |  benchmark_mode  | Ordered                                        | Ordered                                        |
 |  build_type      | release                                        | release                                        |
 |  chunk_size      | 65535                                          | 65535                                          |
 |  clients         | 1                                              | 1                                              |
 |  compiler        | gcc 9.2                                        | gcc 9.2                                        |
 |  cores           | 0                                              | 0                                              |
 |  date            | 2020-10-02 16:43:45                            | 2020-10-02 18:06:49                            |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes         | False                                          | False                                          |
 |  max_duration    | 60000000000                                    | 60000000000                                    |
 |  max_runs        | -1                                             | -1                                             |
 |  time_unit       | ns                                             | ns                                             |
 |  using_scheduler | False                                          | False                                          |
 |  verify          | False                                          | False                                          |
 |  warmup_duration | 0                                              | 0                                              |
 +------------------+------------------------------------------------+------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     59.0 |    56.8 |   -4%  ||    16.95 |    17.59 |   +4%  |  0.0000 |
 | 03      ||     11.8 |    11.8 |   +0%  ||    84.90 |    84.69 |   -0%  |  0.0000 |
 | 06      ||     36.8 |    37.1 |   +1%  ||    27.14 |    26.99 |   -1%  |  0.0000 |

 [...]

 | 99      ||    305.4 |   285.0 |   -7%  ||     3.27 |     3.51 |   +2%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   7391.3 |  7103.0 |   -4%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +3%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```