### PR TITLE
JoinHash: Materialize smaller side first

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -352,7 +352,6 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
     Timer timer_materialization;
     if (_build_input_table->row_count() < _probe_input_table->row_count()) {
-      // TODO fix default arg
       materialize_build_side(EMPTY_BLOOM_FILTER);
       _performance.set_step_runtime(OperatorSteps::BuildSideMaterializing, timer_materialization.lap());
       materialize_probe_side(build_side_bloom_filter);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -327,10 +327,12 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
     const auto materialize_build_side = [&](const auto& input_bloom_filter) {
       if (keep_nulls_build_column) {
         materialized_build_column = materialize_input<BuildColumnType, HashedType, true>(
-            _build_input_table, _column_ids.first, histograms_build_column, _radix_bits, build_side_bloom_filter, input_bloom_filter);
+            _build_input_table, _column_ids.first, histograms_build_column, _radix_bits, build_side_bloom_filter,
+            input_bloom_filter);
       } else {
         materialized_build_column = materialize_input<BuildColumnType, HashedType, false>(
-            _build_input_table, _column_ids.first, histograms_build_column, _radix_bits, build_side_bloom_filter, input_bloom_filter);
+            _build_input_table, _column_ids.first, histograms_build_column, _radix_bits, build_side_bloom_filter,
+            input_bloom_filter);
       }
     };
 
@@ -352,12 +354,12 @@ class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
 
     Timer timer_materialization;
     if (_build_input_table->row_count() < _probe_input_table->row_count()) {
-      materialize_build_side(EMPTY_BLOOM_FILTER);
+      materialize_build_side(ALL_TRUE_BLOOM_FILTER);
       _performance.set_step_runtime(OperatorSteps::BuildSideMaterializing, timer_materialization.lap());
       materialize_probe_side(build_side_bloom_filter);
       _performance.set_step_runtime(OperatorSteps::ProbeSideMaterializing, timer_materialization.lap());
     } else {
-      materialize_probe_side(EMPTY_BLOOM_FILTER);
+      materialize_probe_side(ALL_TRUE_BLOOM_FILTER);
       _performance.set_step_runtime(OperatorSteps::ProbeSideMaterializing, timer_materialization.lap());
       materialize_build_side(probe_side_bloom_filter);
       _performance.set_step_runtime(OperatorSteps::BuildSideMaterializing, timer_materialization.lap());


### PR DESCRIPTION
For the bloom filter to be efficient, it makes sense for the smaller side to be materialized first. That way, the bloom filter created on that side can serve as a filter when materializing the bigger side.

In cases where the build side is bigger than the probe side (unavoidable for some semi/anti joins), this PR flips the order of the two materialization steps.

The overall performance is not tooo impressive, as only few queries are affected. A 49% improvement for TPC-H Q22 is nice to have though.

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 792e6f29a | 07.10.2020 07:35 | Reuse empty bloom filter | real 267.27 user 2509.52 sys 150.72|
| bf4765a4b | 08.10.2020 07:28 | JoinHash: Materialize smaller side first | real 269.89 user 2506.24 sys 148.95|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_bf4765a4b6694757471885ad3efccd1e60e9e802_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-08 07:33:04                                                                                                                    | 2020-10-08 14:29:58                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    821.0 |   825.6 |   +1%  ||     1.22 |     1.21 |   -1%  |  0.3907 |
 | TPC-H 02 ||      4.9 |     4.9 |   -1%  ||   202.89 |   204.39 |   +1%  |  0.3258 |
 | TPC-H 03 ||     81.0 |    81.2 |   +0%  ||    12.35 |    12.32 |   -0%  |  0.1216 |
 | TPC-H 04 ||     68.7 |    68.7 |   +0%  ||    14.55 |    14.55 |   -0%  |  0.9656 |
 | TPC-H 05 ||    218.3 |   216.4 |   -1%  ||     4.58 |     4.62 |   +1%  |  0.0018 |
 | TPC-H 06 ||      3.2 |     3.2 |   +1%  ||   312.24 |   310.05 |   -1%  |  0.0000 |
 | TPC-H 07 ||     58.7 |    59.0 |   +0%  ||    17.03 |    16.96 |   -0%  |  0.6448 |
 | TPC-H 08 ||     68.1 |    68.3 |   +0%  ||    14.67 |    14.65 |   -0%  |  0.7323 |
 | TPC-H 09 ||    481.6 |   486.7 |   +1%  ||     2.08 |     2.05 |   -1%  |  0.0028 |
 | TPC-H 10 ||    168.6 |   169.4 |   +0%  ||     5.93 |     5.90 |   -0%  |  0.3911 |
 | TPC-H 11 ||      9.1 |     9.1 |   -1%  ||   109.73 |   110.39 |   +1%  |  0.0000 |
 | TPC-H 12 ||     43.5 |    43.3 |   -1%  ||    22.97 |    23.10 |   +1%  |  0.0000 |
 | TPC-H 13 ||    367.1 |   355.2 |   -3%  ||     2.72 |     2.82 |   +3%  |  0.0000 |
 | TPC-H 14 ||     21.3 |    21.1 |   -1%  ||    47.04 |    47.50 |   +1%  |  0.0000 |
 | TPC-H 15 ||      7.8 |     7.8 |   -0%  ||   127.61 |   127.92 |   +0%  |  0.0003 |
 | TPC-H 16 ||     90.9 |    91.4 |   +1%  ||    11.00 |    10.94 |   -1%  |  0.0331 |
 | TPC-H 17 ||     17.8 |    17.9 |   +1%  ||    56.05 |    55.74 |   -1%  |  0.0051 |
 | TPC-H 18 ||    698.1 |   695.5 |   -0%  ||     1.43 |     1.44 |   +0%  |  0.6950 |
 | TPC-H 19 ||     29.2 |    29.2 |   -0%  ||    34.19 |    34.25 |   +0%  |  0.0042 |
 | TPC-H 20 ||     16.3 |    16.2 |   -0%  ||    61.50 |    61.55 |   +0%  |  0.7234 |
 | TPC-H 21 ||    420.9 |   409.6 |   -3%  ||     2.38 |     2.44 |   +3%  |  0.0000 |
+| TPC-H 22 ||     49.2 |    33.0 |  -33%  ||    20.34 |    30.26 |  +49%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3745.2 |  3712.7 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st_s01.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_bf4765a4b6694757471885ad3efccd1e60e9e802_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                             | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-08 07:55:22                                                                                                                        | 2020-10-08 14:52:17                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.2 |     7.3 |   +0%  ||   138.33 |   137.89 |   -0%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.5 |   +0%  ||  1891.68 |  1885.93 |   -0%  |  0.4491 |
 | TPC-H 03 ||      0.9 |     0.9 |   -0%  ||  1142.36 |  1146.40 |   +0%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   +0%  ||  1935.90 |  1932.38 |   -0%  |  0.0000 |
 | TPC-H 05 ||      1.2 |     1.2 |   -1%  ||   816.10 |   823.64 |   +1%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   +1%  ||  9662.24 |  9586.42 |   -1%  |  0.0000 |
 | TPC-H 07 ||      1.2 |     1.2 |   +1%  ||   829.41 |   820.55 |   -1%  |  0.3630 |
 | TPC-H 08 ||     14.6 |    14.5 |   -1%  ||    68.37 |    68.80 |   +1%  |  0.4214 |
 | TPC-H 09 ||      2.3 |     2.4 |   +0%  ||   425.92 |   424.55 |   -0%  |  0.2207 |
 | TPC-H 10 ||      0.9 |     0.9 |   +0%  ||  1113.05 |  1109.58 |   -0%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   +0%  ||  3419.14 |  3409.45 |   -0%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   +2%  ||  1590.84 |  1552.95 |   -2%  |  0.0000 |
 | TPC-H 13 ||      2.2 |     2.2 |   +1%  ||   456.05 |   453.27 |   -1%  |  0.0000 |
 | TPC-H 14 ||      0.3 |     0.3 |   -1%  ||  2868.88 |  2896.95 |   +1%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   +0%  ||   904.77 |   902.36 |   -0%  |  0.0000 |
 | TPC-H 16 ||      2.1 |     2.1 |   -0%  ||   472.02 |   472.07 |   +0%  |  0.8234 |
 | TPC-H 17 ||      0.3 |     0.3 |   -0%  ||  3459.57 |  3461.39 |   +0%  |  0.5027 |
 | TPC-H 18 ||      2.7 |     2.7 |   -0%  ||   373.74 |   374.91 |   +0%  |  0.0000 |
 | TPC-H 19 ||      5.4 |     5.4 |   -0%  ||   183.75 |   184.44 |   +0%  |  0.0000 |
 | TPC-H 20 ||      2.3 |     2.3 |   +1%  ||   429.68 |   426.56 |   -1%  |  0.0000 |
 | TPC-H 21 ||      2.1 |     2.0 |   -4%  ||   480.48 |   500.39 |   +4%  |  0.0000 |
+| TPC-H 22 ||      1.3 |     1.1 |  -13%  ||   784.76 |   904.38 |  +15%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     50.3 |    50.0 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st_s10.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_bf4765a4b6694757471885ad3efccd1e60e9e802_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                             | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-08 08:17:26                                                                                                                        | 2020-10-08 15:14:20                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   9061.6 |  8959.2 |   -1%  ||     0.11 |     0.11 |   +1%  |       ˅ |
 | TPC-H 02 ||     52.8 |    52.7 |   -0%  ||    18.93 |    18.97 |   +0%  |  0.6628 |
 | TPC-H 03 ||   1547.1 |  1546.1 |   -0%  ||     0.65 |     0.65 |   +0%  |  0.9306 |
 | TPC-H 04 ||   1656.0 |  1700.7 |   +3%  ||     0.60 |     0.59 |   -3%  |  0.0000 |
 | TPC-H 05 ||   3314.4 |  3348.1 |   +1%  ||     0.30 |     0.30 |   -1%  |  0.1250 |
 | TPC-H 06 ||     34.1 |    34.6 |   +1%  ||    29.30 |    28.92 |   -1%  |  0.0012 |
 | TPC-H 07 ||    938.8 |   942.8 |   +0%  ||     1.07 |     1.06 |   -0%  |  0.0602 |
 | TPC-H 08 ||    652.8 |   653.4 |   +0%  ||     1.53 |     1.53 |   -0%  |  0.4905 |
 | TPC-H 09 ||   7352.1 |  7384.7 |   +0%  ||     0.14 |     0.14 |   -0%  |       ˅ |
 | TPC-H 10 ||   2884.8 |  2892.3 |   +0%  ||     0.35 |     0.35 |   -0%  |  0.5550 |
 | TPC-H 11 ||    131.6 |   130.8 |   -1%  ||     7.60 |     7.64 |   +1%  |  0.0336 |
 | TPC-H 12 ||    709.1 |   704.7 |   -1%  ||     1.41 |     1.42 |   +1%  |  0.0001 |
 | TPC-H 13 ||   5575.5 |  5436.9 |   -2%  ||     0.18 |     0.18 |   +3%  |  0.0005 |
 | TPC-H 14 ||    235.9 |   235.1 |   -0%  ||     4.24 |     4.25 |   +0%  |  0.2090 |
 | TPC-H 15 ||     99.7 |    99.4 |   -0%  ||    10.03 |    10.06 |   +0%  |  0.1761 |
 | TPC-H 16 ||   1195.1 |  1194.2 |   -0%  ||     0.84 |     0.84 |   +0%  |  0.9274 |
 | TPC-H 17 ||    275.8 |   269.0 |   -2%  ||     3.63 |     3.72 |   +3%  |  0.0000 |
 | TPC-H 18 ||  12027.5 | 12521.9 |   +4%  ||     0.08 |     0.08 |   -4%  |       ˅ |
 | TPC-H 19 ||    316.3 |   324.5 |   +3%  ||     3.16 |     3.08 |   -3%  |  0.0000 |
 | TPC-H 20 ||    178.6 |   182.7 |   +2%  ||     5.60 |     5.47 |   -2%  |  0.0000 |
 | TPC-H 21 ||   6970.5 |  6874.8 |   -1%  ||     0.14 |     0.15 |   +1%  |       ˅ |
+| TPC-H 22 ||    728.8 |   492.3 |  -32%  ||     1.37 |     2.03 |  +48%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  55939.1 | 55980.7 |   +0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_bf4765a4b6694757471885ad3efccd1e60e9e802_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-08 08:42:48                                                                                                                    | 2020-10-08 15:39:41                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2534.7 |  2514.3 |   -1%  ||    19.17 |    19.38 |   +1%  |  0.7198 |
 | TPC-H 02 ||     16.8 |    16.8 |   +0%  ||  2362.24 |  2358.72 |   -0%  |  0.4159 |
 | TPC-H 03 ||    498.6 |   495.4 |   -1%  ||    98.68 |    99.35 |   +1%  |  0.6938 |
 | TPC-H 04 ||    308.7 |   311.3 |   +1%  ||   158.23 |   157.24 |   -1%  |  0.5941 |
 | TPC-H 05 ||   1505.7 |  1492.9 |   -1%  ||    32.20 |    32.10 |   -0%  |  0.8005 |
 | TPC-H 06 ||     24.5 |    24.6 |   +0%  ||  1623.02 |  1622.93 |   -0%  |  0.0000 |
 | TPC-H 07 ||    283.9 |   282.8 |   -0%  ||   172.49 |   172.72 |   +0%  |  0.7587 |
 | TPC-H 08 ||    207.9 |   207.0 |   -0%  ||   234.06 |   235.01 |   +0%  |  0.6787 |
 | TPC-H 09 ||   2720.3 |  2801.8 |   +3%  ||    17.26 |    17.23 |   -0%  |  0.4045 |
 | TPC-H 10 ||    984.1 |   982.0 |   -0%  ||    50.13 |    50.13 |   -0%  |  0.8988 |
 | TPC-H 11 ||     76.5 |    76.5 |   +0%  ||   615.74 |   615.56 |   -0%  |  0.8695 |
 | TPC-H 12 ||    147.7 |   148.0 |   +0%  ||   326.98 |   326.33 |   -0%  |  0.8206 |
 | TPC-H 13 ||   2590.2 |  2548.1 |   -2%  ||    18.73 |    18.85 |   +1%  |  0.6170 |
 | TPC-H 14 ||    158.7 |   159.4 |   +0%  ||   305.04 |   303.73 |   -0%  |  0.4900 |
 | TPC-H 15 ||     59.4 |    59.2 |   -0%  ||   780.51 |   782.23 |   +0%  |  0.5276 |
 | TPC-H 16 ||    498.2 |   499.6 |   +0%  ||    98.67 |    98.73 |   +0%  |  0.7997 |
 | TPC-H 17 ||     58.7 |    58.2 |   -1%  ||   790.63 |   797.46 |   +1%  |  0.0724 |
 | TPC-H 18 ||   7060.3 |  7114.2 |   +1%  ||     6.72 |     6.65 |   -1%  |  0.8215 |
 | TPC-H 19 ||     93.2 |    92.8 |   -0%  ||   510.08 |   512.88 |   +1%  |  0.4472 |
 | TPC-H 20 ||     58.8 |    58.5 |   -1%  ||   786.35 |   791.21 |   +1%  |  0.2071 |
+| TPC-H 21 ||   2300.6 |  2204.4 |   -4%  ||    20.05 |    21.20 |   +6%  |  0.3627 |
+| TPC-H 22 ||    777.9 |   288.8 |  -63%  ||    62.99 |   169.41 | +169%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  22965.2 | 22436.6 |   -2%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |   +5%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_bf4765a4b6694757471885ad3efccd1e60e9e802_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                          | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-10-08 09:05:20                                                                                                                     | 2020-10-08 16:02:13                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     28.7 |    29.1 |   +1%  ||    34.80 |    34.32 |   -1%  |  0.0000 |
 | 03      ||      7.0 |     7.2 |   +2%  ||   141.93 |   138.73 |   -2%  |  0.0000 |
-| 06      ||     20.8 |    21.9 |   +5%  ||    48.10 |    45.61 |   -5%  |  0.0000 |
+| 07      ||     33.2 |    31.7 |   -4%  ||    30.16 |    31.53 |   +5%  |  0.0000 |
 | 09      ||    105.9 |   107.3 |   +1%  ||     9.45 |     9.32 |   -1%  |  0.0000 |
 | 10      ||     19.9 |    19.3 |   -3%  ||    50.19 |    51.89 |   +3%  |  0.0000 |
 | 13      ||    115.3 |   118.1 |   +2%  ||     8.67 |     8.47 |   -2%  |  0.0197 |
 | 15      ||     10.2 |    10.2 |   +0%  ||    98.17 |    97.81 |   -0%  |  0.0000 |
 | 17      ||     28.1 |    28.4 |   +1%  ||    35.61 |    35.26 |   -1%  |  0.1294 |
 | 19      ||     10.1 |    10.2 |   +1%  ||    98.91 |    98.25 |   -1%  |  0.0000 |
 | 25      ||     15.4 |    15.5 |   +1%  ||    65.00 |    64.59 |   -1%  |  0.3121 |
 | 26      ||     15.7 |    15.6 |   -0%  ||    63.60 |    63.90 |   +0%  |  0.0000 |
 | 28      ||    904.4 |   919.6 |   +2%  ||     1.11 |     1.09 |   -2%  |  0.0000 |
 | 29      ||     25.7 |    25.7 |   +0%  ||    38.94 |    38.83 |   -0%  |  0.6593 |
 | 31      ||    132.4 |   135.1 |   +2%  ||     7.55 |     7.40 |   -2%  |  0.0000 |
 | 34      ||     29.7 |    29.9 |   +0%  ||    33.64 |    33.48 |   -0%  |  0.0000 |
 | 35      ||     88.9 |    88.6 |   -0%  ||    11.25 |    11.29 |   +0%  |  0.0000 |
 | 39a     ||    176.9 |   180.6 |   +2%  ||     5.65 |     5.54 |   -2%  |  0.0000 |
 | 39b     ||    175.2 |   179.2 |   +2%  ||     5.71 |     5.58 |   -2%  |  0.0000 |
 | 41      ||     25.5 |    26.0 |   +2%  ||    39.26 |    38.42 |   -2%  |  0.0000 |
 | 42      ||      8.0 |     8.1 |   +1%  ||   124.38 |   123.62 |   -1%  |  0.0000 |
 | 43      ||    249.0 |   247.9 |   -0%  ||     4.02 |     4.03 |   +0%  |  0.0000 |
 | 45      ||      9.9 |     9.9 |   +1%  ||   101.38 |   100.51 |   -1%  |  0.0000 |
 | 48      ||     78.0 |    79.3 |   +2%  ||    12.81 |    12.61 |   -2%  |  0.0000 |
 | 50      ||     11.4 |    11.5 |   +1%  ||    87.89 |    87.30 |   -1%  |  0.0000 |
 | 52      ||      8.2 |     8.2 |   +1%  ||   122.29 |   121.67 |   -1%  |  0.0000 |
 | 55      ||      8.0 |     8.0 |   +0%  ||   125.32 |   124.71 |   -0%  |  0.0000 |
 | 62      ||     74.2 |    74.3 |   +0%  ||    13.48 |    13.46 |   -0%  |  0.0000 |
 | 65      ||     62.2 |    63.0 |   +1%  ||    16.07 |    15.87 |   -1%  |  0.0000 |
+| 69      ||     23.0 |    20.6 |  -10%  ||    43.39 |    48.45 |  +12%  |  0.0000 |
 | 73      ||     19.1 |    19.3 |   +1%  ||    52.22 |    51.89 |   -1%  |  0.0000 |
 | 79      ||     45.0 |    45.2 |   +0%  ||    22.23 |    22.13 |   -0%  |  0.0000 |
 | 81      ||     19.1 |    19.3 |   +1%  ||    52.47 |    51.79 |   -1%  |  0.0000 |
 | 83      ||      9.4 |     9.5 |   +1%  ||   106.36 |   105.03 |   -1%  |  0.0000 |
 | 85      ||     52.6 |    53.0 |   +1%  ||    18.99 |    18.88 |   -1%  |  0.7601 |
 | 88      ||    101.2 |   101.4 |   +0%  ||     9.88 |     9.87 |   -0%  |  0.4068 |
 | 91      ||     18.8 |    19.1 |   +2%  ||    53.21 |    52.24 |   -2%  |  0.0000 |
 | 93      ||    260.6 |   264.5 |   +2%  ||     3.84 |     3.78 |   -2%  |  0.0000 |
 | 96      ||      9.1 |     9.1 |   +1%  ||   110.11 |   109.42 |   -1%  |  0.0000 |
 | 97      ||    429.9 |   433.8 |   +1%  ||     2.33 |     2.31 |   -1%  |  0.2727 |
 | 99      ||    149.4 |   149.8 |   +0%  ||     6.70 |     6.67 |   -0%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3615.0 |  3654.2 |   +1%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_bf4765a4b6694757471885ad3efccd1e60e9e802_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                          | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-10-08 09:46:27                                                                                                                     | 2020-10-08 16:43:21                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    231.7 |   233.5 |   +1%  ||   210.75 |   209.07 |   -1%  |  0.3011 |
 | 03      ||     30.1 |    31.4 |   +4%  ||  1467.41 |  1413.71 |   -4%  |  0.0000 |
 | 06      ||    155.9 |   156.6 |   +0%  ||   310.36 |   308.67 |   -1%  |  0.6402 |
 | 07      ||    204.1 |   204.1 |   +0%  ||   238.80 |   238.29 |   -0%  |  0.9821 |
 | 09      ||    574.9 |   555.4 |   -3%  ||    84.46 |    87.87 |   +4%  |  0.2402 |
+| 10      ||     93.1 |    83.1 |  -11%  ||   511.92 |   572.33 |  +12%  |  0.0000 |
 | 13      ||    424.3 |   428.3 |   +1%  ||   115.81 |   114.86 |   -1%  |  0.5028 |
 | 15      ||     77.0 |    77.2 |   +0%  ||   611.07 |   609.28 |   -0%  |  0.6936 |
 | 17      ||    147.1 |   147.7 |   +0%  ||   328.39 |   327.05 |   -0%  |  0.6495 |
+| 19      ||     51.8 |    49.0 |   -6%  ||   887.67 |   935.08 |   +5%  |  0.0000 |
 | 25      ||     80.3 |    80.7 |   +1%  ||   590.35 |   587.38 |   -1%  |  0.4515 |
 | 26      ||    115.7 |   116.2 |   +0%  ||   414.74 |   413.30 |   -0%  |  0.5723 |
 | 28      ||   3416.8 |  3347.6 |   -2%  ||    13.85 |    13.91 |   +0%  |  0.7029 |
 | 29      ||    144.5 |   144.4 |   -0%  ||   333.90 |   334.32 |   +0%  |  0.9296 |
 | 31      ||    884.5 |   895.8 |   +1%  ||    55.22 |    54.41 |   -1%  |  0.6980 |
 | 34      ||    158.2 |   158.6 |   +0%  ||   305.78 |   304.57 |   -0%  |  0.7351 |
+| 35      ||    918.8 |   834.5 |   -9%  ||    53.52 |    58.40 |   +9%  |  0.0000 |
 | 39a     ||   1875.8 |  1860.3 |   -1%  ||    25.95 |    26.10 |   +1%  |  0.7761 |
 | 39b     ||   1873.9 |  1899.1 |   +1%  ||    26.03 |    25.52 |   -2%  |  0.6597 |
-| 41      ||   1393.2 |  1446.6 |   +4%  ||    32.33 |    30.82 |   -5%  |  0.6165 |
+| 42      ||     41.6 |    39.1 |   -6%  ||  1085.59 |  1146.06 |   +6%  |  0.0000 |
 | 43      ||    809.9 |   821.6 |   +1%  ||    60.91 |    59.90 |   -2%  |  0.3135 |
 | 45      ||     57.5 |    57.9 |   +1%  ||   800.86 |   795.30 |   -1%  |  0.1556 |
 | 48      ||    395.1 |   394.4 |   -0%  ||   124.03 |   124.12 |   +0%  |  0.9178 |
 | 50      ||    131.6 |   131.1 |   -0%  ||   365.49 |   366.22 |   +0%  |  0.6759 |
+| 52      ||     42.4 |    39.9 |   -6%  ||  1068.83 |  1126.00 |   +5%  |  0.0000 |
 | 55      ||     38.9 |    37.2 |   -4%  ||  1153.42 |  1199.03 |   +4%  |  0.0000 |
 | 62      ||    339.0 |   340.4 |   +0%  ||   144.94 |   144.15 |   -1%  |  0.6634 |
 | 65      ||    600.6 |   601.7 |   +0%  ||    81.96 |    81.96 |   -0%  |  0.8761 |
+| 69      ||    147.3 |    81.6 |  -45%  ||   327.53 |   577.92 |  +76%  |  0.0000 |
 | 73      ||    113.2 |   114.0 |   +1%  ||   422.50 |   419.70 |   -1%  |  0.3037 |
 | 79      ||    224.7 |   224.5 |   -0%  ||   217.03 |   217.27 |   +0%  |  0.9386 |
 | 81      ||    162.6 |   162.6 |   +0%  ||   297.94 |   297.87 |   -0%  |  0.9945 |
 | 83      ||     78.0 |    78.5 |   +1%  ||   603.59 |   600.03 |   -1%  |  0.3026 |
 | 85      ||    240.3 |   237.7 |   -1%  ||   203.49 |   205.69 |   +1%  |  0.3890 |
 | 88      ||    427.6 |   432.2 |   +1%  ||   113.32 |   113.26 |   -0%  |  0.6776 |
 | 91      ||     83.1 |    83.6 |   +1%  ||   571.11 |   567.25 |   -1%  |  0.1866 |
 | 93      ||   1508.1 |  1509.7 |   +0%  ||    32.10 |    32.05 |   -0%  |  0.9721 |
 | 96      ||     40.9 |    39.9 |   -3%  ||  1108.33 |  1134.64 |   +2%  |  0.0000 |
 | 97      ||   4042.9 |  4048.6 |   +0%  ||    11.72 |    11.73 |   +0%  |  0.9667 |
 | 99      ||    856.4 |   853.6 |   -0%  ||    57.65 |    57.47 |   -0%  |  0.8350 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  23233.6 | 23080.0 |   -1%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +2%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_bf4765a4b6694757471885ad3efccd1e60e9e802_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-10-08 10:27:46                                                                                                                    | 2020-10-08 17:24:41                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     28.2 |    28.5 |   +1%  ||     3.40 |     3.38 |   -1%  | (run time too short) |
 | New-Order    ||     18.0 |    18.1 |   +0%  ||    38.25 |    38.22 |   -0%  | (run time too short) |
 | Order-Status ||      1.2 |     1.2 |   +1%  ||     3.40 |     3.40 |   -0%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   -0%  ||    36.55 |    36.53 |   -0%  | (run time too short) |
 | Stock-Level  ||     34.6 |    34.0 |   -2%  ||     3.40 |     3.40 |   -0%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     84.5 |    84.3 |   -0%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -0%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_bf4765a4b6694757471885ad3efccd1e60e9e802_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                         | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-08 10:28:50                                                                                                                    | 2020-10-08 17:25:45                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    205.6 |   198.6 |   -3%  ||     4.69 |     4.83 |   +3%  | (run time too short) |
 |    unsucc.:  ||      3.9 |     3.8 |   -3%  ||   106.61 |   107.05 |   +0%  |                      |
 | New-Order    ||     89.0 |    89.0 |   +0%  ||    94.51 |    93.60 |   -1%  |               0.9948 |
 |    unsucc.:  ||      5.1 |     5.1 |   +1%  ||  1157.26 |  1165.05 |   +1%  |                      |
 | Order-Status ||      7.1 |     7.1 |   +1%  ||   111.29 |   111.89 |   +1%  | (run time too short) |
 | Payment      ||     13.1 |    13.6 |   +3%  ||     8.64 |     8.62 |   -0%  | (run time too short) |
 |    unsucc.:  ||      4.2 |     4.3 |   +1%  ||  1187.65 |  1194.23 |   +1%  |                      |
 | Stock-Level  ||     66.8 |    64.6 |   -3%  ||   111.17 |   111.77 |   +1%  |               0.0000 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    381.6 |   372.9 |   -2%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +1%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_bf4765a4b6694757471885ad3efccd1e60e9e802_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                              | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-10-08 10:29:56                                                                                                                         | 2020-10-08 17:26:51                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    359.9 |    355.6 |   -1%  ||     2.78 |     2.81 |   +1%  |  0.0000 |
 | 10b     ||    353.2 |    349.2 |   -1%  ||     2.83 |     2.86 |   +1%  |  0.0000 |
 | 10c     ||   1165.1 |   1149.8 |   -1%  ||     0.86 |     0.87 |   +1%  |  0.0051 |
 | 11a     ||    151.6 |    149.7 |   -1%  ||     6.59 |     6.68 |   +1%  |  0.1892 |
 | 11b     ||    142.1 |    140.3 |   -1%  ||     7.04 |     7.13 |   +1%  |  0.2241 |
 | 11c     ||    518.2 |    515.5 |   -1%  ||     1.93 |     1.94 |   +1%  |  0.6040 |
 | 11d     ||   4670.1 |   4781.3 |   +2%  ||     0.21 |     0.21 |   -2%  |  0.2128 |
 | 12a     ||    366.4 |    366.3 |   -0%  ||     2.73 |     2.73 |   +0%  |  0.9776 |
 | 12b     ||    629.9 |    624.3 |   -1%  ||     1.59 |     1.60 |   +1%  |  0.3471 |
 | 12c     ||   3730.7 |   3701.1 |   -1%  ||     0.27 |     0.27 |   +1%  |  0.3837 |
 | 13a     ||    178.9 |    179.9 |   +1%  ||     5.59 |     5.56 |   -1%  |  0.0712 |
 | 13b     ||    252.7 |    247.5 |   -2%  ||     3.96 |     4.04 |   +2%  |  0.0000 |
 | 13c     ||    142.1 |    136.2 |   -4%  ||     7.04 |     7.34 |   +4%  |  0.0000 |
 | 13d     ||    179.0 |    179.2 |   +0%  ||     5.59 |     5.58 |   -0%  |  0.2385 |
 | 14a     ||   4098.2 |   4061.1 |   -1%  ||     0.24 |     0.25 |   +1%  |  0.3220 |
 | 14b     ||   4721.2 |   4676.3 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.3086 |
 | 14c     ||   4097.6 |   4066.7 |   -1%  ||     0.24 |     0.25 |   +1%  |  0.4014 |
 | 15a     ||    212.1 |    214.3 |   +1%  ||     4.72 |     4.67 |   -1%  |  0.0995 |
 | 15b     ||    207.7 |    211.6 |   +2%  ||     4.81 |     4.73 |   -2%  |  0.0001 |
 | 15c     ||    152.3 |    150.5 |   -1%  ||     6.57 |     6.65 |   +1%  |  0.0015 |
 | 15d     ||    458.2 |    462.6 |   +1%  ||     2.18 |     2.16 |   -1%  |  0.0211 |
 | 16a     ||   4661.0 |   4871.8 |   +5%  ||     0.21 |     0.21 |   -4%  |  0.0129 |
 | 16b     ||   6137.4 |   6365.4 |   +4%  ||     0.16 |     0.16 |   -4%  |  0.0035 |
 | 16c     ||   4792.1 |   5014.5 |   +5%  ||     0.21 |     0.20 |   -4%  |  0.0042 |
 | 16d     ||   4793.6 |   4981.8 |   +4%  ||     0.21 |     0.20 |   -4%  |  0.0088 |
 | 17a     ||    970.2 |    968.2 |   -0%  ||     1.03 |     1.03 |   +0%  |  0.7199 |
 | 17b     ||    769.6 |    761.6 |   -1%  ||     1.30 |     1.31 |   +1%  |  0.0631 |
 | 17c     ||    724.9 |    718.4 |   -1%  ||     1.38 |     1.39 |   +1%  |  0.1047 |
 | 17d     ||    837.3 |    829.6 |   -1%  ||     1.19 |     1.21 |   +1%  |  0.0950 |
 | 17e     ||   2924.9 |   2891.7 |   -1%  ||     0.34 |     0.35 |   +1%  |  0.0827 |
 | 17f     ||   1551.8 |   1538.6 |   -1%  ||     0.64 |     0.65 |   +1%  |  0.2666 |
+| 18a     ||    679.7 |    611.0 |  -10%  ||     1.47 |     1.64 |  +11%  |  0.0000 |
 | 18b     ||    231.2 |    228.7 |   -1%  ||     4.32 |     4.37 |   +1%  |  0.0306 |
 | 18c     ||   3787.8 |   3748.7 |   -1%  ||     0.26 |     0.27 |   +1%  |  0.0617 |
 | 19a     ||   7703.9 |   7638.6 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | 19b     ||   4596.5 |   4532.7 |   -1%  ||     0.22 |     0.22 |   +1%  |  0.0001 |
 | 19c     ||   7507.7 |   7423.7 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | 19d     ||   5658.2 |   5643.1 |   -0%  ||     0.18 |     0.18 |   +0%  |  0.7574 |
 | 1a      ||     58.2 |     57.2 |   -2%  ||    17.19 |    17.48 |   +2%  |  0.0000 |
 | 1b      ||     22.2 |     22.0 |   -1%  ||    45.03 |    45.43 |   +1%  |  0.0000 |
 | 1c      ||     22.1 |     22.0 |   -0%  ||    45.26 |    45.41 |   +0%  |  0.0000 |
 | 1d      ||     21.9 |     21.8 |   -0%  ||    45.74 |    45.83 |   +0%  |  0.0000 |
 | 20a     ||   1278.5 |   1253.4 |   -2%  ||     0.78 |     0.80 |   +2%  |  0.0000 |
 | 20b     ||   1092.8 |   1080.0 |   -1%  ||     0.92 |     0.93 |   +1%  |  0.0000 |
 | 20c     ||   1107.5 |   1100.7 |   -1%  ||     0.90 |     0.91 |   +1%  |  0.0008 |
 | 21a     ||   3853.3 |   3821.1 |   -1%  ||     0.26 |     0.26 |   +1%  |  0.0092 |
 | 21b     ||    258.6 |    256.8 |   -1%  ||     3.87 |     3.89 |   +1%  |  0.0088 |
 | 21c     ||   3981.2 |   3951.1 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.0169 |
 | 22a     ||   3496.9 |   3467.7 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.3120 |
 | 22b     ||   3493.1 |   3467.4 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.3796 |
 | 22c     ||   4123.5 |   4089.3 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.2580 |
 | 22d     ||   4139.3 |   4109.3 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.3133 |
 | 23a     ||    154.4 |    153.2 |   -1%  ||     6.48 |     6.53 |   +1%  |  0.0615 |
 | 23b     ||    121.1 |    121.5 |   +0%  ||     8.26 |     8.23 |   -0%  |  0.3451 |
 | 23c     ||    174.1 |    172.2 |   -1%  ||     5.74 |     5.81 |   +1%  |  0.0094 |
 | 24a     ||   4676.5 |   4593.7 |   -2%  ||     0.21 |     0.22 |   +2%  |  0.0106 |
 | 24b     ||   4611.2 |   4554.7 |   -1%  ||     0.22 |     0.22 |   +1%  |  0.4027 |
 | 25a     ||    234.5 |    232.7 |   -1%  ||     4.26 |     4.30 |   +1%  |  0.0740 |
 | 25b     ||    249.5 |    248.9 |   -0%  ||     4.01 |     4.02 |   +0%  |  0.4780 |
 | 25c     ||   3792.3 |   3762.1 |   -1%  ||     0.26 |     0.27 |   +1%  |  0.1156 |
 | 26a     ||    977.7 |    979.1 |   +0%  ||     1.02 |     1.02 |   -0%  |  0.7134 |
 | 26b     ||    966.7 |    966.1 |   -0%  ||     1.03 |     1.04 |   +0%  |  0.9248 |
 | 26c     ||    974.2 |    977.6 |   +0%  ||     1.03 |     1.02 |   -0%  |  0.4859 |
 | 27a     ||   3467.6 |   3474.1 |   +0%  ||     0.29 |     0.29 |   -0%  |  0.7211 |
 | 27b     ||   3434.9 |   3440.8 |   +0%  ||     0.29 |     0.29 |   -0%  |  0.7455 |
 | 27c     ||    199.1 |    201.5 |   +1%  ||     5.02 |     4.96 |   -1%  |  0.1305 |
 | 28a     ||   4132.9 |   4131.2 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.9856 |
 | 28b     ||   3371.0 |   3376.8 |   +0%  ||     0.30 |     0.30 |   -0%  |  0.9498 |
 | 28c     ||   4132.4 |   4128.4 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.9647 |
 | 29a     ||   4532.6 |   4491.9 |   -1%  ||     0.22 |     0.22 |   +1%  |  0.7738 |
 | 29b     ||    200.1 |    201.5 |   +1%  ||     5.00 |     4.96 |   -1%  |  0.8935 |
 | 29c     ||   4658.1 |   4583.7 |   -2%  ||     0.21 |     0.22 |   +2%  |  0.6253 |
 | 2a      ||    109.1 |    109.7 |   +1%  ||     9.17 |     9.11 |   -1%  |  0.0000 |
 | 2b      ||     85.5 |     86.2 |   +1%  ||    11.70 |    11.60 |   -1%  |  0.0000 |
 | 2c      ||     56.4 |     58.9 |   +4%  ||    17.72 |    16.97 |   -4%  |  0.0000 |
 | 2d      ||    134.8 |    140.9 |   +5%  ||     7.42 |     7.10 |   -4%  |  0.0000 |
 | 30a     ||    248.3 |    255.5 |   +3%  ||     4.03 |     3.91 |   -3%  |  0.1263 |
 | 30b     ||   1101.0 |   1090.6 |   -1%  ||     0.91 |     0.92 |   +1%  |  0.6268 |
 | 30c     ||   3792.6 |   3861.4 |   +2%  ||     0.26 |     0.26 |   -2%  |  0.3928 |
 | 31a     ||    286.0 |    294.9 |   +3%  ||     3.50 |     3.39 |   -3%  |  0.0023 |
 | 31b     ||   1130.3 |   1127.0 |   -0%  ||     0.88 |     0.89 |   +0%  |  0.7955 |
 | 31c     ||    289.3 |    298.4 |   +3%  ||     3.46 |     3.35 |   -3%  |  0.0022 |
-| 32a     ||     36.5 |     40.9 |  +12%  ||    27.39 |    24.44 |  -11%  |  0.0000 |
 | 32b     ||    285.5 |    287.1 |   +1%  ||     3.50 |     3.48 |   -1%  |  0.0000 |
 | 33a     ||     69.3 |     69.7 |   +1%  ||    14.44 |    14.35 |   -1%  |  0.3837 |
 | 33b     ||     68.3 |     69.2 |   +1%  ||    14.63 |    14.44 |   -1%  |  0.0456 |
 | 33c     ||     84.3 |     85.6 |   +2%  ||    11.86 |    11.68 |   -2%  |  0.0218 |
 | 3a      ||   3943.8 |   3961.1 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.0000 |
 | 3b      ||     35.7 |     35.9 |   +0%  ||    28.00 |    27.87 |   -0%  |  0.0000 |
 | 3c      ||   5066.5 |   5094.1 |   +1%  ||     0.20 |     0.20 |   -1%  |  0.0217 |
 | 4a      ||    127.0 |    128.4 |   +1%  ||     7.87 |     7.79 |   -1%  |  0.0000 |
 | 4b      ||     26.8 |     26.9 |   +1%  ||    37.35 |    37.16 |   -1%  |  0.0000 |
 | 4c      ||    144.2 |    144.7 |   +0%  ||     6.93 |     6.91 |   -0%  |  0.0072 |
 | 5a      ||   3773.6 |   3813.7 |   +1%  ||     0.26 |     0.26 |   -1%  |  0.0000 |
 | 5b      ||    272.6 |    283.4 |   +4%  ||     3.67 |     3.53 |   -4%  |  0.0000 |
 | 5c      ||   4402.6 |   4491.2 |   +2%  ||     0.23 |     0.22 |   -2%  |  0.0000 |
 | 6a      ||    225.7 |    233.0 |   +3%  ||     4.43 |     4.29 |   -3%  |  0.0000 |
 | 6b      ||    951.4 |    968.2 |   +2%  ||     1.05 |     1.03 |   -2%  |  0.0000 |
 | 6c      ||    225.7 |    233.4 |   +3%  ||     4.43 |     4.28 |   -3%  |  0.0000 |
 | 6d      ||    950.0 |    966.4 |   +2%  ||     1.05 |     1.03 |   -2%  |  0.0000 |
 | 6e      ||    225.5 |    233.2 |   +3%  ||     4.44 |     4.29 |   -3%  |  0.0000 |
 | 6f      ||   1481.8 |   1517.6 |   +2%  ||     0.67 |     0.66 |   -2%  |  0.0000 |
 | 7a      ||    261.4 |    271.0 |   +4%  ||     3.82 |     3.69 |   -4%  |  0.0016 |
 | 7b      ||    136.2 |    141.4 |   +4%  ||     7.34 |     7.07 |   -4%  |  0.0007 |
 | 7c      ||  10766.5 |  11109.6 |   +3%  ||     0.09 |     0.09 |   -3%  |       ˅ |
-| 8a      ||    111.3 |    119.6 |   +7%  ||     8.99 |     8.36 |   -7%  |  0.0000 |
-| 8b      ||    163.9 |    174.6 |   +7%  ||     6.10 |     5.73 |   -6%  |  0.0000 |
 | 8c      ||   4382.3 |   4472.8 |   +2%  ||     0.23 |     0.22 |   -2%  |  0.0039 |
 | 8d      ||   1539.6 |   1570.5 |   +2%  ||     0.65 |     0.64 |   -2%  |  0.0000 |
 | 9a      ||   3475.6 |   3534.7 |   +2%  ||     0.29 |     0.28 |   -2%  |  0.0025 |
 | 9b      ||    325.3 |    336.3 |   +3%  ||     3.07 |     2.97 |   -3%  |  0.0000 |
 | 9c      ||   3513.2 |   3672.5 |   +5%  ||     0.28 |     0.27 |   -4%  |  0.0000 |
 | 9d      ||   4089.7 |   4280.9 |   +5%  ||     0.24 |     0.23 |   -4%  |  0.0000 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 215520.0 | 216690.1 |   +1%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_bf4765a4b6694757471885ad3efccd1e60e9e802_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 792e6f29a93aa55cc6f22ecf05c5061d7e3d64d0-dirty                                                                                              | bf4765a4b6694757471885ad3efccd1e60e9e802-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-10-08 12:25:48                                                                                                                         | 2020-10-08 19:23:06                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)     | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |       new |        ||      old |      new |        |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | 10a     ||    2350.3 |    2327.9 |   -1%  ||    20.18 |    20.48 |   +1%  |  0.8274 |
+| 10b     ||    1650.0 |    1561.6 |   -5%  ||    29.11 |    30.78 |   +6%  |  0.1254 |
 | 10c     ||    9033.7 |    9789.1 |   +8%  ||     4.32 |     4.25 |   -2%  |  0.2818 |
 | 11a     ||     482.0 |     479.7 |   -0%  ||   101.73 |   101.63 |   -0%  |  0.8219 |
 | 11b     ||     443.4 |     441.8 |   -0%  ||   110.81 |   110.49 |   -0%  |  0.8750 |
 | 11c     ||    2700.0 |    2575.1 |   -5%  ||    18.02 |    18.23 |   +1%  |  0.2476 |
+| 11d     ||   25514.6 |   24684.2 |   -3%  ||     1.37 |     1.43 |   +5%  |  0.5923 |
 | 12a     ||    3653.7 |    3520.9 |   -4%  ||    12.70 |    12.60 |   -1%  |  0.5220 |
 | 12b     ||    1497.6 |    1456.8 |   -3%  ||    32.30 |    32.05 |   -1%  |  0.4578 |
 | 12c     ||   19267.2 |   21620.7 |  +12%  ||     1.58 |     1.55 |   -2%  |  0.1979 |
 | 13a     ||    1201.6 |    1202.7 |   +0%  ||    40.31 |    39.97 |   -1%  |  0.9822 |
+| 13b     ||    1491.3 |    1319.5 |  -12%  ||    32.33 |    36.48 |  +13%  |  0.0009 |
+| 13c     ||    1479.7 |    1316.0 |  -11%  ||    32.46 |    36.60 |  +13%  |  0.0025 |
 | 13d     ||    1205.6 |    1214.5 |   +1%  ||    40.36 |    40.13 |   -1%  |  0.8354 |
 | 14a     ||   19535.2 |   19971.2 |   +2%  ||     1.78 |     1.78 |   +0%  |  0.7903 |
 | 14b     ||   18520.8 |   20853.4 |  +13%  ||     1.65 |     1.68 |   +2%  |  0.1683 |
 | 14c     ||   20205.5 |   17782.7 |  -12%  ||     1.78 |     1.73 |   -3%  |  0.1241 |
 | 15a     ||    1158.8 |    1147.9 |   -1%  ||    41.75 |    41.71 |   -0%  |  0.7788 |
 | 15b     ||    1140.4 |    1138.5 |   -0%  ||    42.58 |    42.68 |   +0%  |  0.9599 |
 | 15c     ||     433.0 |     427.7 |   -1%  ||   113.27 |   114.23 |   +1%  |  0.5307 |
 | 15d     ||    2711.6 |    2693.2 |   -1%  ||    17.67 |    17.70 |   +0%  |  0.8652 |
-| 16a     ||   30311.2 |   30052.4 |   -1%  ||     0.95 |     0.90 |   -5%  |  0.8992 |
-| 16b     ||   33508.1 |   37543.2 |  +12%  ||     0.73 |     0.68 |   -7%  |  0.0773 |
-| 16c     ||   33589.9 |   32901.0 |   -2%  ||     0.93 |     0.85 |   -9%  |  0.7782 |
 | 16d     ||   34305.9 |   28583.3 |  -17%  ||     0.92 |     0.93 |   +2%  |  0.0112 |
 | 17a     ||    8593.8 |    8094.1 |   -6%  ||     5.08 |     4.88 |   -4%  |  0.3838 |
 | 17b     ||    7931.9 |    7174.4 |  -10%  ||     5.27 |     5.30 |   +1%  |  0.1510 |
 | 17c     ||    8320.8 |    7661.6 |   -8%  ||     5.22 |     4.98 |   -4%  |  0.1995 |
 | 17d     ||    7997.7 |    8122.9 |   +2%  ||     5.03 |     5.23 |   +4%  |  0.8264 |
 | 17e     ||   13682.7 |   13176.8 |   -4%  ||     2.92 |     2.92 |   +0%  |  0.6095 |
 | 17f     ||    8229.6 |   10189.6 |  +24%  ||     4.20 |     4.15 |   -1%  |  0.0012 |
+| 18a     ||    4538.4 |    3692.6 |  -19%  ||     9.47 |    12.27 |  +30%  |  0.0001 |
 | 18b     ||    2385.7 |    2443.3 |   +2%  ||    19.77 |    19.15 |   -3%  |  0.6376 |
 | 18c     ||   19960.2 |   17781.5 |  -11%  ||     1.88 |     1.88 |   +0%  |  0.1549 |
-| 19a     ||   29091.0 |   36897.0 |  +27%  ||     0.88 |     0.72 |  -19%  |  0.0111 |
 | 19b     ||   12058.7 |   11931.1 |   -1%  ||     3.12 |     3.18 |   +2%  |  0.8967 |
 | 19c     ||   37376.4 |   36956.5 |   -1%  ||     0.72 |     0.72 |   -0%  |  0.8774 |
+| 19d     ||   40992.3 |   41568.3 |   +1%  ||     0.58 |     0.62 |   +6%  |  0.7111 |
 | 1a      ||     357.0 |     355.1 |   -1%  ||   137.52 |   138.13 |   +0%  |  0.7477 |
 | 1b      ||      73.9 |      75.0 |   +1%  ||   632.91 |   624.76 |   -1%  |  0.0702 |
 | 1c      ||      75.1 |      78.1 |   +4%  ||   625.32 |   602.83 |   -4%  |  0.0000 |
 | 1d      ||      73.7 |      74.5 |   +1%  ||   634.66 |   628.88 |   -1%  |  0.1641 |
+| 20a     ||    5655.1 |    5358.3 |   -5%  ||     7.82 |     8.22 |   +5%  |  0.3980 |
 | 20b     ||    4203.3 |    4406.9 |   +5%  ||    10.50 |    10.32 |   -2%  |  0.3680 |
 | 20c     ||    4155.6 |    4232.5 |   +2%  ||    10.85 |    10.50 |   -3%  |  0.7322 |
 | 21a     ||   18499.2 |   17231.9 |   -7%  ||     2.02 |     1.95 |   -3%  |  0.4021 |
 | 21b     ||    1083.6 |    1104.6 |   +2%  ||    44.51 |    43.70 |   -2%  |  0.5817 |
-| 21c     ||   17932.9 |   19037.6 |   +6%  ||     2.03 |     1.87 |   -8%  |  0.4825 |
 | 22a     ||   17583.0 |   20281.9 |  +15%  ||     1.88 |     1.82 |   -4%  |  0.0705 |
 | 22b     ||   18040.6 |   19086.6 |   +6%  ||     1.87 |     1.80 |   -4%  |  0.4933 |
 | 22c     ||   20486.2 |   19407.9 |   -5%  ||     1.80 |     1.75 |   -3%  |  0.4984 |
-| 22d     ||   21739.2 |   20991.4 |   -3%  ||     1.78 |     1.67 |   -7%  |  0.6619 |
 | 23a     ||     468.0 |     467.7 |   -0%  ||   104.95 |   105.04 |   +0%  |  0.9819 |
 | 23b     ||    1002.2 |    1032.6 |   +3%  ||    48.55 |    47.09 |   -3%  |  0.3388 |
 | 23c     ||     556.4 |     559.4 |   +1%  ||    88.31 |    87.64 |   -1%  |  0.8176 |
 | 24a     ||   12015.1 |   12051.2 |   +0%  ||     3.23 |     3.30 |   +2%  |  0.9744 |
 | 24b     ||   11085.8 |   11286.1 |   +2%  ||     3.25 |     3.37 |   +4%  |  0.8219 |
+| 25a     ||    2512.6 |    2371.7 |   -6%  ||    19.08 |    20.00 |   +5%  |  0.2022 |
+| 25b     ||    3017.9 |    2867.7 |   -5%  ||    15.53 |    16.40 |   +6%  |  0.3606 |
 | 25c     ||   16604.2 |   20377.9 |  +23%  ||     1.78 |     1.75 |   -2%  |  0.0191 |
 | 26a     ||    3173.9 |    3276.5 |   +3%  ||    15.12 |    14.58 |   -4%  |  0.5298 |
 | 26b     ||    3089.9 |    3198.9 |   +4%  ||    15.15 |    14.78 |   -2%  |  0.5163 |
-| 26c     ||    2953.0 |    3056.1 |   +3%  ||    15.05 |    14.31 |   -5%  |  0.4844 |
 | 27a     ||   15891.6 |   18339.7 |  +15%  ||     1.90 |     1.88 |   -1%  |  0.1073 |
 | 27b     ||   18916.0 |   18763.7 |   -1%  ||     1.95 |     1.97 |   +1%  |  0.9139 |
 | 27c     ||     946.6 |     958.6 |   +1%  ||    51.79 |    51.22 |   -1%  |  0.6919 |
 | 28a     ||   20300.2 |   19941.5 |   -2%  ||     1.67 |     1.68 |   +1%  |  0.8231 |
 | 28b     ||   17392.0 |   17692.1 |   +2%  ||     2.03 |     1.95 |   -4%  |  0.8362 |
 | 28c     ||   20157.0 |   19063.8 |   -5%  ||     1.68 |     1.72 |   +2%  |  0.5149 |
 | 29a     ||   11460.5 |   11827.4 |   +3%  ||     3.18 |     3.22 |   +1%  |  0.7068 |
 | 29b     ||    2630.8 |    2571.2 |   -2%  ||    18.30 |    18.36 |   +0%  |  0.6608 |
 | 29c     ||   11669.0 |   10711.1 |   -8%  ||     3.03 |     3.15 |   +4%  |  0.3181 |
 | 2a      ||     657.0 |     663.7 |   +1%  ||    74.86 |    73.91 |   -1%  |  0.6807 |
 | 2b      ||     663.2 |     660.6 |   -0%  ||    74.09 |    73.81 |   -0%  |  0.8702 |
 | 2c      ||     557.2 |     563.7 |   +1%  ||    88.08 |    87.25 |   -1%  |  0.6047 |
 | 2d      ||     753.2 |     769.1 |   +2%  ||    64.56 |    63.83 |   -1%  |  0.4158 |
+| 30a     ||    2702.7 |    2621.0 |   -3%  ||    17.00 |    17.81 |   +5%  |  0.5673 |
 | 30b     ||    3088.6 |    2871.8 |   -7%  ||    15.05 |    14.98 |   -0%  |  0.1922 |
 | 30c     ||   21625.2 |   22111.3 |   +2%  ||     1.72 |     1.72 |   +0%  |  0.7838 |
 | 31a     ||    3412.6 |    3098.8 |   -9%  ||    13.75 |    14.30 |   +4%  |  0.0671 |
 | 31b     ||    3393.1 |    3476.5 |   +2%  ||    13.41 |    13.48 |   +1%  |  0.6910 |
 | 31c     ||    2875.8 |    2945.4 |   +2%  ||    15.85 |    16.03 |   +1%  |  0.6672 |
 | 32a     ||     163.5 |     159.5 |   -2%  ||   295.93 |   301.88 |   +2%  |  0.0346 |
 | 32b     ||    1276.6 |    1284.0 |   +1%  ||    38.53 |    38.28 |   -1%  |  0.8198 |
 | 33a     ||     296.0 |     305.1 |   +3%  ||   164.96 |   159.93 |   -3%  |  0.0515 |
 | 33b     ||     291.9 |     301.9 |   +3%  ||   167.44 |   161.98 |   -3%  |  0.0445 |
 | 33c     ||     393.7 |     402.9 |   +2%  ||   124.63 |   121.72 |   -2%  |  0.1944 |
 | 3a      ||   18945.2 |   20638.8 |   +9%  ||     1.70 |     1.63 |   -4%  |  0.3512 |
-| 3b      ||     343.3 |     359.8 |   +5%  ||   142.78 |   136.16 |   -5%  |  0.0027 |
 | 3c      ||   32181.0 |   31068.7 |   -3%  ||     0.85 |     0.82 |   -4%  |  0.6980 |
 | 4a      ||    1096.9 |    1090.3 |   -1%  ||    44.58 |    44.17 |   -1%  |  0.8461 |
 | 4b      ||     107.0 |     110.3 |   +3%  ||   446.80 |   433.98 |   -3%  |  0.0013 |
 | 4c      ||    1325.7 |    1327.5 |   +0%  ||    36.66 |    36.33 |   -1%  |  0.9705 |
 | 5a      ||   17912.8 |   17508.4 |   -2%  ||     1.93 |     1.93 |   -0%  |  0.7676 |
 | 5b      ||    1628.8 |    1643.8 |   +1%  ||    29.91 |    29.41 |   -2%  |  0.8432 |
 | 5c      ||   22015.9 |   22516.2 |   +2%  ||     1.58 |     1.52 |   -4%  |  0.7859 |
+| 6a      ||    2360.5 |    1683.5 |  -29%  ||    20.23 |    27.35 |  +35%  |  0.0000 |
+| 6b      ||    6741.0 |    6769.9 |   +0%  ||     5.58 |     6.30 |  +13%  |  0.9491 |
+| 6c      ||    2455.1 |    1764.1 |  -28%  ||    19.30 |    27.31 |  +42%  |  0.0000 |
+| 6d      ||    7978.0 |    7259.2 |   -9%  ||     5.45 |     5.98 |  +10%  |  0.1531 |
+| 6e      ||    2244.6 |    2071.1 |   -8%  ||    21.13 |    23.18 |  +10%  |  0.0804 |
 | 6f      ||    7217.4 |    7185.4 |   -0%  ||     6.33 |     6.15 |   -3%  |  0.9450 |
 | 7a      ||    1584.7 |    1636.3 |   +3%  ||    30.28 |    29.46 |   -3%  |  0.4301 |
+| 7b      ||    1901.4 |    1751.5 |   -8%  ||    23.83 |    27.23 |  +14%  |  0.0958 |
+| 7c      ||   50167.5 |   43364.7 |  -14%  ||     0.12 |     0.13 |  +14%  |       ˅ |
 | 8a      ||    1524.3 |    1535.1 |   +1%  ||    31.68 |    31.10 |   -2%  |  0.8540 |
 | 8b      ||    1521.7 |    1511.2 |   -1%  ||    31.76 |    31.50 |   -1%  |  0.8582 |
 | 8c      ||   24332.3 |   25973.4 |   +7%  ||     1.20 |     1.20 |   -0%  |  0.4014 |
 | 8d      ||    9092.9 |   11077.1 |  +22%  ||     3.57 |     3.70 |   +4%  |  0.0042 |
-| 9a      ||   26618.5 |   26069.0 |   -2%  ||     1.27 |     1.18 |   -7%  |  0.7989 |
-| 9b      ||    3124.2 |    3437.7 |  +10%  ||    14.87 |    13.33 |  -10%  |  0.0756 |
 | 9c      ||   25808.4 |   25012.6 |   -3%  ||     1.20 |     1.17 |   -3%  |  0.7217 |
+| 9d      ||   25742.9 |   24539.1 |   -5%  ||     1.07 |     1.30 |  +22%  |  0.5087 |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Sum     || 1112473.6 | 1115572.1 |   +0%  ||          |          |        |         |
 | Geomean ||           |           |        ||          |          |   +1%  |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                    |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
```
</details>