### PR TITLE
Create empty bloom filter only once

### DIFF
--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -79,6 +79,9 @@ do
     if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
       echo "Running $benchmark for $commit... (single-threaded, SF 0.01)"
       ( ${build_folder}/$benchmark -s .01 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
+
+      echo "Running $benchmark for $commit... (single-threaded, SF 10)"
+      ( ${build_folder}/$benchmark -s 10 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s10.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s10.log"
     fi
 
     echo "Running $benchmark for $commit... (multi-threaded)"
@@ -138,7 +141,7 @@ for benchmark in $benchmarks
 do
   configs="st mt"
   if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
-    configs="st st_s01 mt"
+    configs="st st_s01 st_s10 mt"
   fi
 
   for config in $configs
@@ -150,6 +153,7 @@ do
     case "${config}" in
       "st") echo -n "single-threaded" ;;
       "st_s01") echo -n "single-threaded, SF 0.01" ;;
+      "st_s10") echo -n "single-threaded, SF 10" ;;
       "mt") echo -n "multi-threaded (${num_mt_clients} clients)" ;;
     esac
     echo "**"

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -206,7 +206,7 @@ using BloomFilter = boost::dynamic_bitset<>;
 
 // ALL_TRUE_BLOOM_FILTER is initialized by creating a BloomFilter with every value being false and using bitwise
 // negation (~x). As the negation is surprisingly expensive, we create a static empty bloom filter and reference
-// it where needed. Having a bloom filter that always returns true means avoids a branch in the hot loop.
+// it where needed. Having a bloom filter that always returns true avoids a branch in the hot loop.
 static const auto ALL_TRUE_BLOOM_FILTER = ~BloomFilter(BLOOM_FILTER_SIZE);
 
 // @param in_table             Table to materialize

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -191,7 +191,7 @@ class PosHashTable {
 //     not optimal in every situation.
 // (3) Check whether using multiple hash functions (k>1) brings any improvement.
 // (4) Use the probe side bloom filter when partitioning the build side. By doing that, we reduce the size of the
-//     intermediary results. When a bloom filter-supported materialization has been done (i.e., materialization has not
+//     intermediary results. When a bloom filter-supported partitioning has been done (i.e., partitioning has not
 //     been skipped), we do not need to use a bloom filter in the build phase anymore.
 // Some of these points could be addressed with relatively low effort and should bring additional, significant benefits.
 // We did not yet work on this because the bloom filter was a byproduct of a research project and we have not had the
@@ -203,6 +203,11 @@ static constexpr auto BLOOM_FILTER_MASK = BLOOM_FILTER_SIZE - 1;
 // needed for merging partial bloom filters created by different threads. Note that the dynamic_bitset(n, value)
 // constructor does not do what you would expect it to, so try to avoid it.
 using BloomFilter = boost::dynamic_bitset<>;
+
+// EMPTY_BLOOM_FILTER is initialized by creating a BloomFilter with every value being false and using bitwise
+// negation (~x). As the negation is surprisingly expensive, we create a static empty bloom filter and reference
+// it where needed.
+static const auto EMPTY_BLOOM_FILTER = ~BloomFilter(BLOOM_FILTER_SIZE);
 
 // @param in_table             Table to materialize
 // @param column_id            Column within that table to materialize
@@ -217,10 +222,7 @@ template <typename T, typename HashedType, bool keep_null_values>
 RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table, const ColumnID column_id,
                                     std::vector<std::vector<size_t>>& histograms, const size_t radix_bits,
                                     BloomFilter& output_bloom_filter,
-                                    const BloomFilter& input_bloom_filter = ~BloomFilter(BLOOM_FILTER_SIZE)) {
-  // input_bloom_filter is default-initialized by creating a BloomFilter with every value being false and using bitwise
-  // negation (~x).
-
+                                    const BloomFilter& input_bloom_filter = EMPTY_BLOOM_FILTER) {
   // Retrieve input chunk_count as it might change during execution if we work on a non-reference table
   auto chunk_count = in_table->chunk_count();
 
@@ -454,9 +456,7 @@ std::vector<std::optional<PosHashTable<HashedType>>> build(const RadixContainer<
 template <typename T, typename HashedType, bool keep_null_values>
 RadixContainer<T> partition_by_radix(const RadixContainer<T>& radix_container,
                                      std::vector<std::vector<size_t>>& histograms, const size_t radix_bits,
-                                     const BloomFilter& input_bloom_filter = ~BloomFilter(BLOOM_FILTER_SIZE)) {
-  // input_bloom_filter is default-initialized by creating a BloomFilter with every value being false and using bitwise
-  // negation (~x).
+                                     const BloomFilter& input_bloom_filter = EMPTY_BLOOM_FILTER) {
   if (radix_container.empty()) return radix_container;
 
   if constexpr (keep_null_values) {


### PR DESCRIPTION
For some reason, `~BloomFilter(BLOOM_FILTER_SIZE);` is quite expensive, resulting in a `> 1 ms` startup time for a join. For as long as we do not have dynamic bloom filter sizes, this is a hotfix:

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 88b690fc4 | 07.10.2020 07:35 | benchmark_all: Include TPC-H SF 10 | real 265.11 user 2399.13 sys 132.74|
| 792e6f29a | 07.10.2020 07:35 | Reuse empty bloom filter | real 266.38 user 2385.16 sys 135.59|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_88b690fc4f1881f9a0dfea42caf2946881517848_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                         | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-07 07:40:16                                                                                                                    | 2020-10-07 14:37:06                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    815.5 |   823.1 |   +1%  ||     1.23 |     1.21 |   -1%  |  0.1388 |
+| TPC-H 02 ||      5.1 |     4.9 |   -5%  ||   194.69 |   204.39 |   +5%  |  0.0000 |
 | TPC-H 03 ||     80.5 |    81.0 |   +1%  ||    12.43 |    12.35 |   -1%  |  0.0000 |
 | TPC-H 04 ||     68.1 |    68.7 |   +1%  ||    14.68 |    14.56 |   -1%  |  0.0000 |
-| TPC-H 05 ||    217.1 |   229.8 |   +6%  ||     4.61 |     4.35 |   -6%  |  0.0000 |
+| TPC-H 06 ||      3.4 |     3.2 |   -5%  ||   297.91 |   313.21 |   +5%  |  0.0000 |
 | TPC-H 07 ||     58.0 |    58.2 |   +0%  ||    17.24 |    17.20 |   -0%  |  0.7748 |
 | TPC-H 08 ||     68.6 |    68.5 |   -0%  ||    14.57 |    14.60 |   +0%  |  0.6851 |
 | TPC-H 09 ||    481.7 |   482.1 |   +0%  ||     2.08 |     2.07 |   -0%  |  0.7908 |
 | TPC-H 10 ||    167.3 |   167.9 |   +0%  ||     5.98 |     5.96 |   -0%  |  0.5086 |
 | TPC-H 11 ||      9.1 |     9.1 |   +0%  ||   110.32 |   110.24 |   -0%  |  0.5013 |
 | TPC-H 12 ||     44.1 |    43.6 |   -1%  ||    22.66 |    22.95 |   +1%  |  0.0000 |
 | TPC-H 13 ||    354.9 |   365.0 |   +3%  ||     2.82 |     2.74 |   -3%  |  0.0000 |
 | TPC-H 14 ||     20.8 |    21.1 |   +1%  ||    48.02 |    47.40 |   -1%  |  0.0000 |
 | TPC-H 15 ||      7.8 |     7.7 |   -1%  ||   127.63 |   129.16 |   +1%  |  0.0000 |
 | TPC-H 16 ||     94.3 |    91.0 |   -4%  ||    10.60 |    10.99 |   +4%  |  0.0000 |
 | TPC-H 17 ||     18.0 |    17.9 |   -1%  ||    55.43 |    55.86 |   +1%  |  0.0001 |
 | TPC-H 18 ||    688.4 |   697.8 |   +1%  ||     1.45 |     1.43 |   -1%  |  0.1728 |
 | TPC-H 19 ||     29.7 |    29.3 |   -1%  ||    33.70 |    34.15 |   +1%  |  0.0000 |
 | TPC-H 20 ||     16.2 |    16.1 |   -0%  ||    61.83 |    61.97 |   +0%  |  0.4158 |
 | TPC-H 21 ||    420.6 |   421.8 |   +0%  ||     2.38 |     2.37 |   -0%  |  0.5384 |
 | TPC-H 22 ||     49.4 |    49.5 |   +0%  ||    20.22 |    20.20 |   -0%  |  0.0122 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3718.6 |  3757.3 |   +1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_88b690fc4f1881f9a0dfea42caf2946881517848_st_s01.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                             | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-07 08:02:34                                                                                                                        | 2020-10-07 14:59:24                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.3 |     7.3 |   -0%  ||   137.54 |   137.60 |   +0%  |  0.4183 |
+| TPC-H 02 ||      0.7 |     0.5 |  -17%  ||  1527.95 |  1849.06 |  +21%  |  0.0000 |
 | TPC-H 03 ||      0.9 |     0.9 |   -2%  ||  1098.37 |  1121.84 |   +2%  |  0.0000 |
+| TPC-H 04 ||      0.5 |     0.5 |   -5%  ||  1831.17 |  1918.32 |   +5%  |  0.0000 |
+| TPC-H 05 ||      1.3 |     1.2 |   -6%  ||   760.05 |   805.82 |   +6%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   -1%  ||  9327.17 |  9403.38 |   +1%  |  0.0000 |
+| TPC-H 07 ||      1.3 |     1.2 |   -8%  ||   744.20 |   810.05 |   +9%  |  0.0000 |
 | TPC-H 08 ||     14.8 |    14.5 |   -2%  ||    67.49 |    68.78 |   +2%  |  0.0159 |
 | TPC-H 09 ||      2.4 |     2.4 |   -2%  ||   413.18 |   420.34 |   +2%  |  0.0000 |
+| TPC-H 10 ||      1.0 |     0.9 |   -5%  ||  1042.21 |  1093.16 |   +5%  |  0.0000 |
+| TPC-H 11 ||      0.3 |     0.3 |  -14%  ||  2894.60 |  3372.29 |  +17%  |  0.0000 |
 | TPC-H 12 ||      0.7 |     0.6 |   -3%  ||  1519.77 |  1568.84 |   +3%  |  0.0000 |
 | TPC-H 13 ||      2.2 |     2.3 |   +1%  ||   446.70 |   442.89 |   -1%  |  0.0000 |
+| TPC-H 14 ||      0.4 |     0.4 |   -6%  ||  2625.98 |  2806.57 |   +7%  |  0.0000 |
 | TPC-H 15 ||      1.2 |     1.1 |   -3%  ||   865.37 |   892.13 |   +3%  |  0.0000 |
 | TPC-H 16 ||      2.2 |     2.1 |   -3%  ||   453.33 |   465.37 |   +3%  |  0.0000 |
+| TPC-H 17 ||      0.3 |     0.3 |  -11%  ||  3040.84 |  3433.56 |  +13%  |  0.0000 |
 | TPC-H 18 ||      2.7 |     2.7 |   -2%  ||   363.97 |   370.04 |   +2%  |  0.0000 |
 | TPC-H 19 ||      5.5 |     5.5 |   -1%  ||   181.07 |   182.59 |   +1%  |  0.0000 |
 | TPC-H 20 ||      2.4 |     2.4 |   -2%  ||   414.93 |   424.94 |   +2%  |  0.0000 |
 | TPC-H 21 ||      2.2 |     2.1 |   -3%  ||   455.55 |   470.85 |   +3%  |  0.0000 |
 | TPC-H 22 ||      1.3 |     1.3 |   -0%  ||   768.69 |   772.04 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     51.8 |    50.7 |   -2%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |   +5%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_88b690fc4f1881f9a0dfea42caf2946881517848_st_s10.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                             | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-07 08:24:37                                                                                                                        | 2020-10-07 15:21:28                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   8870.0 |  8879.6 |   +0%  ||     0.11 |     0.11 |   -0%  |       ˅ |
 | TPC-H 02 ||     54.0 |    52.7 |   -2%  ||    18.53 |    18.97 |   +2%  |  0.0000 |
 | TPC-H 03 ||   1545.1 |  1544.8 |   -0%  ||     0.65 |     0.65 |   +0%  |  0.9765 |
 | TPC-H 04 ||   1683.6 |  1654.2 |   -2%  ||     0.59 |     0.60 |   +2%  |  0.0341 |
 | TPC-H 05 ||   3300.0 |  3306.1 |   +0%  ||     0.30 |     0.30 |   -0%  |  0.8145 |
+| TPC-H 06 ||     36.1 |    34.2 |   -5%  ||    27.71 |    29.28 |   +6%  |  0.0000 |
 | TPC-H 07 ||    933.3 |   935.7 |   +0%  ||     1.07 |     1.07 |   -0%  |  0.2458 |
 | TPC-H 08 ||    644.8 |   647.1 |   +0%  ||     1.55 |     1.55 |   -0%  |  0.0016 |
 | TPC-H 09 ||   7304.5 |  7296.1 |   -0%  ||     0.14 |     0.14 |   +0%  |       ˅ |
 | TPC-H 10 ||   2863.0 |  2860.3 |   -0%  ||     0.35 |     0.35 |   +0%  |  0.7754 |
 | TPC-H 11 ||    128.8 |   129.4 |   +0%  ||     7.76 |     7.73 |   -0%  |  0.0355 |
 | TPC-H 12 ||    709.8 |   706.8 |   -0%  ||     1.41 |     1.41 |   +0%  |  0.0197 |
 | TPC-H 13 ||   5502.2 |  5640.4 |   +3%  ||     0.18 |     0.18 |   -2%  |  0.0000 |
 | TPC-H 14 ||    230.8 |   234.8 |   +2%  ||     4.33 |     4.26 |   -2%  |  0.0000 |
 | TPC-H 15 ||     97.8 |    97.4 |   -0%  ||    10.22 |    10.26 |   +0%  |  0.0411 |
 | TPC-H 16 ||   1215.2 |  1208.9 |   -1%  ||     0.82 |     0.83 |   +1%  |  0.4545 |
 | TPC-H 17 ||    263.0 |   264.7 |   +1%  ||     3.80 |     3.78 |   -1%  |  0.0000 |
 | TPC-H 18 ||  11800.1 | 11902.0 |   +1%  ||     0.08 |     0.08 |   -1%  |       ˅ |
 | TPC-H 19 ||    312.2 |   312.6 |   +0%  ||     3.20 |     3.20 |   -0%  |  0.5648 |
 | TPC-H 20 ||    177.6 |   178.1 |   +0%  ||     5.63 |     5.61 |   -0%  |  0.1870 |
 | TPC-H 21 ||   6835.8 |  6910.6 |   +1%  ||     0.15 |     0.14 |   -1%  |       ˅ |
 | TPC-H 22 ||    728.2 |   716.5 |   -2%  ||     1.37 |     1.40 |   +2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  55235.8 | 55513.0 |   +1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_88b690fc4f1881f9a0dfea42caf2946881517848_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                         | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-07 08:50:02                                                                                                                    | 2020-10-07 15:46:57                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2240.6 |  2252.4 |   +1%  ||    21.68 |    21.57 |   -1%  |  0.7813 |
 | TPC-H 02 ||     16.8 |    16.1 |   -5%  ||  2353.84 |  2340.33 |   -1%  |  0.0000 |
 | TPC-H 03 ||    373.6 |   374.3 |   +0%  ||   131.35 |   131.04 |   -0%  |  0.9048 |
 | TPC-H 04 ||    231.8 |   229.6 |   -1%  ||   210.65 |   212.01 |   +1%  |  0.4684 |
 | TPC-H 05 ||   1144.5 |  1144.9 |   +0%  ||    42.73 |    42.85 |   +0%  |  0.9905 |
 | TPC-H 06 ||     18.5 |    18.5 |   -0%  ||  2369.83 |  2382.38 |   +1%  |  0.8768 |
 | TPC-H 07 ||    214.3 |   210.5 |   -2%  ||   227.08 |   231.16 |   +2%  |  0.1273 |
 | TPC-H 08 ||    181.1 |   178.6 |   -1%  ||   267.76 |   271.36 |   +1%  |  0.1041 |
 | TPC-H 09 ||   2123.5 |  2109.1 |   -1%  ||    22.92 |    23.03 |   +1%  |  0.8261 |
 | TPC-H 10 ||    749.7 |   749.1 |   -0%  ||    65.79 |    65.83 |   +0%  |  0.9518 |
 | TPC-H 11 ||     59.7 |    58.9 |   -1%  ||   776.83 |   786.27 |   +1%  |  0.0040 |
 | TPC-H 12 ||    119.9 |   119.4 |   -0%  ||   400.04 |   401.90 |   +0%  |  0.6101 |
 | TPC-H 13 ||   1953.3 |  1953.5 |   +0%  ||    24.95 |    24.96 |   +0%  |  0.9975 |
 | TPC-H 14 ||    121.5 |   120.0 |   -1%  ||   395.41 |   399.77 |   +1%  |  0.0167 |
 | TPC-H 15 ||     46.2 |    45.7 |   -1%  ||   983.08 |   992.69 |   +1%  |  0.0003 |
 | TPC-H 16 ||    410.2 |   398.9 |   -3%  ||   119.80 |   123.46 |   +3%  |  0.0045 |
 | TPC-H 17 ||     58.9 |    58.7 |   -0%  ||   787.77 |   791.45 |   +0%  |  0.3304 |
 | TPC-H 18 ||   5538.6 |  5547.7 |   +0%  ||     8.53 |     8.57 |   +0%  |  0.9571 |
 | TPC-H 19 ||     92.8 |    92.8 |   -0%  ||   512.11 |   512.60 |   +0%  |  0.9166 |
 | TPC-H 20 ||     50.2 |    48.9 |   -2%  ||   911.66 |   932.21 |   +2%  |  0.0000 |
 | TPC-H 21 ||   2201.5 |  2280.2 |   +4%  ||    21.90 |    21.18 |   -3%  |  0.3675 |
 | TPC-H 22 ||    583.8 |   578.2 |   -1%  ||    83.94 |    84.37 |   +1%  |  0.6852 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  18531.1 | 18586.0 |   +0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -6%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_88b690fc4f1881f9a0dfea42caf2946881517848_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                          | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-10-07 09:12:31                                                                                                                     | 2020-10-07 16:09:26                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     29.3 |    28.8 |   -2%  ||    34.09 |    34.68 |   +2%  |  0.0000 |
 | 03      ||      7.2 |     7.0 |   -3%  ||   138.26 |   141.91 |   +3%  |  0.0000 |
+| 06      ||     21.7 |    20.8 |   -4%  ||    46.05 |    48.14 |   +5%  |  0.0000 |
+| 07      ||     35.8 |    32.0 |  -11%  ||    27.93 |    31.26 |  +12%  |  0.0000 |
+| 09      ||    113.3 |   106.4 |   -6%  ||     8.83 |     9.40 |   +6%  |  0.0000 |
+| 10      ||     21.1 |    20.0 |   -5%  ||    47.45 |    50.12 |   +6%  |  0.0000 |
+| 13      ||    128.4 |   115.0 |  -10%  ||     7.79 |     8.69 |  +12%  |  0.0000 |
 | 15      ||     10.3 |    10.2 |   -1%  ||    97.20 |    97.88 |   +1%  |  0.0000 |
 | 17      ||     29.6 |    28.6 |   -3%  ||    33.81 |    35.01 |   +4%  |  0.0000 |
+| 19      ||     10.7 |    10.2 |   -5%  ||    93.39 |    98.28 |   +5%  |  0.0000 |
 | 25      ||     15.9 |    15.4 |   -3%  ||    62.95 |    64.99 |   +3%  |  0.0000 |
 | 26      ||     16.3 |    15.8 |   -3%  ||    61.43 |    63.31 |   +3%  |  0.0000 |
+| 28      ||   1043.5 |   903.7 |  -13%  ||     0.96 |     1.11 |  +15%  |  0.0000 |
+| 29      ||     27.4 |    26.0 |   -5%  ||    36.53 |    38.39 |   +5%  |  0.0000 |
 | 31      ||    136.5 |   133.2 |   -2%  ||     7.32 |     7.51 |   +2%  |  0.0000 |
+| 34      ||     31.2 |    29.8 |   -5%  ||    32.03 |    33.57 |   +5%  |  0.0000 |
 | 35      ||     91.4 |    89.4 |   -2%  ||    10.94 |    11.19 |   +2%  |  0.0000 |
 | 39a     ||    182.9 |   176.7 |   -3%  ||     5.47 |     5.66 |   +3%  |  0.0000 |
 | 39b     ||    180.1 |   175.1 |   -3%  ||     5.55 |     5.71 |   +3%  |  0.0000 |
 | 41      ||     26.3 |    25.6 |   -3%  ||    37.99 |    39.08 |   +3%  |  0.0000 |
 | 42      ||      8.4 |     8.1 |   -4%  ||   118.90 |   124.13 |   +4%  |  0.0000 |
 | 43      ||    249.0 |   248.8 |   -0%  ||     4.02 |     4.02 |   +0%  |  0.2932 |
 | 45      ||     10.1 |     9.8 |   -3%  ||    99.39 |   101.97 |   +3%  |  0.0000 |
+| 48      ||     85.3 |    78.1 |   -9%  ||    11.72 |    12.81 |   +9%  |  0.0000 |
 | 50      ||     11.7 |    11.4 |   -3%  ||    85.53 |    87.74 |   +3%  |  0.0000 |
 | 52      ||      8.5 |     8.2 |   -4%  ||   117.04 |   121.85 |   +4%  |  0.0000 |
 | 55      ||      8.3 |     8.0 |   -4%  ||   120.04 |   124.95 |   +4%  |  0.0000 |
 | 62      ||     74.6 |    74.4 |   -0%  ||    13.40 |    13.44 |   +0%  |  0.0000 |
 | 65      ||     64.0 |    62.3 |   -3%  ||    15.63 |    16.05 |   +3%  |  0.0000 |
 | 69      ||     24.0 |    23.1 |   -3%  ||    41.73 |    43.23 |   +4%  |  0.0000 |
 | 73      ||     19.8 |    19.2 |   -3%  ||    50.50 |    52.00 |   +3%  |  0.0000 |
 | 79      ||     46.0 |    45.1 |   -2%  ||    21.75 |    22.16 |   +2%  |  0.0000 |
 | 81      ||     19.3 |    19.1 |   -1%  ||    51.69 |    52.37 |   +1%  |  0.0000 |
 | 83      ||      9.6 |     9.4 |   -1%  ||   104.41 |   105.81 |   +1%  |  0.0000 |
+| 85      ||     58.3 |    52.7 |  -10%  ||    17.14 |    18.98 |  +11%  |  0.0000 |
 | 88      ||    104.5 |   101.2 |   -3%  ||     9.57 |     9.89 |   +3%  |  0.0000 |
+| 91      ||     20.9 |    18.7 |  -10%  ||    47.95 |    53.43 |  +11%  |  0.0000 |
 | 93      ||    261.4 |   262.4 |   +0%  ||     3.82 |     3.81 |   -0%  |  0.0122 |
 | 96      ||      9.3 |     9.1 |   -3%  ||   107.26 |   110.31 |   +3%  |  0.0000 |
 | 97      ||    430.4 |   427.1 |   -1%  ||     2.32 |     2.34 |   +1%  |  0.2567 |
 | 99      ||    148.7 |   149.0 |   +0%  ||     6.72 |     6.71 |   -0%  |  0.0002 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||   3831.1 |  3615.0 |   -6%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +4%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_88b690fc4f1881f9a0dfea42caf2946881517848_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                          | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-10-07 09:53:39                                                                                                                     | 2020-10-07 16:50:33                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    172.7 |   171.4 |   -1%  ||   281.05 |   283.16 |   +1%  |  0.2403 |
 | 03      ||     31.1 |    29.8 |   -4%  ||  1428.02 |  1483.42 |   +4%  |  0.0000 |
 | 06      ||    117.6 |   114.4 |   -3%  ||   407.89 |   418.71 |   +3%  |  0.0007 |
 | 07      ||    152.8 |   150.7 |   -1%  ||   316.56 |   320.91 |   +1%  |  0.1317 |
 | 09      ||    531.0 |   556.6 |   +5%  ||    91.62 |    87.92 |   -4%  |  0.1331 |
+| 10      ||     78.3 |    74.6 |   -5%  ||   605.04 |   633.60 |   +5%  |  0.0000 |
+| 13      ||    407.3 |   365.6 |  -10%  ||   120.65 |   134.37 |  +11%  |  0.0000 |
 | 15      ||     60.0 |    59.2 |   -1%  ||   772.87 |   782.59 |   +1%  |  0.0085 |
 | 17      ||    120.3 |   116.2 |   -3%  ||   399.16 |   413.24 |   +4%  |  0.0000 |
 | 19      ||     50.5 |    51.4 |   +2%  ||   908.91 |   895.14 |   -2%  |  0.0000 |
 | 25      ||     72.1 |    70.8 |   -2%  ||   654.82 |   665.99 |   +2%  |  0.0030 |
 | 26      ||     88.0 |    87.0 |   -1%  ||   539.56 |   545.03 |   +1%  |  0.0612 |
+| 28      ||   2932.2 |  2634.9 |  -10%  ||    16.15 |    17.83 |  +10%  |  0.0165 |
 | 29      ||    115.2 |   112.6 |   -2%  ||   415.67 |   425.31 |   +2%  |  0.0034 |
 | 31      ||    680.2 |   667.1 |   -2%  ||    72.26 |    72.90 |   +1%  |  0.4724 |
 | 34      ||    133.7 |   133.6 |   -0%  ||   359.77 |   360.36 |   +0%  |  0.8707 |
 | 35      ||    681.4 |   675.0 |   -1%  ||    72.43 |    72.13 |   -0%  |  0.5775 |
 | 39a     ||   1388.9 |  1395.7 |   +0%  ||    35.06 |    34.91 |   -0%  |  0.8545 |
 | 39b     ||   1367.8 |  1390.8 |   +2%  ||    35.23 |    35.03 |   -1%  |  0.5126 |
+| 41      ||   1320.1 |  1356.8 |   +3%  ||    31.61 |    33.11 |   +5%  |  0.7070 |
 | 42      ||     42.1 |    41.9 |   -1%  ||  1071.48 |  1080.34 |   +1%  |  0.0863 |
 | 43      ||    737.4 |   734.6 |   -0%  ||    66.63 |    66.97 |   +1%  |  0.7889 |
+| 45      ||     45.3 |    43.1 |   -5%  ||   999.60 |  1045.87 |   +5%  |  0.0000 |
 | 48      ||    314.5 |   307.3 |   -2%  ||   155.37 |   159.02 |   +2%  |  0.1248 |
+| 50      ||    153.2 |   133.8 |  -13%  ||   314.81 |   359.61 |  +14%  |  0.0000 |
 | 52      ||     43.6 |    42.9 |   -1%  ||  1039.52 |  1054.19 |   +1%  |  0.0000 |
 | 55      ||     38.6 |    39.4 |   +2%  ||  1160.45 |  1139.97 |   -2%  |  0.0000 |
 | 62      ||    251.1 |   251.6 |   +0%  ||   194.79 |   194.26 |   -0%  |  0.7991 |
 | 65      ||    452.5 |   451.4 |   -0%  ||   108.94 |   109.07 |   +0%  |  0.8143 |
 | 69      ||    113.1 |   108.7 |   -4%  ||   422.64 |   439.19 |   +4%  |  0.0000 |
 | 73      ||     96.5 |    95.1 |   -1%  ||   492.82 |   499.77 |   +1%  |  0.0268 |
 | 79      ||    177.8 |   175.8 |   -1%  ||   273.16 |   276.01 |   +1%  |  0.1475 |
 | 81      ||    123.0 |   120.8 |   -2%  ||   390.41 |   396.99 |   +2%  |  0.0080 |
 | 83      ||     65.4 |    64.8 |   -1%  ||   712.69 |   719.10 |   +1%  |  0.1549 |
+| 85      ||    202.9 |   191.2 |   -6%  ||   240.31 |   254.61 |   +6%  |  0.0000 |
 | 88      ||    421.2 |   412.1 |   -2%  ||   116.30 |   118.83 |   +2%  |  0.4063 |
+| 91      ||     82.8 |    74.0 |  -11%  ||   572.10 |   637.23 |  +11%  |  0.0000 |
 | 93      ||   1130.7 |  1138.2 |   +1%  ||    42.98 |    42.92 |   -0%  |  0.8169 |
 | 96      ||     41.8 |    40.8 |   -2%  ||  1087.02 |  1111.16 |   +2%  |  0.0000 |
 | 97      ||   3074.7 |  3053.7 |   -1%  ||    15.65 |    15.68 |   +0%  |  0.8016 |
 | 99      ||    639.7 |   641.6 |   +0%  ||    77.06 |    76.95 |   -0%  |  0.8250 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  18749.1 | 18377.2 |   -2%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +2%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_88b690fc4f1881f9a0dfea42caf2946881517848_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                         | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-10-07 10:34:57                                                                                                                    | 2020-10-07 17:31:52                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     29.1 |    28.3 |   -3%  ||     3.23 |     3.37 |   +4%  | (run time too short) |
 | New-Order    ||     19.0 |    18.3 |   -4%  ||    36.31 |    37.70 |   +4%  | (run time too short) |
 | Order-Status ||      1.2 |     1.2 |   -1%  ||     3.21 |     3.33 |   +4%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   -2%  ||    34.70 |    36.13 |   +4%  | (run time too short) |
 | Stock-Level  ||     37.5 |    35.2 |   -6%  ||     3.25 |     3.37 |   +4%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     89.4 |    85.6 |   -4%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +4%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_88b690fc4f1881f9a0dfea42caf2946881517848_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                         | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-07 10:36:02                                                                                                                    | 2020-10-07 17:32:57                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    207.1 |   204.5 |   -1%  ||     4.62 |     4.71 |   +2%  | (run time too short) |
 |    unsucc.:  ||      4.0 |     3.8 |   -5%  ||   106.37 |   107.65 |   +1%  |                      |
 | New-Order    ||     89.1 |    88.7 |   -0%  ||    94.15 |    93.38 |   -1%  |               0.6152 |
 |    unsucc.:  ||      5.0 |     5.0 |   -0%  ||  1154.23 |  1170.69 |   +1%  |                      |
 | Order-Status ||      7.1 |     7.1 |   -0%  ||   110.97 |   112.39 |   +1%  | (run time too short) |
+| Payment      ||     13.2 |    14.3 |   +9%  ||     8.54 |     9.08 |   +6%  | (run time too short) |
 |    unsucc.:  ||      4.2 |     4.2 |   +0%  ||  1184.48 |  1199.01 |   +1%  |                      |
 | Stock-Level  ||     67.7 |    64.7 |   -4%  ||   110.87 |   112.27 |   +1%  |               0.0000 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    384.2 |   379.4 |   -1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_88b690fc4f1881f9a0dfea42caf2946881517848_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                              | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-10-07 10:37:07                                                                                                                         | 2020-10-07 17:34:02                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    354.6 |    353.5 |   -0%  ||     2.82 |     2.83 |   +0%  |  0.2558 |
 | 10b     ||    351.5 |    348.6 |   -1%  ||     2.84 |     2.87 |   +1%  |  0.0001 |
 | 10c     ||   1149.3 |   1155.2 |   +1%  ||     0.87 |     0.87 |   -1%  |  0.1978 |
 | 11a     ||    152.4 |    150.6 |   -1%  ||     6.56 |     6.64 |   +1%  |  0.2350 |
 | 11b     ||    142.9 |    141.0 |   -1%  ||     7.00 |     7.09 |   +1%  |  0.1828 |
 | 11c     ||    522.8 |    517.3 |   -1%  ||     1.91 |     1.93 |   +1%  |  0.2942 |
 | 11d     ||   4706.8 |   4673.7 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.6990 |
 | 12a     ||    362.8 |    365.2 |   +1%  ||     2.76 |     2.74 |   -1%  |  0.4792 |
 | 12b     ||    633.3 |    622.5 |   -2%  ||     1.58 |     1.61 |   +2%  |  0.0696 |
 | 12c     ||   3695.8 |   3693.7 |   -0%  ||     0.27 |     0.27 |   +0%  |  0.9526 |
 | 13a     ||    179.1 |    178.8 |   -0%  ||     5.58 |     5.59 |   +0%  |  0.2066 |
+| 13b     ||    264.7 |    252.9 |   -4%  ||     3.78 |     3.95 |   +5%  |  0.0000 |
 | 13c     ||    142.5 |    142.5 |   -0%  ||     7.02 |     7.02 |   +0%  |  0.6493 |
 | 13d     ||    179.1 |    178.2 |   -0%  ||     5.58 |     5.61 |   +0%  |  0.0000 |
 | 14a     ||   4055.8 |   4065.7 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.7912 |
 | 14b     ||   4685.8 |   4673.8 |   -0%  ||     0.21 |     0.21 |   +0%  |  0.7809 |
 | 14c     ||   4055.9 |   4063.2 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.8435 |
 | 15a     ||    212.7 |    221.0 |   +4%  ||     4.70 |     4.53 |   -4%  |  0.0000 |
 | 15b     ||    207.7 |    212.9 |   +2%  ||     4.81 |     4.70 |   -2%  |  0.0000 |
 | 15c     ||    149.6 |    154.0 |   +3%  ||     6.69 |     6.49 |   -3%  |  0.0000 |
 | 15d     ||    457.2 |    462.0 |   +1%  ||     2.19 |     2.16 |   -1%  |  0.0162 |
 | 16a     ||   4645.0 |   4638.1 |   -0%  ||     0.22 |     0.22 |   +0%  |  0.9398 |
 | 16b     ||   6132.5 |   6158.4 |   +0%  ||     0.16 |     0.16 |   -0%  |  0.7091 |
 | 16c     ||   4813.2 |   4814.0 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.9909 |
 | 16d     ||   4819.2 |   4770.3 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.5625 |
 | 17a     ||    962.3 |    963.0 |   +0%  ||     1.04 |     1.04 |   -0%  |  0.8941 |
 | 17b     ||    763.0 |    764.7 |   +0%  ||     1.31 |     1.31 |   -0%  |  0.6844 |
 | 17c     ||    721.9 |    721.5 |   -0%  ||     1.39 |     1.39 |   +0%  |  0.9089 |
 | 17d     ||    831.1 |    830.9 |   -0%  ||     1.20 |     1.20 |   +0%  |  0.9754 |
 | 17e     ||   2905.0 |   2898.2 |   -0%  ||     0.34 |     0.35 |   +0%  |  0.7448 |
 | 17f     ||   1531.0 |   1533.3 |   +0%  ||     0.65 |     0.65 |   -0%  |  0.8197 |
 | 18a     ||    678.1 |    677.1 |   -0%  ||     1.47 |     1.48 |   +0%  |  0.7542 |
 | 18b     ||    229.4 |    228.3 |   -0%  ||     4.36 |     4.38 |   +0%  |  0.3916 |
 | 18c     ||   3747.6 |   3748.1 |   +0%  ||     0.27 |     0.27 |   -0%  |  0.9831 |
 | 19a     ||   7600.8 |   7630.6 |   +0%  ||     0.13 |     0.13 |   -0%  |       ˅ |
 | 19b     ||   4521.7 |   4533.8 |   +0%  ||     0.22 |     0.22 |   -0%  |  0.4497 |
 | 19c     ||   7373.0 |   7390.8 |   +0%  ||     0.14 |     0.14 |   -0%  |       ˅ |
 | 19d     ||   5656.3 |   5638.7 |   -0%  ||     0.18 |     0.18 |   +0%  |  0.7271 |
 | 1a      ||     58.7 |     57.9 |   -1%  ||    17.03 |    17.27 |   +1%  |  0.0000 |
 | 1b      ||     22.1 |     21.9 |   -1%  ||    45.33 |    45.57 |   +1%  |  0.0000 |
 | 1c      ||     22.1 |     21.9 |   -1%  ||    45.34 |    45.64 |   +1%  |  0.0000 |
 | 1d      ||     21.9 |     21.7 |   -1%  ||    45.75 |    46.03 |   +1%  |  0.0000 |
 | 20a     ||   1268.6 |   1265.8 |   -0%  ||     0.79 |     0.79 |   +0%  |  0.4056 |
 | 20b     ||   1087.0 |   1082.9 |   -0%  ||     0.92 |     0.92 |   +0%  |  0.0343 |
 | 20c     ||   1120.2 |   1098.5 |   -2%  ||     0.89 |     0.91 |   +2%  |  0.0000 |
 | 21a     ||   3829.6 |   3819.5 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.3958 |
 | 21b     ||    262.1 |    257.1 |   -2%  ||     3.82 |     3.89 |   +2%  |  0.0000 |
 | 21c     ||   3960.5 |   3946.2 |   -0%  ||     0.25 |     0.25 |   +0%  |  0.2426 |
 | 22a     ||   3476.3 |   3459.3 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.5742 |
 | 22b     ||   3475.1 |   3457.4 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.5584 |
 | 22c     ||   4091.8 |   4084.2 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.8077 |
 | 22d     ||   4113.1 |   4105.3 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.7969 |
 | 23a     ||    153.1 |    156.4 |   +2%  ||     6.53 |     6.39 |   -2%  |  0.0000 |
 | 23b     ||    121.1 |    120.4 |   -1%  ||     8.26 |     8.30 |   +1%  |  0.1330 |
 | 23c     ||    172.4 |    176.1 |   +2%  ||     5.80 |     5.68 |   -2%  |  0.0000 |
 | 24a     ||   4601.2 |   4624.8 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.4182 |
 | 24b     ||   4586.8 |   4524.1 |   -1%  ||     0.22 |     0.22 |   +1%  |  0.3487 |
 | 25a     ||    233.3 |    232.1 |   -1%  ||     4.29 |     4.31 |   +1%  |  0.2154 |
 | 25b     ||    247.2 |    247.3 |   +0%  ||     4.04 |     4.04 |   -0%  |  0.9559 |
 | 25c     ||   3766.2 |   3760.2 |   -0%  ||     0.27 |     0.27 |   +0%  |  0.7529 |
 | 26a     ||    993.4 |    970.2 |   -2%  ||     1.01 |     1.03 |   +2%  |  0.0000 |
 | 26b     ||    983.7 |    959.5 |   -2%  ||     1.02 |     1.04 |   +3%  |  0.0003 |
 | 26c     ||    996.0 |    971.3 |   -2%  ||     1.00 |     1.03 |   +3%  |  0.0000 |
 | 27a     ||   3481.3 |   3461.8 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2891 |
 | 27b     ||   3447.9 |   3433.1 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.4245 |
 | 27c     ||    202.8 |    199.9 |   -1%  ||     4.93 |     5.00 |   +1%  |  0.0611 |
 | 28a     ||   4130.7 |   4124.6 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.9491 |
 | 28b     ||   3380.1 |   3362.7 |   -1%  ||     0.30 |     0.30 |   +1%  |  0.8559 |
 | 28c     ||   4132.9 |   4124.6 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.9296 |
 | 29a     ||   4497.2 |   4495.6 |   -0%  ||     0.22 |     0.22 |   +0%  |  0.9914 |
 | 29b     ||    201.2 |    200.3 |   -0%  ||     4.97 |     4.99 |   +0%  |  0.9279 |
 | 29c     ||   4576.7 |   4576.8 |   +0%  ||     0.22 |     0.22 |   -0%  |  0.9996 |
 | 2a      ||    109.7 |    109.4 |   -0%  ||     9.11 |     9.14 |   +0%  |  0.0000 |
 | 2b      ||     86.4 |     85.8 |   -1%  ||    11.57 |    11.66 |   +1%  |  0.0000 |
 | 2c      ||     57.2 |     56.3 |   -2%  ||    17.48 |    17.77 |   +2%  |  0.0000 |
 | 2d      ||    136.0 |    134.6 |   -1%  ||     7.35 |     7.43 |   +1%  |  0.0000 |
 | 30a     ||    248.9 |    247.5 |   -1%  ||     4.02 |     4.04 |   +1%  |  0.7593 |
 | 30b     ||   1098.8 |   1099.3 |   +0%  ||     0.91 |     0.91 |   -0%  |  0.9829 |
 | 30c     ||   3797.6 |   3784.1 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.8677 |
 | 31a     ||    285.6 |    285.3 |   -0%  ||     3.50 |     3.51 |   +0%  |  0.8953 |
 | 31b     ||   1126.2 |   1128.1 |   +0%  ||     0.89 |     0.89 |   -0%  |  0.8774 |
 | 31c     ||    289.3 |    288.6 |   -0%  ||     3.46 |     3.47 |   +0%  |  0.8192 |
 | 32a     ||     37.0 |     36.6 |   -1%  ||    27.05 |    27.33 |   +1%  |  0.0000 |
 | 32b     ||    286.9 |    285.0 |   -1%  ||     3.49 |     3.51 |   +1%  |  0.0000 |
 | 33a     ||     69.7 |     69.4 |   -0%  ||    14.35 |    14.42 |   +0%  |  0.4732 |
 | 33b     ||     68.8 |     68.3 |   -1%  ||    14.54 |    14.64 |   +1%  |  0.3130 |
 | 33c     ||     85.0 |     84.4 |   -1%  ||    11.76 |    11.85 |   +1%  |  0.2800 |
 | 3a      ||   3944.5 |   3938.0 |   -0%  ||     0.25 |     0.25 |   +0%  |  0.0008 |
 | 3b      ||     36.4 |     35.8 |   -2%  ||    27.49 |    27.94 |   +2%  |  0.0000 |
 | 3c      ||   5054.7 |   5069.4 |   +0%  ||     0.20 |     0.20 |   -0%  |  0.1582 |
 | 4a      ||    127.5 |    129.2 |   +1%  ||     7.84 |     7.74 |   -1%  |  0.0000 |
 | 4b      ||     26.8 |     26.6 |   -1%  ||    37.32 |    37.53 |   +1%  |  0.0000 |
 | 4c      ||    143.9 |    144.1 |   +0%  ||     6.95 |     6.94 |   -0%  |  0.2323 |
 | 5a      ||   3766.5 |   3757.8 |   -0%  ||     0.27 |     0.27 |   +0%  |  0.0001 |
 | 5b      ||    280.0 |    272.6 |   -3%  ||     3.57 |     3.67 |   +3%  |  0.0000 |
 | 5c      ||   4396.3 |   4390.1 |   -0%  ||     0.23 |     0.23 |   +0%  |  0.0660 |
 | 6a      ||    225.0 |    224.2 |   -0%  ||     4.44 |     4.46 |   +0%  |  0.0000 |
 | 6b      ||    953.3 |    947.9 |   -1%  ||     1.05 |     1.05 |   +1%  |  0.0164 |
 | 6c      ||    225.3 |    223.9 |   -1%  ||     4.44 |     4.47 |   +1%  |  0.0000 |
 | 6d      ||    952.6 |    948.3 |   -0%  ||     1.05 |     1.05 |   +0%  |  0.0000 |
 | 6e      ||    225.0 |    224.1 |   -0%  ||     4.44 |     4.46 |   +0%  |  0.0000 |
 | 6f      ||   1496.4 |   1483.3 |   -1%  ||     0.67 |     0.67 |   +1%  |  0.0000 |
+| 7a      ||    278.4 |    260.9 |   -6%  ||     3.59 |     3.83 |   +7%  |  0.0000 |
 | 7b      ||    136.5 |    135.6 |   -1%  ||     7.33 |     7.38 |   +1%  |  0.5397 |
 | 7c      ||  10937.1 |  10837.0 |   -1%  ||     0.09 |     0.09 |   +1%  |       ˅ |
+| 8a      ||    116.6 |    110.4 |   -5%  ||     8.57 |     9.06 |   +6%  |  0.0000 |
 | 8b      ||    168.8 |    162.1 |   -4%  ||     5.92 |     6.17 |   +4%  |  0.0000 |
 | 8c      ||   4371.3 |   4355.1 |   -0%  ||     0.23 |     0.23 |   +0%  |  0.5714 |
 | 8d      ||   1544.3 |   1548.2 |   +0%  ||     0.65 |     0.65 |   -0%  |  0.2840 |
 | 9a      ||   3458.4 |   3437.9 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2687 |
 | 9b      ||    333.0 |    323.4 |   -3%  ||     3.00 |     3.09 |   +3%  |  0.0000 |
 | 9c      ||   3475.7 |   3472.9 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.8747 |
 | 9d      ||   4067.4 |   4062.0 |   -0%  ||     0.25 |     0.25 |   +0%  |  0.8159 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 214832.5 | 214271.3 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_88b690fc4f1881f9a0dfea42caf2946881517848_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 88b690fc4f1881f9a0dfea42caf2946881517848-dirty                                                                                              | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-10-07 12:33:13                                                                                                                         | 2020-10-07 19:29:56                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||   2664.8 |   2694.7 |   +1%  ||    17.70 |    17.86 |   +1%  |  0.8168 |
+| 10b     ||   2114.7 |   2034.2 |   -4%  ||    22.00 |    23.55 |   +7%  |  0.3233 |
 | 10c     ||   7746.5 |   8896.9 |  +15%  ||     4.78 |     4.87 |   +2%  |  0.0397 |
 | 11a     ||    432.3 |    422.6 |   -2%  ||   113.25 |   116.12 |   +3%  |  0.2569 |
 | 11b     ||    401.0 |    391.6 |   -2%  ||   122.19 |   124.66 |   +2%  |  0.2772 |
 | 11c     ||   2229.6 |   2152.9 |   -3%  ||    21.76 |    22.13 |   +2%  |  0.3364 |
+| 11d     ||  22107.4 |  20292.7 |   -8%  ||     1.67 |     1.82 |   +9%  |  0.1382 |
 | 12a     ||   3441.5 |   3387.2 |   -2%  ||    13.42 |    13.75 |   +2%  |  0.7698 |
 | 12b     ||   1356.1 |   1345.5 |   -1%  ||    35.93 |    35.93 |   -0%  |  0.8183 |
+| 12c     ||  15098.6 |  18662.4 |  +24%  ||     2.07 |     2.20 |   +6%  |  0.0066 |
 | 13a     ||   1073.2 |   1052.2 |   -2%  ||    45.78 |    46.15 |   +1%  |  0.5241 |
 | 13b     ||   1204.0 |   1201.3 |   -0%  ||    40.08 |    40.55 |   +1%  |  0.9491 |
 | 13c     ||   1214.3 |   1205.1 |   -1%  ||    40.07 |    40.42 |   +1%  |  0.8249 |
 | 13d     ||   1062.8 |   1048.6 |   -1%  ||    45.45 |    46.35 |   +2%  |  0.7103 |
 | 14a     ||  15545.5 |  15381.3 |   -1%  ||     2.42 |     2.45 |   +1%  |  0.8761 |
 | 14b     ||  15169.2 |  14258.4 |   -6%  ||     2.30 |     2.32 |   +1%  |  0.3959 |
 | 14c     ||  15380.5 |  14087.0 |   -8%  ||     2.45 |     2.42 |   -1%  |  0.2735 |
 | 15a     ||    982.5 |    979.8 |   -0%  ||    49.59 |    49.73 |   +0%  |  0.9235 |
 | 15b     ||    974.3 |    964.7 |   -1%  ||    50.26 |    50.71 |   +1%  |  0.7294 |
 | 15c     ||    412.6 |    415.9 |   +1%  ||   118.48 |   118.01 |   -0%  |  0.6737 |
 | 15d     ||   2154.8 |   2162.2 |   +0%  ||    22.06 |    22.35 |   +1%  |  0.9205 |
-| 16a     ||  26098.2 |  24476.2 |   -6%  ||     1.32 |     1.25 |   -5%  |  0.3876 |
 | 16b     ||  32991.2 |  30509.1 |   -8%  ||     0.93 |     0.95 |   +2%  |  0.2538 |
+| 16c     ||  27540.8 |  26429.3 |   -4%  ||     1.13 |     1.25 |  +10%  |  0.5846 |
+| 16d     ||  26356.8 |  24480.0 |   -7%  ||     1.15 |     1.25 |   +9%  |  0.3410 |
 | 17a     ||   8256.4 |   8024.4 |   -3%  ||     4.88 |     4.97 |   +2%  |  0.7009 |
 | 17b     ||   8390.4 |   8574.1 |   +2%  ||     5.10 |     4.97 |   -3%  |  0.7877 |
 | 17c     ||   8971.8 |   7505.2 |  -16%  ||     4.90 |     4.80 |   -2%  |  0.0171 |
 | 17d     ||   7959.5 |   8458.9 |   +6%  ||     5.08 |     5.17 |   +2%  |  0.4234 |
 | 17e     ||   8987.1 |  10535.6 |  +17%  ||     3.70 |     3.78 |   +2%  |  0.0077 |
-| 17f     ||   9651.3 |   9792.9 |   +1%  ||     4.50 |     4.23 |   -6%  |  0.8499 |
 | 18a     ||   3998.1 |   3970.5 |   -1%  ||    11.42 |    11.65 |   +2%  |  0.9133 |
+| 18b     ||   2995.2 |   2813.1 |   -6%  ||    16.08 |    16.81 |   +5%  |  0.2457 |
 | 18c     ||  15363.2 |  15029.0 |   -2%  ||     2.38 |     2.47 |   +4%  |  0.7893 |
+| 19a     ||  26956.7 |  26503.1 |   -2%  ||     0.98 |     1.07 |   +8%  |  0.8596 |
 | 19b     ||  11320.8 |  11322.6 |   +0%  ||     3.52 |     3.53 |   +0%  |  0.9984 |
 | 19c     ||  28439.5 |  29085.2 |   +2%  ||     1.12 |     1.08 |   -3%  |  0.8038 |
+| 19d     ||  30188.5 |  31418.0 |   +4%  ||     0.97 |     1.02 |   +5%  |  0.5486 |
 | 1a      ||    288.5 |    279.0 |   -3%  ||   169.37 |   175.67 |   +4%  |  0.0189 |
 | 1b      ||     75.7 |     73.2 |   -3%  ||   618.63 |   637.97 |   +3%  |  0.0000 |
 | 1c      ||     77.2 |     73.9 |   -4%  ||   609.37 |   634.46 |   +4%  |  0.0000 |
 | 1d      ||     75.0 |     73.5 |   -2%  ||   624.58 |   636.75 |   +2%  |  0.0106 |
 | 20a     ||   5159.4 |   4980.9 |   -3%  ||     8.17 |     8.30 |   +2%  |  0.5899 |
 | 20b     ||   4237.6 |   4163.7 |   -2%  ||    11.05 |    10.98 |   -1%  |  0.7770 |
 | 20c     ||   3968.9 |   4121.0 |   +4%  ||    11.57 |    11.53 |   -0%  |  0.5403 |
 | 21a     ||  11724.1 |  14259.0 |  +22%  ||     2.70 |     2.73 |   +1%  |  0.0193 |
 | 21b     ||    910.7 |    887.0 |   -3%  ||    53.76 |    55.11 |   +3%  |  0.3550 |
 | 21c     ||  14183.9 |  12481.5 |  -12%  ||     2.60 |     2.62 |   +1%  |  0.0936 |
 | 22a     ||  15783.8 |  14397.1 |   -9%  ||     2.52 |     2.57 |   +2%  |  0.1748 |
 | 22b     ||  13699.5 |  15082.7 |  +10%  ||     2.57 |     2.60 |   +1%  |  0.2115 |
 | 22c     ||  16168.8 |  14249.9 |  -12%  ||     2.45 |     2.42 |   -1%  |  0.0935 |
 | 22d     ||  14749.6 |  14249.4 |   -3%  ||     2.38 |     2.42 |   +1%  |  0.6675 |
 | 23a     ||    435.6 |    437.7 |   +0%  ||   112.78 |   112.31 |   -0%  |  0.8234 |
+| 23b     ||   1155.0 |    977.5 |  -15%  ||    41.71 |    50.10 |  +20%  |  0.0000 |
 | 23c     ||    500.7 |    497.9 |   -1%  ||    97.90 |    98.00 |   +0%  |  0.7932 |
 | 24a     ||  11477.7 |  10793.9 |   -6%  ||     3.57 |     3.52 |   -1%  |  0.3702 |
 | 24b     ||  10644.2 |  11064.3 |   +4%  ||     3.57 |     3.63 |   +2%  |  0.6325 |
+| 25a     ||   2860.4 |   2433.3 |  -15%  ||    16.68 |    19.73 |  +18%  |  0.0003 |
+| 25b     ||   3398.3 |   2856.9 |  -16%  ||    13.70 |    15.88 |  +16%  |  0.0191 |
 | 25c     ||  13803.8 |  16781.0 |  +22%  ||     2.35 |     2.38 |   +1%  |  0.0163 |
 | 26a     ||   2744.1 |   2814.1 |   +3%  ||    17.20 |    16.93 |   -2%  |  0.5744 |
 | 26b     ||   2713.3 |   2785.3 |   +3%  ||    17.30 |    16.92 |   -2%  |  0.5516 |
 | 26c     ||   2715.3 |   2800.6 |   +3%  ||    16.88 |    16.62 |   -2%  |  0.5880 |
 | 27a     ||  13133.5 |  15051.4 |  +15%  ||     2.70 |     2.70 |   -0%  |  0.0677 |
 | 27b     ||  13731.7 |  13493.7 |   -2%  ||     2.73 |     2.73 |   -0%  |  0.8230 |
 | 27c     ||    956.5 |    933.5 |   -2%  ||    50.98 |    51.90 |   +2%  |  0.4592 |
 | 28a     ||  17188.8 |  14934.9 |  -13%  ||     2.35 |     2.37 |   +1%  |  0.0605 |
 | 28b     ||  12307.7 |  13922.2 |  +13%  ||     2.67 |     2.67 |   +0%  |  0.1014 |
 | 28c     ||  16966.9 |  12960.6 |  -24%  ||     2.32 |     2.38 |   +3%  |  0.0007 |
 | 29a     ||  11469.1 |  10344.3 |  -10%  ||     3.60 |     3.65 |   +1%  |  0.1575 |
+| 29b     ||   3025.1 |   2585.8 |  -15%  ||    15.08 |    18.43 |  +22%  |  0.0066 |
 | 29c     ||  10850.9 |  10796.0 |   -1%  ||     3.30 |     3.40 |   +3%  |  0.9548 |
 | 2a      ||    586.6 |    570.5 |   -3%  ||    83.78 |    85.41 |   +2%  |  0.2271 |
 | 2b      ||    703.9 |    679.3 |   -3%  ||    69.28 |    70.94 |   +2%  |  0.1595 |
+| 2c      ||    645.4 |    556.6 |  -14%  ||    76.09 |    88.26 |  +16%  |  0.0000 |
 | 2d      ||    653.2 |    640.5 |   -2%  ||    74.44 |    76.53 |   +3%  |  0.3803 |
+| 30a     ||   3105.2 |   2641.5 |  -15%  ||    15.42 |    18.22 |  +18%  |  0.0017 |
+| 30b     ||   3080.5 |   2888.2 |   -6%  ||    15.06 |    16.07 |   +7%  |  0.2629 |
 | 30c     ||  14996.7 |  14592.3 |   -3%  ||     2.35 |     2.40 |   +2%  |  0.7545 |
+| 31a     ||   3671.0 |   3245.5 |  -12%  ||    12.05 |    14.38 |  +19%  |  0.0383 |
+| 31b     ||   3498.1 |   3289.3 |   -6%  ||    12.97 |    13.82 |   +7%  |  0.2844 |
+| 31c     ||   3407.8 |   2805.0 |  -18%  ||    13.40 |    16.10 |  +20%  |  0.0026 |
+| 32a     ||    299.8 |    170.3 |  -43%  ||   162.89 |   284.24 |  +74%  |  0.0000 |
 | 32b     ||   1047.3 |   1031.7 |   -1%  ||    46.78 |    47.47 |   +1%  |  0.5277 |
 | 33a     ||    260.2 |    252.0 |   -3%  ||   187.83 |   193.94 |   +3%  |  0.0250 |
 | 33b     ||    256.3 |    249.1 |   -3%  ||   190.03 |   196.00 |   +3%  |  0.0599 |
 | 33c     ||    333.8 |    322.2 |   -3%  ||   146.98 |   152.07 |   +3%  |  0.0413 |
 | 3a      ||  13748.0 |  15686.7 |  +14%  ||     2.45 |     2.45 |   +0%  |  0.0955 |
+| 3b      ||    401.1 |    335.5 |  -16%  ||   122.35 |   146.32 |  +20%  |  0.0000 |
 | 3c      ||  27597.7 |  26848.8 |   -3%  ||     1.13 |     1.18 |   +4%  |  0.7536 |
 | 4a      ||    863.2 |    838.8 |   -3%  ||    56.86 |    57.46 |   +1%  |  0.2799 |
 | 4b      ||    111.3 |    106.5 |   -4%  ||   430.31 |   448.18 |   +4%  |  0.0000 |
 | 4c      ||   1058.7 |   1043.2 |   -1%  ||    46.31 |    46.93 |   +1%  |  0.6117 |
 | 5a      ||  13554.5 |  12615.7 |   -7%  ||     2.70 |     2.75 |   +2%  |  0.3207 |
 | 5b      ||   1234.3 |   1223.5 |   -1%  ||    39.14 |    39.78 |   +2%  |  0.7904 |
 | 5c      ||  17907.6 |  16118.5 |  -10%  ||     2.17 |     2.23 |   +3%  |  0.1580 |
+| 6a      ||   2512.2 |   2061.8 |  -18%  ||    18.55 |    23.30 |  +26%  |  0.0000 |
 | 6b      ||   7549.0 |   7634.2 |   +1%  ||     5.43 |     5.53 |   +2%  |  0.8762 |
+| 6c      ||   2457.4 |   1993.4 |  -19%  ||    18.96 |    24.08 |  +27%  |  0.0000 |
+| 6d      ||   7562.7 |   7539.6 |   -0%  ||     5.48 |     5.75 |   +5%  |  0.9658 |
+| 6e      ||   2646.4 |   2003.8 |  -24%  ||    18.18 |    23.50 |  +29%  |  0.0000 |
-| 6f      ||   6491.6 |   5334.7 |  -18%  ||     6.83 |     6.48 |   -5%  |  0.0003 |
 | 7a      ||   1496.1 |   1476.9 |   -1%  ||    32.33 |    33.00 |   +2%  |  0.7132 |
+| 7b      ||   1931.6 |   1647.3 |  -15%  ||    24.47 |    29.53 |  +21%  |  0.0001 |
-| 7c      ||  46763.3 |  40365.3 |  -14%  ||     0.22 |     0.17 |  -23%  |  0.0899 |
+| 8a      ||   1758.0 |   1519.2 |  -14%  ||    27.38 |    31.73 |  +16%  |  0.0001 |
+| 8b      ||   1663.0 |   1507.0 |   -9%  ||    28.80 |    32.08 |  +11%  |  0.0294 |
 | 8c      ||  22032.7 |  21539.3 |   -2%  ||     1.57 |     1.60 |   +2%  |  0.7770 |
 | 8d      ||   9610.5 |  10251.3 |   +7%  ||     4.05 |     4.15 |   +2%  |  0.3717 |
 | 9a      ||  18233.4 |  18463.2 |   +1%  ||     1.90 |     1.88 |   -1%  |  0.8901 |
 | 9b      ||   3151.2 |   3236.0 |   +3%  ||    14.73 |    14.58 |   -1%  |  0.6426 |
 | 9c      ||  20096.2 |  19368.5 |   -4%  ||     1.82 |     1.85 |   +2%  |  0.6550 |
+| 9d      ||  20349.3 |  19878.2 |   -2%  ||     1.77 |     1.90 |   +8%  |  0.7647 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 939740.1 | 915171.4 |   -3%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +4%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>