### PR TITLE
Add threshold for parallel execution in table scan and join hash

### DIFF
--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -22,10 +22,9 @@ class JoinHash : public AbstractJoinOperator {
  public:
   static bool supports(const JoinConfiguration config);
 
-  // The jobs that perform the actual materialize, partition by redix, build and probe are executed directly if the
-  // number of elements of the partitions lies under the `JOB_SPAWN_THRESHOLD` rows, otherwise wrap it into a task.
-  // The upper bound of the chunk size, which defines if it will be executed in parallel or not, still needs to be
-  // re-evaluated over time to find the value which gives the best performance.
+  // The jobs that perform the actual materialization, radix partitioning, building, and probing are added to the
+  // scheduler in case the number of elements to process is above JOB_SPAWN_THRESHOLD. If not, the job is executed
+  // directly. This threshold needs to be re-evaluated over time to find the value which gives the best performance.
   static constexpr auto JOB_SPAWN_THRESHOLD = 500;
 
   JoinHash(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -21,6 +21,10 @@ namespace opossum {
 class JoinHash : public AbstractJoinOperator {
  public:
   static bool supports(const JoinConfiguration config);
+  // Evaluate the expression immediately if it contains less than `JOB_SPAWN_THRESHOLD` rows, otherwise wrap
+  // it into a task. The upper bound of the chunk size, which defines if it will be executed in parallel or not,
+  // still needs to be re-evaluated over time to find the value which gives the best performance.
+  static constexpr auto JOB_SPAWN_THRESHOLD = 500;
 
   JoinHash(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,
            const JoinMode mode, const OperatorJoinPredicate& primary_predicate,

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -21,9 +21,11 @@ namespace opossum {
 class JoinHash : public AbstractJoinOperator {
  public:
   static bool supports(const JoinConfiguration config);
-  // Evaluate the expression immediately if it contains less than `JOB_SPAWN_THRESHOLD` rows, otherwise wrap
-  // it into a task. The upper bound of the chunk size, which defines if it will be executed in parallel or not,
-  // still needs to be re-evaluated over time to find the value which gives the best performance.
+
+  // The jobs that perform the actual materialize, partition by redix, build and probe are executed directly if the
+  // number of elements of the partitions lies under the `JOB_SPAWN_THRESHOLD` rows, otherwise wrap it into a task.
+  // The upper bound of the chunk size, which defines if it will be executed in parallel or not, still needs to be
+  // re-evaluated over time to find the value which gives the best performance.
   static constexpr auto JOB_SPAWN_THRESHOLD = 500;
 
   JoinHash(const std::shared_ptr<const AbstractOperator>& left, const std::shared_ptr<const AbstractOperator>& right,

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -443,10 +443,9 @@ std::vector<std::optional<PosHashTable<HashedType>>> build(const RadixContainer<
     };
 
     if (radix_bits == 0 || JoinHash::JOB_SPAWN_THRESHOLD > elements_count) {
-      // Without radix partitioning, only a single hash table will be written. Parallelizing this would require a
-      // concurrent hash table, which is likely more expensive.
-      // If the size (number of elements) of the partition lies under the threshold, the execution in parallel is
-      // likely more expensive.
+      // Execute the insertion in the hash table sequentially when we do not radix partition (i.e., 0 radix bits) or
+      // the number of elements is too small. Without radix partitioning, only a single hash table will be written.
+      // Parallelizing this would require a concurrent hash table, which is likely more expensive.
       insert_into_hash_table();
     } else {
       jobs.emplace_back(std::make_shared<JobTask>(insert_into_hash_table));
@@ -546,8 +545,6 @@ RadixContainer<T> partition_by_radix(const RadixContainer<T>& radix_container,
       }
     };
     if (JoinHash::JOB_SPAWN_THRESHOLD > elements_count) {
-      // If the size (number of elements) of the partition lies under the threshold, the execution in parallel is
-      // likely more expensive.
       perform_partition();
     } else {
       jobs.emplace_back(std::make_shared<JobTask>(perform_partition));
@@ -725,8 +722,6 @@ void probe(const RadixContainer<ProbeColumnType>& probe_radix_container,
     };
 
     if (JoinHash::JOB_SPAWN_THRESHOLD > elements_count) {
-      // If the size (number of elements) of the partition lies under the threshold, the execution in parallel is
-      // likely more expensive.
       probe_partition();
     } else {
       jobs.emplace_back(std::make_shared<JobTask>(probe_partition));
@@ -845,8 +840,6 @@ void probe_semi_anti(const RadixContainer<ProbeColumnType>& probe_radix_containe
     };
 
     if (JoinHash::JOB_SPAWN_THRESHOLD > elements_count) {
-      // If the size (number of elements) of the partition lies under the threshold, the execution in parallel is
-      // likely more expensive.
       probe_partition();
     } else {
       jobs.emplace_back(std::make_shared<JobTask>(probe_partition));

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -368,8 +368,6 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
       }
     };
     if (JoinHash::JOB_SPAWN_THRESHOLD > num_rows) {
-      // If the chunk size (number of rows) of the partition lies under the threshold, the execution in parallel is
-      // likely more expensive.
       materialize();
     } else {
       jobs.emplace_back(std::make_shared<JobTask>(materialize));

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -251,7 +251,6 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
   std::vector<std::shared_ptr<AbstractTask>> jobs;
   jobs.reserve(chunk_count);
   for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
-
     const auto chunk_in = in_table->get_chunk(chunk_id);
     if (!chunk_in) continue;
 

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -250,7 +250,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
 
   std::vector<std::shared_ptr<AbstractTask>> jobs;
   jobs.reserve(chunk_count);
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk_in = in_table->get_chunk(chunk_id);
     if (!chunk_in) continue;
 
@@ -511,7 +511,7 @@ RadixContainer<T> partition_by_radix(const RadixContainer<T>& radix_container,
   std::vector<std::shared_ptr<AbstractTask>> jobs;
   jobs.reserve(input_partition_count);
 
-  for (ChunkID input_partition_idx{0}; input_partition_idx < input_partition_count; ++input_partition_idx) {
+  for (auto input_partition_idx = ChunkID{0}; input_partition_idx < input_partition_count; ++input_partition_idx) {
     const auto& input_partition = radix_container[input_partition_idx];
     const auto& elements = input_partition.elements;
     const auto elements_count = elements.size();

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -190,9 +190,8 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
       std::lock_guard<std::mutex> lock(output_mutex);
       output_chunks.emplace_back(chunk);
     };
-    // Evaluate the expression immediately if it contains less than `JOB_SPAWN_THRESHOLD` rows, otherwise wrap
-    // it into a task. The upper bound of the chunk size, which defines if it will be executed in parallel or not,
-    // still needs to be re-evaluated over time to find the value which gives the best performance.
+    // Spawn job when chunk sufficiently large. The upper bound of the chunk size, still needs to be re-evaluated over
+    // time to find the value which gives the best performance.
     constexpr auto JOB_SPAWN_THRESHOLD = ChunkOffset{500};
     if (chunk_in->size() >= JOB_SPAWN_THRESHOLD) {
       auto job_task = std::make_shared<JobTask>(perform_table_scan);

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -101,7 +101,7 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
     Assert(chunk_in, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
     // chunk_in – Copy by value since copy by reference is not possible due to the limited scope of the for-iteration.
-    auto job_task = std::make_shared<JobTask>([this, chunk_id, chunk_in, &in_table, &output_mutex, &output_chunks]() {
+    auto perform_table_scan = [this, chunk_id, chunk_in, &in_table, &output_mutex, &output_chunks]() {
       // The actual scan happens in the sub classes of BaseTableScanImpl
       const auto matches_out = _impl->scan_chunk(chunk_id);
       if (matches_out->empty()) return;
@@ -189,9 +189,17 @@ std::shared_ptr<const Table> TableScan::_on_execute() {
       }
       std::lock_guard<std::mutex> lock(output_mutex);
       output_chunks.emplace_back(chunk);
-    });
-
-    jobs.push_back(job_task);
+    };
+    // Evaluate the expression immediately if it contains less than `JOB_SPAWN_THRESHOLD` rows, otherwise wrap
+    // it into a task. The upper bound of the chunk size, which defines if it will be executed in parallel or not,
+    // still needs to be re-evaluated over time to find the value which gives the best performance.
+    constexpr auto JOB_SPAWN_THRESHOLD = ChunkOffset{500};
+    if (chunk_in->size() >= JOB_SPAWN_THRESHOLD) {
+      auto job_task = std::make_shared<JobTask>(perform_table_scan);
+      jobs.push_back(job_task);
+    } else {
+      perform_table_scan();
+    }
   }
 
   Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);


### PR DESCRIPTION
This PR adds a threshold for the parallel execution of jobs in the `build` and `probe` step of the `join hash`.

It is implemented in the following way: 

* A static `JOB_SPAWN_THRESHOLD` attribute is added to the `JoinHash`class
* The jobs that perform the actual *materialize*, *partition by redix*, *build* and *probe* are executed directly if the number of elements of the partitions lies under the `JOB_SPAWN_THRESHOLD`

Like in #2269 the threshold still needs to be re-evaluated over time to find the value which gives the best performance. For now, a threshold of 500 is selected.