### PR TITLE
Projection: Stop materializing forwarded columns

### DIFF
--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -99,8 +99,8 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   }
 
   // Perform the actual projection on a per-chunk level. `output_segments_by_chunk` will contain both forwarded and
-  // newly generated columns. In this loop, we do not yet deal with the projection_result_table indirection described
-  // above.
+  // newly generated columns. In the upcoming loop, we do not yet deal with the projection_result_table indirection
+  // described above.
   auto output_segments_by_chunk = std::vector<Segments>(input_table.chunk_count());
 
   auto forwarding_cost = std::chrono::nanoseconds{};

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -217,7 +217,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       chunk->finalize();
 
       if (projection_result_table) {
-        projection_result_table->append_chunk(std::move(projection_result_segments), input_chunk->mvcc_data());
+        projection_result_table->append_chunk(projection_result_segments, input_chunk->mvcc_data());
         projection_result_table->last_chunk()->increase_invalid_row_count(input_chunk->invalid_row_count());
       }
     }

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -64,12 +64,12 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   //           |a |b |     |a |a+1|   * Input TableType::Data
   //           |DS|DS| --> |DS|VS |   * A column (a) is forwarded
   //           +-----+     +------+   Result: No type change needed, output TableType::Data
-  // 
+  //
   //           +-----+        +---+  Case 2
   //           |a |b |        |a+1|   * Input TableType::References
   //           |RS|RS| -->    |VS |   * No column is forwarded
   //           +-----+        +---+   Result: Output TableType::Data
-  // 
+  //
   // +------+  +-----+     +------+  Case 3
   // |orig_a|  |a |b |     |a |a+1|   * Input TableType::References
   // |VS    |  |RS|RS| --> |RS|RS |   * A column (a) is forwarded

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -51,17 +51,22 @@ std::shared_ptr<const Table> Projection::_on_execute() {
 
   const auto& input_table = *left_input_table();
 
-  /**
-   * For PQPColumnExpressions, it is possible to forward the input column if the input TableType (References or Data)
-   * matches the output column type (ReferenceSegment or not).
-   */
-  const auto only_projects_columns = std::all_of(expressions.begin(), expressions.end(), [&](const auto& expression) {
+  // Determine the type of the output table: If no input columns are forwarded, i.e., all output columns are newly
+  // generated, the output type is always TableType::Data and all segments are ValueSegments. Otherwise, the output type
+  // depends on the input table's type. If the forwarded columns come from a data table, so are the newly generated
+  // columns. However, we cannot return a table that mixes data and reference segments, so if the forwarded columns are
+  // reference columns, the newly generated columns contain reference segments, too. These point to an internal dummy
+  // table, the projection_result_table. The life time of this table is managed by the shared_ptr in
+  // ReferenceSegment::_referenced_table.
+  const auto forwards_any_columns = std::any_of(expressions.begin(), expressions.end(), [&](const auto& expression) {
     return expression->type == ExpressionType::PQPColumn;
   });
+  const auto output_table_type = forwards_any_columns ? input_table.type() : TableType::Data;
 
-  const auto output_table_type = only_projects_columns ? input_table.type() : TableType::Data;
-  const auto forward_columns = input_table.type() == output_table_type;
+  // NULLability information is either forwarded or collected during the execution of the ExpressionEvaluator
+  auto column_is_nullable = std::vector<bool>(expressions.size(), false);
 
+  // Uncorrelated subqueries need to be evaluated exactly once, not once per chunk.
   const auto uncorrelated_subquery_results =
       ExpressionEvaluator::populate_uncorrelated_subquery_results_cache(expressions);
 
@@ -70,167 +75,79 @@ std::shared_ptr<const Table> Projection::_on_execute() {
     step_performance_data.set_step_runtime(OperatorSteps::UncorrelatedSubqueries, timer.lap());
   }
 
-  auto column_is_nullable = std::vector<bool>(expressions.size(), false);
-
-  /**
-   * Perform the projection
-   */
-  auto output_chunk_segments = std::vector<Segments>(input_table.chunk_count());
+  // Perform the actual projection on a per-chunk level. `output_segments_by_chunk` will contain both forwarded and
+  // newly generated columns. In this loop, we do not yet deal with the projection_result_table indirection described
+  // above.
+  auto output_segments_by_chunk = std::vector<Segments>(input_table.chunk_count());
 
   auto forwarding_cost = std::chrono::nanoseconds{};
   auto expression_evaluator_cost = std::chrono::nanoseconds{};
 
-  const auto chunk_count_input_table = input_table.chunk_count();
-  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_input_table; ++chunk_id) {
+  const auto chunk_count = input_table.chunk_count();
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
     Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     auto output_segments = Segments{expressions.size()};
 
+    // The ExpressionEvaluator is created once per chunk so that evaluated sub-expressions can be reused across columns.
     ExpressionEvaluator evaluator(left_input_table(), chunk_id, uncorrelated_subquery_results);
 
     for (auto column_id = ColumnID{0}; column_id < expressions.size(); ++column_id) {
       const auto& expression = expressions[column_id];
 
-      // Forward input column if possible
-      if (expression->type == ExpressionType::PQPColumn && forward_columns) {
-        const auto pqp_column_expression = std::static_pointer_cast<PQPColumnExpression>(expression);
-        output_segments[column_id] = input_chunk->get_segment(pqp_column_expression->column_id);
+      if (expression->type == ExpressionType::PQPColumn) {
+        // Forward input column if possible
+        const auto& pqp_column_expression = static_cast<const PQPColumnExpression&>(*expression);
+        output_segments[column_id] = input_chunk->get_segment(pqp_column_expression.column_id);
         column_is_nullable[column_id] =
-            column_is_nullable[column_id] || input_table.column_is_nullable(pqp_column_expression->column_id);
-        forwarding_cost += timer.lap();
-      } else if (expression->type == ExpressionType::PQPColumn && !forward_columns) {
-        // The current column will be returned without any logical modifications. As other columns do get modified (and
-        // returned as a ValueSegment), all segments (including this one) need to become ValueSegments. This segment is
-        // not yet a ValueSegment (otherwise forward_columns would be true); thus we need to materialize it.
-
-        // TODO(jk): Once we have a smart pos list that knows that a single chunk is referenced in its entirety, we can
-        //           simply forward that chunk here instead of materializing it.
-
-        const auto pqp_column_expression = std::static_pointer_cast<PQPColumnExpression>(expression);
-        const auto segment = input_chunk->get_segment(pqp_column_expression->column_id);
-
-        resolve_data_type(expression->data_type(), [&](const auto data_type) {
-          using ColumnDataType = typename decltype(data_type)::type;
-
-          const auto reference_segment = std::dynamic_pointer_cast<ReferenceSegment>(segment);
-          DebugAssert(reference_segment, "Expected ReferenceSegment");
-
-          // If the ReferenceSegment references a single (FixedString)DictionarySegment, do not materialize it as a
-          // ValueSegment, but re-use its dictionary and only copy the value ids.
-          auto referenced_dictionary_segment = std::shared_ptr<BaseDictionarySegment>{};
-
-          const auto& pos_list = reference_segment->pos_list();
-          if (pos_list->references_single_chunk()) {
-            const auto& referenced_table = reference_segment->referenced_table();
-            const auto& referenced_chunk = referenced_table->get_chunk(pos_list->common_chunk_id());
-            const auto& referenced_segment = referenced_chunk->get_segment(reference_segment->referenced_column_id());
-            referenced_dictionary_segment = std::dynamic_pointer_cast<BaseDictionarySegment>(referenced_segment);
-          }
-
-          if (referenced_dictionary_segment) {
-            // Resolving the BaseDictionarySegment so that we can handle both regular and fixed-string dictionaries
-            resolve_encoded_segment_type<ColumnDataType>(
-                *referenced_dictionary_segment, [&](const auto& typed_segment) {
-                  using DictionarySegmentType = std::decay_t<decltype(typed_segment)>;
-
-                  // Write new a attribute vector containing only positions given from the input_pos_list.
-                  [[maybe_unused]] auto materialize_filtered_attribute_vector = [](const auto& dictionary_segment,
-                                                                                   const auto& input_pos_list) {
-                    auto filtered_attribute_vector = pmr_vector<ValueID::base_type>(input_pos_list->size());
-                    auto iterable = create_iterable_from_attribute_vector(dictionary_segment);
-                    auto chunk_offset = ChunkOffset{0};
-                    iterable.with_iterators(input_pos_list, [&](auto it, auto end) {
-                      while (it != end) {
-                        filtered_attribute_vector[chunk_offset] = it->value();
-                        ++it;
-                        ++chunk_offset;
-                      }
-                    });
-                    // DictionarySegments take BaseCompressedVectors, not an std::vector<ValueId> for the attribute
-                    // vector. But the latter can be wrapped into a FixedSizeByteAligned<uint32_t> without copying.
-                    return std::make_shared<FixedSizeByteAlignedVector<uint32_t>>(std::move(filtered_attribute_vector));
-                  };
-
-                  if constexpr (std::is_same_v<DictionarySegmentType, DictionarySegment<ColumnDataType>>) {  // NOLINT
-                    const auto compressed_attribute_vector =
-                        materialize_filtered_attribute_vector(typed_segment, pos_list);
-                    const auto& dictionary = typed_segment.dictionary();
-
-                    output_segments[column_id] = std::make_shared<DictionarySegment<ColumnDataType>>(
-                        dictionary, std::move(compressed_attribute_vector));
-                  } else if constexpr (std::is_same_v<DictionarySegmentType,  // NOLINT - lint.sh wants {} on same line
-                                                      FixedStringDictionarySegment<ColumnDataType>>) {
-                    const auto compressed_attribute_vector =
-                        materialize_filtered_attribute_vector(typed_segment, pos_list);
-                    const auto& dictionary = typed_segment.fixed_string_dictionary();
-
-                    output_segments[column_id] = std::make_shared<FixedStringDictionarySegment<ColumnDataType>>(
-                        dictionary, std::move(compressed_attribute_vector));
-                  } else {
-                    Fail("Referenced segment was dynamically casted to BaseDictionarySegment, but resolve failed");
-                  }
-                  // clang-format on
-                });
-          } else {
-            // End of dictionary segment shortcut - handle all other referenced segments and ReferenceSegments that
-            // reference more than a single chunk by materializing them into a ValueSegment
-            bool has_null = false;
-            auto values = pmr_vector<ColumnDataType>(segment->size());
-            auto null_values = pmr_vector<bool>(
-                input_table.column_is_nullable(pqp_column_expression->column_id) ? segment->size() : 0);
-
-            auto chunk_offset = ChunkOffset{0};
-            segment_iterate<ColumnDataType>(*segment, [&](const auto& position) {
-              if (position.is_null()) {
-                DebugAssert(!null_values.empty(), "Mismatching NULL information");
-                has_null = true;
-                null_values[chunk_offset] = true;
-              } else {
-                values[chunk_offset] = position.value();
-              }
-              ++chunk_offset;
-            });
-
-            auto value_segment = std::shared_ptr<ValueSegment<ColumnDataType>>{};
-            if (has_null) {
-              value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
-            } else {
-              value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values));
-            }
-
-            output_segments[column_id] = std::move(value_segment);
-            column_is_nullable[column_id] = has_null;
-          }
-        });
+            column_is_nullable[column_id] || input_table.column_is_nullable(pqp_column_expression.column_id);
         forwarding_cost += timer.lap();
       } else {
+        // Newly generated column - the expression needs to be evaluated
         auto output_segment = evaluator.evaluate_expression_to_segment(*expression);
         column_is_nullable[column_id] = column_is_nullable[column_id] || output_segment->is_nullable();
+
+        // Storing the result in output_segments means that the vector may contain both ReferenceSegments and
+        // ValueSegments. We deal with this later.
         output_segments[column_id] = std::move(output_segment);
         expression_evaluator_cost += timer.lap();
       }
     }
 
-    output_chunk_segments[chunk_id] = std::move(output_segments);
+    output_segments_by_chunk[chunk_id] = std::move(output_segments);
   }
 
   step_performance_data.set_step_runtime(OperatorSteps::ForwardUnmodifiedColumns, forwarding_cost);
   step_performance_data.set_step_runtime(OperatorSteps::EvaluateNewColumns, expression_evaluator_cost);
 
-  /**
-   * Determine the TableColumnDefinitions and build the output table
-   */
-  TableColumnDefinitions column_definitions;
+  // Determine the TableColumnDefinitions. We can only do this now because column_is_nullable has been filled in the
+  // loop above. If necessary, projection_result_column_definitions holds those newly generated columns that the
+  // ReferenceSegments point to.
+  TableColumnDefinitions output_column_definitions;
+  TableColumnDefinitions projection_result_column_definitions;
   for (auto column_id = ColumnID{0}; column_id < expressions.size(); ++column_id) {
-    column_definitions.emplace_back(expressions[column_id]->as_column_name(), expressions[column_id]->data_type(),
-                                    column_is_nullable[column_id]);
+    const auto definition = TableColumnDefinition{expressions[column_id]->as_column_name(),
+                                                  expressions[column_id]->data_type(), column_is_nullable[column_id]};
+    output_column_definitions.emplace_back(definition);
+
+    if (expressions[column_id]->type != ExpressionType::PQPColumn && output_table_type == TableType::References) {
+      projection_result_column_definitions.emplace_back(definition);
+    }
   }
 
-  auto output_chunks = std::vector<std::shared_ptr<Chunk>>{chunk_count_input_table};
+  // Create the projection_result_table if needed
+  auto projection_result_table = std::shared_ptr<Table>{};
+  if (!projection_result_column_definitions.empty()) {
+    projection_result_table = std::make_shared<Table>(projection_result_column_definitions, TableType::Data,
+                                                      std::nullopt, input_table.uses_mvcc());
+  }
 
-  // Maps input columns to output columns (which may be reordered). Only contains input column IDs that are forwarded
-  // to the output without modfications.
+  auto output_chunks = std::vector<std::shared_ptr<Chunk>>{chunk_count};
+  auto projection_result_chunks = std::vector<std::shared_ptr<Chunk>>{chunk_count};
+
+  // Create a mapping from input columns to output columns for future use. This is necessary as the order may have been
+  // changed. The mapping only contains input column IDs that are forwarded to the output without modfications.
   auto input_column_to_output_column = std::unordered_map<ColumnID, ColumnID>{};
   for (auto expression_id = ColumnID{0}; expression_id < expressions.size(); ++expression_id) {
     const auto& expression = expressions[expression_id];
@@ -240,15 +157,48 @@ std::shared_ptr<const Table> Projection::_on_execute() {
     }
   }
 
-  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count_input_table; ++chunk_id) {
+
+  // Create the actual chunks, and, if needed, fill the projection_result_table. Also set MVCC and
+  // individually_sorted_by information as needed.
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto input_chunk = input_table.get_chunk(chunk_id);
     Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
+    auto projection_result_segments = Segments{};
+    const auto entire_chunk_pos_list = std::make_shared<EntireChunkPosList>(chunk_id, input_chunk->size());
+    for (auto column_id = ColumnID{0}; column_id < expressions.size(); ++column_id) {
+      // Turn newly generated ValueSegments into ReferenceSegments, if needed
+      if (expressions[column_id]->type != ExpressionType::PQPColumn && output_table_type == TableType::References) {
+        projection_result_segments.emplace_back(output_segments_by_chunk[chunk_id][column_id]);
+
+        const auto projection_result_column_id =
+            ColumnID{static_cast<ColumnID::base_type>(projection_result_segments.size() - 1)};
+
+        output_segments_by_chunk[chunk_id][column_id] = std::make_shared<ReferenceSegment>(
+            projection_result_table, projection_result_column_id, entire_chunk_pos_list);
+      }
+    }
+
     // The output chunk contains all rows that are in the stored chunk, including invalid rows. We forward this
     // information so that following operators (currently, the Validate operator) can use it for optimizations.
-    const auto chunk = std::make_shared<Chunk>(std::move(output_chunk_segments[chunk_id]), input_chunk->mvcc_data());
-    chunk->increase_invalid_row_count(input_chunk->invalid_row_count());
-    chunk->finalize();
+    auto chunk = std::shared_ptr<Chunk>{};
+    if (output_table_type == TableType::Data) {
+      chunk = std::make_shared<Chunk>(std::move(output_segments_by_chunk[chunk_id]), input_chunk->mvcc_data());
+      chunk->increase_invalid_row_count(input_chunk->invalid_row_count());
+      chunk->finalize();
+
+      DebugAssert(projection_result_segments.empty(),
+                  "For TableType::Data, projection_result_segments should be unused");
+    } else {
+      chunk = std::make_shared<Chunk>(std::move(output_segments_by_chunk[chunk_id]));
+      // No need to increase_invalid_row_count here, as it is ignored for reference chunks anyway
+      chunk->finalize();
+
+      if (projection_result_table) {
+        projection_result_table->append_chunk(std::move(projection_result_segments), input_chunk->mvcc_data());
+        projection_result_table->last_chunk()->increase_invalid_row_count(input_chunk->invalid_row_count());
+      }
+    }
 
     // Forward sorted_by flags, mapping column ids
     const auto& sorted_by = input_chunk->individually_sorted_by();
@@ -272,7 +222,7 @@ std::shared_ptr<const Table> Projection::_on_execute() {
 
   step_performance_data.set_step_runtime(OperatorSteps::BuildOutput, timer.lap());
 
-  return std::make_shared<Table>(column_definitions, output_table_type, std::move(output_chunks),
+  return std::make_shared<Table>(output_column_definitions, output_table_type, std::move(output_chunks),
                                  input_table.uses_mvcc());
 }
 

--- a/src/lib/operators/projection.cpp
+++ b/src/lib/operators/projection.cpp
@@ -57,7 +57,8 @@ std::shared_ptr<const Table> Projection::_on_execute() {
   // columns. However, we cannot return a table that mixes data and reference segments, so if the forwarded columns are
   // reference columns, the newly generated columns contain reference segments, too. These point to an internal dummy
   // table, the projection_result_table. The life time of this table is managed by the shared_ptr in
-  // ReferenceSegment::_referenced_table.
+  // ReferenceSegment::_referenced_table. The ReferenceSegments created for this use an EntireChunkPosList, so
+  // segment_iterate on the ReferenceSegment decays to the underlying ValueSegment virtually without overhead.
   const auto forwards_any_columns = std::any_of(expressions.begin(), expressions.end(), [&](const auto& expression) {
     return expression->type == ExpressionType::PQPColumn;
   });
@@ -156,7 +157,6 @@ std::shared_ptr<const Table> Projection::_on_execute() {
       input_column_to_output_column[original_id] = expression_id;
     }
   }
-
 
   // Create the actual chunks, and, if needed, fill the projection_result_table. Also set MVCC and
   // individually_sorted_by information as needed.

--- a/src/lib/storage/chunk.cpp
+++ b/src/lib/storage/chunk.cpp
@@ -224,7 +224,7 @@ void Chunk::set_individually_sorted_by(const SortColumnDefinition& sorted_by) {
 }
 
 void Chunk::set_individually_sorted_by(const std::vector<SortColumnDefinition>& sorted_by) {
-  Assert(!is_mutable(), "Cannot set sorted_by on mutable chunks.");
+  Assert(!is_mutable(), "Cannot set_individually_sorted_by on mutable chunks.");
   // Currently, we assume that set_individually_sorted_by is called only once at most.
   // As such, there should be no existing sorting and the new sorting should contain at least one column.
   // Feel free to remove this assertion if necessary.

--- a/src/lib/storage/segment_iterables.hpp
+++ b/src/lib/storage/segment_iterables.hpp
@@ -152,7 +152,7 @@ class PointAccessibleSegmentIterable : public SegmentIterable<Derived> {
    */
   template <ErasePosListType erase_pos_list_type = ErasePosListType::OnlyInDebugBuild, typename Functor>
   void with_iterators(const std::shared_ptr<const AbstractPosList>& position_filter, const Functor& functor) const {
-    if (!position_filter) {
+    if (!position_filter || dynamic_cast<const EntireChunkPosList*>(&*position_filter)) {
       _self()._on_with_iterators(functor);
     } else {
       DebugAssert(position_filter->references_single_chunk(), "Expected PosList to reference single chunk");

--- a/src/test/lib/operators/projection_test.cpp
+++ b/src/test/lib/operators/projection_test.cpp
@@ -133,7 +133,7 @@ TEST_F(OperatorsProjectionTest, ForwardReferencesWithExpression) {
   EXPECT_TRUE(dynamic_cast<const ReferenceSegment*>(&*output_chunk->get_segment(ColumnID{2})));
 
   for (const auto& row : projection->get_output()->get_rows()) {
-    EXPECT_EQ(boost::get<float>(row[0]) + boost::get<int>(row[1]), boost::get<float>(row[2]));
+    EXPECT_FLOAT_EQ(boost::get<float>(row[0]) + static_cast<float>(boost::get<int>(row[1])), boost::get<float>(row[2]));
   }
 }
 


### PR DESCRIPTION
Up to now, whenever a Projection `SELECT a, a+1 FROM t` emitted a newly generate column (here: `a+1`), it also materialized all columns that it forwarded (here: `a`). The reason for that is that we do not allow ValueSegments and ReferenceSegments to be mixed within one table.

With this PR, we instead forward the ReferenceSegments and create new ReferenceSegments for the newly generated columns. These point to a new, temporary table. Because we use the EntireChunkPosList, this virtually causes no overhead.

Also does a minor improvement to `segment_iterate` which causes a segment that is iterated on using an EntireChunkPosLists to use the sequential iterator, not the random access one.

```
          +-----+     +------+  Case 1
          |a |b |     |a |a+1|   * Input TableType::Data
          |DS|DS| --> |DS|VS |   * A column (a) is forwarded
          +-----+     +------+   Result: No type change needed, output TableType::Data

          +-----+        +---+  Case 2
          |a |b |        |a+1|   * Input TableType::References
          |RS|RS| -->    |VS |   * No column is forwarded
          +-----+        +---+   Result: Output TableType::Data

+------+  +-----+     +------+  Case 3
|orig_a|  |a |b |     |a |a+1|   * Input TableType::References
|VS    |  |RS|RS| --> |RS|RS |   * A column (a) is forwarded
+------+  +-----+     +------+   Result: Type change needed, output TableType::References, RS a is forwarded, a+1
   ^        |          |   |             is a new RS pointing to a new dummy table.
   +--------+----------+   v
                         +---+  (VS: ValueSegment, DS: DictionarySegment, RS: ReferenceSegment)
                         |a+1|
                         |VS |
                         +---+
```

-------------------

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.1TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| dcd55668b | 16.10.2020 23:04 | JoinHash: Materialize smaller side first (#2239) | real 265.90 user 2438.68 sys 148.35|
| 87064e3c4 | 18.10.2020 11:17 | Use sequential iterators for EntireChunkPosList | real 266.99 user 2419.86 sys 148.96|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_dcd55668b1db4e94834f448cc5c04498c50dda00_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                         | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-10-17 00:49:55                                                                                                                    | 2020-10-18 11:37:28                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||    828.8 |   694.2 |  -16%  ||     1.21 |     1.44 |  +19%  |  0.0000 |
 | TPC-H 02 ||      4.8 |     4.8 |   -0%  ||   207.59 |   208.44 |   +0%  |  0.5913 |
 | TPC-H 03 ||     78.8 |    78.5 |   -0%  ||    12.68 |    12.74 |   +0%  |  0.0009 |
 | TPC-H 04 ||     68.8 |    68.8 |   -0%  ||    14.54 |    14.54 |   +0%  |  0.7372 |
 | TPC-H 05 ||    210.4 |   207.9 |   -1%  ||     4.75 |     4.81 |   +1%  |  0.0034 |
 | TPC-H 06 ||      3.4 |     3.3 |   -2%  ||   296.04 |   302.46 |   +2%  |  0.0000 |
 | TPC-H 07 ||     57.2 |    55.8 |   -2%  ||    17.49 |    17.91 |   +2%  |  0.0157 |
 | TPC-H 08 ||     62.6 |    61.9 |   -1%  ||    15.97 |    16.15 |   +1%  |  0.0419 |
 | TPC-H 09 ||    480.6 |   479.3 |   -0%  ||     2.08 |     2.09 |   +0%  |  0.4393 |
+| TPC-H 10 ||    166.8 |   115.2 |  -31%  ||     6.00 |     8.68 |  +45%  |  0.0000 |
 | TPC-H 11 ||      9.1 |     9.1 |   -0%  ||   110.01 |   110.18 |   +0%  |  0.1643 |
 | TPC-H 12 ||     44.1 |    43.7 |   -1%  ||    22.69 |    22.90 |   +1%  |  0.0000 |
 | TPC-H 13 ||    359.3 |   364.0 |   +1%  ||     2.78 |     2.75 |   -1%  |  0.0000 |
 | TPC-H 14 ||     21.2 |    21.0 |   -1%  ||    47.07 |    47.67 |   +1%  |  0.0000 |
 | TPC-H 15 ||      7.9 |     7.6 |   -4%  ||   127.26 |   132.21 |   +4%  |  0.0000 |
 | TPC-H 16 ||     75.6 |    74.8 |   -1%  ||    13.23 |    13.36 |   +1%  |  0.0000 |
 | TPC-H 17 ||     16.7 |    16.7 |   -0%  ||    59.74 |    59.81 |   +0%  |  0.5677 |
 | TPC-H 18 ||    715.5 |   722.0 |   +1%  ||     1.40 |     1.39 |   -1%  |  0.3751 |
 | TPC-H 19 ||     29.2 |    29.4 |   +1%  ||    34.22 |    33.97 |   -1%  |  0.0000 |
 | TPC-H 20 ||     16.2 |    16.7 |   +3%  ||    61.59 |    59.78 |   -3%  |  0.0000 |
 | TPC-H 21 ||    354.5 |   366.9 |   +3%  ||     2.82 |     2.73 |   -3%  |  0.0000 |
 | TPC-H 22 ||     33.3 |    32.2 |   -3%  ||    30.02 |    31.07 |   +3%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||   3644.8 |  3473.7 |   -5%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +3%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -1%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_dcd55668b1db4e94834f448cc5c04498c50dda00_st_s01.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                             | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-17 01:12:13                                                                                                                        | 2020-10-18 11:59:46                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||      7.3 |     6.6 |  -10%  ||   136.64 |   151.60 |  +11%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.6 |   +2%  ||  1843.23 |  1810.60 |   -2%  |  0.0001 |
 | TPC-H 03 ||      0.9 |     0.9 |   -1%  ||  1126.68 |  1143.82 |   +2%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   -1%  ||  1928.75 |  1950.67 |   +1%  |  0.0000 |
 | TPC-H 05 ||      1.2 |     1.2 |   -1%  ||   808.20 |   817.26 |   +1%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   +3%  ||  9384.19 |  9094.60 |   -3%  |  0.0000 |
 | TPC-H 07 ||      1.2 |     1.2 |   -4%  ||   803.13 |   838.01 |   +4%  |  0.0003 |
 | TPC-H 08 ||     14.7 |    14.7 |   -0%  ||    67.83 |    67.90 |   +0%  |  0.8952 |
 | TPC-H 09 ||      2.4 |     2.4 |   -1%  ||   421.19 |   424.51 |   +1%  |  0.0030 |
 | TPC-H 10 ||      0.9 |     0.9 |   -0%  ||  1106.73 |  1110.77 |   +0%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   +4%  ||  3398.24 |  3278.64 |   -4%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   +3%  ||  1593.53 |  1545.04 |   -3%  |  0.0000 |
 | TPC-H 13 ||      2.2 |     2.2 |   +1%  ||   458.07 |   452.87 |   -1%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.4 |   +2%  ||  2847.46 |  2804.10 |   -2%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   +1%  ||   897.59 |   892.49 |   -1%  |  0.0000 |
 | TPC-H 16 ||      2.0 |     2.0 |   +1%  ||   495.73 |   491.43 |   -1%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   +2%  ||  3428.06 |  3366.26 |   -2%  |  0.0000 |
-| TPC-H 18 ||      2.7 |     3.0 |  +10%  ||   373.30 |   338.70 |   -9%  |  0.0000 |
 | TPC-H 19 ||      5.5 |     5.5 |   +0%  ||   183.34 |   183.15 |   -0%  |  0.0010 |
 | TPC-H 20 ||      2.3 |     2.3 |   -0%  ||   427.15 |   427.18 |   +0%  |  0.9589 |
 | TPC-H 21 ||      1.6 |     1.6 |   -2%  ||   608.14 |   619.30 |   +2%  |  0.0000 |
 | TPC-H 22 ||      1.1 |     1.1 |   -1%  ||   895.41 |   902.90 |   +1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     50.0 |    49.5 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_dcd55668b1db4e94834f448cc5c04498c50dda00_st_s10.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                             | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-10-17 01:34:16                                                                                                                        | 2020-10-18 12:21:50                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   9085.2 |  7447.7 |  -18%  ||     0.11 |     0.13 |  +22%  |       ˅ |
 | TPC-H 02 ||     50.5 |    51.2 |   +1%  ||    19.79 |    19.53 |   -1%  |  0.0078 |
 | TPC-H 03 ||   1448.9 |  1409.9 |   -3%  ||     0.69 |     0.71 |   +3%  |  0.0000 |
 | TPC-H 04 ||   1552.1 |  1486.7 |   -4%  ||     0.64 |     0.67 |   +4%  |  0.0001 |
 | TPC-H 05 ||   3139.0 |  3057.2 |   -3%  ||     0.32 |     0.33 |   +3%  |  0.0008 |
 | TPC-H 06 ||     35.8 |    36.7 |   +2%  ||    27.91 |    27.24 |   -2%  |  0.0000 |
 | TPC-H 07 ||    831.4 |   824.7 |   -1%  ||     1.20 |     1.21 |   +1%  |  0.0005 |
 | TPC-H 08 ||    566.1 |   565.3 |   -0%  ||     1.77 |     1.77 |   +0%  |  0.2479 |
 | TPC-H 09 ||   6897.1 |  6902.5 |   +0%  ||     0.14 |     0.14 |   -0%  |       ˅ |
+| TPC-H 10 ||   2742.5 |  1934.6 |  -29%  ||     0.36 |     0.52 |  +42%  |  0.0000 |
 | TPC-H 11 ||    129.4 |   132.6 |   +2%  ||     7.73 |     7.54 |   -2%  |  0.0000 |
 | TPC-H 12 ||    685.0 |   676.4 |   -1%  ||     1.46 |     1.48 |   +1%  |  0.0000 |
 | TPC-H 13 ||   5417.0 |  5596.7 |   +3%  ||     0.18 |     0.18 |   -3%  |  0.0002 |
 | TPC-H 14 ||    233.7 |   231.3 |   -1%  ||     4.28 |     4.32 |   +1%  |  0.0002 |
+| TPC-H 15 ||     97.1 |    91.6 |   -6%  ||    10.30 |    10.91 |   +6%  |  0.0000 |
 | TPC-H 16 ||    909.1 |   925.0 |   +2%  ||     1.10 |     1.08 |   -2%  |  0.0000 |
 | TPC-H 17 ||    256.4 |   255.1 |   -1%  ||     3.90 |     3.92 |   +1%  |  0.0000 |
-| TPC-H 18 ||  11887.0 | 12702.9 |   +7%  ||     0.08 |     0.08 |   -6%  |       ˅ |
 | TPC-H 19 ||    316.5 |   315.0 |   -0%  ||     3.16 |     3.17 |   +0%  |  0.0891 |
 | TPC-H 20 ||    176.8 |   176.8 |   -0%  ||     5.65 |     5.66 |   +0%  |  0.9339 |
 | TPC-H 21 ||   5687.3 |  5696.9 |   +0%  ||     0.18 |     0.18 |   -0%  |  0.8954 |
 | TPC-H 22 ||    478.1 |   467.9 |   -2%  ||     2.09 |     2.14 |   +2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  52622.1 | 50984.7 |   -3%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +3%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_dcd55668b1db4e94834f448cc5c04498c50dda00_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCH_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                         | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-17 01:59:44                                                                                                                    | 2020-10-18 12:47:13                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   2378.5 |  1979.6 |  -17%  ||    20.55 |    24.75 |  +20%  |  0.0000 |
 | TPC-H 02 ||     16.1 |    16.1 |   +0%  ||  2363.12 |  2357.59 |   -0%  |  0.0592 |
 | TPC-H 03 ||    419.6 |   412.5 |   -2%  ||   117.24 |   118.90 |   +1%  |  0.2958 |
 | TPC-H 04 ||    262.6 |   260.6 |   -1%  ||   186.30 |   187.58 |   +1%  |  0.5772 |
-| TPC-H 05 ||   1245.8 |  1370.5 |  +10%  ||    39.29 |    35.46 |  -10%  |  0.0027 |
-| TPC-H 06 ||     20.6 |    24.8 |  +21%  ||  2031.67 |  1679.04 |  -17%  |  0.0000 |
-| TPC-H 07 ||    240.6 |   277.9 |  +15%  ||   202.76 |   175.66 |  -13%  |  0.0000 |
 | TPC-H 08 ||    172.6 |   172.8 |   +0%  ||   281.27 |   280.71 |   -0%  |  0.8619 |
 | TPC-H 09 ||   2372.9 |  2376.5 |   +0%  ||    20.35 |    20.41 |   +0%  |  0.9665 |
+| TPC-H 10 ||    842.4 |   604.6 |  -28%  ||    58.61 |    81.41 |  +39%  |  0.0000 |
 | TPC-H 11 ||     66.6 |    67.0 |   +1%  ||   701.76 |   697.58 |   -1%  |  0.2333 |
 | TPC-H 12 ||    131.3 |   130.7 |   -0%  ||   366.55 |   367.76 |   +0%  |  0.5985 |
 | TPC-H 13 ||   2224.0 |  2232.0 |   +0%  ||    21.93 |    21.80 |   -1%  |  0.8921 |
 | TPC-H 14 ||    137.8 |   140.8 |   +2%  ||   349.91 |   341.59 |   -2%  |  0.0001 |
+| TPC-H 15 ||     52.1 |    49.3 |   -5%  ||   880.40 |   923.04 |   +5%  |  0.0000 |
 | TPC-H 16 ||    389.3 |   386.5 |   -1%  ||   125.75 |   127.13 |   +1%  |  0.5077 |
 | TPC-H 17 ||     55.9 |    56.0 |   +0%  ||   827.16 |   825.72 |   -0%  |  0.6523 |
 | TPC-H 18 ||   6122.1 |  6144.8 |   +0%  ||     7.70 |     7.52 |   -2%  |  0.9070 |
 | TPC-H 19 ||     92.0 |    93.1 |   +1%  ||   517.01 |   510.55 |   -1%  |  0.0532 |
 | TPC-H 20 ||     53.0 |    53.1 |   +0%  ||   866.24 |   863.56 |   -0%  |  0.5445 |
 | TPC-H 21 ||   1307.7 |  1287.7 |   -2%  ||    37.39 |    37.28 |   -0%  |  0.6763 |
 | TPC-H 22 ||    251.4 |   250.6 |   -0%  ||   193.91 |   194.51 |   +0%  |  0.8452 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  18854.9 | 18387.6 |   -2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_dcd55668b1db4e94834f448cc5c04498c50dda00_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                          | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-10-17 02:22:14                                                                                                                     | 2020-10-18 13:09:41                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     28.8 |    28.9 |   +1%  ||    34.73 |    34.54 |   -1%  |  0.0000 |
 | 03      ||      6.7 |     6.7 |   +0%  ||   150.19 |   149.66 |   -0%  |  0.0000 |
 | 06      ||     18.3 |    18.3 |   +0%  ||    54.73 |    54.66 |   -0%  |  0.0000 |
+| 07      ||     31.6 |    29.1 |   -8%  ||    31.69 |    34.35 |   +8%  |  0.0000 |
+| 09      ||    111.3 |   106.0 |   -5%  ||     8.99 |     9.43 |   +5%  |  0.0000 |
 | 10      ||     19.2 |    19.0 |   -1%  ||    52.18 |    52.74 |   +1%  |  0.0000 |
 | 13      ||    126.3 |   125.8 |   -0%  ||     7.92 |     7.95 |   +0%  |  0.7344 |
 | 15      ||     10.2 |    10.1 |   -1%  ||    98.00 |    98.53 |   +1%  |  0.0000 |
 | 17      ||     28.6 |    27.9 |   -3%  ||    34.94 |    35.86 |   +3%  |  0.0001 |
 | 19      ||     10.0 |     9.8 |   -2%  ||    99.59 |   101.67 |   +2%  |  0.0000 |
 | 25      ||     15.4 |    15.0 |   -2%  ||    64.97 |    66.62 |   +3%  |  0.0001 |
+| 26      ||     16.0 |    14.8 |   -8%  ||    62.40 |    67.67 |   +8%  |  0.0000 |
 | 28      ||   1025.3 |  1027.0 |   +0%  ||     0.98 |     0.97 |   -0%  |  0.0040 |
 | 29      ||     25.8 |    25.2 |   -2%  ||    38.82 |    39.71 |   +2%  |  0.0004 |
 | 31      ||    134.4 |   133.3 |   -1%  ||     7.44 |     7.50 |   +1%  |  0.0000 |
+| 34      ||     16.8 |    15.9 |   -5%  ||    59.47 |    62.75 |   +6%  |  0.0000 |
 | 35      ||     87.8 |    86.4 |   -2%  ||    11.39 |    11.57 |   +2%  |  0.0000 |
 | 39a     ||    178.1 |   172.8 |   -3%  ||     5.61 |     5.79 |   +3%  |  0.0000 |
 | 39b     ||    175.7 |   170.9 |   -3%  ||     5.69 |     5.85 |   +3%  |  0.0000 |
 | 41      ||     25.4 |    25.8 |   +1%  ||    39.40 |    38.83 |   -1%  |  0.0000 |
 | 42      ||      8.0 |     7.8 |   -1%  ||   125.59 |   127.41 |   +1%  |  0.0000 |
 | 43      ||    249.1 |   241.9 |   -3%  ||     4.01 |     4.13 |   +3%  |  0.0000 |
 | 45      ||      9.9 |     9.8 |   -1%  ||   101.41 |   101.94 |   +1%  |  0.0000 |
 | 48      ||     83.9 |    81.0 |   -3%  ||    11.92 |    12.35 |   +4%  |  0.0000 |
 | 50      ||     11.4 |    11.3 |   -0%  ||    87.94 |    88.17 |   +0%  |  0.0004 |
 | 52      ||      8.1 |     8.0 |   -1%  ||   123.66 |   125.24 |   +1%  |  0.0000 |
 | 55      ||      7.9 |     7.8 |   -1%  ||   126.92 |   128.64 |   +1%  |  0.0000 |
+| 62      ||     74.5 |    66.9 |  -10%  ||    13.42 |    14.95 |  +11%  |  0.0000 |
 | 65      ||     62.2 |    61.0 |   -2%  ||    16.09 |    16.39 |   +2%  |  0.0000 |
 | 69      ||     18.8 |    18.6 |   -1%  ||    53.16 |    53.71 |   +1%  |  0.0000 |
 | 73      ||     10.1 |     9.9 |   -2%  ||    98.87 |   101.22 |   +2%  |  0.0000 |
 | 79      ||     45.2 |    43.7 |   -3%  ||    22.13 |    22.91 |   +3%  |  0.0000 |
 | 81      ||     19.1 |    18.8 |   -2%  ||    52.26 |    53.10 |   +2%  |  0.0000 |
 | 83      ||      9.5 |     9.4 |   -1%  ||   105.42 |   106.49 |   +1%  |  0.0000 |
 | 85      ||     57.4 |    56.0 |   -2%  ||    17.42 |    17.86 |   +3%  |  0.2196 |
 | 88      ||     67.9 |    66.2 |   -2%  ||    14.72 |    15.10 |   +3%  |  0.0000 |
 | 91      ||     20.8 |    20.1 |   -3%  ||    48.03 |    49.76 |   +4%  |  0.0000 |
 | 93      ||    260.6 |   265.0 |   +2%  ||     3.84 |     3.77 |   -2%  |  0.0000 |
 | 96      ||      7.3 |     7.3 |   -1%  ||   136.35 |   137.79 |   +1%  |  0.0000 |
 | 97      ||    392.3 |   388.7 |   -1%  ||     2.55 |     2.57 |   +1%  |  0.3227 |
+| 99      ||    148.3 |   133.0 |  -10%  ||     6.74 |     7.52 |  +12%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3664.0 |  3600.9 |   -2%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +2%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_dcd55668b1db4e94834f448cc5c04498c50dda00_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                          | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 9.2                                                                                                                                 | gcc 9.2                                                                                                                                 |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-10-17 03:03:21                                                                                                                     | 2020-10-18 13:50:49                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                           | [56, 0, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    197.4 |   197.0 |   -0%  ||   246.47 |   247.16 |   +0%  |  0.7389 |
 | 03      ||     25.3 |    25.3 |   +0%  ||  1618.52 |  1621.37 |   +0%  |  0.0328 |
 | 06      ||    116.7 |   116.8 |   +0%  ||   410.79 |   410.24 |   -0%  |  0.9036 |
 | 07      ||    172.2 |   169.2 |   -2%  ||   281.68 |   286.74 |   +2%  |  0.0681 |
 | 09      ||    527.6 |   542.0 |   +3%  ||    91.45 |    90.37 |   -1%  |  0.3618 |
 | 10      ||     73.7 |    73.2 |   -1%  ||   643.18 |   646.85 |   +1%  |  0.3170 |
 | 13      ||    415.7 |   419.5 |   +1%  ||   118.09 |   117.17 |   -1%  |  0.4544 |
 | 15      ||     65.9 |    65.7 |   -0%  ||   706.68 |   708.63 |   +0%  |  0.5700 |
 | 17      ||    129.0 |   127.9 |   -1%  ||   373.06 |   375.93 |   +1%  |  0.3251 |
 | 19      ||     49.0 |    50.5 |   +3%  ||   935.71 |   908.58 |   -3%  |  0.0000 |
 | 25      ||     74.4 |    74.7 |   +0%  ||   635.70 |   632.57 |   -0%  |  0.5462 |
 | 26      ||     99.7 |   103.2 |   +3%  ||   478.79 |   461.58 |   -4%  |  0.0000 |
 | 28      ||   3127.6 |  3075.1 |   -2%  ||    15.18 |    15.35 |   +1%  |  0.7820 |
 | 29      ||    126.3 |   124.6 |   -1%  ||   380.06 |   385.47 |   +1%  |  0.1025 |
 | 31      ||    773.9 |   763.2 |   -1%  ||    63.44 |    63.74 |   +0%  |  0.6526 |
 | 34      ||     87.1 |    86.8 |   -0%  ||   542.72 |   544.14 |   +0%  |  0.6611 |
 | 35      ||    713.2 |   703.7 |   -1%  ||    68.96 |    70.08 |   +2%  |  0.4628 |
 | 39a     ||   1585.3 |  1592.3 |   +0%  ||    30.60 |    30.81 |   +1%  |  0.8688 |
 | 39b     ||   1576.1 |  1589.8 |   +1%  ||    30.53 |    30.83 |   +1%  |  0.7641 |
 | 41      ||   1384.0 |  1246.6 |  -10%  ||    34.03 |    34.28 |   +1%  |  0.0777 |
 | 42      ||     39.5 |    39.5 |   +0%  ||  1134.93 |  1134.85 |   -0%  |  0.8885 |
 | 43      ||    764.6 |   739.5 |   -3%  ||    64.46 |    66.73 |   +4%  |  0.0125 |
 | 45      ||     49.5 |    48.7 |   -2%  ||   919.25 |   933.06 |   +2%  |  0.0006 |
 | 48      ||    347.7 |   344.5 |   -1%  ||   140.94 |   142.43 |   +1%  |  0.5883 |
 | 50      ||    131.6 |   132.1 |   +0%  ||   365.31 |   363.99 |   -0%  |  0.7002 |
 | 52      ||     39.6 |    39.8 |   +0%  ||  1135.14 |  1129.62 |   -0%  |  0.1836 |
 | 55      ||     37.0 |    37.1 |   +0%  ||  1204.52 |  1201.35 |   -0%  |  0.4534 |
+| 62      ||    287.8 |   238.5 |  -17%  ||   170.14 |   204.87 |  +20%  |  0.0000 |
 | 65      ||    518.6 |   504.1 |   -3%  ||    95.05 |    97.65 |   +3%  |  0.0090 |
 | 69      ||     68.1 |    67.6 |   -1%  ||   687.46 |   692.82 |   +1%  |  0.1635 |
 | 73      ||     45.9 |    47.0 |   +2%  ||   996.30 |   976.05 |   -2%  |  0.0000 |
 | 79      ||    197.1 |   190.2 |   -3%  ||   246.79 |   255.64 |   +4%  |  0.0000 |
 | 81      ||    138.9 |   137.9 |   -1%  ||   347.08 |   349.54 |   +1%  |  0.2750 |
 | 83      ||     69.7 |    68.7 |   -1%  ||   671.58 |   680.80 |   +1%  |  0.0351 |
 | 85      ||    215.7 |   214.5 |   -1%  ||   226.27 |   227.40 |   +0%  |  0.6353 |
-| 88      ||    518.8 |   546.3 |   +5%  ||    93.11 |    88.66 |   -5%  |  0.1024 |
 | 91      ||     84.8 |    84.4 |   -1%  ||   559.20 |   562.15 |   +1%  |  0.2755 |
 | 93      ||   1302.7 |  1294.0 |   -1%  ||    37.54 |    37.41 |   -0%  |  0.8202 |
 | 96      ||     40.8 |    42.9 |   +5%  ||  1106.98 |  1057.70 |   -4%  |  0.0000 |
 | 97      ||   3556.6 |  3546.6 |   -0%  ||    13.50 |    13.57 |   +0%  |  0.9201 |
+| 99      ||    743.7 |   639.6 |  -14%  ||    66.12 |    76.98 |  +16%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  20519.0 | 20150.6 |   -2%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_dcd55668b1db4e94834f448cc5c04498c50dda00_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                         | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-10-17 03:44:41                                                                                                                    | 2020-10-18 14:32:08                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     28.6 |    29.0 |   +1%  ||     3.77 |     3.70 |   -2%  | (run time too short) |
 | New-Order    ||     18.2 |    18.6 |   +2%  ||    42.21 |    41.46 |   -2%  | (run time too short) |
 | Order-Status ||      1.3 |     1.3 |   +0%  ||     3.77 |     3.70 |   -2%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   +2%  ||    40.44 |    39.56 |   -2%  | (run time too short) |
 | Stock-Level  ||      4.1 |     4.1 |   -1%  ||     3.73 |     3.70 |   -1%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     54.7 |    55.5 |   +1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_dcd55668b1db4e94834f448cc5c04498c50dda00_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkTPCC_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                         | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 9.2                                                                                                                                | gcc 9.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-10-17 03:45:45                                                                                                                    | 2020-10-18 14:33:13                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                          | [56, 0, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    217.8 |   217.2 |   -0%  ||     4.44 |     4.44 |   +0%  | (run time too short) |
 |    unsucc.:  ||      3.6 |     3.9 |   +8%  ||   124.93 |   125.23 |   +0%  |                      |
 | New-Order    ||     98.2 |    98.2 |   -0%  ||    88.47 |    87.29 |   -1%  |               0.9663 |
 |    unsucc.:  ||      4.8 |     4.8 |   +1%  ||  1366.83 |  1371.79 |   +0%  |                      |
 | Order-Status ||      7.8 |     7.8 |   -0%  ||   129.37 |   129.69 |   +0%  |               0.5652 |
+| Payment      ||     17.0 |    17.3 |   +1%  ||     5.31 |     5.87 |  +11%  | (run time too short) |
 |    unsucc.:  ||      4.3 |     4.2 |   -1%  ||  1385.50 |  1388.35 |   +0%  |                      |
 | Stock-Level  ||     18.8 |    18.4 |   -2%  ||   129.36 |   129.66 |   +0%  |               0.0814 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    359.6 |   358.8 |   -0%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_dcd55668b1db4e94834f448cc5c04498c50dda00_st.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                              | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-10-17 03:46:51                                                                                                                         | 2020-10-18 14:34:18                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    357.7 |    351.6 |   -2%  ||     2.80 |     2.84 |   +2%  |  0.0000 |
 | 10b     ||    350.0 |    346.7 |   -1%  ||     2.86 |     2.88 |   +1%  |  0.0000 |
 | 10c     ||    938.3 |    930.3 |   -1%  ||     1.07 |     1.07 |   +1%  |  0.0459 |
 | 11a     ||    150.5 |    147.7 |   -2%  ||     6.64 |     6.77 |   +2%  |  0.0553 |
 | 11b     ||    141.1 |    138.9 |   -2%  ||     7.09 |     7.20 |   +2%  |  0.1222 |
 | 11c     ||    492.3 |    490.4 |   -0%  ||     2.03 |     2.04 |   +0%  |  0.7080 |
 | 11d     ||   4809.0 |   4799.7 |   -0%  ||     0.21 |     0.21 |   +0%  |  0.9197 |
 | 12a     ||    294.2 |    292.7 |   -1%  ||     3.40 |     3.42 |   +1%  |  0.5792 |
 | 12b     ||    634.7 |    620.3 |   -2%  ||     1.58 |     1.61 |   +2%  |  0.0176 |
 | 12c     ||   3635.2 |   3618.5 |   -0%  ||     0.28 |     0.28 |   +0%  |  0.6328 |
 | 13a     ||    179.5 |    177.6 |   -1%  ||     5.57 |     5.63 |   +1%  |  0.0000 |
 | 13b     ||    257.6 |    250.9 |   -3%  ||     3.88 |     3.99 |   +3%  |  0.0000 |
 | 13c     ||    137.2 |    136.7 |   -0%  ||     7.29 |     7.31 |   +0%  |  0.0026 |
 | 13d     ||    179.4 |    177.7 |   -1%  ||     5.57 |     5.63 |   +1%  |  0.0000 |
 | 14a     ||   4076.3 |   4085.4 |   +0%  ||     0.25 |     0.24 |   -0%  |  0.8045 |
 | 14b     ||   4699.3 |   4694.4 |   -0%  ||     0.21 |     0.21 |   +0%  |  0.9117 |
 | 14c     ||   4082.1 |   4085.5 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.9296 |
+| 15a     ||    215.1 |    190.1 |  -12%  ||     4.65 |     5.26 |  +13%  |  0.0000 |
+| 15b     ||    212.1 |    187.4 |  -12%  ||     4.71 |     5.34 |  +13%  |  0.0000 |
 | 15c     ||    149.5 |    150.3 |   +1%  ||     6.69 |     6.65 |   -1%  |  0.1203 |
+| 15d     ||    458.0 |    434.5 |   -5%  ||     2.18 |     2.30 |   +5%  |  0.0000 |
 | 16a     ||   4797.4 |   4825.5 |   +1%  ||     0.21 |     0.21 |   -1%  |  0.7658 |
 | 16b     ||   6284.5 |   6312.5 |   +0%  ||     0.16 |     0.16 |   -0%  |  0.6967 |
 | 16c     ||   4933.2 |   4896.4 |   -1%  ||     0.20 |     0.20 |   +1%  |  0.6258 |
 | 16d     ||   4906.2 |   4879.0 |   -1%  ||     0.20 |     0.20 |   +1%  |  0.7222 |
 | 17a     ||    946.5 |    943.3 |   -0%  ||     1.06 |     1.06 |   +0%  |  0.5603 |
 | 17b     ||    749.4 |    743.9 |   -1%  ||     1.33 |     1.34 |   +1%  |  0.1796 |
 | 17c     ||    706.0 |    701.7 |   -1%  ||     1.42 |     1.43 |   +1%  |  0.2627 |
 | 17d     ||    827.0 |    820.0 |   -1%  ||     1.21 |     1.22 |   +1%  |  0.1158 |
 | 17e     ||   2711.3 |   2698.8 |   -0%  ||     0.37 |     0.37 |   +0%  |  0.4893 |
 | 17f     ||   1518.2 |   1509.9 |   -1%  ||     0.66 |     0.66 |   +1%  |  0.4342 |
 | 18a     ||    596.6 |    592.0 |   -1%  ||     1.68 |     1.69 |   +1%  |  0.1210 |
 | 18b     ||    233.2 |    230.9 |   -1%  ||     4.29 |     4.33 |   +1%  |  0.0608 |
 | 18c     ||   3774.7 |   3745.3 |   -1%  ||     0.26 |     0.27 |   +1%  |  0.1544 |
 | 19a     ||   7845.8 |   7642.0 |   -3%  ||     0.13 |     0.13 |   +3%  |       ˅ |
+| 19b     ||   4805.1 |   4546.9 |   -5%  ||     0.21 |     0.22 |   +6%  |  0.0000 |
 | 19c     ||   7655.8 |   7396.9 |   -3%  ||     0.13 |     0.14 |   +3%  |       ˅ |
 | 19d     ||   5710.5 |   5616.0 |   -2%  ||     0.18 |     0.18 |   +2%  |  0.0656 |
 | 1a      ||     58.5 |     58.5 |   +0%  ||    17.10 |    17.09 |   -0%  |  0.4351 |
 | 1b      ||     22.2 |     22.1 |   -0%  ||    45.12 |    45.25 |   +0%  |  0.0000 |
 | 1c      ||     22.1 |     22.0 |   -0%  ||    45.17 |    45.36 |   +0%  |  0.0000 |
 | 1d      ||     21.9 |     21.8 |   -0%  ||    45.61 |    45.81 |   +0%  |  0.0000 |
 | 20a     ||   1235.0 |   1230.4 |   -0%  ||     0.81 |     0.81 |   +0%  |  0.1464 |
 | 20b     ||   1070.4 |   1068.3 |   -0%  ||     0.93 |     0.94 |   +0%  |  0.2552 |
 | 20c     ||   1100.4 |   1081.5 |   -2%  ||     0.91 |     0.92 |   +2%  |  0.0000 |
 | 21a     ||   3840.1 |   3837.3 |   -0%  ||     0.26 |     0.26 |   +0%  |  0.8106 |
 | 21b     ||    247.3 |    243.1 |   -2%  ||     4.04 |     4.11 |   +2%  |  0.0000 |
 | 21c     ||   3967.4 |   3958.8 |   -0%  ||     0.25 |     0.25 |   +0%  |  0.4831 |
 | 22a     ||   3481.7 |   3451.4 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.3082 |
 | 22b     ||   3478.4 |   3447.7 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.3164 |
 | 22c     ||   4097.9 |   4107.2 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.7702 |
 | 22d     ||   4118.9 |   4129.7 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.7282 |
 | 23a     ||    152.6 |    154.1 |   +1%  ||     6.55 |     6.49 |   -1%  |  0.0201 |
 | 23b     ||    121.7 |    120.9 |   -1%  ||     8.22 |     8.27 |   +1%  |  0.0865 |
 | 23c     ||    171.6 |    173.0 |   +1%  ||     5.83 |     5.78 |   -1%  |  0.0438 |
+| 24a     ||   4942.6 |   4646.5 |   -6%  ||     0.20 |     0.22 |   +6%  |  0.0000 |
+| 24b     ||   4835.7 |   4586.7 |   -5%  ||     0.21 |     0.22 |   +5%  |  0.0017 |
 | 25a     ||    236.2 |    234.4 |   -1%  ||     4.23 |     4.27 |   +1%  |  0.0675 |
 | 25b     ||    250.2 |    250.0 |   -0%  ||     4.00 |     4.00 |   +0%  |  0.8323 |
 | 25c     ||   3780.5 |   3759.8 |   -1%  ||     0.26 |     0.27 |   +1%  |  0.2845 |
 | 26a     ||    990.0 |    969.7 |   -2%  ||     1.01 |     1.03 |   +2%  |  0.0000 |
 | 26b     ||    978.4 |    961.4 |   -2%  ||     1.02 |     1.04 |   +2%  |  0.0099 |
 | 26c     ||    989.0 |    971.2 |   -2%  ||     1.01 |     1.03 |   +2%  |  0.0005 |
 | 27a     ||   3479.4 |   3455.9 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2047 |
 | 27b     ||   3454.5 |   3429.8 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.1884 |
-| 27c     ||    200.5 |    210.2 |   +5%  ||     4.99 |     4.76 |   -5%  |  0.0000 |
 | 28a     ||   4135.2 |   4232.0 |   +2%  ||     0.24 |     0.24 |   -2%  |  0.3214 |
 | 28b     ||   3387.3 |   3434.7 |   +1%  ||     0.30 |     0.29 |   -1%  |  0.6272 |
 | 28c     ||   4135.6 |   4228.2 |   +2%  ||     0.24 |     0.24 |   -2%  |  0.3343 |
 | 29a     ||   4783.2 |   4590.6 |   -4%  ||     0.21 |     0.22 |   +4%  |  0.2109 |
 | 29b     ||    201.1 |    207.2 |   +3%  ||     4.97 |     4.83 |   -3%  |  0.5604 |
 | 29c     ||   4874.6 |   4683.2 |   -4%  ||     0.21 |     0.21 |   +4%  |  0.2452 |
 | 2a      ||     99.5 |    102.7 |   +3%  ||    10.05 |     9.74 |   -3%  |  0.0000 |
 | 2b      ||     81.9 |     85.0 |   +4%  ||    12.21 |    11.77 |   -4%  |  0.0000 |
 | 2c      ||     53.9 |     55.9 |   +4%  ||    18.56 |    17.90 |   -4%  |  0.0000 |
 | 2d      ||    124.4 |    128.6 |   +3%  ||     8.04 |     7.77 |   -3%  |  0.0000 |
 | 30a     ||    251.9 |    257.6 |   +2%  ||     3.97 |     3.88 |   -2%  |  0.2318 |
 | 30b     ||   1098.9 |   1088.3 |   -1%  ||     0.91 |     0.92 |   +1%  |  0.6271 |
 | 30c     ||   3805.1 |   3855.7 |   +1%  ||     0.26 |     0.26 |   -1%  |  0.5454 |
 | 31a     ||    287.8 |    294.7 |   +2%  ||     3.47 |     3.39 |   -2%  |  0.0176 |
 | 31b     ||   1128.4 |   1117.3 |   -1%  ||     0.89 |     0.90 |   +1%  |  0.3853 |
 | 31c     ||    290.9 |    298.5 |   +3%  ||     3.44 |     3.35 |   -3%  |  0.0118 |
-| 32a     ||     36.8 |     41.2 |  +12%  ||    27.20 |    24.29 |  -11%  |  0.0000 |
 | 32b     ||    267.8 |    275.2 |   +3%  ||     3.73 |     3.63 |   -3%  |  0.0000 |
 | 33a     ||     70.2 |     72.1 |   +3%  ||    14.24 |    13.86 |   -3%  |  0.0001 |
 | 33b     ||     69.3 |     71.2 |   +3%  ||    14.42 |    14.05 |   -3%  |  0.0001 |
 | 33c     ||     84.7 |     86.8 |   +2%  ||    11.81 |    11.53 |   -2%  |  0.0004 |
 | 3a      ||   3910.0 |   3985.0 |   +2%  ||     0.26 |     0.25 |   -2%  |  0.0000 |
-| 3b      ||     35.6 |     37.9 |   +6%  ||    28.07 |    26.39 |   -6%  |  0.0000 |
 | 3c      ||   4777.5 |   4910.7 |   +3%  ||     0.21 |     0.20 |   -3%  |  0.0000 |
 | 4a      ||    114.5 |    117.2 |   +2%  ||     8.73 |     8.53 |   -2%  |  0.0000 |
-| 4b      ||     26.7 |     28.8 |   +8%  ||    37.38 |    34.74 |   -7%  |  0.0000 |
 | 4c      ||    126.4 |    130.4 |   +3%  ||     7.91 |     7.67 |   -3%  |  0.0000 |
 | 5a      ||   3781.6 |   3882.8 |   +3%  ||     0.26 |     0.26 |   -3%  |  0.0000 |
 | 5b      ||    276.5 |    284.0 |   +3%  ||     3.62 |     3.52 |   -3%  |  0.0000 |
 | 5c      ||   4384.2 |   4508.6 |   +3%  ||     0.23 |     0.22 |   -3%  |  0.0000 |
 | 6a      ||    228.0 |    233.8 |   +3%  ||     4.39 |     4.28 |   -2%  |  0.0000 |
 | 6b      ||    958.1 |    969.3 |   +1%  ||     1.04 |     1.03 |   -1%  |  0.0000 |
 | 6c      ||    227.7 |    233.6 |   +3%  ||     4.39 |     4.28 |   -3%  |  0.0000 |
 | 6d      ||    958.2 |    969.1 |   +1%  ||     1.04 |     1.03 |   -1%  |  0.0000 |
 | 6e      ||    227.3 |    234.2 |   +3%  ||     4.40 |     4.27 |   -3%  |  0.0000 |
 | 6f      ||   1420.0 |   1464.8 |   +3%  ||     0.70 |     0.68 |   -3%  |  0.0000 |
 | 7a      ||    278.1 |    286.5 |   +3%  ||     3.60 |     3.49 |   -3%  |  0.0090 |
 | 7b      ||    136.9 |    141.5 |   +3%  ||     7.31 |     7.07 |   -3%  |  0.0033 |
 | 7c      ||  10247.3 |  10522.2 |   +3%  ||     0.10 |     0.10 |   -3%  |       ˅ |
-| 8a      ||    111.9 |    117.8 |   +5%  ||     8.94 |     8.49 |   -5%  |  0.0000 |
-| 8b      ||    157.3 |    174.8 |  +11%  ||     6.36 |     5.72 |  -10%  |  0.0000 |
 | 8c      ||   3951.7 |   4090.7 |   +4%  ||     0.25 |     0.24 |   -3%  |  0.0000 |
 | 8d      ||   1263.3 |   1300.3 |   +3%  ||     0.79 |     0.77 |   -3%  |  0.0000 |
 | 9a      ||   3451.8 |   3509.2 |   +2%  ||     0.29 |     0.28 |   -2%  |  0.0029 |
 | 9b      ||    313.5 |    322.9 |   +3%  ||     3.19 |     3.10 |   -3%  |  0.0000 |
 | 9c      ||   3437.7 |   3496.4 |   +2%  ||     0.29 |     0.29 |   -2%  |  0.0020 |
 | 9d      ||   4044.4 |   4094.7 |   +1%  ||     0.25 |     0.24 |   -1%  |  0.0302 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 214910.1 | 214265.2 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -0%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_dcd55668b1db4e94834f448cc5c04498c50dda00_mt.json | /home/Markus.Dreseler/hyrise5/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_87064e3c43407d0b6c3e6f5bc728d5fd2902710e_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | dcd55668b1db4e94834f448cc5c04498c50dda00-dirty                                                                                              | 87064e3c43407d0b6c3e6f5bc728d5fd2902710e-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-10-17 05:42:52                                                                                                                         | 2020-10-18 16:30:35                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [56, 0, 0, 0]                                                                                                                               | [56, 0, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)     | Change || Throughput (iter/s) | Change | p-value |
 |         ||       old |       new |        ||      old |      new |        |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
-| 10a     ||    2565.6 |    2565.3 |   -0%  ||    18.96 |    17.75 |   -6%  |  0.9979 |
 | 10b     ||    1830.9 |    1813.7 |   -1%  ||    26.27 |    26.28 |   +0%  |  0.7952 |
 | 10c     ||    6614.6 |    6448.6 |   -3%  ||     6.97 |     6.95 |   -0%  |  0.6533 |
 | 11a     ||     444.9 |     447.6 |   +1%  ||   109.80 |   109.42 |   -0%  |  0.7937 |
 | 11b     ||     410.4 |     413.6 |   +1%  ||   118.34 |   118.50 |   +0%  |  0.7142 |
 | 11c     ||    2220.9 |    2209.3 |   -1%  ||    21.28 |    21.33 |   +0%  |  0.8836 |
-| 11d     ||   22169.3 |   20077.7 |   -9%  ||     1.68 |     1.55 |   -8%  |  0.1027 |
 | 12a     ||    2378.2 |    2389.9 |   +0%  ||    20.40 |    19.95 |   -2%  |  0.9096 |
 | 12b     ||    1411.4 |    1422.3 |   +1%  ||    34.33 |    33.96 |   -1%  |  0.8227 |
 | 12c     ||   18387.9 |   18801.5 |   +2%  ||     1.85 |     1.87 |   +1%  |  0.7914 |
 | 13a     ||    1126.3 |    1167.3 |   +4%  ||    42.66 |    41.48 |   -3%  |  0.3319 |
 | 13b     ||    1166.7 |    1188.1 |   +2%  ||    41.80 |    40.21 |   -4%  |  0.6390 |
 | 13c     ||    1141.3 |    1208.2 |   +6%  ||    42.03 |    40.40 |   -4%  |  0.1281 |
 | 13d     ||    1114.4 |    1141.1 |   +2%  ||    42.53 |    42.28 |   -1%  |  0.5196 |
 | 14a     ||   18719.9 |   16836.4 |  -10%  ||     2.08 |     2.02 |   -3%  |  0.1487 |
 | 14b     ||   19822.0 |   17659.0 |  -11%  ||     1.85 |     1.90 |   +3%  |  0.1414 |
 | 14c     ||   17107.8 |   18812.0 |  +10%  ||     1.95 |     1.95 |   -0%  |  0.1958 |
 | 15a     ||    1124.7 |    1104.4 |   -2%  ||    43.61 |    44.20 |   +1%  |  0.5524 |
 | 15b     ||    1089.8 |    1083.9 |   -1%  ||    44.93 |    45.13 |   +0%  |  0.8568 |
 | 15c     ||     413.6 |     419.7 |   +1%  ||   117.95 |   116.48 |   -1%  |  0.4367 |
 | 15d     ||    2474.1 |    2458.1 |   -1%  ||    19.10 |    19.58 |   +3%  |  0.8607 |
 | 16a     ||   25799.3 |   24188.6 |   -6%  ||     1.07 |     1.03 |   -3%  |  0.4504 |
-| 16b     ||   33967.9 |   32337.4 |   -5%  ||     0.92 |     0.85 |   -7%  |  0.4925 |
+| 16c     ||   29500.1 |   26737.5 |   -9%  ||     0.97 |     1.05 |   +9%  |  0.1525 |
+| 16d     ||   28082.6 |   28214.8 |   +0%  ||     1.05 |     1.13 |   +8%  |  0.9471 |
 | 17a     ||    8703.3 |    8643.3 |   -1%  ||     4.98 |     4.95 |   -1%  |  0.9138 |
 | 17b     ||    8763.5 |    8340.2 |   -5%  ||     4.88 |     4.93 |   +1%  |  0.4678 |
 | 17c     ||    9346.8 |    8133.9 |  -13%  ||     4.83 |     4.90 |   +1%  |  0.0723 |
 | 17d     ||    8506.3 |    7545.9 |  -11%  ||     5.05 |     4.98 |   -1%  |  0.0864 |
 | 17e     ||   12287.4 |   11533.4 |   -6%  ||     3.43 |     3.38 |   -1%  |  0.2925 |
 | 17f     ||    8688.7 |   10461.1 |  +20%  ||     4.25 |     4.07 |   -4%  |  0.0092 |
 | 18a     ||    3377.7 |    3431.7 |   +2%  ||    13.21 |    13.36 |   +1%  |  0.7696 |
 | 18b     ||    2502.5 |    2490.6 |   -0%  ||    19.12 |    19.03 |   -0%  |  0.9222 |
+| 18c     ||   17204.0 |   15255.4 |  -11%  ||     1.98 |     2.08 |   +5%  |  0.1226 |
+| 19a     ||   34413.9 |   33169.1 |   -4%  ||     0.82 |     0.90 |  +10%  |  0.6600 |
 | 19b     ||   10529.0 |   11003.4 |   +5%  ||     3.33 |     3.33 |   -0%  |  0.5507 |
 | 19c     ||   34786.4 |   34788.1 |   +0%  ||     0.80 |     0.82 |   +2%  |  0.9995 |
 | 19d     ||   34870.2 |   34978.1 |   +0%  ||     0.83 |     0.87 |   +4%  |  0.9596 |
 | 1a      ||     320.2 |     323.5 |   +1%  ||   153.17 |   150.99 |   -1%  |  0.5083 |
 | 1b      ||      74.2 |      75.0 |   +1%  ||   630.73 |   624.59 |   -1%  |  0.1660 |
 | 1c      ||      77.1 |      77.9 |   +1%  ||   609.10 |   604.21 |   -1%  |  0.2100 |
 | 1d      ||      74.3 |      74.6 |   +0%  ||   630.53 |   627.68 |   -0%  |  0.6086 |
 | 20a     ||    5429.2 |    5535.0 |   +2%  ||     7.97 |     8.10 |   +2%  |  0.7915 |
 | 20b     ||    4298.5 |    4152.4 |   -3%  ||    10.60 |    10.85 |   +2%  |  0.5516 |
 | 20c     ||    4057.1 |    4125.5 |   +2%  ||    11.10 |    11.00 |   -1%  |  0.7872 |
 | 21a     ||   16538.1 |   14729.9 |  -11%  ||     2.18 |     2.20 |   +1%  |  0.1763 |
 | 21b     ||     983.5 |     984.3 |   +0%  ||    49.81 |    49.67 |   -0%  |  0.9801 |
 | 21c     ||   16142.1 |   16885.1 |   +5%  ||     2.10 |     2.17 |   +3%  |  0.5933 |
 | 22a     ||   17214.5 |   18379.0 |   +7%  ||     2.05 |     2.05 |   -0%  |  0.4033 |
 | 22b     ||   18647.5 |   16297.4 |  -13%  ||     2.02 |     2.07 |   +2%  |  0.0885 |
 | 22c     ||   18299.2 |   17210.1 |   -6%  ||     1.95 |     1.97 |   +1%  |  0.4313 |
 | 22d     ||   17404.8 |   16658.0 |   -4%  ||     1.92 |     1.92 |   +0%  |  0.6179 |
 | 23a     ||     441.9 |     446.2 |   +1%  ||   110.59 |   109.66 |   -1%  |  0.6401 |
 | 23b     ||    1030.1 |    1034.8 |   +0%  ||    47.53 |    47.05 |   -1%  |  0.8753 |
 | 23c     ||     514.4 |     521.4 |   +1%  ||    94.96 |    94.21 |   -1%  |  0.5493 |
 | 24a     ||   11233.1 |   12492.7 |  +11%  ||     3.38 |     3.37 |   -0%  |  0.1617 |
 | 24b     ||    9877.5 |   11363.9 |  +15%  ||     3.40 |     3.48 |   +2%  |  0.0780 |
 | 25a     ||    2280.5 |    2390.7 |   +5%  ||    20.12 |    19.93 |   -1%  |  0.3108 |
 | 25b     ||    2969.6 |    2990.9 |   +1%  ||    15.92 |    15.70 |   -1%  |  0.8924 |
+| 25c     ||   16325.3 |   16457.6 |   +1%  ||     1.90 |     2.00 |   +5%  |  0.9243 |
 | 26a     ||    2973.2 |    2996.4 |   +1%  ||    15.55 |    15.95 |   +3%  |  0.8638 |
 | 26b     ||    2892.7 |    2866.9 |   -1%  ||    16.06 |    16.13 |   +0%  |  0.8575 |
 | 26c     ||    2929.1 |    3052.2 |   +4%  ||    15.55 |    15.67 |   +1%  |  0.4075 |
 | 27a     ||   16975.3 |   14486.0 |  -15%  ||     2.18 |     2.13 |   -2%  |  0.0589 |
+| 27b     ||   18582.6 |   15740.4 |  -15%  ||     2.13 |     2.23 |   +5%  |  0.0541 |
 | 27c     ||     943.3 |     950.6 |   +1%  ||    51.59 |    51.66 |   +0%  |  0.7969 |
 | 28a     ||   18111.3 |   19583.0 |   +8%  ||     1.90 |     1.95 |   +3%  |  0.3401 |
 | 28b     ||   16532.7 |   16983.0 |   +3%  ||     2.17 |     2.17 |   -0%  |  0.7141 |
 | 28c     ||   17925.0 |   19946.1 |  +11%  ||     1.87 |     1.93 |   +4%  |  0.1676 |
 | 29a     ||   12446.2 |   11794.8 |   -5%  ||     3.47 |     3.40 |   -2%  |  0.5346 |
 | 29b     ||    2460.2 |    2620.9 |   +7%  ||    18.83 |    18.22 |   -3%  |  0.2120 |
 | 29c     ||   11925.3 |   11066.4 |   -7%  ||     3.30 |     3.23 |   -2%  |  0.3141 |
 | 2a      ||     659.8 |     655.8 |   -1%  ||    74.57 |    74.34 |   -0%  |  0.8185 |
 | 2b      ||     714.9 |     730.0 |   +2%  ||    67.99 |    67.18 |   -1%  |  0.3991 |
 | 2c      ||     569.8 |     574.0 |   +1%  ||    86.08 |    85.38 |   -1%  |  0.7423 |
 | 2d      ||     713.2 |     722.9 |   +1%  ||    68.51 |    67.90 |   -1%  |  0.6103 |
 | 30a     ||    2592.3 |    2614.1 |   +1%  ||    18.22 |    17.77 |   -2%  |  0.8707 |
 | 30b     ||    2906.7 |    2960.5 |   +2%  ||    15.73 |    15.72 |   -0%  |  0.7431 |
 | 30c     ||   17196.6 |   17458.6 |   +2%  ||     1.90 |     1.93 |   +2%  |  0.8508 |
 | 31a     ||    2997.1 |    3249.7 |   +8%  ||    14.13 |    14.30 |   +1%  |  0.2191 |
 | 31b     ||    3327.7 |    3231.8 |   -3%  ||    13.77 |    13.86 |   +1%  |  0.6211 |
 | 31c     ||    2915.5 |    3079.9 |   +6%  ||    15.80 |    15.40 |   -3%  |  0.3487 |
 | 32a     ||     173.1 |     171.4 |   -1%  ||   279.89 |   282.29 |   +1%  |  0.4564 |
 | 32b     ||    1156.3 |    1158.0 |   +0%  ||    42.28 |    42.36 |   +0%  |  0.9590 |
 | 33a     ||     276.3 |     276.9 |   +0%  ||   176.92 |   176.21 |   -0%  |  0.8889 |
 | 33b     ||     272.4 |     275.3 |   +1%  ||   178.89 |   177.44 |   -1%  |  0.4936 |
 | 33c     ||     358.7 |     361.1 |   +1%  ||   136.73 |   135.84 |   -1%  |  0.7150 |
 | 3a      ||   18684.3 |   17137.2 |   -8%  ||     1.95 |     2.00 |   +3%  |  0.2980 |
 | 3b      ||     373.6 |     370.5 |   -1%  ||   131.48 |   132.14 |   +0%  |  0.6051 |
 | 3c      ||   23874.2 |   23721.6 |   -1%  ||     1.35 |     1.37 |   +1%  |  0.9366 |
 | 4a      ||     962.9 |     956.6 |   -1%  ||    51.03 |    51.40 |   +1%  |  0.8253 |
 | 4b      ||     110.0 |     112.0 |   +2%  ||   434.75 |   427.77 |   -2%  |  0.0729 |
 | 4c      ||    1159.2 |    1126.3 |   -3%  ||    41.91 |    42.28 |   +1%  |  0.3550 |
 | 5a      ||   16316.1 |   15706.7 |   -4%  ||     2.22 |     2.22 |   -0%  |  0.6326 |
 | 5b      ||    1450.5 |    1455.6 |   +0%  ||    32.71 |    33.15 |   +1%  |  0.9354 |
+| 5c      ||   21107.5 |   20046.5 |   -5%  ||     1.78 |     1.93 |   +8%  |  0.5105 |
 | 6a      ||    2074.7 |    2152.4 |   +4%  ||    23.08 |    22.38 |   -3%  |  0.4279 |
 | 6b      ||    7524.3 |    7489.4 |   -0%  ||     5.62 |     5.60 |   -0%  |  0.9524 |
 | 6c      ||    2136.9 |    2089.3 |   -2%  ||    22.22 |    22.77 |   +2%  |  0.6176 |
 | 6d      ||    6944.3 |    7819.9 |  +13%  ||     5.53 |     5.62 |   +2%  |  0.0914 |
 | 6e      ||    2106.7 |    2056.2 |   -2%  ||    22.78 |    22.77 |   -0%  |  0.5961 |
 | 6f      ||    6467.6 |    6526.0 |   +1%  ||     6.67 |     6.63 |   -0%  |  0.8811 |
 | 7a      ||    1510.3 |    1526.1 |   +1%  ||    31.99 |    31.53 |   -1%  |  0.7587 |
+| 7b      ||    1759.6 |    1667.1 |   -5%  ||    27.08 |    28.65 |   +6%  |  0.2089 |
 | 7c      ||   53073.7 |   51219.0 |   -3%  ||     0.47 |     0.48 |   +4%  |  0.0352 |
 | 8a      ||    1556.1 |    1549.2 |   -0%  ||    31.01 |    31.41 |   +1%  |  0.9019 |
 | 8b      ||    1532.7 |    1533.8 |   +0%  ||    30.13 |    30.85 |   +2%  |  0.9872 |
 | 8c      ||   18741.4 |   19104.3 |   +2%  ||     1.60 |     1.57 |   -2%  |  0.7983 |
 | 8d      ||    8007.2 |    7963.9 |   -1%  ||     5.38 |     5.40 |   +0%  |  0.9339 |
 | 9a      ||   24436.6 |   22225.9 |   -9%  ||     1.47 |     1.47 |   +0%  |  0.2619 |
 | 9b      ||    3443.6 |    3426.8 |   -0%  ||    13.15 |    13.01 |   -1%  |  0.9336 |
 | 9c      ||   24608.0 |   25527.0 |   +4%  ||     1.37 |     1.35 |   -1%  |  0.6502 |
+| 9d      ||   23761.9 |   21932.5 |   -8%  ||     1.37 |     1.45 |   +6%  |  0.2088 |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
 | Sum     || 1034548.3 | 1010174.3 |   -2%  ||          |          |        |         |
 | Geomean ||           |           |        ||          |          |   +0%  |         |
 +---------++-----------+-----------+--------++----------+----------+--------+---------+
```
</details>