### PR TITLE
Fix operator performance counters in hash aggregate

### DIFF
--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -645,16 +645,15 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
     ++aggregate_idx;
   }
 
-  // _aggregate, _write_groupby_output, and write_aggregate_output have their own, internal timers.
-  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
-  Timer timer;
-
   // Write the output
+  Timer timer;
   auto output = std::make_shared<Table>(_output_column_definitions, TableType::Data);
   if (_output_segments.at(0)->size() > 0) {
     output->append_chunk(_output_segments);
   }
 
+  // _aggregate, _write_groupby_output, and _write_aggregate_output have their own, internal timers.
+  auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
   step_performance_data.set_step_runtime(OperatorSteps::OutputWriting, timer.lap());
 
   return output;
@@ -953,7 +952,8 @@ void AggregateHash::write_aggregate_output(ColumnID aggregate_index) {
   _output_segments[output_column_id] = output_segment;
 
   auto& step_performance_data = dynamic_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
-  step_performance_data.add_to_step_runtime(OperatorSteps::AggregateColumnsWriting, timer.lap() - write_groupby_output_duration);
+  step_performance_data.add_to_step_runtime(OperatorSteps::AggregateColumnsWriting,
+                                            timer.lap() - write_groupby_output_duration);
 }
 
 template <typename AggregateKey>

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -608,7 +608,6 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
   _output_column_definitions.resize(num_output_columns);
   _output_segments.resize(num_output_columns);
 
-
   // _aggregate<>() has its own, internal timer.
   auto& step_performance_data = static_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
   Timer timer;

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -183,6 +183,9 @@ class AggregateHash : public AbstractAggregateOperator {
   std::vector<std::shared_ptr<BaseValueSegment>> _groupby_segments;
   std::vector<std::shared_ptr<SegmentVisitorContext>> _contexts_per_column;
   bool _has_aggregate_functions;
+
+  std::chrono::nanoseconds groupby_columns_writing_duration{};
+  std::chrono::nanoseconds aggregate_columns_writing_duration{};
 };
 
 }  // namespace opossum

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -92,6 +92,11 @@ struct OperatorPerformanceData : public AbstractOperatorPerformanceData {
     step_runtimes[static_cast<size_t>(step)] = duration;
   }
 
+  void add_to_step_runtime(const Steps step, const std::chrono::nanoseconds duration) {
+    DebugAssert(magic_enum::enum_integer(step) < magic_enum::enum_count<Steps>(), "Invalid step.");
+    step_runtimes[static_cast<size_t>(step)] = get_step_runtime(step) + duration;
+  }
+
   std::array<std::chrono::nanoseconds, magic_enum::enum_count<Steps>()> step_runtimes{};
 };
 

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -58,6 +58,16 @@ struct OperatorPerformanceData : public AbstractOperatorPerformanceData {
       return;
     }
 
+    // Check that the cumulative step runtimes are not larger than the operator's runtime.
+    if constexpr (HYRISE_DEBUG) {
+      auto cumulative_step_runtime = size_t{0};
+      for (auto step_index = size_t{0}; step_index < magic_enum::enum_count<Steps>(); ++step_index) {
+        cumulative_step_runtime += step_runtimes[step_index].count();
+      }
+      Assert(static_cast<size_t>(walltime.count()) >= cumulative_step_runtime,
+             "Cumulative step runtimes larger than operator runtime.");
+    }
+
     static_assert(magic_enum::enum_count<Steps>() <= sizeof(step_runtimes), "Too many steps.");
     stream << (description_mode == DescriptionMode::SingleLine ? " " : "\n")
            << "Operator step runtimes:" << (description_mode == DescriptionMode::SingleLine ? "" : "\n");

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -94,7 +94,7 @@ struct OperatorPerformanceData : public AbstractOperatorPerformanceData {
 
   void add_to_step_runtime(const Steps step, const std::chrono::nanoseconds duration) {
     DebugAssert(magic_enum::enum_integer(step) < magic_enum::enum_count<Steps>(), "Invalid step.");
-    step_runtimes[static_cast<size_t>(step)] = get_step_runtime(step) + duration;
+    step_runtimes[static_cast<size_t>(step)] += duration;
   }
 
   std::array<std::chrono::nanoseconds, magic_enum::enum_count<Steps>()> step_runtimes{};

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -92,11 +92,6 @@ struct OperatorPerformanceData : public AbstractOperatorPerformanceData {
     step_runtimes[static_cast<size_t>(step)] = duration;
   }
 
-  void add_to_step_runtime(const Steps step, const std::chrono::nanoseconds duration) {
-    DebugAssert(magic_enum::enum_integer(step) < magic_enum::enum_count<Steps>(), "Invalid step.");
-    step_runtimes[static_cast<size_t>(step)] += duration;
-  }
-
   std::array<std::chrono::nanoseconds, magic_enum::enum_count<Steps>()> step_runtimes{};
 };
 

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -279,12 +279,17 @@ TEST_F(OperatorPerformanceDataTest, JoinHashPerformanceToOutputStream) {
   performance_data.has_output = true;
   performance_data.output_row_count = 1u;
   performance_data.output_chunk_count = 1u;
-  performance_data.walltime = std::chrono::nanoseconds{2u};
 
+  performance_data.walltime = std::chrono::nanoseconds{2u};
+  std::stringstream stringstream_throw;
+  // output_to_stream() throws when cumulative step runtimes are larger than operator runtime.
+  EXPECT_THROW(performance_data.output_to_stream(stringstream_throw, DescriptionMode::SingleLine), std::logic_error);
+
+  performance_data.walltime = std::chrono::nanoseconds{35u};
   std::stringstream stringstream;
   stringstream << performance_data;
   EXPECT_TRUE(
-      stringstream.str().starts_with("Output: 1 row in 1 chunk, 2 ns. Operator step runtimes: BuildSideMaterializing"
+      stringstream.str().starts_with("Output: 1 row in 1 chunk, 35 ns. Operator step runtimes: BuildSideMaterializing"
                                      " 17 ns, ProbeSideMaterializing 0 ns, Clustering 0 ns, Building 0 ns, Probing"
                                      " 17 ns, OutputWriting 0 ns."));
 }

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -280,10 +280,12 @@ TEST_F(OperatorPerformanceDataTest, JoinHashPerformanceToOutputStream) {
   performance_data.output_row_count = 1u;
   performance_data.output_chunk_count = 1u;
 
-  performance_data.walltime = std::chrono::nanoseconds{2u};
-  std::stringstream stringstream_throw;
-  // output_to_stream() throws when cumulative step runtimes are larger than operator runtime.
-  EXPECT_THROW(performance_data.output_to_stream(stringstream_throw, DescriptionMode::SingleLine), std::logic_error);
+  if constexpr (HYRISE_DEBUG) {
+    performance_data.walltime = std::chrono::nanoseconds{2u};
+    std::stringstream stringstream_throw;
+    // output_to_stream() throws when cumulative step runtimes are larger than operator runtime.
+    EXPECT_THROW(performance_data.output_to_stream(stringstream_throw, DescriptionMode::SingleLine), std::logic_error);
+  }
 
   performance_data.walltime = std::chrono::nanoseconds{35u};
   std::stringstream stringstream;


### PR DESCRIPTION
Resolves #2266.

`_write_groupby_output` can be called at two places. In one of the (`write_aggregate_output()`), its self-recorded step runtime is included in the runtime of the AggregateColumnWriting step, leading to cumulative step runtimes that are larger than the actual operator runtime.