### PR TITLE
Sort: Make performance steps more precise

### DIFF
--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -290,8 +290,7 @@ std::shared_ptr<const Table> Sort::_on_execute() {
 
   auto& step_performance_data = dynamic_cast<OperatorPerformanceData<OperatorSteps>&>(*performance_data);
   step_performance_data.set_step_runtime(OperatorSteps::MaterializeSortColumns, total_materialization_time);
-  step_performance_data.set_step_runtime(OperatorSteps::TemporaryResultWritingTime,
-                                         total_temporary_result_writing_time);
+  step_performance_data.set_step_runtime(OperatorSteps::TemporaryResultWriting, total_temporary_result_writing_time);
   step_performance_data.set_step_runtime(OperatorSteps::Sort, total_sort_time);
 
   // We have to materialize the output (i.e., write ValueSegments) if

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -352,9 +352,9 @@ class Sort::SortImpl {
  public:
   using RowIDValuePair = std::pair<RowID, SortColumnType>;
 
-  std::chrono::nanoseconds materialization_time{0};
-  std::chrono::nanoseconds temporary_result_writing_time{0};
-  std::chrono::nanoseconds sort_time{0};
+  std::chrono::nanoseconds materialization_time{};
+  std::chrono::nanoseconds temporary_result_writing_time{};
+  std::chrono::nanoseconds sort_time{};
 
   SortImpl(const std::shared_ptr<const Table>& table_in, const ColumnID column_id,
            const SortMode sort_mode = SortMode::Ascending)

--- a/src/lib/operators/sort.hpp
+++ b/src/lib/operators/sort.hpp
@@ -23,7 +23,7 @@ class Sort : public AbstractReadOnlyOperator {
  public:
   enum class ForceMaterialization : bool { Yes = true, No = false };
 
-  enum class OperatorSteps : uint8_t { MaterializeSortColumns, Sort, TemporaryResultWritingTime, WriteOutput };
+  enum class OperatorSteps : uint8_t { MaterializeSortColumns, Sort, TemporaryResultWriting, WriteOutput };
 
   Sort(const std::shared_ptr<const AbstractOperator>& in, const std::vector<SortColumnDefinition>& sort_definitions,
        const ChunkOffset output_chunk_size = Chunk::DEFAULT_SIZE,

--- a/src/lib/operators/sort.hpp
+++ b/src/lib/operators/sort.hpp
@@ -23,7 +23,7 @@ class Sort : public AbstractReadOnlyOperator {
  public:
   enum class ForceMaterialization : bool { Yes = true, No = false };
 
-  enum class OperatorSteps : uint8_t { Sort, WriteOutput };
+  enum class OperatorSteps : uint8_t { MaterializeSortColumns, Sort, TemporaryResultWritingTime, WriteOutput };
 
   Sort(const std::shared_ptr<const AbstractOperator>& in, const std::vector<SortColumnDefinition>& sort_definitions,
        const ChunkOffset output_chunk_size = Chunk::DEFAULT_SIZE,


### PR DESCRIPTION
With this PR, we split up the "Sort" step into different phases:

<img width="440" alt="Screenshot 2020-11-25 at 16 32 38" src="https://user-images.githubusercontent.com/575106/100250370-e36cc900-2f3d-11eb-8f4e-f86ff3474018.png">
