### PR TITLE
Sort: Add performance steps

### DIFF
--- a/src/lib/operators/sort.hpp
+++ b/src/lib/operators/sort.hpp
@@ -23,6 +23,8 @@ class Sort : public AbstractReadOnlyOperator {
  public:
   enum class ForceMaterialization : bool { Yes = true, No = false };
 
+  enum class OperatorSteps : uint8_t { Sort, WriteOutput };
+
   Sort(const std::shared_ptr<const AbstractOperator>& in, const std::vector<SortColumnDefinition>& sort_definitions,
        const ChunkOffset output_chunk_size = Chunk::DEFAULT_SIZE,
        const ForceMaterialization force_materialization = ForceMaterialization::No);


### PR DESCRIPTION
I was wondering if incorporating the limit operator into the sort operator could reduce the time spent writing the result. At least in TPC-H Q2, the only one where Sort has a significant cost, it does not.

Still, the performance counters should not go to waste.