### PR TITLE
Validate: Add shortcut for entirely visible even without chunk guarantee

### DIFF
--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -199,9 +199,11 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& in_table, co
           // While this might introduce a small overhead in the case of many unreferenced chunks, it allows us to avoid
           // a branch in the hot loop.
           entirely_visible_chunks = std::vector<bool>(referenced_table->chunk_count(), false);
-          for (auto referenced_table_chunk_id = ChunkID{0}; referenced_table_chunk_id < referenced_table->chunk_count(); ++referenced_table_chunk_id) {
+          for (auto referenced_table_chunk_id = ChunkID{0}; referenced_table_chunk_id < referenced_table->chunk_count();
+               ++referenced_table_chunk_id) {
             const auto referenced_chunk = referenced_table->get_chunk(referenced_table_chunk_id);
-            entirely_visible_chunks[referenced_table_chunk_id] = _is_entire_chunk_visible(referenced_chunk, snapshot_commit_id);
+            entirely_visible_chunks[referenced_table_chunk_id] =
+                _is_entire_chunk_visible(referenced_chunk, snapshot_commit_id);
           }
         }
 


### PR DESCRIPTION
We already have a shortcut for data tables and single-chunk reference segments. For reference segments without the guarantee, we currently perform a validation of each row. By checking which chunks are entirely visible, we can skip this validation for some rows.

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 3  |
| numactl | membind: 3  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 71a783492 | 07.10.2020 08:44 | Sort: Add performance steps (#2234) | real 266.09 user 2382.89 sys 141.05|
| 5fe1cbcde | 07.10.2020 23:56 | Validate: Add shortcut for entirely visible chunks even without chunk guarantee | real 263.72 user 2350.52 sys 131.40|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_71a783492d4faf0a1c55b3626afe46a49d463b80_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_5fe1cbcde6283fc1fd51056dd526d07472d2e2c2_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 71a783492d4faf0a1c55b3626afe46a49d463b80                                                                                               | 5fe1cbcde6283fc1fd51056dd526d07472d2e2c2-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-08 00:01:05                                                                                                                    | 2020-10-08 01:14:57                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    789.8 |   815.0 |   +3%  ||     1.27 |     1.23 |   -3%  |  0.0000 |
 | TPC-H 02 ||      5.1 |     4.9 |   -3%  ||   196.77 |   202.04 |   +3%  |  0.0004 |
 | TPC-H 03 ||     80.7 |    78.4 |   -3%  ||    12.39 |    12.75 |   +3%  |  0.0000 |
 | TPC-H 04 ||     68.0 |    67.9 |   -0%  ||    14.69 |    14.72 |   +0%  |  0.0082 |
+| TPC-H 05 ||    221.9 |   210.1 |   -5%  ||     4.51 |     4.76 |   +6%  |  0.0000 |
 | TPC-H 06 ||      3.2 |     3.2 |   +0%  ||   311.50 |   311.48 |   -0%  |  0.9506 |
+| TPC-H 07 ||     59.0 |    56.4 |   -4%  ||    16.94 |    17.71 |   +5%  |  0.0000 |
+| TPC-H 08 ||     68.5 |    61.9 |  -10%  ||    14.61 |    16.16 |  +11%  |  0.0000 |
 | TPC-H 09 ||    492.0 |   483.7 |   -2%  ||     2.03 |     2.07 |   +2%  |  0.0000 |
 | TPC-H 10 ||    166.6 |   168.8 |   +1%  ||     6.00 |     5.92 |   -1%  |  0.0323 |
 | TPC-H 11 ||      9.1 |     9.1 |   +1%  ||   110.37 |   109.58 |   -1%  |  0.0000 |
 | TPC-H 12 ||     43.4 |    43.3 |   -0%  ||    23.03 |    23.11 |   +0%  |  0.0016 |
+| TPC-H 13 ||    431.6 |   361.5 |  -16%  ||     2.32 |     2.77 |  +19%  |  0.0000 |
 | TPC-H 14 ||     21.0 |    21.1 |   +1%  ||    47.59 |    47.29 |   -1%  |  0.0000 |
 | TPC-H 15 ||      7.9 |     7.9 |   -0%  ||   126.77 |   126.83 |   +0%  |  0.4919 |
 | TPC-H 16 ||     93.0 |    92.4 |   -1%  ||    10.75 |    10.83 |   +1%  |  0.0064 |
+| TPC-H 17 ||     18.1 |    16.8 |   -7%  ||    55.37 |    59.61 |   +8%  |  0.0000 |
-| TPC-H 18 ||    674.2 |   730.3 |   +8%  ||     1.48 |     1.37 |   -8%  |  0.0000 |
 | TPC-H 19 ||     29.5 |    29.1 |   -1%  ||    33.95 |    34.38 |   +1%  |  0.0000 |
 | TPC-H 20 ||     16.3 |    16.3 |   +0%  ||    61.34 |    61.19 |   -0%  |  0.3782 |
+| TPC-H 21 ||    421.1 |   380.3 |  -10%  ||     2.37 |     2.63 |  +11%  |  0.0000 |
 | TPC-H 22 ||     49.6 |    49.7 |   +0%  ||    20.18 |    20.12 |   -0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3769.7 |  3708.1 |   -2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_71a783492d4faf0a1c55b3626afe46a49d463b80_st_s01.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_5fe1cbcde6283fc1fd51056dd526d07472d2e2c2_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 71a783492d4faf0a1c55b3626afe46a49d463b80                                                                                                   | 5fe1cbcde6283fc1fd51056dd526d07472d2e2c2-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-08 00:23:46                                                                                                                        | 2020-10-08 01:37:15                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.2 |     7.2 |   +0%  ||   138.24 |   137.92 |   -0%  |  0.0000 |
 | TPC-H 02 ||      0.6 |     0.6 |   +1%  ||  1558.41 |  1538.15 |   -1%  |  0.0028 |
 | TPC-H 03 ||      0.9 |     0.9 |   +3%  ||  1141.32 |  1105.00 |   -3%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   +1%  ||  1863.94 |  1840.17 |   -1%  |  0.0000 |
 | TPC-H 05 ||      1.3 |     1.3 |   +1%  ||   771.62 |   763.04 |   -1%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   +3%  ||  9751.37 |  9447.76 |   -3%  |  0.0000 |
 | TPC-H 07 ||      1.3 |     1.4 |   +4%  ||   766.74 |   738.96 |   -4%  |  0.0014 |
 | TPC-H 08 ||     14.7 |    14.6 |   -1%  ||    67.99 |    68.55 |   +1%  |  0.2955 |
 | TPC-H 09 ||      2.4 |     2.4 |   +1%  ||   418.62 |   415.80 |   -1%  |  0.0103 |
 | TPC-H 10 ||      0.9 |     1.0 |   +1%  ||  1058.24 |  1046.43 |   -1%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   +2%  ||  2964.98 |  2900.22 |   -2%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.7 |   +1%  ||  1535.91 |  1516.67 |   -1%  |  0.0000 |
+| TPC-H 13 ||      2.3 |     2.2 |   -5%  ||   426.22 |   448.57 |   +5%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.4 |   +2%  ||  2707.59 |  2659.64 |   -2%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   +1%  ||   883.43 |   871.54 |   -1%  |  0.0000 |
 | TPC-H 16 ||      2.2 |     2.2 |   +1%  ||   459.90 |   457.49 |   -1%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   +1%  ||  3087.07 |  3055.56 |   -1%  |  0.0000 |
 | TPC-H 18 ||      2.7 |     2.7 |   +0%  ||   373.03 |   371.45 |   -0%  |  0.0000 |
 | TPC-H 19 ||      5.5 |     5.5 |   +1%  ||   183.32 |   182.31 |   -1%  |  0.0000 |
 | TPC-H 20 ||      2.4 |     2.4 |   +1%  ||   418.49 |   413.34 |   -1%  |  0.0000 |
 | TPC-H 21 ||      2.2 |     2.2 |   +1%  ||   459.50 |   454.96 |   -1%  |  0.0006 |
 | TPC-H 22 ||      1.3 |     1.3 |   +2%  ||   781.16 |   769.52 |   -1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     51.3 |    51.4 |   +0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_71a783492d4faf0a1c55b3626afe46a49d463b80_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_5fe1cbcde6283fc1fd51056dd526d07472d2e2c2_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 71a783492d4faf0a1c55b3626afe46a49d463b80                                                                                               | 5fe1cbcde6283fc1fd51056dd526d07472d2e2c2-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-08 00:45:53                                                                                                                    | 2020-10-08 01:59:19                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 0, 56]                                                                                                                          | [0, 0, 0, 56]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2184.8 |  2202.4 |   +1%  ||    22.28 |    22.08 |   -1%  |  0.6689 |
 | TPC-H 02 ||     17.1 |    17.3 |   +1%  ||  2225.33 |  2209.83 |   -1%  |  0.0000 |
 | TPC-H 03 ||    372.3 |   365.9 |   -2%  ||   131.07 |   133.23 |   +2%  |  0.2426 |
 | TPC-H 04 ||    227.1 |   226.2 |   -0%  ||   211.39 |   212.13 |   +0%  |  0.7557 |
+| TPC-H 05 ||   1131.1 |  1079.4 |   -5%  ||    42.86 |    44.95 |   +5%  |  0.0911 |
 | TPC-H 06 ||     17.6 |    17.6 |   +0%  ||  2402.44 |  2403.84 |   +0%  |  0.5522 |
 | TPC-H 07 ||    212.6 |   208.7 |   -2%  ||   226.48 |   230.67 |   +2%  |  0.1039 |
+| TPC-H 08 ||    174.7 |   157.2 |  -10%  ||   274.31 |   302.16 |  +10%  |  0.0000 |
 | TPC-H 09 ||   2107.1 |  2090.2 |   -1%  ||    23.05 |    23.28 |   +1%  |  0.7989 |
 | TPC-H 10 ||    745.5 |   743.6 |   -0%  ||    66.11 |    66.25 |   +0%  |  0.8453 |
 | TPC-H 11 ||     59.0 |    58.9 |   -0%  ||   784.63 |   786.07 |   +0%  |  0.7258 |
 | TPC-H 12 ||    109.4 |   109.9 |   +0%  ||   412.65 |   412.12 |   -0%  |  0.4400 |
 | TPC-H 13 ||   1940.7 |  1921.7 |   -1%  ||    24.98 |    25.15 |   +1%  |  0.6869 |
 | TPC-H 14 ||    120.7 |   121.0 |   +0%  ||   397.52 |   396.75 |   -0%  |  0.6473 |
 | TPC-H 15 ||     45.9 |    45.9 |   +0%  ||   987.35 |   986.36 |   -0%  |  0.7646 |
 | TPC-H 16 ||    402.3 |   401.0 |   -0%  ||   122.30 |   122.73 |   +0%  |  0.7470 |
 | TPC-H 17 ||     50.9 |    48.1 |   -6%  ||   833.80 |   866.54 |   +4%  |  0.0000 |
 | TPC-H 18 ||   5517.9 |  5529.1 |   +0%  ||     8.53 |     8.57 |   +0%  |  0.9439 |
 | TPC-H 19 ||     95.0 |    95.5 |   +1%  ||   493.60 |   490.50 |   -1%  |  0.1620 |
 | TPC-H 20 ||     49.4 |    49.4 |   +0%  ||   919.98 |   921.73 |   +0%  |  0.9590 |
+| TPC-H 21 ||   2195.4 |  1348.6 |  -39%  ||    21.98 |    35.88 |  +63%  |  0.0000 |
 | TPC-H 22 ||    570.7 |   575.7 |   +1%  ||    84.13 |    84.49 |   +0%  |  0.7182 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||  18347.2 | 17413.3 |   -5%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +3%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>