### PR TITLE
Scheduler: Improve handling of JobTasks with high fan-out and of successor tasks

### DIFF
--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(
 target_link_libraries(
     hyriseServer
     hyrise
-    hyriseBenchmarkLib
 )
 
 # Configure playground

--- a/src/bin/CMakeLists.txt
+++ b/src/bin/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(
 target_link_libraries(
     hyriseServer
     hyrise
+    hyriseBenchmarkLib
 )
 
 # Configure playground

--- a/src/bin/server.cpp
+++ b/src/bin/server.cpp
@@ -1,8 +1,6 @@
 #include "cxxopts.hpp"
 
-#include "benchmark_config.hpp"
 #include "server/server.hpp"
-#include "tpch/tpch_table_generator.hpp"
 
 cxxopts::Options get_server_cli_options() {
   cxxopts::Options cli_options("./hyriseServer", "Starts Hyrise server in order to accept network requests.");
@@ -10,7 +8,6 @@ cxxopts::Options get_server_cli_options() {
   // clang-format off
   cli_options.add_options()
     ("help", "Display this help and exit") // NOLINT
-    ("s,scale_factor", "TPC-H Scale Factor", cxxopts::value<float>()) // NOLINT
     ("address", "Specify the address to run on", cxxopts::value<std::string>()->default_value("0.0.0.0"))  // NOLINT
     ("p,port", "Specify the port number. 0 means randomly select an available one. If no port is specified, the the server will start on PostgreSQL's official port", cxxopts::value<uint16_t>()->default_value("5432"))  // NOLINT
     ("execution_info", "Send execution information after statement execution", cxxopts::value<bool>()->default_value("false")) // NOLINT
@@ -28,15 +25,6 @@ int main(int argc, char* argv[]) {
   if (parsed_options.count("help")) {
     std::cout << cli_options.help() << std::endl;
     return 0;
-  }
-
-  if (parsed_options.count("scale_factor")) {
-    const auto scale_factor = parsed_options["scale_factor"].as<float>();
-    if (scale_factor > 0) {
-      auto config = std::make_shared<opossum::BenchmarkConfig>(opossum::BenchmarkConfig::get_default_config());
-      config->cache_binary_tables = true;
-      opossum::TPCHTableGenerator{scale_factor, config}.generate_and_store();
-    }
   }
 
   const auto execution_info = parsed_options["execution_info"].as<bool>();

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -324,6 +324,7 @@ set(
     optimizer/strategy/subquery_to_join_rule.cpp
     optimizer/strategy/subquery_to_join_rule.hpp
     resolve_type.hpp
+    scheduler/abstract_scheduler.cpp
     scheduler/abstract_scheduler.hpp
     scheduler/abstract_task.cpp
     scheduler/abstract_task.hpp

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -428,10 +428,9 @@ KeysPerChunk<AggregateKey> AggregateHash::_partition_by_groupby_keys() const {
           }
         });
       }));
-      jobs.back()->schedule();
     }
 
-    Hyrise::get().scheduler()->wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
   }
 
   return keys_per_chunk;

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -39,7 +39,7 @@ class IndexScan : public AbstractReadOnlyOperator {
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   void _validate_input();
-  std::shared_ptr<AbstractTask> _create_job_and_schedule(const ChunkID chunk_id, std::mutex& output_mutex);
+  std::shared_ptr<AbstractTask> _create_job(const ChunkID chunk_id, std::mutex& output_mutex);
   RowIDPosList _scan_chunk(const ChunkID chunk_id);
 
  private:

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -365,9 +365,8 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
         output_bloom_filter |= local_output_bloom_filter;
       }
     }));
-    jobs.back()->schedule();
   }
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   return radix_container;
 }
@@ -442,10 +441,9 @@ std::vector<std::optional<PosHashTable<HashedType>>> build(const RadixContainer<
       insert_into_hash_table();
     } else {
       jobs.emplace_back(std::make_shared<JobTask>(insert_into_hash_table));
-      jobs.back()->schedule();
     }
   }
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   // If radix partitioning is used, shrink_to_fit is called above.
   if (radix_bits == 0) hash_tables[0]->shrink_to_fit();
@@ -535,9 +533,8 @@ RadixContainer<T> partition_by_radix(const RadixContainer<T>& radix_container,
         ++output_idx;
       }
     }));
-    jobs.back()->schedule();
   }
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
   jobs.clear();
 
   // Compress null_values_as_char into partition.null_values
@@ -550,9 +547,8 @@ RadixContainer<T> partition_by_radix(const RadixContainer<T>& radix_container,
               null_values_as_char[output_partition_idx][element_idx];
         }
       }));
-      jobs.back()->schedule();
     }
-    Hyrise::get().scheduler()->wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
   }
 
   return output;
@@ -706,10 +702,9 @@ void probe(const RadixContainer<ProbeColumnType>& probe_radix_container,
       pos_lists_build_side[partition_idx] = std::move(pos_list_build_side_local);
       pos_lists_probe_side[partition_idx] = std::move(pos_list_probe_side_local);
     }));
-    jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 }
 
 template <typename ProbeColumnType, typename HashedType, JoinMode mode>
@@ -817,10 +812,9 @@ void probe_semi_anti(const RadixContainer<ProbeColumnType>& probe_radix_containe
 
       pos_lists[partition_idx] = std::move(pos_list_local);
     }));
-    jobs.back()->schedule();
   }
 
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 }
 
 using PosLists = std::vector<std::shared_ptr<const AbstractPosList>>;

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -792,10 +792,9 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
 
         this->_join_cluster(cluster_number, multi_predicate_join_evaluator);
       }));
-      jobs.back()->schedule();
     }
 
-    Hyrise::get().scheduler()->wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
     // The outer joins for the non-equi cases
     // Note: Equi outer joins can be integrated into the main algorithm, while these can not.

--- a/src/lib/operators/join_sort_merge/column_materializer.hpp
+++ b/src/lib/operators/join_sort_merge/column_materializer.hpp
@@ -81,10 +81,9 @@ class ColumnMaterializer {
 
       jobs.push_back(
           _create_chunk_materialization_job(output, null_rows, chunk_id, input, column_id, subsamples.back()));
-      jobs.back()->schedule();
     }
 
-    Hyrise::get().scheduler()->wait_for_tasks(jobs);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
     auto gathered_samples = std::vector<T>();
     gathered_samples.reserve(samples_per_chunk * chunk_count);

--- a/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
+++ b/src/lib/operators/join_sort_merge/radix_cluster_sort.hpp
@@ -191,10 +191,9 @@ class RadixClusterSort {
       });
 
       histogram_jobs.push_back(job);
-      job->schedule();
     }
 
-    Hyrise::get().scheduler()->wait_for_tasks(histogram_jobs);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(histogram_jobs);
 
     // Aggregate the chunks histograms to a table histogram and initialize the insert positions for each chunk
     for (auto& chunk_information : table_information.chunk_information) {
@@ -225,10 +224,9 @@ class RadixClusterSort {
             }
           });
       cluster_jobs.push_back(job);
-      job->schedule();
     }
 
-    Hyrise::get().scheduler()->wait_for_tasks(cluster_jobs);
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(cluster_jobs);
 
     return output_table;
   }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -192,10 +192,9 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
     });
 
     jobs.push_back(job_task);
-    job_task->schedule();
   }
 
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   auto& scan_performance_data = static_cast<PerformanceData&>(*performance_data);
   scan_performance_data.chunk_scans_skipped = _impl->chunk_scans_skipped;

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
   const auto our_tid = transaction_context->transaction_id();
   const auto snapshot_commit_id = transaction_context->snapshot_commit_id();
 
-  std::vector<std::shared_ptr<JobTask>> jobs;
+  std::vector<std::shared_ptr<AbstractTask>> jobs;
   std::vector<std::shared_ptr<Chunk>> output_chunks;
   output_chunks.reserve(chunk_count);
   std::mutex output_mutex;
@@ -113,6 +113,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
 
     // Small chunks are bundled together to avoid unnecessary scheduling overhead.
     // Therefore, we count the number of rows to ensure a minimum of rows per job (default chunk size).
+    // TODO throw this out
     job_row_count += chunk->size();
     if (job_row_count >= Chunk::DEFAULT_SIZE || job_end_chunk_id == (chunk_count - 1)) {
       // Single tasks are executed directly instead of scheduling a single job.
@@ -126,7 +127,6 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
           _validate_chunks(in_table, job_start_chunk_id, job_end_chunk_id, our_tid, snapshot_commit_id, output_chunks,
                            output_mutex);
         }));
-        jobs.back()->schedule();
 
         // Prepare next job
         job_start_chunk_id = job_end_chunk_id + 1;
@@ -136,7 +136,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
     job_end_chunk_id++;
   }
 
-  Hyrise::get().scheduler()->wait_for_tasks(jobs);
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -113,7 +113,6 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
 
     // Small chunks are bundled together to avoid unnecessary scheduling overhead.
     // Therefore, we count the number of rows to ensure a minimum of rows per job (default chunk size).
-    // TODO throw this out
     job_row_count += chunk->size();
     if (job_row_count >= Chunk::DEFAULT_SIZE || job_end_chunk_id == (chunk_count - 1)) {
       // Single tasks are executed directly instead of scheduling a single job.

--- a/src/lib/scheduler/abstract_scheduler.cpp
+++ b/src/lib/scheduler/abstract_scheduler.cpp
@@ -13,10 +13,8 @@ void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<Abstrac
               }()),
               "In order to wait for a task’s completion, it needs to have been scheduled first.");
 
-  /**
- * In case wait_for_tasks() is called from a Task being executed in a Worker, let the Worker handle the join()-ing,
- * otherwise join right here
- */
+  // In case wait_for_tasks() is called from a Task being executed in a Worker, let the Worker handle the join()-ing,
+  // otherwise join right here
   auto worker = Worker::get_this_thread_worker();
   if (worker) {
     worker->_wait_for_tasks(tasks);

--- a/src/lib/scheduler/abstract_scheduler.cpp
+++ b/src/lib/scheduler/abstract_scheduler.cpp
@@ -19,7 +19,7 @@ void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<Abstrac
   if (worker) {
     worker->_wait_for_tasks(tasks);
   } else {
-    for (auto& task : tasks) task->_join();
+    for (const auto& task : tasks) task->_join();
   }
 }
 

--- a/src/lib/scheduler/abstract_scheduler.cpp
+++ b/src/lib/scheduler/abstract_scheduler.cpp
@@ -13,7 +13,7 @@ void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<Abstrac
               }()),
               "In order to wait for a task’s completion, it needs to have been scheduled first.");
 
-/**
+  /**
  * In case wait_for_tasks() is called from a Task being executed in a Worker, let the Worker handle the join()-ing,
  * otherwise join right here
  */
@@ -25,7 +25,7 @@ void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<Abstrac
   }
 }
 
-void AbstractScheduler::group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
+void AbstractScheduler::_group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
   // Do nothing - grouping tasks is implementation-defined
 }
 
@@ -38,10 +38,10 @@ void AbstractScheduler::schedule_tasks(const std::vector<std::shared_ptr<Abstrac
 }
 
 void AbstractScheduler::schedule_and_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
-  group_tasks(tasks);
+  _group_tasks(tasks);
   schedule_tasks(tasks);
   DTRACE_PROBE1(HYRISE, SCHEDULE_TASKS_AND_WAIT, tasks.size());
   wait_for_tasks(tasks);
 }
 
-}
+}  // namespace opossum

--- a/src/lib/scheduler/abstract_scheduler.cpp
+++ b/src/lib/scheduler/abstract_scheduler.cpp
@@ -4,7 +4,7 @@ namespace opossum {
 
 void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
   DebugAssert(([&]() {
-                for (auto& task : tasks) {
+                for (const auto& task : tasks) {
                   if (!task->is_scheduled()) {
                     return false;
                   }
@@ -15,7 +15,7 @@ void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<Abstrac
 
   // In case wait_for_tasks() is called from a Task being executed in a Worker, let the Worker handle the join()-ing,
   // otherwise join right here
-  auto worker = Worker::get_this_thread_worker();
+  const auto worker = Worker::get_this_thread_worker();
   if (worker) {
     worker->_wait_for_tasks(tasks);
   } else {
@@ -29,7 +29,7 @@ void AbstractScheduler::_group_tasks(const std::vector<std::shared_ptr<AbstractT
 
 void AbstractScheduler::schedule_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
   DTRACE_PROBE1(HYRISE, SCHEDULE_TASKS, tasks.size());
-  for (auto& task : tasks) {
+  for (const auto& task : tasks) {
     DTRACE_PROBE2(HYRISE, TASKS, reinterpret_cast<uintptr_t>(&tasks), reinterpret_cast<uintptr_t>(task.get()));
     task->schedule();
   }

--- a/src/lib/scheduler/abstract_scheduler.cpp
+++ b/src/lib/scheduler/abstract_scheduler.cpp
@@ -1,0 +1,47 @@
+#include "abstract_scheduler.hpp"
+
+namespace opossum {
+
+void AbstractScheduler::wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
+  DebugAssert(([&]() {
+                for (auto& task : tasks) {
+                  if (!task->is_scheduled()) {
+                    return false;
+                  }
+                }
+                return true;
+              }()),
+              "In order to wait for a task’s completion, it needs to have been scheduled first.");
+
+/**
+ * In case wait_for_tasks() is called from a Task being executed in a Worker, let the Worker handle the join()-ing,
+ * otherwise join right here
+ */
+  auto worker = Worker::get_this_thread_worker();
+  if (worker) {
+    worker->_wait_for_tasks(tasks);
+  } else {
+    for (auto& task : tasks) task->_join();
+  }
+}
+
+void AbstractScheduler::group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
+  // Do nothing - grouping tasks is implementation-defined
+}
+
+void AbstractScheduler::schedule_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
+  DTRACE_PROBE1(HYRISE, SCHEDULE_TASKS, tasks.size());
+  for (auto& task : tasks) {
+    DTRACE_PROBE2(HYRISE, TASKS, reinterpret_cast<uintptr_t>(&tasks), reinterpret_cast<uintptr_t>(task.get()));
+    task->schedule();
+  }
+}
+
+void AbstractScheduler::schedule_and_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
+  group_tasks(tasks);
+  schedule_tasks(tasks);
+  DTRACE_PROBE1(HYRISE, SCHEDULE_TASKS_AND_WAIT, tasks.size());
+  wait_for_tasks(tasks);
+}
+
+}

--- a/src/lib/scheduler/abstract_scheduler.hpp
+++ b/src/lib/scheduler/abstract_scheduler.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 
+#include "scheduler/abstract_task.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
 #include "utils/tracing/probes.hpp"
@@ -10,7 +11,6 @@
 
 namespace opossum {
 
-class AbstractTask;
 class TaskQueue;
 
 class AbstractScheduler : public Noncopyable {
@@ -41,45 +41,14 @@ class AbstractScheduler : public Noncopyable {
   virtual void schedule(std::shared_ptr<AbstractTask> task, NodeID preferred_node_id = CURRENT_NODE_ID,
                         SchedulePriority priority = SchedulePriority::Default) = 0;
 
-  template <typename TaskType>
-  void wait_for_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {
-    DebugAssert(([&]() {
-                  for (auto& task : tasks) {
-                    if (!task->is_scheduled()) {
-                      return false;
-                    }
-                  }
-                  return true;
-                }()),
-                "In order to wait for a task’s completion, it needs to have been scheduled first.");
+  void wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
 
-    /**
-   * In case wait_for_tasks() is called from a Task being executed in a Worker, let the Worker handle the join()-ing,
-   * otherwise join right here
-   */
-    auto worker = Worker::get_this_thread_worker();
-    if (worker) {
-      worker->_wait_for_tasks(tasks);
-    } else {
-      for (auto& task : tasks) task->_join();
-    }
-  }
+  // TODO
+  virtual void group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const;
 
-  template <typename TaskType>
-  void schedule_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {
-    DTRACE_PROBE1(HYRISE, SCHEDULE_TASKS, tasks.size());
-    for (auto& task : tasks) {
-      DTRACE_PROBE2(HYRISE, TASKS, reinterpret_cast<uintptr_t>(&tasks), reinterpret_cast<uintptr_t>(task.get()));
-      task->schedule();
-    }
-  }
+  void schedule_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
 
-  template <typename TaskType>
-  void schedule_and_wait_for_tasks(const std::vector<std::shared_ptr<TaskType>>& tasks) {
-    schedule_tasks(tasks);
-    DTRACE_PROBE1(HYRISE, SCHEDULE_TASKS_AND_WAIT, tasks.size());
-    wait_for_tasks(tasks);
-  }
+  void schedule_and_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
 };
 
 }  // namespace opossum

--- a/src/lib/scheduler/abstract_scheduler.hpp
+++ b/src/lib/scheduler/abstract_scheduler.hpp
@@ -43,16 +43,15 @@ class AbstractScheduler : public Noncopyable {
 
   // Schedules the given tasks for execution and returns immediately.
   // If no asynchronicity is needed, prefer schedule_and_wait_for_tasks.
-  void schedule_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
+  static void schedule_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
 
   // Blocks until all specified tasks are completed.
   // If no asynchronicity is needed, prefer schedule_and_wait_for_tasks.
-  void wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
+  static void wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
 
   // Schedules the given tasks for execution and waits for them to complete before returning. Tasks may be reorganized
-  // internally, e.g., to reduce the number of tasks being executed in parallel. For example, a scan on 1,000 chunks
-  // would usually create the same number of tasks. By grouping the work into 10 tasks, the scheduling overhead is
-  // reduced.
+  // internally, e.g., to reduce the number of tasks being executed in parallel. See the implementation of
+  // NodeQueueScheduler::_group_tasks for an example.
   void schedule_and_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks);
 
  protected:

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -89,7 +89,7 @@ void AbstractTask::execute() {
   // read/write combination in whoever scheduled this task and the task itself. As schedule() (in "thread" A) writes to
   // _is_scheduled and this assert (potentially in "thread" B) reads it, it is guaranteed that no writes of whoever
   // spawned the task are pushed down to a point where this thread is already running.
-  Assert(_is_scheduled, "Task should be have been scheduled before being executed");
+  Assert(_is_scheduled, "Task should have been scheduled before being executed");
 
   _on_execute();
 
@@ -124,7 +124,8 @@ void AbstractTask::_on_predecessor_done() {
       // the sake of a clearly defined life cycle, we wait for the task to be scheduled.
       if (!_is_scheduled) return;
 
-      worker->queue()->push(shared_from_this(), static_cast<uint32_t>(SchedulePriority::High));
+      worker->execute_immediately(shared_from_this());
+      // worker->queue()->push(shared_from_this(), static_cast<uint32_t>(SchedulePriority::High));
     } else {
       if (_is_scheduled) execute();
       // Otherwise it will get execute()d once it is scheduled. It is entirely possible for Tasks to "become ready"

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -124,8 +124,9 @@ void AbstractTask::_on_predecessor_done() {
       // the sake of a clearly defined life cycle, we wait for the task to be scheduled.
       if (!_is_scheduled) return;
 
+      // Instead of adding the current task to the queue, try to execute it immediately on the same worker as the last
+      // predecessor. This should improve cache locality and reduce the scheduling costs.
       current_worker->execute_next(shared_from_this());
-      // current_worker->queue()->push(shared_from_this(), static_cast<uint32_t>(SchedulePriority::High));
     } else {
       if (_is_scheduled) execute();
       // Otherwise it will get execute()d once it is scheduled. It is entirely possible for Tasks to "become ready"

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -20,6 +20,9 @@ class Worker;
  * Derive and implement logic in _on_execute()
  */
 class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
+  // Using friend classes is quite uncommon in Hyrise. The reason it is done here is that the _join method must
+  // absolutely not be called from anyone but the scheduler. As the interface could tempt developers to do so if that
+  // method was public, we chose this approach.
   friend class AbstractScheduler;
 
  public:

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -119,7 +119,15 @@ void NodeQueueScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID pre
   queue->push(task, static_cast<uint32_t>(priority));
 }
 
-void NodeQueueScheduler::group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
+void NodeQueueScheduler::_group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
+  // Adds predecessor/successor relationships between tasks so that only num_groups tasks can be executed in parallel.
+  // The optimal value of num_groups depends on the number of cores and the number of queries being executed
+  // concurrently. The current value has been found with a divining rod.
+  //
+  // Approach: Skip all tasks that already have predecessors or successors, as adding relationships to these could
+  // introduce cyclic dependencies. This ignores the preferred node of tasks. Again, this is far from perfect, but
+  // better than not grouping the tasks.
+
   const auto num_groups = 10;
 
   auto round_robin_counter = 0;

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -120,22 +120,31 @@ void NodeQueueScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID pre
 }
 
 void NodeQueueScheduler::_group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
-  // Adds predecessor/successor relationships between tasks so that only num_groups tasks can be executed in parallel.
-  // The optimal value of num_groups depends on the number of cores and the number of queries being executed
+  // Adds predecessor/successor relationships between tasks so that only NUM_GROUPS tasks can be executed in parallel.
+  // The optimal value of NUM_GROUPS depends on the number of cores and the number of queries being executed
   // concurrently. The current value has been found with a divining rod.
   //
   // Approach: Skip all tasks that already have predecessors or successors, as adding relationships to these could
-  // introduce cyclic dependencies. This ignores the preferred node of tasks. Again, this is far from perfect, but
-  // better than not grouping the tasks.
-
-  const auto num_groups = 10;
+  // introduce cyclic dependencies. Again, this is far from perfect, but better than not grouping the tasks.
 
   auto round_robin_counter = 0;
+  auto common_node_id = std::optional<NodeID>{};
 
-  std::vector<std::shared_ptr<AbstractTask>> grouped_tasks(num_groups);
+  std::vector<std::shared_ptr<AbstractTask>> grouped_tasks(NUM_GROUPS);
   for (const auto& task : tasks) {
     if (!task->predecessors().empty() || !task->successors().empty()) return;
-    const auto group_id = round_robin_counter % num_groups;
+
+    if (common_node_id) {
+      // This is not really a hard assertion. As the chain will likely be executed on the same Worker (see
+      // Worker::execute_next), we would ignore all but the first node_id. At the time of writing, we did not do any
+      // smart node assignment. This assertion is only here so that this behavior is understood if we ever assign NUMA
+      // node ids.
+      Assert(task->node_id() == *common_node_id, "Expected all grouped tasks to have the same node_id");
+    } else {
+      common_node_id = task->node_id();
+    }
+
+    const auto group_id = round_robin_counter % NUM_GROUPS;
     const auto& first_task_in_group = grouped_tasks[group_id];
     if (first_task_in_group) {
       task->set_as_predecessor_of(first_task_in_group);

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -118,4 +118,23 @@ void NodeQueueScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID pre
   auto queue = _queues[preferred_node_id];
   queue->push(task, static_cast<uint32_t>(priority));
 }
+
+void NodeQueueScheduler::group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const {
+  const auto num_groups = 10;
+
+  auto round_robin_counter = 0;
+
+  std::vector<std::shared_ptr<AbstractTask>> grouped_tasks(num_groups);
+  for (const auto& task : tasks) {
+    if (!task->predecessors().empty() || !task->successors().empty()) return;
+    const auto group_id = round_robin_counter % num_groups;
+    const auto& first_task_in_group = grouped_tasks[group_id];
+    if (first_task_in_group) {
+      task->set_as_predecessor_of(first_task_in_group);
+    }
+    grouped_tasks[group_id] = task;
+    ++round_robin_counter;
+  }
+}
+
 }  // namespace opossum

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -139,7 +139,7 @@ void NodeQueueScheduler::_group_tasks(const std::vector<std::shared_ptr<Abstract
       // Worker::execute_next), we would ignore all but the first node_id. At the time of writing, we did not do any
       // smart node assignment. This assertion is only here so that this behavior is understood if we ever assign NUMA
       // node ids.
-      Assert(task->node_id() == *common_node_id, "Expected all grouped tasks to have the same node_id");
+      DebugAssert(task->node_id() == *common_node_id, "Expected all grouped tasks to have the same node_id");
     } else {
       common_node_id = task->node_id();
     }

--- a/src/lib/scheduler/node_queue_scheduler.hpp
+++ b/src/lib/scheduler/node_queue_scheduler.hpp
@@ -106,7 +106,8 @@ class NodeQueueScheduler : public AbstractScheduler {
 
   void wait_for_all_tasks() override;
 
-  void group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const override;
+ protected:
+  void _group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const override;
 
  private:
   std::atomic<TaskID> _task_counter{TaskID{0}};

--- a/src/lib/scheduler/node_queue_scheduler.hpp
+++ b/src/lib/scheduler/node_queue_scheduler.hpp
@@ -106,6 +106,9 @@ class NodeQueueScheduler : public AbstractScheduler {
 
   void wait_for_all_tasks() override;
 
+  // Number of groups for _group_tasks
+  static constexpr auto NUM_GROUPS = 10;
+
  protected:
   void _group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const override;
 

--- a/src/lib/scheduler/node_queue_scheduler.hpp
+++ b/src/lib/scheduler/node_queue_scheduler.hpp
@@ -106,6 +106,8 @@ class NodeQueueScheduler : public AbstractScheduler {
 
   void wait_for_all_tasks() override;
 
+  void group_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) const override;
+
  private:
   std::atomic<TaskID> _task_counter{TaskID{0}};
   std::shared_ptr<UidAllocator> _worker_id_allocator;

--- a/src/lib/scheduler/operator_task.cpp
+++ b/src/lib/scheduler/operator_task.cpp
@@ -19,17 +19,17 @@ std::string OperatorTask::description() const {
   return "OperatorTask with id: " + std::to_string(id()) + " for op: " + _op->description();
 }
 
-std::vector<std::shared_ptr<OperatorTask>> OperatorTask::make_tasks_from_operator(
+std::vector<std::shared_ptr<AbstractTask>> OperatorTask::make_tasks_from_operator(
     const std::shared_ptr<AbstractOperator>& op) {
-  std::vector<std::shared_ptr<OperatorTask>> tasks;
-  std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>> task_by_op;
+  std::vector<std::shared_ptr<AbstractTask>> tasks;
+  std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<AbstractTask>> task_by_op;
   _add_tasks_from_operator(op, tasks, task_by_op);
   return tasks;
 }
 
-std::shared_ptr<OperatorTask> OperatorTask::_add_tasks_from_operator(
-    const std::shared_ptr<AbstractOperator>& op, std::vector<std::shared_ptr<OperatorTask>>& tasks,
-    std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>>& task_by_op) {
+std::shared_ptr<AbstractTask> OperatorTask::_add_tasks_from_operator(
+    const std::shared_ptr<AbstractOperator>& op, std::vector<std::shared_ptr<AbstractTask>>& tasks,
+    std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<AbstractTask>>& task_by_op) {
   const auto task_by_op_it = task_by_op.find(op);
   if (task_by_op_it != task_by_op.end()) return task_by_op_it->second;
 

--- a/src/lib/scheduler/operator_task.hpp
+++ b/src/lib/scheduler/operator_task.hpp
@@ -22,7 +22,7 @@ class OperatorTask : public AbstractTask {
   /**
    * Create tasks recursively from result operator and set task dependencies automatically.
    */
-  static std::vector<std::shared_ptr<OperatorTask>> make_tasks_from_operator(
+  static std::vector<std::shared_ptr<AbstractTask>> make_tasks_from_operator(
       const std::shared_ptr<AbstractOperator>& op);
 
   const std::shared_ptr<AbstractOperator>& get_operator() const;
@@ -36,9 +36,9 @@ class OperatorTask : public AbstractTask {
    * Create tasks recursively. Called by `make_tasks_from_operator`. Returns the root of the subtree that was added.
    * @param task_by_op  Cache to avoid creating duplicate Tasks for diamond shapes
    */
-  static std::shared_ptr<OperatorTask> _add_tasks_from_operator(
-      const std::shared_ptr<AbstractOperator>& op, std::vector<std::shared_ptr<OperatorTask>>& tasks,
-      std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<OperatorTask>>& task_by_op);
+  static std::shared_ptr<AbstractTask> _add_tasks_from_operator(
+      const std::shared_ptr<AbstractOperator>& op, std::vector<std::shared_ptr<AbstractTask>>& tasks,
+      std::unordered_map<std::shared_ptr<AbstractOperator>, std::shared_ptr<AbstractTask>>& task_by_op);
 
  private:
   std::shared_ptr<AbstractOperator> _op;

--- a/src/lib/scheduler/topology.hpp
+++ b/src/lib/scheduler/topology.hpp
@@ -42,7 +42,7 @@ class Topology final : public Noncopyable {
 
   /**
    * Use a NUMA topology.
-   * The topology has a number of cores equal to either max_num_cores or the number of physically availyble cores,
+   * The topology has a number of cores equal to either max_num_cores or the number of physically available cores,
    * whichever one is lower. The cores are distributed among the available NUMA nodes in a way that a node is filled up
    * to it's maximum core count first, bevor a new node is added.
    *

--- a/src/lib/scheduler/topology.hpp
+++ b/src/lib/scheduler/topology.hpp
@@ -43,8 +43,8 @@ class Topology final : public Noncopyable {
   /**
    * Use a NUMA topology.
    * The topology has a number of cores equal to either max_num_cores or the number of physically available cores,
-   * whichever one is lower. The cores are distributed among the available NUMA nodes in a way that a node is filled up
-   * to it's maximum core count first, bevor a new node is added.
+   * whichever one is lower. If max_num_cores is lower than the number of available physical cores, all cores from node 0
+   * are used before any cores from node 1 are used.
    *
    * Calls _init_numa_topology() internally.
    * Calls _init_fake_numa_topology() if on a non-NUMA system.

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -101,7 +101,8 @@ void Worker::execute_next(const std::shared_ptr<AbstractTask>& task) {
   DebugAssert(&*get_this_thread_worker() == this,
               "execute_next must be called from the same thread that the worker works in");
   if (!_next_task) {
-    if (!task->try_mark_as_enqueued()) return;
+    const auto already_enqueued = task->try_mark_as_enqueued();
+    Assert(!already_enqueued, "Task was already enqueued, expected to be solely responsible for execution");
     _next_task = task;
   } else {
     _queue->push(task, static_cast<uint32_t>(SchedulePriority::High));

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -101,8 +101,8 @@ void Worker::execute_next(const std::shared_ptr<AbstractTask>& task) {
   DebugAssert(&*get_this_thread_worker() == this,
               "execute_next must be called from the same thread that the worker works in");
   if (!_next_task) {
-    const auto already_enqueued = task->try_mark_as_enqueued();
-    Assert(!already_enqueued, "Task was already enqueued, expected to be solely responsible for execution");
+    const auto successfully_enqueued = task->try_mark_as_enqueued();
+    Assert(successfully_enqueued, "Task was already enqueued, expected to be solely responsible for execution");
     _next_task = task;
   } else {
     _queue->push(task, static_cast<uint32_t>(SchedulePriority::High));

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -83,6 +83,10 @@ void Worker::_work() {
     }
   }
 
+  execute_immediately(task);
+}
+
+void Worker::execute_immediately(const std::shared_ptr<AbstractTask>& task) {
   task->execute();
 
   // This is part of the Scheduler shutdown system. Count the number of tasks a Worker executed to allow the

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -5,6 +5,7 @@
 #include <thread>
 #include <vector>
 
+#include "scheduler/abstract_task.hpp"
 #include "types.hpp"
 #include "utils/assert.hpp"
 
@@ -33,6 +34,8 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
 
   void start();
   void join();
+
+  void execute_immediately(const std::shared_ptr<AbstractTask>& task);
 
   uint64_t num_finished_tasks() const;
 

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -35,7 +35,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   void start();
   void join();
 
-  void execute_immediately(const std::shared_ptr<AbstractTask>& task);
+  void execute_next(const std::shared_ptr<AbstractTask>& task);
 
   uint64_t num_finished_tasks() const;
 
@@ -70,6 +70,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
    */
   void _set_affinity();
 
+  std::shared_ptr<AbstractTask> _next_task;
   std::shared_ptr<TaskQueue> _queue;
   WorkerID _id;
   CpuID _cpu_id;

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -35,10 +35,11 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   void start();
   void join();
 
-  // Try to execute task immediately after this worker finishes the execution of the current task. Useful for making
-  // sure that a task's successor is executed without having to go through the queue again (at which point all data
-  // would have been removed from the caches). Adds task to the queue if called multiple times without having had the
-  // chance to execute the tasks in between.
+  // Try to execute task immediately after this worker finishes the execution of the current task. The goal is to
+  // execute the task while the caches are still fresh instead of having to wait for it to be scheduled again. A task
+  // can have multiple successors and all of them could become executable at the same time. In that case, the current
+  // worker can only execute one of them immediately. The others are placed into a high priority queue on the same node
+  // so that they are worked on as soon as possible by either this or another worker.
   void execute_next(const std::shared_ptr<AbstractTask>& task);
 
   uint64_t num_finished_tasks() const;

--- a/src/lib/server/query_handler.cpp
+++ b/src/lib/server/query_handler.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<const Table> QueryHandler::execute_prepared_plan(
     const std::shared_ptr<AbstractOperator>& physical_plan) {
   const auto tasks = OperatorTask::make_tasks_from_operator(physical_plan);
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
-  return tasks.back()->get_operator()->get_output();
+  return static_cast<const OperatorTask&>(*tasks.back()).get_operator()->get_output();
 }
 
 void QueryHandler::_handle_transaction_statement_message(ExecutionInformation& execution_info,

--- a/src/test/lib/operators/operator_deep_copy_test.cpp
+++ b/src/test/lib/operators/operator_deep_copy_test.cpp
@@ -206,7 +206,7 @@ TEST_F(OperatorDeepCopyTest, Subquery) {
   const auto tasks = OperatorTask::make_tasks_from_operator(copied_plan);
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
 
-  const auto copied_result = tasks.back()->get_operator()->get_output();
+  const auto copied_result = static_cast<const OperatorTask&>(*tasks.back()).get_operator()->get_output();
 
   auto expected_copied = std::make_shared<Table>(column_definitions, TableType::Data);
   expected_copied->append({11, 10, 11});

--- a/src/test/lib/scheduler/operator_task_test.cpp
+++ b/src/test/lib/scheduler/operator_task_test.cpp
@@ -38,7 +38,7 @@ TEST_F(OperatorTaskTest, BasicTasksFromOperatorTest) {
   auto result_task = tasks.back();
   result_task->schedule();
 
-  EXPECT_TABLE_EQ_UNORDERED(_test_table_a, result_task->get_operator()->get_output());
+  EXPECT_TABLE_EQ_UNORDERED(_test_table_a, static_cast<const OperatorTask&>(*result_task).get_operator()->get_output());
 }
 
 TEST_F(OperatorTaskTest, SingleDependencyTasksFromOperatorTest) {
@@ -53,7 +53,8 @@ TEST_F(OperatorTaskTest, SingleDependencyTasksFromOperatorTest) {
   }
 
   auto expected_result = load_table("resources/test_data/tbl/int_float_filtered.tbl", 2);
-  EXPECT_TABLE_EQ_UNORDERED(expected_result, tasks.back()->get_operator()->get_output());
+  EXPECT_TABLE_EQ_UNORDERED(expected_result,
+                            static_cast<const OperatorTask&>(*tasks.back()).get_operator()->get_output());
 
   // Check that everything was properly cleaned up
   EXPECT_EQ(gt->get_output(), nullptr);
@@ -73,7 +74,8 @@ TEST_F(OperatorTaskTest, DoubleDependencyTasksFromOperatorTest) {
   }
 
   auto expected_result = load_table("resources/test_data/tbl/join_operators/int_inner_join.tbl", 2);
-  EXPECT_TABLE_EQ_UNORDERED(expected_result, tasks.back()->get_operator()->get_output());
+  EXPECT_TABLE_EQ_UNORDERED(expected_result,
+                            static_cast<const OperatorTask&>(*tasks.back()).get_operator()->get_output());
 
   // Check that everything was properly cleaned up
   EXPECT_EQ(gt_a->get_output(), nullptr);
@@ -92,11 +94,11 @@ TEST_F(OperatorTaskTest, MakeDiamondShape) {
   auto tasks = OperatorTask::make_tasks_from_operator(union_positions);
 
   ASSERT_EQ(tasks.size(), 5u);
-  EXPECT_EQ(tasks[0]->get_operator(), gt_a);
-  EXPECT_EQ(tasks[1]->get_operator(), scan_a);
-  EXPECT_EQ(tasks[2]->get_operator(), scan_b);
-  EXPECT_EQ(tasks[3]->get_operator(), scan_c);
-  EXPECT_EQ(tasks[4]->get_operator(), union_positions);
+  EXPECT_EQ(static_cast<const OperatorTask&>(*tasks[0]).get_operator(), gt_a);
+  EXPECT_EQ(static_cast<const OperatorTask&>(*tasks[1]).get_operator(), scan_a);
+  EXPECT_EQ(static_cast<const OperatorTask&>(*tasks[2]).get_operator(), scan_b);
+  EXPECT_EQ(static_cast<const OperatorTask&>(*tasks[3]).get_operator(), scan_c);
+  EXPECT_EQ(static_cast<const OperatorTask&>(*tasks[4]).get_operator(), union_positions);
 
   std::vector<std::shared_ptr<AbstractTask>> expected_successors_0({tasks[1]});
   EXPECT_EQ(tasks[0]->successors(), expected_successors_0);

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -146,7 +146,7 @@ TEST_F(SchedulerTest, LinearDependenciesWithScheduler) {
 
 TEST_F(SchedulerTest, Grouping) {
   // Tests the grouping described in AbstractScheduler::schedule_and_wait_for_tasks and
-  // NodeQueueScheduler::_group_tasks. Also test that successor tasks are called immediately after their dependencies
+  // NodeQueueScheduler::_group_tasks. Also tests that successor tasks are called immediately after their dependencies
   // finish. Not really a multi-threading test, though.
   Hyrise::get().topology.use_fake_numa_topology(1, 1);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
@@ -154,19 +154,22 @@ TEST_F(SchedulerTest, Grouping) {
   auto output = std::vector<size_t>{};
   auto tasks = std::vector<std::shared_ptr<AbstractTask>>{};
 
-  for (auto i = 0; i < 50; ++i) {
-    tasks.emplace_back(std::make_shared<JobTask>([&output, i] { output.emplace_back(i); }));
+  constexpr auto TASK_COUNT = 50;
+
+  for (auto task_id = 0; task_id < TASK_COUNT; ++task_id) {
+    tasks.emplace_back(std::make_shared<JobTask>([&output, task_id] { output.emplace_back(task_id); }));
   }
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(tasks);
   Hyrise::get().scheduler()->finish();
 
-  // We expect num_groups (currently 10) chains of tasks to be created. As tasks are added to the chains by calling
-  // AbstractTask::set_predecessor_of, the first task in the input vector ends up being the last task being called.
-  // This results in [40 30 20 10 0 41 31 21 11 1 ...]
-  const auto num_groups = 10;
+  // We expect NUM_GROUPS chains of tasks to be created. As tasks are added to the chains by calling
+  // AbstractTask::set_predecessor_of, the first task in the input vector ends up being the last task being called. This
+  // results in [40 30 20 10 0 41 31 21 11 1 ...]
+  const auto num_groups = NodeQueueScheduler::NUM_GROUPS;
+  EXPECT_EQ(TASK_COUNT % num_groups, 0);
   auto expected_output = std::vector<size_t>{};
   for (auto group = 0; group < num_groups; ++group) {
-    for (auto task_id = 0; task_id < 5; ++task_id) {
+    for (auto task_id = 0; task_id < TASK_COUNT / NUM_GROUPS; ++task_id) {
       expected_output.emplace_back(tasks.size() - (task_id + 1) * num_groups + group);
     }
   }

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -169,7 +169,7 @@ TEST_F(SchedulerTest, Grouping) {
   EXPECT_EQ(TASK_COUNT % num_groups, 0);
   auto expected_output = std::vector<size_t>{};
   for (auto group = 0; group < num_groups; ++group) {
-    for (auto task_id = 0; task_id < TASK_COUNT / NUM_GROUPS; ++task_id) {
+    for (auto task_id = 0; task_id < TASK_COUNT / num_groups; ++task_id) {
       expected_output.emplace_back(tasks.size() - (task_id + 1) * num_groups + group);
     }
   }

--- a/src/test/lib/tasks/chunk_compression_task_test.cpp
+++ b/src/test/lib/tasks/chunk_compression_task_test.cpp
@@ -27,13 +27,11 @@ TEST_F(ChunkCompressionTaskTest, CompressionPreservesTableContent) {
   compression_task1->set_done_callback([]() {
     auto compression_task2 =
         std::make_shared<ChunkCompressionTask>("table_dict", std::vector<ChunkID>{ChunkID{1}, ChunkID{2}});
-    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(
-        std::vector<std::shared_ptr<ChunkCompressionTask>>{compression_task2});
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks({compression_task2});
   });
   auto compression_task3 = std::make_shared<ChunkCompressionTask>("table_dict", ChunkID{3});
 
-  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(
-      std::vector<std::shared_ptr<ChunkCompressionTask>>{compression_task1, compression_task3});
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks({compression_task1, compression_task3});
 
   EXPECT_TABLE_EQ_UNORDERED(table, table_dict);
 
@@ -55,8 +53,7 @@ TEST_F(ChunkCompressionTaskTest, DictionarySize) {
   Hyrise::get().storage_manager.add_table("table_dict", table_dict);
 
   auto compression = std::make_shared<ChunkCompressionTask>("table_dict", std::vector<ChunkID>{ChunkID{0}, ChunkID{1}});
-  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(
-      std::vector<std::shared_ptr<ChunkCompressionTask>>{compression});
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks({compression});
 
   constexpr auto chunk_count = 2u;
 
@@ -97,8 +94,7 @@ TEST_F(ChunkCompressionTaskTest, CompressionWithAbortedInsert) {
 
   auto compression = std::make_shared<ChunkCompressionTask>(
       "table_insert", std::vector<ChunkID>{ChunkID{0}, ChunkID{1}, ChunkID{2}, ChunkID{3}});
-  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(
-      std::vector<std::shared_ptr<ChunkCompressionTask>>{compression});
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks({compression});
 
   for (auto i = ChunkID{0}; i < table->chunk_count() - 1; ++i) {
     auto dict_segment =


### PR DESCRIPTION
Some optimizations for scheduling:

* We have previously seen how a high number of tasks can impact the scheduling performance (#2202). By grouping these tasks and allowing a maximum task fan-out of 10, we can further reduce the impact of this. While this means that we limit the degree of concurrency and might not use all cores in a single-node environment, it improves the overall performance. Some day in the future we might have a resource monitor that automatically adjusts the fan-out depending on the system load.
* This only works when all tasks are scheduled at the same time. Make all operators use `schedule_and_wait_for_tasks` to enable this.
* When a task is done, we currently add the successor task(s) to the high priority queue. This means that they are worked on before an entirely new stream of work is started. However, it can result in a different worker on the same node working on this tasks. Even worse, it might result in the task being stolen.
 
TPC-H SF 10, 10 clients on nemea, single node:
![benchmark_comparison_performance](https://user-images.githubusercontent.com/575106/95855512-d19de080-0d58-11eb-93c7-b69cf2f79f1f.png)

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 1  |
| numactl | membind: 1  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 44f8c4aa8 | 08.10.2020 21:29 | Create empty bloom filter only once (#2236) | real 270.68 user 2492.41 sys 152.64|
| e4e95ce0a | 13.10.2020 08:12 | Revert "PredicateSplitUpRule: Create UnionAll for NOT LIKE (#2238)" | real 267.40 user 2466.36 sys 149.60|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_e4e95ce0ac5e4980820622339e90e37b4a861583_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-12 09:35:29                                                                                                                    | 2020-10-13 08:17:02                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    800.1 |   830.5 |   +4%  ||     1.25 |     1.20 |   -4%  |  0.0000 |
 | TPC-H 02 ||      5.0 |     4.9 |   -1%  ||   199.76 |   202.52 |   +1%  |  0.0693 |
 | TPC-H 03 ||     81.8 |    80.2 |   -2%  ||    12.22 |    12.46 |   +2%  |  0.0000 |
 | TPC-H 04 ||     68.7 |    67.3 |   -2%  ||    14.56 |    14.85 |   +2%  |  0.0000 |
+| TPC-H 05 ||    232.3 |   220.4 |   -5%  ||     4.30 |     4.54 |   +5%  |  0.0000 |
+| TPC-H 06 ||      3.6 |     3.2 |  -11%  ||   277.13 |   311.76 |  +12%  |  0.0000 |
 | TPC-H 07 ||     60.0 |    57.6 |   -4%  ||    16.67 |    17.36 |   +4%  |  0.0000 |
 | TPC-H 08 ||     69.3 |    68.1 |   -2%  ||    14.43 |    14.68 |   +2%  |  0.0011 |
 | TPC-H 09 ||    497.0 |   479.3 |   -4%  ||     2.01 |     2.09 |   +4%  |  0.0000 |
 | TPC-H 10 ||    168.9 |   167.2 |   -1%  ||     5.92 |     5.98 |   +1%  |  0.0757 |
 | TPC-H 11 ||      9.1 |     8.9 |   -3%  ||   109.45 |   112.47 |   +3%  |  0.0000 |
 | TPC-H 12 ||     43.8 |    43.1 |   -2%  ||    22.82 |    23.20 |   +2%  |  0.0000 |
+| TPC-H 13 ||    434.1 |   364.9 |  -16%  ||     2.30 |     2.74 |  +19%  |  0.0000 |
 | TPC-H 14 ||     21.3 |    21.0 |   -2%  ||    46.88 |    47.66 |   +2%  |  0.0000 |
 | TPC-H 15 ||      7.9 |     7.8 |   -1%  ||   126.76 |   128.53 |   +1%  |  0.0000 |
 | TPC-H 16 ||     95.3 |    92.2 |   -3%  ||    10.50 |    10.85 |   +3%  |  0.0000 |
 | TPC-H 17 ||     18.2 |    17.8 |   -2%  ||    54.94 |    56.09 |   +2%  |  0.0000 |
 | TPC-H 18 ||    708.7 |   722.9 |   +2%  ||     1.41 |     1.38 |   -2%  |  0.1383 |
 | TPC-H 19 ||     29.9 |    29.7 |   -1%  ||    33.43 |    33.67 |   +1%  |  0.0000 |
 | TPC-H 20 ||     16.3 |    16.3 |   +0%  ||    61.36 |    61.29 |   -0%  |  0.6611 |
 | TPC-H 21 ||    425.8 |   421.4 |   -1%  ||     2.35 |     2.37 |   +1%  |  0.0240 |
 | TPC-H 22 ||     50.6 |    49.6 |   -2%  ||    19.76 |    20.15 |   +2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3847.8 |  3774.4 |   -2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +3%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st_s01.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_e4e95ce0ac5e4980820622339e90e37b4a861583_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                             | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-12 09:58:12                                                                                                                        | 2020-10-13 08:39:21                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.3 |     7.3 |   -0%  ||   136.40 |   136.54 |   +0%  |  0.0466 |
 | TPC-H 02 ||      0.5 |     0.5 |   -0%  ||  1836.58 |  1843.05 |   +0%  |  0.4344 |
+| TPC-H 03 ||      0.9 |     0.9 |   -4%  ||  1109.36 |  1161.33 |   +5%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   -2%  ||  1907.08 |  1942.93 |   +2%  |  0.0000 |
 | TPC-H 05 ||      1.3 |     1.2 |   -4%  ||   789.40 |   821.81 |   +4%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   -3%  ||  9181.73 |  9444.06 |   +3%  |  0.0000 |
+| TPC-H 07 ||      1.3 |     1.2 |   -4%  ||   777.75 |   813.11 |   +5%  |  0.0003 |
 | TPC-H 08 ||     15.3 |    14.9 |   -3%  ||    65.45 |    67.31 |   +3%  |  0.0003 |
 | TPC-H 09 ||      2.4 |     2.4 |   -3%  ||   411.65 |   424.04 |   +3%  |  0.0000 |
 | TPC-H 10 ||      0.9 |     0.9 |   -2%  ||  1079.99 |  1103.52 |   +2%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   -2%  ||  3309.06 |  3369.76 |   +2%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   +1%  ||  1549.18 |  1538.08 |   -1%  |  0.0000 |
+| TPC-H 13 ||      2.4 |     2.2 |   -9%  ||   414.33 |   454.24 |  +10%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.4 |   -3%  ||  2773.34 |  2847.56 |   +3%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   -3%  ||   868.63 |   892.40 |   +3%  |  0.0000 |
 | TPC-H 16 ||      2.2 |     2.2 |   -2%  ||   448.88 |   458.73 |   +2%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   -3%  ||  3314.43 |  3405.21 |   +3%  |  0.0000 |
 | TPC-H 18 ||      2.7 |     2.7 |   -3%  ||   364.06 |   374.15 |   +3%  |  0.0000 |
 | TPC-H 19 ||      5.6 |     5.5 |   -2%  ||   177.11 |   181.10 |   +2%  |  0.0000 |
 | TPC-H 20 ||      2.4 |     2.3 |   -4%  ||   410.26 |   427.02 |   +4%  |  0.0000 |
+| TPC-H 21 ||      1.9 |     1.8 |   -4%  ||   520.23 |   544.66 |   +5%  |  0.0000 |
 | TPC-H 22 ||      1.3 |     1.3 |   -4%  ||   744.21 |   772.81 |   +4%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     52.1 |    50.6 |   -3%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +3%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st_s10.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_e4e95ce0ac5e4980820622339e90e37b4a861583_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                             | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-12 10:20:19                                                                                                                        | 2020-10-13 09:01:25                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
-| TPC-H 01 ||   8758.1 |  9377.7 |   +7%  ||     0.11 |     0.11 |   -7%  |       ˅ |
 | TPC-H 02 ||     55.1 |    54.8 |   -1%  ||    18.15 |    18.26 |   +1%  |  0.2149 |
 | TPC-H 03 ||   1561.3 |  1586.4 |   +2%  ||     0.64 |     0.63 |   -2%  |  0.0585 |
 | TPC-H 04 ||   1669.7 |  1681.2 |   +1%  ||     0.60 |     0.59 |   -1%  |  0.3539 |
 | TPC-H 05 ||   3385.1 |  3429.2 |   +1%  ||     0.30 |     0.29 |   -1%  |  0.0576 |
+| TPC-H 06 ||     39.7 |    35.5 |  -11%  ||    25.20 |    28.20 |  +12%  |  0.0000 |
 | TPC-H 07 ||    964.5 |   963.9 |   -0%  ||     1.04 |     1.04 |   +0%  |  0.7980 |
 | TPC-H 08 ||    676.5 |   665.5 |   -2%  ||     1.48 |     1.50 |   +2%  |  0.0000 |
 | TPC-H 09 ||   7664.3 |  7501.8 |   -2%  ||     0.13 |     0.13 |   +2%  |       ˅ |
 | TPC-H 10 ||   2993.7 |  2932.3 |   -2%  ||     0.33 |     0.34 |   +2%  |  0.0000 |
 | TPC-H 11 ||    133.6 |   132.3 |   -1%  ||     7.49 |     7.56 |   +1%  |  0.0004 |
 | TPC-H 12 ||    731.3 |   725.6 |   -1%  ||     1.37 |     1.38 |   +1%  |  0.0000 |
+| TPC-H 13 ||   6800.8 |  5789.7 |  -15%  ||     0.15 |     0.17 |  +17%  |       ˅ |
+| TPC-H 14 ||    255.2 |   237.6 |   -7%  ||     3.92 |     4.21 |   +7%  |  0.0000 |
 | TPC-H 15 ||    102.9 |   100.3 |   -3%  ||     9.71 |     9.97 |   +3%  |  0.0000 |
+| TPC-H 16 ||   1292.8 |  1209.5 |   -6%  ||     0.77 |     0.83 |   +7%  |  0.0000 |
 | TPC-H 17 ||    280.0 |   272.5 |   -3%  ||     3.57 |     3.67 |   +3%  |  0.0000 |
 | TPC-H 18 ||  12680.8 | 12683.6 |   +0%  ||     0.08 |     0.08 |   -0%  |       ˅ |
+| TPC-H 19 ||    334.4 |   319.0 |   -5%  ||     2.99 |     3.14 |   +5%  |  0.0000 |
 | TPC-H 20 ||    184.1 |   180.2 |   -2%  ||     5.43 |     5.55 |   +2%  |  0.0000 |
 | TPC-H 21 ||   7109.6 |  7007.0 |   -1%  ||     0.14 |     0.14 |   +1%  |       ˅ |
 | TPC-H 22 ||    738.1 |   726.0 |   -2%  ||     1.35 |     1.38 |   +2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  58411.4 | 57611.4 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_e4e95ce0ac5e4980820622339e90e37b4a861583_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-12 10:50:02                                                                                                                    | 2020-10-13 09:26:55                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2422.6 |  2328.8 |   -4%  ||    20.08 |    20.91 |   +4%  |  0.0481 |
 | TPC-H 02 ||     16.6 |    16.0 |   -4%  ||  2356.73 |  2356.75 |   +0%  |  0.0000 |
 | TPC-H 03 ||    467.4 |   459.1 |   -2%  ||   105.23 |   107.21 |   +2%  |  0.2412 |
 | TPC-H 04 ||    290.1 |   286.2 |   -1%  ||   168.70 |   170.73 |   +1%  |  0.3567 |
 | TPC-H 05 ||   1423.0 |  1405.8 |   -1%  ||    34.21 |    34.40 |   +1%  |  0.7009 |
 | TPC-H 06 ||     23.5 |    23.1 |   -1%  ||  1666.56 |  1654.00 |   -1%  |  0.0000 |
+| TPC-H 07 ||    289.9 |   259.9 |  -10%  ||   168.15 |   187.78 |  +12%  |  0.0000 |
 | TPC-H 08 ||    200.6 |   194.2 |   -3%  ||   242.69 |   250.26 |   +3%  |  0.0006 |
 | TPC-H 09 ||   2641.9 |  2619.4 |   -1%  ||    18.13 |    18.47 |   +2%  |  0.7972 |
 | TPC-H 10 ||    923.0 |   919.1 |   -0%  ||    53.28 |    53.62 |   +1%  |  0.7691 |
 | TPC-H 11 ||     73.1 |    71.7 |   -2%  ||   643.21 |   654.35 |   +2%  |  0.0004 |
 | TPC-H 12 ||    141.5 |   137.3 |   -3%  ||   340.69 |   351.46 |   +3%  |  0.0003 |
 | TPC-H 13 ||   2440.2 |  2368.8 |   -3%  ||    19.80 |    20.33 |   +3%  |  0.3648 |
 | TPC-H 14 ||    151.0 |   152.4 |   +1%  ||   320.24 |   317.12 |   -1%  |  0.0951 |
 | TPC-H 15 ||     58.1 |    55.9 |   -4%  ||   794.62 |   824.57 |   +4%  |  0.0000 |
+| TPC-H 16 ||    496.8 |   467.2 |   -6%  ||    99.01 |   105.29 |   +6%  |  0.0000 |
+| TPC-H 17 ||     58.8 |    47.0 |  -20%  ||   790.34 |   971.86 |  +23%  |  0.0000 |
 | TPC-H 18 ||   6616.6 |  6495.1 |   -2%  ||     7.03 |     7.22 |   +3%  |  0.5441 |
+| TPC-H 19 ||     93.4 |    72.8 |  -22%  ||   508.96 |   642.42 |  +26%  |  0.0000 |
 | TPC-H 20 ||     55.8 |    55.1 |   -1%  ||   825.42 |   834.98 |   +1%  |  0.0101 |
 | TPC-H 21 ||   2357.8 |  2357.6 |   -0%  ||    20.56 |    20.26 |   -1%  |  0.9982 |
 | TPC-H 22 ||    725.1 |   729.2 |   +1%  ||    65.70 |    67.42 |   +3%  |  0.8331 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  21966.7 | 21521.9 |   -2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +4%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_e4e95ce0ac5e4980820622339e90e37b4a861583_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                          | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-10-12 11:12:30                                                                                                                     | 2020-10-13 09:49:26                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     28.9 |    29.0 |   +0%  ||    34.55 |    34.53 |   -0%  |  0.5742 |
 | 03      ||      7.1 |     7.2 |   +2%  ||   141.74 |   139.51 |   -2%  |  0.0000 |
 | 06      ||     18.2 |    18.6 |   +2%  ||    54.98 |    53.85 |   -2%  |  0.0000 |
 | 07      ||     32.4 |    31.0 |   -4%  ||    30.89 |    32.23 |   +4%  |  0.0000 |
+| 09      ||    122.5 |   107.6 |  -12%  ||     8.16 |     9.29 |  +14%  |  0.0000 |
 | 10      ||     19.7 |    19.9 |   +1%  ||    50.77 |    50.37 |   -1%  |  0.0000 |
+| 13      ||    129.5 |   120.1 |   -7%  ||     7.72 |     8.33 |   +8%  |  0.0000 |
 | 15      ||     10.2 |    10.2 |   -1%  ||    97.68 |    98.48 |   +1%  |  0.0000 |
 | 17      ||     28.3 |    28.7 |   +2%  ||    35.34 |    34.78 |   -2%  |  0.0152 |
 | 19      ||     10.2 |    10.3 |   +1%  ||    98.34 |    97.42 |   -1%  |  0.0000 |
 | 25      ||     15.5 |    15.2 |   -1%  ||    64.69 |    65.62 |   +1%  |  0.0232 |
+| 26      ||     16.0 |    14.6 |   -9%  ||    62.32 |    68.63 |  +10%  |  0.0000 |
+| 28      ||   1029.0 |   935.1 |   -9%  ||     0.97 |     1.07 |  +10%  |  0.0000 |
 | 29      ||     26.0 |    26.8 |   +3%  ||    38.53 |    37.38 |   -3%  |  0.0000 |
 | 31      ||    132.8 |   136.0 |   +2%  ||     7.53 |     7.36 |   -2%  |  0.0000 |
 | 34      ||     16.9 |    17.1 |   +1%  ||    59.10 |    58.59 |   -1%  |  0.0000 |
 | 35      ||     89.2 |    90.1 |   +1%  ||    11.22 |    11.10 |   -1%  |  0.0000 |
 | 39a     ||    174.9 |   175.9 |   +1%  ||     5.72 |     5.69 |   -1%  |  0.0000 |
 | 39b     ||    173.9 |   176.2 |   +1%  ||     5.75 |     5.67 |   -1%  |  0.0000 |
 | 41      ||     24.8 |    25.6 |   +3%  ||    40.39 |    39.12 |   -3%  |  0.0000 |
 | 42      ||      8.1 |     8.3 |   +2%  ||   124.02 |   121.16 |   -2%  |  0.0000 |
 | 43      ||    248.0 |   252.5 |   +2%  ||     4.03 |     3.96 |   -2%  |  0.0000 |
 | 45      ||      9.8 |     9.9 |   +1%  ||   101.89 |   100.75 |   -1%  |  0.0000 |
+| 48      ||     86.4 |    79.7 |   -8%  ||    11.57 |    12.55 |   +8%  |  0.0000 |
 | 50      ||     11.4 |    11.6 |   +2%  ||    87.79 |    86.04 |   -2%  |  0.0000 |
 | 52      ||      8.2 |     8.4 |   +3%  ||   122.03 |   118.94 |   -3%  |  0.0000 |
 | 55      ||      8.0 |     8.2 |   +2%  ||   124.25 |   122.23 |   -2%  |  0.0000 |
 | 62      ||     74.3 |    74.8 |   +1%  ||    13.45 |    13.37 |   -1%  |  0.0000 |
 | 65      ||     61.9 |    62.5 |   +1%  ||    16.15 |    15.99 |   -1%  |  0.0000 |
-| 69      ||     22.1 |    23.2 |   +5%  ||    45.24 |    43.17 |   -5%  |  0.0000 |
 | 73      ||     10.7 |    10.9 |   +2%  ||    93.22 |    91.53 |   -2%  |  0.0000 |
 | 79      ||     45.0 |    45.4 |   +1%  ||    22.21 |    22.04 |   -1%  |  0.0000 |
 | 81      ||     19.0 |    19.1 |   +1%  ||    52.64 |    52.24 |   -1%  |  0.0000 |
 | 83      ||      9.4 |     9.4 |   +0%  ||   105.93 |   105.82 |   -0%  |  0.0009 |
+| 85      ||     60.2 |    54.0 |  -10%  ||    16.60 |    18.52 |  +12%  |  0.0000 |
 | 88      ||     70.5 |    71.9 |   +2%  ||    14.19 |    13.91 |   -2%  |  0.0000 |
+| 91      ||     22.3 |    19.3 |  -13%  ||    44.87 |    51.71 |  +15%  |  0.0000 |
-| 93      ||    257.4 |   273.4 |   +6%  ||     3.89 |     3.66 |   -6%  |  0.0000 |
 | 96      ||      7.4 |     7.6 |   +3%  ||   135.41 |   131.84 |   -3%  |  0.0000 |
-| 97      ||    412.5 |   447.4 |   +8%  ||     2.42 |     2.24 |   -8%  |  0.0000 |
 | 99      ||    148.7 |   148.8 |   +0%  ||     6.72 |     6.72 |   -0%  |  0.4370 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3707.3 |  3641.3 |   -2%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +0%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +14%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_e4e95ce0ac5e4980820622339e90e37b4a861583_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                          | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-10-12 11:53:50                                                                                                                     | 2020-10-13 10:30:33                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    214.4 |   218.3 |   +2%  ||   227.49 |   223.60 |   -2%  |  0.0081 |
 | 03      ||     30.1 |    29.2 |   -3%  ||  1472.75 |  1502.81 |   +2%  |  0.0000 |
 | 06      ||    125.1 |   124.9 |   -0%  ||   384.46 |   385.14 |   +0%  |  0.8395 |
 | 07      ||    185.5 |   181.1 |   -2%  ||   261.80 |   268.58 |   +3%  |  0.0136 |
+| 09      ||    520.2 |   404.0 |  -22%  ||    93.11 |   121.49 |  +30%  |  0.0000 |
+| 10      ||     86.4 |    82.2 |   -5%  ||   550.18 |   576.47 |   +5%  |  0.0000 |
+| 13      ||    437.8 |   412.2 |   -6%  ||   112.40 |   118.59 |   +6%  |  0.0000 |
 | 15      ||     71.3 |    71.7 |   +1%  ||   656.70 |   653.39 |   -1%  |  0.3406 |
+| 17      ||    138.0 |   131.9 |   -4%  ||   349.33 |   365.23 |   +5%  |  0.0000 |
+| 19      ||     50.8 |    33.7 |  -34%  ||   903.87 |  1309.06 |  +45%  |  0.0000 |
+| 25      ||     77.0 |    69.1 |  -10%  ||   614.82 |   680.74 |  +11%  |  0.0000 |
 | 26      ||    108.9 |   108.2 |   -1%  ||   439.69 |   442.13 |   +1%  |  0.3383 |
 | 28      ||   3126.1 |  3141.5 |   +0%  ||    14.43 |    14.25 |   -1%  |  0.9221 |
 | 29      ||    136.7 |   130.9 |   -4%  ||   352.37 |   367.40 |   +4%  |  0.0000 |
 | 31      ||    818.0 |   806.5 |   -1%  ||    59.05 |    60.33 |   +2%  |  0.6204 |
+| 34      ||     93.3 |    84.5 |   -9%  ||   508.48 |   559.19 |  +10%  |  0.0000 |
 | 35      ||    846.5 |   838.4 |   -1%  ||    57.90 |    58.76 |   +1%  |  0.6152 |
 | 39a     ||   1740.9 |  1726.6 |   -1%  ||    27.86 |    28.11 |   +1%  |  0.7626 |
 | 39b     ||   1733.7 |  1738.2 |   +0%  ||    27.98 |    28.02 |   +0%  |  0.9259 |
+| 41      ||   1324.4 |  1045.2 |  -21%  ||    31.76 |    46.03 |  +45%  |  0.0003 |
+| 42      ||     41.3 |    25.7 |  -38%  ||  1094.74 |  1686.59 |  +54%  |  0.0000 |
 | 43      ||    784.5 |   786.6 |   +0%  ||    62.78 |    62.74 |   -0%  |  0.8480 |
 | 45      ||     53.5 |    53.8 |   +1%  ||   855.59 |   851.70 |   -0%  |  0.2343 |
 | 48      ||    376.2 |   360.4 |   -4%  ||   130.54 |   136.00 |   +4%  |  0.0091 |
+| 50      ||    140.6 |    42.5 |  -70%  ||   342.60 |  1060.93 | +210%  |  0.0000 |
+| 52      ||     42.3 |    26.0 |  -39%  ||  1067.06 |  1665.39 |  +56%  |  0.0000 |
+| 55      ||     38.8 |    24.7 |  -36%  ||  1157.21 |  1746.38 |  +51%  |  0.0000 |
 | 62      ||    310.0 |   313.6 |   +1%  ||   158.01 |   156.13 |   -1%  |  0.2109 |
 | 65      ||    551.4 |   550.8 |   -0%  ||    89.33 |    89.44 |   +0%  |  0.9299 |
 | 69      ||    129.9 |   126.3 |   -3%  ||   370.05 |   380.55 |   +3%  |  0.0017 |
+| 73      ||     52.9 |    44.3 |  -16%  ||   872.45 |  1027.57 |  +18%  |  0.0000 |
 | 79      ||    211.6 |   211.3 |   -0%  ||   230.10 |   230.80 |   +0%  |  0.8641 |
 | 81      ||    154.4 |   150.2 |   -3%  ||   313.26 |   321.80 |   +3%  |  0.0002 |
 | 83      ||     75.0 |    72.6 |   -3%  ||   627.05 |   647.53 |   +3%  |  0.0000 |
 | 85      ||    234.2 |   224.6 |   -4%  ||   208.42 |   217.48 |   +4%  |  0.0005 |
+| 88      ||    436.4 |   250.9 |  -43%  ||   112.36 |   194.01 |  +73%  |  0.0000 |
+| 91      ||     89.4 |    82.1 |   -8%  ||   532.12 |   577.46 |   +9%  |  0.0000 |
 | 93      ||   1377.5 |  1425.1 |   +3%  ||    34.25 |    34.17 |   -0%  |  0.2462 |
+| 96      ||     47.6 |    23.8 |  -50%  ||   962.20 |  1827.48 |  +90%  |  0.0000 |
 | 97      ||   3898.6 |  3744.1 |   -4%  ||    12.37 |    12.67 |   +2%  |  0.2087 |
 | 99      ||    801.3 |   799.6 |   -0%  ||    61.13 |    61.42 |   +0%  |  0.8854 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||  21712.4 | 20717.1 |   -5%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |  +14%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +3%
 ||
Geometric mean of throughput changes: -4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_e4e95ce0ac5e4980820622339e90e37b4a861583_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-10-12 12:35:10                                                                                                                    | 2020-10-13 11:11:52                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     28.7 |    29.4 |   +2%  ||     3.77 |     3.63 |   -4%  | (run time too short) |
 | New-Order    ||     18.2 |    19.0 |   +5%  ||    42.37 |    40.67 |   -4%  | (run time too short) |
 | Order-Status ||      1.3 |     1.3 |   +2%  ||     3.77 |     3.62 |   -4%  | (run time too short) |
 | Payment      ||      2.5 |     2.6 |   +3%  ||    40.42 |    38.94 |   -4%  | (run time too short) |
 | Stock-Level  ||      4.2 |     4.2 |   -0%  ||     3.75 |     3.63 |   -3%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     54.8 |    56.4 |   +3%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -4%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -14%
 ||
Geometric mean of throughput changes: +16%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_e4e95ce0ac5e4980820622339e90e37b4a861583_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-12 12:36:14                                                                                                                    | 2020-10-13 11:12:57                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
+| Delivery     ||    224.5 |   193.0 |  -14%  ||     4.30 |     5.01 |  +16%  | (run time too short) |
 |    unsucc.:  ||      4.1 |     4.2 |   +3%  ||   123.98 |   128.93 |   +4%  |                      |
+| New-Order    ||    100.9 |    85.0 |  -16%  ||    84.98 |   100.26 |  +18%  |               0.0000 |
 |    unsucc.:  ||      5.0 |     4.9 |   -3%  ||  1358.40 |  1406.37 |   +4%  |                      |
 | Order-Status ||      8.0 |     7.7 |   -3%  ||   128.30 |   133.94 |   +4%  |               0.0000 |
+| Payment      ||     18.3 |    15.3 |  -17%  ||     5.53 |     7.75 |  +40%  | (run time too short) |
 |    unsucc.:  ||      4.3 |     4.2 |   -1%  ||  1373.77 |  1432.06 |   +4%  |                      |
 | Stock-Level  ||     18.8 |    18.8 |   +0%  ||   128.30 |   133.92 |   +4%  |               0.8697 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
+| Sum          ||    370.4 |   319.8 |  -14%  ||          |          |        |                      |
+| Geomean      ||          |         |        ||          |          |  +16%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_e4e95ce0ac5e4980820622339e90e37b4a861583_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                              | e4e95ce0ac5e4980820622339e90e37b4a861583-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-10-12 12:37:20                                                                                                                         | 2020-10-13 11:14:02                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    360.8 |    357.4 |   -1%  ||     2.77 |     2.80 |   +1%  |  0.0007 |
 | 10b     ||    356.7 |    351.3 |   -2%  ||     2.80 |     2.85 |   +2%  |  0.0000 |
 | 10c     ||   1161.4 |   1163.5 |   +0%  ||     0.86 |     0.86 |   -0%  |  0.6955 |
 | 11a     ||    155.8 |    151.9 |   -3%  ||     6.42 |     6.58 |   +3%  |  0.0086 |
 | 11b     ||    144.6 |    142.4 |   -2%  ||     6.92 |     7.02 |   +2%  |  0.1354 |
 | 11c     ||    530.5 |    524.0 |   -1%  ||     1.88 |     1.91 |   +1%  |  0.2164 |
 | 11d     ||   4704.2 |   4770.4 |   +1%  ||     0.21 |     0.21 |   -1%  |  0.4517 |
 | 12a     ||    367.4 |    371.8 |   +1%  ||     2.72 |     2.69 |   -1%  |  0.2007 |
 | 12b     ||    655.5 |    629.3 |   -4%  ||     1.53 |     1.59 |   +4%  |  0.0000 |
 | 12c     ||   3718.9 |   3758.1 |   +1%  ||     0.27 |     0.27 |   -1%  |  0.2813 |
 | 13a     ||    178.7 |    180.2 |   +1%  ||     5.60 |     5.55 |   -1%  |  0.0000 |
+| 13b     ||    265.7 |    249.2 |   -6%  ||     3.76 |     4.01 |   +7%  |  0.0000 |
 | 13c     ||    142.9 |    142.2 |   -0%  ||     7.00 |     7.03 |   +0%  |  0.0000 |
 | 13d     ||    180.9 |    178.5 |   -1%  ||     5.53 |     5.60 |   +1%  |  0.0000 |
 | 14a     ||   4117.6 |   4089.0 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.4262 |
 | 14b     ||   4803.0 |   4691.2 |   -2%  ||     0.21 |     0.21 |   +2%  |  0.0343 |
 | 14c     ||   4131.5 |   4084.7 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.2457 |
+| 15a     ||    211.2 |    193.8 |   -8%  ||     4.74 |     5.16 |   +9%  |  0.0000 |
+| 15b     ||    207.5 |    189.6 |   -9%  ||     4.82 |     5.27 |   +9%  |  0.0000 |
 | 15c     ||    153.0 |    154.2 |   +1%  ||     6.54 |     6.49 |   -1%  |  0.0717 |
 | 15d     ||    465.7 |    454.6 |   -2%  ||     2.15 |     2.20 |   +2%  |  0.0000 |
 | 16a     ||   4732.8 |   4725.2 |   -0%  ||     0.21 |     0.21 |   +0%  |  0.9308 |
 | 16b     ||   6162.6 |   6192.4 |   +0%  ||     0.16 |     0.16 |   -0%  |  0.7195 |
 | 16c     ||   4888.2 |   4842.7 |   -1%  ||     0.20 |     0.21 |   +1%  |  0.5317 |
 | 16d     ||   4798.3 |   4813.3 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.8260 |
 | 17a     ||    976.4 |    975.6 |   -0%  ||     1.02 |     1.02 |   +0%  |  0.9042 |
 | 17b     ||    774.8 |    773.5 |   -0%  ||     1.29 |     1.29 |   +0%  |  0.7708 |
 | 17c     ||    730.0 |    728.9 |   -0%  ||     1.37 |     1.37 |   +0%  |  0.7943 |
 | 17d     ||    841.0 |    843.6 |   +0%  ||     1.19 |     1.19 |   -0%  |  0.5795 |
 | 17e     ||   2958.4 |   2956.3 |   -0%  ||     0.34 |     0.34 |   +0%  |  0.9267 |
 | 17f     ||   1552.0 |   1557.3 |   +0%  ||     0.64 |     0.64 |   -0%  |  0.6381 |
 | 18a     ||    684.4 |    687.0 |   +0%  ||     1.46 |     1.46 |   -0%  |  0.4886 |
 | 18b     ||    232.8 |    232.4 |   -0%  ||     4.30 |     4.30 |   +0%  |  0.7479 |
 | 18c     ||   3790.9 |   3801.9 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.6426 |
 | 19a     ||   7646.3 |   7725.6 |   +1%  ||     0.13 |     0.13 |   -1%  |       ˅ |
 | 19b     ||   4528.7 |   4607.1 |   +2%  ||     0.22 |     0.22 |   -2%  |  0.0001 |
 | 19c     ||   7428.9 |   7500.7 |   +1%  ||     0.13 |     0.13 |   -1%  |       ˅ |
 | 19d     ||   5717.5 |   5756.9 |   +1%  ||     0.17 |     0.17 |   -1%  |  0.4439 |
 | 1a      ||     58.8 |     56.5 |   -4%  ||    17.01 |    17.70 |   +4%  |  0.0000 |
 | 1b      ||     22.0 |     22.1 |   +0%  ||    45.52 |    45.31 |   -0%  |  0.0000 |
 | 1c      ||     22.0 |     22.3 |   +1%  ||    45.46 |    44.80 |   -1%  |  0.0000 |
-| 1d      ||     21.9 |     23.5 |   +7%  ||    45.68 |    42.52 |   -7%  |  0.0000 |
 | 20a     ||   1276.7 |   1292.8 |   +1%  ||     0.78 |     0.77 |   -1%  |  0.0000 |
 | 20b     ||   1091.7 |   1105.4 |   +1%  ||     0.92 |     0.90 |   -1%  |  0.0000 |
 | 20c     ||   1127.5 |   1111.9 |   -1%  ||     0.89 |     0.90 |   +1%  |  0.0000 |
 | 21a     ||   3857.7 |   3925.5 |   +2%  ||     0.26 |     0.25 |   -2%  |  0.0000 |
 | 21b     ||    265.3 |    265.7 |   +0%  ||     3.77 |     3.76 |   -0%  |  0.6615 |
 | 21c     ||   3984.1 |   4068.4 |   +2%  ||     0.25 |     0.25 |   -2%  |  0.0000 |
 | 22a     ||   3487.3 |   3559.6 |   +2%  ||     0.29 |     0.28 |   -2%  |  0.0256 |
 | 22b     ||   3491.9 |   3562.3 |   +2%  ||     0.29 |     0.28 |   -2%  |  0.0290 |
 | 22c     ||   4126.7 |   4217.6 |   +2%  ||     0.24 |     0.24 |   -2%  |  0.0068 |
 | 22d     ||   4143.6 |   4250.5 |   +3%  ||     0.24 |     0.24 |   -3%  |  0.0019 |
-| 23a     ||    156.4 |    171.9 |  +10%  ||     6.39 |     5.82 |   -9%  |  0.0000 |
-| 23b     ||    122.1 |    132.9 |   +9%  ||     8.19 |     7.52 |   -8%  |  0.0000 |
-| 23c     ||    174.7 |    189.6 |   +9%  ||     5.72 |     5.27 |   -8%  |  0.0000 |
 | 24a     ||   4621.1 |   4689.9 |   +1%  ||     0.22 |     0.21 |   -1%  |  0.0484 |
 | 24b     ||   4564.8 |   4701.4 |   +3%  ||     0.22 |     0.21 |   -3%  |  0.0370 |
 | 25a     ||    236.4 |    235.2 |   -0%  ||     4.23 |     4.25 |   +0%  |  0.2559 |
 | 25b     ||    250.2 |    250.7 |   +0%  ||     4.00 |     3.99 |   -0%  |  0.5310 |
 | 25c     ||   3788.3 |   3785.7 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.8910 |
 | 26a     ||    995.4 |    963.2 |   -3%  ||     1.00 |     1.04 |   +3%  |  0.0000 |
 | 26b     ||    984.3 |    952.8 |   -3%  ||     1.02 |     1.05 |   +3%  |  0.0000 |
 | 26c     ||   1001.4 |    964.8 |   -4%  ||     1.00 |     1.04 |   +4%  |  0.0000 |
 | 27a     ||   3506.6 |   3484.0 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2395 |
 | 27b     ||   3485.0 |   3450.5 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.0766 |
 | 27c     ||    205.7 |    201.4 |   -2%  ||     4.86 |     4.96 |   +2%  |  0.0065 |
 | 28a     ||   4155.3 |   4155.0 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.9980 |
 | 28b     ||   3393.6 |   3426.4 |   +1%  ||     0.29 |     0.29 |   -1%  |  0.7280 |
 | 28c     ||   4153.5 |   4157.9 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.9629 |
 | 29a     ||   4502.8 |   4530.7 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.8467 |
 | 29b     ||    201.6 |    201.1 |   -0%  ||     4.96 |     4.97 |   +0%  |  0.9621 |
 | 29c     ||   4593.4 |   4630.5 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.8042 |
 | 2a      ||    110.3 |    110.0 |   -0%  ||     9.07 |     9.09 |   +0%  |  0.0002 |
 | 2b      ||     86.4 |     86.3 |   -0%  ||    11.57 |    11.59 |   +0%  |  0.0043 |
 | 2c      ||     56.7 |     56.9 |   +0%  ||    17.63 |    17.57 |   -0%  |  0.0000 |
 | 2d      ||    136.2 |    136.4 |   +0%  ||     7.34 |     7.33 |   -0%  |  0.0245 |
 | 30a     ||    253.0 |    250.7 |   -1%  ||     3.95 |     3.99 |   +1%  |  0.6398 |
+| 30b     ||   1137.7 |   1082.6 |   -5%  ||     0.88 |     0.92 |   +5%  |  0.0127 |
 | 30c     ||   3815.8 |   3830.7 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.8546 |
 | 31a     ||    290.9 |    289.6 |   -0%  ||     3.44 |     3.45 |   +0%  |  0.6443 |
 | 31b     ||   1167.2 |   1118.2 |   -4%  ||     0.86 |     0.89 |   +4%  |  0.0003 |
 | 31c     ||    294.1 |    291.6 |   -1%  ||     3.40 |     3.43 |   +1%  |  0.3972 |
 | 32a     ||     37.2 |     36.8 |   -1%  ||    26.88 |    27.17 |   +1%  |  0.0000 |
 | 32b     ||    288.1 |    287.8 |   -0%  ||     3.47 |     3.48 |   +0%  |  0.1435 |
 | 33a     ||     70.1 |     69.3 |   -1%  ||    14.27 |    14.43 |   +1%  |  0.1046 |
 | 33b     ||     69.2 |     68.4 |   -1%  ||    14.44 |    14.61 |   +1%  |  0.0736 |
 | 33c     ||     85.4 |     84.7 |   -1%  ||    11.70 |    11.81 |   +1%  |  0.2028 |
 | 3a      ||   3968.1 |   3987.6 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.0000 |
 | 3b      ||     36.4 |     36.4 |   -0%  ||    27.47 |    27.48 |   +0%  |  0.2082 |
 | 3c      ||   5108.8 |   5195.1 |   +2%  ||     0.20 |     0.19 |   -2%  |  0.0000 |
 | 4a      ||    128.8 |    132.0 |   +2%  ||     7.76 |     7.57 |   -2%  |  0.0000 |
-| 4b      ||     27.2 |     29.1 |   +7%  ||    36.78 |    34.40 |   -6%  |  0.0000 |
 | 4c      ||    145.5 |    149.4 |   +3%  ||     6.87 |     6.69 |   -3%  |  0.0000 |
 | 5a      ||   3798.3 |   3824.4 |   +1%  ||     0.26 |     0.26 |   -1%  |  0.0000 |
 | 5b      ||    278.8 |    277.7 |   -0%  ||     3.59 |     3.60 |   +0%  |  0.0039 |
 | 5c      ||   4435.8 |   4461.3 |   +1%  ||     0.23 |     0.22 |   -1%  |  0.0000 |
 | 6a      ||    229.9 |    229.6 |   -0%  ||     4.35 |     4.36 |   +0%  |  0.1404 |
 | 6b      ||    961.5 |    965.1 |   +0%  ||     1.04 |     1.04 |   -0%  |  0.1168 |
 | 6c      ||    230.4 |    232.3 |   +1%  ||     4.34 |     4.31 |   -1%  |  0.0000 |
 | 6d      ||    965.6 |    967.0 |   +0%  ||     1.04 |     1.03 |   -0%  |  0.3187 |
 | 6e      ||    230.5 |    234.0 |   +2%  ||     4.34 |     4.27 |   -1%  |  0.0000 |
 | 6f      ||   1501.0 |   1522.8 |   +1%  ||     0.67 |     0.66 |   -1%  |  0.0000 |
+| 7a      ||    280.0 |    265.9 |   -5%  ||     3.57 |     3.76 |   +5%  |  0.0000 |
 | 7b      ||    137.3 |    137.9 |   +0%  ||     7.28 |     7.25 |   -0%  |  0.6895 |
 | 7c      ||  11011.9 |  10926.3 |   -1%  ||     0.09 |     0.09 |   +1%  |       ˅ |
 | 8a      ||    111.9 |    116.7 |   +4%  ||     8.93 |     8.57 |   -4%  |  0.0000 |
 | 8b      ||    167.0 |    170.7 |   +2%  ||     5.99 |     5.86 |   -2%  |  0.0000 |
 | 8c      ||   4396.4 |   4430.5 |   +1%  ||     0.23 |     0.23 |   -1%  |  0.2246 |
 | 8d      ||   1552.1 |   1556.5 |   +0%  ||     0.64 |     0.64 |   -0%  |  0.3121 |
 | 9a      ||   3515.1 |   3452.6 |   -2%  ||     0.28 |     0.29 |   +2%  |  0.0025 |
 | 9b      ||    331.2 |    328.5 |   -1%  ||     3.02 |     3.04 |   +1%  |  0.1289 |
 | 9c      ||   3531.0 |   3483.2 |   -1%  ||     0.28 |     0.29 |   +1%  |  0.0240 |
 | 9d      ||   4107.4 |   4054.7 |   -1%  ||     0.24 |     0.25 |   +1%  |  0.0293 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 216613.4 | 217274.8 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -21%
 ||
Geometric mean of throughput changes: +43%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_e4e95ce0ac5e4980820622339e90e37b4a861583_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                              | daf666960c0f3a90c479bc6e24ecd4dc0c1d3591-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-10-12 14:33:31                                                                                                                         | 2020-10-13 00:49:23                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++-----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)    | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |      new |        ||      old |      new |        |         |
 +---------++-----------+----------+--------++----------+----------+--------+---------+
+| 10a     ||    2465.3 |    959.5 |  -61%  ||    19.15 |    50.73 | +165%  |  0.0000 |
+| 10b     ||    1725.0 |    954.2 |  -45%  ||    27.85 |    50.94 |  +83%  |  0.0000 |
 | 10c     ||    8961.8 |   8281.2 |   -8%  ||     4.62 |     4.78 |   +4%  |  0.2617 |
+| 11a     ||     466.1 |    431.1 |   -8%  ||   105.36 |   114.05 |   +8%  |  0.0000 |
+| 11b     ||     429.6 |    394.3 |   -8%  ||   113.91 |   124.08 |   +9%  |  0.0001 |
 | 11c     ||    2429.4 |   2404.2 |   -1%  ||    19.40 |    19.55 |   +1%  |  0.7966 |
+| 11d     ||   23698.6 |  23432.3 |   -1%  ||     1.38 |     1.50 |   +8%  |  0.8400 |
 | 12a     ||    3553.8 |   3550.2 |   -0%  ||    12.92 |    12.78 |   -1%  |  0.9880 |
+| 12b     ||    1487.7 |   1167.5 |  -22%  ||    32.75 |    41.48 |  +27%  |  0.0000 |
+| 12c     ||   21279.0 |  14968.6 |  -30%  ||     1.58 |     1.95 |  +23%  |  0.0002 |
+| 13a     ||    1178.8 |   1025.6 |  -13%  ||    41.48 |    47.13 |  +14%  |  0.0000 |
+| 13b     ||    1415.6 |   1106.4 |  -22%  ||    34.28 |    43.91 |  +28%  |  0.0000 |
+| 13c     ||    1402.5 |   1094.3 |  -22%  ||    34.25 |    44.40 |  +30%  |  0.0000 |
+| 13d     ||    1191.2 |   1046.1 |  -12%  ||    40.98 |    46.67 |  +14%  |  0.0000 |
+| 14a     ||   16797.9 |  14200.3 |  -15%  ||     1.92 |     2.13 |  +11%  |  0.1028 |
+| 14b     ||   18364.9 |  12372.2 |  -33%  ||     1.73 |     2.02 |  +16%  |  0.0001 |
+| 14c     ||   18211.8 |  13846.5 |  -24%  ||     1.85 |     2.10 |  +14%  |  0.0054 |
+| 15a     ||    1124.2 |    882.0 |  -22%  ||    43.13 |    55.28 |  +28%  |  0.0000 |
+| 15b     ||    1106.7 |    863.6 |  -22%  ||    44.20 |    56.65 |  +28%  |  0.0000 |
+| 15c     ||     421.9 |    370.0 |  -12%  ||   115.36 |   132.37 |  +15%  |  0.0000 |
+| 15d     ||    2538.6 |   2383.2 |   -6%  ||    18.85 |    20.26 |   +8%  |  0.0968 |
+| 16a     ||   29064.4 |  27962.5 |   -4%  ||     0.98 |     1.17 |  +19%  |  0.6178 |
+| 16b     ||   36543.0 |  29783.2 |  -18%  ||     0.75 |     0.80 |   +7%  |  0.0031 |
+| 16c     ||   31555.5 |  25210.9 |  -20%  ||     0.87 |     1.12 |  +29%  |  0.0025 |
+| 16d     ||   28006.7 |  27410.7 |   -2%  ||     0.97 |     1.10 |  +14%  |  0.7645 |
+| 17a     ||    8386.2 |   4809.3 |  -43%  ||     4.93 |     9.35 |  +90%  |  0.0000 |
+| 17b     ||    7311.9 |   3546.1 |  -52%  ||     5.07 |    12.48 | +146%  |  0.0000 |
+| 17c     ||    6893.0 |   3380.5 |  -51%  ||     5.02 |    13.20 | +163%  |  0.0000 |
+| 17d     ||    7747.9 |   3703.1 |  -52%  ||     5.13 |    12.48 | +143%  |  0.0000 |
 | 17e     ||   13714.1 |  13808.1 |   +1%  ||     2.98 |     3.10 |   +4%  |  0.9241 |
+| 17f     ||    9330.9 |   6865.5 |  -26%  ||     4.47 |     6.07 |  +36%  |  0.0000 |
+| 18a     ||    4835.6 |   4510.0 |   -7%  ||     9.57 |    10.52 |  +10%  |  0.2549 |
+| 18b     ||    2400.1 |    849.9 |  -65%  ||    20.10 |    57.26 | +185%  |  0.0000 |
+| 18c     ||   18554.2 |  11529.1 |  -38%  ||     1.88 |     2.33 |  +24%  |  0.0000 |
+| 19a     ||   36772.0 |  24165.6 |  -34%  ||     0.77 |     1.10 |  +43%  |  0.0002 |
+| 19b     ||   11929.7 |   9517.4 |  -20%  ||     3.25 |     4.03 |  +24%  |  0.0089 |
+| 19c     ||   36246.4 |  25207.8 |  -30%  ||     0.80 |     1.10 |  +37%  |  0.0001 |
 | 19d     ||   37691.5 |  32820.8 |  -13%  ||     0.72 |     0.73 |   +2%  |  0.0471 |
 | 1a      ||     339.2 |    336.5 |   -1%  ||   144.44 |   145.53 |   +1%  |  0.6216 |
+| 1b      ||      73.3 |     51.3 |  -30%  ||   637.05 |   885.45 |  +39%  |  0.0000 |
+| 1c      ||      74.6 |     53.6 |  -28%  ||   629.70 |   855.17 |  +36%  |  0.0000 |
+| 1d      ||      73.7 |     51.4 |  -30%  ||   634.65 |   884.52 |  +39%  |  0.0000 |
+| 20a     ||    5693.4 |   3342.8 |  -41%  ||     7.87 |    13.67 |  +74%  |  0.0000 |
+| 20b     ||    4309.3 |   2778.1 |  -36%  ||    10.43 |    16.52 |  +58%  |  0.0000 |
+| 20c     ||    4337.8 |   2976.8 |  -31%  ||    10.53 |    15.83 |  +50%  |  0.0000 |
+| 21a     ||   17114.1 |  11400.2 |  -33%  ||     2.13 |     2.38 |  +12%  |  0.0000 |
 | 21b     ||    1057.5 |   1048.9 |   -1%  ||    45.78 |    46.67 |   +2%  |  0.7965 |
+| 21c     ||   15822.4 |  12406.9 |  -22%  ||     2.07 |     2.30 |  +11%  |  0.0242 |
+| 22a     ||   17748.3 |  10788.1 |  -39%  ||     1.92 |     2.28 |  +19%  |  0.0000 |
+| 22b     ||   16477.4 |  14448.3 |  -12%  ||     1.90 |     2.28 |  +20%  |  0.1650 |
+| 22c     ||   19483.4 |  14977.9 |  -23%  ||     1.83 |     2.12 |  +15%  |  0.0052 |
+| 22d     ||   19531.6 |  16156.5 |  -17%  ||     1.80 |     2.07 |  +15%  |  0.0414 |
+| 23a     ||     459.1 |    399.1 |  -13%  ||   107.14 |   122.76 |  +15%  |  0.0000 |
+| 23b     ||     983.6 |    462.6 |  -53%  ||    49.53 |   106.27 | +115%  |  0.0000 |
+| 23c     ||     543.9 |    487.9 |  -10%  ||    90.27 |   100.68 |  +12%  |  0.0000 |
+| 24a     ||   11156.0 |   7704.2 |  -31%  ||     3.27 |     4.15 |  +27%  |  0.0000 |
+| 24b     ||   10896.9 |   8063.2 |  -26%  ||     3.47 |     4.18 |  +21%  |  0.0010 |
+| 25a     ||    2339.4 |    817.0 |  -65%  ||    20.33 |    59.68 | +194%  |  0.0000 |
+| 25b     ||    2943.3 |    827.5 |  -72%  ||    15.63 |    58.28 | +273%  |  0.0000 |
+| 25c     ||   18827.8 |  13519.1 |  -28%  ||     1.87 |     2.32 |  +24%  |  0.0004 |
+| 26a     ||    2936.3 |   2364.6 |  -19%  ||    15.26 |    18.32 |  +20%  |  0.0001 |
+| 26b     ||    3079.4 |   2482.6 |  -19%  ||    15.58 |    18.72 |  +20%  |  0.0003 |
+| 26c     ||    3010.9 |   2508.2 |  -17%  ||    14.98 |    18.33 |  +22%  |  0.0018 |
+| 27a     ||   16778.3 |  14336.3 |  -15%  ||     2.03 |     2.40 |  +18%  |  0.1048 |
+| 27b     ||   16232.1 |  13883.7 |  -14%  ||     2.07 |     2.50 |  +21%  |  0.1068 |
+| 27c     ||     933.9 |    612.8 |  -34%  ||    52.53 |    79.96 |  +52%  |  0.0000 |
+| 28a     ||   18459.2 |  15676.2 |  -15%  ||     1.83 |     2.02 |  +10%  |  0.0848 |
+| 28b     ||   17587.7 |  13881.9 |  -21%  ||     2.12 |     2.42 |  +14%  |  0.0181 |
+| 28c     ||   19529.4 |   9546.1 |  -51%  ||     1.85 |     2.10 |  +14%  |  0.0000 |
+| 29a     ||   11933.3 |  10137.1 |  -15%  ||     3.32 |     4.15 |  +25%  |  0.0746 |
+| 29b     ||    2531.2 |    628.7 |  -75%  ||    18.85 |    77.60 | +312%  |  0.0000 |
+| 29c     ||   11901.4 |   9040.7 |  -24%  ||     3.22 |     4.08 |  +27%  |  0.0021 |
+| 2a      ||     630.3 |    594.5 |   -6%  ||    77.68 |    82.32 |   +6%  |  0.0085 |
+| 2b      ||     676.9 |    440.4 |  -35%  ||    72.56 |   111.08 |  +53%  |  0.0000 |
+| 2c      ||     552.9 |    207.8 |  -62%  ||    88.66 |   234.21 | +164%  |  0.0000 |
+| 2d      ||     728.2 |    695.7 |   -4%  ||    66.88 |    70.50 |   +5%  |  0.0481 |
+| 30a     ||    2677.7 |    929.9 |  -65%  ||    17.70 |    52.06 | +194%  |  0.0000 |
+| 30b     ||    3093.4 |   2150.2 |  -30%  ||    15.13 |    22.01 |  +45%  |  0.0000 |
+| 30c     ||   21731.0 |  14774.3 |  -32%  ||     1.80 |     2.22 |  +23%  |  0.0000 |
+| 31a     ||    3226.5 |   1003.1 |  -69%  ||    14.13 |    48.55 | +244%  |  0.0000 |
+| 31b     ||    3455.4 |   2136.6 |  -38%  ||    13.50 |    21.90 |  +62%  |  0.0000 |
+| 31c     ||    2735.9 |   1005.5 |  -63%  ||    15.75 |    48.11 | +205%  |  0.0000 |
+| 32a     ||     161.4 |     92.2 |  -43%  ||   299.58 |   511.69 |  +71%  |  0.0000 |
 | 32b     ||    1206.5 |   1171.3 |   -3%  ||    40.60 |    41.90 |   +3%  |  0.2055 |
+| 33a     ||     283.8 |    250.6 |  -12%  ||   172.28 |   194.51 |  +13%  |  0.0000 |
+| 33b     ||     282.3 |    249.5 |  -12%  ||   172.88 |   195.37 |  +13%  |  0.0000 |
+| 33c     ||     376.6 |    347.0 |   -8%  ||   130.28 |   141.22 |   +8%  |  0.0000 |
+| 3a      ||   19096.6 |  12286.6 |  -36%  ||     1.83 |     2.15 |  +17%  |  0.0000 |
+| 3b      ||     343.7 |    116.7 |  -66%  ||   142.80 |   411.15 | +188%  |  0.0000 |
+| 3c      ||   32175.9 |  21821.7 |  -32%  ||     0.90 |     1.22 |  +35%  |  0.0001 |
 | 4a      ||    1019.0 |    998.6 |   -2%  ||    47.36 |    48.88 |   +3%  |  0.4683 |
+| 4b      ||     106.8 |     67.8 |  -37%  ||   446.84 |   686.74 |  +54%  |  0.0000 |
 | 4c      ||    1248.6 |   1224.3 |   -2%  ||    39.13 |    39.45 |   +1%  |  0.5376 |
+| 5a      ||   17452.9 |  13736.6 |  -21%  ||     2.12 |     2.35 |  +11%  |  0.0054 |
 | 5b      ||    1483.5 |   1504.4 |   +1%  ||    31.86 |    32.35 |   +2%  |  0.7333 |
+| 5c      ||   18719.5 |  14522.0 |  -22%  ||     1.67 |     1.90 |  +14%  |  0.0087 |
+| 6a      ||    2046.9 |    738.6 |  -64%  ||    23.55 |    66.04 | +180%  |  0.0000 |
+| 6b      ||    6349.5 |   4242.2 |  -33%  ||     5.60 |    10.75 |  +92%  |  0.0000 |
+| 6c      ||    2031.9 |    736.8 |  -64%  ||    23.73 |    66.27 | +179%  |  0.0000 |
+| 6d      ||    6945.2 |   4040.2 |  -42%  ||     5.72 |    10.78 |  +89%  |  0.0000 |
+| 6e      ||    1983.4 |    739.5 |  -63%  ||    24.00 |    65.66 | +174%  |  0.0000 |
+| 6f      ||    7039.1 |   5507.0 |  -22%  ||     6.57 |     8.48 |  +29%  |  0.0003 |
+| 7a      ||    1545.5 |   1129.2 |  -27%  ||    31.40 |    43.24 |  +38%  |  0.0000 |
+| 7b      ||    1602.4 |    369.8 |  -77%  ||    30.23 |   132.69 | +339%  |  0.0000 |
+| 7c      ||   43175.6 |  50479.8 |  +17%  ||     0.13 |     0.15 |  +13%  |       ˅ |
+| 8a      ||    1528.9 |    507.0 |  -67%  ||    31.75 |    96.18 | +203%  |  0.0000 |
+| 8b      ||    1470.6 |    479.7 |  -67%  ||    32.87 |   102.47 | +212%  |  0.0000 |
+| 8c      ||   26159.0 |  26520.4 |   +1%  ||     1.27 |     1.33 |   +5%  |  0.8569 |
 | 8d      ||   10585.3 |  10458.2 |   -1%  ||     3.90 |     4.02 |   +3%  |  0.8832 |
+| 9a      ||   20250.0 |  20084.2 |   -1%  ||     1.37 |     1.52 |  +11%  |  0.9360 |
+| 9b      ||    3072.8 |   1885.3 |  -39%  ||    15.01 |    25.76 |  +72%  |  0.0000 |
+| 9c      ||   26411.6 |  20847.3 |  -21%  ||     1.28 |     1.40 |   +9%  |  0.0089 |
-| 9d      ||   24958.6 |  23834.6 |   -5%  ||     1.40 |     1.32 |   -6%  |  0.5369 |
 +---------++-----------+----------+--------++----------+----------+--------+---------+
+| Sum     || 1073054.5 | 843937.7 |  -21%  ||          |          |        |         |
+| Geomean ||           |          |        ||          |          |  +43%  |         |
 +---------++-----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                   |
 +---------++-----------+----------+--------++----------+----------+--------+---------+
```
</details>

