### PR TITLE
Add key constraints for the TPC-DS benchmark

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
-tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TpcdsTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
+tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
 try {
   node {
@@ -315,7 +315,7 @@ try {
           sh "mkdir clang-debug && cd clang-debug && /usr/local/bin/cmake ${unity} ${debug} -DCMAKE_C_COMPILER=/usr/local/Cellar/llvm/9.0.0/bin/clang -DCMAKE_CXX_COMPILER=/usr/local/Cellar/llvm/9.0.0/bin/clang++ .."
           sh "cd clang-debug && make -j8"
           sh "./clang-debug/hyriseTest"
-          sh "./clang-debug/hyriseSystemTest --gtest_filter=-TPCCTest*:TpcdsTableGeneratorTest.*:TPCHTableGeneratorTest.RowCountsMediumScaleFactor:*.CompareToSQLite/Line1*WithLZ4"
+          sh "./clang-debug/hyriseSystemTest --gtest_filter=-TPCCTest*:TPCDSTableGeneratorTest.*:TPCHTableGeneratorTest.RowCountsMediumScaleFactor:*.CompareToSQLite/Line1*WithLZ4"
           sh "PATH=/usr/local/bin/:$PATH ./scripts/test/hyriseConsole_test.py clang-debug"
           sh "PATH=/usr/local/bin/:$PATH ./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
         } finally {

--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]) {
     query_generator->load_dedicated_expected_results(
         std::filesystem::path{"resources/benchmark/tpcds/tpcds-result-reproduction/answer_sets_tbl"});
   }
-  auto table_generator = std::make_unique<TpcdsTableGenerator>(scale_factor, config);
+  auto table_generator = std::make_unique<TPCDSTableGenerator>(scale_factor, config);
   auto benchmark_runner = BenchmarkRunner{*config, std::move(query_generator), std::move(table_generator),
                                           opossum::BenchmarkRunner::create_context(*config)};
   if (config->verify) {

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -1165,7 +1165,7 @@ void TPCDSTableGenerator::_add_constraints(
    * Adds all PRIMARY KEY key constraints as described in the official TPC-DS specification.
    * (Section 2: Logical Database Design)
    */
-  
+
   // Fact Tables (7)
   const auto& store_sales_table = table_info_by_name.at("store_sales").table;
   store_sales_table->add_soft_key_constraint(

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -1161,6 +1161,11 @@ std::shared_ptr<Table> TPCDSTableGenerator::generate_web_site(ds_key_t max_rows)
 
 void TPCDSTableGenerator::_add_constraints(
     std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name) const {
+  /**
+   * Adds all PRIMARY KEY key constraints as described in the official TPC-DS specification.
+   * (Section 2: Logical Database Design)
+   */
+  
   // Fact Tables (7)
   const auto& store_sales_table = table_info_by_name.at("store_sales").table;
   store_sales_table->add_soft_key_constraint(
@@ -1232,9 +1237,9 @@ void TPCDSTableGenerator::_add_constraints(
       {{customer_address_table->column_id_by_name("ca_address_sk")}, KeyConstraintType::PRIMARY_KEY});
 
   const auto& customer_demographics_table = table_info_by_name.at("customer_demographics").table;
-  customer_demographics_table->add_soft_key_constraint({{customer_demographics_table->column_id_by_name("cd_demo_sk")},
+  customer_demographics_table->add_soft_key_constraint(
+      {{customer_demographics_table->column_id_by_name("cd_demo_sk")}, KeyConstraintType::PRIMARY_KEY});
 
-                                                        KeyConstraintType::PRIMARY_KEY});
   const auto& date_dim_table = table_info_by_name.at("date_dim").table;
   date_dim_table->add_soft_key_constraint(
       {{date_dim_table->column_id_by_name("d_date_sk")}, KeyConstraintType::PRIMARY_KEY});

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -1159,4 +1159,50 @@ std::shared_ptr<Table> TPCDSTableGenerator::generate_web_site(ds_key_t max_rows)
   return web_site_builder.finish_table();
 }
 
+void TPCDSTableGenerator::_add_constraints(
+    std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name) const {
+  // Fact Tables (7)
+  const auto& store_sales_table = table_info_by_name.at("store_sales").table;
+  store_sales_table->add_soft_key_constraint(
+      {{store_sales_table->column_id_by_name("ss_item_sk"), store_sales_table->column_id_by_name("ss_ticket_number")},
+       KeyConstraintType::PRIMARY_KEY});
+
+  const auto& store_returns_table = table_info_by_name.at("store_returns").table;
+  store_returns_table->add_soft_key_constraint({{store_returns_table->column_id_by_name("sr_item_sk"),
+                                                 store_returns_table->column_id_by_name("sr_ticket_number")},
+                                                KeyConstraintType::PRIMARY_KEY});
+
+  const auto& catalog_sales_table = table_info_by_name.at("catalog_sales").table;
+  catalog_sales_table->add_soft_key_constraint({{catalog_sales_table->column_id_by_name("cs_item_sk"),
+                                                 catalog_sales_table->column_id_by_name("cs_order_number")},
+                                                KeyConstraintType::PRIMARY_KEY});
+
+  const auto& catalog_returns_table = table_info_by_name.at("catalog_returns").table;
+  catalog_returns_table->add_soft_key_constraint({{catalog_returns_table->column_id_by_name("cr_item_sk"),
+                                                   catalog_returns_table->column_id_by_name("cr_order_number")},
+                                                  KeyConstraintType::PRIMARY_KEY});
+
+  const auto& web_sales_table = table_info_by_name.at("web_sales").table;
+  web_sales_table->add_soft_key_constraint(
+      {{web_sales_table->column_id_by_name("ws_item_sk"), web_sales_table->column_id_by_name("ws_order_number")},
+       KeyConstraintType::PRIMARY_KEY});
+
+  const auto& web_returns_table = table_info_by_name.at("web_returns").table;
+  web_returns_table->add_soft_key_constraint(
+      {{web_returns_table->column_id_by_name("wr_item_sk"), web_returns_table->column_id_by_name("wr_order_number")},
+       KeyConstraintType::PRIMARY_KEY});
+
+  const auto& inventory_table = table_info_by_name.at("inventory").table;
+  inventory_table->add_soft_key_constraint(
+      {{inventory_table->column_id_by_name("inv_date_sk"), inventory_table->column_id_by_name("inv_item_sk"),
+        inventory_table->column_id_by_name("inv_warehouse_sk")},
+       KeyConstraintType::PRIMARY_KEY});
+
+  // Dimension Tables (7)
+
+
+
+
+}
+
 }  // namespace opossum

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -1198,11 +1198,73 @@ void TPCDSTableGenerator::_add_constraints(
         inventory_table->column_id_by_name("inv_warehouse_sk")},
        KeyConstraintType::PRIMARY_KEY});
 
-  // Dimension Tables (7)
+  // Dimension Tables (17)
+  const auto& store_table = table_info_by_name.at("store").table;
+  store_table->add_soft_key_constraint(
+      {{store_table->column_id_by_name("s_store_sk")}, KeyConstraintType::PRIMARY_KEY});
 
+  const auto& call_center_table = table_info_by_name.at("call_center").table;
+  call_center_table->add_soft_key_constraint(
+      {{call_center_table->column_id_by_name("cc_call_center_sk")}, KeyConstraintType::PRIMARY_KEY});
 
+  const auto& catalog_page_table = table_info_by_name.at("catalog_page").table;
+  catalog_page_table->add_soft_key_constraint(
+      {{catalog_page_table->column_id_by_name("cp_catalog_page_sk")}, KeyConstraintType::PRIMARY_KEY});
 
+  const auto& web_site_table = table_info_by_name.at("web_site").table;
+  web_site_table->add_soft_key_constraint(
+      {{web_site_table->column_id_by_name("web_site_sk")}, KeyConstraintType::PRIMARY_KEY});
 
+  const auto& web_page_table = table_info_by_name.at("web_page").table;
+  web_page_table->add_soft_key_constraint(
+      {{web_page_table->column_id_by_name("wp_web_page_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& warehouse_table = table_info_by_name.at("warehouse").table;
+  warehouse_table->add_soft_key_constraint(
+      {{warehouse_table->column_id_by_name("w_warehouse_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& customer_table = table_info_by_name.at("customer").table;
+  customer_table->add_soft_key_constraint(
+      {{customer_table->column_id_by_name("c_customer_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& customer_address_table = table_info_by_name.at("customer_address").table;
+  customer_address_table->add_soft_key_constraint(
+      {{customer_address_table->column_id_by_name("ca_address_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& customer_demographics_table = table_info_by_name.at("customer_demographics").table;
+  customer_demographics_table->add_soft_key_constraint({{customer_demographics_table->column_id_by_name("cd_demo_sk")},
+
+                                                        KeyConstraintType::PRIMARY_KEY});
+  const auto& date_dim_table = table_info_by_name.at("date_dim").table;
+  date_dim_table->add_soft_key_constraint(
+      {{date_dim_table->column_id_by_name("d_date_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& household_demographics_table = table_info_by_name.at("household_demographics").table;
+  household_demographics_table->add_soft_key_constraint(
+      {{household_demographics_table->column_id_by_name("hd_demo_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& item_table = table_info_by_name.at("item").table;
+  item_table->add_soft_key_constraint({{item_table->column_id_by_name("i_item_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& income_band_table = table_info_by_name.at("income_band").table;
+  income_band_table->add_soft_key_constraint(
+      {{income_band_table->column_id_by_name("ib_income_band_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& promotion_table = table_info_by_name.at("promotion").table;
+  promotion_table->add_soft_key_constraint(
+      {{promotion_table->column_id_by_name("p_promo_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& reason_table = table_info_by_name.at("reason").table;
+  reason_table->add_soft_key_constraint(
+      {{reason_table->column_id_by_name("r_reason_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& ship_mode_table = table_info_by_name.at("ship_mode").table;
+  ship_mode_table->add_soft_key_constraint(
+      {{ship_mode_table->column_id_by_name("sm_ship_mode_sk")}, KeyConstraintType::PRIMARY_KEY});
+
+  const auto& time_dim_table = table_info_by_name.at("time_dim").table;
+  time_dim_table->add_soft_key_constraint(
+      {{time_dim_table->column_id_by_name("t_time_sk")}, KeyConstraintType::PRIMARY_KEY});
 }
 
 }  // namespace opossum

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -257,18 +257,18 @@ const auto web_site_column_names = boost::hana::make_tuple("web_site_sk" , "web_
 
 namespace opossum {
 
-TpcdsTableGenerator::TpcdsTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, int rng_seed)
+TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size, int rng_seed)
     : AbstractTableGenerator(create_benchmark_config_with_chunk_size(chunk_size)), _scale_factor{scale_factor} {
   init_tpcds_tools(scale_factor, rng_seed);
 }
 
-TpcdsTableGenerator::TpcdsTableGenerator(uint32_t scale_factor,
+TPCDSTableGenerator::TPCDSTableGenerator(uint32_t scale_factor,
                                          const std::shared_ptr<BenchmarkConfig>& benchmark_config, int rng_seed)
     : AbstractTableGenerator(benchmark_config), _scale_factor{scale_factor} {
   init_tpcds_tools(scale_factor, rng_seed);
 }
 
-std::unordered_map<std::string, BenchmarkTableInfo> TpcdsTableGenerator::generate() {
+std::unordered_map<std::string, BenchmarkTableInfo> TPCDSTableGenerator::generate() {
   auto table_info_by_name = std::unordered_map<std::string, BenchmarkTableInfo>{};
 
   // try to load cached tables
@@ -311,7 +311,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> TpcdsTableGenerator::generat
   return table_info_by_name;
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::_generate_table(const std::string& table_name) const {
+std::shared_ptr<Table> TPCDSTableGenerator::_generate_table(const std::string& table_name) const {
   if (table_name == "call_center") {
     return generate_call_center();
   } else if (table_name == "catalog_page") {
@@ -353,7 +353,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::_generate_table(const std::string& t
   }
 }
 
-std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::_generate_sales_and_returns_tables(
+std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TPCDSTableGenerator::_generate_sales_and_returns_tables(
     const std::string& sales_table_name) const {
   if (sales_table_name == "catalog_sales") {
     return generate_catalog_sales_and_returns();
@@ -366,7 +366,7 @@ std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::_
   }
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_call_center(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_call_center(ds_key_t max_rows) const {
   auto [call_center_first, call_center_count] = prepare_for_table(CALL_CENTER);
   call_center_count = std::min(call_center_count, max_rows);
 
@@ -413,7 +413,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_call_center(ds_key_t max_ro
   return call_center_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_catalog_page(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_catalog_page(ds_key_t max_rows) const {
   auto [catalog_page_first, catalog_page_count] = prepare_for_table(CATALOG_PAGE);
   catalog_page_count = std::min(catalog_page_count, max_rows);
 
@@ -440,7 +440,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_catalog_page(ds_key_t max_r
   return catalog_page_builder.finish_table();
 }
 
-std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::generate_catalog_sales_and_returns(
+std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TPCDSTableGenerator::generate_catalog_sales_and_returns(
     ds_key_t max_rows) const {
   auto [catalog_sales_first, catalog_sales_count] = prepare_for_table(CATALOG_SALES);
   // catalog_sales_count is NOT the actual number of catalog sales created, for each of these "master" catalog_sales
@@ -544,7 +544,7 @@ std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::g
   return {catalog_sales_builder.finish_table(), catalog_returns_builder.finish_table()};
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_customer_address(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_customer_address(ds_key_t max_rows) const {
   auto [customer_address_first, customer_address_count] = prepare_for_table(CUSTOMER_ADDRESS);
   customer_address_count = std::min(customer_address_count, max_rows);
 
@@ -574,7 +574,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_customer_address(ds_key_t m
   return customer_address_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_customer(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_customer(ds_key_t max_rows) const {
   auto [customer_first, customer_count] = prepare_for_table(CUSTOMER);
   customer_count = std::min(customer_count, max_rows);
 
@@ -602,7 +602,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_customer(ds_key_t max_rows)
   return customer_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_customer_demographics(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_customer_demographics(ds_key_t max_rows) const {
   auto [customer_demographics_first, customer_demographics_count] = prepare_for_table(CUSTOMER_DEMOGRAPHICS);
   customer_demographics_count = std::min(customer_demographics_count, max_rows);
 
@@ -629,7 +629,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_customer_demographics(ds_ke
   return customer_demographics_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_date_dim(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_date_dim(ds_key_t max_rows) const {
   auto [date_first, date_count] = prepare_for_table(DATE);
   date_count = std::min(date_count, max_rows);
 
@@ -666,7 +666,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_date_dim(ds_key_t max_rows)
   return date_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_household_demographics(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_household_demographics(ds_key_t max_rows) const {
   auto [household_demographics_first, household_demographics_count] = prepare_for_table(HOUSEHOLD_DEMOGRAPHICS);
   household_demographics_count = std::min(household_demographics_count, max_rows);
 
@@ -691,7 +691,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_household_demographics(ds_k
   return household_demographics_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_income_band(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_income_band(ds_key_t max_rows) const {
   auto [income_band_first, income_band_count] = prepare_for_table(INCOME_BAND);
   income_band_count = std::min(income_band_count, max_rows);
 
@@ -709,7 +709,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_income_band(ds_key_t max_ro
   return income_band_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_inventory(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_inventory(ds_key_t max_rows) const {
   auto [inventory_first, inventory_count] = prepare_for_table(INVENTORY);
   inventory_count = std::min(inventory_count, max_rows);
 
@@ -726,7 +726,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_inventory(ds_key_t max_rows
   return inventory_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_item(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_item(ds_key_t max_rows) const {
   auto [item_first, item_count] = prepare_for_table(ITEM);
   item_count = std::min(item_count, max_rows);
 
@@ -753,7 +753,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_item(ds_key_t max_rows) con
   return item_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_promotion(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_promotion(ds_key_t max_rows) const {
   auto [promotion_first, promotion_count] = prepare_for_table(PROMOTION);
   promotion_count = std::min(promotion_count, max_rows);
 
@@ -783,7 +783,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_promotion(ds_key_t max_rows
   return promotion_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_reason(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_reason(ds_key_t max_rows) const {
   auto [reason_first, reason_count] = prepare_for_table(REASON);
   reason_count = std::min(reason_count, max_rows);
 
@@ -800,7 +800,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_reason(ds_key_t max_rows) c
   return reason_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_ship_mode(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_ship_mode(ds_key_t max_rows) const {
   auto [ship_mode_first, ship_mode_count] = prepare_for_table(SHIP_MODE);
   ship_mode_count = std::min(ship_mode_count, max_rows);
 
@@ -820,7 +820,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_ship_mode(ds_key_t max_rows
   return ship_mode_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_store(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_store(ds_key_t max_rows) const {
   auto [store_first, store_count] = prepare_for_table(STORE);
   store_count = std::min(store_count, max_rows);
 
@@ -860,7 +860,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_store(ds_key_t max_rows) co
   return store_builder.finish_table();
 }
 
-std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::generate_store_sales_and_returns(
+std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TPCDSTableGenerator::generate_store_sales_and_returns(
     ds_key_t max_rows) const {
   auto [store_sales_first, store_sales_count] = prepare_for_table(STORE_SALES);
 
@@ -942,7 +942,7 @@ std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::g
   return {store_sales_builder.finish_table(), store_returns_builder.finish_table()};
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_time_dim(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_time_dim(ds_key_t max_rows) const {
   auto [time_first, time_count] = prepare_for_table(TIME);
   time_count = std::min(time_count, max_rows);
 
@@ -962,7 +962,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_time_dim(ds_key_t max_rows)
   return time_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_warehouse(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_warehouse(ds_key_t max_rows) const {
   auto [warehouse_first, warehouse_count] = prepare_for_table(WAREHOUSE);
   warehouse_count = std::min(warehouse_count, max_rows);
 
@@ -992,7 +992,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_warehouse(ds_key_t max_rows
   return warehouse_builder.finish_table();
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_web_page(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_web_page(ds_key_t max_rows) const {
   auto [web_page_first, web_page_count] = prepare_for_table(WEB_PAGE);
   web_page_count = std::min(web_page_count, max_rows);
 
@@ -1018,7 +1018,7 @@ std::shared_ptr<Table> TpcdsTableGenerator::generate_web_page(ds_key_t max_rows)
   return web_page_builder.finish_table();
 }
 
-std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::generate_web_sales_and_returns(
+std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TPCDSTableGenerator::generate_web_sales_and_returns(
     ds_key_t max_rows) const {
   auto [web_sales_first, web_sales_count] = prepare_for_table(WEB_SALES);
 
@@ -1116,7 +1116,7 @@ std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> TpcdsTableGenerator::g
   return {web_sales_builder.finish_table(), web_returns_builder.finish_table()};
 }
 
-std::shared_ptr<Table> TpcdsTableGenerator::generate_web_site(ds_key_t max_rows) const {
+std::shared_ptr<Table> TPCDSTableGenerator::generate_web_site(ds_key_t max_rows) const {
   auto [web_site_first, web_site_count] = prepare_for_table(WEB_SITE);
   web_site_count = std::min(web_site_count, max_rows);
 

--- a/src/benchmarklib/tpcds/tpcds_table_generator.hpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.hpp
@@ -28,12 +28,12 @@ namespace opossum {
  * data can no longer be generated. We decided that being able to generate tpcds data multiple times in for example a
  * hyriseConsole session is more important than fixing these small memory leaks (<1MB for 1GB of generated data).
  */
-class TpcdsTableGenerator final : public AbstractTableGenerator {
+class TPCDSTableGenerator final : public AbstractTableGenerator {
  public:
   // rng seed 19620718 is the same dsdgen uses as default
-  explicit TpcdsTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
+  explicit TPCDSTableGenerator(uint32_t scale_factor, ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
                                int rng_seed = 19620718);
-  TpcdsTableGenerator(uint32_t scale_factor, const std::shared_ptr<BenchmarkConfig>& benchmark_config,
+  TPCDSTableGenerator(uint32_t scale_factor, const std::shared_ptr<BenchmarkConfig>& benchmark_config,
                       int rng_seed = 19620718);
 
   std::unordered_map<std::string, BenchmarkTableInfo> generate() override;

--- a/src/benchmarklib/tpcds/tpcds_table_generator.hpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.hpp
@@ -64,6 +64,9 @@ class TPCDSTableGenerator final : public AbstractTableGenerator {
       ds_key_t max_rows = _ds_key_max) const;
   std::shared_ptr<Table> generate_web_site(ds_key_t max_rows = _ds_key_max) const;
 
+ protected:
+  void _add_constraints(std::unordered_map<std::string, BenchmarkTableInfo>& table_info_by_name) const override;
+
  private:
   std::shared_ptr<Table> _generate_table(const std::string& table_name) const;
   std::pair<std::shared_ptr<Table>, std::shared_ptr<Table>> _generate_sales_and_returns_tables(

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -527,7 +527,7 @@ int Console::_generate_tpcds(const std::string& args) {
   }
 
   out("Generating all TPC-DS tables (this might take a while) ...\n");
-  TpcdsTableGenerator{scale_factor, chunk_size}.generate_and_store();
+  TPCDSTableGenerator{scale_factor, chunk_size}.generate_and_store();
 
   return ReturnCode::Ok;
 }

--- a/src/lib/storage/segment_iterate.hpp
+++ b/src/lib/storage/segment_iterate.hpp
@@ -14,8 +14,8 @@
  *      segment_with_iterators[_filtered]()    Calls the functor with a begin and end iterator
  *      segment_iterate[_filtered]()           Calls the functor with each value in the segment
  *
- * The *_filtered() variants of the functions take a AbstractPosList wnich allows for selective access to the values in a
- * segment.
+ * The *_filtered() variants of the functions take a AbstractPosList which allows for selective access to the values in
+ * a segment.
  *
  * The template parameter T is either (if known to the caller) the DataType of the values contained in the segment, or
  * ResolveDataTypeTag if the type is unknown to the caller. ALWAYS pass in the DataType of the Segment if is already

--- a/src/test/benchmarklib/tpcds/tpcds_db_generator_test.cpp
+++ b/src/test/benchmarklib/tpcds/tpcds_db_generator_test.cpp
@@ -17,23 +17,23 @@ std::shared_ptr<Table> load_csv(const std::string& file_name) {
 
 namespace opossum {
 
-class TpcdsTableGeneratorTest : public BaseTest {};
+class TPCDSTableGeneratorTest : public BaseTest {};
 
-TEST_F(TpcdsTableGeneratorTest, TableContentsFirstRows) {
+TEST_F(TPCDSTableGeneratorTest, TableContentsFirstRows) {
   /**
-   * Check whether the data that TpcdsTableGenerator generates is the exact same that dsdgen generates.
+   * Check whether the data that TPCDSTableGenerator generates is the exact same that dsdgen generates.
    * Since dsdgen does not support very small scale factors only generate and check first rows for each table.
    */
   const auto rows_to_check = ds_key_t{50};
 
   // Initialize with different params to check whether global state is correctly reset.
-  TpcdsTableGenerator(10, 2, 42);
+  TPCDSTableGenerator(10, 2, 42);
 
   // Run generation twice to make sure no global state (of which tpcds_dbgen has plenty :( ) from the
   //  first generation process carried over into the second
   for (auto i = 1; i <= 2; i++) {
     SCOPED_TRACE("TableContentsFirstRows iteration " + std::to_string(i));
-    const auto table_generator = TpcdsTableGenerator(1, Chunk::DEFAULT_SIZE, 305);  // seed 305 includes Mrs. Null
+    const auto table_generator = TPCDSTableGenerator(1, Chunk::DEFAULT_SIZE, 305);  // seed 305 includes Mrs. Null
     EXPECT_TABLE_EQ_ORDERED(table_generator.generate_call_center(rows_to_check), load_csv("call_center.csv"));
     EXPECT_TABLE_EQ_ORDERED(table_generator.generate_catalog_page(rows_to_check), load_csv("catalog_page.csv"));
     const auto [catalog_sales_table, catalog_returns_table] =
@@ -68,9 +68,9 @@ TEST_F(TpcdsTableGeneratorTest, TableContentsFirstRows) {
   }
 }
 
-TEST_F(TpcdsTableGeneratorTest, GenerateAndStoreRowCounts) {
+TEST_F(TPCDSTableGeneratorTest, GenerateAndStoreRowCounts) {
   /**
- * Check whether all TPC-DS tables are created by the TpcdsTableGenerator and added to the StorageManager.
+ * Check whether all TPC-DS tables are created by the TPCDSTableGenerator and added to the StorageManager.
  * Then check whether the row count is correct for all tables.
  */
 
@@ -101,7 +101,7 @@ TEST_F(TpcdsTableGeneratorTest, GenerateAndStoreRowCounts) {
 
   EXPECT_EQ(Hyrise::get().storage_manager.tables().size(), 0);
 
-  TpcdsTableGenerator(1, Chunk::DEFAULT_SIZE, 0).generate_and_store();
+  TPCDSTableGenerator(1, Chunk::DEFAULT_SIZE, 0).generate_and_store();
 
   for (const auto& [name, size] : expected_sizes) {
     SCOPED_TRACE("checking table " + std::string{name});


### PR DESCRIPTION
Adds all PRIMARY KEY key constraints from the TPC-DS spec, so that we can profit from unique constraints and FDs in our query plans.

**TPC-DS, SF=1**
<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------------------------------------------+------------------------------------------------+
 | Parameter        | results_master.json                            | results_constraints.json                       |
 +------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH        | 2905a7817d9d8d62581160431c07ff657e537441-dirty | c0e706da1384d8c0bfd54f8e5590c63b1956bc61-dirty |
 |  benchmark_mode  | Ordered                                        | Ordered                                        |
 |  build_type      | release                                        | release                                        |
 |  chunk_size      | 65535                                          | 65535                                          |
 |  clients         | 1                                              | 1                                              |
 |  compiler        | gcc 9.2                                        | gcc 9.2                                        |
 |  cores           | 0                                              | 0                                              |
 |  date            | 2020-10-02 16:43:45                            | 2020-10-02 18:06:49                            |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes         | False                                          | False                                          |
 |  max_duration    | 60000000000                                    | 60000000000                                    |
 |  max_runs        | -1                                             | -1                                             |
 |  time_unit       | ns                                             | ns                                             |
 |  using_scheduler | False                                          | False                                          |
 |  verify          | False                                          | False                                          |
 |  warmup_duration | 0                                              | 0                                              |
 +------------------+------------------------------------------------+------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     59.0 |    56.8 |   -4%  ||    16.95 |    17.59 |   +4%  |  0.0000 |
 | 03      ||     11.8 |    11.8 |   +0%  ||    84.90 |    84.69 |   -0%  |  0.0000 |
 | 06      ||     36.8 |    37.1 |   +1%  ||    27.14 |    26.99 |   -1%  |  0.0000 |
+| 07      ||    118.9 |    66.5 |  -44%  ||     8.41 |    15.04 |  +79%  |  0.0000 |
 | 09      ||    272.7 |   273.8 |   +0%  ||     3.67 |     3.65 |   -0%  |  0.0218 |
+| 10      ||     41.1 |    39.1 |   -5%  ||    24.34 |    25.54 |   +5%  |  0.0000 |
 | 13      ||    214.2 |   215.0 |   +0%  ||     4.67 |     4.65 |   -0%  |  0.8476 |
+| 15      ||     21.8 |    20.1 |   -8%  ||    45.78 |    49.67 |   +8%  |  0.0000 |
+| 17      ||     60.5 |    55.9 |   -8%  ||    16.52 |    17.89 |   +8%  |  0.0000 |
 | 19      ||     16.6 |    16.3 |   -2%  ||    60.25 |    61.17 |   +2%  |  0.0000 |
+| 25      ||     31.4 |    28.0 |  -11%  ||    31.84 |    35.71 |  +12%  |  0.0000 |
+| 26      ||     57.5 |    30.8 |  -46%  ||    17.38 |    32.43 |  +87%  |  0.0000 |
 | 28      ||   1694.7 |  1699.3 |   +0%  ||     0.59 |     0.59 |   -0%  |  0.0068 |
+| 29      ||     60.7 |    48.5 |  -20%  ||    16.46 |    20.62 |  +25%  |  0.0000 |
 | 31      ||    252.4 |   252.9 |   +0%  ||     3.96 |     3.95 |   -0%  |  0.4365 |
 | 34      ||     52.2 |    52.0 |   -0%  ||    19.14 |    19.24 |   +0%  |  0.0053 |
+| 35      ||    202.2 |   179.8 |  -11%  ||     4.94 |     5.56 |  +12%  |  0.0000 |
+| 39a     ||    390.1 |   360.8 |   -8%  ||     2.56 |     2.77 |   +8%  |  0.0000 |
+| 39b     ||    387.0 |   352.9 |   -9%  ||     2.58 |     2.83 |  +10%  |  0.0000 |
 | 41      ||     59.0 |    59.5 |   +1%  ||    16.96 |    16.82 |   -1%  |  0.0000 |
 | 42      ||     12.4 |    12.5 |   +1%  ||    80.45 |    79.94 |   -1%  |  0.0000 |
 | 43      ||    586.0 |   587.2 |   +0%  ||     1.71 |     1.70 |   -0%  |  0.0134 |
+| 45      ||     20.1 |    18.8 |   -6%  ||    49.81 |    53.13 |   +7%  |  0.0000 |
+| 48      ||    181.7 |   152.1 |  -16%  ||     5.50 |     6.58 |  +19%  |  0.0000 |
+| 50      ||     20.0 |    19.1 |   -5%  ||    49.89 |    52.40 |   +5%  |  0.0000 |
 | 52      ||     12.7 |    12.8 |   +1%  ||    78.87 |    78.32 |   -1%  |  0.0000 |
 | 55      ||     12.5 |    12.3 |   -2%  ||    79.71 |    81.27 |   +2%  |  0.0000 |
+| 62      ||    148.0 |   139.8 |   -6%  ||     6.76 |     7.15 |   +6%  |  0.0000 |
+| 65      ||    154.8 |   129.4 |  -16%  ||     6.46 |     7.73 |  +20%  |  0.0000 |
+| 69      ||     54.8 |    47.9 |  -13%  ||    18.24 |    20.87 |  +14%  |  0.0000 |
 | 73      ||     32.6 |    33.6 |   +3%  ||    30.67 |    29.73 |   -3%  |  0.0000 |
+| 79      ||    105.8 |    94.3 |  -11%  ||     9.45 |    10.61 |  +12%  |  0.0000 |
 | 81      ||     36.0 |    34.9 |   -3%  ||    27.75 |    28.63 |   +3%  |  0.0000 |
 | 83      ||     17.6 |    17.4 |   -1%  ||    56.81 |    57.45 |   +1%  |  0.0000 |
+| 85      ||    110.7 |   101.0 |   -9%  ||     9.03 |     9.90 |  +10%  |  0.0057 |
 | 88      ||    158.8 |   160.4 |   +1%  ||     6.30 |     6.24 |   -1%  |  0.0006 |
 | 91      ||     33.5 |    32.6 |   -3%  ||    29.83 |    30.68 |   +3%  |  0.0000 |
 | 93      ||    492.7 |   493.7 |   +0%  ||     2.03 |     2.03 |   -0%  |  0.2760 |
 | 96      ||     14.1 |    14.2 |   +1%  ||    70.97 |    70.55 |   -1%  |  0.0000 |
 | 97      ||    840.4 |   847.2 |   +1%  ||     1.19 |     1.18 |   -1%  |  0.0223 |
+| 99      ||    305.4 |   285.0 |   -7%  ||     3.27 |     3.51 |   +7%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   7391.3 |  7103.0 |   -4%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |   +8%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```