### PR TITLE
Add support for clang-11 and gcc-10

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/google/benchmark.git
 [submodule "third_party/cpp-btree"]
 	path = third_party/cpp-btree
-	url = https://github.com/dmeister/cpp-btree
+	url = https://github.com/mrks/cpp-btree
 [submodule "third_party/cpplint"]
 	path = third_party/cpplint
 	url = https://github.com/cpplint/cpplint.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/google/benchmark.git
 [submodule "third_party/cpp-btree"]
 	path = third_party/cpp-btree
-	url = https://github.com/algorithm-ninja/cpp-btree
+	url = https://github.com/dmeister/cpp-btree
 [submodule "third_party/cpplint"]
 	path = third_party/cpplint
 	url = https://github.com/cpplint/cpplint.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,10 @@ if (${ENABLE_LTO})
         else()
             message(WARNING "LTO not supported: ${ipo_output}")
         endif()
+
+        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0) # TODO change to PCH_INSTANTIATE_TEMPLATES with clang 3.19
+            add_compile_options(-fpch-instantiate-templates -fwhole-program-vtables)
+        endif()
     endif()
 endif()
 
@@ -146,7 +150,7 @@ endif()
 add_subdirectory(third_party/ EXCLUDE_FROM_ALL)
 
 # Some third-party libs don't support LTO (if enabled above):
-foreach(no_lto_target gtest gtest_main gmock gmock_main)
+foreach(no_lto_target gtest gtest_main gmock gmock_main nlohmann_json::nlohmann_json) # TODO properly exclude json
     if(TARGET no_lto_target)
         set_property(TARGET ${no_lto_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,10 +139,6 @@ if (${ENABLE_LTO})
         else()
             message(WARNING "LTO not supported: ${ipo_output}")
         endif()
-
-        if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11.0) # TODO change to PCH_INSTANTIATE_TEMPLATES with clang 3.19
-            add_compile_options(-fpch-instantiate-templates -fwhole-program-vtables)
-        endif()
     endif()
 endif()
 
@@ -150,7 +146,7 @@ endif()
 add_subdirectory(third_party/ EXCLUDE_FROM_ALL)
 
 # Some third-party libs don't support LTO (if enabled above):
-foreach(no_lto_target gtest gtest_main gmock gmock_main nlohmann_json::nlohmann_json) # TODO properly exclude json
+foreach(no_lto_target gtest gtest_main gmock gmock_main)
     if(TARGET no_lto_target)
         set_property(TARGET ${no_lto_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
     endif()

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,7 @@
 
 exitcode=0
 
-find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/utils/boost_curry_override.hpp" -print0 | parallel --null --no-notice -j 100% --nice 17 /usr/bin/env python3 ./third_party/cpplint/cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11,-build/include_what_you_use,-readability/nolint,-whitespace/braces --linelength=120 {} 2\>\&1 \| grep -v \'\^Done processing\' \| grep -v \'\^Total errors found: 0\' \; test \${PIPESTATUS[0]} -eq 0
+find src \( -iname "*.cpp" -o -iname "*.hpp" \) -a -not -path "src/lib/utils/boost_curry_override.hpp" -a -not -path "src/lib/utils/boost_bimap_core_override.hpp" -print0 | parallel --null --no-notice -j 100% --nice 17 /usr/bin/env python3 ./third_party/cpplint/cpplint.py --verbose=0 --extensions=hpp,cpp --counting=detailed --filter=-legal/copyright,-whitespace/newline,-runtime/references,-build/c++11,-build/include_what_you_use,-readability/nolint,-whitespace/braces --linelength=120 {} 2\>\&1 \| grep -v \'\^Done processing\' \| grep -v \'\^Total errors found: 0\' \; test \${PIPESTATUS[0]} -eq 0
 let "exitcode |= $?"
 #                             /------------------ runs in parallel -------------------\
 # Conceptual: find | parallel python cpplint \| grep -v \| test \${PIPESTATUS[0]} -eq 0

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,7 @@ include_directories(
     SYSTEM
     ${TBB_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/third_party/benchmark/include
-    ${PROJECT_SOURCE_DIR}/third_party/cpp-btree
+    ${PROJECT_SOURCE_DIR}/third_party/cpp-btree/include/btree
     ${PROJECT_SOURCE_DIR}/third_party/cxxopts/include
     ${PROJECT_SOURCE_DIR}/third_party/flat_hash_map
     ${PROJECT_SOURCE_DIR}/third_party/json

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,7 +53,7 @@ if (NOT "${HYRISE_RELAXED_BUILD}")
     # -Wno-deprecated-dynamic-exception-spec is needed for jemalloc, at least for the older version that we are using
 
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories)
+        add_compile_options(-Weverything -Wshadow-all -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-documentation -Wno-padded -Wno-global-constructors -Wno-sign-conversion -Wno-exit-time-destructors -Wno-switch-enum -Wno-weak-vtables -Wno-double-promotion -Wno-covered-switch-default -Wno-unused-macros -Wno-newline-eof -Wno-missing-variable-declarations -Wno-weak-template-vtables -Wno-missing-prototypes -Wno-float-equal -Wno-return-std-move-in-c++11 -Wno-unreachable-code-break -Wno-undefined-func-template -Wno-unknown-warning-option -Wno-pass-failed -Wno-ctad-maybe-unsupported -Wno-header-hygiene -Wno-poison-system-directories -Wno-zero-as-null-pointer-constant)
     endif()
 
 else()

--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -29,7 +29,7 @@ class TableWrapper;
 // Defining the base fixture class
 class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
  public:
-  void SetUp(::benchmark::State& state) {
+  void SetUp(::benchmark::State& state) override {
     auto& sm = Hyrise::get().storage_manager;
     const auto scale_factor = 0.01f;
     const auto default_encoding = EncodingType::Dictionary;
@@ -87,7 +87,7 @@ class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
   // Required to avoid resetting of StorageManager in MicroBenchmarkBasicFixture::TearDown()
-  void TearDown(::benchmark::State&) {}
+  void TearDown(::benchmark::State&) override {}
 
   std::map<std::string, std::shared_ptr<TableWrapper>> create_table_wrappers(StorageManager& sm) {
     std::map<std::string, std::shared_ptr<TableWrapper>> wrapper_map;

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -87,7 +87,7 @@ class Console : public Singleton<Console> {
    * Non-public constructor, since Console is a Singleton.
    */
   Console();
-  ~Console();
+  ~Console() override;
 
   friend class Singleton;
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -557,6 +557,7 @@ set(
     utils/abstract_plugin.hpp
     utils/aligned_size.hpp
     utils/assert.hpp
+    utils/boost_bimap_core_override.hpp
     utils/boost_curry_override.hpp
     utils/check_table_equal.cpp
     utils/check_table_equal.hpp

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -35,7 +35,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
 
   explicit GDFSCache(size_t capacity = DEFAULT_CACHE_CAPACITY) : AbstractCache<Key, Value>(capacity), _inflation(0.0) {}
 
-  void set(const Key& key, const Value& value, double cost = 1.0, double size = 1.0) {
+  void set(const Key& key, const Value& value, double cost = 1.0, double size = 1.0) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     if (this->_capacity == 0) return;
     auto it = _map.find(key);
@@ -66,7 +66,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
     _map[key] = handle;
   }
 
-  std::optional<Value> try_get(const Key& query) {
+  std::optional<Value> try_get(const Key& query) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     auto it = _map.find(query);
     if (it == _map.end()) return std::nullopt;
@@ -79,23 +79,23 @@ class GDFSCache : public AbstractCache<Key, Value> {
     return entry.value;
   }
 
-  bool has(const Key& key) const {
+  bool has(const Key& key) const final {
     std::shared_lock<std::shared_mutex> lock(_mutex);
     return _map.contains(key);
   }
 
-  size_t size() const {
+  size_t size() const final {
     std::shared_lock<std::shared_mutex> lock(_mutex);
     return _map.size();
   }
 
-  void clear() {
+  void clear() final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     _map.clear();
     _queue.clear();
   }
 
-  void resize(size_t capacity) {
+  void resize(size_t capacity) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     while (_queue.size() > capacity) {
       _evict();
@@ -103,7 +103,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
     this->_capacity = capacity;
   }
 
-  std::unordered_map<Key, SnapshotEntry> snapshot() const {
+  std::unordered_map<Key, SnapshotEntry> snapshot() const final {
     std::shared_lock<std::shared_mutex> lock(_mutex);
     std::unordered_map<Key, SnapshotEntry> map_copy(_map.size());
     for (const auto& [key, entry] : _map) {
@@ -133,7 +133,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
   // Inflation value that will be updated whenever an item is evicted.
   double _inflation;
 
-  void _evict() {
+  void _evict() final {
     auto top = _queue.top();
 
     _inflation = top.priority;

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -1,10 +1,5 @@
 #include "constant_mappings.hpp"
 
-// TODO clang10:
-// - Test LTO
-// - Test Flags from Blog Article
-// - Remove boost hack
-
 #include <unordered_map>
 
 #include <boost/bimap.hpp>

--- a/src/lib/constant_mappings.cpp
+++ b/src/lib/constant_mappings.cpp
@@ -1,5 +1,10 @@
 #include "constant_mappings.hpp"
 
+// TODO clang10:
+// - Test LTO
+// - Test Flags from Blog Article
+// - Remove boost hack
+
 #include <unordered_map>
 
 #include <boost/bimap.hpp>

--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -61,11 +61,7 @@ class AbstractJoinOperator : public AbstractReadOnlyOperator {
   // Some operators need an internal implementation class, mostly in cases where
   // their execute method depends on a template parameter. An example for this is
   // found in join_hash.hpp.
-  class AbstractJoinOperatorImpl : public AbstractReadOnlyOperatorImpl {
-   public:
-    virtual ~AbstractJoinOperatorImpl() = default;
-    virtual std::shared_ptr<const Table> _on_execute() = 0;
-  };
+  class AbstractJoinOperatorImpl : public AbstractReadOnlyOperatorImpl {};  // TODO remove this?
 };
 
 }  // namespace opossum

--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -57,7 +57,6 @@ class AbstractJoinOperator : public AbstractReadOnlyOperator {
 
   std::shared_ptr<Table> _build_output_table(std::vector<std::shared_ptr<Chunk>>&& chunks,
                                              const TableType table_type = TableType::References) const;
-
 };
 
 }  // namespace opossum

--- a/src/lib/operators/abstract_join_operator.hpp
+++ b/src/lib/operators/abstract_join_operator.hpp
@@ -58,10 +58,6 @@ class AbstractJoinOperator : public AbstractReadOnlyOperator {
   std::shared_ptr<Table> _build_output_table(std::vector<std::shared_ptr<Chunk>>&& chunks,
                                              const TableType table_type = TableType::References) const;
 
-  // Some operators need an internal implementation class, mostly in cases where
-  // their execute method depends on a template parameter. An example for this is
-  // found in join_hash.hpp.
-  class AbstractJoinOperatorImpl : public AbstractReadOnlyOperatorImpl {};  // TODO remove this?
 };
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -220,7 +220,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
 void JoinHash::_on_cleanup() { _impl.reset(); }
 
 template <typename BuildColumnType, typename ProbeColumnType>
-class JoinHash::JoinHashImpl : public AbstractJoinOperatorImpl {
+class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
  public:
   JoinHashImpl(const JoinHash& join_hash, const std::shared_ptr<const Table>& build_input_table,
                const std::shared_ptr<const Table>& probe_input_table, const JoinMode mode,

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -42,7 +42,7 @@ class JoinIndex : public AbstractJoinOperator {
   enum class OperatorSteps : uint8_t { IndexJoining, NestedLoopJoining, OutputWriting };
 
   struct PerformanceData : public OperatorPerformanceData<OperatorSteps> {
-    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const;
+    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override;
 
     size_t chunks_scanned_with_index{0};
     size_t chunks_scanned_without_index{0};

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -88,7 +88,7 @@ const std::string& JoinSortMerge::name() const {
 ** Start of implementation.
 **/
 template <typename T>
-class JoinSortMerge::JoinSortMergeImpl : public AbstractJoinOperatorImpl {
+class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
  public:
   JoinSortMergeImpl<T>(JoinSortMerge& sort_merge_join, ColumnID left_column_id, ColumnID right_column_id,
                        const PredicateCondition op, JoinMode mode,

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -46,7 +46,7 @@ class JoinSortMerge : public AbstractJoinOperator {
   template <typename T>
   friend class JoinSortMergeImpl;
 
-  std::unique_ptr<AbstractJoinOperatorImpl> _impl;
+  std::unique_ptr<AbstractReadOnlyOperatorImpl> _impl;
 };
 
 }  // namespace opossum

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -39,7 +39,7 @@ struct AbstractOperatorPerformanceData : public Noncopyable {
  */
 template <typename Steps>
 struct OperatorPerformanceData : public AbstractOperatorPerformanceData {
-  void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
+  void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
     if (!executed) {
       stream << "Not executed.";
       return;

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -52,7 +52,7 @@ class TableScan : public AbstractReadOnlyOperator {
     size_t chunk_scans_skipped{0};
     size_t chunk_scans_sorted{0};
 
-    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
+    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
       if (chunk_scans_skipped == 0 && chunk_scans_sorted == 0) {
         return;
       }

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -47,8 +47,6 @@ class AdaptiveRadixTreeIndex : public AbstractIndex {
 
   AdaptiveRadixTreeIndex(AdaptiveRadixTreeIndex&&) = default;
 
-  virtual ~AdaptiveRadixTreeIndex() = default;
-
   /**
    *All keys in the ART have to be binary comparable in the sense that if the most significant differing bit between
    *BinaryComparable a and BinaryComparable b is greater for a <=> a > b.
@@ -83,7 +81,7 @@ class AdaptiveRadixTreeIndex : public AbstractIndex {
   std::shared_ptr<ARTNode> _bulk_insert(const std::vector<std::pair<BinaryComparable, ChunkOffset>>& values,
                                         size_t depth, Iterator& it);
 
-  std::vector<std::shared_ptr<const AbstractSegment>> _get_indexed_segments() const;
+  std::vector<std::shared_ptr<const AbstractSegment>> _get_indexed_segments() const final;
 
   size_t _memory_consumption() const final;
 

--- a/src/lib/storage/index/group_key/composite_group_key_index.hpp
+++ b/src/lib/storage/index/group_key/composite_group_key_index.hpp
@@ -51,7 +51,6 @@ class CompositeGroupKeyIndex : public AbstractIndex {
   static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
 
   CompositeGroupKeyIndex(CompositeGroupKeyIndex&&) = default;
-  ~CompositeGroupKeyIndex() = default;
 
   explicit CompositeGroupKeyIndex(const std::vector<std::shared_ptr<const AbstractSegment>>& segments_to_index);
 

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -85,7 +85,7 @@ class GroupKeyIndex : public AbstractIndex {
    */
   Iterator _get_positions_iterator_at(ValueID value_id) const;
 
-  std::vector<std::shared_ptr<const AbstractSegment>> _get_indexed_segments() const;
+  std::vector<std::shared_ptr<const AbstractSegment>> _get_indexed_segments() const override;
 
   size_t _memory_consumption() const final;
 

--- a/src/lib/storage/segment_iterables/segment_positions.hpp
+++ b/src/lib/storage/segment_iterables/segment_positions.hpp
@@ -53,9 +53,9 @@ class SegmentPosition final : public AbstractSegmentPosition<T> {
   SegmentPosition(const T& value, const bool null_value, const ChunkOffset& chunk_offset)
       : _value{value}, _null_value{null_value}, _chunk_offset{chunk_offset} {}
 
-  const T& value() const { return _value; }
-  bool is_null() const { return _null_value; }
-  ChunkOffset chunk_offset() const { return _chunk_offset; }
+  const T& value() const override { return _value; }
+  bool is_null() const override { return _null_value; }
+  ChunkOffset chunk_offset() const override { return _chunk_offset; }
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization
@@ -77,9 +77,9 @@ class NonNullSegmentPosition final : public AbstractSegmentPosition<T> {
   NonNullSegmentPosition(const T& value, const ChunkOffset& chunk_offset)
       : _value{value}, _chunk_offset{chunk_offset} {}
 
-  const T& value() const { return _value; }
-  bool is_null() const { return false; }
-  ChunkOffset chunk_offset() const { return _chunk_offset; }
+  const T& value() const override { return _value; }
+  bool is_null() const override { return false; }
+  ChunkOffset chunk_offset() const override { return _chunk_offset; }
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization
@@ -101,9 +101,9 @@ class IsNullSegmentPosition final : public AbstractSegmentPosition<boost::blank>
   IsNullSegmentPosition(const bool null_value, const ChunkOffset& chunk_offset)
       : _null_value{null_value}, _chunk_offset{chunk_offset} {}
 
-  const boost::blank& value() const { return _blank; }
-  bool is_null() const { return _null_value; }
-  ChunkOffset chunk_offset() const { return _chunk_offset; }
+  const boost::blank& value() const override { return _blank; }
+  bool is_null() const override { return _null_value; }
+  ChunkOffset chunk_offset() const override { return _chunk_offset; }
 
  private:
   // The alignment improves the suitability of the iterator for (auto-)vectorization

--- a/src/lib/storage/table_key_constraint.cpp
+++ b/src/lib/storage/table_key_constraint.cpp
@@ -8,8 +8,6 @@ TableKeyConstraint::TableKeyConstraint(std::unordered_set<ColumnID> init_columns
 KeyConstraintType TableKeyConstraint::key_type() const { return _key_type; }
 
 bool TableKeyConstraint::_on_equals(const AbstractTableConstraint& table_constraint) const {
-  DebugAssert(dynamic_cast<const AbstractTableConstraint*>(&table_constraint),
-              "Different table_constraint type should have been caught by AbstractTableConstraint::operator==");
   return key_type() == static_cast<const TableKeyConstraint&>(table_constraint).key_type();
 }
 

--- a/src/lib/storage/table_key_constraint.cpp
+++ b/src/lib/storage/table_key_constraint.cpp
@@ -8,6 +8,8 @@ TableKeyConstraint::TableKeyConstraint(std::unordered_set<ColumnID> init_columns
 KeyConstraintType TableKeyConstraint::key_type() const { return _key_type; }
 
 bool TableKeyConstraint::_on_equals(const AbstractTableConstraint& table_constraint) const {
+  DebugAssert(dynamic_cast<const TableKeyConstraint*>(&table_constraint),
+              "Different table_constraint type should have been caught by AbstractTableConstraint::operator==");
   return key_type() == static_cast<const TableKeyConstraint&>(table_constraint).key_type();
 }
 

--- a/src/lib/storage/vector_compression/fixed_size_byte_aligned/fixed_size_byte_aligned_vector.hpp
+++ b/src/lib/storage/vector_compression/fixed_size_byte_aligned/fixed_size_byte_aligned_vector.hpp
@@ -26,7 +26,6 @@ class FixedSizeByteAlignedVector : public CompressedVector<FixedSizeByteAlignedV
 
  public:
   explicit FixedSizeByteAlignedVector(pmr_vector<UnsignedIntType> data) : _data{std::move(data)} {}
-  ~FixedSizeByteAlignedVector() = default;
 
   const pmr_vector<UnsignedIntType>& data() const { return _data; }
 

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_decompressor.hpp
@@ -35,7 +35,7 @@ class SimdBp128Decompressor : public BaseVectorDecompressor {
   SimdBp128Decompressor& operator=(const SimdBp128Decompressor& other);
   SimdBp128Decompressor& operator=(SimdBp128Decompressor&& other) noexcept;
 
-  ~SimdBp128Decompressor() = default;
+  ~SimdBp128Decompressor() override = default;
 
   uint32_t get(const size_t i) final {
     if (_is_index_within_cached_block(i)) {

--- a/src/lib/storage/vector_compression/simd_bp128/simd_bp128_vector.hpp
+++ b/src/lib/storage/vector_compression/simd_bp128/simd_bp128_vector.hpp
@@ -24,7 +24,7 @@ namespace opossum {
 class SimdBp128Vector : public CompressedVector<SimdBp128Vector> {
  public:
   explicit SimdBp128Vector(pmr_vector<uint128_t> vector, size_t size);
-  ~SimdBp128Vector() = default;
+  ~SimdBp128Vector() override = default;
 
   const pmr_vector<uint128_t>& data() const;
 

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -10,6 +10,11 @@
 #include <tuple>
 #include <vector>
 
+#include <boost/version.hpp>
+#if BOOST_VERSION < 107400                      // TODO(anyone): remove this block once Ubuntu ships boost 1.74
+#include "utils/boost_bimap_core_override.hpp"  // NOLINT
+#endif
+
 #include <boost/bimap.hpp>
 #include <boost/circular_buffer.hpp>
 #include <boost/container/pmr/polymorphic_allocator.hpp>

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -110,7 +110,7 @@ struct RowID {
 
   // Joins need to use RowIDs as keys for maps.
   bool operator<(const RowID& other) const {
-    return std::tie(chunk_id, chunk_offset) < std::tie(other.chunk_id, other.chunk_offset);
+    return chunk_id < other.chunk_id || (chunk_id == other.chunk_id && chunk_offset < other.chunk_offset);
   }
 
   // Useful when comparing a row ID to NULL_ROW_ID

--- a/src/lib/types.hpp
+++ b/src/lib/types.hpp
@@ -110,7 +110,7 @@ struct RowID {
 
   // Joins need to use RowIDs as keys for maps.
   bool operator<(const RowID& other) const {
-    return chunk_id < other.chunk_id || (chunk_id == other.chunk_id && chunk_offset < other.chunk_offset);
+    return std::tie(chunk_id, chunk_offset) < std::tie(other.chunk_id, other.chunk_offset);
   }
 
   // Useful when comparing a row ID to NULL_ROW_ID

--- a/src/lib/utils/boost_bimap_core_override.hpp
+++ b/src/lib/utils/boost_bimap_core_override.hpp
@@ -1,3 +1,6 @@
+// Backport for the fix of https://github.com/boostorg/bimap/issues/23
+// Remove this once Ubuntu finally has boost 1.74
+
 // Boost.Bimap
 //
 // Copyright (c) 2006-2007 Matias Capeletto

--- a/src/lib/utils/boost_bimap_core_override.hpp
+++ b/src/lib/utils/boost_bimap_core_override.hpp
@@ -1,0 +1,480 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/bimap_core.hpp
+/// \brief Bimap base definition.
+
+#ifndef BOOST_BIMAP_DETAIL_BIMAP_CORE_HPP
+#define BOOST_BIMAP_DETAIL_BIMAP_CORE_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/mpl/placeholders.hpp>
+#include <boost/mpl/push_front.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/mpl/vector.hpp>
+
+#include <boost/type_traits/add_const.hpp>
+#include <boost/type_traits/is_same.hpp>
+
+#include <boost/concept_check.hpp>
+#include <boost/container/allocator_traits.hpp>
+
+// Boost.MultiIndex
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/member.hpp>
+
+// Boost.Bimap
+#include <boost/bimap/relation/mutant_relation.hpp>
+#include <boost/bimap/relation/member_at.hpp>
+#include <boost/bimap/relation/support/data_extractor.hpp>
+#include <boost/bimap/tags/support/default_tagged.hpp>
+#include <boost/bimap/tags/tagged.hpp>
+#include <boost/bimap/detail/manage_bimap_key.hpp>
+#include <boost/bimap/detail/manage_additional_parameters.hpp>
+#include <boost/bimap/detail/map_view_iterator.hpp>
+#include <boost/bimap/detail/set_view_iterator.hpp>
+
+#include <boost/bimap/set_of.hpp>
+#include <boost/bimap/unconstrained_set_of.hpp>
+
+namespace boost {
+namespace bimaps {
+
+/// \brief Library details
+
+namespace detail {
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+template< class Type >
+struct get_value_type
+{
+    typedef BOOST_DEDUCED_TYPENAME Type::value_type type;
+};
+
+struct independent_index_tag {};
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+
+/// \brief Base for the bimap class.
+/**
+
+
+See also bimap.
+                                                                        **/
+
+
+template< class LeftSetType, class RightSetType, class AP1, class AP2, class AP3 >
+class bimap_core
+{
+    // Manage bimap key instantiation
+    // --------------------------------------------------------------------
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME manage_bimap_key
+    <
+        LeftSetType
+
+    >::type left_set_type;
+
+    typedef BOOST_DEDUCED_TYPENAME manage_bimap_key
+    <
+        RightSetType
+
+    >::type right_set_type;
+
+
+    private:
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::default_tagged
+    <
+        BOOST_DEDUCED_TYPENAME left_set_type::user_type,
+        ::boost::bimaps::relation::member_at::left
+
+    >::type left_tagged_type;
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::default_tagged
+    <
+        BOOST_DEDUCED_TYPENAME right_set_type::user_type,
+        ::boost::bimaps::relation::member_at::right
+
+    >::type right_tagged_type;
+
+    public:
+
+    //@{
+
+        typedef BOOST_DEDUCED_TYPENAME  left_tagged_type::tag  left_tag;
+        typedef BOOST_DEDUCED_TYPENAME right_tagged_type::tag right_tag;
+
+    //@}
+
+    //@{
+
+        typedef BOOST_DEDUCED_TYPENAME  left_set_type::value_type  left_key_type;
+        typedef BOOST_DEDUCED_TYPENAME right_set_type::value_type right_key_type;
+
+    //@}
+
+    //@{
+
+        typedef right_key_type  left_data_type;
+        typedef  left_key_type right_data_type;
+
+    //@}
+
+    // Manage the additional parameters
+    // --------------------------------------------------------------------
+    private:
+
+    typedef BOOST_DEDUCED_TYPENAME manage_additional_parameters<AP1,AP2,AP3>::type parameters;
+
+    /// \brief Relation type stored by the bimap.
+    // --------------------------------------------------------------------
+    public:
+
+    typedef ::boost::bimaps::relation::mutant_relation
+    <
+
+        ::boost::bimaps::tags::tagged<
+            BOOST_DEDUCED_TYPENAME mpl::if_<
+                mpl::and_
+                <
+                    BOOST_DEDUCED_TYPENAME left_set_type::mutable_key,
+                    BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::left_mutable_key
+                >,
+            // {
+                    left_key_type,
+            // }
+            // else
+            // {
+                    BOOST_DEDUCED_TYPENAME ::boost::add_const< left_key_type >::type
+            // }
+
+            >::type,
+            left_tag
+        >,
+
+        ::boost::bimaps::tags::tagged<
+            BOOST_DEDUCED_TYPENAME mpl::if_<
+                mpl::and_
+                <
+                    BOOST_DEDUCED_TYPENAME right_set_type::mutable_key,
+                    BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::right_mutable_key
+                >,
+            // {
+                    right_key_type,
+            // }
+            // else
+            // {
+                    BOOST_DEDUCED_TYPENAME ::boost::add_const< right_key_type >::type
+            // }
+
+            >::type,
+            right_tag
+        >,
+
+        // It is ::boost::mpl::na if no info_hook was included
+        BOOST_DEDUCED_TYPENAME parameters::additional_info,
+
+        // Force mutable keys
+        true
+
+    > relation;
+
+    //@{
+
+        typedef BOOST_DEDUCED_TYPENAME relation::left_pair  left_value_type;
+        typedef BOOST_DEDUCED_TYPENAME relation::right_pair right_value_type;
+
+    //@}
+
+    // Bind the member of the relation, so multi_index can manage them
+    // --------------------------------------------------------------------
+    private:
+
+    typedef BOOST_DEDUCED_TYPENAME relation::storage_base relation_storage_base;
+
+    typedef BOOST_MULTI_INDEX_MEMBER(relation_storage_base, left_key_type, left)
+        left_member_extractor;
+
+    typedef BOOST_MULTI_INDEX_MEMBER(relation_storage_base,right_key_type,right)
+        right_member_extractor;
+
+    // The core indices are somewhat complicated to calculate, because they
+    // can be zero, one, two or three indices, depending on the use of
+    // {side}_based set type of relations and unconstrained_set_of and
+    // unconstrained_set_of_relation specifications.
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        ::boost::bimaps::detail::is_unconstrained_set_of< left_set_type >,
+    // {
+            mpl::vector<>,
+    // }
+    // else
+    // {
+            mpl::vector
+            <
+                BOOST_DEDUCED_TYPENAME left_set_type::
+                BOOST_NESTED_TEMPLATE index_bind
+                <
+                    left_member_extractor,
+                    left_tag
+
+                >::type
+            >
+    // }
+    >::type left_core_indices;
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        ::boost::bimaps::detail::is_unconstrained_set_of< right_set_type >,
+    // {
+            left_core_indices,
+    // }
+    // else
+    // {
+            BOOST_DEDUCED_TYPENAME mpl::push_front
+            <
+                left_core_indices,
+
+                BOOST_DEDUCED_TYPENAME right_set_type::
+                BOOST_NESTED_TEMPLATE index_bind
+                <
+                    right_member_extractor,
+                    right_tag
+
+                >::type
+
+            >::type
+    // }
+    >::type basic_core_indices;
+
+    // If it is based either on the left or on the right, then only the side
+    // indices are needed. But the set type of the relation can be completely
+    // diferent from the one used for the sides in wich case we have to add yet
+    // another index to the core.
+
+    // TODO
+    // If all the set types are unsconstrained there must be readable compile
+    // time error.
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+
+        is_same< BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, left_based >,
+    // {
+            ::boost::bimaps::tags::tagged< left_set_type, left_tag >,
+    // }
+    /* else */ BOOST_DEDUCED_TYPENAME mpl::if_<
+            is_same< BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, right_based >,
+    // {
+            ::boost::bimaps::tags::tagged< right_set_type, right_tag >,
+    // }
+    // else
+    // {
+            tags::tagged
+            <
+                BOOST_DEDUCED_TYPENAME parameters::
+                set_type_of_relation::BOOST_NESTED_TEMPLATE bind_to
+                <
+                    relation
+
+                >::type,
+                independent_index_tag
+            >
+    // }
+    >::type
+    >::type tagged_set_of_relation_type;
+
+    protected:
+
+    typedef BOOST_DEDUCED_TYPENAME tagged_set_of_relation_type::tag
+                        relation_set_tag;
+
+    typedef BOOST_DEDUCED_TYPENAME tagged_set_of_relation_type::value_type
+                        relation_set_type_of;
+
+    // Logic tags
+    // This is a necesary extra level of indirection to allow unconstrained
+    // sets to be plug in the design. The bimap constructors use this logic
+    // tags.
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        ::boost::bimaps::detail::is_unconstrained_set_of< left_set_type >,
+
+        BOOST_DEDUCED_TYPENAME mpl::if_<
+            ::boost::bimaps::detail::is_unconstrained_set_of< right_set_type >,
+
+            independent_index_tag,
+            right_tag
+
+        >::type,
+
+        left_tag
+
+    >::type logic_left_tag;
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        ::boost::bimaps::detail::is_unconstrained_set_of< right_set_type >,
+
+        BOOST_DEDUCED_TYPENAME mpl::if_< 
+            ::boost::bimaps::detail::is_unconstrained_set_of< left_set_type >,
+
+            independent_index_tag,
+            left_tag
+
+        >::type,
+
+        right_tag
+
+    >::type logic_right_tag;
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_< 
+        is_same< relation_set_tag, independent_index_tag >,
+
+        BOOST_DEDUCED_TYPENAME mpl::if_< 
+            ::boost::bimaps::detail::
+                is_unconstrained_set_of< relation_set_type_of >,
+
+            logic_left_tag,
+            independent_index_tag
+
+        >::type,
+
+        BOOST_DEDUCED_TYPENAME mpl::if_<
+            is_same< BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, left_based >,
+
+            logic_left_tag,
+            logic_right_tag
+
+        >::type
+
+    >::type logic_relation_set_tag;
+
+    private:
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        mpl::and_< is_same< relation_set_tag, independent_index_tag >,
+                   mpl::not_<
+                       ::boost::bimaps::detail::
+                            is_unconstrained_set_of< relation_set_type_of > 
+                   >
+        >,
+    // {
+            BOOST_DEDUCED_TYPENAME mpl::push_front
+            <
+                basic_core_indices,
+
+                BOOST_DEDUCED_TYPENAME relation_set_type_of::
+                BOOST_NESTED_TEMPLATE index_bind
+                <
+                    ::boost::bimaps::relation::support::both_keys_extractor<relation>,
+                    independent_index_tag
+
+                >::type
+
+            >::type,
+    // }
+    // else
+    // {
+            basic_core_indices
+    // }
+
+    >::type complete_core_indices;
+
+    struct core_indices : public complete_core_indices {};
+
+    // Define the core using compute_index_type to translate the
+    // set type to an multi-index specification
+    // --------------------------------------------------------------------
+    public:
+
+    typedef multi_index::multi_index_container
+    <
+        relation,
+        core_indices,
+        BOOST_DEDUCED_TYPENAME ::boost::container::allocator_traits
+        <
+            BOOST_DEDUCED_TYPENAME parameters::allocator
+        >::
+            BOOST_NESTED_TEMPLATE portable_rebind_alloc<relation>::type
+    > core_type;
+
+    // Core metadata
+    // --------------------------------------------------------------------
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::
+        index<core_type, logic_left_tag>::type  left_index;
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::
+        index<core_type,logic_right_tag>::type right_index;
+
+    typedef BOOST_DEDUCED_TYPENAME  left_index::iterator        left_core_iterator;
+    typedef BOOST_DEDUCED_TYPENAME  left_index::const_iterator  left_core_const_iterator;
+
+    typedef BOOST_DEDUCED_TYPENAME right_index::iterator       right_core_iterator;
+    typedef BOOST_DEDUCED_TYPENAME right_index::const_iterator right_core_const_iterator;
+
+    // Relation set view
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::index
+    <
+        core_type, logic_relation_set_tag
+
+    >::type relation_set_core_index;
+
+    typedef BOOST_DEDUCED_TYPENAME relation_set_type_of::
+    BOOST_NESTED_TEMPLATE set_view_bind
+    <
+        relation_set_core_index
+
+    >::type relation_set;
+
+    public:
+
+    typedef bimap_core bimap_core_;
+};
+
+// Two auxiliar metafunctions to compute the map view types
+// The map view type can not be computed inside the bimap core because a 
+// they need the bimap core to be parsed first.
+
+template< class BimapBaseType >
+struct left_map_view_type
+{
+    typedef BOOST_DEDUCED_TYPENAME BimapBaseType::left_set_type left_set_type;
+    typedef BOOST_DEDUCED_TYPENAME
+        left_set_type::BOOST_NESTED_TEMPLATE map_view_bind<
+            BOOST_DEDUCED_TYPENAME BimapBaseType::left_tag, BimapBaseType
+        >::type type;
+};
+
+template< class BimapBaseType >
+struct right_map_view_type
+{
+    typedef BOOST_DEDUCED_TYPENAME BimapBaseType::right_set_type right_set_type;
+    typedef BOOST_DEDUCED_TYPENAME
+        right_set_type::BOOST_NESTED_TEMPLATE map_view_bind<
+            BOOST_DEDUCED_TYPENAME BimapBaseType::right_tag, BimapBaseType
+        >::type type;
+};
+
+
+} // namespace detail
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_DETAIL_BIMAP_CORE_HPP

--- a/src/lib/utils/boost_bimap_core_override.hpp
+++ b/src/lib/utils/boost_bimap_core_override.hpp
@@ -21,11 +21,11 @@
 
 #include <boost/config.hpp>
 
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/not.hpp>
 #include <boost/mpl/placeholders.hpp>
 #include <boost/mpl/push_front.hpp>
-#include <boost/mpl/if.hpp>
-#include <boost/mpl/and.hpp>
-#include <boost/mpl/not.hpp>
 #include <boost/mpl/vector.hpp>
 
 #include <boost/type_traits/add_const.hpp>
@@ -35,19 +35,19 @@
 #include <boost/container/allocator_traits.hpp>
 
 // Boost.MultiIndex
-#include <boost/multi_index_container.hpp>
 #include <boost/multi_index/member.hpp>
+#include <boost/multi_index_container.hpp>
 
 // Boost.Bimap
-#include <boost/bimap/relation/mutant_relation.hpp>
+#include <boost/bimap/detail/manage_additional_parameters.hpp>
+#include <boost/bimap/detail/manage_bimap_key.hpp>
+#include <boost/bimap/detail/map_view_iterator.hpp>
+#include <boost/bimap/detail/set_view_iterator.hpp>
 #include <boost/bimap/relation/member_at.hpp>
+#include <boost/bimap/relation/mutant_relation.hpp>
 #include <boost/bimap/relation/support/data_extractor.hpp>
 #include <boost/bimap/tags/support/default_tagged.hpp>
 #include <boost/bimap/tags/tagged.hpp>
-#include <boost/bimap/detail/manage_bimap_key.hpp>
-#include <boost/bimap/detail/manage_additional_parameters.hpp>
-#include <boost/bimap/detail/map_view_iterator.hpp>
-#include <boost/bimap/detail/set_view_iterator.hpp>
 
 #include <boost/bimap/set_of.hpp>
 #include <boost/bimap/unconstrained_set_of.hpp>
@@ -61,16 +61,14 @@ namespace detail {
 
 #ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
 
-template< class Type >
-struct get_value_type
-{
-    typedef BOOST_DEDUCED_TYPENAME Type::value_type type;
+template <class Type>
+struct get_value_type {
+  typedef BOOST_DEDUCED_TYPENAME Type::value_type type;
 };
 
 struct independent_index_tag {};
 
-#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
-
+#endif  // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
 
 /// \brief Base for the bimap class.
 /**
@@ -79,405 +77,317 @@ struct independent_index_tag {};
 See also bimap.
                                                                         **/
 
+template <class LeftSetType, class RightSetType, class AP1, class AP2, class AP3>
+class bimap_core {
+  // Manage bimap key instantiation
+  // --------------------------------------------------------------------
+ public:
+  typedef BOOST_DEDUCED_TYPENAME manage_bimap_key<LeftSetType
 
-template< class LeftSetType, class RightSetType, class AP1, class AP2, class AP3 >
-class bimap_core
-{
-    // Manage bimap key instantiation
-    // --------------------------------------------------------------------
-    public:
+                                                  >::type left_set_type;
 
-    typedef BOOST_DEDUCED_TYPENAME manage_bimap_key
-    <
-        LeftSetType
+  typedef BOOST_DEDUCED_TYPENAME manage_bimap_key<RightSetType
 
-    >::type left_set_type;
+                                                  >::type right_set_type;
 
-    typedef BOOST_DEDUCED_TYPENAME manage_bimap_key
-    <
-        RightSetType
+ private:
+  typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::default_tagged<
+      BOOST_DEDUCED_TYPENAME left_set_type::user_type, ::boost::bimaps::relation::member_at::left
 
-    >::type right_set_type;
+      >::type left_tagged_type;
 
+  typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::default_tagged<
+      BOOST_DEDUCED_TYPENAME right_set_type::user_type, ::boost::bimaps::relation::member_at::right
 
-    private:
+      >::type right_tagged_type;
 
-    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::default_tagged
-    <
-        BOOST_DEDUCED_TYPENAME left_set_type::user_type,
-        ::boost::bimaps::relation::member_at::left
+ public:
+  //@{
 
-    >::type left_tagged_type;
+  typedef BOOST_DEDUCED_TYPENAME left_tagged_type::tag left_tag;
+  typedef BOOST_DEDUCED_TYPENAME right_tagged_type::tag right_tag;
 
-    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::default_tagged
-    <
-        BOOST_DEDUCED_TYPENAME right_set_type::user_type,
-        ::boost::bimaps::relation::member_at::right
+  //@}
 
-    >::type right_tagged_type;
+  //@{
 
-    public:
+  typedef BOOST_DEDUCED_TYPENAME left_set_type::value_type left_key_type;
+  typedef BOOST_DEDUCED_TYPENAME right_set_type::value_type right_key_type;
 
-    //@{
+  //@}
 
-        typedef BOOST_DEDUCED_TYPENAME  left_tagged_type::tag  left_tag;
-        typedef BOOST_DEDUCED_TYPENAME right_tagged_type::tag right_tag;
+  //@{
 
-    //@}
+  typedef right_key_type left_data_type;
+  typedef left_key_type right_data_type;
 
-    //@{
+  //@}
 
-        typedef BOOST_DEDUCED_TYPENAME  left_set_type::value_type  left_key_type;
-        typedef BOOST_DEDUCED_TYPENAME right_set_type::value_type right_key_type;
+  // Manage the additional parameters
+  // --------------------------------------------------------------------
+ private:
+  typedef BOOST_DEDUCED_TYPENAME manage_additional_parameters<AP1, AP2, AP3>::type parameters;
 
-    //@}
+  /// \brief Relation type stored by the bimap.
+  // --------------------------------------------------------------------
+ public:
+  typedef ::boost::bimaps::relation::mutant_relation<
 
-    //@{
+      ::boost::bimaps::tags::tagged<
+          BOOST_DEDUCED_TYPENAME
+              mpl::if_<mpl::and_<BOOST_DEDUCED_TYPENAME left_set_type::mutable_key,
+                                 BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::left_mutable_key>,
+                       // {
+                       left_key_type,
+                       // }
+                       // else
+                       // {
+                       BOOST_DEDUCED_TYPENAME ::boost::add_const<left_key_type>::type
+                       // }
 
-        typedef right_key_type  left_data_type;
-        typedef  left_key_type right_data_type;
+                       >::type,
+          left_tag>,
 
-    //@}
+      ::boost::bimaps::tags::tagged<
+          BOOST_DEDUCED_TYPENAME
+              mpl::if_<mpl::and_<BOOST_DEDUCED_TYPENAME right_set_type::mutable_key,
+                                 BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::right_mutable_key>,
+                       // {
+                       right_key_type,
+                       // }
+                       // else
+                       // {
+                       BOOST_DEDUCED_TYPENAME ::boost::add_const<right_key_type>::type
+                       // }
 
-    // Manage the additional parameters
-    // --------------------------------------------------------------------
-    private:
+                       >::type,
+          right_tag>,
 
-    typedef BOOST_DEDUCED_TYPENAME manage_additional_parameters<AP1,AP2,AP3>::type parameters;
+      // It is ::boost::mpl::na if no info_hook was included
+      BOOST_DEDUCED_TYPENAME parameters::additional_info,
 
-    /// \brief Relation type stored by the bimap.
-    // --------------------------------------------------------------------
-    public:
+      // Force mutable keys
+      true
 
-    typedef ::boost::bimaps::relation::mutant_relation
-    <
+      >
+      relation;
 
-        ::boost::bimaps::tags::tagged<
-            BOOST_DEDUCED_TYPENAME mpl::if_<
-                mpl::and_
-                <
-                    BOOST_DEDUCED_TYPENAME left_set_type::mutable_key,
-                    BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::left_mutable_key
-                >,
-            // {
-                    left_key_type,
-            // }
-            // else
-            // {
-                    BOOST_DEDUCED_TYPENAME ::boost::add_const< left_key_type >::type
-            // }
+  //@{
 
-            >::type,
-            left_tag
-        >,
+  typedef BOOST_DEDUCED_TYPENAME relation::left_pair left_value_type;
+  typedef BOOST_DEDUCED_TYPENAME relation::right_pair right_value_type;
 
-        ::boost::bimaps::tags::tagged<
-            BOOST_DEDUCED_TYPENAME mpl::if_<
-                mpl::and_
-                <
-                    BOOST_DEDUCED_TYPENAME right_set_type::mutable_key,
-                    BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::right_mutable_key
-                >,
-            // {
-                    right_key_type,
-            // }
-            // else
-            // {
-                    BOOST_DEDUCED_TYPENAME ::boost::add_const< right_key_type >::type
-            // }
+  //@}
 
-            >::type,
-            right_tag
-        >,
+  // Bind the member of the relation, so multi_index can manage them
+  // --------------------------------------------------------------------
+ private:
+  typedef BOOST_DEDUCED_TYPENAME relation::storage_base relation_storage_base;
 
-        // It is ::boost::mpl::na if no info_hook was included
-        BOOST_DEDUCED_TYPENAME parameters::additional_info,
+  typedef BOOST_MULTI_INDEX_MEMBER(relation_storage_base, left_key_type, left) left_member_extractor;
 
-        // Force mutable keys
-        true
+  typedef BOOST_MULTI_INDEX_MEMBER(relation_storage_base, right_key_type, right) right_member_extractor;
 
-    > relation;
+  // The core indices are somewhat complicated to calculate, because they
+  // can be zero, one, two or three indices, depending on the use of
+  // {side}_based set type of relations and unconstrained_set_of and
+  // unconstrained_set_of_relation specifications.
 
-    //@{
+  typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+      ::boost::bimaps::detail::is_unconstrained_set_of<left_set_type>,
+      // {
+      mpl::vector<>,
+      // }
+      // else
+      // {
+      mpl::vector<BOOST_DEDUCED_TYPENAME left_set_type::BOOST_NESTED_TEMPLATE index_bind<left_member_extractor, left_tag
 
-        typedef BOOST_DEDUCED_TYPENAME relation::left_pair  left_value_type;
-        typedef BOOST_DEDUCED_TYPENAME relation::right_pair right_value_type;
+                                                                                         >::type>
+      // }
+      >::type left_core_indices;
 
-    //@}
-
-    // Bind the member of the relation, so multi_index can manage them
-    // --------------------------------------------------------------------
-    private:
-
-    typedef BOOST_DEDUCED_TYPENAME relation::storage_base relation_storage_base;
-
-    typedef BOOST_MULTI_INDEX_MEMBER(relation_storage_base, left_key_type, left)
-        left_member_extractor;
-
-    typedef BOOST_MULTI_INDEX_MEMBER(relation_storage_base,right_key_type,right)
-        right_member_extractor;
-
-    // The core indices are somewhat complicated to calculate, because they
-    // can be zero, one, two or three indices, depending on the use of
-    // {side}_based set type of relations and unconstrained_set_of and
-    // unconstrained_set_of_relation specifications.
-
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
-        ::boost::bimaps::detail::is_unconstrained_set_of< left_set_type >,
-    // {
-            mpl::vector<>,
-    // }
-    // else
-    // {
-            mpl::vector
-            <
-                BOOST_DEDUCED_TYPENAME left_set_type::
-                BOOST_NESTED_TEMPLATE index_bind
-                <
-                    left_member_extractor,
-                    left_tag
-
-                >::type
-            >
-    // }
-    >::type left_core_indices;
-
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
-        ::boost::bimaps::detail::is_unconstrained_set_of< right_set_type >,
-    // {
-            left_core_indices,
-    // }
-    // else
-    // {
-            BOOST_DEDUCED_TYPENAME mpl::push_front
-            <
+  typedef BOOST_DEDUCED_TYPENAME
+      mpl::if_< ::boost::bimaps::detail::is_unconstrained_set_of<right_set_type>,
+                // {
                 left_core_indices,
+                // }
+                // else
+                // {
+                BOOST_DEDUCED_TYPENAME mpl::push_front<left_core_indices,
 
-                BOOST_DEDUCED_TYPENAME right_set_type::
-                BOOST_NESTED_TEMPLATE index_bind
-                <
-                    right_member_extractor,
-                    right_tag
+                                                       BOOST_DEDUCED_TYPENAME right_set_type::BOOST_NESTED_TEMPLATE
+                                                           index_bind<right_member_extractor, right_tag
 
-                >::type
+                                                                      >::type
 
-            >::type
-    // }
-    >::type basic_core_indices;
+                                                       >::type
+                // }
+                >::type basic_core_indices;
 
-    // If it is based either on the left or on the right, then only the side
-    // indices are needed. But the set type of the relation can be completely
-    // diferent from the one used for the sides in wich case we have to add yet
-    // another index to the core.
+  // If it is based either on the left or on the right, then only the side
+  // indices are needed. But the set type of the relation can be completely
+  // diferent from the one used for the sides in wich case we have to add yet
+  // another index to the core.
 
-    // TODO
-    // If all the set types are unsconstrained there must be readable compile
-    // time error.
+  // TODO
+  // If all the set types are unsconstrained there must be readable compile
+  // time error.
 
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+  typedef BOOST_DEDUCED_TYPENAME mpl::if_<
 
-        is_same< BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, left_based >,
-    // {
-            ::boost::bimaps::tags::tagged< left_set_type, left_tag >,
-    // }
-    /* else */ BOOST_DEDUCED_TYPENAME mpl::if_<
-            is_same< BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, right_based >,
-    // {
-            ::boost::bimaps::tags::tagged< right_set_type, right_tag >,
-    // }
-    // else
-    // {
-            tags::tagged
-            <
-                BOOST_DEDUCED_TYPENAME parameters::
-                set_type_of_relation::BOOST_NESTED_TEMPLATE bind_to
-                <
-                    relation
+      is_same<BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, left_based>,
+      // {
+      ::boost::bimaps::tags::tagged<left_set_type, left_tag>,
+      // }
+      /* else */
+      BOOST_DEDUCED_TYPENAME mpl::if_<
+          is_same<BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, right_based>,
+          // {
+          ::boost::bimaps::tags::tagged<right_set_type, right_tag>,
+          // }
+          // else
+          // {
+          tags::tagged<BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation::BOOST_NESTED_TEMPLATE bind_to<relation
 
-                >::type,
-                independent_index_tag
-            >
-    // }
-    >::type
-    >::type tagged_set_of_relation_type;
+                                                                                                              >::type,
+                       independent_index_tag>
+          // }
+          >::type>::type tagged_set_of_relation_type;
 
-    protected:
+ protected:
+  typedef BOOST_DEDUCED_TYPENAME tagged_set_of_relation_type::tag relation_set_tag;
 
-    typedef BOOST_DEDUCED_TYPENAME tagged_set_of_relation_type::tag
-                        relation_set_tag;
+  typedef BOOST_DEDUCED_TYPENAME tagged_set_of_relation_type::value_type relation_set_type_of;
 
-    typedef BOOST_DEDUCED_TYPENAME tagged_set_of_relation_type::value_type
-                        relation_set_type_of;
+  // Logic tags
+  // This is a necesary extra level of indirection to allow unconstrained
+  // sets to be plug in the design. The bimap constructors use this logic
+  // tags.
 
-    // Logic tags
-    // This is a necesary extra level of indirection to allow unconstrained
-    // sets to be plug in the design. The bimap constructors use this logic
-    // tags.
+  typedef BOOST_DEDUCED_TYPENAME
+      mpl::if_< ::boost::bimaps::detail::is_unconstrained_set_of<left_set_type>,
 
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
-        ::boost::bimaps::detail::is_unconstrained_set_of< left_set_type >,
+                BOOST_DEDUCED_TYPENAME mpl::if_< ::boost::bimaps::detail::is_unconstrained_set_of<right_set_type>,
 
-        BOOST_DEDUCED_TYPENAME mpl::if_<
-            ::boost::bimaps::detail::is_unconstrained_set_of< right_set_type >,
+                                                 independent_index_tag, right_tag
 
-            independent_index_tag,
-            right_tag
+                                                 >::type,
 
-        >::type,
+                left_tag
 
-        left_tag
+                >::type logic_left_tag;
 
-    >::type logic_left_tag;
+  typedef BOOST_DEDUCED_TYPENAME
+      mpl::if_< ::boost::bimaps::detail::is_unconstrained_set_of<right_set_type>,
 
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
-        ::boost::bimaps::detail::is_unconstrained_set_of< right_set_type >,
+                BOOST_DEDUCED_TYPENAME mpl::if_< ::boost::bimaps::detail::is_unconstrained_set_of<left_set_type>,
 
-        BOOST_DEDUCED_TYPENAME mpl::if_< 
-            ::boost::bimaps::detail::is_unconstrained_set_of< left_set_type >,
+                                                 independent_index_tag, left_tag
 
-            independent_index_tag,
-            left_tag
+                                                 >::type,
 
-        >::type,
+                right_tag
 
-        right_tag
+                >::type logic_right_tag;
 
-    >::type logic_right_tag;
+  typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+      is_same<relation_set_tag, independent_index_tag>,
 
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_< 
-        is_same< relation_set_tag, independent_index_tag >,
+      BOOST_DEDUCED_TYPENAME mpl::if_< ::boost::bimaps::detail::is_unconstrained_set_of<relation_set_type_of>,
 
-        BOOST_DEDUCED_TYPENAME mpl::if_< 
-            ::boost::bimaps::detail::
-                is_unconstrained_set_of< relation_set_type_of >,
+                                       logic_left_tag, independent_index_tag
 
-            logic_left_tag,
-            independent_index_tag
+                                       >::type,
 
-        >::type,
+      BOOST_DEDUCED_TYPENAME mpl::if_<is_same<BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, left_based>,
 
-        BOOST_DEDUCED_TYPENAME mpl::if_<
-            is_same< BOOST_DEDUCED_TYPENAME parameters::set_type_of_relation, left_based >,
+                                      logic_left_tag, logic_right_tag
 
-            logic_left_tag,
-            logic_right_tag
+                                      >::type
 
-        >::type
+      >::type logic_relation_set_tag;
 
-    >::type logic_relation_set_tag;
+ private:
+  typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+      mpl::and_<is_same<relation_set_tag, independent_index_tag>,
+                mpl::not_< ::boost::bimaps::detail::is_unconstrained_set_of<relation_set_type_of> > >,
+      // {
+      BOOST_DEDUCED_TYPENAME
+          mpl::push_front<basic_core_indices,
 
-    private:
+                          BOOST_DEDUCED_TYPENAME relation_set_type_of::BOOST_NESTED_TEMPLATE index_bind<
+                              ::boost::bimaps::relation::support::both_keys_extractor<relation>, independent_index_tag
 
-    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
-        mpl::and_< is_same< relation_set_tag, independent_index_tag >,
-                   mpl::not_<
-                       ::boost::bimaps::detail::
-                            is_unconstrained_set_of< relation_set_type_of > 
-                   >
-        >,
-    // {
-            BOOST_DEDUCED_TYPENAME mpl::push_front
-            <
-                basic_core_indices,
+                              >::type
 
-                BOOST_DEDUCED_TYPENAME relation_set_type_of::
-                BOOST_NESTED_TEMPLATE index_bind
-                <
-                    ::boost::bimaps::relation::support::both_keys_extractor<relation>,
-                    independent_index_tag
+                          >::type,
+      // }
+      // else
+      // {
+      basic_core_indices
+      // }
 
-                >::type
+      >::type complete_core_indices;
 
-            >::type,
-    // }
-    // else
-    // {
-            basic_core_indices
-    // }
+  struct core_indices : public complete_core_indices {};
 
-    >::type complete_core_indices;
+  // Define the core using compute_index_type to translate the
+  // set type to an multi-index specification
+  // --------------------------------------------------------------------
+ public:
+  typedef multi_index::multi_index_container<
+      relation, core_indices,
+      BOOST_DEDUCED_TYPENAME ::boost::container::allocator_traits<
+          BOOST_DEDUCED_TYPENAME parameters::allocator>::BOOST_NESTED_TEMPLATE portable_rebind_alloc<relation>::type>
+      core_type;
 
-    struct core_indices : public complete_core_indices {};
+  // Core metadata
+  // --------------------------------------------------------------------
+ public:
+  typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::index<core_type, logic_left_tag>::type left_index;
 
-    // Define the core using compute_index_type to translate the
-    // set type to an multi-index specification
-    // --------------------------------------------------------------------
-    public:
+  typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::index<core_type, logic_right_tag>::type right_index;
 
-    typedef multi_index::multi_index_container
-    <
-        relation,
-        core_indices,
-        BOOST_DEDUCED_TYPENAME ::boost::container::allocator_traits
-        <
-            BOOST_DEDUCED_TYPENAME parameters::allocator
-        >::
-            BOOST_NESTED_TEMPLATE portable_rebind_alloc<relation>::type
-    > core_type;
+  typedef BOOST_DEDUCED_TYPENAME left_index::iterator left_core_iterator;
+  typedef BOOST_DEDUCED_TYPENAME left_index::const_iterator left_core_const_iterator;
 
-    // Core metadata
-    // --------------------------------------------------------------------
-    public:
+  typedef BOOST_DEDUCED_TYPENAME right_index::iterator right_core_iterator;
+  typedef BOOST_DEDUCED_TYPENAME right_index::const_iterator right_core_const_iterator;
 
-    typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::
-        index<core_type, logic_left_tag>::type  left_index;
+  // Relation set view
 
-    typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::
-        index<core_type,logic_right_tag>::type right_index;
+  typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::index<core_type, logic_relation_set_tag
 
-    typedef BOOST_DEDUCED_TYPENAME  left_index::iterator        left_core_iterator;
-    typedef BOOST_DEDUCED_TYPENAME  left_index::const_iterator  left_core_const_iterator;
+                                                             >::type relation_set_core_index;
 
-    typedef BOOST_DEDUCED_TYPENAME right_index::iterator       right_core_iterator;
-    typedef BOOST_DEDUCED_TYPENAME right_index::const_iterator right_core_const_iterator;
+  typedef BOOST_DEDUCED_TYPENAME relation_set_type_of::BOOST_NESTED_TEMPLATE set_view_bind<relation_set_core_index
 
-    // Relation set view
+                                                                                           >::type relation_set;
 
-    typedef BOOST_DEDUCED_TYPENAME ::boost::multi_index::index
-    <
-        core_type, logic_relation_set_tag
-
-    >::type relation_set_core_index;
-
-    typedef BOOST_DEDUCED_TYPENAME relation_set_type_of::
-    BOOST_NESTED_TEMPLATE set_view_bind
-    <
-        relation_set_core_index
-
-    >::type relation_set;
-
-    public:
-
-    typedef bimap_core bimap_core_;
+ public:
+  typedef bimap_core bimap_core_;
 };
 
 // Two auxiliar metafunctions to compute the map view types
-// The map view type can not be computed inside the bimap core because a 
+// The map view type can not be computed inside the bimap core because a
 // they need the bimap core to be parsed first.
 
-template< class BimapBaseType >
-struct left_map_view_type
-{
-    typedef BOOST_DEDUCED_TYPENAME BimapBaseType::left_set_type left_set_type;
-    typedef BOOST_DEDUCED_TYPENAME
-        left_set_type::BOOST_NESTED_TEMPLATE map_view_bind<
-            BOOST_DEDUCED_TYPENAME BimapBaseType::left_tag, BimapBaseType
-        >::type type;
+template <class BimapBaseType>
+struct left_map_view_type {
+  typedef BOOST_DEDUCED_TYPENAME BimapBaseType::left_set_type left_set_type;
+  typedef BOOST_DEDUCED_TYPENAME left_set_type::BOOST_NESTED_TEMPLATE
+      map_view_bind<BOOST_DEDUCED_TYPENAME BimapBaseType::left_tag, BimapBaseType>::type type;
 };
 
-template< class BimapBaseType >
-struct right_map_view_type
-{
-    typedef BOOST_DEDUCED_TYPENAME BimapBaseType::right_set_type right_set_type;
-    typedef BOOST_DEDUCED_TYPENAME
-        right_set_type::BOOST_NESTED_TEMPLATE map_view_bind<
-            BOOST_DEDUCED_TYPENAME BimapBaseType::right_tag, BimapBaseType
-        >::type type;
+template <class BimapBaseType>
+struct right_map_view_type {
+  typedef BOOST_DEDUCED_TYPENAME BimapBaseType::right_set_type right_set_type;
+  typedef BOOST_DEDUCED_TYPENAME right_set_type::BOOST_NESTED_TEMPLATE
+      map_view_bind<BOOST_DEDUCED_TYPENAME BimapBaseType::right_tag, BimapBaseType>::type type;
 };
 
+}  // namespace detail
+}  // namespace bimaps
+}  // namespace boost
 
-} // namespace detail
-} // namespace bimaps
-} // namespace boost
-
-#endif // BOOST_BIMAP_DETAIL_BIMAP_CORE_HPP
+#endif  // BOOST_BIMAP_DETAIL_BIMAP_CORE_HPP

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -43,7 +43,7 @@ class BaseTestWithParam
    * safely without preventing the BaseTest-cleanup from happening.
    * GTest runs the destructor right after TearDown(): https://github.com/abseil/googletest/blob/master/googletest/docs/faq.md#should-i-use-the-constructordestructor-of-the-test-fixture-or-setupteardown
    */
-  ~BaseTestWithParam() { Hyrise::reset(); }
+  ~BaseTestWithParam() override { Hyrise::reset(); }
 };
 
 using BaseTest = BaseTestWithParam<void>;

--- a/src/test/lib/expression/expression_test.cpp
+++ b/src/test/lib/expression/expression_test.cpp
@@ -25,7 +25,7 @@ namespace opossum {
 
 class ExpressionTest : public BaseTest {
  public:
-  void SetUp() {
+  void SetUp() override {
     table_int_float = load_table("resources/test_data/tbl/int_float.tbl");
     table_int_float_with_null = load_table("resources/test_data/tbl/int_float_with_null.tbl");
     Hyrise::get().storage_manager.add_table("int_float", table_int_float);

--- a/src/test/lib/expression/lqp_subquery_expression_test.cpp
+++ b/src/test/lib/expression/lqp_subquery_expression_test.cpp
@@ -21,7 +21,7 @@ namespace opossum {
 
 class LQPSubqueryExpressionTest : public BaseTest {
  public:
-  void SetUp() {
+  void SetUp() override {
     Hyrise::get().storage_manager.add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
 
     int_float_node_a = StoredTableNode::make("int_float");

--- a/src/test/lib/expression/pqp_subquery_expression_test.cpp
+++ b/src/test/lib/expression/pqp_subquery_expression_test.cpp
@@ -21,7 +21,7 @@ namespace opossum {
 
 class PQPSubqueryExpressionTest : public BaseTest {
  public:
-  void SetUp() {
+  void SetUp() override {
     table_a = load_table("resources/test_data/tbl/int_float.tbl");
     Hyrise::get().storage_manager.add_table("int_float", table_a);
     a_a = PQPColumnExpression::from_table(*table_a, "a");

--- a/src/test/lib/operators/change_meta_table_test.cpp
+++ b/src/test/lib/operators/change_meta_table_test.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 class ChangeMetaTableTest : public BaseTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
 
     auto column_definitions = MetaMockTable().column_definitions();
@@ -34,7 +34,7 @@ class ChangeMetaTableTest : public BaseTest {
     context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::Yes);
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   std::shared_ptr<AbstractOperator> left_input;
   std::shared_ptr<AbstractOperator> right_input;

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -19,7 +19,7 @@ using namespace opossum::expression_functional;  // NOLINT
 namespace opossum {
 class OperatorsDifferenceTest : public BaseTest {
  protected:
-  virtual void SetUp() override {
+  void SetUp() override {
     _table_wrapper_a = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float.tbl", 2));
 
     _table_wrapper_b = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float3.tbl", 2));

--- a/src/test/lib/operators/difference_test.cpp
+++ b/src/test/lib/operators/difference_test.cpp
@@ -19,7 +19,7 @@ using namespace opossum::expression_functional;  // NOLINT
 namespace opossum {
 class OperatorsDifferenceTest : public BaseTest {
  protected:
-  virtual void SetUp() {
+  virtual void SetUp() override {
     _table_wrapper_a = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float.tbl", 2));
 
     _table_wrapper_b = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float3.tbl", 2));

--- a/src/test/lib/operators/product_test.cpp
+++ b/src/test/lib/operators/product_test.cpp
@@ -17,7 +17,7 @@ class OperatorsProductTest : public BaseTest {
  public:
   std::shared_ptr<opossum::TableWrapper> _table_wrapper_a, _table_wrapper_b, _table_wrapper_c;
 
-  virtual void SetUp() {
+  virtual void SetUp() override {
     _table_wrapper_a = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int.tbl", 5));
     _table_wrapper_b = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/float.tbl", 2));
     _table_wrapper_c = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_int.tbl", 2));

--- a/src/test/lib/operators/product_test.cpp
+++ b/src/test/lib/operators/product_test.cpp
@@ -17,7 +17,7 @@ class OperatorsProductTest : public BaseTest {
  public:
   std::shared_ptr<opossum::TableWrapper> _table_wrapper_a, _table_wrapper_b, _table_wrapper_c;
 
-  virtual void SetUp() override {
+  void SetUp() override {
     _table_wrapper_a = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int.tbl", 5));
     _table_wrapper_b = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/float.tbl", 2));
     _table_wrapper_c = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_int.tbl", 2));

--- a/src/test/lib/operators/union_all_test.cpp
+++ b/src/test/lib/operators/union_all_test.cpp
@@ -15,7 +15,7 @@
 namespace opossum {
 class OperatorsUnionAllTest : public BaseTest {
  protected:
-  virtual void SetUp() {
+  virtual void SetUp() override {
     _table_wrapper_a = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float.tbl", 2));
 
     _table_wrapper_b = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float2.tbl", 2));

--- a/src/test/lib/operators/union_all_test.cpp
+++ b/src/test/lib/operators/union_all_test.cpp
@@ -15,7 +15,7 @@
 namespace opossum {
 class OperatorsUnionAllTest : public BaseTest {
  protected:
-  virtual void SetUp() override {
+  void SetUp() override {
     _table_wrapper_a = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float.tbl", 2));
 
     _table_wrapper_b = std::make_shared<TableWrapper>(load_table("resources/test_data/tbl/int_float2.tbl", 2));

--- a/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner.hpp
+++ b/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner.hpp
@@ -68,7 +68,7 @@ class SQLiteTestRunner : public BaseTestWithParam<SQLiteTestRunnerParam> {
   inline static bool _last_run_successful{true};
 };
 
-auto sqlite_testrunner_formatter = [](const ::testing::TestParamInfo<SQLiteTestRunnerParam>& info) {
+inline auto sqlite_testrunner_formatter = [](const ::testing::TestParamInfo<SQLiteTestRunnerParam>& info) {
   const auto& query_pair = std::get<0>(info.param);
   const auto& encoding_type = std::get<1>(info.param);
 

--- a/src/test/lib/storage/reference_segment_test.cpp
+++ b/src/test/lib/storage/reference_segment_test.cpp
@@ -21,7 +21,7 @@
 namespace opossum {
 
 class ReferenceSegmentTest : public BaseTest {
-  virtual void SetUp() override {
+  void SetUp() override {
     TableColumnDefinitions column_definitions;
     column_definitions.emplace_back("a", DataType::Int, true);
     column_definitions.emplace_back("b", DataType::Float, false);

--- a/src/test/lib/storage/reference_segment_test.cpp
+++ b/src/test/lib/storage/reference_segment_test.cpp
@@ -21,7 +21,7 @@
 namespace opossum {
 
 class ReferenceSegmentTest : public BaseTest {
-  virtual void SetUp() {
+  virtual void SetUp() override {
     TableColumnDefinitions column_definitions;
     column_definitions.emplace_back("a", DataType::Int, true);
     column_definitions.emplace_back("b", DataType::Float, false);

--- a/src/test/lib/utils/meta_table_manager_test.cpp
+++ b/src/test/lib/utils/meta_table_manager_test.cpp
@@ -55,7 +55,7 @@ class MetaTableManagerTest : public BaseTest {
  protected:
   std::shared_ptr<const Table> mock_manipulation_values;
 
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
 
     const auto column_definitions = MetaMockTable().column_definitions();
@@ -66,7 +66,7 @@ class MetaTableManagerTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 };
 
 class MetaTableManagerMultiTablesTest : public MetaTableManagerTest, public ::testing::WithParamInterface<MetaTable> {};

--- a/src/test/lib/utils/meta_tables/meta_log_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_log_table_test.cpp
@@ -7,12 +7,12 @@ namespace opossum {
 
 class MetaLogTest : public BaseTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     meta_log_table = std::make_shared<MetaLogTable>();
     Hyrise::get().log_manager.add_message("foo", "bar", LogLevel::Info);
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   const std::shared_ptr<Table> generate_meta_table() const { return meta_log_table->_on_generate(); }
 

--- a/src/test/lib/utils/meta_tables/meta_mock_table.hpp
+++ b/src/test/lib/utils/meta_tables/meta_mock_table.hpp
@@ -32,7 +32,8 @@ class MetaMockTable : public AbstractMetaTable {
   std::shared_ptr<Table> _on_generate() const final;
   void _on_insert(const std::vector<AllTypeVariant>& values) final;
   void _on_remove(const std::vector<AllTypeVariant>& values) final;
-  void _on_update(const std::vector<AllTypeVariant>& selected_values, const std::vector<AllTypeVariant>& update_values) final;
+  void _on_update(const std::vector<AllTypeVariant>& selected_values,
+                  const std::vector<AllTypeVariant>& update_values) final;
 
   size_t _insert_calls = 0;
   size_t _remove_calls = 0;

--- a/src/test/lib/utils/meta_tables/meta_mock_table.hpp
+++ b/src/test/lib/utils/meta_tables/meta_mock_table.hpp
@@ -12,9 +12,9 @@ class MetaMockTable : public AbstractMetaTable {
  public:
   MetaMockTable();
 
-  bool can_insert() const;
-  bool can_delete() const;
-  bool can_update() const;
+  bool can_insert() const final;
+  bool can_delete() const final;
+  bool can_update() const final;
 
   const std::string& name() const final;
 
@@ -29,10 +29,10 @@ class MetaMockTable : public AbstractMetaTable {
   const std::vector<AllTypeVariant> update_updated_values() const;
 
  protected:
-  std::shared_ptr<Table> _on_generate() const;
-  void _on_insert(const std::vector<AllTypeVariant>& values);
-  void _on_remove(const std::vector<AllTypeVariant>& values);
-  void _on_update(const std::vector<AllTypeVariant>& selected_values, const std::vector<AllTypeVariant>& update_values);
+  std::shared_ptr<Table> _on_generate() const final;
+  void _on_insert(const std::vector<AllTypeVariant>& values) final;
+  void _on_remove(const std::vector<AllTypeVariant>& values) final;
+  void _on_update(const std::vector<AllTypeVariant>& selected_values, const std::vector<AllTypeVariant>& update_values) final;
 
   size_t _insert_calls = 0;
   size_t _remove_calls = 0;

--- a/src/test/lib/utils/meta_tables/meta_plugins_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_plugins_table_test.cpp
@@ -13,7 +13,7 @@ class MetaPluginsTest : public BaseTest {
   std::shared_ptr<AbstractSetting> mock_setting;
   std::shared_ptr<AbstractMetaTable> meta_plugins_table;
 
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
     meta_plugins_table = std::make_shared<MetaPluginsTable>();
     const auto column_definitions = meta_plugins_table->column_definitions();
@@ -24,7 +24,7 @@ class MetaPluginsTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   const std::shared_ptr<Table> generate_meta_table(const std::shared_ptr<AbstractMetaTable>& table) const {
     return table->_generate();

--- a/src/test/lib/utils/meta_tables/meta_settings_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_settings_table_test.cpp
@@ -13,7 +13,7 @@ class MetaSettingsTest : public BaseTest {
   std::shared_ptr<AbstractMetaTable> meta_settings_table;
   std::shared_ptr<Table> expected_table;
 
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
     Hyrise::get().settings_manager = SettingsManager{};
 
@@ -35,7 +35,7 @@ class MetaSettingsTest : public BaseTest {
     mock_setting->register_at_settings_manager();
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   const std::shared_ptr<Table> generate_meta_table(const std::shared_ptr<AbstractMetaTable>& table) const {
     return table->_generate();

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -57,7 +57,7 @@ class MetaTableTest : public BaseTest {
   std::shared_ptr<Table> int_int_int_null;
   std::shared_ptr<const Table> mock_manipulation_values;
 
-  void SetUp() {
+  void SetUp() override {
     auto& storage_manager = Hyrise::get().storage_manager;
 
     int_int = load_table("resources/test_data/tbl/int_int.tbl", 2);
@@ -79,7 +79,7 @@ class MetaTableTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   void _add_meta_table(const std::shared_ptr<AbstractMetaTable>& table) {
     Hyrise::get().meta_table_manager._add(table);

--- a/src/test/lib/utils/setting_test.cpp
+++ b/src/test/lib/utils/setting_test.cpp
@@ -6,12 +6,12 @@ namespace opossum {
 
 class SettingTest : public BaseTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
     mock_setting = std::make_shared<MockSetting>("mock_setting");
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   std::shared_ptr<AbstractSetting> mock_setting;
 };

--- a/src/test/lib/utils/settings_manager_test.cpp
+++ b/src/test/lib/utils/settings_manager_test.cpp
@@ -7,13 +7,13 @@ namespace opossum {
 
 class SettingsManagerTest : public BaseTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
     mock_setting = std::make_shared<MockSetting>("mock_setting");
     another_mock_setting = std::make_shared<MockSetting>("mock_setting");
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   void add_setting(std::shared_ptr<AbstractSetting> setting) { Hyrise::get().settings_manager._add(setting); }
 


### PR DESCRIPTION
To enable `brew upgrade`, I fixed the issues that came up with clang-11. Nothing big, details can be found in the comments.

This does not yet add gcc-10/clang-11 to any dependencies. It also does not fix any issues that clang-tidy-11 might complain about.

This was tested on OS X 10.15.6 and Ubuntu 20.10 dev.