### PR TITLE
Add support for complex join conditions

### DIFF
--- a/src/lib/optimizer/join_ordering/join_graph_builder.hpp
+++ b/src/lib/optimizer/join_ordering/join_graph_builder.hpp
@@ -83,7 +83,7 @@ class JoinGraphBuilder final {
    * Lookup which vertices an expression references
    */
   static JoinGraphVertexSet _get_vertex_set_accessed_by_expression(
-      const AbstractExpression& expression, const std::vector<std::shared_ptr<AbstractLQPNode>>& vertices);
+      const std::shared_ptr<AbstractExpression>& expression, const std::vector<std::shared_ptr<AbstractLQPNode>>& vertices);
 
   std::vector<std::shared_ptr<AbstractLQPNode>> _vertices;
   std::vector<std::shared_ptr<AbstractExpression>> _predicates;


### PR DESCRIPTION
Enables the JoinOrderingRule to detect join conditions such as `t1.a + t2.b = t3.c`. Up to now, these were executed as a cross join with a following ColumnVsColumnTableScan.

TODOs:
- [ ] Check if this adds projections anywhere where they shouldn't be. It's probably easiest to add a debug print at `lqp_insert_node(vertex, LQPInputSide::Left, projection_node);`, run our benchmarks, and check which of those are affected.
- [ ] Check if vertex root is a projection - if so, just add `expression` instead of creating a second projection node on top
- [ ] Tests
- [ ] Benchmarks