### PR TITLE
Improve PQP tooltip of table scan

### DIFF
--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -99,10 +99,14 @@ class CompareBenchmarkScriptTest:
 
             # Check the latency values for both JSON files
             assert_latency_equals(
-                len(old_successful_runs), [run["duration"] for run in old_successful_runs], fields[3],
+                len(old_successful_runs),
+                [run["duration"] for run in old_successful_runs],
+                fields[3],
             )
             assert_latency_equals(
-                len(new_successful_runs), [run["duration"] for run in new_successful_runs], fields[4],
+                len(new_successful_runs),
+                [run["duration"] for run in new_successful_runs],
+                fields[4],
             )
 
             # Get the divisors for both benchmark files. They differ for Ordered and Shuffled mode.
@@ -133,7 +137,9 @@ class CompareBenchmarkScriptTest:
 
                 if len(old_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(old_unsuccessful_runs), [run["duration"] for run in old_unsuccessful_runs], fields[3],
+                        len(old_unsuccessful_runs),
+                        [run["duration"] for run in old_unsuccessful_runs],
+                        fields[3],
                     )
                     assert_throughput_equals(len(old_unsuccessful_runs), divisors[0], fields[7])
                 else:
@@ -142,7 +148,9 @@ class CompareBenchmarkScriptTest:
 
                 if len(new_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(new_unsuccessful_runs), [run["duration"] for run in new_unsuccessful_runs], fields[4],
+                        len(new_unsuccessful_runs),
+                        [run["duration"] for run in new_unsuccessful_runs],
+                        fields[4],
                     )
                     assert_throughput_equals(len(new_unsuccessful_runs), divisors[1], fields[8])
                 else:

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -197,8 +197,8 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   auto& scan_performance_data = dynamic_cast<PerformanceData&>(*performance_data);
-  scan_performance_data.chunk_scans_skipped = _impl->chunk_scans_skipped;
-  scan_performance_data.chunk_scans_sorted = _impl->chunk_scans_sorted;
+  scan_performance_data.num_chunks_with_early_out = _impl->num_chunks_with_early_out;
+  scan_performance_data.num_chunks_with_binary_search = _impl->num_chunks_with_binary_search;
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -196,7 +196,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
 
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
-  auto& scan_performance_data = static_cast<PerformanceData&>(*performance_data);
+  auto& scan_performance_data = dynamic_cast<PerformanceData&>(*performance_data);
   scan_performance_data.chunk_scans_skipped = _impl->chunk_scans_skipped;
   scan_performance_data.chunk_scans_sorted = _impl->chunk_scans_sorted;
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -197,8 +197,8 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   auto& scan_performance_data = dynamic_cast<PerformanceData&>(*performance_data);
-  scan_performance_data.num_chunks_with_early_out = _impl->num_chunks_with_early_out;
-  scan_performance_data.num_chunks_with_binary_search = _impl->num_chunks_with_binary_search;
+  scan_performance_data.num_chunks_with_early_out = _impl->num_chunks_with_early_out.load();
+  scan_performance_data.num_chunks_with_binary_search = _impl->num_chunks_with_binary_search.load();
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));
 }

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -53,22 +53,11 @@ class TableScan : public AbstractReadOnlyOperator {
     size_t chunk_scans_sorted{0};
 
     void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
-      if (chunk_scans_skipped == 0 && chunk_scans_sorted == 0) {
-        return;
-      }
+      OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps>::output_to_stream(stream, description_mode);
 
       const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-      stream << separator << "Chunks: ";
-      if (chunk_scans_skipped > 0) {
-        stream << chunk_scans_skipped << " skipped";
-      }
-      if (chunk_scans_skipped > 0 && chunk_scans_sorted > 0) {
-        stream << ", ";
-      }
-      if (chunk_scans_sorted > 0) {
-        stream << chunk_scans_sorted << " scanned using binary search";
-      }
-      stream << ". ";
+      stream << separator << "Chunks: " << chunk_scans_skipped << " skipped, ";
+      stream << chunk_scans_sorted << " scanned using binary search.";
     }
   };
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -49,15 +49,15 @@ class TableScan : public AbstractReadOnlyOperator {
   std::vector<ChunkID> excluded_chunk_ids;
 
   struct PerformanceData : public OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps> {
-    size_t chunk_scans_skipped{0};
-    size_t chunk_scans_sorted{0};
+    std::atomic<size_t> num_chunks_with_early_out{0};
+    std::atomic<size_t> num_chunks_with_binary_search{0};
 
     void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
       OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps>::output_to_stream(stream, description_mode);
 
       const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-      stream << separator << "Chunks: " << chunk_scans_skipped << " skipped, ";
-      stream << chunk_scans_sorted << " scanned using binary search.";
+      stream << separator << "Chunks: " << num_chunks_with_early_out << " skipped, ";
+      stream << num_chunks_with_binary_search << " scanned using binary search.";
     }
   };
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -56,8 +56,8 @@ class TableScan : public AbstractReadOnlyOperator {
       OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps>::output_to_stream(stream, description_mode);
 
       const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-      stream << separator << "Chunks: " << num_chunks_with_early_out << " skipped, ";
-      stream << num_chunks_with_binary_search << " scanned using binary search.";
+      stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped, ";
+      stream << num_chunks_with_binary_search.load() << " scanned using binary search.";
     }
   };
 

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -27,8 +27,8 @@ class AbstractTableScanImpl {
 
   virtual std::shared_ptr<RowIDPosList> scan_chunk(ChunkID chunk_id) = 0;
 
-  std::atomic<size_t> chunk_scans_skipped{0};
-  std::atomic<size_t> chunk_scans_sorted{0};
+  std::atomic<size_t> num_chunks_with_early_out{0};
+  std::atomic<size_t> num_chunks_with_binary_search{0};
 
  protected:
   /**

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
@@ -49,7 +49,7 @@ void ColumnBetweenTableScanImpl::_scan_non_reference_segment(
     for (const auto& sorted_by : chunk_sorted_by) {
       if (sorted_by.column == _column_id) {
         _scan_sorted_segment(segment, chunk_id, matches, position_filter, sorted_by.sort_mode);
-        ++chunk_scans_sorted;
+        ++num_chunks_with_binary_search;
         return;
       }
     }
@@ -145,7 +145,7 @@ void ColumnBetweenTableScanImpl::_scan_dictionary_segment(
    * Early out: No entries match
    */
   if (lower_bound_value_id == INVALID_VALUE_ID || lower_bound_value_id >= upper_bound_value_id) {
-    ++chunk_scans_skipped;
+    ++num_chunks_with_early_out;
     return;
   }
 

--- a/src/lib/operators/table_scan/column_is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_is_null_table_scan_impl.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<RowIDPosList> ColumnIsNullTableScanImpl::scan_chunk(const ChunkI
       for (const auto& sorted_by : chunk_sorted_by) {
         if (sorted_by.column == _column_id) {
           _scan_generic_sorted_segment(*segment, chunk_id, *matches, sorted_by.sort_mode);
-          ++chunk_scans_sorted;
+          ++num_chunks_with_binary_search;
           return matches;
         }
       }
@@ -100,7 +100,7 @@ void ColumnIsNullTableScanImpl::_scan_value_segment(const BaseValueSegment& segm
   }
 
   if (_matches_none(segment)) {
-    ++chunk_scans_skipped;
+    ++num_chunks_with_early_out;
     return;
   }
 

--- a/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_like_table_scan_impl.cpp
@@ -98,7 +98,7 @@ void ColumnLikeTableScanImpl::_scan_dictionary_segment(const BaseDictionarySegme
 
   // LIKE matches no rows
   if (match_count == 0u) {
-    ++chunk_scans_skipped;
+    ++num_chunks_with_early_out;
     return;
   }
 

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -39,7 +39,7 @@ void ColumnVsValueTableScanImpl::_scan_non_reference_segment(
     for (const auto& sorted_by : chunk_sorted_by) {
       if (sorted_by.column == _column_id) {
         _scan_sorted_segment(segment, chunk_id, matches, position_filter, sorted_by.sort_mode);
-        ++chunk_scans_sorted;
+        ++num_chunks_with_binary_search;
         return;
       }
     }
@@ -142,7 +142,7 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(
   }
 
   if (_value_matches_none(segment, search_value_id)) {
-    ++chunk_scans_skipped;
+    ++num_chunks_with_early_out;
     return;
   }
 

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -75,8 +75,8 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
 
     auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_skipped, 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_sorted, 0ul);
+    EXPECT_EQ(performance_data.num_chunks_with_early_out, 0ul);
+    EXPECT_EQ(performance_data.num_chunks_with_binary_search, 0ul);
   }
 
   {
@@ -89,8 +89,8 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
 
     const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_skipped, 1ul);
-    EXPECT_EQ(performance_data.chunk_scans_sorted, 0ul);
+    EXPECT_EQ(performance_data.num_chunks_with_early_out, 1ul);
+    EXPECT_EQ(performance_data.num_chunks_with_binary_search, 0ul);
   }
 
   // Check counters for sorted segment scanning (value scan)
@@ -106,8 +106,8 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
 
     const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_skipped, 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_sorted, 2ul);
+    EXPECT_EQ(performance_data.num_chunks_with_early_out, 0ul);
+    EXPECT_EQ(performance_data.num_chunks_with_binary_search, 2ul);
   }
 
   // Between scan
@@ -121,8 +121,8 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
 
     const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_skipped, 0ul);
-    EXPECT_EQ(performance_data.chunk_scans_sorted, 2ul);
+    EXPECT_EQ(performance_data.num_chunks_with_early_out, 0ul);
+    EXPECT_EQ(performance_data.num_chunks_with_binary_search, 2ul);
   }
 }
 

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -73,7 +73,7 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
         std::make_shared<TableScan>(table_wrapper, equals_(get_column_expression(table_wrapper, ColumnID{0}), 2));
     table_scan->execute();
 
-    auto& performance_data = static_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
+    auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
     EXPECT_EQ(performance_data.chunk_scans_skipped, 0ul);
     EXPECT_EQ(performance_data.chunk_scans_sorted, 0ul);
@@ -87,7 +87,7 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
         std::make_shared<TableScan>(table_wrapper, equals_(get_column_expression(table_wrapper, ColumnID{0}), 1));
     table_scan->execute();
 
-    const auto& performance_data = static_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
+    const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
     EXPECT_EQ(performance_data.chunk_scans_skipped, 1ul);
     EXPECT_EQ(performance_data.chunk_scans_sorted, 0ul);
@@ -104,7 +104,7 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
         std::make_shared<TableScan>(table_wrapper, equals_(get_column_expression(table_wrapper, ColumnID{0}), 2));
     table_scan->execute();
 
-    const auto& performance_data = static_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
+    const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
     EXPECT_EQ(performance_data.chunk_scans_skipped, 0ul);
     EXPECT_EQ(performance_data.chunk_scans_sorted, 2ul);
@@ -119,7 +119,7 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
         table_wrapper, between_inclusive_(get_column_expression(table_wrapper, ColumnID{0}), 1, 2));
     table_scan->execute();
 
-    const auto& performance_data = static_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
+    const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     EXPECT_GT(performance_data.walltime.count(), 0ul);
     EXPECT_EQ(performance_data.chunk_scans_skipped, 0ul);
     EXPECT_EQ(performance_data.chunk_scans_sorted, 2ul);
@@ -132,7 +132,7 @@ TEST_F(OperatorPerformanceDataTest, JoinHashStepRuntimes) {
       OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
   join->execute();
 
-  const auto& perf = static_cast<const OperatorPerformanceData<JoinHash::OperatorSteps>&>(*join->performance_data);
+  const auto& perf = dynamic_cast<const OperatorPerformanceData<JoinHash::OperatorSteps>&>(*join->performance_data);
 
   for (const auto step : magic_enum::enum_values<JoinHash::OperatorSteps>()) {
     if (step == JoinHash::OperatorSteps::Clustering) {
@@ -156,7 +156,7 @@ TEST_F(OperatorPerformanceDataTest, JoinIndexStepRuntimes) {
         table_wrapper, table_wrapper, JoinMode::Inner,
         OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
     join->execute();
-    auto& perf = static_cast<const JoinIndex::PerformanceData&>(*join->performance_data);
+    auto& perf = dynamic_cast<const JoinIndex::PerformanceData&>(*join->performance_data);
 
     EXPECT_EQ(perf.get_step_runtime(JoinIndex::OperatorSteps::IndexJoining).count(), 0);
     EXPECT_GT(perf.get_step_runtime(JoinIndex::OperatorSteps::NestedLoopJoining).count(), 0);
@@ -174,7 +174,7 @@ TEST_F(OperatorPerformanceDataTest, JoinIndexStepRuntimes) {
         table_wrapper, table_wrapper, JoinMode::Inner,
         OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
     join->execute();
-    auto& perf = static_cast<const JoinIndex::PerformanceData&>(*join->performance_data);
+    auto& perf = dynamic_cast<const JoinIndex::PerformanceData&>(*join->performance_data);
 
     EXPECT_GT(perf.get_step_runtime(JoinIndex::OperatorSteps::IndexJoining).count(), 0);
     EXPECT_EQ(perf.get_step_runtime(JoinIndex::OperatorSteps::NestedLoopJoining).count(), 0);
@@ -190,7 +190,7 @@ TEST_F(OperatorPerformanceDataTest, JoinIndexStepRuntimes) {
         table_wrapper, table_wrapper, JoinMode::Inner,
         OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
     join->execute();
-    auto& perf = static_cast<const JoinIndex::PerformanceData&>(*join->performance_data);
+    auto& perf = dynamic_cast<const JoinIndex::PerformanceData&>(*join->performance_data);
 
     EXPECT_GT(perf.get_step_runtime(JoinIndex::OperatorSteps::IndexJoining).count(), 0);
     EXPECT_GT(perf.get_step_runtime(JoinIndex::OperatorSteps::NestedLoopJoining).count(), 0);
@@ -211,7 +211,7 @@ TEST_F(OperatorPerformanceDataTest, AggregateHashStepRuntimes) {
   aggregate->execute();
 
   auto& performance_data =
-      static_cast<const OperatorPerformanceData<AggregateHash::OperatorSteps>&>(*aggregate->performance_data);
+      dynamic_cast<const OperatorPerformanceData<AggregateHash::OperatorSteps>&>(*aggregate->performance_data);
 
   for (const auto step : magic_enum::enum_values<AggregateHash::OperatorSteps>()) {
     EXPECT_GT(performance_data.get_step_runtime(step).count(), 0);


### PR DESCRIPTION
I was wondering, why table scans did not show any skipping (e.g., due to value not existing in the dictionary) for scans that should skip (at least that was what I thought).
Turns out, this information is only shown when there have been at least one chunk that was skipped or scanned binary.
This PR now fixes that (i) there has not been a tooltip before when no chunks were skipped and (ii) the skip information is always shown now.

Before Q19 (no information for non-skipped):
<img width="737" alt="image" src="https://user-images.githubusercontent.com/1745857/101933819-043f4a80-3bdd-11eb-8e17-d2844f844ae8.png">

Now:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/1745857/101949766-66577a00-3bf4-11eb-9d12-b8994fed7a77.png">

<img width="528" alt="image" src="https://user-images.githubusercontent.com/1745857/101949803-74a59600-3bf4-11eb-954e-715fbf1c66e4.png">


Further changed the table scan operator as well as the tests to use `dynamic_cast` over `static_cast` to ensure that wrong casts are catched. It's not in a hot loop, so that should not matter.

One potentially open question is how to handle table scan's splitting of reference table into their actual physical chunks. The table scan skips 92 chunks, even though just 30 chunks are passed into it.