### PR TITLE
Make AbstractExpression Noncopyable

### DIFF
--- a/src/lib/expression/abstract_expression.hpp
+++ b/src/lib/expression/abstract_expression.hpp
@@ -47,6 +47,7 @@ class AbstractExpression : public std::enable_shared_from_this<AbstractExpressio
  public:
   explicit AbstractExpression(const ExpressionType init_type,
                               const std::vector<std::shared_ptr<AbstractExpression>>& init_arguments);
+  AbstractExpression(const AbstractExpression&) = default;
   virtual ~AbstractExpression() = default;
 
   /**

--- a/src/lib/expression/abstract_expression.hpp
+++ b/src/lib/expression/abstract_expression.hpp
@@ -43,11 +43,10 @@ enum class ExpressionType {
  *
  * Expressions are evaluated (typically for all rows of a Chunk) using the ExpressionEvaluator.
  */
-class AbstractExpression : public std::enable_shared_from_this<AbstractExpression> {
+class AbstractExpression : public std::enable_shared_from_this<AbstractExpression>, private Noncopyable {
  public:
-  explicit AbstractExpression(const ExpressionType init_type,
-                              const std::vector<std::shared_ptr<AbstractExpression>>& init_arguments);
-  AbstractExpression(const AbstractExpression&) = default;
+  AbstractExpression(const ExpressionType init_type,
+                     const std::vector<std::shared_ptr<AbstractExpression>>& init_arguments);
   virtual ~AbstractExpression() = default;
 
   /**

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -51,8 +51,8 @@ bool predicates_are_mutually_exclusive(const std::vector<std::shared_ptr<Abstrac
     return false;
   }
 
-  const auto first_value_expression = static_cast<const ValueExpression&>(*first_binary_predicate->right_operand());
-  const auto second_value_expression = static_cast<const ValueExpression&>(*second_binary_predicate->right_operand());
+  const auto& first_value_expression = static_cast<const ValueExpression&>(*first_binary_predicate->right_operand());
+  const auto& second_value_expression = static_cast<const ValueExpression&>(*second_binary_predicate->right_operand());
 
   auto first_less_than_second = false;
   boost::apply_visitor(


### PR DESCRIPTION
I was not able to build with Clang 9 and disabled precompiled headers.
Error was:
```
In file included from ../src/lib/logical_query_plan/abstract_lqp_node.hpp:8:
../src/lib/expression/abstract_expression.hpp:50:11: error: definition of implicit copy constructor for 'AbstractExpression' is deprecated because it has a user-declared destructor [-Werror,-Wdeprecated]
  virtual ~AbstractExpression() = default;
```

Not sure what I am doing here, but it fixed the issue. Not sure why this was not caught by our CI.