### PR TITLE
Add null scan removal rule

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -309,6 +309,8 @@ set(
     optimizer/strategy/join_ordering_rule.hpp
     optimizer/strategy/join_predicate_ordering_rule.cpp
     optimizer/strategy/join_predicate_ordering_rule.hpp
+    optimizer/strategy/null_scan_removal_rule.cpp
+    optimizer/strategy/null_scan_removal_rule.hpp
     optimizer/strategy/predicate_merge_rule.cpp
     optimizer/strategy/predicate_merge_rule.hpp
     optimizer/strategy/predicate_placement_rule.cpp

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   auto optimizer = std::make_shared<Optimizer>();
 
   optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
-  
+
   optimizer->add_rule(std::make_unique<ExpressionReductionRule>());
 
   // Run before the JoinOrderingRule so that the latter has simple (non-conjunctive) predicates. However, as the

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -37,6 +37,8 @@ namespace opossum {
 std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   auto optimizer = std::make_shared<Optimizer>();
 
+  optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
+  
   optimizer->add_rule(std::make_unique<ExpressionReductionRule>());
 
   // Run before the JoinOrderingRule so that the latter has simple (non-conjunctive) predicates. However, as the
@@ -97,8 +99,6 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   optimizer->add_rule(std::make_unique<IndexScanRule>());
 
   optimizer->add_rule(std::make_unique<PredicateMergeRule>());
-
-  optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
 
   return optimizer;
 }

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -155,6 +155,8 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
 
   optimizer->add_rule(std::make_unique<PredicateMergeRule>());
 
+  optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
+
   return optimizer;
 }
 

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -16,6 +16,7 @@
 #include "strategy/index_scan_rule.hpp"
 #include "strategy/join_ordering_rule.hpp"
 #include "strategy/join_predicate_ordering_rule.hpp"
+#include "strategy/null_scan_removal_rule.hpp"
 #include "strategy/predicate_merge_rule.hpp"
 #include "strategy/predicate_placement_rule.hpp"
 #include "strategy/predicate_reordering_rule.hpp"

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -37,8 +37,6 @@ namespace opossum {
 std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   auto optimizer = std::make_shared<Optimizer>();
 
-  optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
-
   optimizer->add_rule(std::make_unique<ExpressionReductionRule>());
 
   // Run before the JoinOrderingRule so that the latter has simple (non-conjunctive) predicates. However, as the
@@ -60,6 +58,8 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   optimizer->add_rule(std::make_unique<PredicatePlacementRule>());
 
   optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
+
+  optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
 
   optimizer->add_rule(std::make_unique<SubqueryToJoinRule>());
 

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -1,0 +1,1 @@
+#include "null_scan_removal_rule.hpp"

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -1,1 +1,72 @@
 #include "null_scan_removal_rule.hpp"
+
+#include <algorithm>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "constant_mappings.hpp"
+#include "cost_estimation/abstract_cost_estimator.hpp"
+#include "expression/is_null_expression.hpp"
+#include "expression/lqp_column_expression.hpp"
+#include "hyrise.hpp"
+#include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "optimizer/join_ordering/join_graph.hpp"
+#include "statistics/cardinality_estimation_cache.hpp"
+#include "statistics/cardinality_estimator.hpp"
+#include "statistics/table_statistics.hpp"
+#include "utils/assert.hpp"
+
+namespace opossum {
+
+void NullScanRemovalRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
+  Assert(root->type == LQPNodeType::Root, "NullScanRemovalRule needs root to hold onto");
+  _remove_nodes(_nodes_to_remove(root));
+}
+
+std::vector<std::shared_ptr<AbstractLQPNode>> NullScanRemovalRule::_nodes_to_remove(
+    const std::shared_ptr<AbstractLQPNode>& root) const {
+  std::vector<std::shared_ptr<AbstractLQPNode>> nodes_to_remove;
+
+  auto visiter = [&](const auto& node) {
+    if (node->type != LQPNodeType::Predicate) return LQPVisitation::VisitInputs;
+
+    const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
+    const auto predicate = predicate_node->predicate();
+
+    if (const auto is_null_expression = std::dynamic_pointer_cast<IsNullExpression>(predicate)) {
+      if (is_null_expression->predicate_condition == PredicateCondition::IsNull) return LQPVisitation::VisitInputs;
+
+      const auto& column = std::dynamic_pointer_cast<LQPColumnExpression>(is_null_expression->operand());
+      if (!column) return LQPVisitation::VisitInputs;
+
+      const auto& stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(column->original_node.lock());
+      if (!stored_table_node) return LQPVisitation::VisitInputs;
+
+      const auto& table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
+
+      const auto original_column_id = column->original_column_id;
+
+      const auto table_column_definition = table->column_definitions()[original_column_id];
+
+      if (table_column_definition.nullable == false) {
+        nodes_to_remove.push_back(node);
+      }
+    }
+    return LQPVisitation::VisitInputs;
+  };
+  visit_lqp(root, visiter);
+  return nodes_to_remove;
+}
+
+void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) const {
+  for (const auto& node : nodes) {
+    lqp_remove_node(node);
+  }
+}
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -42,27 +42,29 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
 
     const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
     const auto predicate = predicate_node->predicate();
+    
     // Checks for condition 2
-    if (const auto is_null_expression = std::dynamic_pointer_cast<IsNullExpression>(predicate)) {
-      // Checks for condition 3
-      if (is_null_expression->predicate_condition == PredicateCondition::IsNull) return LQPVisitation::VisitInputs;
+    const auto is_null_expression = std::dynamic_pointer_cast<IsNullExpression>(predicate);
+    if (!is_null_expression) return LQPVisitation::VisitInputs;
 
-      const auto& column = std::dynamic_pointer_cast<LQPColumnExpression>(is_null_expression->operand());
-      // Checks for condition 4
-      if (!column) return LQPVisitation::VisitInputs;
+    // Checks for condition 3
+    if (is_null_expression->predicate_condition == PredicateCondition::IsNull) return LQPVisitation::VisitInputs;
 
-      const auto& stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(column->original_node.lock());
-      // Checks for condition 5
-      if (!stored_table_node) return LQPVisitation::VisitInputs;
+    const auto& column = std::dynamic_pointer_cast<LQPColumnExpression>(is_null_expression->operand());
+    // Checks for condition 4
+    if (!column) return LQPVisitation::VisitInputs;
 
-      const auto& table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
-      const auto original_column_id = column->original_column_id;
-      const auto table_column_definition = table->column_definitions()[original_column_id];
-      // Checks for condition 6
-      if (table_column_definition.nullable == false) {
-        nodes_to_remove.push_back(node);
-      }
-    }
+    const auto& stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(column->original_node.lock());
+    // Checks for condition 5
+    if (!stored_table_node) return LQPVisitation::VisitInputs;
+
+    const auto& table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
+    const auto original_column_id = column->original_column_id;
+    const auto table_column_definition = table->column_definitions()[original_column_id];
+    // Checks for condition 6
+    if (table_column_definition.nullable == true) return LQPVisitation::VisitInputs;
+    
+    nodes_to_remove.push_back(node);
     return LQPVisitation::VisitInputs;
   };
 

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -11,6 +11,7 @@
 #include "expression/lqp_column_expression.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/logical_plan_root_node.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
@@ -22,7 +23,7 @@
 
 namespace opossum {
 
-void NullScanRemovalRule::apply_to(const std::shared_ptr<AbstractLQPNode>& root) const {
+void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const {
   Assert(root->type == LQPNodeType::Root, "NullScanRemovalRule needs root to hold onto");
 
   std::vector<std::shared_ptr<AbstractLQPNode>> nodes_to_remove;
@@ -74,6 +75,10 @@ void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<Abstra
   for (const auto& node : nodes) {
     lqp_remove_node(node);
   }
+}
+
+void NullScanRemovalRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+  Fail("Did not expect this function to be called.");
 }
 
 }  // namespace opossum

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -40,28 +40,27 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
     // Checks condition 1
     if (node->type != LQPNodeType::Predicate) return LQPVisitation::VisitInputs;
 
+    // Checks for condition 2
     const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
     const auto predicate = predicate_node->predicate();
-
-    // Checks for condition 2
     const auto is_null_expression = std::dynamic_pointer_cast<IsNullExpression>(predicate);
     if (!is_null_expression) return LQPVisitation::VisitInputs;
 
     // Checks for condition 3
     if (is_null_expression->predicate_condition == PredicateCondition::IsNull) return LQPVisitation::VisitInputs;
 
-    const auto& column = std::dynamic_pointer_cast<LQPColumnExpression>(is_null_expression->operand());
     // Checks for condition 4
+    const auto& column = std::dynamic_pointer_cast<LQPColumnExpression>(is_null_expression->operand());
     if (!column) return LQPVisitation::VisitInputs;
 
-    const auto& stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(column->original_node.lock());
     // Checks for condition 5
+    const auto& stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(column->original_node.lock());
     if (!stored_table_node) return LQPVisitation::VisitInputs;
 
+    // Checks for condition 6
     const auto& table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
     const auto original_column_id = column->original_column_id;
     const auto table_column_definition = table->column_definitions()[original_column_id];
-    // Checks for condition 6
     if (table_column_definition.nullable == true) return LQPVisitation::VisitInputs;
 
     nodes_to_remove.push_back(node);

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -42,7 +42,7 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
 
     const auto predicate_node = std::dynamic_pointer_cast<PredicateNode>(node);
     const auto predicate = predicate_node->predicate();
-    
+
     // Checks for condition 2
     const auto is_null_expression = std::dynamic_pointer_cast<IsNullExpression>(predicate);
     if (!is_null_expression) return LQPVisitation::VisitInputs;
@@ -63,7 +63,7 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
     const auto table_column_definition = table->column_definitions()[original_column_id];
     // Checks for condition 6
     if (table_column_definition.nullable == true) return LQPVisitation::VisitInputs;
-    
+
     nodes_to_remove.push_back(node);
     return LQPVisitation::VisitInputs;
   };

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -1,7 +1,6 @@
 #include "null_scan_removal_rule.hpp"
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -30,13 +30,13 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
 
   // To determine if the rule applies to a node it must meet all of the following conditions:
   // 1. The node must be of type Predicate
-  // 2. The predicate must be a `null expression`
-  // 3. The predicate condition must be `is not null`
-  // 4. The predicate operand needs to be an `LQP Column expression`
-  // 5. The original node of the `LQP Column expression` needs to be a not defective `storage table node`
-  // 6. The column (referenced by the `LQP Column expression`) is not nullable
-  // All nodes where the conditions apply are removed from the LQP Tree.
-  auto visiter = [&](const auto& node) {
+  // 2. The predicate must be a null expression
+  // 3. The predicate condition must be is not null
+  // 4. The predicate operand needs to be an LQP Column expression
+  // 5. The original node of the LQP Column expression needs to be a storage table node
+  // 6. The column (referenced by the LQP Column expression) is not nullable
+  // All nodes where the conditions apply are removed from the LQP.
+  auto visitor = [&](const auto& node) {
     // Checks condition 1
     if (node->type != LQPNodeType::Predicate) return LQPVisitation::VisitInputs;
 
@@ -66,7 +66,7 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
     return LQPVisitation::VisitInputs;
   };
 
-  visit_lqp(root, visiter);
+  visit_lqp(root, visitor);
 
   _remove_nodes(nodes_to_remove);
 }

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -72,7 +72,7 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
   _remove_nodes(nodes_to_remove);
 }
 
-void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) const {
+void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) {
   for (const auto& node : nodes) {
     lqp_remove_node(node);
   }

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -11,6 +11,7 @@ namespace opossum {
 class AbstractLQPNode;
 class PredicateNode;
 
+// This rule removes null scans on columns that are not nullable.
 class NullScanRemovalRule : public AbstractRule {
  public:
   void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -18,7 +18,7 @@ class NullScanRemovalRule : public AbstractRule {
   void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
 
  private:
-  void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) const;
+  static void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes);
 
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -16,7 +16,6 @@ class NullScanRemovalRule : public AbstractRule {
   void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
 
  private:
-  std::vector<std::shared_ptr<AbstractLQPNode>> _nodes_to_remove(const std::shared_ptr<AbstractLQPNode>& root) const;
   void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) const;
 };
 

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "abstract_rule.hpp"
+
+namespace opossum {
+
+class AbstractLQPNode;
+class PredicateNode;
+
+class NullScanRemovalRule : public AbstractRule {
+ public:
+  void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
+
+ private:
+  std::vector<std::shared_ptr<AbstractLQPNode>> _nodes_to_remove(const std::shared_ptr<AbstractLQPNode>& root) const;
+  void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) const;
+};
+
+}  // namespace opossum

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -11,7 +11,8 @@ namespace opossum {
 class AbstractLQPNode;
 class PredicateNode;
 
-// This rule removes null scans on columns that are not nullable.
+// This rule removes PredicateNodes that hold IsNull expressions if the scanned columns are known to not be nullable.
+// It does not yet deal with IsNotNull predicates or cases where Is(Not)Null is nested within another expression.
 class NullScanRemovalRule : public AbstractRule {
  public:
   void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -13,10 +13,13 @@ class PredicateNode;
 
 class NullScanRemovalRule : public AbstractRule {
  public:
-  void apply_to(const std::shared_ptr<AbstractLQPNode>& root) const override;
+  void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
 
  private:
   void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) const;
+
+ protected:
+  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace opossum

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -132,6 +132,7 @@ set(
     lib/optimizer/strategy/index_scan_rule_test.cpp
     lib/optimizer/strategy/join_ordering_rule_test.cpp
     lib/optimizer/strategy/join_predicate_ordering_rule_test.cpp
+    lib/optimizer/strategy/null_scan_removal_rule_test.cpp
     lib/optimizer/strategy/predicate_merge_rule_test.cpp
     lib/optimizer/strategy/predicate_placement_rule_test.cpp
     lib/optimizer/strategy/predicate_reordering_rule_test.cpp

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -34,8 +34,8 @@ class NullScanRemovalRuleTest : public StrategyBaseTest {
 
 TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
   // The rule can't apply on a node that is not of type Predicate.
-  const auto actual_lqp = apply_rule(rule, mock_node);
   const auto expected_lqp = mock_node->deep_copy();
+  const auto actual_lqp = apply_rule(rule, mock_node);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -43,8 +43,8 @@ TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
 TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
   // The rule can't apply on a predicate that is not a null expression.
   const auto input_lqp = PredicateNode::make(equals_(mock_node_column, 42), mock_node);
-  const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, input_lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -52,8 +52,8 @@ TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
 TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
   // The rule can't apply on a predicate which condition is not is not null.
   const auto input_lqp = PredicateNode::make(is_null_(mock_node_column), mock_node);
-  const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, input_lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -61,8 +61,8 @@ TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
 TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
   // The rule can't apply where the predicate operand is not a LQP Column expression.
   const auto input_lqp = PredicateNode::make(is_not_null_(42), mock_node);
-  const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, input_lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -70,8 +70,8 @@ TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
 TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
   // The rule can't apply where the original node of the LQP Column expression is not a storage table node.
   const auto input_lqp = PredicateNode::make(is_not_null_(mock_node_column), mock_node);
-  const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, input_lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -79,8 +79,8 @@ TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
 TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNullable) {
   // The rule can't apply, if the column is not nullable
   const auto input_lqp = PredicateNode::make(is_not_null_(nullable_table_node_column), nullable_table_node);
-  const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, input_lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -94,8 +94,8 @@ TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
   // 5. The original node of the LQP Column expression needs to be a storage table node
   // 6. The column (referenced by the LQP Column expression) is not nullable
   const auto input_lqp = PredicateNode::make(is_not_null_(table_node_column), table_node);
-  const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = table_node->deep_copy();
+  const auto actual_lqp = apply_rule(rule, input_lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -1,0 +1,75 @@
+#include <memory>
+
+#include "base_test.hpp"
+#include "expression/expression_functional.hpp"
+#include "logical_query_plan/lqp_utils.hpp"
+#include "logical_query_plan/predicate_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
+#include "optimizer/strategy/null_scan_removal_rule.hpp"
+
+using namespace opossum::expression_functional;  // NOLINT
+
+namespace opossum {
+
+class NullScanRemovalRuleTest : public BaseTest {};
+
+TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
+    mock_node = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+    
+
+}
+
+TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
+
+
+}
+
+TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
+
+
+}
+
+TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
+
+
+}
+
+TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
+
+
+}
+
+TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNullable) {
+
+
+}
+
+TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
+
+
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+}  // namespace opossum

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -1,75 +1,101 @@
 #include <memory>
 
-#include "base_test.hpp"
 #include "expression/expression_functional.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "optimizer/strategy/null_scan_removal_rule.hpp"
+#include "strategy_base_test.hpp"
 
 using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class NullScanRemovalRuleTest : public BaseTest {};
+class NullScanRemovalRuleTest : public StrategyBaseTest {};
 
 TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
-    mock_node = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
-    
+  auto input_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+  auto rule = std::make_shared<NullScanRemovalRule>();
 
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
+  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+  auto rule = std::make_shared<NullScanRemovalRule>();
+  auto a_a = node_a->get_column("a");
 
+  const auto input_lqp = PredicateNode::make(equals_(a_a, 42), node_a);
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = input_lqp->deep_copy();
 
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
+  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+  auto rule = std::make_shared<NullScanRemovalRule>();
+  auto a_a = node_a->get_column("a");
 
+  const auto input_lqp = PredicateNode::make(is_null_(a_a), node_a);
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = input_lqp->deep_copy();
 
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
+  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+  auto rule = std::make_shared<NullScanRemovalRule>();
+  auto a_a = node_a->get_column("a");
 
+  const auto input_lqp = PredicateNode::make(is_not_null_(42), node_a);
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = input_lqp->deep_copy();
 
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
+  // Test that column original node is not a stored table node.
+  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+  auto rule = std::make_shared<NullScanRemovalRule>();
+  auto a_a = node_a->get_column("a");
 
+  const auto input_lqp = PredicateNode::make(is_not_null_(a_a), node_a);
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = input_lqp->deep_copy();
 
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNullable) {
+  // table column is nullable, so no node should be removed.
+  Hyrise::get().storage_manager.add_table("table_a", load_table("resources/test_data/tbl/int_float_null_1.tbl", 2));
+  auto rule = std::make_shared<NullScanRemovalRule>();
+  auto _table_node = StoredTableNode::make("table_a");
+  auto column = lqp_column_(_table_node, ColumnID{0});
 
+  const auto input_lqp = PredicateNode::make(is_not_null_(column), _table_node);
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = input_lqp->deep_copy();
 
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
+  Hyrise::get().storage_manager.add_table("table_a", load_table("resources/test_data/tbl/int_float4_or_1.tbl", 2));
+  auto rule = std::make_shared<NullScanRemovalRule>();
+  auto _table_node = StoredTableNode::make("table_a");
+  auto column = lqp_column_(_table_node, ColumnID{0});
 
+  const auto input_lqp = PredicateNode::make(is_not_null_(column), _table_node);
+  const auto actual_lqp = apply_rule(rule, input_lqp);
+  const auto expected_lqp = _table_node->deep_copy();
 
+  EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 }  // namespace opossum

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -41,7 +41,7 @@ TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
-  // The rule can't apply on a predicate that is not a `null expression`.
+  // The rule can't apply on a predicate that is not a null expression.
   const auto input_lqp = PredicateNode::make(equals_(mock_node_column, 42), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
@@ -50,7 +50,7 @@ TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
-  // The rule can't apply on a predicate which condition is not `is not null`.
+  // The rule can't apply on a predicate which condition is not is not null.
   const auto input_lqp = PredicateNode::make(is_null_(mock_node_column), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
@@ -59,7 +59,7 @@ TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
-  // The rule can't apply where the predicate operand is not a `LQP Column expression`.
+  // The rule can't apply where the predicate operand is not a LQP Column expression.
   const auto input_lqp = PredicateNode::make(is_not_null_(42), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
@@ -68,7 +68,7 @@ TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
 }
 
 TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
-  // The rule can't apply where the original node of the `LQP Column expression` is not a `storage table node`.
+  // The rule can't apply where the original node of the LQP Column expression is not a storage table node.
   const auto input_lqp = PredicateNode::make(is_not_null_(mock_node_column), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
@@ -88,11 +88,11 @@ TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNullable) {
 TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
   // All needed conditions to remove the node are matched:
   // 1. The node must be of type Predicate
-  // 2. The predicate must be a `null expression`
-  // 3. The predicate condition must be `is not null`
-  // 4. The predicate operand needs to be an `LQP Column expression`
-  // 5. The original node of the `LQP Column expression` needs to be a not defective `storage table node`
-  // 6. The column (referenced by the `LQP Column expression`) is not nullable
+  // 2. The predicate must be a null expression
+  // 3. The predicate condition must be is not null
+  // 4. The predicate operand needs to be an LQP Column expression
+  // 5. The original node of the LQP Column expression needs to be a storage table node
+  // 6. The column (referenced by the LQP Column expression) is not nullable
   const auto input_lqp = PredicateNode::make(is_not_null_(table_node_column), table_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = table_node->deep_copy();

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -11,23 +11,36 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
-class NullScanRemovalRuleTest : public StrategyBaseTest {};
+class NullScanRemovalRuleTest : public StrategyBaseTest {
+ public:
+  void SetUp() override {
+    rule = std::make_shared<NullScanRemovalRule>();
+    mock_node = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
+    mock_node_column = mock_node->get_column("a");
+
+    Hyrise::get().storage_manager.add_table("nullable_table",
+                                            load_table("resources/test_data/tbl/int_float_null_1.tbl", 2));
+    Hyrise::get().storage_manager.add_table("table", load_table("resources/test_data/tbl/int_float4_or_1.tbl", 2));
+    nullable_table_node = StoredTableNode::make("nullable_table");
+    table_node = StoredTableNode::make("table");
+    nullable_table_node_column = lqp_column_(nullable_table_node, ColumnID{0});
+    table_node_column = lqp_column_(table_node, ColumnID{0});
+  }
+  std::shared_ptr<MockNode> mock_node;
+  std::shared_ptr<NullScanRemovalRule> rule;
+  std::shared_ptr<LQPColumnExpression> mock_node_column, nullable_table_node_column, table_node_column;
+  std::shared_ptr<StoredTableNode> nullable_table_node, table_node;
+};
 
 TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
-  auto input_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
-  auto rule = std::make_shared<NullScanRemovalRule>();
+  const auto actual_lqp = apply_rule(rule, mock_node);
+  const auto expected_lqp = mock_node->deep_copy();
 
-  const auto actual_lqp = apply_rule(rule, input_lqp);
-  const auto expected_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
-  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
-  auto rule = std::make_shared<NullScanRemovalRule>();
-  auto a_a = node_a->get_column("a");
-
-  const auto input_lqp = PredicateNode::make(equals_(a_a, 42), node_a);
+  const auto input_lqp = PredicateNode::make(equals_(mock_node_column, 42), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
 
@@ -35,11 +48,7 @@ TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
-  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
-  auto rule = std::make_shared<NullScanRemovalRule>();
-  auto a_a = node_a->get_column("a");
-
-  const auto input_lqp = PredicateNode::make(is_null_(a_a), node_a);
+  const auto input_lqp = PredicateNode::make(is_null_(mock_node_column), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
 
@@ -47,11 +56,7 @@ TEST_F(NullScanRemovalRuleTest, PredicateConditionIsNotNull) {
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
-  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
-  auto rule = std::make_shared<NullScanRemovalRule>();
-  auto a_a = node_a->get_column("a");
-
-  const auto input_lqp = PredicateNode::make(is_not_null_(42), node_a);
+  const auto input_lqp = PredicateNode::make(is_not_null_(42), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
 
@@ -60,11 +65,7 @@ TEST_F(NullScanRemovalRuleTest, PredicateOperandIsNotLQPColumnExpression) {
 
 TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
   // Test that column original node is not a stored table node.
-  auto node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
-  auto rule = std::make_shared<NullScanRemovalRule>();
-  auto a_a = node_a->get_column("a");
-
-  const auto input_lqp = PredicateNode::make(is_not_null_(a_a), node_a);
+  const auto input_lqp = PredicateNode::make(is_not_null_(mock_node_column), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
 
@@ -73,12 +74,7 @@ TEST_F(NullScanRemovalRuleTest, LQPColumnOriginalNodeIsNotStoredTableNode) {
 
 TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNullable) {
   // table column is nullable, so no node should be removed.
-  Hyrise::get().storage_manager.add_table("table_a", load_table("resources/test_data/tbl/int_float_null_1.tbl", 2));
-  auto rule = std::make_shared<NullScanRemovalRule>();
-  auto _table_node = StoredTableNode::make("table_a");
-  auto column = lqp_column_(_table_node, ColumnID{0});
-
-  const auto input_lqp = PredicateNode::make(is_not_null_(column), _table_node);
+  const auto input_lqp = PredicateNode::make(is_not_null_(nullable_table_node_column), nullable_table_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();
 
@@ -86,14 +82,9 @@ TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNullable) {
 }
 
 TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
-  Hyrise::get().storage_manager.add_table("table_a", load_table("resources/test_data/tbl/int_float4_or_1.tbl", 2));
-  auto rule = std::make_shared<NullScanRemovalRule>();
-  auto _table_node = StoredTableNode::make("table_a");
-  auto column = lqp_column_(_table_node, ColumnID{0});
-
-  const auto input_lqp = PredicateNode::make(is_not_null_(column), _table_node);
+  const auto input_lqp = PredicateNode::make(is_not_null_(table_node_column), table_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
-  const auto expected_lqp = _table_node->deep_copy();
+  const auto expected_lqp = table_node->deep_copy();
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -33,7 +33,7 @@ class NullScanRemovalRuleTest : public StrategyBaseTest {
 };
 
 TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
-  // The rule can't apply on a node that is not from type Predicate.
+  // The rule can't apply on a node that is not of type Predicate.
   const auto actual_lqp = apply_rule(rule, mock_node);
   const auto expected_lqp = mock_node->deep_copy();
 
@@ -41,7 +41,7 @@ TEST_F(NullScanRemovalRuleTest, LQPNodeTypeIsNotPredicate) {
 }
 
 TEST_F(NullScanRemovalRuleTest, PredicateIsNotNullExpression) {
-  // The rule can't apply on a predicate that in not a `null expression`.
+  // The rule can't apply on a predicate that is not a `null expression`.
   const auto input_lqp = PredicateNode::make(equals_(mock_node_column, 42), mock_node);
   const auto actual_lqp = apply_rule(rule, input_lqp);
   const auto expected_lqp = input_lqp->deep_copy();


### PR DESCRIPTION
This PR adds the `null scan removal rule` to the optimizer's strategies. The goal of this rule is to not do null scans on columns if we know that they are not nullable. 

The rule checks if a node meets all the required conditions to be removed from the LQP DAG: 
1. The node must be of type Predicate
2. The predicate must be a `null expression`
3. The predicate condition must be `is not null`
4. The predicate operand needs to be an `LQP Column expression`
5. The original node of the `LQP Column expression` needs to be a not defective `storage table node`
6. The column (referenced by the `LQP Column expression`) is not nullable