### PR TITLE
Fix sorted aggregation micro benchmarks

### DIFF
--- a/src/benchmark/operators/join_aggregate_benchmark.cpp
+++ b/src/benchmark/operators/join_aggregate_benchmark.cpp
@@ -43,6 +43,8 @@ pmr_vector<int32_t> generate_ids(const size_t table_size) {
     values[row_index] = dist(random_engine);
   }
 
+  std::sort(values.begin(), values.end());
+
   return values;
 }
 
@@ -82,6 +84,8 @@ pmr_vector<int32_t> generate_ages(const size_t table_size) {
     values[row_index] = dist(random_engine);
   }
 
+  std::sort(values.begin(), values.end());
+
   return values;
 }
 
@@ -120,8 +124,7 @@ std::shared_ptr<TableWrapper> create_zip_table(const size_t table_size) {
   for (auto chunk_index = ChunkID{0}; chunk_index < chunk_count; ++chunk_index) {
     auto chunk = zip_table->get_chunk(chunk_index);
     chunk->finalize();
-    chunk->set_individually_sorted_by(SortColumnDefinition(ColumnID{0}, SortMode::Ascending));
-    chunk->set_individually_sorted_by(SortColumnDefinition(ColumnID{1}, SortMode::Ascending));
+    chunk->set_individually_sorted_by({SortColumnDefinition(ColumnID{0}, SortMode::Ascending), SortColumnDefinition(ColumnID{1}, SortMode::Ascending)});
   }
 
   return std::make_shared<TableWrapper>(zip_table);
@@ -173,6 +176,8 @@ void BM_Join_Aggregate(benchmark::State& state) {
   }
 }
 
+// Note: the generated data does not explicitly set a possible clustering of the table (cf.
+// table->value_clustered_by()), which is exploited by the sort-based aggregate.
 BENCHMARK_TEMPLATE(BM_Join_Aggregate, AggregateSort, JoinSortMerge);
 BENCHMARK_TEMPLATE(BM_Join_Aggregate, AggregateSort, JoinHash);
 BENCHMARK_TEMPLATE(BM_Join_Aggregate, AggregateHash, JoinSortMerge);

--- a/src/benchmark/operators/join_aggregate_benchmark.cpp
+++ b/src/benchmark/operators/join_aggregate_benchmark.cpp
@@ -124,7 +124,8 @@ std::shared_ptr<TableWrapper> create_zip_table(const size_t table_size) {
   for (auto chunk_index = ChunkID{0}; chunk_index < chunk_count; ++chunk_index) {
     auto chunk = zip_table->get_chunk(chunk_index);
     chunk->finalize();
-    chunk->set_individually_sorted_by({SortColumnDefinition(ColumnID{0}, SortMode::Ascending), SortColumnDefinition(ColumnID{1}, SortMode::Ascending)});
+    chunk->set_individually_sorted_by({SortColumnDefinition(ColumnID{0}, SortMode::Ascending),
+                                       SortColumnDefinition(ColumnID{1}, SortMode::Ascending)});
   }
 
   return std::make_shared<TableWrapper>(zip_table);

--- a/src/benchmark/operators/join_aggregate_benchmark.cpp
+++ b/src/benchmark/operators/join_aggregate_benchmark.cpp
@@ -176,8 +176,6 @@ void BM_Join_Aggregate(benchmark::State& state) {
   }
 }
 
-// Note: the generated data does not explicitly set a possible clustering of the table (cf.
-// table->value_clustered_by()), which is exploited by the sort-based aggregate.
 BENCHMARK_TEMPLATE(BM_Join_Aggregate, AggregateSort, JoinSortMerge);
 BENCHMARK_TEMPLATE(BM_Join_Aggregate, AggregateSort, JoinHash);
 BENCHMARK_TEMPLATE(BM_Join_Aggregate, AggregateHash, JoinSortMerge);


### PR DESCRIPTION
One micro benchmark has been defunct. I don't want to remove this benchmark, because I am working on a related topic that might make sorted aggregations an actual option.

