### PR TITLE
Add Like predicate to min max filter

### DIFF
--- a/src/lib/expression/evaluation/like_matcher.cpp
+++ b/src/lib/expression/evaluation/like_matcher.cpp
@@ -57,7 +57,6 @@ std::pair<pmr_string, pmr_string> LikeMatcher::get_lower_upper_bound(const pmr_s
   const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_ascii_character;
 
   return std::pair<pmr_string, pmr_string>(lower_bound, upper_bound);
-
 }
 
 LikeMatcher::AllPatternVariant LikeMatcher::pattern_string_to_pattern_variant(const pmr_string& pattern) {

--- a/src/lib/expression/evaluation/like_matcher.cpp
+++ b/src/lib/expression/evaluation/like_matcher.cpp
@@ -1,5 +1,7 @@
 #include "like_matcher.hpp"
 
+#include <utility>
+
 #include "boost/algorithm/string/replace.hpp"
 
 #include "utils/assert.hpp"
@@ -37,6 +39,25 @@ LikeMatcher::PatternTokens LikeMatcher::pattern_string_to_tokens(const pmr_strin
   }
 
   return tokens;
+}
+
+std::pair<pmr_string, pmr_string> LikeMatcher::get_lower_upper_bound(const pmr_string& pattern) {
+  // Calculate lower bound of the search Pattern
+  const auto wildcard_pos = get_index_of_next_wildcard(pattern);
+  const auto lower_bound = pattern.substr(0, wildcard_pos);
+  const auto last_character_of_lower_bound = lower_bound.back();
+
+  // Calculate upper bound of the search pattern according to ASCII-table
+  constexpr int MAX_ASCII_VALUE = 127;
+  if (last_character_of_lower_bound >= MAX_ASCII_VALUE) {
+    // current_character_value + 1 would overflow.
+    return std::pair<pmr_string, pmr_string>(lower_bound, lower_bound);
+  }
+  const auto next_ascii_character = static_cast<char>(last_character_of_lower_bound + 1);
+  const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_ascii_character;
+
+  return std::pair<pmr_string, pmr_string>(lower_bound, upper_bound);
+
 }
 
 LikeMatcher::AllPatternVariant LikeMatcher::pattern_string_to_pattern_variant(const pmr_string& pattern) {

--- a/src/lib/expression/evaluation/like_matcher.cpp
+++ b/src/lib/expression/evaluation/like_matcher.cpp
@@ -44,7 +44,7 @@ LikeMatcher::PatternTokens LikeMatcher::pattern_string_to_tokens(const pmr_strin
 
 std::optional<std::pair<pmr_string, pmr_string>> LikeMatcher::bounds(const pmr_string& pattern) {
   if (!contains_wildcard(pattern)) {
-    const auto upper_bound = pmr_string(pattern) + static_cast<char>(0);
+    const auto upper_bound = pmr_string(pattern) + '\0';
     return std::pair<pmr_string, pmr_string>(pattern, upper_bound);
   }
   const auto wildcard_pos = get_index_of_next_wildcard(pattern);

--- a/src/lib/expression/evaluation/like_matcher.cpp
+++ b/src/lib/expression/evaluation/like_matcher.cpp
@@ -1,5 +1,6 @@
 #include "like_matcher.hpp"
 
+#include <optional>
 #include <utility>
 
 #include "boost/algorithm/string/replace.hpp"
@@ -41,9 +42,13 @@ LikeMatcher::PatternTokens LikeMatcher::pattern_string_to_tokens(const pmr_strin
   return tokens;
 }
 
-std::pair<pmr_string, pmr_string> LikeMatcher::get_lower_upper_bound(const pmr_string& pattern) {
+std::optional<std::pair<pmr_string, pmr_string>> LikeMatcher::get_lower_upper_bound(const pmr_string& pattern) {
   // Calculate lower bound of the search Pattern
   const auto wildcard_pos = get_index_of_next_wildcard(pattern);
+  if (wildcard_pos == 0) {
+    return std::nullopt;
+  }
+
   const auto lower_bound = pattern.substr(0, wildcard_pos);
   const auto last_character_of_lower_bound = lower_bound.back();
 
@@ -51,7 +56,7 @@ std::pair<pmr_string, pmr_string> LikeMatcher::get_lower_upper_bound(const pmr_s
   constexpr int MAX_ASCII_VALUE = 127;
   if (last_character_of_lower_bound >= MAX_ASCII_VALUE) {
     // current_character_value + 1 would overflow.
-    return std::pair<pmr_string, pmr_string>(lower_bound, lower_bound);
+    return std::nullopt;
   }
   const auto next_ascii_character = static_cast<char>(last_character_of_lower_bound + 1);
   const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_ascii_character;

--- a/src/lib/expression/evaluation/like_matcher.cpp
+++ b/src/lib/expression/evaluation/like_matcher.cpp
@@ -42,9 +42,6 @@ LikeMatcher::PatternTokens LikeMatcher::pattern_string_to_tokens(const pmr_strin
   return tokens;
 }
 
-// The following table shows examples of the return for some patterns:
-// test%        | %test   | test\x7F% | test            | '' (empty string)
-// {test, tesu} | nullopt | nullopt   | {test, test\0}  | {'', '\0'}
 std::optional<std::pair<pmr_string, pmr_string>> LikeMatcher::bounds(const pmr_string& pattern) {
   if (!contains_wildcard(pattern)) {
     const auto upper_bound = pmr_string(pattern) + static_cast<char>(0);

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -52,6 +52,9 @@ class LikeMatcher {
   // `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the lower bound, the second
   // the upper bound. If the char ASCII value before the wild-card has the max ASCII value 127, or the first character
   // of the pattern is a wild-card, nullopt is returned.
+  // The following table shows examples of the return for some patterns:
+  // test%        | %test   | test\x7F% | test            | '' (empty string)
+  // {test, tesu} | nullopt | nullopt   | {test, test\0}  | {'', '\0'}
   static std::optional<std::pair<pmr_string, pmr_string>> bounds(const pmr_string& pattern);
 
   /**

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <experimental/functional>
+#include <optional>
 #include <regex>
 #include <string>
 #include <utility>
@@ -51,7 +52,7 @@ class LikeMatcher {
   // `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the lower bound the second
   // the upper bound. if the char ASCII value before the wildcard has the max ASCII value 127, the upper and lower bound
   // are the same.
-  static std::pair<pmr_string, pmr_string> get_lower_upper_bound(const pmr_string& pattern);
+  static std::optional<std::pair<pmr_string, pmr_string>> get_lower_upper_bound(const pmr_string& pattern);
 
   /**
    * To speed up LIKE there are special implementations available for simple, common patterns.

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <variant>
 #include <vector>
+#include <utility>
 
 #include "types.hpp"
 #include "utils/assert.hpp"
@@ -45,6 +46,11 @@ class LikeMatcher {
    * PatternWildcard::AnyChars, "ld"}
    */
   static PatternTokens pattern_string_to_tokens(const pmr_string& pattern);
+
+  // Calculates the upper and lower bound of a given pattern. For example, with the pattern `Japan%`, the lower
+  // bound `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the
+  // lower bound the second the upper bound.
+  static std::pair<pmr_string, pmr_string> get_lower_upper_bound(const pmr_string& pattern);
 
   /**
    * To speed up LIKE there are special implementations available for simple, common patterns.

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -3,9 +3,9 @@
 #include <experimental/functional>
 #include <regex>
 #include <string>
+#include <utility>
 #include <variant>
 #include <vector>
-#include <utility>
 
 #include "types.hpp"
 #include "utils/assert.hpp"

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -49,10 +49,10 @@ class LikeMatcher {
   static PatternTokens pattern_string_to_tokens(const pmr_string& pattern);
 
   // Calculates the upper and lower bound of a given pattern. For example, with the pattern `Japan%`, the lower bound
-  // `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the lower bound the second
-  // the upper bound. if the char ASCII value before the wildcard has the max ASCII value 127, the upper and lower bound
-  // are the same.
-  static std::optional<std::pair<pmr_string, pmr_string>> get_lower_upper_bound(const pmr_string& pattern);
+  // `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the lower bound, the second
+  // the upper bound. If the char ASCII value before the wild-card has the max ASCII value 127, or the first character
+  // of the pattern is a wild-card, nullopt is returned.
+  static std::optional<std::pair<pmr_string, pmr_string>> bounds(const pmr_string& pattern);
 
   /**
    * To speed up LIKE there are special implementations available for simple, common patterns.

--- a/src/lib/expression/evaluation/like_matcher.hpp
+++ b/src/lib/expression/evaluation/like_matcher.hpp
@@ -47,9 +47,10 @@ class LikeMatcher {
    */
   static PatternTokens pattern_string_to_tokens(const pmr_string& pattern);
 
-  // Calculates the upper and lower bound of a given pattern. For example, with the pattern `Japan%`, the lower
-  // bound `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the
-  // lower bound the second the upper bound.
+  // Calculates the upper and lower bound of a given pattern. For example, with the pattern `Japan%`, the lower bound
+  // `Japan` and upper bound `Japao` is returned. The first value of the returned pair is the lower bound the second
+  // the upper bound. if the char ASCII value before the wildcard has the max ASCII value 127, the upper and lower bound
+  // are the same.
   static std::pair<pmr_string, pmr_string> get_lower_upper_bound(const pmr_string& pattern);
 
   /**

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -202,10 +202,11 @@ void ExpressionReductionRule::rewrite_like_prefix_wildcard(std::shared_ptr<Abstr
   }
 
   const auto multi_char_wildcard_pos = pattern.find_first_of('%');
-  // TODO: we do not rewrite LIKEs with multiple wildcards here. Theoretically, we could rewrite "c LIKE RED%E%" to "c >= RED
-  //and C < REE and c LIKE RED%E%" but that would require adding new predicate nodes. For now, we assume that the potential
-  //pruning of such LIKE predicates via the chunk pruning rule is sufficient. However, if not many chunks can be pruned,
-  //rewriting with additional predicates might show to be beneficial.
+  // TODO(user): we do not rewrite LIKEs with multiple wildcards here. Theoretically, we could rewrite
+  // "c LIKE RED%E%" to "c >= RED and C < REE and c LIKE RED%E%" but that would require adding new predicate
+  // nodes. For now, we assume that the potential pruning of such LIKE predicates via the chunk pruning
+  // rule is sufficient. However, if not many chunks can be pruned, rewriting with additional predicates
+  // might show to be beneficial.
   if (multi_char_wildcard_pos == std::string::npos || multi_char_wildcard_pos == 0 ||
       multi_char_wildcard_pos + 1 != pattern.size()) {
     return;

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -202,11 +202,10 @@ void ExpressionReductionRule::rewrite_like_prefix_wildcard(std::shared_ptr<Abstr
   }
 
   const auto multi_char_wildcard_pos = pattern.find_first_of('%');
-  // TODO(user): we do not rewrite LIKEs with multiple wildcards here. Theoretically, we could rewrite
-  // "c LIKE RED%E%" to "c >= RED and C < REE and c LIKE RED%E%" but that would require adding new predicate
-  // nodes. For now, we assume that the potential pruning of such LIKE predicates via the chunk pruning
-  // rule is sufficient. However, if not many chunks can be pruned, rewriting with additional predicates
-  // might show to be beneficial.
+  // TODO(anyone): we do not rewrite LIKEs with multiple wildcards here. Theoretically, we could rewrite "c LIKE RED%E%"
+  // to "c >= RED and C < REE and c LIKE RED%E%" but that would require adding new predicate nodes. For now, we assume
+  // that the potential pruning of such LIKE predicates via the chunk pruning rule is sufficient. However, if not many
+  // chunks can be pruned, rewriting with additional predicates might show to be beneficial.
   if (multi_char_wildcard_pos == std::string::npos || multi_char_wildcard_pos == 0 ||
       multi_char_wildcard_pos + 1 != pattern.size()) {
     return;

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -216,7 +216,7 @@ void ExpressionReductionRule::rewrite_like_prefix_wildcard(std::shared_ptr<Abstr
   // In case of an ASCII overflow
   if (!bounds) return;
 
-  const auto [lower_bound, upper_bound] = bounds.value();
+  const auto [lower_bound, upper_bound] = *bounds;
 
   if (binary_predicate->predicate_condition == PredicateCondition::Like) {
     input_expression = between_upper_exclusive_(binary_predicate->left_operand(), lower_bound, upper_bound);

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -211,7 +211,7 @@ void ExpressionReductionRule::rewrite_like_prefix_wildcard(std::shared_ptr<Abstr
       multi_char_wildcard_pos + 1 != pattern.size()) {
     return;
   }
-  const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+  const auto bounds = LikeMatcher::bounds(pattern);
 
   // In case of an ASCII overflow
   if (!bounds) return;

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -211,12 +211,12 @@ void ExpressionReductionRule::rewrite_like_prefix_wildcard(std::shared_ptr<Abstr
       multi_char_wildcard_pos + 1 != pattern.size()) {
     return;
   }
+  const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
 
-  const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
+  // In case of an ASCII overflow
+  if (!bounds) return;
 
-  if (lower_bound == upper_bound) {
-    return;
-  }
+  const auto [lower_bound, upper_bound] = bounds.value();
 
   if (binary_predicate->predicate_condition == PredicateCondition::Like) {
     input_expression = between_upper_exclusive_(binary_predicate->left_operand(), lower_bound, upper_bound);

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -202,6 +202,10 @@ void ExpressionReductionRule::rewrite_like_prefix_wildcard(std::shared_ptr<Abstr
   }
 
   const auto multi_char_wildcard_pos = pattern.find_first_of('%');
+  // TODO: we do not rewrite LIKEs with multiple wildcards here. Theoretically, we could rewrite "c LIKE RED%E%" to "c >= RED
+  //and C < REE and c LIKE RED%E%" but that would require adding new predicate nodes. For now, we assume that the potential
+  //pruning of such LIKE predicates via the chunk pruning rule is sufficient. However, if not many chunks can be pruned,
+  //rewriting with additional predicates might show to be beneficial.
   if (multi_char_wildcard_pos == std::string::npos || multi_char_wildcard_pos == 0 ||
       multi_char_wildcard_pos + 1 != pattern.size()) {
     return;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -1,11 +1,11 @@
 #include "min_max_filter.hpp"
 
+#include <iostream>
 #include <memory>
 #include <optional>
-#include <utility>
-#include <string>
-#include <iostream>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include "abstract_statistics_object.hpp"
 #include "all_type_variant.hpp"
@@ -174,16 +174,16 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
 
         auto wildcard_pos = size_t{};
 
-        if (!single_valid_char_wildcard_exist && !multi_char_wildcard_pos_exsists){
+        if (!single_valid_char_wildcard_exist && !multi_char_wildcard_pos_exsists) {
           return false;
         }
         if (single_char_wildcard_pos == 0 || multi_char_wildcard_pos == 0) {
           return false;
         }
-        if (single_valid_char_wildcard_exist && single_char_wildcard_pos != 0){
+        if (single_valid_char_wildcard_exist && single_char_wildcard_pos != 0) {
           wildcard_pos = single_char_wildcard_pos;
         }
-        if (multi_char_wildcard_pos_exsists && multi_char_wildcard_pos != 0 && wildcard_pos < multi_char_wildcard_pos){
+        if (multi_char_wildcard_pos_exsists && multi_char_wildcard_pos != 0 && wildcard_pos < multi_char_wildcard_pos) {
           wildcard_pos = multi_char_wildcard_pos;
         }
 
@@ -194,7 +194,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
         //// Calculate upper bound of the search pattern according to ASCII-table
         constexpr int MAX_ASCII_VALUE = 127;
         if (current_character_value >= MAX_ASCII_VALUE) {
-          // current_character_value + 1 would overflow. 
+          // current_character_value + 1 would overflow.
           return max < lower_bound;
         }
         const auto next_character = static_cast<char>(current_character_value + 1);
@@ -202,7 +202,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
 
         return max < lower_bound || upper_bound < min;
       }
-    return false;
+      return false;
     }
     default:
       return false;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -1,10 +1,7 @@
 #include "min_max_filter.hpp"
 
-#include <iostream>
 #include <memory>
 #include <optional>
-#include <sstream>
-#include <string>
 #include <utility>
 
 #include "abstract_statistics_object.hpp"

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -163,25 +163,14 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       if constexpr (std::is_same_v<T, pmr_string>) {
         const auto pattern = boost::get<pmr_string>(variant_value);
 
-        const auto single_char_wildcard_pos = pattern.find_first_of('_');
-        const auto multi_char_wildcard_pos = pattern.find_first_of('%');
+        const auto wildcard_pos = pattern.find_first_of("_%");
 
-        const auto single_valid_char_wildcard_exist = (single_char_wildcard_pos != std::string::npos);
-        const auto multi_char_wildcard_pos_exsists = (multi_char_wildcard_pos != std::string::npos);
+        if (wildcard_pos == std::string::npos) {
+          return value < min || value > max;
+        }
 
-        auto wildcard_pos = size_t{};
-
-        if (!single_valid_char_wildcard_exist && !multi_char_wildcard_pos_exsists) {
+        if (wildcard_pos == 0) {
           return false;
-        }
-        if (single_char_wildcard_pos == 0 || multi_char_wildcard_pos == 0) {
-          return false;
-        }
-        if (single_valid_char_wildcard_exist && single_char_wildcard_pos != 0) {
-          wildcard_pos = single_char_wildcard_pos;
-        }
-        if (multi_char_wildcard_pos_exsists && multi_char_wildcard_pos != 0 && wildcard_pos < multi_char_wildcard_pos) {
-          wildcard_pos = multi_char_wildcard_pos;
         }
 
         // Calculate lower bound of the search pattern

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -161,7 +161,6 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
     }
     case PredicateCondition::Like: {
       if constexpr (std::is_same_v<T, pmr_string>) {
-
         if (!LikeMatcher::contains_wildcard(value)) {
           return value < min || value > max;
         }
@@ -181,7 +180,6 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
     }
     case PredicateCondition::NotLike: {
       if constexpr (std::is_same_v<T, pmr_string>) {
-
         if (!LikeMatcher::contains_wildcard(value)) {
           return value == min && value == max;
         }

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -159,7 +159,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       const auto value2 = boost::get<T>(*variant_value2);
       return value >= max || value2 <= min;
     }
-    case PredicateCondition::Like: {  // NOLINTNEXTLINE - clang-tidy doesn't like the the else path of the if constexpr
+    case PredicateCondition::Like: {  // NOLINTNEXTLINE - clang-tidy doesn't like the else path of the if constexpr
       // Examples for the handling of Like predicate:
       //                        | test%         | %test   | test\x7F% | test           | '' (empty string)
       // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}
@@ -176,8 +176,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
 
       return false;
     }
-    case PredicateCondition::
-        NotLike: {  // NOLINTNEXTLINE - clang-tidy doesn't like the the else path of the if constexpr
+    case PredicateCondition::NotLike: {  // NOLINTNEXTLINE - clang-tidy doesn't like the else path of the if constexpr
       // Examples for the handling of NotLike predicate:
       //                          | test%           | %test   | test\x7F% | test             | '' (empty string)
       // LikeMatcher::bounds()    | {test, tesu}    | nullopt | nullopt   | {test, test\0}   | {'', '\0'}

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -160,6 +160,9 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       return value >= max || value2 <= min;
     }
     case PredicateCondition::Like: {  // NOLINTNEXTLINE - clang-tidy doesn't like the else path of the if constexpr
+      // We do not handle the case of outlier min/max values. For example `USA%` is not pruned whenever just a single
+      // value with a lower case exists, because the default ASCII-based sorting places all upper case values before
+      // lower case values.
       // Examples for the handling of Like predicate:
       //                        | test%         | %test   | test\x7F% | test           | '' (empty string)
       // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -6,10 +6,10 @@
 
 #include "abstract_statistics_object.hpp"
 #include "all_type_variant.hpp"
+#include "expression/evaluation/like_matcher.hpp"
 #include "lossless_cast.hpp"
 #include "resolve_type.hpp"
 #include "types.hpp"
-#include "expression/evaluation/like_matcher.hpp"
 
 namespace opossum {
 
@@ -171,7 +171,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
           return false;
         }
 
-        auto [lower_bound, upper_bound] =  LikeMatcher::get_lower_upper_bound(pattern);
+        auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
 
         if (lower_bound == upper_bound) {
           return max < lower_bound;
@@ -194,7 +194,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
           return true;
         }
 
-        auto [lower_bound, upper_bound] =  LikeMatcher::get_lower_upper_bound(pattern);
+        auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
 
         if (lower_bound == upper_bound) {
           return max == lower_bound && lower_bound == min;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -162,48 +162,47 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       return value >= max || value2 <= min;
     }
     case PredicateCondition::Like: {
-      
-      const auto pattern = boost::get<pmr_string>(variant_value);
+      if constexpr (std::is_same_v<T, pmr_string>) {
+        const auto pattern = boost::get<pmr_string>(variant_value);
 
-      const auto single_char_wildcard_pos = pattern.find_first_of('_');
-      const auto multi_char_wildcard_pos = pattern.find_first_of('%');
+        const auto single_char_wildcard_pos = pattern.find_first_of('_');
+        const auto multi_char_wildcard_pos = pattern.find_first_of('%');
 
-      const auto single_valid_char_wildcard_exist = bool{(single_char_wildcard_pos != std::string::npos)};
-      const auto multi_char_wildcard_pos_exsists = bool{(multi_char_wildcard_pos != std::string::npos)};
+        const auto single_valid_char_wildcard_exist = bool{(single_char_wildcard_pos != std::string::npos)};
+        const auto multi_char_wildcard_pos_exsists = bool{(multi_char_wildcard_pos != std::string::npos)};
 
-      auto wildcard_pos = size_t{};
+        auto wildcard_pos = size_t{};
 
-      if (!single_valid_char_wildcard_exist && !multi_char_wildcard_pos_exsists){
+        if (!single_valid_char_wildcard_exist && !multi_char_wildcard_pos_exsists){
+          return false;
+        }
+        if (single_char_wildcard_pos == 0 || multi_char_wildcard_pos == 0) {
+          return false;
+        }
+        if (single_valid_char_wildcard_exist && single_char_wildcard_pos != 0){
+          wildcard_pos = single_char_wildcard_pos;
+        }
+        if (multi_char_wildcard_pos_exsists && multi_char_wildcard_pos != 0 && wildcard_pos < multi_char_wildcard_pos){
+          wildcard_pos = multi_char_wildcard_pos;
+        }
+        // Calculate lower bound of the search pattern
+        const auto lower_bound = pattern.substr(0, wildcard_pos);
+        const auto current_character_value = lower_bound.back();
+
+        // Find next value according to ASCII-table
+        constexpr int MAX_ASCII_VALUE = 127;
+        if (current_character_value >= MAX_ASCII_VALUE) {
+          // current_character_value + 1 would overflow; TODO: need to be handled
+          return max < lower_bound;
+        }
+
+        const auto next_character = static_cast<char>(current_character_value + 1);
+        const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_character;
+
+        return max < lower_bound || upper_bound < min;
+      } else {
         return false;
       }
-      if (single_char_wildcard_pos == 0 || multi_char_wildcard_pos == 0) {
-        return false;
-      }
-      if (single_valid_char_wildcard_exist && single_char_wildcard_pos != 0){
-        wildcard_pos = single_char_wildcard_pos;
-      }
-      if (multi_char_wildcard_pos_exsists && multi_char_wildcard_pos != 0 && wildcard_pos < multi_char_wildcard_pos){
-        wildcard_pos = multi_char_wildcard_pos;
-      }
-      // Calculate lower bound of the search pattern
-      const auto lower_bound = pattern.substr(0, wildcard_pos);
-      const auto current_character_value = lower_bound.back();
-
-      const auto value_lower_bound = boost::get<T>(variant_value);
-
-      // Find next value according to ASCII-table
-      constexpr int MAX_ASCII_VALUE = 127;
-      if (current_character_value >= MAX_ASCII_VALUE) {
-        // current_character_value + 1 would overflow; TODO: need to be handled
-        return max < value_lower_bound;
-      }
-
-      const auto next_character = static_cast<char>(current_character_value + 1);
-      const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_character;
-
-      const auto value_upper_bound = boost::get<T>(upper_bound);
-
-      return max < value_lower_bound || value_upper_bound < min;
     }
     default:
       return false;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -171,7 +171,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
           return false;
         }
 
-        auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
+        const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
 
         if (lower_bound == upper_bound) {
           return max < lower_bound;
@@ -194,7 +194,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
           return true;
         }
 
-        auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
+        const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
 
         if (lower_bound == upper_bound) {
           return max == lower_bound && lower_bound == min;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -162,34 +162,6 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       return value >= max || value2 <= min;
     }
     case PredicateCondition::Like: {
-
-      const auto pattern = boost::get<pmr_string>(variant_value);
-
-      // Continue only if pattern don't start with "_"-wildcard
-      if (pattern.find_first_of('_') != std::string::npos) {
-        return false;
-      }
-
-      const auto multi_char_wildcard_pos = pattern.find_first_of('%');
-        
-      // Only continue if "%"-wildcard exist and isn't on position 0.
-      if (multi_char_wildcard_pos == std::string::npos || multi_char_wildcard_pos == 0){
-        return false;
-      }
-
-      // Calculate lower bound of the search pattern
-      const auto lower_bound = pattern.substr(0, multi_char_wildcard_pos);
-      const auto current_character_value = lower_bound.back();
-
-      // Find next value according to ASCII-table
-      constexpr int MAX_ASCII_VALUE = 127;
-      if (current_character_value >= MAX_ASCII_VALUE) {
-        // current_character_value + 1 would overflow; TODO: need to be handled
-        return false;
-      }
-
-      const auto next_character = static_cast<char>(current_character_value + 1);
-      const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_character;
       //hacky solution. Somehow I can't simply compare max/min and lower_bound/upper_bound with each other. TODO find a better solution
       std::stringstream max_ss;
       std::stringstream min_ss;
@@ -197,7 +169,43 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       std::stringstream upper_bound_ss;
       max_ss << max;
       min_ss << min;
+
+      const auto pattern = boost::get<pmr_string>(variant_value);
+
+      const auto single_char_wildcard_pos = pattern.find_first_of('_');
+      const auto multi_char_wildcard_pos = pattern.find_first_of('%');
+
+      const auto single_valid_char_wildcard_exist = bool{(single_char_wildcard_pos != std::string::npos)};
+      const auto multi_char_wildcard_pos_exsists = bool{(multi_char_wildcard_pos != std::string::npos)};
+
+      auto wildcard_pos = size_t{};
+
+      if (!single_valid_char_wildcard_exist && !multi_char_wildcard_pos_exsists){
+        return false;
+      }
+      if (single_char_wildcard_pos == 0 || multi_char_wildcard_pos == 0) {
+        return false;
+      }
+      if (single_valid_char_wildcard_exist && single_char_wildcard_pos != 0){
+        wildcard_pos = single_char_wildcard_pos;
+      }
+      if (multi_char_wildcard_pos_exsists && multi_char_wildcard_pos != 0 && wildcard_pos < multi_char_wildcard_pos){
+        wildcard_pos = multi_char_wildcard_pos;
+      }
+      // Calculate lower bound of the search pattern
+      const auto lower_bound = pattern.substr(0, wildcard_pos);
+      const auto current_character_value = lower_bound.back();
       lower_bound_ss << lower_bound;
+
+      // Find next value according to ASCII-table
+      constexpr int MAX_ASCII_VALUE = 127;
+      if (current_character_value >= MAX_ASCII_VALUE) {
+        // current_character_value + 1 would overflow; TODO: need to be handled
+        return max_ss.str() < lower_bound_ss.str();
+      }
+
+      const auto next_character = static_cast<char>(current_character_value + 1);
+      const auto upper_bound = lower_bound.substr(0, lower_bound.size() - 1) + next_character;
       upper_bound_ss << upper_bound;
 
       return max_ss.str() < lower_bound_ss.str() || upper_bound_ss.str() < min_ss.str();

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -162,11 +162,10 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
     case PredicateCondition::Like: {
       // Examples for the handle of Like predicate:
       //                        | test%         | %test   | test\x7F% | test           | '' (empty string)
-      // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}    
+      // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}
       // does_not_contain(Like) | max < test || | false   | false     | max < test ||  | max < '' ||
       //                        | min >= tesu   |         |           | min >= test\0  | min >= '\0'
       if constexpr (std::is_same_v<T, pmr_string>) {
-
         const auto bounds = LikeMatcher::bounds(value);
         if (!bounds) return false;
 
@@ -180,11 +179,10 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
     case PredicateCondition::NotLike: {
       // Examples for the handle of NotLike predicate:
       //                          | test%          | %test   | test\x7F% | test            | '' (empty string)
-      // LikeMatcher::bounds()    | {test, tesu}   | nullopt | nullopt   | {test, test\0}  | {'', '\0'}    
-      // does_not_contain(NotLike)| min >= test && | false   | false     | min >= test &&  | min >= '\0' && 
+      // LikeMatcher::bounds()    | {test, tesu}   | nullopt | nullopt   | {test, test\0}  | {'', '\0'}
+      // does_not_contain(NotLike)| min >= test && | false   | false     | min >= test &&  | min >= '\0' &&
       //                          | max < tesu     |         |           | max < test\0    | max < '\0'
       if constexpr (std::is_same_v<T, pmr_string>) {
-
         const auto bounds = LikeMatcher::bounds(value);
         if (!bounds) return false;
 

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -160,9 +160,9 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       return value >= max || value2 <= min;
     }
     case PredicateCondition::Like: {  // NOLINTNEXTLINE - clang-tidy doesn't like the else path of the if constexpr
-      // We do not handle the case of outlier min/max values. For example `USA%` is not pruned whenever just a single
-      // value with a lower case exists, because the default ASCII-based sorting places all upper case values before
-      // lower case values.
+      // We use the ascii collation for min/max filters. This means that lower case letters are considered larger than
+      // upper case letters. This can lead to a situation, where the USA% (e.g., JOB query XXXXX) is not pruned
+      // whenever just a single value starts with a lower case letter.
       // Examples for the handling of Like predicate:
       //                        | test%         | %test   | test\x7F% | test           | '' (empty string)
       // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -160,10 +160,10 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       return value >= max || value2 <= min;
     }
     case PredicateCondition::Like: {
-      // Examples for the handle of Like predicate:
+      // Examples for the handling of Like predicate:
       //                        | test%         | %test   | test\x7F% | test           | '' (empty string)
       // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}
-      // does_not_contain(Like) | max < test || | false   | false     | max < test ||  | max < '' ||
+      // does_not_contain(Like) | max < test or | false   | false     | max < test or  | max < '' or
       //                        | min >= tesu   |         |           | min >= test\0  | min >= '\0'
       if constexpr (std::is_same_v<T, pmr_string>) {
         const auto bounds = LikeMatcher::bounds(value);
@@ -177,11 +177,11 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       return false;
     }
     case PredicateCondition::NotLike: {
-      // Examples for the handle of NotLike predicate:
-      //                          | test%          | %test   | test\x7F% | test            | '' (empty string)
-      // LikeMatcher::bounds()    | {test, tesu}   | nullopt | nullopt   | {test, test\0}  | {'', '\0'}
-      // does_not_contain(NotLike)| min >= test && | false   | false     | min >= test &&  | min >= '\0' &&
-      //                          | max < tesu     |         |           | max < test\0    | max < '\0'
+      // Examples for the handling of NotLike predicate:
+      //                          | test%           | %test   | test\x7F% | test             | '' (empty string)
+      // LikeMatcher::bounds()    | {test, tesu}    | nullopt | nullopt   | {test, test\0}   | {'', '\0'}
+      // does_not_contain(NotLike)| min >= test and | false   | false     | min >= test and  | min >= '\0' and
+      //                          | max < tesu      |         |           | max < test\0     | max < '\0'
       if constexpr (std::is_same_v<T, pmr_string>) {
         const auto bounds = LikeMatcher::bounds(value);
         if (!bounds) return false;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -159,7 +159,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
       const auto value2 = boost::get<T>(*variant_value2);
       return value >= max || value2 <= min;
     }
-    case PredicateCondition::Like: {
+    case PredicateCondition::Like: {  // NOLINTNEXTLINE - clang-tidy doesn't like the the else path of the if constexpr
       // Examples for the handling of Like predicate:
       //                        | test%         | %test   | test\x7F% | test           | '' (empty string)
       // LikeMatcher::bounds()  | {test, tesu}  | nullopt | nullopt   | {test, test\0} | {'', '\0'}
@@ -176,7 +176,8 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
 
       return false;
     }
-    case PredicateCondition::NotLike: {
+    case PredicateCondition::
+        NotLike: {  // NOLINTNEXTLINE - clang-tidy doesn't like the the else path of the if constexpr
       // Examples for the handling of NotLike predicate:
       //                          | test%           | %test   | test\x7F% | test             | '' (empty string)
       // LikeMatcher::bounds()    | {test, tesu}    | nullopt | nullopt   | {test, test\0}   | {'', '\0'}

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -169,7 +169,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
         const auto bounds = LikeMatcher::bounds(value);
         if (!bounds) return false;
 
-        const auto [lower_bound, upper_bound] = bounds.value();
+        const auto [lower_bound, upper_bound] = *bounds;
 
         return max < lower_bound || upper_bound <= min;
       }
@@ -186,7 +186,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
         const auto bounds = LikeMatcher::bounds(value);
         if (!bounds) return false;
 
-        const auto [lower_bound, upper_bound] = bounds.value();
+        const auto [lower_bound, upper_bound] = *bounds;
 
         return max < upper_bound && lower_bound <= min;
       }

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -161,13 +161,12 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
     }
     case PredicateCondition::Like: {
       if constexpr (std::is_same_v<T, pmr_string>) {
-        const auto pattern = boost::get<pmr_string>(variant_value);
 
-        if (!LikeMatcher::contains_wildcard(pattern)) {
+        if (!LikeMatcher::contains_wildcard(value)) {
           return value < min || value > max;
         }
 
-        const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+        const auto bounds = LikeMatcher::get_lower_upper_bound(value);
         // In case of an ASCII overflow or Leading wildcard
         if (!bounds) {
           return false;
@@ -182,17 +181,16 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
     }
     case PredicateCondition::NotLike: {
       if constexpr (std::is_same_v<T, pmr_string>) {
-        const auto pattern = boost::get<pmr_string>(variant_value);
 
-        if (!LikeMatcher::contains_wildcard(pattern)) {
+        if (!LikeMatcher::contains_wildcard(value)) {
           return value == min && value == max;
         }
 
-        if (LikeMatcher::get_index_of_next_wildcard(pattern, 0) == 0) {
+        if (LikeMatcher::get_index_of_next_wildcard(value, 0) == 0) {
           return true;
         }
 
-        const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+        const auto bounds = LikeMatcher::get_lower_upper_bound(value);
         // In case of an ASCII overflow
         if (!bounds) {
           return false;

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -167,15 +167,13 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
           return value < min || value > max;
         }
 
-        if (LikeMatcher::get_index_of_next_wildcard(pattern, 0) == 0) {
+        const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+        // In case of an ASCII overflow or Leading wildcard
+        if (!bounds) {
           return false;
         }
 
-        const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
-
-        if (lower_bound == upper_bound) {
-          return max < lower_bound;
-        }
+        const auto [lower_bound, upper_bound] = bounds.value();
 
         return max < lower_bound || upper_bound < min;
       }
@@ -194,11 +192,13 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
           return true;
         }
 
-        const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
-
-        if (lower_bound == upper_bound) {
-          return max == lower_bound && lower_bound == min;
+        const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+        // In case of an ASCII overflow
+        if (!bounds) {
+          return false;
         }
+
+        const auto [lower_bound, upper_bound] = bounds.value();
 
         return max <= upper_bound && lower_bound <= min;
       }

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -173,7 +173,7 @@ bool MinMaxFilter<T>::does_not_contain(const PredicateCondition predicate_condit
 
         const auto [lower_bound, upper_bound] = bounds.value();
 
-        return max < lower_bound || upper_bound < min;
+        return max < lower_bound || upper_bound <= min;
       }
 
       return false;

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -57,7 +57,7 @@ TEST_F(LikeMatcherTest, NotMatching) {
 
 TEST_F(LikeMatcherTest, LowerUpperBound) {
   const auto pattern = pmr_string("Japan%");
-  const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+  const auto bounds = LikeMatcher::bounds(pattern);
   const auto [lower_bound, upper_bound] = bounds.value();
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, "Japao");
@@ -67,15 +67,35 @@ TEST_F(LikeMatcherTest, ASCIIOverflow) {
   // Check that if the char ASCII value before the wildcard has the max ASCII value 127, std::nullopt is returned.
   auto max_ascii_value = pmr_string(1, static_cast<char>(127));
   max_ascii_value.append("%");
-  const auto bounds = LikeMatcher::get_lower_upper_bound(max_ascii_value);
+  const auto bounds = LikeMatcher::bounds(max_ascii_value);
   EXPECT_FALSE(bounds);
 }
 
 TEST_F(LikeMatcherTest, LeadingWildcard) {
   // Check that if the pattern has a leading wildcard, std::nullopt is returned.
   const auto pattern = pmr_string("%Japan");
-  const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+  const auto bounds = LikeMatcher::bounds(pattern);
   EXPECT_FALSE(bounds);
+}
+
+TEST_F(LikeMatcherTest, NoWildcard) {
+  // Check that if the pattern has no wildcard, std::nullopt is returned.
+  const auto pattern = pmr_string("Japan");
+  const auto expected_upper_bound = pmr_string("Japan") + static_cast<char>(0);
+  const auto bounds = LikeMatcher::bounds(pattern);
+  const auto [lower_bound, upper_bound] = bounds.value();
+  ASSERT_EQ(lower_bound, "Japan");
+  ASSERT_EQ(upper_bound, expected_upper_bound);
+}
+
+TEST_F(LikeMatcherTest, EmptyString) {
+  // Check that if the pattern has no wildcard, std::nullopt is returned.
+  const auto pattern = pmr_string("");
+  const auto expected_upper_bound = pmr_string("") + static_cast<char>(0);
+  const auto bounds = LikeMatcher::bounds(pattern);
+  const auto [lower_bound, upper_bound] = bounds.value();
+  ASSERT_EQ(lower_bound, "");
+  ASSERT_EQ(upper_bound, expected_upper_bound);
 }
 
 }  // namespace opossum

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <utility>
 
 #include "base_test.hpp"
 
@@ -52,6 +53,19 @@ TEST_F(LikeMatcherTest, NotMatching) {
   EXPECT_FALSE(match("hello", "Hello"));
   EXPECT_FALSE(match("Hello", "Hello_"));
   EXPECT_FALSE(match("Hello", "He_o"));
+}
+
+TEST_F(LikeMatcherTest, LowerUpperBound) {
+  auto pattern = pmr_string("Japan%");
+  auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
+  ASSERT_EQ(lower_bound, "Japan");
+  ASSERT_EQ(upper_bound, "Japao");
+
+  auto max_ascii_value = pmr_string(1, static_cast<char>(127));
+  max_ascii_value.append("%");
+  auto [lower_bound_max_ascii, upper_bound_max_ascii] = LikeMatcher::get_lower_upper_bound(max_ascii_value);
+  ASSERT_EQ(lower_bound_max_ascii, pmr_string(1, static_cast<char>(127)));
+  ASSERT_EQ(lower_bound_max_ascii, upper_bound_max_ascii);
 }
 
 }  // namespace opossum

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -61,6 +61,8 @@ TEST_F(LikeMatcherTest, LowerUpperBound) {
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, "Japao");
 
+  // Check that if the char ASCII value before the wildcard has the max ASCII value 127, the upper and lower bound are
+  // the same.
   auto max_ascii_value = pmr_string(1, static_cast<char>(127));
   max_ascii_value.append("%");
   const auto [lower_bound_max_ascii, upper_bound_max_ascii] = LikeMatcher::get_lower_upper_bound(max_ascii_value);

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -56,14 +56,14 @@ TEST_F(LikeMatcherTest, NotMatching) {
 }
 
 TEST_F(LikeMatcherTest, LowerUpperBound) {
-  auto pattern = pmr_string("Japan%");
-  auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
+  const auto pattern = pmr_string("Japan%");
+  const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, "Japao");
 
   auto max_ascii_value = pmr_string(1, static_cast<char>(127));
   max_ascii_value.append("%");
-  auto [lower_bound_max_ascii, upper_bound_max_ascii] = LikeMatcher::get_lower_upper_bound(max_ascii_value);
+  const auto [lower_bound_max_ascii, upper_bound_max_ascii] = LikeMatcher::get_lower_upper_bound(max_ascii_value);
   ASSERT_EQ(lower_bound_max_ascii, pmr_string(1, static_cast<char>(127)));
   ASSERT_EQ(lower_bound_max_ascii, upper_bound_max_ascii);
 }

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -60,7 +60,9 @@ TEST_F(LikeMatcherTest, LowerUpperBound) {
   const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, "Japao");
+}
 
+TEST_F(LikeMatcherTest, ASCIIOverflow) {
   // Check that if the char ASCII value before the wildcard has the max ASCII value 127, the upper and lower bound are
   // the same.
   auto max_ascii_value = pmr_string(1, static_cast<char>(127));

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -79,7 +79,6 @@ TEST_F(LikeMatcherTest, LeadingWildcard) {
 }
 
 TEST_F(LikeMatcherTest, NoWildcard) {
-  // Check that if the pattern has no wildcard, std::nullopt is returned.
   const auto pattern = pmr_string("Japan");
   const auto expected_upper_bound = pmr_string("Japan") + static_cast<char>(0);
   const auto bounds = LikeMatcher::bounds(pattern);

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -57,19 +57,25 @@ TEST_F(LikeMatcherTest, NotMatching) {
 
 TEST_F(LikeMatcherTest, LowerUpperBound) {
   const auto pattern = pmr_string("Japan%");
-  const auto [lower_bound, upper_bound] = LikeMatcher::get_lower_upper_bound(pattern);
+  const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+  const auto [lower_bound, upper_bound] = bounds.value();
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, "Japao");
 }
 
 TEST_F(LikeMatcherTest, ASCIIOverflow) {
-  // Check that if the char ASCII value before the wildcard has the max ASCII value 127, the upper and lower bound are
-  // the same.
+  // Check that if the char ASCII value before the wildcard has the max ASCII value 127, std::nullopt is returned.
   auto max_ascii_value = pmr_string(1, static_cast<char>(127));
   max_ascii_value.append("%");
-  const auto [lower_bound_max_ascii, upper_bound_max_ascii] = LikeMatcher::get_lower_upper_bound(max_ascii_value);
-  ASSERT_EQ(lower_bound_max_ascii, pmr_string(1, static_cast<char>(127)));
-  ASSERT_EQ(lower_bound_max_ascii, upper_bound_max_ascii);
+  const auto bounds = LikeMatcher::get_lower_upper_bound(max_ascii_value);
+  EXPECT_FALSE(bounds);
+}
+
+TEST_F(LikeMatcherTest, LeadingWildcard) {
+  // Check that if the pattern has a leading wildcard, std::nullopt is returned.
+  const auto pattern = pmr_string("%Japan");
+  const auto bounds = LikeMatcher::get_lower_upper_bound(pattern);
+  EXPECT_FALSE(bounds);
 }
 
 }  // namespace opossum

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -80,7 +80,7 @@ TEST_F(LikeMatcherTest, LeadingWildcard) {
 
 TEST_F(LikeMatcherTest, NoWildcard) {
   const auto pattern = pmr_string("Japan");
-  const auto expected_upper_bound = pmr_string("Japan") + static_cast<char>(0);
+  const auto expected_upper_bound = pmr_string("Japan") + '\0';
   const auto bounds = LikeMatcher::bounds(pattern);
   const auto [lower_bound, upper_bound] = bounds.value();
   ASSERT_EQ(lower_bound, "Japan");
@@ -90,7 +90,7 @@ TEST_F(LikeMatcherTest, NoWildcard) {
 TEST_F(LikeMatcherTest, EmptyString) {
   // Check that if the pattern has no wildcard, std::nullopt is returned.
   const auto pattern = pmr_string("");
-  const auto expected_upper_bound = pmr_string("") + static_cast<char>(0);
+  const auto expected_upper_bound = pmr_string("") + '\0';
   const auto bounds = LikeMatcher::bounds(pattern);
   const auto [lower_bound, upper_bound] = bounds.value();
   ASSERT_EQ(lower_bound, "");

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -97,6 +97,10 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::Like, max_ascii_value));
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
+
+  // The following test should make sure, that the pruning differentiate between upper and lower case characters.
+  const auto filter_max_lower_case = std::make_unique<MinMaxFilter<pmr_string>>("T", "t");
+  EXPECT_TRUE(filter_max_lower_case->does_not_contain(PredicateCondition::Like, "USA%"));
 }
 
 using MixMaxFilterTypes = ::testing::Types<int, float, double, pmr_string>;

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -98,7 +98,8 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::Like, max_ascii_value));
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
 
-  // We do not handle the case of outlier min/max values.
+  // We use the ascii collation for min/max filters. This means that lower case letters are considered larger than
+  // upper case letters. In this test USA% is not pruned since t is a lower case value.
   const auto filter_max_lower_case = std::make_unique<MinMaxFilter<pmr_string>>("T", "t");
   EXPECT_FALSE(filter_max_lower_case->does_not_contain(PredicateCondition::Like, "USA%"));
 }

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -64,6 +64,7 @@ TEST_F(MinMaxFilterTestLike, CanPrune) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "z%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "switzerland:%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "at%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%at%"));
   
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "au%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "switzerland%"));
@@ -71,6 +72,8 @@ TEST_F(MinMaxFilterTestLike, CanPrune) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:%200%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:.....%200%"));
+
+
 
 }
 

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -65,6 +65,7 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "aa_"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc_"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "a"));
 
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "bbbb%"));
@@ -73,6 +74,7 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b"));
 
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "b%"));
 

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -77,12 +77,14 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "c"));
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::Like, max_ascii_value));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "b%"));
 
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "b%"));
   EXPECT_TRUE(filter_equal_values->does_not_contain(PredicateCondition::NotLike, "a"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "%"));
 
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "b"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "%"));
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "a%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "c%"));

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -80,8 +80,8 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc_"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "a"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, max_ascii_value));
 
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, max_ascii_value));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "bbbb%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "c%"));
@@ -95,8 +95,8 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "b%"));
   EXPECT_TRUE(filter_equal_values->does_not_contain(PredicateCondition::NotLike, "a"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "%"));
-  EXPECT_TRUE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
 
+  EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "a%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "c%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "bb%"));

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -50,10 +50,12 @@ class MinMaxFilterTest<pmr_string> : public BaseTest {
 
 class MinMaxFilterTestLike : public BaseTest {
  protected:
-  void SetUp() override { 
+  void SetUp() override {
     _values = pmr_vector<pmr_string>{"b", "bb", "bbb", "bbbb", "c"};
-    _values_max_ascii = pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(127)) ,pmr_string(1, static_cast<char>(127))};
-    _values_with_max_ascii = pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(126)) ,pmr_string(1, static_cast<char>(127))};
+    _values_max_ascii =
+        pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(127)), pmr_string(1, static_cast<char>(127))};
+    _values_with_max_ascii =
+        pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(126)), pmr_string(1, static_cast<char>(127))};
     _equal_values = pmr_vector<pmr_string>{"a", "a", "a"};
     max_ascii_value = pmr_string(1, static_cast<char>(127));
     max_ascii_value.append("%");
@@ -64,9 +66,12 @@ class MinMaxFilterTestLike : public BaseTest {
 
 TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   auto filter = std::make_unique<MinMaxFilter<pmr_string>>(this->_values.front(), this->_values.back());
-  auto filter_with_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(this->_values_with_max_ascii.front(), this->_values_with_max_ascii.back());
-  auto filter_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(this->_values_max_ascii.front(), this->_values_max_ascii.back());
-  auto filter_equal_values = std::make_unique<MinMaxFilter<pmr_string>>(this->_equal_values.front(), this->_equal_values.back());
+  auto filter_with_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(this->_values_with_max_ascii.front(),
+                                                                          this->_values_with_max_ascii.back());
+  auto filter_max_ascii =
+      std::make_unique<MinMaxFilter<pmr_string>>(this->_values_max_ascii.front(), this->_values_max_ascii.back());
+  auto filter_equal_values =
+      std::make_unique<MinMaxFilter<pmr_string>>(this->_equal_values.front(), this->_equal_values.back());
   // for the predicate condition of Like, we expect only values where the lower_bound is bigger then max
   // or the upper_bound is smaller then min to be prunable
 

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -72,9 +72,6 @@ TEST_F(MinMaxFilterTestLike, CanPrune) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:%200%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:.....%200%"));
-
-
-
 }
 
 using MixMaxFilterTypes = ::testing::Types<int, float, double, pmr_string>;

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -98,9 +98,9 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::Like, max_ascii_value));
   EXPECT_FALSE(filter_max_ascii->does_not_contain(PredicateCondition::NotLike, max_ascii_value));
 
-  // The following test should make sure, that the pruning differentiate between upper and lower case characters.
+  // We do not handle the case of outlier min/max values.
   const auto filter_max_lower_case = std::make_unique<MinMaxFilter<pmr_string>>("T", "t");
-  EXPECT_TRUE(filter_max_lower_case->does_not_contain(PredicateCondition::Like, "USA%"));
+  EXPECT_FALSE(filter_max_lower_case->does_not_contain(PredicateCondition::Like, "USA%"));
 }
 
 using MixMaxFilterTypes = ::testing::Types<int, float, double, pmr_string>;

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -50,26 +50,39 @@ class MinMaxFilterTest<pmr_string> : public BaseTest {
 
 class MinMaxFilterTestLike : public BaseTest {
  protected:
-  void SetUp() override { _values = pmr_vector<pmr_string>{"bb", "cc", "dd"}; }
+  void SetUp() override { 
+    _values = pmr_vector<pmr_string>{"b", "bb", "bbb", "bbbb", "c"};
+  }
   pmr_vector<pmr_string> _values;
 };
 
-TEST_F(MinMaxFilterTestLike, CanPrune) {
+TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   auto filter = std::make_unique<MinMaxFilter<pmr_string>>(this->_values.front(), this->_values.back());
   // for the predicate condition of Like, we expect only values where the lower_bound is bigger then max
   // or the upper_bound is smaller then min to be prunable
 
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "aa%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "aa_"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "ee%"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "ee_"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc_"));
 
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "ba%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "dd%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "bbbb%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "c%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "a%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_%"));
+
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "b%"));
+
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "a%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "c%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "bb%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "d%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::NotLike, "aa%"));
 }
+
 
 using MixMaxFilterTypes = ::testing::Types<int, float, double, pmr_string>;
 TYPED_TEST_SUITE(MinMaxFilterTest, MixMaxFilterTypes, );  // NOLINT(whitespace/parens)

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -52,12 +52,18 @@ class MinMaxFilterTestLike : public BaseTest {
  protected:
   void SetUp() override { 
     _values = pmr_vector<pmr_string>{"b", "bb", "bbb", "bbbb", "c"};
+    _values_with_max_ascii = pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(126)) ,pmr_string(1, static_cast<char>(127))};
+    max_ascii_value = pmr_string(1, static_cast<char>(127));
+    max_ascii_value.append("%");
   }
   pmr_vector<pmr_string> _values;
+  pmr_vector<pmr_string> _values_with_max_ascii;
+  pmr_string max_ascii_value;
 };
 
 TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   auto filter = std::make_unique<MinMaxFilter<pmr_string>>(this->_values.front(), this->_values.back());
+  auto filter_with_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(this->_values_with_max_ascii.front(), this->_values_with_max_ascii.back());
   // for the predicate condition of Like, we expect only values where the lower_bound is bigger then max
   // or the upper_bound is smaller then min to be prunable
 
@@ -66,6 +72,7 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc_"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "a"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, max_ascii_value));
 
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "bbbb%"));
@@ -75,6 +82,8 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b"));
+  EXPECT_FALSE(filter_with_max_ascii->does_not_contain(PredicateCondition::Like, max_ascii_value));
+
 
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::NotLike, "b%"));
 

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -67,12 +67,12 @@ TEST_F(MinMaxFilterTestLike, CanPruneLike) {
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "cc_"));
   EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "a"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "a%"));
 
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, max_ascii_value));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "b%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "bbbb%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "c%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "a%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_%"));

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -49,10 +49,8 @@ class MinMaxFilterTest<pmr_string> : public BaseTest {
 };
 
 class MinMaxFilterTestLike : public BaseTest {
-protected: 
-  void SetUp() override {
-    _values = pmr_vector<pmr_string>{"bb", "cc", "dd"};
-  }
+ protected:
+  void SetUp() override { _values = pmr_vector<pmr_string>{"bb", "cc", "dd"}; }
   pmr_vector<pmr_string> _values;
 };
 
@@ -71,7 +69,6 @@ TEST_F(MinMaxFilterTestLike, CanPrune) {
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%"));
   EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
-
 }
 
 using MixMaxFilterTypes = ::testing::Types<int, float, double, pmr_string>;

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -48,30 +48,17 @@ class MinMaxFilterTest<pmr_string> : public BaseTest {
   pmr_string _before_range, _min_value, _max_value, _after_range, _in_between, _in_between2;
 };
 
-class MinMaxFilterTestLike : public BaseTest {
- protected:
-  void SetUp() override {
-    _values = pmr_vector<pmr_string>{"b", "bb", "bbb", "bbbb", "c"};
-    _values_max_ascii =
-        pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(127)), pmr_string(1, static_cast<char>(127))};
-    _values_with_max_ascii =
-        pmr_vector<pmr_string>{pmr_string(1, static_cast<char>(126)), pmr_string(1, static_cast<char>(127))};
-    _equal_values = pmr_vector<pmr_string>{"a", "a", "a"};
-    max_ascii_value = pmr_string(1, static_cast<char>(127));
-    max_ascii_value.append("%");
-  }
-  pmr_vector<pmr_string> _values, _values_max_ascii, _values_with_max_ascii, _equal_values;
-  pmr_string max_ascii_value;
-};
+class MinMaxFilterTestLike : public BaseTest {};
 
 TEST_F(MinMaxFilterTestLike, CanPruneLike) {
-  auto filter = std::make_unique<MinMaxFilter<pmr_string>>(this->_values.front(), this->_values.back());
-  auto filter_with_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(this->_values_with_max_ascii.front(),
-                                                                          this->_values_with_max_ascii.back());
-  auto filter_max_ascii =
-      std::make_unique<MinMaxFilter<pmr_string>>(this->_values_max_ascii.front(), this->_values_max_ascii.back());
-  auto filter_equal_values =
-      std::make_unique<MinMaxFilter<pmr_string>>(this->_equal_values.front(), this->_equal_values.back());
+  auto max_ascii_value = pmr_string(1, static_cast<char>(127));
+  max_ascii_value.append("%");
+  const auto filter = std::make_unique<MinMaxFilter<pmr_string>>("b", "c");
+  const auto filter_with_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(pmr_string(1, static_cast<char>(126)),
+                                                                                pmr_string(1, static_cast<char>(127)));
+  const auto filter_max_ascii = std::make_unique<MinMaxFilter<pmr_string>>(pmr_string(1, static_cast<char>(127)),
+                                                                           pmr_string(1, static_cast<char>(127)));
+  const auto filter_equal_values = std::make_unique<MinMaxFilter<pmr_string>>("a", "a");
   // for the predicate condition of Like, we expect only values where the lower_bound is bigger then max
   // or the upper_bound is smaller then min to be prunable
 

--- a/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
+++ b/src/test/lib/statistics/statistics_objects/min_max_filter_test.cpp
@@ -51,7 +51,7 @@ class MinMaxFilterTest<pmr_string> : public BaseTest {
 class MinMaxFilterTestLike : public BaseTest {
 protected: 
   void SetUp() override {
-    _values = pmr_vector<pmr_string>{"aus", "denmark", "japan", "japan:200", "japan:12344200", "switzerland"};
+    _values = pmr_vector<pmr_string>{"bb", "cc", "dd"};
   }
   pmr_vector<pmr_string> _values;
 };
@@ -60,18 +60,18 @@ TEST_F(MinMaxFilterTestLike, CanPrune) {
   auto filter = std::make_unique<MinMaxFilter<pmr_string>>(this->_values.front(), this->_values.back());
   // for the predicate condition of Like, we expect only values where the lower_bound is bigger then max
   // or the upper_bound is smaller then min to be prunable
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "A:%"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "z%"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "switzerland:%"));
-  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "at%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%at%"));
-  
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "au%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "switzerland%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "aur%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:%200%"));
-  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "japan:.....%200%"));
+
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "aa%"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "aa_"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "ee%"));
+  EXPECT_TRUE(filter->does_not_contain(PredicateCondition::Like, "ee_"));
+
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "ba%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "dd%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "cc%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "%"));
+  EXPECT_FALSE(filter->does_not_contain(PredicateCondition::Like, "_"));
+
 }
 
 using MixMaxFilterTypes = ::testing::Types<int, float, double, pmr_string>;


### PR DESCRIPTION
This PR adds the `LIKE` and `NOT LIKE` predicate to the `min_max_filter`. 

The `does_not_contain` method works now as follows, if the predicate is `LIKE` or `NOT LIKE`: 

* Check if a wild card exists
* Calculate the upper and lower bound of the value. For example, if the value is `Japan%` the lower bound will be `Japan` and the upper will be `Japao`.
* Check if the lower bound is bigger than the max value or the upper bound smaller than the min value. If either of the cases occurs, we can say that the value is not included.

The following table shows the pruning effectiveness (JOB with one run and unsorted): 

<details><summary>show table</summary>
<p>

`pruning failed` = (max < lower_bound || upper_bound <= min) failed  

`bounds not valid` = pattern has a leading wildcard, or upper_bound and lower_bound have an ASCII overflow

|Query|bounds not valid|bounds not valid %|pruning failed|pruning failed %|pruned|pruned %|
 | -- | -- | -- | -- | -- | -- | -- |
     |10a|            7752|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |10b|            3876|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |10c|            3876|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |11a|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |11b|              77|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |11c|               0|               0 %|             0|             0 %|     0|     0 %|
     |11d|               0|               0 %|             0|             0 %|     0|     0 %|
     |12a|               0|               0 %|             0|             0 %|     0|     0 %|
     |12b|               0|               0 %|             0|             0 %|     0|     0 %|
     |12c|               0|               0 %|             0|             0 %|     0|     0 %|
     |13a|               0|               0 %|             0|             0 %|     0|     0 %|
     |13b|               0|               0 %|             0|             0 %|     0|     0 %|
     |13c|               0|               0 %|             0|             0 %|     0|     0 %|
     |13d|               0|               0 %|             0|             0 %|     0|     0 %|
     |14a|               0|               0 %|             0|             0 %|     0|     0 %|
     |14b|               0|               0 %|             0|             0 %|     0|     0 %|
     |14c|               0|               0 %|             0|             0 %|     0|     0 %|
     |15a|           13456|          38.123 %|         15792|        44.742 %|  6048|17.135 %|
     |15b|            6728|          38.123 %|          7896|        44.742 %|  3024|17.135 %|
     |15c|            8160|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |15d|            3060|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |16a|               0|               0 %|             0|             0 %|     0|     0 %|
     |16b|               0|               0 %|             0|             0 %|     0|     0 %|
     |16c|               0|               0 %|             0|             0 %|     0|     0 %|
     |16d|               0|               0 %|             0|             0 %|     0|     0 %|
     |17a|               0|               0 %|             0|             0 %|     0|     0 %|
     |17b|               0|               0 %|             0|             0 %|     0|     0 %|
     |17c|               0|               0 %|             0|             0 %|     0|     0 %|
     |17d|             392|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |17e|               0|               0 %|             0|             0 %|     0|     0 %|
     |17f|             392|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |18a|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |18b|               0|               0 %|             0|             0 %|     0|     0 %|
     |18c|               0|               0 %|             0|             0 %|     0|     0 %|
     |19a|             784|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |19b|            1976|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |19c|             588|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |19d|               0|               0 %|             0|             0 %|     0|     0 %|
     | 1a|               0|               0 %|             0|             0 %|     0|     0 %|
     | 1b|               0|               0 %|             0|             0 %|     0|     0 %|
     | 1c|             152|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 1d|               0|               0 %|             0|             0 %|     0|     0 %|
     |20a|              16|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |20b|             114|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |20c|              16|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |21a|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |21b|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |21c|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |22a|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |22b|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |22c|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |22d|               0|               0 %|             0|             0 %|     0|     0 %|
     |23a|            2040|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |23b|             255|          35.915 %|           329|        46.338 %|   126|17.746 %|
     |23c|            2040|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |24a|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |24b|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |25a|               0|               0 %|             0|             0 %|     0|     0 %|
     |25b|               0|               0 %|             0|             0 %|     0|     0 %|
     |25c|               0|               0 %|             0|             0 %|     0|     0 %|
     |26a|              12|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |26b|               8|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |26c|              12|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |27a|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |27b|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |27c|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |28a|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |28b|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |28c|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |29a|           18816|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |29b|           37632|          95.387 %|          1316|         3.336 %|   504| 1.278 %|
     |29c|             196|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 2a|               0|               0 %|             0|             0 %|     0|     0 %|
     | 2b|               0|               0 %|             0|             0 %|     0|     0 %|
     | 2c|               0|               0 %|             0|             0 %|     0|     0 %|
     | 2d|               0|               0 %|             0|             0 %|     0|     0 %|
     |30a|               0|               0 %|             0|             0 %|     0|     0 %|
     |30b|               0|               0 %|             0|             0 %|     0|     0 %|
     |30c|               0|               0 %|             0|             0 %|     0|     0 %|
     |31a|               0|               0 %|             0|             0 %|     0|     0 %|
     |31b|           12312|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |31c|               0|               0 %|             0|             0 %|     0|     0 %|
     |32a|               0|               0 %|             0|             0 %|     0|     0 %|
     |32b|               0|               0 %|             0|             0 %|     0|     0 %|
     |33a|               0|               0 %|             0|             0 %|     0|     0 %|
     |33b|              32|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     |33c|               0|               0 %|             0|             0 %|     0|     0 %|
     | 3a|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 3b|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 3c|               8|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 4a|               8|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 4b|               4|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 4c|               8|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 5a|             608|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 5b|             912|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 5c|             304|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 6a|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 6b|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 6c|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 6d|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 6e|              98|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 6f|               0|               0 %|             0|             0 %|     0|     0 %|
     | 7a|              21|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 7b|             126|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 7c|               0|               0 %|             0|             0 %|     0|     0 %|
     | 8a|             500|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 8b|            1108|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 8c|               0|               0 %|             0|             0 %|     0|     0 %|
     | 8d|               0|               0 %|             0|             0 %|     0|     0 %|
     | 9a|             196|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 9b|            1108|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 9c|             196|           100.0 %|             0|           0.0 %|     0|   0.0 %|
     | 9d|               0|               0 %|             0|             0 %|     0|     0 %|

</p>
</details>