### PR TITLE
Improve ColumnPruningRule for COUNT(*) aggregates

### DIFF
--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -108,7 +108,7 @@ ExpressionUnorderedSet gather_locally_required_expressions(
              *     is the only type of aggregate function, we simply require the first output expression from the
              *     left input node.
              */
-            if(!locally_required_expressions.empty() || expression_idx < node_expressions.size() - 1) continue;
+            if (!locally_required_expressions.empty() || expression_idx < node_expressions.size() - 1) continue;
             DebugAssert(!node->left_input()->output_expressions().empty(), "Did not expect empty output expressions");
             locally_required_expressions.emplace(node->left_input()->output_expressions().at(0));
           }

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -84,35 +84,24 @@ ExpressionUnorderedSet gather_locally_required_expressions(
     case LQPNodeType::Aggregate: {
       const auto& aggregate_node = static_cast<AggregateNode&>(*node);
 
-      for (auto expression_idx = size_t{0}; expression_idx < node->node_expressions.size(); ++expression_idx) {
-        const auto& expression = node->node_expressions[expression_idx];
+      const auto& node_expressions = node->node_expressions;
+      for (auto expression_idx = size_t{0}; expression_idx < node_expressions.size(); ++expression_idx) {
+        const auto& expression = node_expressions[expression_idx];
 
         // The AggregateNode's node_expressions contain both the group_by- and the aggregate_expressions in that order,
         // separated by aggregate_expressions_begin_idx.
         if (expression_idx < aggregate_node.aggregate_expressions_begin_idx) {
-          // This is a group by expression that is required from the input
+          // Group by expressions are required
           locally_required_expressions.emplace(expression);
         } else {
-          // This is an aggregate expression
+          // We require the argument expressions of Aggregates
           DebugAssert(expression->type == ExpressionType::Aggregate, "Expected AggregateExpression");
           if (!AggregateExpression::is_count_star(*expression)) {
-            //  We need the argument
             locally_required_expressions.emplace(expression->arguments[0]);
-          } else {
-            // Handling COUNT(*) (which is represented as an LQPColumnExpression with a valid original_node and an
-            // INVALID_COLUMN_ID) is difficult, as we need to make sure that at least one expression from that
-            // original node survives the pruning. Otherwise, we could not resolve that original_node later on.
-            // For now, we simply stop pruning (i.e., add all expressions as required) once we encounter COUNT(*).
-            // TODO Doc
-            // Invalid column id -> Instead we mark the first input expression as required that is not part of
-            // the group-by clause
-            const auto& input_expressions = node->left_input()->output_expressions();
-            for (const auto& input_expression : input_expressions) {
-              if (locally_required_expressions.emplace(input_expression).second) {
-                // We added a single non-group-by expression which is enough.
-                break;
-              }
-            }
+          } else if (locally_required_expressions.empty() && expression_idx == (node_expressions.size() - 1)) {
+            // Ensure, that we require at least one output expression for ungrouped COUNT(*) aggregations.
+            DebugAssert(!node->left_input()->output_expressions().empty(), "Did not expect empty output expressions");
+            locally_required_expressions.emplace(node->left_input()->output_expressions().at(0));
           }
         }
       }

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -97,10 +97,16 @@ ExpressionUnorderedSet gather_locally_required_expressions(
         }
       }
       if (has_count_star) {
-        for (const auto& input_expression : node->left_input()->output_expressions()) {
-          locally_required_expressions.emplace(input_expression);
+        const auto& unique_constraints = aggregate_node.unique_constraints();
+        if(unique_constraints->empty()) {
+          for (const auto& input_expression : node->left_input()->output_expressions()) {
+            locally_required_expressions.emplace(input_expression);
+          }
+          break;
         }
-        break;
+        // To discuss
+        const auto& expressions = unique_constraints->at(0).expressions;
+        locally_required_expressions.insert(expressions.cbegin(), expressions.cend());
       }
 
       for (auto expression_idx = size_t{0}; expression_idx < node->node_expressions.size(); ++expression_idx) {

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -109,7 +109,6 @@ ExpressionUnorderedSet gather_locally_required_expressions(
              *     left input node.
              */
             if (!locally_required_expressions.empty() || expression_idx < node_expressions.size() - 1) continue;
-            DebugAssert(!node->left_input()->output_expressions().empty(), "Did not expect empty output expressions");
             locally_required_expressions.emplace(node->left_input()->output_expressions().at(0));
           }
         }

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -262,15 +262,14 @@ TEST_F(ColumnPruningRuleTest, UngroupedCountStar) {
   // Create deep copy so we can set pruned ColumnIDs on node_a below without manipulating the input LQP
   lqp = lqp->deep_copy();
 
-  const auto pruned_node_a = pruned(node_a, {ColumnID{2}});
+  const auto pruned_node_a = pruned(node_a, {ColumnID{1}, ColumnID{2}});
   const auto pruned_a = pruned_node_a->get_column("a");
-  const auto pruned_b = pruned_node_a->get_column("b");
 
   const auto actual_lqp = apply_rule(rule, lqp);
 
   const auto expected_lqp =
   AggregateNode::make(expression_vector(), expression_vector(count_star_(pruned_node_a)),
-    ProjectionNode::make(expression_vector(pruned_a, pruned_b, add_(pruned_a, 2)),
+    ProjectionNode::make(expression_vector(pruned_a),
       pruned_node_a));
   // clang-format on
 
@@ -297,7 +296,7 @@ TEST_F(ColumnPruningRuleTest, GroupedCountStar) {
 
   const auto expected_lqp =
   AggregateNode::make(expression_vector(pruned_b, pruned_a), expression_vector(count_star_(pruned_node_a)),
-    ProjectionNode::make(expression_vector(pruned_a, pruned_b, add_(pruned_a, 2)),
+    ProjectionNode::make(expression_vector(pruned_a, pruned_b),
       pruned_node_a));
   // clang-format on
 

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -276,6 +276,32 @@ TEST_F(ColumnPruningRuleTest, UngroupedCountStar) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(ColumnPruningRuleTest, UngroupedCountStarAndSum) {
+  auto lqp = std::shared_ptr<AbstractLQPNode>{};
+
+  // clang-format off
+  lqp =
+      AggregateNode::make(expression_vector(), expression_vector(count_star_(node_a), sum_(b)),
+                          ProjectionNode::make(expression_vector(a, b, add_(a, 2)),
+                                               node_a));
+
+  // Create deep copy so we can set pruned ColumnIDs on node_a below without manipulating the input LQP
+  lqp = lqp->deep_copy();
+
+  const auto pruned_node_a = pruned(node_a, {ColumnID{0}, ColumnID{2}});
+  const auto pruned_b = pruned_node_a->get_column("b");
+
+  const auto actual_lqp = apply_rule(rule, lqp);
+
+  const auto expected_lqp =
+      AggregateNode::make(expression_vector(), expression_vector(count_star_(pruned_node_a), sum_(pruned_b)),
+                          ProjectionNode::make(expression_vector(pruned_b),
+                                               pruned_node_a));
+  // clang-format on
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
 TEST_F(ColumnPruningRuleTest, GroupedCountStar) {
   auto lqp = std::shared_ptr<AbstractLQPNode>{};
 

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -281,9 +281,9 @@ TEST_F(ColumnPruningRuleTest, UngroupedCountStarAndSum) {
 
   // clang-format off
   lqp =
-      AggregateNode::make(expression_vector(), expression_vector(count_star_(node_a), sum_(b)),
-                          ProjectionNode::make(expression_vector(a, b, add_(a, 2)),
-                                               node_a));
+  AggregateNode::make(expression_vector(), expression_vector(count_star_(node_a), sum_(b)),
+    ProjectionNode::make(expression_vector(a, b, add_(a, 2)),
+      node_a));
 
   // Create deep copy so we can set pruned ColumnIDs on node_a below without manipulating the input LQP
   lqp = lqp->deep_copy();
@@ -294,9 +294,9 @@ TEST_F(ColumnPruningRuleTest, UngroupedCountStarAndSum) {
   const auto actual_lqp = apply_rule(rule, lqp);
 
   const auto expected_lqp =
-      AggregateNode::make(expression_vector(), expression_vector(count_star_(pruned_node_a), sum_(pruned_b)),
-                          ProjectionNode::make(expression_vector(pruned_b),
-                                               pruned_node_a));
+  AggregateNode::make(expression_vector(), expression_vector(count_star_(pruned_node_a), sum_(pruned_b)),
+    ProjectionNode::make(expression_vector(pruned_b),
+      pruned_node_a));
   // clang-format on
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);


### PR DESCRIPTION
The ColumnPruningRule prunes columns from StoredTableNodes which are not relevant to other LQP nodes. Therefore, it has to check each LQP node for required expressions. 
In terms of AggregateNodes, the rule considers group-by expressions and the arguments of aggregate functions as required. Ungrouped `COUNT(*)` aggregations, however, are an edge case because we cannot derive any required expressions. Until now, the rule considered all input expressions as required whenever there was a `COUNT(*)` aggregate function. In consequence, column pruning became effectively disabled for some queries.

This PR enables column pruning for AggregateNodes with `COUNT(*)` aggregates. 
Some TPC-DS queries heavily profit from this change due to the semi join reformulations that were not possible before.

**TPC-DS, SF=1:**

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------------------------------------------+------------------------------------------------+
 | Parameter        | results_constraints.json                       | results_improve_column_pruning_count_star.json |
 +------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH        | c0e706da1384d8c0bfd54f8e5590c63b1956bc61-dirty | 9eb39134c702509e21210bf7a6c52a87182b3fd9-dirty |
 |  benchmark_mode  | Ordered                                        | Ordered                                        |
 |  build_type      | release                                        | release                                        |
 |  chunk_size      | 65535                                          | 65535                                          |
 |  clients         | 1                                              | 1                                              |
 |  compiler        | gcc 9.2                                        | gcc 9.2                                        |
 |  cores           | 0                                              | 0                                              |
 |  date            | 2020-10-02 18:06:49                            | 2020-10-06 17:54:31                            |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes         | False                                          | False                                          |
 |  max_duration    | 60000000000                                    | 60000000000                                    |
 |  max_runs        | -1                                             | -1                                             |
 |  time_unit       | ns                                             | ns                                             |
 |  using_scheduler | False                                          | False                                          |
 |  verify          | False                                          | False                                          |
 |  warmup_duration | 0                                              | 0                                              |
 +------------------+------------------------------------------------+------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     56.8 |    55.9 |   -2%  ||    17.59 |    17.88 |   +2%  |  0.0000 |
 | 03      ||     11.8 |    11.8 |   +0%  ||    84.69 |    84.57 |   -0%  |  0.0000 |
+| 06      ||     37.1 |    32.4 |  -13%  ||    26.99 |    30.84 |  +14%  |  0.0000 |
 | 07      ||     66.5 |    66.4 |   -0%  ||    15.04 |    15.06 |   +0%  |  0.4475 |
 | 09      ||    273.8 |   273.2 |   -0%  ||     3.65 |     3.66 |   +0%  |  0.3217 |
 | 10      ||     39.1 |    38.1 |   -3%  ||    25.54 |    26.22 |   +3%  |  0.0000 |
 | 13      ||    215.0 |   208.2 |   -3%  ||     4.65 |     4.80 |   +3%  |  0.0478 |
 | 15      ||     20.1 |    19.5 |   -3%  ||    49.67 |    51.39 |   +3%  |  0.0000 |
 | 17      ||     55.9 |    54.4 |   -3%  ||    17.89 |    18.38 |   +3%  |  0.0120 |
 | 19      ||     16.3 |    16.3 |   -0%  ||    61.17 |    61.44 |   +0%  |  0.0045 |
 | 25      ||     28.0 |    27.0 |   -4%  ||    35.71 |    37.07 |   +4%  |  0.0004 |
 | 26      ||     30.8 |    30.7 |   -0%  ||    32.43 |    32.56 |   +0%  |  0.0031 |
 | 28      ||   1699.3 |  1692.0 |   -0%  ||     0.59 |     0.59 |   +0%  |  0.0004 |
 | 29      ||     48.5 |    47.4 |   -2%  ||    20.62 |    21.08 |   +2%  |  0.0372 |
 | 31      ||    252.9 |   251.1 |   -1%  ||     3.95 |     3.98 |   +1%  |  0.0000 |
+| 34      ||     52.0 |    30.6 |  -41%  ||    19.24 |    32.71 |  +70%  |  0.0000 |
 | 35      ||    179.8 |   177.8 |   -1%  ||     5.56 |     5.62 |   +1%  |  0.0000 |
 | 39a     ||    360.8 |   358.1 |   -1%  ||     2.77 |     2.79 |   +1%  |  0.0353 |
 | 39b     ||    352.9 |   354.2 |   +0%  ||     2.83 |     2.82 |   -0%  |  0.0141 |
+| 41      ||     59.5 |    56.7 |   -5%  ||    16.82 |    17.65 |   +5%  |  0.0000 |
 | 42      ||     12.5 |    12.5 |   -0%  ||    79.94 |    80.02 |   +0%  |  0.0040 |
 | 43      ||    587.2 |   575.4 |   -2%  ||     1.70 |     1.74 |   +2%  |  0.0000 |
 | 45      ||     18.8 |    18.5 |   -1%  ||    53.13 |    53.90 |   +1%  |  0.0000 |
 | 48      ||    152.1 |   150.9 |   -1%  ||     6.58 |     6.63 |   +1%  |  0.0235 |
 | 50      ||     19.1 |    19.0 |   -0%  ||    52.40 |    52.60 |   +0%  |  0.0031 |
 | 52      ||     12.8 |    12.7 |   -0%  ||    78.32 |    78.59 |   +0%  |  0.0000 |
 | 55      ||     12.3 |    12.3 |   -0%  ||    81.27 |    81.40 |   +0%  |  0.0000 |
 | 62      ||    139.8 |   138.4 |   -1%  ||     7.15 |     7.22 |   +1%  |  0.0000 |
 | 65      ||    129.4 |   129.9 |   +0%  ||     7.73 |     7.70 |   -0%  |  0.0014 |
+| 69      ||     47.9 |    44.5 |   -7%  ||    20.87 |    22.45 |   +8%  |  0.0000 |
+| 73      ||     33.6 |    17.1 |  -49%  ||    29.73 |    58.51 |  +97%  |  0.0000 |
 | 79      ||     94.3 |    93.1 |   -1%  ||    10.61 |    10.74 |   +1%  |  0.0000 |
 | 81      ||     34.9 |    34.3 |   -2%  ||    28.63 |    29.12 |   +2%  |  0.0000 |
 | 83      ||     17.4 |    16.9 |   -3%  ||    57.45 |    59.29 |   +3%  |  0.0000 |
 | 85      ||    101.0 |    99.8 |   -1%  ||     9.90 |    10.02 |   +1%  |  0.7180 |
+| 88      ||    160.4 |   111.9 |  -30%  ||     6.24 |     8.93 |  +43%  |  0.0000 |
 | 91      ||     32.6 |    32.4 |   -0%  ||    30.68 |    30.82 |   +0%  |  0.0064 |
 | 93      ||    493.7 |   496.4 |   +1%  ||     2.03 |     2.01 |   -1%  |  0.0089 |
+| 96      ||     14.2 |    11.5 |  -19%  ||    70.55 |    86.61 |  +23%  |  0.0000 |
 | 97      ||    847.2 |   849.9 |   +0%  ||     1.18 |     1.18 |   -0%  |  0.4154 |
 | 99      ||    285.0 |   285.0 |   +0%  ||     3.51 |     3.51 |   -0%  |  0.9631 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   7103.0 |  6964.3 |   -2%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |   +6%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```

**TPC-H, SF=1:**

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+------------------------------------------------+-----------------------------------------------------+
 | Parameter                | results_tpch_master.json                       | results_tpch_improve_column_pruning_count_star.json |
 +--------------------------+------------------------------------------------+-----------------------------------------------------+
 |  GIT-HASH                | 71a783492d4faf0a1c55b3626afe46a49d463b80-dirty | b8fc760eba72a7da2c650f2208c067f988796645-dirty      |
 |  benchmark_mode          | Ordered                                        | Ordered                                             |
 |  build_type              | release                                        | release                                             |
 |  chunk_size              | 65535                                          | 65535                                               |
 |  clients                 | 1                                              | 1                                                   |
 |  compiler                | gcc 9.2                                        | gcc 9.2                                             |
 |  cores                   | 0                                              | 0                                                   |
 |  date                    | 2020-10-07 13:30:57                            | 2020-10-07 14:43:10                                 |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}             |
 |  indexes                 | False                                          | False                                               |
 |  max_duration            | 60000000000                                    | 60000000000                                         |
 |  max_runs                | -1                                             | -1                                                  |
 |  scale_factor            | 1.0                                            | 1.0                                                 |
 |  time_unit               | ns                                             | ns                                                  |
 |  use_prepared_statements | False                                          | False                                               |
 |  using_scheduler         | False                                          | False                                               |
 |  verify                  | False                                          | False                                               |
 |  warmup_duration         | 0                                              | 0                                                   |
 +--------------------------+------------------------------------------------+-----------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   1710.0 |  1688.7 |   -1%  ||     0.58 |     0.59 |   +1%  |  0.4510 |
 | TPC-H 02 ||     10.2 |    10.2 |   +0%  ||    97.80 |    97.63 |   -0%  |  0.8869 |
 | TPC-H 03 ||    164.7 |   165.3 |   +0%  ||     6.07 |     6.05 |   -0%  |  0.0561 |
 | TPC-H 04 ||    143.5 |   142.5 |   -1%  ||     6.97 |     7.02 |   +1%  |  0.0000 |
 | TPC-H 05 ||    454.3 |   465.3 |   +2%  ||     2.20 |     2.15 |   -2%  |  0.0000 |
 | TPC-H 06 ||      8.1 |     8.1 |   +0%  ||   124.13 |   123.77 |   -0%  |  0.2640 |
 | TPC-H 07 ||    120.7 |   120.2 |   -0%  ||     8.29 |     8.32 |   +0%  |  0.7346 |
 | TPC-H 08 ||    131.7 |   132.5 |   +1%  ||     7.59 |     7.55 |   -1%  |  0.2651 |
 | TPC-H 09 ||    897.6 |   892.8 |   -1%  ||     1.11 |     1.12 |   +1%  |  0.2486 |
 | TPC-H 10 ||    327.0 |   320.6 |   -2%  ||     3.06 |     3.12 |   +2%  |  0.0000 |
 | TPC-H 11 ||     15.1 |    15.0 |   -1%  ||    66.12 |    66.47 |   +1%  |  0.0037 |
 | TPC-H 12 ||     87.6 |    87.2 |   -1%  ||    11.41 |    11.47 |   +1%  |  0.0055 |
 | TPC-H 13 ||    710.7 |   707.9 |   -0%  ||     1.41 |     1.41 |   +0%  |  0.0207 |
 | TPC-H 14 ||     37.4 |    37.7 |   +1%  ||    26.73 |    26.53 |   -1%  |  0.0000 |
 | TPC-H 15 ||     17.6 |    17.8 |   +1%  ||    56.73 |    56.26 |   -1%  |  0.0000 |
 | TPC-H 16 ||    176.2 |   175.9 |   -0%  ||     5.68 |     5.69 |   +0%  |  0.6292 |
 | TPC-H 17 ||     45.6 |    45.7 |   +0%  ||    21.91 |    21.89 |   -0%  |  0.6936 |
 | TPC-H 18 ||   1294.4 |  1268.8 |   -2%  ||     0.77 |     0.79 |   +2%  |  0.0002 |
 | TPC-H 19 ||     66.6 |    66.5 |   -0%  ||    15.01 |    15.03 |   +0%  |  0.2851 |
 | TPC-H 20 ||     29.2 |    29.2 |   +0%  ||    34.21 |    34.19 |   -0%  |  0.8112 |
 | TPC-H 21 ||    793.5 |   809.3 |   +2%  ||     1.26 |     1.24 |   -2%  |  0.0021 |
 | TPC-H 22 ||    125.4 |   127.7 |   +2%  ||     7.97 |     7.83 |   -2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   7367.2 |  7335.1 |   -0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
