### PR TITLE
Disable binary caches for CI

### DIFF
--- a/scripts/test/hyriseBenchmarkCore.py
+++ b/scripts/test/hyriseBenchmarkCore.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Run 2
+# Run 3
 
 import os
 import sys

--- a/scripts/test/hyriseBenchmarkCore.py
+++ b/scripts/test/hyriseBenchmarkCore.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-#bla
+# Run 2
 
 import os
 import sys

--- a/scripts/test/hyriseBenchmarkCore.py
+++ b/scripts/test/hyriseBenchmarkCore.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-# Run 3
-
 import os
 import sys
 import pexpect
@@ -45,10 +43,6 @@ def initialize():
 
 
 def run_benchmark(build_dir, arguments, benchmark_name, verbose):
-    # We run tests in parallel. As binary files would be written into the --table_path, concurrent tests might
-    # interfere with each other. Thus, we disable the binary caching.
-    arguments["--dont_cache_binary_tables"] = True
-
     if "--table_path" in arguments and not os.path.isdir(arguments["--table_path"].replace("'", "")):
         print(
             "Cannot find "

--- a/scripts/test/hyriseBenchmarkCore.py
+++ b/scripts/test/hyriseBenchmarkCore.py
@@ -43,6 +43,10 @@ def initialize():
 
 
 def run_benchmark(build_dir, arguments, benchmark_name, verbose):
+    # We run tests in parallel. As binary files would be written into the --table_path, concurrent tests might
+    # interfere with each other. Thus, we disable the binary caching.
+    arguments["--dont_cache_binary_tables"] = True
+
     if "--table_path" in arguments and not os.path.isdir(arguments["--table_path"].replace("'", "")):
         print(
             "Cannot find "

--- a/scripts/test/hyriseBenchmarkCore.py
+++ b/scripts/test/hyriseBenchmarkCore.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+#bla
+
 import os
 import sys
 import pexpect

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import glob
 import json
 import os
 import sys
@@ -44,7 +45,7 @@ def main():
     benchmark.expect_exact("Max runs per item is 100")
     benchmark.expect_exact("Max duration per item is 10 seconds")
     benchmark.expect_exact("No warmup runs are performed")
-    benchmark.expect_exact("Not caching tables as binary files")
+    benchmark.expect_exact("Caching tables as binary files")
     benchmark.expect_exact("Benchmarking queries from resources/test_data/queries/file_based/")
     benchmark.expect_exact("Running on tables from resources/test_data/tbl/file_based/")
     benchmark.expect_exact("Running subset of queries: select_statement")
@@ -64,6 +65,10 @@ def main():
     check_exit_status(benchmark)
 
     CompareBenchmarkScriptTest(compare_benchmarks_path, output_filename_1, output_filename_2).run()
+
+    if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
+        print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
+        return_error = True
 
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -66,10 +66,6 @@ def main():
 
     CompareBenchmarkScriptTest(compare_benchmarks_path, output_filename_1, output_filename_2).run()
 
-    if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
-        print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
-        return_error = True
-
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 
     if not os.path.isfile(arguments["--output"].replace("'", "")):

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import glob
 import json
 import os
 import sys
@@ -69,12 +68,6 @@ def main():
     check_exit_status(benchmark)
 
     CompareBenchmarkScriptTest(compare_benchmarks_path, output_filename_1, output_filename_2).run()
-
-    if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
-        print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
-        return_error = True
-
-    os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 
     if not os.path.isfile(arguments["--output"].replace("'", "")):
         print("ERROR: Cannot find output file " + arguments["--output"])

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import glob
 import json
 import os
 import sys

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -45,7 +45,7 @@ def main():
     benchmark.expect_exact("Max runs per item is 100")
     benchmark.expect_exact("Max duration per item is 10 seconds")
     benchmark.expect_exact("No warmup runs are performed")
-    benchmark.expect_exact("Caching tables as binary files")
+    benchmark.expect_exact("Not caching tables as binary files")
     benchmark.expect_exact("Benchmarking queries from resources/test_data/queries/file_based/")
     benchmark.expect_exact("Running on tables from resources/test_data/tbl/file_based/")
     benchmark.expect_exact("Running subset of queries: select_statement")

--- a/scripts/test/hyriseBenchmarkFileBased_test.py
+++ b/scripts/test/hyriseBenchmarkFileBased_test.py
@@ -33,6 +33,10 @@ def main():
     arguments["--scheduler"] = "false"
     arguments["--clients"] = "1"
 
+    # Binary tables would be written into the table_path. In CI, this path is shared by different targets that are
+    # potentially executed concurrently. This sometimes led to issues with corrupted binary files.
+    arguments["--dont_cache_binary_tables"] = "true"
+
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 
     benchmark = run_benchmark(build_dir, arguments, "hyriseBenchmarkFileBased", True)
@@ -45,7 +49,7 @@ def main():
     benchmark.expect_exact("Max runs per item is 100")
     benchmark.expect_exact("Max duration per item is 10 seconds")
     benchmark.expect_exact("No warmup runs are performed")
-    benchmark.expect_exact("Caching tables as binary files")
+    benchmark.expect_exact("Not caching tables as binary files")
     benchmark.expect_exact("Benchmarking queries from resources/test_data/queries/file_based/")
     benchmark.expect_exact("Running on tables from resources/test_data/tbl/file_based/")
     benchmark.expect_exact("Running subset of queries: select_statement")
@@ -129,6 +133,7 @@ def main():
     arguments["--scheduler"] = "true"
     arguments["--clients"] = "4"
     arguments["--verify"] = "true"
+    arguments["--dont_cache_binary_tables"] = "true"
 
     benchmark = run_benchmark(build_dir, arguments, "hyriseBenchmarkFileBased", True)
 

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-import glob
+# import glob
 import json
 import os
 import sys
@@ -98,9 +98,9 @@ def main():
         output["context"]["clients"], int(arguments["--clients"]), "Client count doesn't match with JSON:", return_error
     )
 
-    #if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
-    #    print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
-    #    return_error = True
+    # if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
+    #     print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
+    #     return_error = True
 
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -98,9 +98,9 @@ def main():
         output["context"]["clients"], int(arguments["--clients"]), "Client count doesn't match with JSON:", return_error
     )
 
-    if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
-        print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
-        return_error = True
+    #if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
+    #    print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
+    #    return_error = True
 
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -41,7 +41,7 @@ def main():
     benchmark.expect_exact("Max runs per item is 100")
     benchmark.expect_exact("Max duration per item is 10 seconds")
     benchmark.expect_exact("No warmup runs are performed")
-    benchmark.expect_exact("Caching tables as binary files")
+    benchmark.expect_exact("Not caching tables as binary files")
     benchmark.expect_exact("Retrieving the IMDB dataset.")
     benchmark.expect_exact("IMDB setup already complete, no setup action required")
     benchmark.expect_exact("Benchmarking queries from third_party/join-order-benchmark")

--- a/scripts/test/hyriseBenchmarkJoinOrder_test.py
+++ b/scripts/test/hyriseBenchmarkJoinOrder_test.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-# import glob
 import json
 import os
 import sys
@@ -28,6 +27,10 @@ def main():
     arguments["--encoding"] = "'Unencoded'"
     arguments["--clients"] = "1"
     arguments["--scheduler"] = "false"
+
+    # Binary tables would be written into the table_path. In CI, this path is shared by different targets that are
+    # potentially executed concurrently. This sometimes led to issues with corrupted binary files.
+    arguments["--dont_cache_binary_tables"] = "true"
 
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 
@@ -98,10 +101,6 @@ def main():
         output["context"]["clients"], int(arguments["--clients"]), "Client count doesn't match with JSON:", return_error
     )
 
-    # if not glob.glob(arguments["--table_path"].replace("'", "") + "*.bin"):
-    #     print("ERROR: Cannot find binary tables in " + arguments["--table_path"])
-    #     return_error = True
-
     os.system(f'rm -rf {arguments["--table_path"]}/*.bin')
 
     arguments = {}
@@ -115,6 +114,7 @@ def main():
     arguments["--clients"] = "4"
     arguments["--chunk_size"] = "100000"
     arguments["--verify"] = "true"
+    arguments["--dont_cache_binary_tables"] = "true"
 
     benchmark = run_benchmark(build_dir, arguments, "hyriseBenchmarkJoinOrder", True)
 

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -83,6 +83,7 @@ using RadixContainer = std::vector<Partition<T>>;
 // in the compressed RowIDPosList. This is comparable to the interface of std::equal_range.
 template <typename HashedType>
 class PosHashTable {
+ public:
   // If we end up with a partition that has more values than Offset can hold, the partitioning algorithm is at fault.
   using Offset = uint32_t;
 
@@ -102,7 +103,6 @@ class PosHashTable {
     std::vector<size_t> offsets;
   };
 
- public:
   explicit PosHashTable(const JoinHashBuildMode mode, const size_t max_size)
       : _mode(mode),
         _small_pos_lists(mode == JoinHashBuildMode::AllPositions ? max_size + 1 : 0,
@@ -211,11 +211,12 @@ class PosHashTable {
 
 // The bloom filter (with k=1) is used during the materialization and build phases. It contains `true` for each
 // `hash_function(value) % BLOOM_FILTER_SIZE`. Much of how the bloom filter is used in the hash join could be improved:
-// (1) Dynamically check whether bloom filters are worth the memory and computational costs This could be based on the
+// (1) Dynamically check whether bloom filters are worth the memory and computational costs. This could be based on the
 //     input table sizes, the expected cardinalities, the hardware characteristics, or other factors.
 // (2) Choosing an appropriate filter size. 2^20 was experimentally found to be good for TPC-H SF 10, but is certainly
 //     not optimal in every situation.
-// (3) Check whether using multiple hash functions (k>1) brings any improvement.
+// (3) Check whether using multiple hash functions (k>1) brings any improvement. For single-threaded TPC-H SF 10 (which
+//     mostly joins on integers where many are under 2^20), it however appears as if this has no immediate benefits.
 // (4) Use the probe side bloom filter when partitioning the build side. By doing that, we reduce the size of the
 //     intermediary results. When a bloom filter-supported partitioning has been done (i.e., partitioning has not
 //     been skipped), we do not need to use a bloom filter in the build phase anymore.

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -215,8 +215,8 @@ class PosHashTable {
 //     input table sizes, the expected cardinalities, the hardware characteristics, or other factors.
 // (2) Choosing an appropriate filter size. 2^20 was experimentally found to be good for TPC-H SF 10, but is certainly
 //     not optimal in every situation.
-// (3) Check whether using multiple hash functions (k>1) brings any improvement. For single-threaded TPC-H SF 10 (which
-//     mostly joins on integers where many are under 2^20), it however appears as if this has no immediate benefits.
+// (3) Evaluate whether using multiple hash functions (k>1) brings any improvement. In a first experiment, however, we
+//     saw no benefits for single-threaded TPC-H SF 10.
 // (4) Use the probe side bloom filter when partitioning the build side. By doing that, we reduce the size of the
 //     intermediary results. When a bloom filter-supported partitioning has been done (i.e., partitioning has not
 //     been skipped), we do not need to use a bloom filter in the build phase anymore.

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -123,7 +123,7 @@ std::pair<size_t, std::vector<bool>> ColumnLikeTableScanImpl::_find_matches_in_d
 
   _matcher.resolve(_invert_results, [&](const auto& matcher) {
 #ifdef __clang__
-// For the loop through the dictionary, we want to use const auto& for DictionaySegments. However,
+// For the loop through the dictionary, we want to use const auto& for DictionarySegments. However,
 // FixedStringVector iterators return an std::string_view value. Thus, we disable clang's -Wrange-loop-analysis
 // error about a potential copy for the loop value.
 #pragma GCC diagnostic push

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -9,7 +9,7 @@
 
 namespace opossum {
 void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
-  Assert(lqp_root->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto");
+  Assert(lqp_root->type == LQPNodeType::Root, "Rule needs root to hold onto");
 
   // Adding semi joins inside visit_lqp might lead to endless recursions. Thus, we use visit_lqp to identify the
   // reductions that we want to add to the plan, write them into semi_join_reductions and actually add them after

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -24,8 +24,7 @@ void MvccDeletePlugin::stop() {
   // Call destructor of PausableLoopThread to terminate its thread
   _loop_thread_logical_delete.reset();
   _loop_thread_physical_delete.reset();
-  std::queue<TableAndChunkID> empty;
-  std::swap(_physical_delete_queue, empty);
+  _physical_delete_queue = {};
 }
 
 /**

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -54,7 +54,9 @@ TEST_F(StressTest, TestTransactionConflicts) {
   };
 
   // Create the async objects and spawn them asynchronously (i.e., as their own threads)
-  // Note that async has a bunch of issues (cf. Mastering the C++17 STL, pages 205f).
+  // Note that async has a bunch of issues:
+  //  - https://stackoverflow.com/questions/12508653/what-is-the-issue-with-stdasync
+  //  - Mastering the C++17 STL, pages 205f
   // TODO(anyone): Change this to proper threads+futures, or at least do not reuse this code.
   const auto num_threads = 100u;
   std::vector<std::future<void>> thread_futures;

--- a/src/test/lib/concurrency/stress_test.cpp
+++ b/src/test/lib/concurrency/stress_test.cpp
@@ -54,6 +54,8 @@ TEST_F(StressTest, TestTransactionConflicts) {
   };
 
   // Create the async objects and spawn them asynchronously (i.e., as their own threads)
+  // Note that async has a bunch of issues (cf. Mastering the C++17 STL, pages 205f).
+  // TODO(anyone): Change this to proper threads+futures, or at least do not reuse this code.
   const auto num_threads = 100u;
   std::vector<std::future<void>> thread_futures;
   thread_futures.reserve(num_threads);

--- a/src/test/lib/server/server_test_runner.cpp
+++ b/src/test/lib/server/server_test_runner.cpp
@@ -403,6 +403,8 @@ TEST_F(ServerTestRunner, TestParallelConnections) {
   };
 
   // Create the async objects and spawn them asynchronously (i.e., as their own threads)
+  // Note that async has a bunch of issues (cf. Mastering the C++17 STL, pages 205f).
+  // TODO(anyone): Change this to proper threads+futures, or at least do not reuse this code.
   const auto num_threads = 100u;
   std::vector<std::future<void>> thread_futures;
   thread_futures.reserve(num_threads);

--- a/src/test/lib/server/server_test_runner.cpp
+++ b/src/test/lib/server/server_test_runner.cpp
@@ -403,7 +403,9 @@ TEST_F(ServerTestRunner, TestParallelConnections) {
   };
 
   // Create the async objects and spawn them asynchronously (i.e., as their own threads)
-  // Note that async has a bunch of issues (cf. Mastering the C++17 STL, pages 205f).
+  // Note that async has a bunch of issues:
+  //  - https://stackoverflow.com/questions/12508653/what-is-the-issue-with-stdasync
+  //  - Mastering the C++17 STL, pages 205f
   // TODO(anyone): Change this to proper threads+futures, or at least do not reuse this code.
   const auto num_threads = 100u;
   std::vector<std::future<void>> thread_futures;


### PR DESCRIPTION
For the join order benchmark, binary tables are written into the table_path. In CI, this path is shared by different targets that are potentially executed concurrently. This sometimes led to issues with corrupted binary files.

I am also sneaking in some things that are too minor to have their own PR.