### PR TITLE
PredicateSplitUpRule: Create UnionAll for NOT LIKE

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -114,14 +114,14 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   optimizer->add_rule(std::make_unique<PredicatePlacementRule>());
 
-  optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
-
   optimizer->add_rule(std::make_unique<SubqueryToJoinRule>());
 
   // Run the ColumnPruningRule before the PredicatePlacementRule, as it might turn joins into semi joins, which
   // can be treated as predicates and pushed further down. For the same reason, run it after the JoinOrderingRule,
   // which does not like semi joins (see above).
   optimizer->add_rule(std::make_unique<ColumnPruningRule>());
+
+  optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
 
   optimizer->add_rule(std::make_unique<SemiJoinReductionRule>());
 

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -121,6 +121,8 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   // which does not like semi joins (see above).
   optimizer->add_rule(std::make_unique<ColumnPruningRule>());
 
+  // Run the PredicateSplitUpRule after the ColumnPruningRule, as it may create UNION ALLs which are not handled in the
+  // column pruning rule yet.
   optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
 
   optimizer->add_rule(std::make_unique<SemiJoinReductionRule>());

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -27,7 +27,7 @@ bool predicates_are_mutually_exclusive(const std::vector<std::shared_ptr<Abstrac
   const auto second_binary_predicate = std::dynamic_pointer_cast<BinaryPredicateExpression>(predicates[1]);
   if (!first_binary_predicate || !second_binary_predicate) return false;
 
-  // Check for pattern `col_x < 'val' AND col_x >= 'vam'`
+  // Check for pattern `col_x < 'val' OR col_x >= 'vam'`
   if (first_binary_predicate->predicate_condition != PredicateCondition::LessThan ||
       second_binary_predicate->predicate_condition != PredicateCondition::GreaterThanEquals) {
     // Wrong predicates

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -1,11 +1,61 @@
 #include "predicate_split_up_rule.hpp"
 
+#include "expression/binary_predicate_expression.hpp"
 #include "expression/expression_utils.hpp"
 #include "expression/logical_expression.hpp"
+#include "expression/value_expression.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/union_node.hpp"
 
 namespace opossum {
+
+namespace {
+bool can_use_union_all(const std::vector<std::shared_ptr<AbstractExpression>>& predicates) {
+  // Optimization: The ExpressionReductionRule transforms `x NOT LIKE 'foo%'` into `x < 'foo' OR x >= 'fop'`. For this
+  // special case, we know that the two OR arguments are mutually exclusive. In this case, we do not need to use
+  // SetOperationMode::Positions but can use SetOperationMode::All. This surely applies to other cases, too, but those
+  // are not covered yet. Note that this is not equal to XOR. Here, we know that both sides cannot be true at the same
+  // time. XOR would require us to check if both are true and discard the row if they are.
+  if (predicates.size() != 2) return false;
+
+  const auto first_binary_predicate = std::dynamic_pointer_cast<BinaryPredicateExpression>(predicates[0]);
+  const auto second_binary_predicate = std::dynamic_pointer_cast<BinaryPredicateExpression>(predicates[1]);
+  if (!first_binary_predicate || !second_binary_predicate) return false;
+
+  // Check for pattern `col_x < 'val' AND col_x >= 'vam'`
+  if (first_binary_predicate->predicate_condition != PredicateCondition::LessThan ||
+      second_binary_predicate->predicate_condition != PredicateCondition::GreaterThanEquals) {
+    // Wrong predicates
+    return false;
+  }
+
+  if (first_binary_predicate->left_operand()->type != ExpressionType::LQPColumn ||
+      first_binary_predicate->left_operand() != second_binary_predicate->left_operand()) {
+    // Left side of predicates is not a column or is a different column for both expressions
+    return false;
+  }
+
+  if (first_binary_predicate->right_operand()->type != ExpressionType::Value ||
+      first_binary_predicate->right_operand()->type != ExpressionType::Value) {
+    // Right side of predicates is not a value
+    return false;
+  }
+
+  if (first_binary_predicate->right_operand()->data_type() != DataType::String ||
+      first_binary_predicate->right_operand()->data_type() != DataType::String) {
+    // Right side of predicates is not a string
+    return false;
+  }
+
+  const auto lower_string_expression = static_cast<const ValueExpression&>(*first_binary_predicate->right_operand());
+  auto lower_string_plus_one = boost::get<pmr_string>(lower_string_expression.value);
+  const auto upper_string_expression = static_cast<const ValueExpression&>(*second_binary_predicate->right_operand());
+  const auto upper_string = boost::get<pmr_string>(upper_string_expression.value);
+
+  ++lower_string_plus_one[lower_string_plus_one.size() - 1];
+  return lower_string_plus_one == upper_string;
+}
+}  // namespace
 
 PredicateSplitUpRule::PredicateSplitUpRule(const bool split_disjunctions) : _split_disjunctions(split_disjunctions) {}
 
@@ -83,7 +133,9 @@ void PredicateSplitUpRule::_split_disjunction(const std::shared_ptr<PredicateNod
   }
 
   // Step 1: Insert initial diamond
-  auto top_union_node = UnionNode::make(SetOperationMode::Positions);
+  const auto set_operation_mode =
+      can_use_union_all(flat_disjunction) ? SetOperationMode::All : SetOperationMode::Positions;
+  auto top_union_node = UnionNode::make(set_operation_mode);
   const auto diamond_bottom = predicate_node->left_input();
   lqp_replace_node(predicate_node, top_union_node);
   {

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -10,12 +10,17 @@
 namespace opossum {
 
 namespace {
-bool can_use_union_all(const std::vector<std::shared_ptr<AbstractExpression>>& predicates) {
+bool predicates_are_mutually_exclusive(const std::vector<std::shared_ptr<AbstractExpression>>& predicates) {
   // Optimization: The ExpressionReductionRule transforms `x NOT LIKE 'foo%'` into `x < 'foo' OR x >= 'fop'`. For this
   // special case, we know that the two OR arguments are mutually exclusive. In this case, we do not need to use
-  // SetOperationMode::Positions but can use SetOperationMode::All. This surely applies to other cases, too, but those
-  // are not covered yet. Note that this is not equal to XOR. Here, we know that both sides cannot be true at the same
-  // time. XOR would require us to check if both are true and discard the row if they are.
+  // SetOperationMode::Positions but can use SetOperationMode::All. For now, we only cover cases with less-than and
+  // greater-than-equals. There are more cases, too, but those are not covered yet. For example, the optimization
+  // expects the two predicates in the order mentioned above. Also, it does not cover less-than/greater-than (not
+  // greater-than-equals)
+  //
+  // Note that this is not equal to XOR. In the case handled here, we know that both sides cannot be true at the same
+  // time. XOR would require us to check if both are true and discard the row if they are. As such, even if we later
+  // introduce PredicateCondition::Xor, we cannot automatically use ::All for that expression.
   if (predicates.size() != 2) return false;
 
   const auto first_binary_predicate = std::dynamic_pointer_cast<BinaryPredicateExpression>(predicates[0]);
@@ -36,24 +41,28 @@ bool can_use_union_all(const std::vector<std::shared_ptr<AbstractExpression>>& p
   }
 
   if (first_binary_predicate->right_operand()->type != ExpressionType::Value ||
-      first_binary_predicate->right_operand()->type != ExpressionType::Value) {
+      second_binary_predicate->right_operand()->type != ExpressionType::Value) {
     // Right side of predicates is not a value
     return false;
   }
 
-  if (first_binary_predicate->right_operand()->data_type() != DataType::String ||
-      first_binary_predicate->right_operand()->data_type() != DataType::String) {
-    // Right side of predicates is not a string
+  if (first_binary_predicate->right_operand()->data_type() != second_binary_predicate->right_operand()->data_type()) {
+    // Different data types - to keep things simple, we do not handle this case here.
     return false;
   }
 
-  const auto lower_string_expression = static_cast<const ValueExpression&>(*first_binary_predicate->right_operand());
-  auto lower_string_plus_one = boost::get<pmr_string>(lower_string_expression.value);
-  const auto upper_string_expression = static_cast<const ValueExpression&>(*second_binary_predicate->right_operand());
-  const auto upper_string = boost::get<pmr_string>(upper_string_expression.value);
+  const auto first_value_expression = static_cast<const ValueExpression&>(*first_binary_predicate->right_operand());
+  const auto second_value_expression = static_cast<const ValueExpression&>(*second_binary_predicate->right_operand());
 
-  ++lower_string_plus_one[lower_string_plus_one.size() - 1];
-  return lower_string_plus_one == upper_string;
+  auto first_less_than_second = false;
+  boost::apply_visitor(
+      [&](const auto first_value) {
+        const auto second_value = boost::get<decltype(first_value)>(second_value_expression.value);
+        first_less_than_second = first_value < second_value;
+      },
+      first_value_expression.value);
+
+  return first_less_than_second;
 }
 }  // namespace
 
@@ -134,7 +143,7 @@ void PredicateSplitUpRule::_split_disjunction(const std::shared_ptr<PredicateNod
 
   // Step 1: Insert initial diamond
   const auto set_operation_mode =
-      can_use_union_all(flat_disjunction) ? SetOperationMode::All : SetOperationMode::Positions;
+      predicates_are_mutually_exclusive(flat_disjunction) ? SetOperationMode::All : SetOperationMode::Positions;
   auto top_union_node = UnionNode::make(set_operation_mode);
   const auto diamond_bottom = predicate_node->left_input();
   lqp_replace_node(predicate_node, top_union_node);

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -61,7 +61,7 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpConjunctionInPredicateNode) {
 }
 
 TEST_F(PredicateSplitUpRuleTest, SplitUpSimpleDisjunctionInPredicateNode) {
-  // SELECT * FROM a WHERE a < 3 OR a >= 5
+  // SELECT * FROM a WHERE a < 3 OR a > 5
   // clang-format off
   const auto input_lqp =
   PredicateNode::make(or_(less_than_(a_a, value_(3)), greater_than_(a_a, value_(5))),

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -64,14 +64,14 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpSimpleDisjunctionInPredicateNode) {
   // SELECT * FROM a WHERE a < 3 OR a >= 5
   // clang-format off
   const auto input_lqp =
-  PredicateNode::make(or_(less_than_(a_a, value_(3)), greater_than_equals_(a_a, value_(5))),
+  PredicateNode::make(or_(less_than_(a_a, value_(3)), greater_than_(a_a, value_(5))),
     node_a);
 
   const auto expected_lqp =
   UnionNode::make(SetOperationMode::Positions,
     PredicateNode::make(less_than_(a_a, value_(3)),
       node_a),
-    PredicateNode::make(greater_than_equals_(a_a, value_(5)),
+    PredicateNode::make(greater_than_(a_a, value_(5)),
       node_a));
   // clang-format on
 
@@ -131,14 +131,14 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpNotLikeDoesNotApply1) {
   // SELECT * FROM a WHERE c < 'foo' OR c >= 'foq' - looks like SplitUpNotLike, but the optimization does not apply
   // clang-format off
   const auto input_lqp =
-  PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_c, value_("foq"))),
+  PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_c, value_("bar"))),
     node_a);
 
   const auto expected_lqp =
   UnionNode::make(SetOperationMode::Positions,
     PredicateNode::make(less_than_(a_c, value_("foo")),
       node_a),
-    PredicateNode::make(greater_than_equals_(a_c, value_("foq")),
+    PredicateNode::make(greater_than_equals_(a_c, value_("bar")),
       node_a));
   // clang-format on
 
@@ -159,6 +159,27 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpNotLikeDoesNotApply2) {
     PredicateNode::make(less_than_(a_c, value_("foo")),
       node_a),
     PredicateNode::make(greater_than_equals_(a_d, value_("fop")),
+      node_a));
+  // clang-format on
+
+  const auto actual_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(PredicateSplitUpRuleTest, SplitUpMutuallyExclusiveInts) {
+  // SELECT * FROM a WHERE a < 5 OR b >= 8 - should identify the conditions as mutually exclusive and use
+  // SetOperationMode::All
+  // clang-format off
+  const auto input_lqp =
+  PredicateNode::make(or_(less_than_(a_a, value_(5)), greater_than_equals_(a_a, value_(8))),
+    node_a);
+
+  const auto expected_lqp =
+  UnionNode::make(SetOperationMode::All,
+    PredicateNode::make(less_than_(a_a, value_(5)),
+      node_a),
+    PredicateNode::make(greater_than_equals_(a_a, value_(8)),
       node_a));
   // clang-format on
 

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -108,7 +108,9 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpComplexDisjunctionInPredicateNode) {
 
 TEST_F(PredicateSplitUpRuleTest, SplitUpNotLike) {
   // SELECT * FROM a WHERE a < 'foo' OR a >= 'fop' - should identify the conditions as mutually exclusive and use
-  // SetOperationMode::All
+  // SetOperationMode::All. The expression could have been the result of the ExpressionReductionRule being applied
+  // to `a NOT LIKE 'foo%'`.
+
   // clang-format off
   const auto input_lqp =
   PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_c, value_("fop"))),

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -14,9 +14,12 @@ namespace opossum {
 class PredicateSplitUpRuleTest : public StrategyBaseTest {
  public:
   void SetUp() override {
-    node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}});
+    node_a = MockNode::make(MockNode::ColumnDefinitions{
+        {DataType::Int, "a"}, {DataType::Int, "b"}, {DataType::String, "c"}, {DataType::String, "d"}});
     a_a = node_a->get_column("a");
     a_b = node_a->get_column("b");
+    a_c = node_a->get_column("c");
+    a_d = node_a->get_column("d");
 
     node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Int, "b"}}, "b");
     b_a = node_b->get_column("a");
@@ -26,7 +29,7 @@ class PredicateSplitUpRuleTest : public StrategyBaseTest {
   }
 
   std::shared_ptr<MockNode> node_a, node_b;
-  std::shared_ptr<LQPColumnExpression> a_a, a_b, b_a, b_b;
+  std::shared_ptr<LQPColumnExpression> a_a, a_b, a_c, a_d, b_a, b_b;
   std::shared_ptr<PredicateSplitUpRule> rule;
 };
 
@@ -96,6 +99,67 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpComplexDisjunctionInPredicateNode) {
           node_a),
         PredicateNode::make(less_than_(9, a_b),
           node_a))));
+  // clang-format on
+
+  const auto actual_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(PredicateSplitUpRuleTest, SplitUpNotLike) {
+  // SELECT * FROM a WHERE a < 'foo' OR a >= 'fop' - should identify the conditions as mutually exclusive and use
+  // SetOperationMode::All
+  // clang-format off
+  const auto input_lqp =
+  PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_c, value_("fop"))),
+    node_a);
+
+  const auto expected_lqp =
+  UnionNode::make(SetOperationMode::All,
+    PredicateNode::make(less_than_(a_c, value_("foo")),
+      node_a),
+    PredicateNode::make(greater_than_equals_(a_c, value_("fop")),
+      node_a));
+  // clang-format on
+
+  const auto actual_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(PredicateSplitUpRuleTest, SplitUpNotLikeDoesNotApply1) {
+  // SELECT * FROM a WHERE c < 'foo' OR c >= 'foq' - looks like SplitUpNotLike, but the optimization does not apply
+  // clang-format off
+  const auto input_lqp =
+  PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_c, value_("foq"))),
+    node_a);
+
+  const auto expected_lqp =
+  UnionNode::make(SetOperationMode::Positions,
+    PredicateNode::make(less_than_(a_c, value_("foo")),
+      node_a),
+    PredicateNode::make(greater_than_equals_(a_c, value_("foq")),
+      node_a));
+  // clang-format on
+
+  const auto actual_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);
+
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(PredicateSplitUpRuleTest, SplitUpNotLikeDoesNotApply2) {
+  // SELECT * FROM a WHERE c < 'foo' OR d >= 'fop' - looks like SplitUpNotLike, but the optimization does not apply
+  // clang-format off
+  const auto input_lqp =
+  PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_d, value_("fop"))),
+    node_a);
+
+  const auto expected_lqp =
+  UnionNode::make(SetOperationMode::Positions,
+    PredicateNode::make(less_than_(a_c, value_("foo")),
+      node_a),
+    PredicateNode::make(greater_than_equals_(a_d, value_("fop")),
+      node_a));
   // clang-format on
 
   const auto actual_lqp = StrategyBaseTest::apply_rule(rule, input_lqp);

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -130,7 +130,7 @@ TEST_F(PredicateSplitUpRuleTest, SplitUpNotLike) {
 }
 
 TEST_F(PredicateSplitUpRuleTest, SplitUpNotLikeDoesNotApply1) {
-  // SELECT * FROM a WHERE c < 'foo' OR c >= 'foq' - looks like SplitUpNotLike, but the optimization does not apply
+  // SELECT * FROM a WHERE c < 'foo' OR c >= 'bar' - looks like SplitUpNotLike, but the optimization does not apply
   // clang-format off
   const auto input_lqp =
   PredicateNode::make(or_(less_than_(a_c, value_("foo")), greater_than_equals_(a_c, value_("bar"))),


### PR DESCRIPTION
Optimization: The ExpressionReductionRule transforms `x NOT LIKE 'foo%'` into `x < 'foo' OR x >= 'fop'`. For this special case, we know that the two OR arguments are mutually exclusive. In this case, we do not need to use SetOperationMode::Positions but can use SetOperationMode::All. This surely applies to other cases, too, but those are not covered yet.

This only applies to TPC-H Q16; other benchmarks do not use this construct.


**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.3TB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 71a783492 | 07.10.2020 08:44 | Sort: Add performance steps (#2234) | real 264.75 user 2384.03 sys 137.46|
| b4b3d7870 | 07.10.2020 23:51 | PredicateSplitUpRule: Create UnionAll for NOT LIKE | real 265.00 user 2375.82 sys 136.82|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_71a783492d4faf0a1c55b3626afe46a49d463b80_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_b4b3d787051f570067045756f132785e7eaafdde_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 71a783492d4faf0a1c55b3626afe46a49d463b80-dirty                                                                                         | b4b3d787051f570067045756f132785e7eaafdde-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-07 23:55:54                                                                                                                    | 2020-10-08 06:28:04                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    790.1 |   818.7 |   +4%  ||     1.27 |     1.22 |   -3%  |  0.0000 |
 | TPC-H 02 ||      5.1 |     5.2 |   +2%  ||   195.89 |   192.61 |   -2%  |  0.0250 |
 | TPC-H 03 ||     80.7 |    80.8 |   +0%  ||    12.38 |    12.38 |   -0%  |  0.8444 |
 | TPC-H 04 ||     68.2 |    68.2 |   +0%  ||    14.66 |    14.66 |   -0%  |  0.9465 |
 | TPC-H 05 ||    217.2 |   216.8 |   -0%  ||     4.60 |     4.61 |   +0%  |  0.5237 |
 | TPC-H 06 ||      3.2 |     3.2 |   +0%  ||   310.80 |   309.33 |   -0%  |  0.0000 |
 | TPC-H 07 ||     59.0 |    59.1 |   +0%  ||    16.96 |    16.91 |   -0%  |  0.7666 |
 | TPC-H 08 ||     67.9 |    68.6 |   +1%  ||    14.74 |    14.58 |   -1%  |  0.0446 |
 | TPC-H 09 ||    487.6 |   483.9 |   -1%  ||     2.05 |     2.07 |   +1%  |  0.0586 |
 | TPC-H 10 ||    167.7 |   169.4 |   +1%  ||     5.96 |     5.90 |   -1%  |  0.1289 |
 | TPC-H 11 ||      9.1 |     9.2 |   +0%  ||   109.70 |   109.20 |   -0%  |  0.0002 |
 | TPC-H 12 ||     43.6 |    43.6 |   +0%  ||    22.93 |    22.92 |   -0%  |  0.7535 |
+| TPC-H 13 ||    432.4 |   358.7 |  -17%  ||     2.31 |     2.79 |  +21%  |  0.0000 |
 | TPC-H 14 ||     20.9 |    21.0 |   +1%  ||    47.81 |    47.54 |   -1%  |  0.0000 |
 | TPC-H 15 ||      7.8 |     7.9 |   +1%  ||   127.97 |   126.69 |   -1%  |  0.0000 |
+| TPC-H 16 ||     92.8 |    76.6 |  -17%  ||    10.77 |    13.06 |  +21%  |  0.0000 |
 | TPC-H 17 ||     18.1 |    18.2 |   +1%  ||    55.13 |    54.79 |   -1%  |  0.0164 |
-| TPC-H 18 ||    664.0 |   698.8 |   +5%  ||     1.51 |     1.43 |   -5%  |  0.0000 |
 | TPC-H 19 ||     29.6 |    29.5 |   -0%  ||    33.81 |    33.90 |   +0%  |  0.0754 |
 | TPC-H 20 ||     16.3 |    16.4 |   +0%  ||    61.25 |    61.15 |   -0%  |  0.5683 |
 | TPC-H 21 ||    423.5 |   422.7 |   -0%  ||     2.36 |     2.37 |   +0%  |  0.7061 |
 | TPC-H 22 ||     49.6 |    49.9 |   +1%  ||    20.15 |    20.02 |   -1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3754.5 |  3726.4 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_71a783492d4faf0a1c55b3626afe46a49d463b80_st_s01.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_b4b3d787051f570067045756f132785e7eaafdde_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 71a783492d4faf0a1c55b3626afe46a49d463b80-dirty                                                                                             | b4b3d787051f570067045756f132785e7eaafdde-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-08 00:18:36                                                                                                                        | 2020-10-08 06:50:23                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.3 |     7.3 |   +0%  ||   137.72 |   137.08 |   -0%  |  0.0000 |
 | TPC-H 02 ||      0.7 |     0.7 |   +0%  ||  1527.31 |  1525.88 |   -0%  |  0.8088 |
 | TPC-H 03 ||      0.9 |     0.9 |   -0%  ||  1095.94 |  1098.31 |   +0%  |  0.0007 |
 | TPC-H 04 ||      0.5 |     0.5 |   -0%  ||  1842.93 |  1846.12 |   +0%  |  0.0000 |
 | TPC-H 05 ||      1.3 |     1.3 |   -0%  ||   761.81 |   762.94 |   +0%  |  0.2753 |
 | TPC-H 06 ||      0.1 |     0.1 |   -0%  ||  9513.20 |  9525.51 |   +0%  |  0.0000 |
 | TPC-H 07 ||      1.3 |     1.3 |   +0%  ||   758.29 |   757.60 |   -0%  |  0.9288 |
 | TPC-H 08 ||     14.8 |    15.0 |   +1%  ||    67.58 |    66.75 |   -1%  |  0.1026 |
 | TPC-H 09 ||      2.4 |     2.4 |   -1%  ||   412.31 |   415.48 |   +1%  |  0.0040 |
 | TPC-H 10 ||      1.0 |     1.0 |   +0%  ||  1047.39 |  1045.65 |   -0%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   -0%  ||  2908.50 |  2921.52 |   +0%  |  0.0000 |
 | TPC-H 12 ||      0.7 |     0.7 |   +0%  ||  1519.63 |  1512.56 |   -0%  |  0.0000 |
+| TPC-H 13 ||      2.4 |     2.2 |   -7%  ||   421.31 |   453.40 |   +8%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.4 |   +0%  ||  2670.34 |  2663.85 |   -0%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   +0%  ||   871.60 |   870.39 |   -0%  |  0.0000 |
+| TPC-H 16 ||      2.2 |     2.0 |   -6%  ||   458.66 |   489.01 |   +7%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   -1%  ||  3043.61 |  3064.37 |   +1%  |  0.0000 |
 | TPC-H 18 ||      2.7 |     2.7 |   +1%  ||   370.88 |   366.62 |   -1%  |  0.0000 |
+| TPC-H 19 ||      5.5 |     5.2 |   -5%  ||   181.92 |   191.80 |   +5%  |  0.0000 |
 | TPC-H 20 ||      2.4 |     2.4 |   -0%  ||   413.95 |   415.58 |   +0%  |  0.0292 |
 | TPC-H 21 ||      2.2 |     2.2 |   +0%  ||   459.74 |   458.58 |   -0%  |  0.3719 |
 | TPC-H 22 ||      1.3 |     1.3 |   +1%  ||   770.85 |   766.37 |   -1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     51.7 |    51.4 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_71a783492d4faf0a1c55b3626afe46a49d463b80_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_b4b3d787051f570067045756f132785e7eaafdde_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 71a783492d4faf0a1c55b3626afe46a49d463b80-dirty                                                                                         | b4b3d787051f570067045756f132785e7eaafdde-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-08 00:40:43                                                                                                                    | 2020-10-08 07:12:26                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 56, 0]                                                                                                                          | [0, 0, 56, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2233.4 |  2216.9 |   -1%  ||    21.82 |    22.11 |   +1%  |  0.6896 |
 | TPC-H 02 ||     17.5 |    17.5 |   -0%  ||  2176.44 |  2174.33 |   -0%  |  0.8898 |
 | TPC-H 03 ||    332.2 |   329.8 |   -1%  ||   146.84 |   147.69 |   +1%  |  0.5900 |
 | TPC-H 04 ||    201.5 |   202.3 |   +0%  ||   237.20 |   236.53 |   -0%  |  0.7646 |
 | TPC-H 05 ||   1004.3 |  1006.0 |   +0%  ||    48.66 |    48.52 |   -0%  |  0.9474 |
 | TPC-H 06 ||     16.3 |    16.6 |   +2%  ||  2411.42 |  2406.34 |   -0%  |  0.0000 |
 | TPC-H 07 ||    188.8 |   188.5 |   -0%  ||   254.57 |   255.21 |   +0%  |  0.8706 |
 | TPC-H 08 ||    176.6 |   176.8 |   +0%  ||   271.63 |   271.09 |   -0%  |  0.9277 |
 | TPC-H 09 ||   1849.0 |  1856.8 |   +0%  ||    26.11 |    26.21 |   +0%  |  0.8980 |
 | TPC-H 10 ||    671.9 |   670.7 |   -0%  ||    73.41 |    73.48 |   +0%  |  0.8790 |
 | TPC-H 11 ||     54.4 |    54.2 |   -0%  ||   845.19 |   847.69 |   +0%  |  0.4532 |
 | TPC-H 12 ||    106.3 |   106.7 |   +0%  ||   422.29 |   421.17 |   -0%  |  0.5169 |
 | TPC-H 13 ||   1717.5 |  1719.0 |   +0%  ||    28.41 |    28.48 |   +0%  |  0.9700 |
 | TPC-H 14 ||    110.0 |   109.7 |   -0%  ||   433.99 |   435.64 |   +0%  |  0.5536 |
 | TPC-H 15 ||     42.9 |    42.9 |   -0%  ||  1047.44 |  1047.49 |   +0%  |  0.9916 |
+| TPC-H 16 ||    379.2 |   324.7 |  -14%  ||   129.66 |   150.91 |  +16%  |  0.0000 |
 | TPC-H 17 ||     52.6 |    52.6 |   +0%  ||   809.03 |   808.34 |   -0%  |  0.9022 |
 | TPC-H 18 ||   5050.0 |  4992.5 |   -1%  ||     9.42 |     9.48 |   +1%  |  0.6620 |
 | TPC-H 19 ||     96.9 |    96.4 |   -1%  ||   483.97 |   486.33 |   +0%  |  0.2339 |
 | TPC-H 20 ||     49.3 |    49.7 |   +1%  ||   921.48 |   914.29 |   -1%  |  0.0693 |
 | TPC-H 21 ||   2148.0 |  2134.6 |   -1%  ||    22.48 |    22.12 |   -2%  |  0.8614 |
 | TPC-H 22 ||    503.4 |   500.0 |   -1%  ||    96.78 |    97.19 |   +0%  |  0.7546 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  17002.0 | 16864.8 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>