### PR TITLE
Make hyriseBenchmarkX loading faster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "third_party/zstd"]
 	path = third_party/zstd
 	url = https://github.com/facebook/zstd.git
+[submodule "third_party/robin-map"]
+	path = third_party/robin-map
+	url = https://github.com/Tessil/robin-map.git

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -29,21 +29,4 @@
 | valgrind                  | any              |    All   |            Yes, memory checking in CI |
 
 
-## Dependencies that are integrated in our build process via git submodules
-- benchmark (https://github.com/google/benchmark)
-- cpp-btree (https://github.com/algorithm-ninja/cpp-btree)
-- cpplint (https://github.com/cpplint/cpplint.git)
-- cxxopts (https://github.com/jarro2783/cxxopts.git)
-- flash_hash_map (https://github.com/skarupke/flat_hash_map)
-- googletest (https://github.com/google/googletest)
-- jemalloc (https://github.com/jemalloc/jemalloc)
-- join-order-benchmark (https://github.com/gregrahn/join-order-benchmark)
-- libpqxx (https://github.com/jtv/libpqxx)
-- lz4 (https://github.com/lz4/lz4)
-- magic_enum (https://github.com/Neargye/magic_enum)
-- nlohmann_json (https://github.com/nlohmann/json)
-- pgasus (https://github.com/kateyy/pgasus)
-- sql-parser (https://github.com/hyrise/sql-parser)
-- tpcds-kit (https://github.com/hyrise-mp/tpcds-kit.git)
-- tpcds-result-reproduction (https://github.com/hyrise-mp/tpcds-result-reproduction.git)
-- zstd (https://github.com/facebook/zstd)
+For dependencies that are integrated in our build process via git submodules, please check .gitmodules

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -337,13 +337,15 @@ if github_format:
     green_control_sequence = colored("", "green")[0:5]
     red_control_sequence = colored("", "red")[0:5]
 
-    table_string_reformatted = "<details>\n" + \
-                               "<summary>Configuration Overview - click to expand</summary>\n\n" + \
-                               "```diff\n" + \
-                               create_context_overview(old_data, new_data, github_format) + \
-                               "```\n" + \
-                               "</details>\n\n" + \
-                               "```diff\n"
+    table_string_reformatted = (
+        "<details>\n"
+        + "<summary>Configuration Overview - click to expand</summary>\n\n"
+        + "```diff\n"
+        + create_context_overview(old_data, new_data, github_format)
+        + "```\n"
+        + "</details>\n\n"
+        + "```diff\n"
+    )
     for line in table_string.splitlines():
         if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):
             table_string_reformatted += "+"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ if (NOT "${HYRISE_RELAXED_BUILD}")
     # -Wno-deprecated-dynamic-exception-spec is needed for jemalloc, at least for the older version that we are using
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-documentation-unknown-command)
+        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories)
     endif()
 
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ if (NOT "${HYRISE_RELAXED_BUILD}")
     # -Wno-deprecated-dynamic-exception-spec is needed for jemalloc, at least for the older version that we are using
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories)
+        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-documentation-unknown-command)
     endif()
 
 else()

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -94,8 +94,9 @@ void AbstractTableGenerator::generate_and_store() {
           });
 
           if (is_sorted) {
-            auto output = std::string{"-  Table '"} + table_name + "' is already sorted by '" + column_name + "'\n";
-            std::cout << output << std::flush;
+            auto output = std::stringstream;
+            output << "-  Table '" << table_name << "' is already sorted by '" << column_name << "'\n";
+            std::cout << output.str() << std::flush;
             const SortColumnDefinition sort_column{sort_column_id, sort_mode};
 
             if (_all_chunks_sorted_by(table, sort_column)) return;

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -140,9 +140,10 @@ void AbstractTableGenerator::generate_and_store() {
             table->get_chunk(chunk_id)->set_individually_sorted_by(SortColumnDefinition(sort_column_id, sort_mode));
           }
 
-          auto output = std::string{"-  Sorted '"} + table_name + "' by '" + column_name + "' (" +
-                        per_table_timer.lap_formatted() + ")\n";
-          std::cout << output << std::flush;
+          auto output = std::stringstream{};
+          output << "-  Sorted '" << table_name << "' by '" << column_name << "' (" << per_table_timer.lap_formatted()
+                 << ")\n";
+          std::cout << output.str() << std::flush;
         });
       }
       for (auto& thread : threads) thread.join();
@@ -184,10 +185,11 @@ void AbstractTableGenerator::generate_and_store() {
         Timer per_table_timer;
         table_info.re_encoded =
             BenchmarkTableEncoder::encode(table_name, table_info.table, _benchmark_config->encoding_config);
-        auto output = std::string{"-  Encoding '"} + table_name + "' - " +
-                      (table_info.re_encoded ? "encoding applied" : "no encoding necessary") + " (" +
-                      per_table_timer.lap_formatted() + ")\n";
-        std::cout << output << std::flush;
+        auto output = std::stringstream{};
+        output << "-  Encoding '" + table_name << "' - "
+               << (table_info.re_encoded ? "encoding applied" : "no encoding necessary") << " ("
+               << per_table_timer.lap_formatted() << ")\n";
+        std::cout << output.str() << std::flush;
       });
     }
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -94,7 +94,7 @@ void AbstractTableGenerator::generate_and_store() {
           });
 
           if (is_sorted) {
-            auto output = std::stringstream;
+            auto output = std::stringstream{};
             output << "-  Table '" << table_name << "' is already sorted by '" << column_name << "'\n";
             std::cout << output.str() << std::flush;
             const SortColumnDefinition sort_column{sort_column_id, sort_mode};

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -44,8 +44,8 @@ void AbstractTableGenerator::generate_and_store() {
     if (!sort_order_by_table.empty()) {
       std::cout << "- Sorting tables" << std::endl;
 
-      // We do not use JobTasks here (and in the rest of this file) because we want this part to be multi-threaded even if
-      // Hyrise uses no scheduler.
+      // We do not use JobTasks here (and in the rest of this file) because we want this part to be multi-threaded even
+      // if Hyrise uses no scheduler.
       auto threads = std::vector<std::thread>{};
       for (const auto& [table_name, column_name] : sort_order_by_table) {
         threads.emplace_back([&] {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -644,6 +644,7 @@ set(
 set(
     LIBRARIES
     lz4
+    robin_map
     sqlparser
     uninitialized_vector
     zstd

--- a/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
@@ -7,7 +7,7 @@
 #include <utility>
 #include <vector>
 
-#include <robin_map.h>
+#include <robin_map.h>  // NOLINT
 
 #include "generic_histogram.hpp"
 #include "resolve_type.hpp"

--- a/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
@@ -1,12 +1,13 @@
 #include "equal_distinct_count_histogram.hpp"
 
 #include <cmath>
-
 #include <memory>
 #include <numeric>
 #include <string>
 #include <utility>
 #include <vector>
+
+#include <robin_map.h>
 
 #include "generic_histogram.hpp"
 #include "resolve_type.hpp"
@@ -16,9 +17,17 @@ namespace {
 
 using namespace opossum;  // NOLINT
 
+// Think of this as an unordered_map<T, HistogramCountType>. The hash, equals, and allocator template parameter are
+// defaults so that we can set the last parameter. It controls whether the hash for a value should be cached. Doing
+// so reduces the cost of rehashing at the cost of slightly higher memory consumption. We only do it for strings,
+// where hashing is somewhat expensive.
 template <typename T>
-void add_segment_to_value_distribution(const AbstractSegment& segment,
-                                       std::unordered_map<T, HistogramCountType>& value_distribution,
+using ValueDistributionMap =
+    tsl::robin_map<T, HistogramCountType, std::hash<T>, std::equal_to<T>,
+                   std::allocator<std::pair<T, HistogramCountType>>, std::is_same_v<std::decay_t<T>, pmr_string>>;
+
+template <typename T>
+void add_segment_to_value_distribution(const AbstractSegment& segment, ValueDistributionMap<T>& value_distribution,
                                        const HistogramDomain<T>& domain) {
   segment_iterate<T>(segment, [&](const auto& iterator_value) {
     if (iterator_value.is_null()) return;
@@ -42,7 +51,7 @@ std::vector<std::pair<T, HistogramCountType>> value_distribution_from_column(con
                                                                              const HistogramDomain<T>& domain) {
   // TODO(anybody) If you want to look into performance, this would probably benefit greatly from monotonic buffer
   //               resources.
-  std::unordered_map<T, HistogramCountType> value_distribution_map;
+  ValueDistributionMap<T> value_distribution_map;
 
   const auto chunk_count = table.chunk_count();
   for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {

--- a/src/lib/statistics/table_statistics.cpp
+++ b/src/lib/statistics/table_statistics.cpp
@@ -24,7 +24,8 @@ std::shared_ptr<TableStatistics> TableStatistics::from_table(const Table& table)
   auto threads = std::vector<std::thread>{};
 
   /**
-   * Parallely create statistics objects for the Table's columns
+   * Parallely create statistics objects for the Table's columns. Do not use JobTask as we want this to be parallel
+   * even if Hyrise is running without a scheduler.
    */
   for (auto thread_id = 0u;
        thread_id < std::min(static_cast<uint>(table.column_count()), std::thread::hardware_concurrency() + 1);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -183,6 +183,18 @@ add_library(uninitialized_vector INTERFACE)
 target_include_directories(uninitialized_vector INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uninitialized_vector/)
 target_sources(uninitialized_vector INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uninitialized_vector/uninitialized_vector.hpp)
 
+add_library(robin_map INTERFACE)
+target_include_directories(robin_map INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl)
+target_sources(
+  robin_map
+  INTERFACE
+
+  ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl/robin_growth_policy.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl/robin_hash.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl/robin_map.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl/robin_set.h
+)
+
 if(NOT APPLE)
   # Only configure jemalloc for non-Apple builds, as we cannot properly replace the allocator on Mac using static linking:
   #   If you ./configure jemalloc with --with-jemalloc-prefix="" on OSX and static link the library, your malloc's will

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -184,7 +184,7 @@ target_include_directories(uninitialized_vector INTERFACE ${CMAKE_CURRENT_SOURCE
 target_sources(uninitialized_vector INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/uninitialized_vector/uninitialized_vector.hpp)
 
 add_library(robin_map INTERFACE)
-target_include_directories(robin_map INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl)
+target_include_directories(robin_map SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/robin-map/include/tsl)
 target_sources(
   robin_map
   INTERFACE


### PR DESCRIPTION
* For the generation of the table histograms, use the robin_map. It allows us to cache the hash of strings, which makes generation much faster. We will likely replace the current bytell hash map with this one for other things, too.
* Parallelize some steps of the benchmark start. Hide whitespaces when reviewing this.

Old:
- Sorting tables done (5 s 957 ms)
- Encoding tables and generating pruning statistic done (10 s 692 ms)
- Adding tables to StorageManager and generating table statistics done (2 min 41 s)
- Total time from binary start to first query: 3 min 21 s

New:
- Sorting tables done (5 s 238 ms)
- Encoding tables and generating pruning statistic done (8 s 778 ms)
- Adding tables to StorageManager and generating table statistics done (1 min 23 s)
- Total time from binary start to first query: 1 min 50 s