### PR TITLE
TableScan: track number of chunks where all rows match

### DIFF
--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -198,6 +198,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
 
   auto& scan_performance_data = dynamic_cast<PerformanceData&>(*performance_data);
   scan_performance_data.num_chunks_with_early_out = _impl->num_chunks_with_early_out.load();
+  scan_performance_data.num_chunks_with_all_rows_matching = _impl->num_chunks_with_all_rows_matching.load();
   scan_performance_data.num_chunks_with_binary_search = _impl->num_chunks_with_binary_search.load();
 
   return std::make_shared<Table>(in_table->column_definitions(), TableType::References, std::move(output_chunks));

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -50,6 +50,7 @@ class TableScan : public AbstractReadOnlyOperator {
 
   struct PerformanceData : public OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps> {
     std::atomic<size_t> num_chunks_with_early_out{0};
+    std::atomic<size_t> num_chunks_with_all_rows_matching{0};
     std::atomic<size_t> num_chunks_with_binary_search{0};
 
     void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
@@ -57,6 +58,7 @@ class TableScan : public AbstractReadOnlyOperator {
 
       const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
       stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped, ";
+      stream << separator << num_chunks_with_all_rows_matching.load() << " matched all rows,";
       stream << num_chunks_with_binary_search.load() << " scanned using binary search.";
     }
   };

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -57,8 +57,8 @@ class TableScan : public AbstractReadOnlyOperator {
       OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps>::output_to_stream(stream, description_mode);
 
       const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-      stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped, ";
-      stream << separator << num_chunks_with_all_rows_matching.load() << " matched all rows,";
+      stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped with no results, ";
+      stream << separator << num_chunks_with_all_rows_matching.load() << " skipped with all matching,";
       stream << num_chunks_with_binary_search.load() << " scanned using binary search.";
     }
   };

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -58,7 +58,7 @@ class TableScan : public AbstractReadOnlyOperator {
 
       const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
       stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped with no results, ";
-      stream << separator << num_chunks_with_all_rows_matching.load() << " skipped with all matching,";
+      stream << separator << num_chunks_with_all_rows_matching.load() << " skipped with all matching, ";
       stream << num_chunks_with_binary_search.load() << " scanned using binary search.";
     }
   };

--- a/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/abstract_table_scan_impl.hpp
@@ -28,6 +28,7 @@ class AbstractTableScanImpl {
   virtual std::shared_ptr<RowIDPosList> scan_chunk(ChunkID chunk_id) = 0;
 
   std::atomic<size_t> num_chunks_with_early_out{0};
+  std::atomic<size_t> num_chunks_with_all_rows_matching{0};
   std::atomic<size_t> num_chunks_with_binary_search{0};
 
  protected:

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
@@ -49,7 +49,6 @@ void ColumnBetweenTableScanImpl::_scan_non_reference_segment(
     for (const auto& sorted_by : chunk_sorted_by) {
       if (sorted_by.column == _column_id) {
         _scan_sorted_segment(segment, chunk_id, matches, position_filter, sorted_by.sort_mode);
-        ++num_chunks_with_binary_search;
         return;
       }
     }
@@ -121,6 +120,7 @@ void ColumnBetweenTableScanImpl::_scan_dictionary_segment(
       });
     } else {
       // No NULLs, all entries match.
+      ++num_chunks_with_all_rows_matching;
       const auto output_size = position_filter ? position_filter->size() : segment.size();
       const auto output_start_offset = matches.size();
       matches.resize(matches.size() + output_size);
@@ -176,7 +176,7 @@ void ColumnBetweenTableScanImpl::_scan_dictionary_segment(
 void ColumnBetweenTableScanImpl::_scan_sorted_segment(const AbstractSegment& segment, const ChunkID chunk_id,
                                                       RowIDPosList& matches,
                                                       const std::shared_ptr<const AbstractPosList>& position_filter,
-                                                      const SortMode sort_mode) const {
+                                                      const SortMode sort_mode) {
   resolve_data_and_segment_type(segment, [&](const auto type, const auto& typed_segment) {
     using ColumnDataType = typename decltype(type)::type;
 
@@ -193,6 +193,14 @@ void ColumnBetweenTableScanImpl::_scan_sorted_segment(const AbstractSegment& seg
         sorted_segment_search.scan_sorted_segment([&](auto begin, auto end) {
           sorted_segment_search._write_rows_to_matches(begin, end, chunk_id, matches, position_filter);
         });
+
+        if (sorted_segment_search.no_rows_matching) {
+          ++num_chunks_with_early_out;
+        } else if (sorted_segment_search.all_rows_matching) {
+          ++num_chunks_with_all_rows_matching;
+        } else {
+          ++num_chunks_with_binary_search;
+        }
       });
     }
   });

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.hpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.hpp
@@ -44,8 +44,7 @@ class ColumnBetweenTableScanImpl : public AbstractDereferencedColumnTableScanImp
                                 const std::shared_ptr<const AbstractPosList>& position_filter);
 
   void _scan_sorted_segment(const AbstractSegment& segment, const ChunkID chunk_id, RowIDPosList& matches,
-                            const std::shared_ptr<const AbstractPosList>& position_filter,
-                            const SortMode sort_mode) const;
+                            const std::shared_ptr<const AbstractPosList>& position_filter, const SortMode sort_mode);
 
  private:
   const bool _column_is_nullable;

--- a/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_value_table_scan_impl.cpp
@@ -121,6 +121,7 @@ void ColumnVsValueTableScanImpl::_scan_dictionary_segment(
       });
     } else {
       // No NULLs, all rows match.
+      ++num_chunks_with_all_rows_matching;
       const auto output_size = position_filter ? position_filter->size() : segment.size();
       const auto output_start_offset = matches.size();
       matches.resize(matches.size() + output_size);

--- a/src/lib/operators/table_scan/sorted_segment_search.hpp
+++ b/src/lib/operators/table_scan/sorted_segment_search.hpp
@@ -154,10 +154,14 @@ class SortedSegmentSearch {
     }
 
     // early out everything matches
-    if (first_value > _first_search_value && last_value < *_second_search_value) return;
+    if (first_value > _first_search_value && last_value < *_second_search_value) {
+      all_rows_matching = true;
+      return;
+    }
 
     // early out nothing matches
     if (first_value > *_second_search_value || last_value < _first_search_value) {
+      no_rows_matching = true;
       _begin = _end;
       return;
     }
@@ -294,6 +298,10 @@ class SortedSegmentSearch {
       }
     }
   }
+
+  // Flags to indicate whether a shortcut was taken to skip scanning.
+  bool no_rows_matching{false};
+  bool all_rows_matching{false};
 
  private:
   // _begin and _end will be modified to match the search range and will be passed to the ResultConsumer, except when

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -128,8 +128,9 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
     const auto& performance_data = dynamic_cast<TableScan::PerformanceData&>(*table_scan->performance_data);
     /*
      * TODO(anyone) actually, there could be 3 chunks with all rows matching, and none with binary search.
-     * However, the all-match shortcurt of the sorted segment search currently always assumes an exclusive between.
-     * Consequently, the first chunk must be scanned
+     * However, the all-match shortcurt of the sorted segment search currently always assumes an exclusive between
+     * when checking for the all-match-shortcut, and an inclusive between when checking for the no-match-shortcut.
+     * This is not wrong, so it should not break anything, but it may lead to unnecessary sorted scans.
      */
     EXPECT_GT(performance_data.walltime.count(), 0ul);
     EXPECT_EQ(performance_data.num_chunks_with_early_out, 0ul);
@@ -165,7 +166,7 @@ TEST_F(OperatorPerformanceDataTest, TableScanPerformanceData) {
     EXPECT_EQ(performance_data.num_chunks_with_binary_search, 0ul);
   }
 
-  // Between scan
+  // Between scan on nullable columns
   {
     const auto table_wrapper = std::make_shared<TableWrapper>(table);
     table_wrapper->execute();


### PR DESCRIPTION
While working with @dey4ss on our research seminar topic (what-if clustering cost models), we noticed that the table scan currently tracks only the number of chunks for which the scan was skipped because no row matches. However, this number is often 0 because those chunks get pruned before the scan is executed.
This PR adds an additional counter to track the number of chunks for which the scan was skipped because all rows match. This does happen, e.g., for `BETWEEN` scans on `l_shipdate`.

Those two metrics are not identical because for the latter we still need to write the output.

EDIT: As @Bensk1 pointed out, this PR changes the way sorted scans are tracked: If sorted BETWEEN scans use an early exit (no match) or an all-match-shortcut, the scan now increases the respective no/all-match counter, rather than the sorted scan counter, as the scan is not really executed with binary search. ColumnVsValue scans are not affected because they do not have a similar early-exit code path (unless I missed it).