### PR TITLE
Hash join: track which input table is build side

### DIFF
--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -99,10 +99,14 @@ class CompareBenchmarkScriptTest:
 
             # Check the latency values for both JSON files
             assert_latency_equals(
-                len(old_successful_runs), [run["duration"] for run in old_successful_runs], fields[3],
+                len(old_successful_runs),
+                [run["duration"] for run in old_successful_runs],
+                fields[3],
             )
             assert_latency_equals(
-                len(new_successful_runs), [run["duration"] for run in new_successful_runs], fields[4],
+                len(new_successful_runs),
+                [run["duration"] for run in new_successful_runs],
+                fields[4],
             )
 
             # Get the divisors for both benchmark files. They differ for Ordered and Shuffled mode.
@@ -133,7 +137,9 @@ class CompareBenchmarkScriptTest:
 
                 if len(old_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(old_unsuccessful_runs), [run["duration"] for run in old_unsuccessful_runs], fields[3],
+                        len(old_unsuccessful_runs),
+                        [run["duration"] for run in old_unsuccessful_runs],
+                        fields[3],
                     )
                     assert_throughput_equals(len(old_unsuccessful_runs), divisors[0], fields[7])
                 else:
@@ -142,7 +148,9 @@ class CompareBenchmarkScriptTest:
 
                 if len(new_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(new_unsuccessful_runs), [run["duration"] for run in new_unsuccessful_runs], fields[4],
+                        len(new_unsuccessful_runs),
+                        [run["duration"] for run in new_unsuccessful_runs],
+                        fields[4],
                     )
                     assert_throughput_equals(len(new_unsuccessful_runs), divisors[1], fields[8])
                 else:

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -214,9 +214,7 @@ std::ostream& operator<<(std::ostream& stream, const AbstractOperator& abstract_
                 << output->column_count() << " column(s)/";
 
       fn_stream << format_bytes(output->memory_usage(MemoryUsageCalculationMode::Sampled));
-      fn_stream << "/";
-      fn_stream << *abstract_operator.performance_data;
-      fn_stream << ")";
+      fn_stream << "/" << *abstract_operator.performance_data << ")";
     }
   };
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -652,9 +652,7 @@ void JoinHash::PerformanceData::output_to_stream(std::ostream& stream, Descripti
 
   const auto *const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
   stream << separator << "Radix bits:" << separator << radix_bits;
-  if (!left_input_is_build_side) {
-    stream << "." << separator <<  "Input sides have been flipped.";
-  }
+  stream << "." << separator <<  "Build side is " << (left_input_is_build_side ? "left." : "right.");
 }
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -46,7 +46,7 @@ JoinHash::JoinHash(const std::shared_ptr<const AbstractOperator>& left,
                    const std::vector<OperatorJoinPredicate>& secondary_predicates,
                    const std::optional<size_t>& radix_bits)
     : AbstractJoinOperator(OperatorType::JoinHash, left, right, mode, primary_predicate, secondary_predicates,
-                           std::make_unique<OperatorPerformanceData<OperatorSteps>>()),
+                           std::make_unique<PerformanceData>()),
       _radix_bits(radix_bits) {}
 
 const std::string& JoinHash::name() const {
@@ -178,7 +178,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
     output_column_order = OutputColumnOrder::BuildFirstProbeSecond;
   }
 
-  auto& join_hash_performance_data = static_cast<PerformanceData&>(*performance_data);
+  auto& join_hash_performance_data = dynamic_cast<PerformanceData&>(*performance_data);
   resolve_data_type(build_column_type, [&](const auto build_data_type_t) {
     using BuildColumnDataType = typename decltype(build_data_type_t)::type;
     resolve_data_type(probe_column_type, [&](const auto probe_data_type_t) {

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -648,7 +648,7 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
 void JoinHash::PerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
   OperatorPerformanceData<OperatorSteps>::output_to_stream(stream, description_mode);
 
-   const auto *const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
+  const auto *const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
   stream << separator << "Radix bits:" << separator << radix_bits;
   if (!left_input_is_build_side) {
     stream << "." << separator <<  "Input sides have been flipped.";

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -94,8 +94,8 @@ size_t JoinHash::calculate_radix_bits(const size_t build_relation_size, const si
 
   // We assume an L2 cache of 1024 KB for an Intel Xeon Platinum 8180. For local deployments or other CPUs, this size
   // might be different (e.g., an AMD EPYC 7F72 CPU has an L2 cache size of 512 KB and Apple's M1 has 16 MB).
-  constexpr auto l2_cache_size = 1'024'000;                   // bytes
-  constexpr auto l2_cache_max_usable = l2_cache_size * 0.75;  // use 75% of the L2 cache size
+  constexpr auto L2_CACHE_SIZE = 1'024'000;                   // bytes
+  constexpr auto L2_CACHE_MAX_USABLE = L2_CACHE_SIZE * 0.75;  // use 75% of the L2 cache size
 
   // For information about the sizing of the bytell hash map, see the comments:
   // https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
@@ -108,7 +108,7 @@ size_t JoinHash::calculate_radix_bits(const size_t build_relation_size, const si
       // key + value (and one byte overhead, see link above)
       static_cast<double>(sizeof(T) + 1) / 0.85;
 
-  const auto cluster_count = std::max(1.0, complete_hash_map_size / l2_cache_max_usable);
+  const auto cluster_count = std::max(1.0, complete_hash_map_size / L2_CACHE_MAX_USABLE);
 
   return static_cast<size_t>(std::ceil(std::log2(cluster_count)));
 }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -136,12 +136,6 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
    *   JoinMode::Left/Right   The outer relation becomes the probe side, the inner relation becomes the build side
    *   JoinMode::FullOuter    Not supported by JoinHash
    *   JoinMode::Semi/Anti*   The left relation becomes the probe side, the right relation becomes the build side
-
-   * One example are semi/anti* joins, where the probe side
-   * is per convention the left side (that's how Hyrise determines which input table to keep and filter in the semi
-   * join). For outer join modes, we use the right input table as the build side (e.g., left outer
-   * join) or the left input table (right outer joins) for easier tracking of NULL values. For inner joins, we consider
-   * the size of the input tables as it does not matter which side is probed.
    */
   const auto build_hash_table_for_right_input =
       _mode == JoinMode::Left || _mode == JoinMode::AntiNullAsTrue || _mode == JoinMode::AntiNullAsFalse ||

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -72,8 +72,7 @@ std::shared_ptr<AbstractOperator> JoinHash::_on_deep_copy(
 void JoinHash::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 template <typename T>
-size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size,
-                                      const JoinMode mode) {
+size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode) {
   /*
     The number of radix bits is used to determine the number of build partitions. The idea is to size the partitions in
     a way that keeps the whole hash map cache resident. We aim for the largest unshared cache (for most Intel systems
@@ -90,8 +89,8 @@ size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t
     /*
       Hash joins perform best when the build side is small. For inner joins, we can simply select the smaller input
       table as the build side. For other joins, such as semi or outer joins, the build side is fixed. In this case,
-      other join operators might be more efficient. We emit performance warning in this case. Note, as of now we do not
-      consider such cases of inefficient hash joins and do not switch to other join algorithms.
+      other join operators might be more efficient. We emit performance warning in this case. In the future, the
+      optimizer could identify these cases of potentially inefficient hash joins and switch to other join algorithms.
     */
     std::stringstream performance_warning;
     performance_warning << "Build side larger than probe side in hash join (join mode: " << magic_enum::enum_name(mode)
@@ -658,8 +657,8 @@ void JoinHash::PerformanceData::output_to_stream(std::ostream& stream, Descripti
   OperatorPerformanceData<OperatorSteps>::output_to_stream(stream, description_mode);
 
   const auto* const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
-  stream << separator << "Radix bits:" << separator << radix_bits;
-  stream << "." << separator << "Build side is " << (left_input_is_build_side ? "left." : "right.");
+  stream << separator << "Radix bits: " << radix_bits << ".";
+  stream << separator << "Build side is " << (left_input_is_build_side ? "left." : "right.");
 }
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -106,7 +106,7 @@ size_t JoinHash::calculate_radix_bits(const size_t build_relation_size, const si
       // number of items in map
       static_cast<double>(build_relation_size) *
       // key + value (and one byte overhead, see link above)
-      static_cast<double>(sizeof(T) + 1) / 0.85;
+      static_cast<double>(sizeof(uint32_t)) / 0.8;
 
   const auto cluster_count = std::max(1.0, complete_hash_map_size / L2_CACHE_MAX_USABLE);
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -74,41 +74,41 @@ void JoinHash::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeV
 template <typename T>
 size_t JoinHash::calculate_radix_bits(const size_t build_relation_size, const size_t probe_relation_size) {
   /*
-    Setting number of bits for radix clustering:
-    The number of bits is used to create probe partitions with a size that can
-    be expected to fit into the L2 cache.
-    This should incorporate hardware knowledge, once available in Hyrise.
-    As of now, we assume a L2 cache size of 1024 KB (L2 cache size of recent
-    Intel Xeon CPUs), of which we use 50%.
+    The number of radix bits is used to determine the number of build partitions whose hash maps have a size that can
+    be expected to fit into the L2 cache. This should incorporate hardware knowledge, once available in Hyrise. As of
+    now, we assume a L2 cache size of 1024 KB, of which we use 75 %.
+
     We estimate the size the following way:
       - we assume each key appears once (that is an overestimation space-wise, but we
       aim rather for a hash map that is slightly smaller than L2 than slightly larger)
-      - each entry in the hash map is a uint32_t offset (see hash_join_steps.hpp)
+      - each entry in the hash map is a pair of the actual hash key and the SmallPosList storing uint32_t offsets (see
+        hash_join_steps.hpp)
   */
   if (build_relation_size > probe_relation_size) {
     /*
-      Hash joins perform best when the build relation is small. In case the
-      optimizer selects the hash join due to such a situation, but neglects that the
-      input will be switched (e.g., due to the join mode), the user will be warned.
+      Hash joins perform best when the build relation is small. In case the inputs are switched (e.g., due to the join
+      mode) making the build partition larger than the probe partition, the user will be warned.
     */
     PerformanceWarning("Build relation larger than probe relation in hash join");
   }
 
-  const auto l2_cache_size = 1'024'000;                  // bytes
-  const auto l2_cache_max_usable = l2_cache_size * 0.5;  // use 50% of the L2 cache size
+  // We assume an L2 cache of 1024 KB for an Intel Xeon Platinum 8180. For local deployments or other CPUs, this size
+  // might be different (e.g., an AMD EPYC 7F72 CPU has an L2 cache size of 512 KB and Apple's M1 has 16 MB).
+  constexpr auto l2_cache_size = 1'024'000;                   // bytes
+  constexpr auto l2_cache_max_usable = l2_cache_size * 0.75;  // use 75% of the L2 cache size
 
   // For information about the sizing of the bytell hash map, see the comments:
   // https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
-  // Bytell hash map has a maximum fill factor of 0.9375. Since it's hard to estimate the actual size of
+  // Bytell hash map has a maximum fill factor of 0.9375. Since it's hard to estimate the number of distinct values in
   // a radix partition (and thus the size of each hash table), we accomodate a little bit extra space for
   // slightly skewed data distributions and aim for a fill level of 80%.
   const auto complete_hash_map_size =
       // number of items in map
       static_cast<double>(build_relation_size) *
       // key + value (and one byte overhead, see link above)
-      static_cast<double>(sizeof(uint32_t)) / 0.8;
+      static_cast<double>(sizeof(T) + 1) / 0.85;
 
-  auto cluster_count = std::max(1.0, complete_hash_map_size / l2_cache_max_usable);
+  const auto cluster_count = std::max(1.0, complete_hash_map_size / l2_cache_max_usable);
 
   return static_cast<size_t>(std::ceil(std::log2(cluster_count)));
 }
@@ -178,6 +178,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
     output_column_order = OutputColumnOrder::BuildFirstProbeSecond;
   }
 
+  auto& join_hash_performance_data = static_cast<PerformanceData&>(*performance_data);
   resolve_data_type(build_column_type, [&](const auto build_data_type_t) {
     using BuildColumnDataType = typename decltype(build_data_type_t)::type;
     resolve_data_type(probe_column_type, [&](const auto probe_data_type_t) {
@@ -206,13 +207,16 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
         _impl = std::make_unique<JoinHashImpl<BuildColumnDataType, ProbeColumnDataType>>(
             *this, build_input_table, probe_input_table, _mode, adjusted_column_ids,
             _primary_predicate.predicate_condition, output_column_order, *_radix_bits,
-            dynamic_cast<OperatorPerformanceData<JoinHash::OperatorSteps>&>(*performance_data),
-            std::move(adjusted_secondary_predicates));
+            join_hash_performance_data, std::move(adjusted_secondary_predicates));
       } else {
         Fail("Cannot join String with non-String column");
       }
     });
   });
+
+  DebugAssert(_radix_bits, "Radix bits are not set.");
+  join_hash_performance_data.radix_bits = *_radix_bits;
+  join_hash_performance_data.left_input_is_build_side = !build_hash_table_for_right_input;
 
   return _impl->_on_execute();
 }
@@ -226,7 +230,7 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
                const std::shared_ptr<const Table>& probe_input_table, const JoinMode mode,
                const ColumnIDPair& column_ids, const PredicateCondition predicate_condition,
                const OutputColumnOrder output_column_order, const size_t radix_bits,
-               OperatorPerformanceData<JoinHash::OperatorSteps>& performance_data,
+               JoinHash::PerformanceData& performance_data,
                std::vector<OperatorJoinPredicate> secondary_predicates = {})
       : _join_hash(join_hash),
         _build_input_table(build_input_table),
@@ -245,7 +249,8 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
   const JoinMode _mode;
   const ColumnIDPair _column_ids;
   const PredicateCondition _predicate_condition;
-  OperatorPerformanceData<JoinHash::OperatorSteps>& _performance;
+  JoinHash::PerformanceData& _performance;
+
 
   OutputColumnOrder _output_column_order;
 
@@ -639,5 +644,15 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
     return _join_hash._build_output_table(std::move(output_chunks));
   }
 };
+
+void JoinHash::PerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
+  OperatorPerformanceData<OperatorSteps>::output_to_stream(stream, description_mode);
+
+   const auto *const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
+  stream << separator << "Radix bits:" << separator << radix_bits;
+  if (!left_input_is_build_side) {
+    stream << "." << separator <<  "Input sides have been flipped.";
+  }
+}
 
 }  // namespace opossum

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -204,10 +204,10 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
                                                                   probe_input_table->row_count(), _mode);
         }
 
-        // It needs to be ensured that the build partition does not get too large, because the
-        // used offsets in the hash map might otherwise overflow. Since radix partitioning aims
-        // to avoid large build partitions, this should never happen. Nonetheless, we better
-        // assert since the effects of overflows will probably hard to debug.
+        // It needs to be ensured that the build partitions do not get too large, because the used offsets in the
+        // hash maps might otherwise overflow. Since radix partitioning aims to avoid large build partitions, this
+        // should never happen. Nonetheless, we better assert since the effects of overflows will probably be hard to
+        // debug.
         const auto max_partition_size = std::numeric_limits<uint32_t>::max() * 0.5;
         Assert(static_cast<uint32_t>(static_cast<double>(build_input_table->row_count()) / std::pow(2, *_radix_bits)) <
                    max_partition_size,

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -35,7 +35,8 @@ class JoinHash : public AbstractJoinOperator {
   std::string description(DescriptionMode description_mode) const override;
 
   template <typename T>
-  static size_t calculate_radix_bits(const size_t build_relation_size, const size_t probe_relation_size);
+  static size_t calculate_radix_bits(const size_t build_relation_size, const size_t probe_relation_size,
+                                     const JoinMode mode);
 
   enum class OperatorSteps : uint8_t {
     BuildSideMaterializing,
@@ -47,7 +48,7 @@ class JoinHash : public AbstractJoinOperator {
   };
 
   struct PerformanceData : public OperatorPerformanceData<OperatorSteps> {
-    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const;
+    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override;
 
     size_t radix_bits{0};
     // Initially, the left input is the build side and the right side is the probe side.

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -35,8 +35,7 @@ class JoinHash : public AbstractJoinOperator {
   std::string description(DescriptionMode description_mode) const override;
 
   template <typename T>
-  static size_t calculate_radix_bits(const size_t build_relation_size, const size_t probe_relation_size,
-                                     const JoinMode mode);
+  static size_t calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode);
 
   enum class OperatorSteps : uint8_t {
     BuildSideMaterializing,

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -42,6 +42,14 @@ class JoinHash : public AbstractJoinOperator {
     OutputWriting
   };
 
+  struct PerformanceData : public OperatorPerformanceData<OperatorSteps> {
+    void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const;
+
+     size_t radix_bits{0};
+    // Initially, the left input is the build side and the right side is the probe side.
+    bool left_input_is_build_side{true};
+  };
+
  protected:
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -49,7 +49,7 @@ class JoinHash : public AbstractJoinOperator {
   struct PerformanceData : public OperatorPerformanceData<OperatorSteps> {
     void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const;
 
-     size_t radix_bits{0};
+    size_t radix_bits{0};
     // Initially, the left input is the build side and the right side is the probe side.
     bool left_input_is_build_side{true};
   };

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -109,13 +109,13 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 }
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
-  // Simpe tests to check that side switching and zero-sizes work.
+  // Simple tests to check that side switching and zero-sizes work.
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 0), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 1), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 0), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 1), 0ul);
   EXPECT_TRUE(JoinHash::calculate_radix_bits<int32_t>(std::numeric_limits<size_t>::max(),
-                                                       std::numeric_limits<size_t>::max()) > 0ul);
+                                                      std::numeric_limits<size_t>::max()) > 0ul);
 }
 
 }  // namespace opossum

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -115,7 +115,7 @@ TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 0, JoinMode::Inner), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 1, JoinMode::Inner), 0ul);
   EXPECT_TRUE(JoinHash::calculate_radix_bits<int32_t>(std::numeric_limits<size_t>::max(),
-                                                      std::numeric_limits<size_t>::max()) > 0ul);
+                                                      std::numeric_limits<size_t>::max(), JoinMode::Inner) > 0ul);
 }
 
 }  // namespace opossum

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -109,12 +109,13 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 }
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
-  // Simple cases: handle minimal inputs and very large inputs
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 1), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int>(0, 1), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int>(1, 0), 0ul);
-  EXPECT_TRUE(JoinHash::calculate_radix_bits<int>(std::numeric_limits<size_t>::max(),
-                                                  std::numeric_limits<size_t>::max()) > 0ul);
+  // Simpe tests to check that side switching and zero-sizes workk.
+  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(1, 0), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(0, 1), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(0, 0), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(1, 1), 0ul);
+  EXPECT_TRUE(JoinHash::calculate_radix_bits<uint32_t>(std::numeric_limits<size_t>::max(),
+                                                       std::numeric_limits<size_t>::max()) > 0ul);
 }
 
 }  // namespace opossum

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -110,11 +110,11 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
   // Simpe tests to check that side switching and zero-sizes workk.
-  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(1, 0), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(0, 1), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(0, 0), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<uint32_t>(1, 1), 0ul);
-  EXPECT_TRUE(JoinHash::calculate_radix_bits<uint32_t>(std::numeric_limits<size_t>::max(),
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 0), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 1), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 0), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 1), 0ul);
+  EXPECT_TRUE(JoinHash::calculate_radix_bits<int32_t>(std::numeric_limits<size_t>::max(),
                                                        std::numeric_limits<size_t>::max()) > 0ul);
 }
 

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -109,7 +109,7 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 }
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
-  // Simpe tests to check that side switching and zero-sizes workk.
+  // Simpe tests to check that side switching and zero-sizes work.
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 0), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 1), 0ul);
   EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 0), 0ul);

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -110,10 +110,10 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
   // Simple tests to check that side switching and zero-sizes work.
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 0), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 1), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 0), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 1), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 0, JoinMode::Inner), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 1, JoinMode::Inner), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(0, 0, JoinMode::Inner), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits<int32_t>(1, 1, JoinMode::Inner), 0ul);
   EXPECT_TRUE(JoinHash::calculate_radix_bits<int32_t>(std::numeric_limits<size_t>::max(),
                                                       std::numeric_limits<size_t>::max()) > 0ul);
 }


### PR DESCRIPTION
Track the build side of the hash join by setting a flag in the operator performance struct. This information is important for join runtime estimations. @dey4ss, @aloeser, and me currently solve it by copying the if statement of the join, which is not an ideal solution.
Moreover, it's convenient to have this information in the PQP visualization.