### PR TITLE
Fix Performance Regression caused by split-or

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -114,16 +114,14 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   optimizer->add_rule(std::make_unique<PredicatePlacementRule>());
 
+  optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
+
   optimizer->add_rule(std::make_unique<SubqueryToJoinRule>());
 
   // Run the ColumnPruningRule before the PredicatePlacementRule, as it might turn joins into semi joins, which
   // can be treated as predicates and pushed further down. For the same reason, run it after the JoinOrderingRule,
   // which does not like semi joins (see above).
   optimizer->add_rule(std::make_unique<ColumnPruningRule>());
-
-  // Run the PredicateSplitUpRule after the ColumnPruningRule, as it may create UNION ALLs which are not handled in the
-  // column pruning rule yet.
-  optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
 
   optimizer->add_rule(std::make_unique<SemiJoinReductionRule>());
 

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -149,16 +149,15 @@ ExpressionUnorderedSet gather_locally_required_expressions(
       const auto& union_node = static_cast<const UnionNode&>(*node);
       switch (union_node.set_operation_mode) {
         case SetOperationMode::Positions: {
-          // UnionNode does not require any expressions itself for the Positions mode. Once we add actual unions from two
-          // tables, we will probably have to change something here in this rule that the required expressions are kept on
-          // both the left and right sides.
+          // UnionNode does not require any expressions itself for the Positions mode. As Positions by definition
+          // operates on the same table left and right, we simply require the same input expressions from both sides.
         } break;
 
         case SetOperationMode::All: {
           // Similarly, if the two input tables are only glued together, the UnionNode itself does not require any
           // expressions. Currently, this mode is used to merge the result of two mutually exclusive or conditions (see
-          // PredicateSplitUpRule). Once we have a union operator that merges data from different tables, we have to look
-          // into this more deeply.
+          // PredicateSplitUpRule). Once we have a union operator that merges data from different tables, we have to
+          // look into this more deeply.
           Assert(union_node.left_input()->output_expressions() == union_node.right_input()->output_expressions(),
                  "Can only handle SetOperationMode::All if both inputs have the same expressions");
         } break;

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -83,38 +83,42 @@ TEST_F(ColumnPruningRuleTest, NoUnion) {
 }
 
 TEST_F(ColumnPruningRuleTest, WithUnion) {
-  auto lqp = std::shared_ptr<AbstractLQPNode>{};
+  for (auto union_mode : {SetOperationMode::Positions, SetOperationMode::All}) {
+    SCOPED_TRACE(std::string{"union_mode: "} + set_operation_mode_to_string.left.at(union_mode));
 
-  // clang-format off
-  lqp =
-  ProjectionNode::make(expression_vector(a),
-    UnionNode::make(SetOperationMode::Positions,
-      PredicateNode::make(greater_than_(a, 5),
-        node_a),
-      PredicateNode::make(greater_than_(b, 5),
-        node_a)));
+    auto lqp = std::shared_ptr<AbstractLQPNode>{};
 
-  // Create deep copy so we can set pruned ColumnIDs on node_a below without manipulating the input LQP
-  lqp = lqp->deep_copy();
+    // clang-format off
+    lqp =
+    ProjectionNode::make(expression_vector(a),
+      UnionNode::make(SetOperationMode::Positions,
+        PredicateNode::make(greater_than_(a, 5),
+          node_a),
+        PredicateNode::make(greater_than_(b, 5),
+          node_a)));
+
+    // Create deep copy so we can set pruned ColumnIDs on node_a below without manipulating the input LQP
+    lqp = lqp->deep_copy();
 
 
-  const auto pruned_node_a = pruned(node_a, {ColumnID{2}});
-  const auto pruned_a = pruned_node_a->get_column("a");
-  const auto pruned_b = pruned_node_a->get_column("b");
+    const auto pruned_node_a = pruned(node_a, {ColumnID{2}});
+    const auto pruned_a = pruned_node_a->get_column("a");
+    const auto pruned_b = pruned_node_a->get_column("b");
 
-  const auto actual_lqp = apply_rule(rule, lqp);
+    const auto actual_lqp = apply_rule(rule, lqp);
 
-  // Column c is not used anywhere above the union, so it can be pruned at least in the Positions mode
-  const auto expected_lqp =
-  ProjectionNode::make(expression_vector(pruned_a),
-    UnionNode::make(SetOperationMode::Positions,
-      PredicateNode::make(greater_than_(pruned_a, 5),
-        pruned_node_a),
-      PredicateNode::make(greater_than_(pruned_b, 5),
-        pruned_node_a)));
-  // clang-format on
+    // Column c is not used anywhere above the union, so it can be pruned at least in the Positions mode
+    const auto expected_lqp =
+    ProjectionNode::make(expression_vector(pruned_a),
+      UnionNode::make(SetOperationMode::Positions,
+        PredicateNode::make(greater_than_(pruned_a, 5),
+          pruned_node_a),
+        PredicateNode::make(greater_than_(pruned_b, 5),
+          pruned_node_a)));
+    // clang-format on
 
-  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+  }
 }
 
 TEST_F(ColumnPruningRuleTest, WithMultipleProjections) {

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -91,7 +91,7 @@ TEST_F(ColumnPruningRuleTest, WithUnion) {
     // clang-format off
     lqp =
     ProjectionNode::make(expression_vector(a),
-      UnionNode::make(SetOperationMode::Positions,
+      UnionNode::make(union_mode,
         PredicateNode::make(greater_than_(a, 5),
           node_a),
         PredicateNode::make(greater_than_(b, 5),
@@ -110,7 +110,7 @@ TEST_F(ColumnPruningRuleTest, WithUnion) {
     // Column c is not used anywhere above the union, so it can be pruned at least in the Positions mode
     const auto expected_lqp =
     ProjectionNode::make(expression_vector(pruned_a),
-      UnionNode::make(SetOperationMode::Positions,
+      UnionNode::make(union_mode,
         PredicateNode::make(greater_than_(pruned_a, 5),
           pruned_node_a),
         PredicateNode::make(greater_than_(pruned_b, 5),


### PR DESCRIPTION
#2238 introduced a performance regression in TPC-DS:

```diff
-| 10      ||     19.7 |    6060.5 |   +30674%  ||    50.77 |     0.17 | -100%  |  0.0000 |
-| 35      ||     89.2 | 1303100.2 | +1461565%  ||    11.22 |     0.00 | -100%  |       ˅ |
-| 45      ||      9.8 |      17.4 |      +77%  ||   101.89 |    57.59 |  -43%  |  0.0000 |
```

This went unnoticed because <s>I</s> someone did not have sufficient compute resources and only ran the TPC-H benchmark. What happened was that some disjunctions were made unavailable for the SubqueryToJoinRule.

With this PR, that someone reverts the old order in the optimizer and instead fixes the ColumnPruningRule to be able to deal with certain types of UnionAll.

<details>
<summary>Here is the complete benchmark_all result for #2238</summary>

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 44f8c4aa8 | 08.10.2020 21:29 | Create empty bloom filter only once (#2236) | real 270.68 user 2492.41 sys 152.64|
| f518e3173 | 10.10.2020 21:19 | PredicateSplitUpRule: Create UnionAll for NOT LIKE (#2238) | real 269.13 user 2467.01 sys 148.58|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_f518e3173f1aabef3983b361fc6aa7fa81190d51_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-12 09:35:29                                                                                                                    | 2020-10-13 22:34:03                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    800.1 |   827.2 |   +3%  ||     1.25 |     1.21 |   -3%  |  0.0000 |
 | TPC-H 02 ||      5.0 |     5.0 |   -0%  ||   199.76 |   200.71 |   +0%  |  0.5311 |
 | TPC-H 03 ||     81.8 |    81.3 |   -1%  ||    12.22 |    12.31 |   +1%  |  0.0000 |
 | TPC-H 04 ||     68.7 |    68.4 |   -0%  ||    14.56 |    14.62 |   +0%  |  0.0000 |
+| TPC-H 05 ||    232.3 |   216.8 |   -7%  ||     4.30 |     4.61 |   +7%  |  0.0000 |
 | TPC-H 06 ||      3.6 |     3.6 |   -1%  ||   277.13 |   279.00 |   +1%  |  0.0000 |
 | TPC-H 07 ||     60.0 |    59.6 |   -1%  ||    16.67 |    16.78 |   +1%  |  0.5025 |
 | TPC-H 08 ||     69.3 |    69.4 |   +0%  ||    14.43 |    14.42 |   -0%  |  0.8406 |
 | TPC-H 09 ||    497.0 |   485.8 |   -2%  ||     2.01 |     2.06 |   +2%  |  0.0000 |
 | TPC-H 10 ||    168.9 |   169.2 |   +0%  ||     5.92 |     5.91 |   -0%  |  0.7903 |
 | TPC-H 11 ||      9.1 |     9.1 |   -1%  ||   109.45 |   110.12 |   +1%  |  0.0000 |
 | TPC-H 12 ||     43.8 |    43.6 |   -0%  ||    22.82 |    22.93 |   +0%  |  0.0001 |
+| TPC-H 13 ||    434.1 |   360.5 |  -17%  ||     2.30 |     2.77 |  +20%  |  0.0000 |
 | TPC-H 14 ||     21.3 |    21.0 |   -2%  ||    46.88 |    47.71 |   +2%  |  0.0000 |
 | TPC-H 15 ||      7.9 |     7.8 |   -0%  ||   126.76 |   127.35 |   +0%  |  0.0000 |
+| TPC-H 16 ||     95.3 |    75.4 |  -21%  ||    10.50 |    13.26 |  +26%  |  0.0000 |
 | TPC-H 17 ||     18.2 |    18.2 |   -0%  ||    54.94 |    55.04 |   +0%  |  0.3465 |
 | TPC-H 18 ||    708.7 |   682.0 |   -4%  ||     1.41 |     1.47 |   +4%  |  0.0010 |
 | TPC-H 19 ||     29.9 |    29.7 |   -1%  ||    33.43 |    33.67 |   +1%  |  0.0000 |
 | TPC-H 20 ||     16.3 |    16.3 |   -0%  ||    61.36 |    61.44 |   +0%  |  0.6615 |
 | TPC-H 21 ||    425.8 |   422.0 |   -1%  ||     2.35 |     2.37 |   +1%  |  0.0429 |
 | TPC-H 22 ||     50.6 |    49.4 |   -2%  ||    19.76 |    20.24 |   +2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3847.8 |  3721.1 |   -3%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +3%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st_s01.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_f518e3173f1aabef3983b361fc6aa7fa81190d51_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                             | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-12 09:58:12                                                                                                                        | 2020-10-13 22:56:21                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.3 |     7.3 |   -0%  ||   136.40 |   137.00 |   +0%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.5 |   -1%  ||  1836.58 |  1855.86 |   +1%  |  0.0167 |
 | TPC-H 03 ||      0.9 |     0.9 |   -2%  ||  1109.36 |  1136.81 |   +2%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   -2%  ||  1907.08 |  1937.88 |   +2%  |  0.0000 |
 | TPC-H 05 ||      1.3 |     1.2 |   -4%  ||   789.40 |   819.03 |   +4%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   -2%  ||  9181.73 |  9339.90 |   +2%  |  0.0000 |
 | TPC-H 07 ||      1.3 |     1.2 |   -4%  ||   777.75 |   810.40 |   +4%  |  0.0006 |
 | TPC-H 08 ||     15.3 |    14.7 |   -4%  ||    65.45 |    68.01 |   +4%  |  0.0000 |
 | TPC-H 09 ||      2.4 |     2.4 |   -3%  ||   411.65 |   425.20 |   +3%  |  0.0000 |
 | TPC-H 10 ||      0.9 |     0.9 |   -3%  ||  1079.99 |  1111.68 |   +3%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   -2%  ||  3309.06 |  3366.76 |   +2%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   -3%  ||  1549.18 |  1593.98 |   +3%  |  0.0000 |
+| TPC-H 13 ||      2.4 |     2.2 |   -9%  ||   414.33 |   455.73 |  +10%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.3 |   -3%  ||  2773.34 |  2863.84 |   +3%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   -4%  ||   868.63 |   901.56 |   +4%  |  0.0000 |
+| TPC-H 16 ||      2.2 |     2.0 |  -10%  ||   448.88 |   498.11 |  +11%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   -4%  ||  3314.43 |  3452.28 |   +4%  |  0.0000 |
 | TPC-H 18 ||      2.7 |     2.7 |   -3%  ||   364.06 |   374.43 |   +3%  |  0.0000 |
+| TPC-H 19 ||      5.6 |     5.1 |   -9%  ||   177.11 |   194.76 |  +10%  |  0.0000 |
+| TPC-H 20 ||      2.4 |     2.3 |   -5%  ||   410.26 |   429.77 |   +5%  |  0.0000 |
 | TPC-H 21 ||      1.9 |     1.9 |   -3%  ||   520.23 |   538.80 |   +4%  |  0.0000 |
+| TPC-H 22 ||      1.3 |     1.3 |   -5%  ||   744.21 |   784.39 |   +5%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     52.1 |    49.9 |   -4%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +4%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st_s10.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_f518e3173f1aabef3983b361fc6aa7fa81190d51_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                             | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-12 10:20:19                                                                                                                        | 2020-10-13 23:18:25                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   8758.1 |  9049.4 |   +3%  ||     0.11 |     0.11 |   -3%  |       ˅ |
 | TPC-H 02 ||     55.1 |    53.2 |   -3%  ||    18.15 |    18.78 |   +4%  |  0.0000 |
 | TPC-H 03 ||   1561.3 |  1538.7 |   -1%  ||     0.64 |     0.65 |   +1%  |  0.0596 |
 | TPC-H 04 ||   1669.7 |  1641.9 |   -2%  ||     0.60 |     0.61 |   +2%  |  0.0076 |
 | TPC-H 05 ||   3385.1 |  3346.7 |   -1%  ||     0.30 |     0.30 |   +1%  |  0.0631 |
+| TPC-H 06 ||     39.7 |    37.8 |   -5%  ||    25.20 |    26.44 |   +5%  |  0.0000 |
 | TPC-H 07 ||    964.5 |   940.0 |   -3%  ||     1.04 |     1.06 |   +3%  |  0.0000 |
 | TPC-H 08 ||    676.5 |   651.1 |   -4%  ||     1.48 |     1.54 |   +4%  |  0.0000 |
 | TPC-H 09 ||   7664.3 |  7348.9 |   -4%  ||     0.13 |     0.14 |   +4%  |       ˅ |
 | TPC-H 10 ||   2993.7 |  2866.5 |   -4%  ||     0.33 |     0.35 |   +4%  |  0.0000 |
 | TPC-H 11 ||    133.6 |   129.7 |   -3%  ||     7.49 |     7.71 |   +3%  |  0.0000 |
 | TPC-H 12 ||    731.3 |   704.6 |   -4%  ||     1.37 |     1.42 |   +4%  |  0.0000 |
+| TPC-H 13 ||   6800.8 |  5485.6 |  -19%  ||     0.15 |     0.18 |  +24%  |       ˅ |
+| TPC-H 14 ||    255.2 |   236.4 |   -7%  ||     3.92 |     4.23 |   +8%  |  0.0000 |
 | TPC-H 15 ||    102.9 |    98.7 |   -4%  ||     9.71 |    10.13 |   +4%  |  0.0000 |
+| TPC-H 16 ||   1292.8 |  1005.2 |  -22%  ||     0.77 |     0.99 |  +29%  |  0.0000 |
 | TPC-H 17 ||    280.0 |   268.8 |   -4%  ||     3.57 |     3.72 |   +4%  |  0.0000 |
+| TPC-H 18 ||  12680.8 | 11940.6 |   -6%  ||     0.08 |     0.08 |   +6%  |       ˅ |
 | TPC-H 19 ||    334.4 |   321.5 |   -4%  ||     2.99 |     3.11 |   +4%  |  0.0000 |
 | TPC-H 20 ||    184.1 |   178.2 |   -3%  ||     5.43 |     5.61 |   +3%  |  0.0000 |
 | TPC-H 21 ||   7109.6 |  6944.3 |   -2%  ||     0.14 |     0.14 |   +2%  |       ˅ |
 | TPC-H 22 ||    738.1 |   718.0 |   -3%  ||     1.35 |     1.39 |   +3%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||  58411.4 | 55505.8 |   -5%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |   +5%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_f518e3173f1aabef3983b361fc6aa7fa81190d51_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-12 10:50:02                                                                                                                    | 2020-10-13 23:43:51                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2422.6 |  2427.0 |   +0%  ||    20.08 |    20.03 |   -0%  |  0.9283 |
 | TPC-H 02 ||     16.6 |    16.5 |   -0%  ||  2356.73 |  2359.79 |   +0%  |  0.0001 |
 | TPC-H 03 ||    467.4 |   461.1 |   -1%  ||   105.23 |   106.74 |   +1%  |  0.4045 |
 | TPC-H 04 ||    290.1 |   288.0 |   -1%  ||   168.70 |   169.45 |   +0%  |  0.6324 |
 | TPC-H 05 ||   1423.0 |  1419.3 |   -0%  ||    34.21 |    34.41 |   +1%  |  0.9323 |
 | TPC-H 06 ||     23.5 |    23.3 |   -1%  ||  1666.56 |  1667.04 |   +0%  |  0.0000 |
+| TPC-H 07 ||    289.9 |   263.9 |   -9%  ||   168.15 |   185.35 |  +10%  |  0.0000 |
 | TPC-H 08 ||    200.6 |   199.3 |   -1%  ||   242.69 |   244.11 |   +1%  |  0.5088 |
 | TPC-H 09 ||   2641.9 |  2532.7 |   -4%  ||    18.13 |    18.53 |   +2%  |  0.1730 |
 | TPC-H 10 ||    923.0 |   921.6 |   -0%  ||    53.28 |    53.31 |   +0%  |  0.9177 |
 | TPC-H 11 ||     73.1 |    72.0 |   -2%  ||   643.21 |   652.05 |   +1%  |  0.0058 |
 | TPC-H 12 ||    141.5 |   139.8 |   -1%  ||   340.69 |   344.72 |   +1%  |  0.1480 |
 | TPC-H 13 ||   2440.2 |  2418.2 |   -1%  ||    19.80 |    20.12 |   +2%  |  0.7641 |
 | TPC-H 14 ||    151.0 |   149.1 |   -1%  ||   320.24 |   324.18 |   +1%  |  0.0357 |
 | TPC-H 15 ||     58.1 |    55.7 |   -4%  ||   794.62 |   828.57 |   +4%  |  0.0000 |
+| TPC-H 16 ||    496.8 |   421.8 |  -15%  ||    99.01 |   116.62 |  +18%  |  0.0000 |
 | TPC-H 17 ||     58.8 |    58.4 |   -1%  ||   790.34 |   795.03 |   +1%  |  0.2121 |
 | TPC-H 18 ||   6616.6 |  6516.2 |   -2%  ||     7.03 |     7.27 |   +3%  |  0.6226 |
 | TPC-H 19 ||     93.4 |    94.0 |   +1%  ||   508.96 |   506.25 |   -1%  |  0.2869 |
 | TPC-H 20 ||     55.8 |    55.8 |   +0%  ||   825.42 |   825.82 |   +0%  |  0.9551 |
 | TPC-H 21 ||   2357.8 |  2389.2 |   +1%  ||    20.56 |    20.17 |   -2%  |  0.7385 |
 | TPC-H 22 ||    725.1 |   732.3 |   +1%  ||    65.70 |    67.28 |   +2%  |  0.7150 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  21966.7 | 21655.2 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +35312%
 ||
Geometric mean of throughput changes: -33%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_f518e3173f1aabef3983b361fc6aa7fa81190d51_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                          | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-10-12 11:12:30                                                                                                                     | 2020-10-14 00:06:21                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+-----------+------------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)    |     Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |       new |            ||      old |      new |        |         |
 +---------++----------+-----------+------------++----------+----------+--------+---------+
 | 01      ||     28.9 |      28.7 |       -1%  ||    34.55 |    34.89 |   +1%  |  0.0000 |
 | 03      ||      7.1 |       7.0 |       -0%  ||   141.74 |   141.95 |   +0%  |  0.0000 |
 | 06      ||     18.2 |      18.2 |       +0%  ||    54.98 |    54.96 |   -0%  |  0.2332 |
 | 07      ||     32.4 |      32.8 |       +1%  ||    30.89 |    30.52 |   -1%  |  0.0000 |
 | 09      ||    122.5 |     119.9 |       -2%  ||     8.16 |     8.34 |   +2%  |  0.0000 |
-| 10      ||     19.7 |    6060.5 |   +30674%  ||    50.77 |     0.17 | -100%  |  0.0000 |
 | 13      ||    129.5 |     128.7 |       -1%  ||     7.72 |     7.77 |   +1%  |  0.5072 |
 | 15      ||     10.2 |      10.2 |       -0%  ||    97.68 |    97.99 |   +0%  |  0.0000 |
 | 17      ||     28.3 |      29.4 |       +4%  ||    35.34 |    34.04 |   -4%  |  0.0000 |
 | 19      ||     10.2 |      10.1 |       -0%  ||    98.34 |    98.53 |   +0%  |  0.0331 |
 | 25      ||     15.5 |      15.5 |       +0%  ||    64.69 |    64.67 |   -0%  |  0.9656 |
 | 26      ||     16.0 |      16.0 |       -0%  ||    62.32 |    62.46 |   +0%  |  0.0000 |
 | 28      ||   1029.0 |    1028.3 |       -0%  ||     0.97 |     0.97 |   +0%  |  0.2988 |
 | 29      ||     26.0 |      26.5 |       +2%  ||    38.53 |    37.80 |   -2%  |  0.0028 |
 | 31      ||    132.8 |     132.2 |       -0%  ||     7.53 |     7.56 |   +0%  |  0.0003 |
 | 34      ||     16.9 |      16.9 |       -0%  ||    59.10 |    59.20 |   +0%  |  0.0000 |
-| 35      ||     89.2 | 1303100.2 | +1461565%  ||    11.22 |     0.00 | -100%  |       ˅ |
 | 39a     ||    174.9 |     177.2 |       +1%  ||     5.72 |     5.64 |   -1%  |  0.0000 |
 | 39b     ||    173.9 |     175.2 |       +1%  ||     5.75 |     5.71 |   -1%  |  0.0000 |
 | 41      ||     24.8 |      24.8 |       +0%  ||    40.39 |    40.38 |   -0%  |  0.8170 |
 | 42      ||      8.1 |       8.1 |       +0%  ||   124.02 |   123.46 |   -0%  |  0.0000 |
 | 43      ||    248.0 |     249.1 |       +0%  ||     4.03 |     4.01 |   -0%  |  0.0000 |
-| 45      ||      9.8 |      17.4 |      +77%  ||   101.89 |    57.59 |  -43%  |  0.0000 |
 | 48      ||     86.4 |      86.5 |       +0%  ||    11.57 |    11.56 |   -0%  |  0.6908 |
 | 50      ||     11.4 |      11.5 |       +1%  ||    87.79 |    87.17 |   -1%  |  0.0000 |
 | 52      ||      8.2 |       8.2 |       +0%  ||   122.03 |   121.49 |   -0%  |  0.0000 |
 | 55      ||      8.0 |       8.0 |       -0%  ||   124.25 |   124.55 |   +0%  |  0.0000 |
 | 62      ||     74.3 |      74.3 |       +0%  ||    13.45 |    13.45 |   -0%  |  0.5646 |
 | 65      ||     61.9 |      62.5 |       +1%  ||    16.15 |    16.00 |   -1%  |  0.0000 |
 | 69      ||     22.1 |      22.4 |       +1%  ||    45.24 |    44.65 |   -1%  |  0.0000 |
 | 73      ||     10.7 |      10.8 |       +1%  ||    93.22 |    92.69 |   -1%  |  0.0000 |
 | 79      ||     45.0 |      45.4 |       +1%  ||    22.21 |    22.02 |   -1%  |  0.0000 |
 | 81      ||     19.0 |      19.5 |       +3%  ||    52.64 |    51.35 |   -2%  |  0.0000 |
 | 83      ||      9.4 |       9.8 |       +4%  ||   105.93 |   102.15 |   -4%  |  0.0000 |
 | 85      ||     60.2 |      62.6 |       +4%  ||    16.60 |    15.97 |   -4%  |  0.0532 |
 | 88      ||     70.5 |      73.0 |       +4%  ||    14.19 |    13.70 |   -3%  |  0.0000 |
 | 91      ||     22.3 |      23.2 |       +4%  ||    44.87 |    43.06 |   -4%  |  0.0000 |
-| 93      ||    257.4 |     282.5 |      +10%  ||     3.89 |     3.54 |   -9%  |  0.0000 |
 | 96      ||      7.4 |       7.6 |       +3%  ||   135.41 |   132.08 |   -2%  |  0.0000 |
 | 97      ||    412.5 |     408.6 |       -1%  ||     2.42 |     2.45 |   +1%  |  0.1909 |
 | 99      ||    148.7 |     152.5 |       +3%  ||     6.72 |     6.56 |   -2%  |  0.0000 |
 +---------++----------+-----------+------------++----------+----------+--------+---------+
-| Sum     ||   3707.3 | 1312801.5 |   +35312%  ||          |          |        |         |
-| Geomean ||          |           |            ||          |          |  -33%  |         |
 +---------++----------+-----------+------------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                       |
 +---------++----------+-----------+------------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +126%
 ||
Geometric mean of throughput changes: -100%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_f518e3173f1aabef3983b361fc6aa7fa81190d51_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                          | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-10-12 11:53:50                                                                                                                     | 2020-10-14 01:08:12                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+----------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  |   Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |          ||      old |      new |        |                      |
 +---------++----------+---------+----------++----------+----------+--------+----------------------+
 | 01      ||    214.4 |   216.5 |     +1%  ||   227.49 |   225.22 |   -1%  |               0.1834 |
 | 03      ||     30.1 |    30.0 |     -0%  ||  1472.75 |  1472.91 |   +0%  |               0.2911 |
 | 06      ||    125.1 |   128.0 |     +2%  ||   384.46 |   376.01 |   -2%  |               0.0057 |
 | 07      ||    185.5 |   188.6 |     +2%  ||   261.80 |   258.00 |   -1%  |               0.1053 |
 | 09      ||    520.2 |   503.3 |     -3%  ||    93.11 |    95.61 |   +3%  |               0.2906 |
-| 10      ||     86.4 | 28542.4 | +32929%  ||   550.18 |     0.28 | -100%  |               0.0000 |
 | 13      ||    437.8 |   435.1 |     -1%  ||   112.40 |   113.03 |   +1%  |               0.6474 |
 | 15      ||     71.3 |    71.5 |     +0%  ||   656.70 |   655.56 |   -0%  |               0.6285 |
 | 17      ||    138.0 |   138.9 |     +1%  ||   349.33 |   346.99 |   -1%  |               0.4726 |
 | 19      ||     50.8 |    51.1 |     +1%  ||   903.87 |   899.01 |   -1%  |               0.1824 |
 | 25      ||     77.0 |    77.9 |     +1%  ||   614.82 |   607.51 |   -1%  |               0.0644 |
 | 26      ||    108.9 |   109.1 |     +0%  ||   439.69 |   439.08 |   -0%  |               0.8164 |
 | 28      ||   3126.1 |  2997.0 |     -4%  ||    14.43 |    14.38 |   -0%  |               0.3890 |
 | 29      ||    136.7 |   137.1 |     +0%  ||   352.37 |   351.28 |   -0%  |               0.7608 |
 | 31      ||    818.0 |   814.5 |     -0%  ||    59.05 |    58.65 |   -1%  |               0.8861 |
 | 34      ||     93.3 |    93.8 |     +1%  ||   508.48 |   506.00 |   -0%  |               0.4396 |
-| 35      ||    846.5 |     nan |          ||    57.90 |     0.00 | -100%  | (run time too short) |
 | 39a     ||   1740.9 |  1737.3 |     -0%  ||    27.86 |    27.86 |   -0%  |               0.9384 |
 | 39b     ||   1733.7 |  1747.2 |     +1%  ||    27.98 |    27.95 |   -0%  |               0.7912 |
+| 41      ||   1324.4 |  1331.1 |     +1%  ||    31.76 |    33.78 |   +6%  |               0.9428 |
 | 42      ||     41.3 |    42.4 |     +3%  ||  1094.74 |  1064.62 |   -3%  |               0.0000 |
 | 43      ||    784.5 |   799.3 |     +2%  ||    62.78 |    61.84 |   -1%  |               0.1765 |
-| 45      ||     53.5 |    58.8 |    +10%  ||   855.59 |   782.62 |   -9%  |               0.0000 |
 | 48      ||    376.2 |   378.4 |     +1%  ||   130.54 |   129.32 |   -1%  |               0.7272 |
+| 50      ||    140.6 |   132.2 |     -6%  ||   342.60 |   363.69 |   +6%  |               0.0000 |
 | 52      ||     42.3 |    42.7 |     +1%  ||  1067.06 |  1060.07 |   -1%  |               0.0142 |
 | 55      ||     38.8 |    38.8 |     +0%  ||  1157.21 |  1156.62 |   -0%  |               0.8289 |
 | 62      ||    310.0 |   314.4 |     +1%  ||   158.01 |   155.96 |   -1%  |               0.1244 |
 | 65      ||    551.4 |   559.7 |     +2%  ||    89.33 |    87.99 |   -2%  |               0.1867 |
 | 69      ||    129.9 |   130.6 |     +0%  ||   370.05 |   368.28 |   -0%  |               0.6072 |
 | 73      ||     52.9 |    52.8 |     -0%  ||   872.45 |   873.41 |   +0%  |               0.5476 |
 | 79      ||    211.6 |   212.0 |     +0%  ||   230.10 |   230.02 |   -0%  |               0.8257 |
 | 81      ||    154.4 |   152.2 |     -1%  ||   313.26 |   317.55 |   +1%  |               0.0497 |
 | 83      ||     75.0 |    75.8 |     +1%  ||   627.05 |   619.98 |   -1%  |               0.1141 |
 | 85      ||    234.2 |   234.2 |     -0%  ||   208.42 |   208.66 |   +0%  |               0.9808 |
 | 88      ||    436.4 |   448.6 |     +3%  ||   112.36 |   109.20 |   -3%  |               0.3231 |
 | 91      ||     89.4 |    89.3 |     -0%  ||   532.12 |   532.51 |   +0%  |               0.8635 |
 | 93      ||   1377.5 |  1431.5 |     +4%  ||    34.25 |    34.16 |   -0%  |               0.1897 |
 | 96      ||     47.6 |    46.0 |     -3%  ||   962.20 |   994.12 |   +3%  |               0.0000 |
 | 97      ||   3898.6 |  3781.1 |     -3%  ||    12.37 |    12.65 |   +2%  |               0.3089 |
 | 99      ||    801.3 |   794.9 |     -1%  ||    61.13 |    61.74 |   +1%  |               0.5893 |
 +---------++----------+---------+----------++----------+----------+--------+----------------------+
-| Sum     ||  21712.4 | 49165.7 |   +126%  ||          |          |        |                      |
-| Geomean ||          |         |          ||          |          | -100%  |                      |
 +---------++----------+---------+----------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_f518e3173f1aabef3983b361fc6aa7fa81190d51_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-10-12 12:35:10                                                                                                                    | 2020-10-14 05:44:43                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     28.7 |    28.7 |   +0%  ||     3.77 |     3.67 |   -3%  | (run time too short) |
 | New-Order    ||     18.2 |    18.6 |   +2%  ||    42.37 |    41.55 |   -2%  | (run time too short) |
 | Order-Status ||      1.3 |     1.2 |   -0%  ||     3.77 |     3.68 |   -2%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   +2%  ||    40.42 |    39.55 |   -2%  | (run time too short) |
 | Stock-Level  ||      4.2 |     4.2 |   -0%  ||     3.75 |     3.70 |   -1%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     54.8 |    55.3 |   +1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_f518e3173f1aabef3983b361fc6aa7fa81190d51_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-12 12:36:14                                                                                                                    | 2020-10-14 05:45:48                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    224.5 |   219.8 |   -2%  ||     4.30 |     4.38 |   +2%  | (run time too short) |
 |    unsucc.:  ||      4.1 |     4.1 |   -1%  ||   123.98 |   123.54 |   -0%  |                      |
 | New-Order    ||    100.9 |    99.2 |   -2%  ||    84.98 |    85.66 |   +1%  |               0.0815 |
 |    unsucc.:  ||      5.0 |     5.1 |   +2%  ||  1358.40 |  1353.31 |   -0%  |                      |
 | Order-Status ||      8.0 |     8.0 |   -0%  ||   128.30 |   127.92 |   -0%  |               0.8959 |
+| Payment      ||     18.3 |    17.0 |   -7%  ||     5.53 |     5.79 |   +5%  | (run time too short) |
 |    unsucc.:  ||      4.3 |     4.3 |   +1%  ||  1373.77 |  1369.40 |   -0%  |                      |
 | Stock-Level  ||     18.8 |    18.6 |   -1%  ||   128.30 |   127.89 |   -0%  |               0.2468 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    370.4 |   362.5 |   -2%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +1%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_f518e3173f1aabef3983b361fc6aa7fa81190d51_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                              | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-10-12 12:37:20                                                                                                                         | 2020-10-14 05:46:53                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    360.8 |    357.2 |   -1%  ||     2.77 |     2.80 |   +1%  |  0.0003 |
 | 10b     ||    356.7 |    347.1 |   -3%  ||     2.80 |     2.88 |   +3%  |  0.0000 |
 | 10c     ||   1161.4 |   1155.2 |   -1%  ||     0.86 |     0.87 |   +1%  |  0.2452 |
 | 11a     ||    155.8 |    154.3 |   -1%  ||     6.42 |     6.48 |   +1%  |  0.2919 |
 | 11b     ||    144.6 |    144.7 |   +0%  ||     6.92 |     6.91 |   -0%  |  0.8996 |
 | 11c     ||    530.5 |    519.5 |   -2%  ||     1.88 |     1.92 |   +2%  |  0.0374 |
 | 11d     ||   4704.2 |   4670.1 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.7095 |
 | 12a     ||    367.4 |    367.7 |   +0%  ||     2.72 |     2.72 |   -0%  |  0.9138 |
 | 12b     ||    655.5 |    654.4 |   -0%  ||     1.53 |     1.53 |   +0%  |  0.8723 |
 | 12c     ||   3718.9 |   3718.0 |   -0%  ||     0.27 |     0.27 |   +0%  |  0.9796 |
 | 13a     ||    178.7 |    179.1 |   +0%  ||     5.60 |     5.58 |   -0%  |  0.0208 |
 | 13b     ||    265.7 |    264.6 |   -0%  ||     3.76 |     3.78 |   +0%  |  0.0283 |
 | 13c     ||    142.9 |    149.3 |   +5%  ||     7.00 |     6.70 |   -4%  |  0.0000 |
-| 13d     ||    180.9 |    189.8 |   +5%  ||     5.53 |     5.27 |   -5%  |  0.0000 |
 | 14a     ||   4117.6 |   4301.8 |   +4%  ||     0.24 |     0.23 |   -4%  |  0.0000 |
 | 14b     ||   4803.0 |   4973.7 |   +4%  ||     0.21 |     0.20 |   -3%  |  0.0029 |
 | 14c     ||   4131.5 |   4240.2 |   +3%  ||     0.24 |     0.24 |   -3%  |  0.0119 |
 | 15a     ||    211.2 |    216.3 |   +2%  ||     4.74 |     4.62 |   -2%  |  0.0008 |
 | 15b     ||    207.5 |    209.9 |   +1%  ||     4.82 |     4.76 |   -1%  |  0.0122 |
 | 15c     ||    153.0 |    153.7 |   +0%  ||     6.54 |     6.51 |   -0%  |  0.2049 |
 | 15d     ||    465.7 |    460.5 |   -1%  ||     2.15 |     2.17 |   +1%  |  0.0210 |
 | 16a     ||   4732.8 |   4682.6 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.5555 |
 | 16b     ||   6162.6 |   6186.0 |   +0%  ||     0.16 |     0.16 |   -0%  |  0.7712 |
 | 16c     ||   4888.2 |   4914.3 |   +1%  ||     0.20 |     0.20 |   -1%  |  0.7267 |
 | 16d     ||   4798.3 |   4840.1 |   +1%  ||     0.21 |     0.21 |   -1%  |  0.5352 |
 | 17a     ||    976.4 |    986.6 |   +1%  ||     1.02 |     1.01 |   -1%  |  0.1041 |
 | 17b     ||    774.8 |    782.1 |   +1%  ||     1.29 |     1.28 |   -1%  |  0.1034 |
 | 17c     ||    730.0 |    737.6 |   +1%  ||     1.37 |     1.36 |   -1%  |  0.0736 |
 | 17d     ||    841.0 |    852.3 |   +1%  ||     1.19 |     1.17 |   -1%  |  0.0157 |
 | 17e     ||   2958.4 |   2952.9 |   -0%  ||     0.34 |     0.34 |   +0%  |  0.8093 |
 | 17f     ||   1552.0 |   1575.7 |   +2%  ||     0.64 |     0.63 |   -2%  |  0.0333 |
 | 18a     ||    684.4 |    685.9 |   +0%  ||     1.46 |     1.46 |   -0%  |  0.6886 |
 | 18b     ||    232.8 |    235.0 |   +1%  ||     4.30 |     4.26 |   -1%  |  0.0787 |
 | 18c     ||   3790.9 |   3794.6 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.8789 |
 | 19a     ||   7646.3 |   7676.8 |   +0%  ||     0.13 |     0.13 |   -0%  |       ˅ |
 | 19b     ||   4528.7 |   4564.4 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.0212 |
 | 19c     ||   7428.9 |   7450.3 |   +0%  ||     0.13 |     0.13 |   -0%  |       ˅ |
 | 19d     ||   5717.5 |   5738.9 |   +0%  ||     0.17 |     0.17 |   -0%  |  0.6314 |
 | 1a      ||     58.8 |     58.7 |   -0%  ||    17.01 |    17.03 |   +0%  |  0.2044 |
 | 1b      ||     22.0 |     22.2 |   +1%  ||    45.52 |    45.09 |   -1%  |  0.0000 |
 | 1c      ||     22.0 |     22.2 |   +1%  ||    45.46 |    45.08 |   -1%  |  0.0000 |
 | 1d      ||     21.9 |     22.0 |   +0%  ||    45.68 |    45.47 |   -0%  |  0.0000 |
 | 20a     ||   1276.7 |   1288.2 |   +1%  ||     0.78 |     0.78 |   -1%  |  0.0017 |
 | 20b     ||   1091.7 |   1101.3 |   +1%  ||     0.92 |     0.91 |   -1%  |  0.0002 |
 | 20c     ||   1127.5 |   1129.9 |   +0%  ||     0.89 |     0.88 |   -0%  |  0.2886 |
 | 21a     ||   3857.7 |   3856.8 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.9445 |
 | 21b     ||    265.3 |    263.6 |   -1%  ||     3.77 |     3.79 |   +1%  |  0.0233 |
 | 21c     ||   3984.1 |   3999.1 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.2719 |
 | 22a     ||   3487.3 |   3488.1 |   +0%  ||     0.29 |     0.29 |   -0%  |  0.9785 |
 | 22b     ||   3491.9 |   3491.5 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.9888 |
 | 22c     ||   4126.7 |   4132.2 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8592 |
 | 22d     ||   4143.6 |   4152.5 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.7762 |
 | 23a     ||    156.4 |    156.8 |   +0%  ||     6.39 |     6.38 |   -0%  |  0.5686 |
 | 23b     ||    122.1 |    122.4 |   +0%  ||     8.19 |     8.17 |   -0%  |  0.5067 |
 | 23c     ||    174.7 |    176.2 |   +1%  ||     5.72 |     5.68 |   -1%  |  0.0397 |
 | 24a     ||   4621.1 |   4660.6 |   +1%  ||     0.22 |     0.21 |   -1%  |  0.2411 |
 | 24b     ||   4564.8 |   4616.3 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.4521 |
 | 25a     ||    236.4 |    237.6 |   +1%  ||     4.23 |     4.21 |   -1%  |  0.2317 |
 | 25b     ||    250.2 |    251.2 |   +0%  ||     4.00 |     3.98 |   -0%  |  0.2451 |
 | 25c     ||   3788.3 |   3806.6 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.3492 |
 | 26a     ||    995.4 |   1001.0 |   +1%  ||     1.00 |     1.00 |   -1%  |  0.1523 |
 | 26b     ||    984.3 |    990.0 |   +1%  ||     1.02 |     1.01 |   -1%  |  0.3968 |
 | 26c     ||   1001.4 |   1003.3 |   +0%  ||     1.00 |     1.00 |   -0%  |  0.7085 |
 | 27a     ||   3506.6 |   3495.9 |   -0%  ||     0.29 |     0.29 |   +0%  |  0.5686 |
 | 27b     ||   3485.0 |   3462.3 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2373 |
 | 27c     ||    205.7 |    205.8 |   +0%  ||     4.86 |     4.86 |   -0%  |  0.9600 |
 | 28a     ||   4155.3 |   4168.9 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8867 |
 | 28b     ||   3393.6 |   3401.0 |   +0%  ||     0.29 |     0.29 |   -0%  |  0.9387 |
 | 28c     ||   4153.5 |   4170.8 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8552 |
 | 29a     ||   4502.8 |   4525.4 |   +1%  ||     0.22 |     0.22 |   -0%  |  0.8781 |
 | 29b     ||    201.6 |    202.2 |   +0%  ||     4.96 |     4.95 |   -0%  |  0.9505 |
 | 29c     ||   4593.4 |   4621.5 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.8520 |
 | 2a      ||    110.3 |    110.4 |   +0%  ||     9.07 |     9.05 |   -0%  |  0.0262 |
 | 2b      ||     86.4 |     86.8 |   +0%  ||    11.57 |    11.52 |   -0%  |  0.0000 |
 | 2c      ||     56.7 |     57.0 |   +0%  ||    17.63 |    17.55 |   -0%  |  0.0000 |
 | 2d      ||    136.2 |    136.4 |   +0%  ||     7.34 |     7.33 |   -0%  |  0.0879 |
 | 30a     ||    253.0 |    253.3 |   +0%  ||     3.95 |     3.95 |   -0%  |  0.9417 |
 | 30b     ||   1137.7 |   1142.0 |   +0%  ||     0.88 |     0.88 |   -0%  |  0.8457 |
 | 30c     ||   3815.8 |   3832.7 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.8347 |
 | 31a     ||    290.9 |    290.1 |   -0%  ||     3.44 |     3.45 |   +0%  |  0.7762 |
 | 31b     ||   1167.2 |   1170.6 |   +0%  ||     0.86 |     0.85 |   -0%  |  0.8001 |
 | 31c     ||    294.1 |    294.5 |   +0%  ||     3.40 |     3.40 |   -0%  |  0.8978 |
 | 32a     ||     37.2 |     37.3 |   +0%  ||    26.88 |    26.79 |   -0%  |  0.0001 |
 | 32b     ||    288.1 |    290.0 |   +1%  ||     3.47 |     3.45 |   -1%  |  0.0000 |
 | 33a     ||     70.1 |     70.4 |   +0%  ||    14.27 |    14.21 |   -0%  |  0.4936 |
 | 33b     ||     69.2 |     69.6 |   +0%  ||    14.44 |    14.38 |   -0%  |  0.4974 |
 | 33c     ||     85.4 |     85.7 |   +0%  ||    11.70 |    11.67 |   -0%  |  0.6851 |
 | 3a      ||   3968.1 |   3979.1 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.0000 |
 | 3b      ||     36.4 |     36.6 |   +0%  ||    27.47 |    27.36 |   -0%  |  0.0000 |
 | 3c      ||   5108.8 |   5103.9 |   -0%  ||     0.20 |     0.20 |   +0%  |  0.6705 |
 | 4a      ||    128.8 |    128.7 |   -0%  ||     7.76 |     7.77 |   +0%  |  0.1557 |
 | 4b      ||     27.2 |     27.0 |   -1%  ||    36.78 |    37.00 |   +1%  |  0.0000 |
 | 4c      ||    145.5 |    146.0 |   +0%  ||     6.87 |     6.85 |   -0%  |  0.0104 |
 | 5a      ||   3798.3 |   3797.0 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.7266 |
 | 5b      ||    278.8 |    278.5 |   -0%  ||     3.59 |     3.59 |   +0%  |  0.4353 |
 | 5c      ||   4435.8 |   4421.7 |   -0%  ||     0.23 |     0.23 |   +0%  |  0.0028 |
 | 6a      ||    229.9 |    228.4 |   -1%  ||     4.35 |     4.38 |   +1%  |  0.0000 |
 | 6b      ||    961.5 |    964.0 |   +0%  ||     1.04 |     1.04 |   -0%  |  0.2806 |
 | 6c      ||    230.4 |    229.4 |   -0%  ||     4.34 |     4.36 |   +0%  |  0.0000 |
 | 6d      ||    965.6 |    969.2 |   +0%  ||     1.04 |     1.03 |   -0%  |  0.0821 |
 | 6e      ||    230.5 |    229.0 |   -1%  ||     4.34 |     4.37 |   +1%  |  0.0000 |
 | 6f      ||   1501.0 |   1507.5 |   +0%  ||     0.67 |     0.66 |   -0%  |  0.0072 |
 | 7a      ||    280.0 |    278.8 |   -0%  ||     3.57 |     3.59 |   +0%  |  0.7159 |
 | 7b      ||    137.3 |    136.5 |   -1%  ||     7.28 |     7.33 |   +1%  |  0.6040 |
 | 7c      ||  11011.9 |  10987.1 |   -0%  ||     0.09 |     0.09 |   +0%  |       ˅ |
 | 8a      ||    111.9 |    111.8 |   -0%  ||     8.93 |     8.95 |   +0%  |  0.5847 |
 | 8b      ||    167.0 |    166.2 |   -0%  ||     5.99 |     6.02 |   +0%  |  0.1244 |
 | 8c      ||   4396.4 |   4434.2 |   +1%  ||     0.23 |     0.23 |   -1%  |  0.1624 |
 | 8d      ||   1552.1 |   1563.3 |   +1%  ||     0.64 |     0.64 |   -1%  |  0.0263 |
 | 9a      ||   3515.1 |   3478.2 |   -1%  ||     0.28 |     0.29 |   +1%  |  0.0518 |
 | 9b      ||    331.2 |    328.9 |   -1%  ||     3.02 |     3.04 |   +1%  |  0.1875 |
 | 9c      ||   3531.0 |   3504.7 |   -1%  ||     0.28 |     0.29 |   +1%  |  0.1887 |
 | 9d      ||   4107.4 |   4089.6 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.4572 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 216613.4 | 217439.2 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_f518e3173f1aabef3983b361fc6aa7fa81190d51_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                              | f518e3173f1aabef3983b361fc6aa7fa81190d51-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-10-12 14:33:31                                                                                                                         | 2020-10-14 07:43:03                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)     | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |       new |        ||      old |      new |        |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
+| 10a     ||    2465.3 |    2332.4 |   -5%  ||    19.15 |    20.37 |   +6%  |  0.2328 |
 | 10b     ||    1725.0 |    1648.4 |   -4%  ||    27.85 |    29.03 |   +4%  |  0.2118 |
 | 10c     ||    8961.8 |    8908.7 |   -1%  ||     4.62 |     4.57 |   -1%  |  0.9300 |
 | 11a     ||     466.1 |     467.4 |   +0%  ||   105.36 |   105.23 |   -0%  |  0.8888 |
 | 11b     ||     429.6 |     428.8 |   -0%  ||   113.91 |   113.78 |   -0%  |  0.9312 |
 | 11c     ||    2429.4 |    2483.0 |   +2%  ||    19.40 |    19.45 |   +0%  |  0.5742 |
+| 11d     ||   23698.6 |   24230.7 |   +2%  ||     1.38 |     1.45 |   +5%  |  0.6821 |
 | 12a     ||    3553.8 |    3699.3 |   +4%  ||    12.92 |    12.85 |   -1%  |  0.5724 |
 | 12b     ||    1487.7 |    1492.4 |   +0%  ||    32.75 |    32.73 |   -0%  |  0.9271 |
 | 12c     ||   21279.0 |   22150.3 |   +4%  ||     1.58 |     1.65 |   +4%  |  0.6179 |
 | 13a     ||    1178.8 |    1183.2 |   +0%  ||    41.48 |    41.33 |   -0%  |  0.9100 |
 | 13b     ||    1415.6 |    1412.0 |   -0%  ||    34.28 |    34.30 |   +0%  |  0.9505 |
 | 13c     ||    1402.5 |    1405.5 |   +0%  ||    34.25 |    34.55 |   +1%  |  0.9582 |
 | 13d     ||    1191.2 |    1185.0 |   -1%  ||    40.98 |    41.40 |   +1%  |  0.8796 |
 | 14a     ||   16797.9 |   19026.0 |  +13%  ||     1.92 |     1.92 |   +0%  |  0.1312 |
 | 14b     ||   18364.9 |   17677.7 |   -4%  ||     1.73 |     1.80 |   +4%  |  0.6543 |
 | 14c     ||   18211.8 |   18680.1 |   +3%  ||     1.85 |     1.88 |   +2%  |  0.7628 |
 | 15a     ||    1124.2 |    1113.4 |   -1%  ||    43.13 |    43.53 |   +1%  |  0.7531 |
 | 15b     ||    1106.7 |    1080.7 |   -2%  ||    44.20 |    44.34 |   +0%  |  0.4849 |
 | 15c     ||     421.9 |     427.0 |   +1%  ||   115.36 |   115.10 |   -0%  |  0.5343 |
 | 15d     ||    2538.6 |    2548.9 |   +0%  ||    18.85 |    19.25 |   +2%  |  0.9154 |
-| 16a     ||   29064.4 |   28494.7 |   -2%  ||     0.98 |     0.92 |   -7%  |  0.7998 |
 | 16b     ||   36543.0 |   37823.9 |   +4%  ||     0.75 |     0.78 |   +4%  |  0.6224 |
+| 16c     ||   31555.5 |   28532.2 |  -10%  ||     0.87 |     0.95 |  +10%  |  0.1588 |
 | 16d     ||   28006.7 |   32664.6 |  +17%  ||     0.97 |     1.00 |   +3%  |  0.0314 |
 | 17a     ||    8386.2 |    8033.0 |   -4%  ||     4.93 |     5.00 |   +1%  |  0.5835 |
 | 17b     ||    7311.9 |    8163.3 |  +12%  ||     5.07 |     4.98 |   -2%  |  0.1152 |
 | 17c     ||    6893.0 |    8068.8 |  +17%  ||     5.02 |     4.92 |   -2%  |  0.0128 |
 | 17d     ||    7747.9 |    8081.5 |   +4%  ||     5.13 |     5.18 |   +1%  |  0.5727 |
 | 17e     ||   13714.1 |   13551.9 |   -1%  ||     2.98 |     2.92 |   -2%  |  0.8583 |
-| 17f     ||    9330.9 |   10489.1 |  +12%  ||     4.47 |     4.00 |  -10%  |  0.1164 |
 | 18a     ||    4835.6 |    4619.9 |   -4%  ||     9.57 |     9.53 |   -0%  |  0.4487 |
 | 18b     ||    2400.1 |    2207.7 |   -8%  ||    20.10 |    20.96 |   +4%  |  0.0907 |
 | 18c     ||   18554.2 |   17686.2 |   -5%  ||     1.88 |     1.92 |   +2%  |  0.5422 |
+| 19a     ||   36772.0 |   32838.8 |  -11%  ||     0.77 |     0.82 |   +7%  |  0.2064 |
 | 19b     ||   11929.7 |   12196.4 |   +2%  ||     3.25 |     3.22 |   -1%  |  0.7889 |
 | 19c     ||   36246.4 |   37108.4 |   +2%  ||     0.80 |     0.78 |   -2%  |  0.7252 |
+| 19d     ||   37691.5 |   36831.5 |   -2%  ||     0.72 |     0.83 |  +16%  |  0.6997 |
 | 1a      ||     339.2 |     339.8 |   +0%  ||   144.44 |   144.39 |   -0%  |  0.9078 |
 | 1b      ||      73.3 |      73.8 |   +1%  ||   637.05 |   634.26 |   -0%  |  0.4374 |
 | 1c      ||      74.6 |      74.7 |   +0%  ||   629.70 |   628.80 |   -0%  |  0.8036 |
 | 1d      ||      73.7 |      74.0 |   +0%  ||   634.65 |   632.53 |   -0%  |  0.5967 |
 | 20a     ||    5693.4 |    5442.1 |   -4%  ||     7.87 |     7.82 |   -1%  |  0.4635 |
 | 20b     ||    4309.3 |    4452.1 |   +3%  ||    10.43 |    10.52 |   +1%  |  0.5653 |
+| 20c     ||    4337.8 |    4180.4 |   -4%  ||    10.53 |    11.08 |   +5%  |  0.5162 |
 | 21a     ||   17114.1 |   17832.1 |   +4%  ||     2.13 |     2.10 |   -2%  |  0.6243 |
 | 21b     ||    1057.5 |    1052.2 |   -1%  ||    45.78 |    46.30 |   +1%  |  0.8778 |
 | 21c     ||   15822.4 |   16932.3 |   +7%  ||     2.07 |     2.05 |   -1%  |  0.4504 |
+| 22a     ||   17748.3 |   16881.5 |   -5%  ||     1.92 |     2.07 |   +8%  |  0.5254 |
+| 22b     ||   16477.4 |   18775.8 |  +14%  ||     1.90 |     2.07 |   +9%  |  0.1152 |
+| 22c     ||   19483.4 |   17123.8 |  -12%  ||     1.83 |     2.00 |   +9%  |  0.1004 |
+| 22d     ||   19531.6 |   19572.2 |   +0%  ||     1.80 |     1.95 |   +8%  |  0.9776 |
 | 23a     ||     459.1 |     459.1 |   +0%  ||   107.14 |   107.11 |   -0%  |  0.9942 |
 | 23b     ||     983.6 |     974.7 |   -1%  ||    49.53 |    50.03 |   +1%  |  0.7579 |
 | 23c     ||     543.9 |     538.0 |   -1%  ||    90.27 |    90.98 |   +1%  |  0.6236 |
 | 24a     ||   11156.0 |   11554.8 |   +4%  ||     3.27 |     3.38 |   +4%  |  0.6651 |
 | 24b     ||   10896.9 |   12329.8 |  +13%  ||     3.47 |     3.40 |   -2%  |  0.1264 |
 | 25a     ||    2339.4 |    2257.7 |   -3%  ||    20.33 |    20.98 |   +3%  |  0.3686 |
+| 25b     ||    2943.3 |    2713.3 |   -8%  ||    15.63 |    16.35 |   +5%  |  0.1416 |
 | 25c     ||   18827.8 |   17572.5 |   -7%  ||     1.87 |     1.85 |   -1%  |  0.3922 |
 | 26a     ||    2936.3 |    2989.1 |   +2%  ||    15.26 |    15.33 |   +0%  |  0.7299 |
 | 26b     ||    3079.4 |    3097.4 |   +1%  ||    15.58 |    15.30 |   -2%  |  0.9142 |
 | 26c     ||    3010.9 |    3071.3 |   +2%  ||    14.98 |    15.12 |   +1%  |  0.7280 |
 | 27a     ||   16778.3 |   16374.4 |   -2%  ||     2.03 |     2.10 |   +3%  |  0.7843 |
 | 27b     ||   16232.1 |   14946.3 |   -8%  ||     2.07 |     2.10 |   +2%  |  0.3270 |
 | 27c     ||     933.9 |     931.9 |   -0%  ||    52.53 |    52.08 |   -1%  |  0.9488 |
 | 28a     ||   18459.2 |   18446.6 |   -0%  ||     1.83 |     1.83 |   +0%  |  0.9932 |
 | 28b     ||   17587.7 |   16178.9 |   -8%  ||     2.12 |     2.05 |   -3%  |  0.2577 |
 | 28c     ||   19529.4 |   17934.0 |   -8%  ||     1.85 |     1.83 |   -1%  |  0.2821 |
 | 29a     ||   11933.3 |   10998.3 |   -8%  ||     3.32 |     3.33 |   +1%  |  0.3597 |
 | 29b     ||    2531.2 |    2484.5 |   -2%  ||    18.85 |    19.45 |   +3%  |  0.7162 |
 | 29c     ||   11901.4 |   13504.0 |  +13%  ||     3.22 |     3.17 |   -2%  |  0.1102 |
 | 2a      ||     630.3 |     624.5 |   -1%  ||    77.68 |    78.61 |   +1%  |  0.7021 |
 | 2b      ||     676.9 |     661.9 |   -2%  ||    72.56 |    74.16 |   +2%  |  0.3617 |
 | 2c      ||     552.9 |     553.4 |   +0%  ||    88.66 |    88.74 |   +0%  |  0.9660 |
 | 2d      ||     728.2 |     720.2 |   -1%  ||    66.88 |    67.96 |   +2%  |  0.6409 |
+| 30a     ||    2677.7 |    2616.1 |   -2%  ||    17.70 |    18.52 |   +5%  |  0.6447 |
 | 30b     ||    3093.4 |    2998.3 |   -3%  ||    15.13 |    15.56 |   +3%  |  0.5653 |
+| 30c     ||   21731.0 |   19523.3 |  -10%  ||     1.80 |     1.90 |   +6%  |  0.1833 |
 | 31a     ||    3226.5 |    3292.6 |   +2%  ||    14.13 |    14.17 |   +0%  |  0.7221 |
 | 31b     ||    3455.4 |    3413.0 |   -1%  ||    13.50 |    13.37 |   -1%  |  0.8460 |
 | 31c     ||    2735.9 |    2822.2 |   +3%  ||    15.75 |    16.13 |   +2%  |  0.5750 |
 | 32a     ||     161.4 |     160.6 |   -1%  ||   299.58 |   300.90 |   +0%  |  0.6469 |
 | 32b     ||    1206.5 |    1196.0 |   -1%  ||    40.60 |    40.94 |   +1%  |  0.7207 |
 | 33a     ||     283.8 |     282.4 |   -0%  ||   172.28 |   172.99 |   +0%  |  0.7552 |
 | 33b     ||     282.3 |     280.1 |   -1%  ||   172.88 |   174.78 |   +1%  |  0.6249 |
 | 33c     ||     376.6 |     372.7 |   -1%  ||   130.28 |   131.49 |   +1%  |  0.5635 |
 | 3a      ||   19096.6 |   16360.4 |  -14%  ||     1.83 |     1.88 |   +3%  |  0.0748 |
 | 3b      ||     343.7 |     339.9 |   -1%  ||   142.80 |   144.24 |   +1%  |  0.4783 |
 | 3c      ||   32175.9 |   33951.6 |   +6%  ||     0.90 |     0.92 |   +2%  |  0.5104 |
 | 4a      ||    1019.0 |    1011.4 |   -1%  ||    47.36 |    48.53 |   +2%  |  0.7826 |
 | 4b      ||     106.8 |     106.1 |   -1%  ||   446.84 |   449.76 |   +1%  |  0.4733 |
 | 4c      ||    1248.6 |    1227.9 |   -2%  ||    39.13 |    39.88 |   +2%  |  0.5956 |
 | 5a      ||   17452.9 |   15520.5 |  -11%  ||     2.12 |     2.13 |   +1%  |  0.1129 |
 | 5b      ||    1483.5 |    1493.4 |   +1%  ||    31.86 |    32.50 |   +2%  |  0.8684 |
 | 5c      ||   18719.5 |   20569.9 |  +10%  ||     1.67 |     1.70 |   +2%  |  0.2436 |
 | 6a      ||    2046.9 |    1999.4 |   -2%  ||    23.55 |    23.71 |   +1%  |  0.5870 |
 | 6b      ||    6349.5 |    7534.2 |  +19%  ||     5.60 |     5.80 |   +4%  |  0.0176 |
 | 6c      ||    2031.9 |    2068.9 |   +2%  ||    23.73 |    23.13 |   -3%  |  0.6942 |
 | 6d      ||    6945.2 |    6724.9 |   -3%  ||     5.72 |     5.70 |   -0%  |  0.7064 |
 | 6e      ||    1983.4 |    1974.8 |   -0%  ||    24.00 |    24.38 |   +2%  |  0.9305 |
 | 6f      ||    7039.1 |    6597.1 |   -6%  ||     6.57 |     6.42 |   -2%  |  0.3419 |
 | 7a      ||    1545.5 |    1531.2 |   -1%  ||    31.40 |    32.01 |   +2%  |  0.7902 |
+| 7b      ||    1602.4 |    1454.2 |   -9%  ||    30.23 |    32.53 |   +8%  |  0.0063 |
-| 7c      ||   43175.6 |   41021.7 |   -5%  ||     0.13 |     0.12 |  -12%  |       ˅ |
 | 8a      ||    1528.9 |    1554.2 |   +2%  ||    31.75 |    30.93 |   -3%  |  0.6570 |
 | 8b      ||    1470.6 |    1488.7 |   +1%  ||    32.87 |    32.48 |   -1%  |  0.7679 |
-| 8c      ||   26159.0 |   24203.8 |   -7%  ||     1.27 |     1.17 |   -8%  |  0.2912 |
-| 8d      ||   10585.3 |   11117.6 |   +5%  ||     3.90 |     3.60 |   -8%  |  0.5360 |
+| 9a      ||   20250.0 |   23946.0 |  +18%  ||     1.37 |     1.43 |   +5%  |  0.0560 |
 | 9b      ||    3072.8 |    3164.6 |   +3%  ||    15.01 |    15.08 |   +0%  |  0.6261 |
 | 9c      ||   26411.6 |   22989.8 |  -13%  ||     1.28 |     1.30 |   +1%  |  0.0957 |
-| 9d      ||   24958.6 |   24627.1 |   -1%  ||     1.40 |     1.30 |   -7%  |  0.8493 |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Sum     || 1073054.5 | 1067232.8 |   -1%  ||          |          |        |         |
 | Geomean ||           |           |        ||          |          |   +1%  |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                    |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
```
</details>
</details>

<details>
<summary>And here is what it should have looked like, i.e., #2238 with the patch from this PR</summary>

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.2TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 44f8c4aa8 | 08.10.2020 21:29 | Create empty bloom filter only once (#2236) | real 270.68 user 2492.41 sys 152.64|
| 583cb10ad | 13.10.2020 20:42 | Actually use union_mode... | real 269.25 user 2468.79 sys 151.64|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_583cb10adc7c603f484064b4bf4bb49f3b1783db_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-12 09:35:29                                                                                                                    | 2020-10-14 09:47:11                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
-| TPC-H 01 ||    800.1 |   841.5 |   +5%  ||     1.25 |     1.19 |   -5%  |  0.0000 |
 | TPC-H 02 ||      5.0 |     5.0 |   +0%  ||   199.76 |   198.97 |   -0%  |  0.5966 |
 | TPC-H 03 ||     81.8 |    82.2 |   +0%  ||    12.22 |    12.16 |   -0%  |  0.0011 |
 | TPC-H 04 ||     68.7 |    69.4 |   +1%  ||    14.56 |    14.40 |   -1%  |  0.0000 |
+| TPC-H 05 ||    232.3 |   219.8 |   -5%  ||     4.30 |     4.55 |   +6%  |  0.0000 |
 | TPC-H 06 ||      3.6 |     3.6 |   +1%  ||   277.13 |   274.51 |   -1%  |  0.0000 |
 | TPC-H 07 ||     60.0 |    59.2 |   -1%  ||    16.67 |    16.89 |   +1%  |  0.1729 |
 | TPC-H 08 ||     69.3 |    69.2 |   -0%  ||    14.43 |    14.46 |   +0%  |  0.7159 |
 | TPC-H 09 ||    497.0 |   488.8 |   -2%  ||     2.01 |     2.05 |   +2%  |  0.0000 |
 | TPC-H 10 ||    168.9 |   167.7 |   -1%  ||     5.92 |     5.96 |   +1%  |  0.2173 |
 | TPC-H 11 ||      9.1 |     9.2 |   +1%  ||   109.45 |   108.65 |   -1%  |  0.0000 |
 | TPC-H 12 ||     43.8 |    44.2 |   +1%  ||    22.82 |    22.64 |   -1%  |  0.0000 |
+| TPC-H 13 ||    434.1 |   357.7 |  -18%  ||     2.30 |     2.80 |  +21%  |  0.0000 |
 | TPC-H 14 ||     21.3 |    21.1 |   -1%  ||    46.88 |    47.34 |   +1%  |  0.0000 |
 | TPC-H 15 ||      7.9 |     7.9 |   -0%  ||   126.76 |   126.93 |   +0%  |  0.0524 |
+| TPC-H 16 ||     95.3 |    75.7 |  -21%  ||    10.50 |    13.22 |  +26%  |  0.0000 |
 | TPC-H 17 ||     18.2 |    18.1 |   -0%  ||    54.94 |    55.15 |   +0%  |  0.0569 |
+| TPC-H 18 ||    708.7 |   675.5 |   -5%  ||     1.41 |     1.48 |   +5%  |  0.0000 |
 | TPC-H 19 ||     29.9 |    29.8 |   -1%  ||    33.43 |    33.60 |   +1%  |  0.0000 |
 | TPC-H 20 ||     16.3 |    16.3 |   +0%  ||    61.36 |    61.34 |   -0%  |  0.9025 |
 | TPC-H 21 ||    425.8 |   427.8 |   +0%  ||     2.35 |     2.34 |   -0%  |  0.2812 |
 | TPC-H 22 ||     50.6 |    50.5 |   -0%  ||    19.76 |    19.81 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3847.8 |  3740.3 |   -3%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st_s01.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_583cb10adc7c603f484064b4bf4bb49f3b1783db_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                             | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-12 09:58:12                                                                                                                        | 2020-10-14 10:09:29                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      7.3 |     7.5 |   +2%  ||   136.40 |   133.90 |   -2%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.5 |   +0%  ||  1836.58 |  1830.24 |   -0%  |  0.4154 |
 | TPC-H 03 ||      0.9 |     0.9 |   -1%  ||  1109.36 |  1120.76 |   +1%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   -0%  ||  1907.08 |  1915.67 |   +0%  |  0.0000 |
 | TPC-H 05 ||      1.3 |     1.2 |   -2%  ||   789.40 |   803.63 |   +2%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   -1%  ||  9181.73 |  9311.78 |   +1%  |  0.0000 |
 | TPC-H 07 ||      1.3 |     1.3 |   -2%  ||   777.75 |   792.55 |   +2%  |  0.1212 |
 | TPC-H 08 ||     15.3 |    15.0 |   -2%  ||    65.45 |    66.73 |   +2%  |  0.0117 |
 | TPC-H 09 ||      2.4 |     2.4 |   -0%  ||   411.65 |   412.60 |   +0%  |  0.4016 |
 | TPC-H 10 ||      0.9 |     0.9 |   +0%  ||  1079.99 |  1078.48 |   -0%  |  0.0002 |
 | TPC-H 11 ||      0.3 |     0.3 |   +1%  ||  3309.06 |  3262.75 |   -1%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   +0%  ||  1549.18 |  1547.46 |   -0%  |  0.0424 |
+| TPC-H 13 ||      2.4 |     2.3 |   -6%  ||   414.33 |   442.12 |   +7%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.4 |   +0%  ||  2773.34 |  2768.15 |   -0%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.2 |   +0%  ||   868.63 |   867.19 |   -0%  |  0.0000 |
+| TPC-H 16 ||      2.2 |     2.1 |   -6%  ||   448.88 |   476.32 |   +6%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   -1%  ||  3314.43 |  3340.94 |   +1%  |  0.0000 |
 | TPC-H 18 ||      2.7 |     2.9 |   +4%  ||   364.06 |   350.41 |   -4%  |  0.0000 |
 | TPC-H 19 ||      5.6 |     5.6 |   -0%  ||   177.11 |   177.48 |   +0%  |  0.0000 |
 | TPC-H 20 ||      2.4 |     2.4 |   -0%  ||   410.26 |   412.21 |   +0%  |  0.0090 |
 | TPC-H 21 ||      1.9 |     1.9 |   -1%  ||   520.23 |   522.95 |   +1%  |  0.0446 |
 | TPC-H 22 ||      1.3 |     1.3 |   -0%  ||   744.21 |   745.83 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     52.1 |    51.6 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st_s10.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_583cb10adc7c603f484064b4bf4bb49f3b1783db_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                             | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-12 10:20:19                                                                                                                        | 2020-10-14 10:31:32                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
-| TPC-H 01 ||   8758.1 |  9356.7 |   +7%  ||     0.11 |     0.11 |   -6%  |       ˅ |
 | TPC-H 02 ||     55.1 |    55.2 |   +0%  ||    18.15 |    18.10 |   -0%  |  0.5879 |
 | TPC-H 03 ||   1561.3 |  1599.1 |   +2%  ||     0.64 |     0.63 |   -2%  |  0.0044 |
 | TPC-H 04 ||   1669.7 |  1700.5 |   +2%  ||     0.60 |     0.59 |   -2%  |  0.0096 |
 | TPC-H 05 ||   3385.1 |  3431.3 |   +1%  ||     0.30 |     0.29 |   -1%  |  0.0610 |
 | TPC-H 06 ||     39.7 |    39.3 |   -1%  ||    25.20 |    25.47 |   +1%  |  0.0066 |
 | TPC-H 07 ||    964.5 |   960.8 |   -0%  ||     1.04 |     1.04 |   +0%  |  0.1145 |
 | TPC-H 08 ||    676.5 |   668.9 |   -1%  ||     1.48 |     1.50 |   +1%  |  0.0000 |
 | TPC-H 09 ||   7664.3 |  7560.4 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | TPC-H 10 ||   2993.7 |  2957.5 |   -1%  ||     0.33 |     0.34 |   +1%  |  0.0045 |
 | TPC-H 11 ||    133.6 |   132.5 |   -1%  ||     7.49 |     7.55 |   +1%  |  0.0017 |
 | TPC-H 12 ||    731.3 |   723.9 |   -1%  ||     1.37 |     1.38 |   +1%  |  0.0000 |
+| TPC-H 13 ||   6800.8 |  5654.5 |  -17%  ||     0.15 |     0.18 |  +20%  |       ˅ |
+| TPC-H 14 ||    255.2 |   243.3 |   -5%  ||     3.92 |     4.11 |   +5%  |  0.0000 |
 | TPC-H 15 ||    102.9 |   103.0 |   +0%  ||     9.71 |     9.71 |   -0%  |  0.8368 |
+| TPC-H 16 ||   1292.8 |  1075.2 |  -17%  ||     0.77 |     0.93 |  +20%  |  0.0000 |
 | TPC-H 17 ||    280.0 |   278.1 |   -1%  ||     3.57 |     3.60 |   +1%  |  0.0000 |
 | TPC-H 18 ||  12680.8 | 12815.5 |   +1%  ||     0.08 |     0.08 |   -1%  |       ˅ |
 | TPC-H 19 ||    334.4 |   331.1 |   -1%  ||     2.99 |     3.02 |   +1%  |  0.0512 |
 | TPC-H 20 ||    184.1 |   183.1 |   -1%  ||     5.43 |     5.46 |   +1%  |  0.0239 |
 | TPC-H 21 ||   7109.6 |  7092.6 |   -0%  ||     0.14 |     0.14 |   +0%  |       ˅ |
 | TPC-H 22 ||    738.1 |   735.3 |   -0%  ||     1.35 |     1.36 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  58411.4 | 57697.9 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_583cb10adc7c603f484064b4bf4bb49f3b1783db_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-12 10:50:02                                                                                                                    | 2020-10-14 10:57:01                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   2422.6 |  2456.7 |   +1%  ||    20.08 |    19.85 |   -1%  |  0.4889 |
 | TPC-H 02 ||     16.6 |    16.6 |   -0%  ||  2356.73 |  2355.37 |   -0%  |  0.0472 |
 | TPC-H 03 ||    467.4 |   458.1 |   -2%  ||   105.23 |   107.54 |   +2%  |  0.2048 |
 | TPC-H 04 ||    290.1 |   285.1 |   -2%  ||   168.70 |   171.46 |   +2%  |  0.2395 |
 | TPC-H 05 ||   1423.0 |  1393.1 |   -2%  ||    34.21 |    34.66 |   +1%  |  0.4943 |
 | TPC-H 06 ||     23.5 |    23.2 |   -1%  ||  1666.56 |  1677.16 |   +1%  |  0.0000 |
+| TPC-H 07 ||    289.9 |   264.2 |   -9%  ||   168.15 |   185.18 |  +10%  |  0.0000 |
 | TPC-H 08 ||    200.6 |   198.8 |   -1%  ||   242.69 |   244.88 |   +1%  |  0.3509 |
 | TPC-H 09 ||   2641.9 |  2594.8 |   -2%  ||    18.13 |    18.55 |   +2%  |  0.5776 |
 | TPC-H 10 ||    923.0 |   925.6 |   +0%  ||    53.28 |    53.25 |   -0%  |  0.8453 |
 | TPC-H 11 ||     73.1 |    72.8 |   -0%  ||   643.21 |   645.61 |   +0%  |  0.4250 |
 | TPC-H 12 ||    141.5 |   140.1 |   -1%  ||   340.69 |   344.03 |   +1%  |  0.2342 |
 | TPC-H 13 ||   2440.2 |  2362.4 |   -3%  ||    19.80 |    20.00 |   +1%  |  0.2811 |
 | TPC-H 14 ||    151.0 |   149.9 |   -1%  ||   320.24 |   322.69 |   +1%  |  0.1912 |
+| TPC-H 15 ||     58.1 |    55.4 |   -5%  ||   794.62 |   832.18 |   +5%  |  0.0000 |
+| TPC-H 16 ||    496.8 |   420.8 |  -15%  ||    99.01 |   116.77 |  +18%  |  0.0000 |
 | TPC-H 17 ||     58.8 |    58.9 |   +0%  ||   790.34 |   788.20 |   -0%  |  0.5501 |
 | TPC-H 18 ||   6616.6 |  6486.1 |   -2%  ||     7.03 |     7.23 |   +3%  |  0.5258 |
 | TPC-H 19 ||     93.4 |    94.1 |   +1%  ||   508.96 |   505.31 |   -1%  |  0.2330 |
 | TPC-H 20 ||     55.8 |    56.1 |   +1%  ||   825.42 |   821.01 |   -1%  |  0.2473 |
-| TPC-H 21 ||   2357.8 |  2423.1 |   +3%  ||    20.56 |    19.63 |   -5%  |  0.4905 |
 | TPC-H 22 ||    725.1 |   726.2 |   +0%  ||    65.70 |    67.12 |   +2%  |  0.9591 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  21966.7 | 21662.0 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_583cb10adc7c603f484064b4bf4bb49f3b1783db_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                          | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-10-12 11:12:30                                                                                                                     | 2020-10-14 11:19:32                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     28.9 |    29.1 |   +0%  ||    34.55 |    34.41 |   -0%  |  0.0004 |
 | 03      ||      7.1 |     7.1 |   +1%  ||   141.74 |   140.24 |   -1%  |  0.0000 |
 | 06      ||     18.2 |    18.6 |   +2%  ||    54.98 |    53.77 |   -2%  |  0.0000 |
 | 07      ||     32.4 |    32.5 |   +0%  ||    30.89 |    30.81 |   -0%  |  0.1407 |
 | 09      ||    122.5 |   120.8 |   -1%  ||     8.16 |     8.28 |   +1%  |  0.0000 |
 | 10      ||     19.7 |    19.8 |   +0%  ||    50.77 |    50.53 |   -0%  |  0.0000 |
 | 13      ||    129.5 |   129.2 |   -0%  ||     7.72 |     7.74 |   +0%  |  0.8323 |
 | 15      ||     10.2 |    10.3 |   +0%  ||    97.68 |    97.21 |   -0%  |  0.0000 |
 | 17      ||     28.3 |    28.7 |   +1%  ||    35.34 |    34.85 |   -1%  |  0.0318 |
 | 19      ||     10.2 |    10.3 |   +1%  ||    98.34 |    97.50 |   -1%  |  0.0000 |
 | 25      ||     15.5 |    15.6 |   +1%  ||    64.69 |    64.20 |   -1%  |  0.2296 |
 | 26      ||     16.0 |    16.3 |   +1%  ||    62.32 |    61.52 |   -1%  |  0.0000 |
 | 28      ||   1029.0 |  1030.9 |   +0%  ||     0.97 |     0.97 |   -0%  |  0.0219 |
 | 29      ||     26.0 |    26.2 |   +1%  ||    38.53 |    38.14 |   -1%  |  0.1137 |
 | 31      ||    132.8 |   133.7 |   +1%  ||     7.53 |     7.48 |   -1%  |  0.0000 |
 | 34      ||     16.9 |    17.0 |   +1%  ||    59.10 |    58.76 |   -1%  |  0.0000 |
 | 35      ||     89.2 |    89.3 |   +0%  ||    11.22 |    11.20 |   -0%  |  0.0008 |
 | 39a     ||    174.9 |   178.0 |   +2%  ||     5.72 |     5.62 |   -2%  |  0.0000 |
 | 39b     ||    173.9 |   175.9 |   +1%  ||     5.75 |     5.68 |   -1%  |  0.0000 |
 | 41      ||     24.8 |    24.8 |   +0%  ||    40.39 |    40.33 |   -0%  |  0.2121 |
 | 42      ||      8.1 |     8.1 |   +1%  ||   124.02 |   122.85 |   -1%  |  0.0000 |
 | 43      ||    248.0 |   249.7 |   +1%  ||     4.03 |     4.00 |   -1%  |  0.0000 |
 | 45      ||      9.8 |     9.9 |   +1%  ||   101.89 |   100.56 |   -1%  |  0.0000 |
 | 48      ||     86.4 |    87.4 |   +1%  ||    11.57 |    11.44 |   -1%  |  0.0000 |
 | 50      ||     11.4 |    11.6 |   +2%  ||    87.79 |    86.21 |   -2%  |  0.0000 |
 | 52      ||      8.2 |     8.3 |   +2%  ||   122.03 |   119.96 |   -2%  |  0.0000 |
 | 55      ||      8.0 |     8.2 |   +1%  ||   124.25 |   122.66 |   -1%  |  0.0000 |
 | 62      ||     74.3 |    75.3 |   +1%  ||    13.45 |    13.27 |   -1%  |  0.0000 |
 | 65      ||     61.9 |    63.6 |   +3%  ||    16.15 |    15.73 |   -3%  |  0.0000 |
 | 69      ||     22.1 |    22.6 |   +2%  ||    45.24 |    44.16 |   -2%  |  0.0000 |
 | 73      ||     10.7 |    10.9 |   +2%  ||    93.22 |    91.39 |   -2%  |  0.0000 |
 | 79      ||     45.0 |    45.7 |   +2%  ||    22.21 |    21.88 |   -2%  |  0.0000 |
 | 81      ||     19.0 |    19.4 |   +2%  ||    52.64 |    51.60 |   -2%  |  0.0000 |
 | 83      ||      9.4 |     9.6 |   +2%  ||   105.93 |   103.71 |   -2%  |  0.0000 |
 | 85      ||     60.2 |    60.7 |   +1%  ||    16.60 |    16.46 |   -1%  |  0.6772 |
 | 88      ||     70.5 |    71.0 |   +1%  ||    14.19 |    14.09 |   -1%  |  0.0000 |
 | 91      ||     22.3 |    22.5 |   +1%  ||    44.87 |    44.45 |   -1%  |  0.0000 |
 | 93      ||    257.4 |   264.5 |   +3%  ||     3.89 |     3.78 |   -3%  |  0.0000 |
 | 96      ||      7.4 |     7.5 |   +1%  ||   135.41 |   133.84 |   -1%  |  0.0000 |
 | 97      ||    412.5 |   405.6 |   -2%  ||     2.42 |     2.47 |   +2%  |  0.0229 |
 | 99      ||    148.7 |   149.5 |   +0%  ||     6.72 |     6.69 |   -0%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3707.3 |  3725.7 |   +0%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_583cb10adc7c603f484064b4bf4bb49f3b1783db_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                          | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-10-12 11:53:50                                                                                                                     | 2020-10-14 12:00:40                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    214.4 |   214.7 |   +0%  ||   227.49 |   226.97 |   -0%  |  0.8341 |
 | 03      ||     30.1 |    30.1 |   -0%  ||  1472.75 |  1472.18 |   -0%  |  0.6571 |
 | 06      ||    125.1 |   127.0 |   +2%  ||   384.46 |   378.50 |   -2%  |  0.0566 |
 | 07      ||    185.5 |   188.3 |   +2%  ||   261.80 |   258.25 |   -1%  |  0.1438 |
+| 09      ||    520.2 |   499.3 |   -4%  ||    93.11 |    98.64 |   +6%  |  0.1760 |
 | 10      ||     86.4 |    87.1 |   +1%  ||   550.18 |   545.73 |   -1%  |  0.2777 |
 | 13      ||    437.8 |   436.3 |   -0%  ||   112.40 |   112.57 |   +0%  |  0.8017 |
 | 15      ||     71.3 |    71.7 |   +1%  ||   656.70 |   653.30 |   -1%  |  0.3040 |
 | 17      ||    138.0 |   140.2 |   +2%  ||   349.33 |   343.92 |   -2%  |  0.0746 |
 | 19      ||     50.8 |    51.5 |   +1%  ||   903.87 |   893.92 |   -1%  |  0.0035 |
 | 25      ||     77.0 |    78.9 |   +2%  ||   614.82 |   600.20 |   -2%  |  0.0002 |
 | 26      ||    108.9 |   110.1 |   +1%  ||   439.69 |   435.10 |   -1%  |  0.1325 |
 | 28      ||   3126.1 |  3141.1 |   +0%  ||    14.43 |    14.38 |   -0%  |  0.9255 |
 | 29      ||    136.7 |   137.4 |   +0%  ||   352.37 |   350.25 |   -1%  |  0.5778 |
 | 31      ||    818.0 |   834.1 |   +2%  ||    59.05 |    58.37 |   -1%  |  0.5073 |
 | 34      ||     93.3 |    94.4 |   +1%  ||   508.48 |   502.68 |   -1%  |  0.0918 |
 | 35      ||    846.5 |   857.2 |   +1%  ||    57.90 |    57.46 |   -1%  |  0.5201 |
 | 39a     ||   1740.9 |  1747.9 |   +0%  ||    27.86 |    27.80 |   -0%  |  0.8863 |
 | 39b     ||   1733.7 |  1757.2 |   +1%  ||    27.98 |    27.83 |   -1%  |  0.6436 |
 | 41      ||   1324.4 |  1429.2 |   +8%  ||    31.76 |    31.90 |   +0%  |  0.3272 |
 | 42      ||     41.3 |    41.6 |   +1%  ||  1094.74 |  1085.45 |   -1%  |  0.0108 |
 | 43      ||    784.5 |   798.3 |   +2%  ||    62.78 |    61.54 |   -2%  |  0.1880 |
 | 45      ||     53.5 |    54.1 |   +1%  ||   855.59 |   847.49 |   -1%  |  0.0284 |
 | 48      ||    376.2 |   377.4 |   +0%  ||   130.54 |   129.69 |   -1%  |  0.8523 |
+| 50      ||    140.6 |   131.8 |   -6%  ||   342.60 |   364.74 |   +6%  |  0.0000 |
 | 52      ||     42.3 |    42.1 |   -0%  ||  1067.06 |  1073.83 |   +1%  |  0.1463 |
 | 55      ||     38.8 |    39.4 |   +2%  ||  1157.21 |  1141.56 |   -1%  |  0.0000 |
 | 62      ||    310.0 |   312.6 |   +1%  ||   158.01 |   156.77 |   -1%  |  0.3544 |
 | 65      ||    551.4 |   556.5 |   +1%  ||    89.33 |    88.53 |   -1%  |  0.3986 |
 | 69      ||    129.9 |   129.6 |   -0%  ||   370.05 |   370.68 |   +0%  |  0.7655 |
 | 73      ||     52.9 |    53.2 |   +0%  ||   872.45 |   868.38 |   -0%  |  0.2095 |
 | 79      ||    211.6 |   211.8 |   +0%  ||   230.10 |   230.16 |   +0%  |  0.9413 |
 | 81      ||    154.4 |   151.7 |   -2%  ||   313.26 |   318.79 |   +2%  |  0.0195 |
 | 83      ||     75.0 |    75.1 |   +0%  ||   627.05 |   625.57 |   -0%  |  0.7595 |
 | 85      ||    234.2 |   233.8 |   -0%  ||   208.42 |   208.95 |   +0%  |  0.8910 |
 | 88      ||    436.4 |   443.5 |   +2%  ||   112.36 |   109.04 |   -3%  |  0.5484 |
 | 91      ||     89.4 |    88.9 |   -1%  ||   532.12 |   535.13 |   +1%  |  0.2992 |
 | 93      ||   1377.5 |  1420.0 |   +3%  ||    34.25 |    34.23 |   -0%  |  0.2974 |
+| 96      ||     47.6 |    45.2 |   -5%  ||   962.20 |  1009.55 |   +5%  |  0.0000 |
 | 97      ||   3898.6 |  3667.1 |   -6%  ||    12.37 |    12.80 |   +4%  |  0.0730 |
 | 99      ||    801.3 |   793.3 |   -1%  ||    61.13 |    62.20 |   +2%  |  0.5046 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  21712.4 | 21700.6 |   -0%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -0%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_583cb10adc7c603f484064b4bf4bb49f3b1783db_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-10-12 12:35:10                                                                                                                    | 2020-10-14 12:41:59                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     28.7 |    28.6 |   -0%  ||     3.77 |     3.73 |   -1%  | (run time too short) |
 | New-Order    ||     18.2 |    18.3 |   +1%  ||    42.37 |    42.12 |   -1%  | (run time too short) |
 | Order-Status ||      1.3 |     1.3 |   +1%  ||     3.77 |     3.77 |   -0%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   +2%  ||    40.42 |    40.24 |   -0%  | (run time too short) |
 | Stock-Level  ||      4.2 |     4.2 |   +1%  ||     3.75 |     3.75 |   -0%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     54.8 |    54.9 |   +0%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -0%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_583cb10adc7c603f484064b4bf4bb49f3b1783db_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                         | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-12 12:36:14                                                                                                                    | 2020-10-14 12:43:03                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    224.5 |   223.3 |   -1%  ||     4.30 |     4.33 |   +1%  | (run time too short) |
 |    unsucc.:  ||      4.1 |     4.1 |   -1%  ||   123.98 |   121.13 |   -2%  |                      |
 | New-Order    ||    100.9 |   101.9 |   +1%  ||    84.98 |    84.91 |   -0%  |               0.3402 |
 |    unsucc.:  ||      5.0 |     5.2 |   +4%  ||  1358.40 |  1326.35 |   -2%  |                      |
 | Order-Status ||      8.0 |     8.1 |   +2%  ||   128.30 |   125.46 |   -2%  |               0.0640 |
-| Payment      ||     18.3 |    18.5 |   +1%  ||     5.53 |     5.27 |   -5%  | (run time too short) |
 |    unsucc.:  ||      4.3 |     4.5 |   +5%  ||  1373.77 |  1343.39 |   -2%  |                      |
 | Stock-Level  ||     18.8 |    19.2 |   +2%  ||   128.30 |   125.41 |   -2%  |               0.1050 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    370.4 |   371.0 |   +0%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +3%
 ||
Geometric mean of throughput changes: -4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_583cb10adc7c603f484064b4bf4bb49f3b1783db_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                              | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-10-12 12:37:20                                                                                                                         | 2020-10-14 12:44:09                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    360.8 |    369.6 |   +2%  ||     2.77 |     2.71 |   -2%  |  0.0000 |
 | 10b     ||    356.7 |    365.2 |   +2%  ||     2.80 |     2.74 |   -2%  |  0.0000 |
 | 10c     ||   1161.4 |   1214.8 |   +5%  ||     0.86 |     0.82 |   -4%  |  0.0000 |
-| 11a     ||    155.8 |    173.7 |  +11%  ||     6.42 |     5.76 |  -10%  |  0.0000 |
-| 11b     ||    144.6 |    165.6 |  +15%  ||     6.92 |     6.04 |  -13%  |  0.0000 |
 | 11c     ||    530.5 |    544.9 |   +3%  ||     1.88 |     1.84 |   -3%  |  0.0082 |
 | 11d     ||   4704.2 |   4921.0 |   +5%  ||     0.21 |     0.20 |   -4%  |  0.0218 |
-| 12a     ||    367.4 |    385.4 |   +5%  ||     2.72 |     2.59 |   -5%  |  0.0000 |
 | 12b     ||    655.5 |    671.4 |   +2%  ||     1.53 |     1.49 |   -2%  |  0.0136 |
 | 12c     ||   3718.9 |   3862.1 |   +4%  ||     0.27 |     0.26 |   -4%  |  0.0004 |
 | 13a     ||    178.7 |    186.0 |   +4%  ||     5.60 |     5.38 |   -4%  |  0.0000 |
 | 13b     ||    265.7 |    273.1 |   +3%  ||     3.76 |     3.66 |   -3%  |  0.0000 |
 | 13c     ||    142.9 |    149.2 |   +4%  ||     7.00 |     6.70 |   -4%  |  0.0000 |
 | 13d     ||    180.9 |    186.5 |   +3%  ||     5.53 |     5.36 |   -3%  |  0.0000 |
 | 14a     ||   4117.6 |   4226.4 |   +3%  ||     0.24 |     0.24 |   -3%  |  0.0060 |
 | 14b     ||   4803.0 |   4922.7 |   +2%  ||     0.21 |     0.20 |   -2%  |  0.0241 |
 | 14c     ||   4131.5 |   4226.8 |   +2%  ||     0.24 |     0.24 |   -2%  |  0.0260 |
-| 15a     ||    211.2 |    226.3 |   +7%  ||     4.74 |     4.42 |   -7%  |  0.0000 |
-| 15b     ||    207.5 |    219.3 |   +6%  ||     4.82 |     4.56 |   -5%  |  0.0000 |
-| 15c     ||    153.0 |    171.9 |  +12%  ||     6.54 |     5.82 |  -11%  |  0.0000 |
 | 15d     ||    465.7 |    477.8 |   +3%  ||     2.15 |     2.09 |   -3%  |  0.0000 |
 | 16a     ||   4732.8 |   4851.3 |   +3%  ||     0.21 |     0.21 |   -2%  |  0.1218 |
 | 16b     ||   6162.6 |   6409.9 |   +4%  ||     0.16 |     0.16 |   -4%  |  0.0047 |
 | 16c     ||   4888.2 |   5024.2 |   +3%  ||     0.20 |     0.20 |   -3%  |  0.0808 |
 | 16d     ||   4798.3 |   5010.0 |   +4%  ||     0.21 |     0.20 |   -4%  |  0.0187 |
 | 17a     ||    976.4 |   1012.8 |   +4%  ||     1.02 |     0.99 |   -4%  |  0.0000 |
 | 17b     ||    774.8 |    803.9 |   +4%  ||     1.29 |     1.24 |   -4%  |  0.0000 |
 | 17c     ||    730.0 |    757.9 |   +4%  ||     1.37 |     1.32 |   -4%  |  0.0000 |
 | 17d     ||    841.0 |    872.5 |   +4%  ||     1.19 |     1.15 |   -4%  |  0.0000 |
 | 17e     ||   2958.4 |   3069.1 |   +4%  ||     0.34 |     0.33 |   -4%  |  0.0000 |
 | 17f     ||   1552.0 |   1615.3 |   +4%  ||     0.64 |     0.62 |   -4%  |  0.0000 |
 | 18a     ||    684.4 |    703.9 |   +3%  ||     1.46 |     1.42 |   -3%  |  0.0000 |
 | 18b     ||    232.8 |    242.2 |   +4%  ||     4.30 |     4.13 |   -4%  |  0.0000 |
 | 18c     ||   3790.9 |   3909.9 |   +3%  ||     0.26 |     0.26 |   -3%  |  0.0000 |
 | 19a     ||   7646.3 |   7944.4 |   +4%  ||     0.13 |     0.13 |   -4%  |       ˅ |
-| 19b     ||   4528.7 |   4765.6 |   +5%  ||     0.22 |     0.21 |   -5%  |  0.0000 |
 | 19c     ||   7428.9 |   7739.6 |   +4%  ||     0.13 |     0.13 |   -4%  |       ˅ |
 | 19d     ||   5717.5 |   5878.2 |   +3%  ||     0.17 |     0.17 |   -3%  |  0.0011 |
 | 1a      ||     58.8 |     61.4 |   +4%  ||    17.01 |    16.29 |   -4%  |  0.0000 |
-| 1b      ||     22.0 |     23.9 |   +9%  ||    45.52 |    41.81 |   -8%  |  0.0000 |
-| 1c      ||     22.0 |     24.2 |  +10%  ||    45.46 |    41.27 |   -9%  |  0.0000 |
-| 1d      ||     21.9 |     24.0 |  +10%  ||    45.68 |    41.61 |   -9%  |  0.0000 |
 | 20a     ||   1276.7 |   1320.9 |   +3%  ||     0.78 |     0.76 |   -3%  |  0.0000 |
 | 20b     ||   1091.7 |   1129.7 |   +3%  ||     0.92 |     0.89 |   -3%  |  0.0000 |
 | 20c     ||   1127.5 |   1158.8 |   +3%  ||     0.89 |     0.86 |   -3%  |  0.0000 |
 | 21a     ||   3857.7 |   3968.9 |   +3%  ||     0.26 |     0.25 |   -3%  |  0.0000 |
 | 21b     ||    265.3 |    277.2 |   +4%  ||     3.77 |     3.61 |   -4%  |  0.0000 |
 | 21c     ||   3984.1 |   4111.9 |   +3%  ||     0.25 |     0.24 |   -3%  |  0.0000 |
 | 22a     ||   3487.3 |   3605.4 |   +3%  ||     0.29 |     0.28 |   -3%  |  0.0005 |
 | 22b     ||   3491.9 |   3595.6 |   +3%  ||     0.29 |     0.28 |   -3%  |  0.0015 |
 | 22c     ||   4126.7 |   4244.8 |   +3%  ||     0.24 |     0.24 |   -3%  |  0.0006 |
 | 22d     ||   4143.6 |   4270.9 |   +3%  ||     0.24 |     0.23 |   -3%  |  0.0002 |
-| 23a     ||    156.4 |    174.8 |  +12%  ||     6.39 |     5.72 |  -11%  |  0.0000 |
-| 23b     ||    122.1 |    135.7 |  +11%  ||     8.19 |     7.37 |  -10%  |  0.0000 |
-| 23c     ||    174.7 |    195.9 |  +12%  ||     5.72 |     5.10 |  -11%  |  0.0000 |
 | 24a     ||   4621.1 |   4797.7 |   +4%  ||     0.22 |     0.21 |   -4%  |  0.0000 |
 | 24b     ||   4564.8 |   4774.6 |   +5%  ||     0.22 |     0.21 |   -4%  |  0.0043 |
 | 25a     ||    236.4 |    245.2 |   +4%  ||     4.23 |     4.08 |   -4%  |  0.0000 |
 | 25b     ||    250.2 |    260.1 |   +4%  ||     4.00 |     3.84 |   -4%  |  0.0000 |
 | 25c     ||   3788.3 |   3912.1 |   +3%  ||     0.26 |     0.26 |   -3%  |  0.0000 |
 | 26a     ||    995.4 |   1020.6 |   +3%  ||     1.00 |     0.98 |   -2%  |  0.0000 |
 | 26b     ||    984.3 |   1008.9 |   +2%  ||     1.02 |     0.99 |   -2%  |  0.0004 |
 | 26c     ||   1001.4 |   1022.2 |   +2%  ||     1.00 |     0.98 |   -2%  |  0.0001 |
 | 27a     ||   3506.6 |   3607.2 |   +3%  ||     0.29 |     0.28 |   -3%  |  0.0000 |
 | 27b     ||   3485.0 |   3562.2 |   +2%  ||     0.29 |     0.28 |   -2%  |  0.0007 |
-| 27c     ||    205.7 |    231.6 |  +13%  ||     4.86 |     4.32 |  -11%  |  0.0000 |
 | 28a     ||   4155.3 |   4270.7 |   +3%  ||     0.24 |     0.23 |   -3%  |  0.2207 |
 | 28b     ||   3393.6 |   3497.3 |   +3%  ||     0.29 |     0.29 |   -3%  |  0.2747 |
 | 28c     ||   4153.5 |   4271.6 |   +3%  ||     0.24 |     0.23 |   -3%  |  0.2067 |
 | 29a     ||   4502.8 |   4670.3 |   +4%  ||     0.22 |     0.21 |   -4%  |  0.2737 |
 | 29b     ||    201.6 |    210.2 |   +4%  ||     4.96 |     4.76 |   -4%  |  0.4115 |
 | 29c     ||   4593.4 |   4777.0 |   +4%  ||     0.22 |     0.21 |   -4%  |  0.2394 |
-| 2a      ||    110.3 |    116.2 |   +5%  ||     9.07 |     8.60 |   -5%  |  0.0000 |
-| 2b      ||     86.4 |     91.4 |   +6%  ||    11.57 |    10.94 |   -5%  |  0.0000 |
-| 2c      ||     56.7 |     60.4 |   +6%  ||    17.63 |    16.55 |   -6%  |  0.0000 |
-| 2d      ||    136.2 |    143.7 |   +6%  ||     7.34 |     6.96 |   -5%  |  0.0000 |
 | 30a     ||    253.0 |    260.7 |   +3%  ||     3.95 |     3.84 |   -3%  |  0.1117 |
 | 30b     ||   1137.7 |   1165.5 |   +2%  ||     0.88 |     0.86 |   -2%  |  0.2141 |
 | 30c     ||   3815.8 |   3935.3 |   +3%  ||     0.26 |     0.25 |   -3%  |  0.1379 |
 | 31a     ||    290.9 |    301.3 |   +4%  ||     3.44 |     3.32 |   -3%  |  0.0004 |
 | 31b     ||   1167.2 |   1196.4 |   +3%  ||     0.86 |     0.84 |   -2%  |  0.0331 |
 | 31c     ||    294.1 |    304.6 |   +4%  ||     3.40 |     3.28 |   -3%  |  0.0007 |
-| 32a     ||     37.2 |     41.5 |  +12%  ||    26.88 |    24.07 |  -10%  |  0.0000 |
 | 32b     ||    288.1 |    300.6 |   +4%  ||     3.47 |     3.33 |   -4%  |  0.0000 |
-| 33a     ||     70.1 |     73.9 |   +5%  ||    14.27 |    13.53 |   -5%  |  0.0000 |
-| 33b     ||     69.2 |     73.3 |   +6%  ||    14.44 |    13.64 |   -6%  |  0.0000 |
-| 33c     ||     85.4 |     90.2 |   +6%  ||    11.70 |    11.09 |   -5%  |  0.0000 |
 | 3a      ||   3968.1 |   4082.0 |   +3%  ||     0.25 |     0.24 |   -3%  |  0.0000 |
-| 3b      ||     36.4 |     39.4 |   +8%  ||    27.47 |    25.38 |   -8%  |  0.0000 |
 | 3c      ||   5108.8 |   5275.9 |   +3%  ||     0.20 |     0.19 |   -3%  |  0.0000 |
-| 4a      ||    128.8 |    135.2 |   +5%  ||     7.76 |     7.39 |   -5%  |  0.0000 |
-| 4b      ||     27.2 |     29.3 |   +8%  ||    36.78 |    34.10 |   -7%  |  0.0000 |
-| 4c      ||    145.5 |    154.0 |   +6%  ||     6.87 |     6.49 |   -6%  |  0.0000 |
 | 5a      ||   3798.3 |   3922.5 |   +3%  ||     0.26 |     0.25 |   -3%  |  0.0000 |
-| 5b      ||    278.8 |    293.0 |   +5%  ||     3.59 |     3.41 |   -5%  |  0.0000 |
 | 5c      ||   4435.8 |   4576.8 |   +3%  ||     0.23 |     0.22 |   -3%  |  0.0000 |
 | 6a      ||    229.9 |    238.7 |   +4%  ||     4.35 |     4.19 |   -4%  |  0.0000 |
 | 6b      ||    961.5 |    999.0 |   +4%  ||     1.04 |     1.00 |   -4%  |  0.0000 |
 | 6c      ||    230.4 |    238.5 |   +4%  ||     4.34 |     4.19 |   -3%  |  0.0000 |
 | 6d      ||    965.6 |    993.7 |   +3%  ||     1.04 |     1.01 |   -3%  |  0.0000 |
 | 6e      ||    230.5 |    239.1 |   +4%  ||     4.34 |     4.18 |   -4%  |  0.0000 |
 | 6f      ||   1501.0 |   1561.0 |   +4%  ||     0.67 |     0.64 |   -4%  |  0.0000 |
 | 7a      ||    280.0 |    289.5 |   +3%  ||     3.57 |     3.45 |   -3%  |  0.0034 |
 | 7b      ||    137.3 |    142.9 |   +4%  ||     7.28 |     7.00 |   -4%  |  0.0003 |
 | 7c      ||  11011.9 |  11357.0 |   +3%  ||     0.09 |     0.09 |   -3%  |       ˅ |
-| 8a      ||    111.9 |    119.9 |   +7%  ||     8.93 |     8.34 |   -7%  |  0.0000 |
-| 8b      ||    167.0 |    185.3 |  +11%  ||     5.99 |     5.40 |  -10%  |  0.0000 |
-| 8c      ||   4396.4 |   4644.6 |   +6%  ||     0.23 |     0.22 |   -5%  |  0.0000 |
-| 8d      ||   1552.1 |   1638.1 |   +6%  ||     0.64 |     0.61 |   -5%  |  0.0000 |
 | 9a      ||   3515.1 |   3605.9 |   +3%  ||     0.28 |     0.28 |   -3%  |  0.0001 |
 | 9b      ||    331.2 |    340.6 |   +3%  ||     3.02 |     2.94 |   -3%  |  0.0000 |
 | 9c      ||   3531.0 |   3584.9 |   +2%  ||     0.28 |     0.28 |   -2%  |  0.0108 |
 | 9d      ||   4107.4 |   4184.1 |   +2%  ||     0.24 |     0.24 |   -2%  |  0.0023 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 216613.4 | 224040.1 |   +3%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -4%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_44f8c4aa8ffb1b6010213922c15aa04b551bc73c_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_583cb10adc7c603f484064b4bf4bb49f3b1783db_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 44f8c4aa8ffb1b6010213922c15aa04b551bc73c-dirty                                                                                              | 583cb10adc7c603f484064b4bf4bb49f3b1783db-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-10-12 14:33:31                                                                                                                         | 2020-10-14 14:40:34                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)     | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |       new |        ||      old |      new |        |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | 10a     ||    2465.3 |    2410.5 |   -2%  ||    19.15 |    19.70 |   +3%  |  0.6439 |
 | 10b     ||    1725.0 |    1673.2 |   -3%  ||    27.85 |    28.77 |   +3%  |  0.4480 |
 | 10c     ||    8961.8 |    8837.3 |   -1%  ||     4.62 |     4.58 |   -1%  |  0.8535 |
 | 11a     ||     466.1 |     465.5 |   -0%  ||   105.36 |   105.19 |   -0%  |  0.9510 |
 | 11b     ||     429.6 |     432.8 |   +1%  ||   113.91 |   113.54 |   -0%  |  0.7404 |
 | 11c     ||    2429.4 |    2440.6 |   +0%  ||    19.40 |    19.51 |   +1%  |  0.9091 |
+| 11d     ||   23698.6 |   24208.5 |   +2%  ||     1.38 |     1.48 |   +7%  |  0.7091 |
 | 12a     ||    3553.8 |    3606.8 |   +1%  ||    12.92 |    12.87 |   -0%  |  0.8062 |
 | 12b     ||    1487.7 |    1485.0 |   -0%  ||    32.75 |    32.68 |   -0%  |  0.9568 |
+| 12c     ||   21279.0 |   20082.5 |   -6%  ||     1.58 |     1.67 |   +5%  |  0.5061 |
 | 13a     ||    1178.8 |    1192.4 |   +1%  ||    41.48 |    40.88 |   -1%  |  0.7453 |
 | 13b     ||    1415.6 |    1429.9 |   +1%  ||    34.28 |    34.15 |   -0%  |  0.8071 |
 | 13c     ||    1402.5 |    1402.1 |   -0%  ||    34.25 |    34.53 |   +1%  |  0.9942 |
 | 13d     ||    1191.2 |    1183.7 |   -1%  ||    40.98 |    41.22 |   +1%  |  0.8497 |
 | 14a     ||   16797.9 |   16967.6 |   +1%  ||     1.92 |     1.88 |   -2%  |  0.8966 |
 | 14b     ||   18364.9 |   17546.2 |   -4%  ||     1.73 |     1.77 |   +2%  |  0.6016 |
 | 14c     ||   18211.8 |   19324.6 |   +6%  ||     1.85 |     1.88 |   +2%  |  0.4799 |
 | 15a     ||    1124.2 |    1123.3 |   -0%  ||    43.13 |    43.49 |   +1%  |  0.9802 |
 | 15b     ||    1106.7 |    1107.5 |   +0%  ||    44.20 |    44.21 |   +0%  |  0.9850 |
 | 15c     ||     421.9 |     424.2 |   +1%  ||   115.36 |   115.46 |   +0%  |  0.7825 |
 | 15d     ||    2538.6 |    2532.1 |   -0%  ||    18.85 |    18.65 |   -1%  |  0.9526 |
 | 16a     ||   29064.4 |   28071.8 |   -3%  ||     0.98 |     0.95 |   -3%  |  0.6424 |
+| 16b     ||   36543.0 |   36718.9 |   +0%  ||     0.75 |     0.80 |   +7%  |  0.9404 |
+| 16c     ||   31555.5 |   29684.0 |   -6%  ||     0.87 |     0.92 |   +6%  |  0.3924 |
 | 16d     ||   28006.7 |   31424.0 |  +12%  ||     0.97 |     0.97 |   -0%  |  0.1143 |
 | 17a     ||    8386.2 |    7024.5 |  -16%  ||     4.93 |     4.83 |   -2%  |  0.0124 |
 | 17b     ||    7311.9 |    8580.0 |  +17%  ||     5.07 |     5.00 |   -1%  |  0.0249 |
 | 17c     ||    6893.0 |    8498.1 |  +23%  ||     5.02 |     5.07 |   +1%  |  0.0018 |
 | 17d     ||    7747.9 |    8478.1 |   +9%  ||     5.13 |     5.12 |   -0%  |  0.1786 |
 | 17e     ||   13714.1 |   11651.6 |  -15%  ||     2.98 |     2.90 |   -3%  |  0.0164 |
-| 17f     ||    9330.9 |    8605.0 |   -8%  ||     4.47 |     4.03 |  -10%  |  0.2298 |
 | 18a     ||    4835.6 |    4888.2 |   +1%  ||     9.57 |     9.63 |   +1%  |  0.8655 |
 | 18b     ||    2400.1 |    2332.0 |   -3%  ||    20.10 |    20.23 |   +1%  |  0.5456 |
 | 18c     ||   18554.2 |   17348.0 |   -7%  ||     1.88 |     1.92 |   +2%  |  0.3894 |
 | 19a     ||   36772.0 |   36169.7 |   -2%  ||     0.77 |     0.78 |   +2%  |  0.8424 |
 | 19b     ||   11929.7 |   11301.1 |   -5%  ||     3.25 |     3.27 |   +1%  |  0.4691 |
 | 19c     ||   36246.4 |   34592.4 |   -5%  ||     0.80 |     0.83 |   +4%  |  0.5386 |
+| 19d     ||   37691.5 |   34897.0 |   -7%  ||     0.72 |     0.88 |  +23%  |  0.1906 |
 | 1a      ||     339.2 |     340.8 |   +0%  ||   144.44 |   143.97 |   -0%  |  0.7761 |
 | 1b      ||      73.3 |      74.3 |   +1%  ||   637.05 |   629.70 |   -1%  |  0.0974 |
 | 1c      ||      74.6 |      74.8 |   +0%  ||   629.70 |   628.12 |   -0%  |  0.6347 |
 | 1d      ||      73.7 |      74.1 |   +1%  ||   634.65 |   631.18 |   -1%  |  0.4755 |
 | 20a     ||    5693.4 |    5697.5 |   +0%  ||     7.87 |     7.77 |   -1%  |  0.9905 |
 | 20b     ||    4309.3 |    4166.2 |   -3%  ||    10.43 |    10.37 |   -1%  |  0.5466 |
 | 20c     ||    4337.8 |    4329.2 |   -0%  ||    10.53 |    10.77 |   +2%  |  0.9730 |
 | 21a     ||   17114.1 |   16620.5 |   -3%  ||     2.13 |     2.13 |   +0%  |  0.7228 |
 | 21b     ||    1057.5 |    1051.5 |   -1%  ||    45.78 |    46.21 |   +1%  |  0.8621 |
 | 21c     ||   15822.4 |   16411.7 |   +4%  ||     2.07 |     2.08 |   +1%  |  0.6733 |
 | 22a     ||   17748.3 |   18701.6 |   +5%  ||     1.92 |     1.98 |   +3%  |  0.4998 |
 | 22b     ||   16477.4 |   19216.2 |  +17%  ||     1.90 |     1.93 |   +2%  |  0.0783 |
 | 22c     ||   19483.4 |   18858.6 |   -3%  ||     1.83 |     1.88 |   +3%  |  0.6709 |
 | 22d     ||   19531.6 |   19536.3 |   +0%  ||     1.80 |     1.87 |   +4%  |  0.9977 |
 | 23a     ||     459.1 |     451.9 |   -2%  ||   107.14 |   107.86 |   +1%  |  0.4666 |
 | 23b     ||     983.6 |     974.2 |   -1%  ||    49.53 |    49.98 |   +1%  |  0.7599 |
 | 23c     ||     543.9 |     533.1 |   -2%  ||    90.27 |    91.37 |   +1%  |  0.3659 |
 | 24a     ||   11156.0 |   11763.6 |   +5%  ||     3.27 |     3.30 |   +1%  |  0.4855 |
 | 24b     ||   10896.9 |   12341.7 |  +13%  ||     3.47 |     3.40 |   -2%  |  0.0992 |
 | 25a     ||    2339.4 |    2354.5 |   +1%  ||    20.33 |    20.35 |   +0%  |  0.8998 |
 | 25b     ||    2943.3 |    2910.6 |   -1%  ||    15.63 |    16.33 |   +4%  |  0.8446 |
 | 25c     ||   18827.8 |   17539.4 |   -7%  ||     1.87 |     1.87 |   +0%  |  0.3975 |
 | 26a     ||    2936.3 |    3128.3 |   +7%  ||    15.26 |    15.10 |   -1%  |  0.2506 |
 | 26b     ||    3079.4 |    3066.5 |   -0%  ||    15.58 |    15.63 |   +0%  |  0.9386 |
 | 26c     ||    3010.9 |    3190.6 |   +6%  ||    14.98 |    15.12 |   +1%  |  0.3226 |
 | 27a     ||   16778.3 |   17378.5 |   +4%  ||     2.03 |     2.08 |   +2%  |  0.6704 |
 | 27b     ||   16232.1 |   16877.3 |   +4%  ||     2.07 |     2.15 |   +4%  |  0.6313 |
 | 27c     ||     933.9 |     937.0 |   +0%  ||    52.53 |    52.08 |   -1%  |  0.9176 |
 | 28a     ||   18459.2 |   19343.2 |   +5%  ||     1.83 |     1.83 |   +0%  |  0.5325 |
 | 28b     ||   17587.7 |   14307.9 |  -19%  ||     2.12 |     2.20 |   +4%  |  0.0086 |
 | 28c     ||   19529.4 |   19262.6 |   -1%  ||     1.85 |     1.83 |   -1%  |  0.8632 |
 | 29a     ||   11933.3 |   10313.9 |  -14%  ||     3.32 |     3.40 |   +3%  |  0.1049 |
+| 29b     ||    2531.2 |    2420.0 |   -4%  ||    18.85 |    19.76 |   +5%  |  0.3470 |
 | 29c     ||   11901.4 |   12333.3 |   +4%  ||     3.22 |     3.17 |   -2%  |  0.6542 |
 | 2a      ||     630.3 |     623.0 |   -1%  ||    77.68 |    78.49 |   +1%  |  0.6323 |
 | 2b      ||     676.9 |     668.0 |   -1%  ||    72.56 |    73.48 |   +1%  |  0.5890 |
 | 2c      ||     552.9 |     555.4 |   +0%  ||    88.66 |    88.47 |   -0%  |  0.8407 |
 | 2d      ||     728.2 |     710.8 |   -2%  ||    66.88 |    68.07 |   +2%  |  0.3218 |
+| 30a     ||    2677.7 |    2370.5 |  -11%  ||    17.70 |    19.31 |   +9%  |  0.0256 |
 | 30b     ||    3093.4 |    3028.2 |   -2%  ||    15.13 |    15.73 |   +4%  |  0.6865 |
 | 30c     ||   21731.0 |   20525.6 |   -6%  ||     1.80 |     1.87 |   +4%  |  0.4463 |
 | 31a     ||    3226.5 |    3194.5 |   -1%  ||    14.13 |    14.77 |   +4%  |  0.8566 |
 | 31b     ||    3455.4 |    3418.8 |   -1%  ||    13.50 |    13.83 |   +2%  |  0.8676 |
+| 31c     ||    2735.9 |    2680.9 |   -2%  ||    15.75 |    17.45 |  +11%  |  0.7074 |
 | 32a     ||     161.4 |     163.1 |   +1%  ||   299.58 |   296.23 |   -1%  |  0.3871 |
 | 32b     ||    1206.5 |    1199.3 |   -1%  ||    40.60 |    40.99 |   +1%  |  0.8050 |
 | 33a     ||     283.8 |     282.1 |   -1%  ||   172.28 |   173.52 |   +1%  |  0.6975 |
 | 33b     ||     282.3 |     279.5 |   -1%  ||   172.88 |   175.10 |   +1%  |  0.5147 |
 | 33c     ||     376.6 |     371.0 |   -1%  ||   130.28 |   132.29 |   +2%  |  0.4134 |
 | 3a      ||   19096.6 |   17985.6 |   -6%  ||     1.83 |     1.90 |   +4%  |  0.4929 |
 | 3b      ||     343.7 |     341.8 |   -1%  ||   142.80 |   143.71 |   +1%  |  0.7170 |
 | 3c      ||   32175.9 |   31775.6 |   -1%  ||     0.90 |     0.90 |   -0%  |  0.8788 |
 | 4a      ||    1019.0 |     993.0 |   -3%  ||    47.36 |    48.83 |   +3%  |  0.3668 |
 | 4b      ||     106.8 |     106.3 |   -1%  ||   446.84 |   449.47 |   +1%  |  0.5845 |
 | 4c      ||    1248.6 |    1219.3 |   -2%  ||    39.13 |    40.01 |   +2%  |  0.4499 |
+| 5a      ||   17452.9 |   16756.5 |   -4%  ||     2.12 |     2.23 |   +6%  |  0.5791 |
 | 5b      ||    1483.5 |    1479.3 |   -0%  ||    31.86 |    32.62 |   +2%  |  0.9462 |
 | 5c      ||   18719.5 |   19960.3 |   +7%  ||     1.67 |     1.72 |   +3%  |  0.4337 |
 | 6a      ||    2046.9 |    2011.7 |   -2%  ||    23.55 |    24.12 |   +2%  |  0.6900 |
 | 6b      ||    6349.5 |    6770.5 |   +7%  ||     5.60 |     5.77 |   +3%  |  0.3112 |
 | 6c      ||    2031.9 |    1926.9 |   -5%  ||    23.73 |    24.31 |   +2%  |  0.2343 |
 | 6d      ||    6945.2 |    7406.2 |   +7%  ||     5.72 |     5.82 |   +2%  |  0.4336 |
 | 6e      ||    1983.4 |    1977.5 |   -0%  ||    24.00 |    24.00 |   -0%  |  0.9440 |
 | 6f      ||    7039.1 |    6810.4 |   -3%  ||     6.57 |     6.60 |   +0%  |  0.6036 |
 | 7a      ||    1545.5 |    1522.4 |   -1%  ||    31.40 |    32.10 |   +2%  |  0.6878 |
+| 7b      ||    1602.4 |    1361.3 |  -15%  ||    30.23 |    35.83 |  +19%  |  0.0000 |
+| 7c      ||   43175.6 |   35416.2 |  -18%  ||     0.13 |     0.15 |  +13%  |       ˅ |
 | 8a      ||    1528.9 |    1470.6 |   -4%  ||    31.75 |    32.05 |   +1%  |  0.2657 |
 | 8b      ||    1470.6 |    1412.4 |   -4%  ||    32.87 |    33.93 |   +3%  |  0.2738 |
-| 8c      ||   26159.0 |   25193.4 |   -4%  ||     1.27 |     1.12 |  -12%  |  0.6277 |
 | 8d      ||   10585.3 |   10802.1 |   +2%  ||     3.90 |     3.90 |   +0%  |  0.7869 |
 | 9a      ||   20250.0 |   23735.7 |  +17%  ||     1.37 |     1.40 |   +2%  |  0.0803 |
 | 9b      ||    3072.8 |    3051.3 |   -1%  ||    15.01 |    15.32 |   +2%  |  0.8994 |
+| 9c      ||   26411.6 |   23463.5 |  -11%  ||     1.28 |     1.37 |   +6%  |  0.1576 |
 | 9d      ||   24958.6 |   25100.5 |   +1%  ||     1.40 |     1.35 |   -4%  |  0.9377 |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Sum     || 1073054.5 | 1056843.2 |   -2%  ||          |          |        |         |
 | Geomean ||           |           |        ||          |          |   +2%  |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                    |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
```
</details>
</details>