### PR TITLE
Make MetaTableManager::_add() public

### DIFF
--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -42,6 +42,12 @@ bool MetaTableManager::is_meta_table_name(const std::string& name) {
 
 const std::vector<std::string>& MetaTableManager::table_names() const { return _table_names; }
 
+void MetaTableManager::add_table(const std::shared_ptr<AbstractMetaTable>& table) {
+  _meta_tables[table->name()] = table;
+  _table_names.push_back(table->name());
+  std::sort(_table_names.begin(), _table_names.end());
+}
+
 bool MetaTableManager::has_table(const std::string& table_name) const {
   return _meta_tables.count(_trim_table_name(table_name));
 }
@@ -91,12 +97,6 @@ void MetaTableManager::update(const std::string& table_name, const std::shared_p
   for (size_t row = 0; row < selected_rows.size(); row++) {
     _meta_tables.at(table_name)->_update(selected_rows[row], update_rows[row]);
   }
-}
-
-void MetaTableManager::add(const std::shared_ptr<AbstractMetaTable>& table) {
-  _meta_tables[table->name()] = table;
-  _table_names.push_back(table->name());
-  std::sort(_table_names.begin(), _table_names.end());
 }
 
 std::string MetaTableManager::_trim_table_name(const std::string& table_name) {

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -46,6 +46,10 @@ bool MetaTableManager::has_table(const std::string& table_name) const {
   return _meta_tables.count(_trim_table_name(table_name));
 }
 
+std::shared_ptr<AbstractMetaTable> MetaTableManager::get_table(const std::string& table_name) const {
+  return _meta_tables.at(_trim_table_name(table_name));
+}
+
 std::shared_ptr<Table> MetaTableManager::generate_table(const std::string& table_name) const {
   return (_meta_tables.at(_trim_table_name(table_name)))->_generate();
 }
@@ -89,7 +93,7 @@ void MetaTableManager::update(const std::string& table_name, const std::shared_p
   }
 }
 
-void MetaTableManager::_add(const std::shared_ptr<AbstractMetaTable>& table) {
+void MetaTableManager::add(const std::shared_ptr<AbstractMetaTable>& table) {
   _meta_tables[table->name()] = table;
   _table_names.push_back(table->name());
   std::sort(_table_names.begin(), _table_names.end());

--- a/src/lib/utils/meta_table_manager.hpp
+++ b/src/lib/utils/meta_table_manager.hpp
@@ -19,7 +19,9 @@ class MetaTableManager : public Noncopyable {
   // Returns a sorted list of all meta table names (without prefix)
   const std::vector<std::string>& table_names() const;
 
+  void add(const std::shared_ptr<AbstractMetaTable>& table);
   bool has_table(const std::string& table_name) const;
+  std::shared_ptr<AbstractMetaTable> get_table(const std::string& table_name) const;
 
   // Generates the meta table specified by table_name (which can include the prefix)
   std::shared_ptr<Table> generate_table(const std::string& table_name) const;
@@ -35,13 +37,9 @@ class MetaTableManager : public Noncopyable {
 
  protected:
   friend class Hyrise;
-  friend class MetaTableManagerTest;
-  friend class MetaTableTest;
-  friend class ChangeMetaTableTest;
 
   MetaTableManager();
 
-  void _add(const std::shared_ptr<AbstractMetaTable>& table);
   static std::string _trim_table_name(const std::string& table_name);
 
   std::unordered_map<std::string, std::shared_ptr<AbstractMetaTable>> _meta_tables;

--- a/src/lib/utils/meta_table_manager.hpp
+++ b/src/lib/utils/meta_table_manager.hpp
@@ -19,7 +19,7 @@ class MetaTableManager : public Noncopyable {
   // Returns a sorted list of all meta table names (without prefix)
   const std::vector<std::string>& table_names() const;
 
-  void add(const std::shared_ptr<AbstractMetaTable>& table);
+  void add_table(const std::shared_ptr<AbstractMetaTable>& table);
   bool has_table(const std::string& table_name) const;
   std::shared_ptr<AbstractMetaTable> get_table(const std::string& table_name) const;
 

--- a/src/test/lib/operators/change_meta_table_test.cpp
+++ b/src/test/lib/operators/change_meta_table_test.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 class ChangeMetaTableTest : public BaseTest {
  protected:
-  void SetUp() override {
+  void SetUp() {
     Hyrise::reset();
 
     auto column_definitions = MetaMockTable().column_definitions();
@@ -34,7 +34,7 @@ class ChangeMetaTableTest : public BaseTest {
     context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::Yes);
   }
 
-  void TearDown() override { Hyrise::reset(); }
+  void TearDown() { Hyrise::reset(); }
 
   std::shared_ptr<AbstractOperator> left_input;
   std::shared_ptr<AbstractOperator> right_input;

--- a/src/test/lib/operators/change_meta_table_test.cpp
+++ b/src/test/lib/operators/change_meta_table_test.cpp
@@ -29,7 +29,7 @@ class ChangeMetaTableTest : public BaseTest {
     right_input->execute();
 
     meta_mock_table = std::make_shared<MetaMockTable>();
-    Hyrise::get().meta_table_manager.add(meta_mock_table);
+    Hyrise::get().meta_table_manager.add_table(meta_mock_table);
 
     context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::Yes);
   }

--- a/src/test/lib/operators/change_meta_table_test.cpp
+++ b/src/test/lib/operators/change_meta_table_test.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 
 class ChangeMetaTableTest : public BaseTest {
  protected:
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
 
     auto column_definitions = MetaMockTable().column_definitions();
@@ -29,12 +29,12 @@ class ChangeMetaTableTest : public BaseTest {
     right_input->execute();
 
     meta_mock_table = std::make_shared<MetaMockTable>();
-    Hyrise::get().meta_table_manager._add(meta_mock_table);
+    Hyrise::get().meta_table_manager.add(meta_mock_table);
 
     context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::Yes);
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   std::shared_ptr<AbstractOperator> left_input;
   std::shared_ptr<AbstractOperator> right_input;

--- a/src/test/lib/utils/meta_table_manager_test.cpp
+++ b/src/test/lib/utils/meta_table_manager_test.cpp
@@ -55,7 +55,7 @@ class MetaTableManagerTest : public BaseTest {
  protected:
   std::shared_ptr<const Table> mock_manipulation_values;
 
-  void SetUp() override {
+  void SetUp() {
     Hyrise::reset();
 
     const auto column_definitions = MetaMockTable().column_definitions();
@@ -66,7 +66,7 @@ class MetaTableManagerTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() override { Hyrise::reset(); }
+  void TearDown() { Hyrise::reset(); }
 };
 
 class MetaTableManagerMultiTablesTest : public MetaTableManagerTest, public ::testing::WithParamInterface<MetaTable> {};

--- a/src/test/lib/utils/meta_table_manager_test.cpp
+++ b/src/test/lib/utils/meta_table_manager_test.cpp
@@ -48,10 +48,6 @@ class MetaTableManagerTest : public BaseTest {
     return names;
   }
 
-  // We need this as the add method of MetaTableManager is protected.
-  // Won't compile if add is not called by test class, which is a friend of MetaTableManager.
-  static void add_meta_table(const MetaTable& table) { Hyrise::get().meta_table_manager.add(table); }
-
  protected:
   std::shared_ptr<const Table> mock_manipulation_values;
 
@@ -95,7 +91,7 @@ TEST_F(MetaTableManagerTest, ForwardsMethodCalls) {
   const auto mock_table = std::make_shared<MetaMockTable>();
   auto& mtm = Hyrise::get().meta_table_manager;
 
-  MetaTableManagerTest::add_meta_table(mock_table);
+  Hyrise::get().meta_table_manager.add(mock_table);
   mtm.insert_into(mock_table->name(), mock_manipulation_values);
   mtm.delete_from(mock_table->name(), mock_manipulation_values);
   mtm.update(mock_table->name(), mock_manipulation_values, mock_manipulation_values);

--- a/src/test/lib/utils/meta_table_manager_test.cpp
+++ b/src/test/lib/utils/meta_table_manager_test.cpp
@@ -50,12 +50,12 @@ class MetaTableManagerTest : public BaseTest {
 
   // We need this as the add method of MetaTableManager is protected.
   // Won't compile if add is not called by test class, which is a friend of MetaTableManager.
-  static void add_meta_table(const MetaTable& table) { Hyrise::get().meta_table_manager._add(table); }
+  static void add_meta_table(const MetaTable& table) { Hyrise::get().meta_table_manager.add(table); }
 
  protected:
   std::shared_ptr<const Table> mock_manipulation_values;
 
-  void SetUp() {
+  void SetUp() override {
     Hyrise::reset();
 
     const auto column_definitions = MetaMockTable().column_definitions();
@@ -66,7 +66,7 @@ class MetaTableManagerTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 };
 
 class MetaTableManagerMultiTablesTest : public MetaTableManagerTest, public ::testing::WithParamInterface<MetaTable> {};

--- a/src/test/lib/utils/meta_table_manager_test.cpp
+++ b/src/test/lib/utils/meta_table_manager_test.cpp
@@ -91,7 +91,7 @@ TEST_F(MetaTableManagerTest, ForwardsMethodCalls) {
   const auto mock_table = std::make_shared<MetaMockTable>();
   auto& mtm = Hyrise::get().meta_table_manager;
 
-  Hyrise::get().meta_table_manager.add(mock_table);
+  Hyrise::get().meta_table_manager.add_table(mock_table);
   mtm.insert_into(mock_table->name(), mock_manipulation_values);
   mtm.delete_from(mock_table->name(), mock_manipulation_values);
   mtm.update(mock_table->name(), mock_manipulation_values, mock_manipulation_values);
@@ -99,6 +99,15 @@ TEST_F(MetaTableManagerTest, ForwardsMethodCalls) {
   EXPECT_EQ(mock_table->insert_calls(), 1);
   EXPECT_EQ(mock_table->remove_calls(), 1);
   EXPECT_EQ(mock_table->update_calls(), 1);
+}
+
+TEST_F(MetaTableManagerTest, RetrieveAddedTable) {
+  const auto mock_table = std::make_shared<MetaMockTable>();
+  Hyrise::get().meta_table_manager.add_table(mock_table);
+
+  // Check that added table can be retrieved
+  const auto mock_table2 = Hyrise::get().meta_table_manager.get_table("mock");
+  EXPECT_EQ(mock_table, std::static_pointer_cast<MetaMockTable>(mock_table2));
 }
 
 TEST_P(MetaTableManagerMultiTablesTest, HasAllTables) {

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -135,18 +135,18 @@ TEST_P(MultiMetaTablesTest, IsDynamic) {
   EXPECT_TABLE_EQ_UNORDERED(meta_table, expected_table);
 }
 
-TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) {
-  // Meta tables that access stored tables without going through GetTable need to handle nullptr explicitly. We do IsNotCached
+TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) { 
+  // Meta tables that access stored tables without going through GetTable need to handle nullptr explicitly. We do not
   // check the actual results in order to avoid the number of test tables (that would have to be updated if the memory
   // consumption changes) low. Instead, we simply ensure that the meta table is generated without dereferencing said
   // nullptr.
 
-   const auto int_int = Hyrise::get().storage_manager.get_table("int_int");
+  const auto int_int = Hyrise::get().storage_manager.get_table("int_int");
 
-   SQLPipelineBuilder{"DELETE FROM int_int"}.create_pipeline().get_result_table();
-   int_int->remove_chunk(ChunkID{0});
+  SQLPipelineBuilder{"DELETE FROM int_int"}.create_pipeline().get_result_table();
+  int_int->remove_chunk(ChunkID{0});
 
-   generate_meta_table(GetParam());
+  generate_meta_table(GetParam());
 }
 
 

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -57,16 +57,16 @@ class MetaTableTest : public BaseTest {
   std::shared_ptr<Table> int_int_int_null;
   std::shared_ptr<const Table> mock_manipulation_values;
 
-  void SetUp() override {
+  void SetUp() {
     auto& storage_manager = Hyrise::get().storage_manager;
 
     int_int = load_table("resources/test_data/tbl/int_int.tbl", 2);
     int_int_int_null = load_table("resources/test_data/tbl/int_int_int_null.tbl", 100);
 
     ChunkEncoder::encode_chunk(int_int_int_null->get_chunk(ChunkID{0}), int_int_int_null->column_data_types(),
-                               {SegmentEncodingSpec{EncodingType::RunLength},
-                                SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-                                SegmentEncodingSpec{EncodingType::Unencoded}});
+                               {{EncodingType::RunLength},
+                                {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+                                {EncodingType::Unencoded}});
 
     storage_manager.add_table("int_int", int_int);
     storage_manager.add_table("int_int_int_null", int_int_int_null);
@@ -79,7 +79,7 @@ class MetaTableTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() override { Hyrise::reset(); }
+  void TearDown() { Hyrise::reset(); }
 
   void _add_meta_table(const std::shared_ptr<AbstractMetaTable>& table) {
     Hyrise::get().meta_table_manager._add(table);
@@ -126,27 +126,13 @@ TEST_P(MultiMetaTablesTest, IsDynamic) {
     Hyrise::get()
         .storage_manager.get_table("int_int")
         ->get_chunk(ChunkID{0})
-        ->set_individually_sorted_by(SortColumnDefinition(ColumnID{1}, SortMode::Ascending));
+        ->set_sorted_by(SortColumnDefinition(ColumnID{1}, SortMode::Ascending));
   }
 
   const auto expected_table = load_table(test_file_path + GetParam()->name() + suffix + "_updated.tbl");
   const auto meta_table = generate_meta_table(GetParam());
 
   EXPECT_TABLE_EQ_UNORDERED(meta_table, expected_table);
-}
-
-TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) {
-  // Meta tables that access stored tables without going through GetTable need to handle nullptr explicitly. We do not
-  // check the actual results in order to avoid the number of test tables (that would have to be updated if the memory
-  // consumption changes) low. Instead, we simply ensure that the meta table is generated without dereferencing said
-  // nullptr.
-
-  const auto int_int = Hyrise::get().storage_manager.get_table("int_int");
-
-  SQLPipelineBuilder{"DELETE FROM int_int"}.create_pipeline().get_result_table();
-  int_int->remove_chunk(ChunkID{0});
-
-  generate_meta_table(GetParam());
 }
 
 TEST_P(MultiMetaTablesTest, SQLFeatures) {

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -57,16 +57,16 @@ class MetaTableTest : public BaseTest {
   std::shared_ptr<Table> int_int_int_null;
   std::shared_ptr<const Table> mock_manipulation_values;
 
-  void SetUp() {
+  void SetUp() override {
     auto& storage_manager = Hyrise::get().storage_manager;
 
     int_int = load_table("resources/test_data/tbl/int_int.tbl", 2);
     int_int_int_null = load_table("resources/test_data/tbl/int_int_int_null.tbl", 100);
 
     ChunkEncoder::encode_chunk(int_int_int_null->get_chunk(ChunkID{0}), int_int_int_null->column_data_types(),
-                               {{EncodingType::RunLength},
-                                {EncodingType::Dictionary, VectorCompressionType::SimdBp128},
-                                {EncodingType::Unencoded}});
+                               {SegmentEncodingSpec{EncodingType::RunLength},
+                                SegmentEncodingSpec{EncodingType::Dictionary, VectorCompressionType::SimdBp128},
+                                SegmentEncodingSpec{EncodingType::Unencoded}});
 
     storage_manager.add_table("int_int", int_int);
     storage_manager.add_table("int_int_int_null", int_int_int_null);
@@ -79,7 +79,7 @@ class MetaTableTest : public BaseTest {
     mock_manipulation_values = table_wrapper->get_output();
   }
 
-  void TearDown() { Hyrise::reset(); }
+  void TearDown() override { Hyrise::reset(); }
 
   void _add_meta_table(const std::shared_ptr<AbstractMetaTable>& table) {
     Hyrise::get().meta_table_manager._add(table);
@@ -126,7 +126,7 @@ TEST_P(MultiMetaTablesTest, IsDynamic) {
     Hyrise::get()
         .storage_manager.get_table("int_int")
         ->get_chunk(ChunkID{0})
-        ->set_sorted_by(SortColumnDefinition(ColumnID{1}, SortMode::Ascending));
+        ->set_individually_sorted_by(SortColumnDefinition(ColumnID{1}, SortMode::Ascending));
   }
 
   const auto expected_table = load_table(test_file_path + GetParam()->name() + suffix + "_updated.tbl");
@@ -134,6 +134,21 @@ TEST_P(MultiMetaTablesTest, IsDynamic) {
 
   EXPECT_TABLE_EQ_UNORDERED(meta_table, expected_table);
 }
+
+TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) {
+  // Meta tables that access stored tables without going through GetTable need to handle nullptr explicitly. We do IsNotCached
+  // check the actual results in order to avoid the number of test tables (that would have to be updated if the memory
+  // consumption changes) low. Instead, we simply ensure that the meta table is generated without dereferencing said
+  // nullptr.
+
+   const auto int_int = Hyrise::get().storage_manager.get_table("int_int");
+
+   SQLPipelineBuilder{"DELETE FROM int_int"}.create_pipeline().get_result_table();
+   int_int->remove_chunk(ChunkID{0});
+
+   generate_meta_table(GetParam());
+}
+
 
 TEST_P(MultiMetaTablesTest, SQLFeatures) {
   // TEST SQL features on meta tables

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -82,7 +82,7 @@ class MetaTableTest : public BaseTest {
   void TearDown() override { Hyrise::reset(); }
 
   void _add_meta_table(const std::shared_ptr<AbstractMetaTable>& table) {
-    Hyrise::get().meta_table_manager.add(table);
+    Hyrise::get().meta_table_manager.add_table(table);
   }
 };
 

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -82,7 +82,7 @@ class MetaTableTest : public BaseTest {
   void TearDown() override { Hyrise::reset(); }
 
   void _add_meta_table(const std::shared_ptr<AbstractMetaTable>& table) {
-    Hyrise::get().meta_table_manager._add(table);
+    Hyrise::get().meta_table_manager.add(table);
   }
 };
 

--- a/src/test/lib/utils/meta_tables/meta_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_table_test.cpp
@@ -135,7 +135,7 @@ TEST_P(MultiMetaTablesTest, IsDynamic) {
   EXPECT_TABLE_EQ_UNORDERED(meta_table, expected_table);
 }
 
-TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) { 
+TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) {
   // Meta tables that access stored tables without going through GetTable need to handle nullptr explicitly. We do not
   // check the actual results in order to avoid the number of test tables (that would have to be updated if the memory
   // consumption changes) low. Instead, we simply ensure that the meta table is generated without dereferencing said
@@ -148,7 +148,6 @@ TEST_P(MultiMetaTablesTest, HandlesDeletedChunks) {
 
   generate_meta_table(GetParam());
 }
-
 
 TEST_P(MultiMetaTablesTest, SQLFeatures) {
   // TEST SQL features on meta tables


### PR DESCRIPTION
I am currently working on a plugin and found the meta tables to be an excellent way of storing information.
This PR simply makes the add table method public, so that a plugin can add meta tables to Hyise.

A sample use case (also what I am currently working on) is a plugin that extracts all operators from the query plan cache and makes it queryable. The Hyrise cockpit can then simply do a `SELECT * FROM meta_cool_new_list_of_operator_instances`.