### PR TITLE
AggregateHash: Cache result ids

### DIFF
--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -60,7 +60,10 @@ typename Results::reference get_or_add_result(CacheResultIds, ResultIds& result_
     // by storing the index in the lower 63 bits of first_key_entry and setting the most significant bit to 1 as a
     // marker that the AggregateKeyEntry now contains a cached result. We can do this because AggregateKeyEntry can not
     // become larger than the maximum size of a table (i.e., the maximum representable RowID), which is 2^31 * 2^31 ==
-    // 2^62.
+    // 2^62. This avoids making the AggregateKey bigger: Adding another 64-bit value (for an index of 2^62 values) for
+    // the cached value would double the size of the AggregateKey in the case of a single group-by column, thus halving
+    // the utilization of the CPU cache. Same for a discriminating union, where the data structure alignment would also
+    // result in another 8 bytes being used.
     static_assert(std::is_same_v<AggregateKeyEntry, uint64_t>,
                   "Expected AggregateKeyEntry to be unsigned 64-bit value");
     constexpr auto MASK = AggregateKeyEntry{1} << 63u;

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -27,43 +27,92 @@
 namespace {
 using namespace opossum;  // NOLINT
 
-// Given an AggregateKey key, and a RowId row_id where this AggregateKey was encountered, this first checks if the
-// AggregateKey was seen before. If not, a new aggregate result is inserted into results and connected to the row id.
-// This is important so that we can reconstruct the original values later. In any case, a reference to the result is
-// returned so that result information, such as the aggregate's count or sum, can be modified by the caller.
-template <typename ResultIds, typename Results, typename AggregateKey>
-typename Results::reference get_or_add_result(ResultIds& result_ids, Results& results, const AggregateKey& key,
+// For a given AggregateKey key, and a RowId row_id where this AggregateKey was encountered, this returns a reference
+// to the AggregateResult for the group defined by the AggregateKey. If GroupBy is used, this includes a lookup in the
+// result_ids hashmap, which stores the AggregateKey->Results[i] mapping.
+//
+// If the operator calculates multiple aggregate functions, we only need to perform this lookup as part of the first
+// aggregate function. By setting CacheResultIds to true_type, we can store the result of the lookup in the
+// AggregateKey. Following aggregate functions can then retrieve the index from the AggregateKey.
+template <typename CacheResultIds, typename ResultIds, typename Results, typename AggregateKey>
+typename Results::reference get_or_add_result(CacheResultIds _, ResultIds& result_ids, Results& results, AggregateKey& key,
                                               const RowID& row_id) {
-  // Get the result id for the current key or add it to the id map
   if constexpr (std::is_same_v<AggregateKey, EmptyAggregateKey>) {
+    // The aggregation uses no GROUP BY. To avoid special handling, get_or_add_result is still called, however, we
+    // always return the same result.
     if (results.empty()) {
       results.emplace_back();
       results[0].row_id = row_id;
     }
     return results[0];
   } else {
-    auto it = result_ids.find(key);
-    if (it != result_ids.end()) return results[it->second];
+    // As described above, we may store the index into the results vector in the AggregateKey. As the AggregateKey may
+    // contain multiple entries, we always use its first entry and store a (non-owning, raw) pointer to that entry in
+    // first_key_entry.
+    AggregateKeyEntry *first_key_entry;
+    if constexpr (std::is_same_v<AggregateKey, AggregateKeyEntry>) {
+      first_key_entry = &key;
+    } else {
+      first_key_entry = &key[0];
+    }
 
+    // If we store the result of the hashmap lookup (i.e., the index into results) in the AggregateKeyEntry, we do this
+    // by storing the index in the lower 63 bits of first_key_entry and setting the most significant bit to 1 as a
+    // marker that the AggregateKeyEntry now contains a cached result. We can do this because AggregateKeyEntry can not
+    // become larger than the maximum size of a table, which is 2^31 * 2^31 == 2^62.
+    static_assert(std::is_same_v<AggregateKeyEntry, uint64_t>, "Expected AggregateKeyEntry to be unsigned 64-bit value");
+    constexpr auto mask = AggregateKeyEntry{1} << 63;
+
+    // Check if the AggregateKey already contains a stored index.
+    if constexpr (std::is_same_v<CacheResultIds, std::true_type>) {
+      if (*first_key_entry & mask) {
+        // The most significant bit is a 1, remove it by xoring the mask gives us the index into the results vector.
+        const auto result_id = *first_key_entry ^ mask;
+
+        // If we have not seen this index as part of the current aggregate function, the results vector may not yet have
+        // the correct size. Resize it if necessary and write the current row_id so that we can recover the GroupBy
+        // column(s) later
+        results.resize(std::max(results.size(), static_cast<size_t>(result_id + 1)));
+        results[result_id].row_id = row_id;
+
+        return results[result_id];
+      }
+    }
+
+    // Lookup the key in the result_ids map and insert a new entry if it does not yet exist.
     auto result_id = results.size();
+    auto [it, inserted] = result_ids.emplace(key, result_id);
 
-    result_ids.emplace_hint(it, key, result_id);
+    if (!inserted) {
+      // We have already seen this group and need to return a reference to the group's result.
+      result_id = it->second;
+      if constexpr (std::is_same_v<CacheResultIds, std::true_type>) {
+        // If requested, store the index the the first_key_entry and set the most significant bit to 1.
+        *first_key_entry = mask | result_id;
+      }
+      return results[result_id];
+    }
 
-    // If it was added to the id map, add the current row id to the result list so that we can revert the
-    // value(s) -> key mapping
+    // We are seeing this group (i.e., this AggregateKey) for the first time, so we need to add it to the list of
+    // results and set the row_id needed for restoring the GroupBy column(s).
     results.emplace_back();
     results[result_id].row_id = row_id;
+
+    if constexpr (std::is_same_v<CacheResultIds, std::true_type>) {
+      // If requested, store the index the the first_key_entry and set the most significant bit to 1.
+      *first_key_entry = mask | result_id;
+    }
 
     return results[result_id];
   }
 }
 
 template <typename AggregateKey>
-const AggregateKey& get_aggregate_key([[maybe_unused]] const KeysPerChunk<AggregateKey>& keys_per_chunk,
+AggregateKey& get_aggregate_key([[maybe_unused]] KeysPerChunk<AggregateKey>& keys_per_chunk,
                                       [[maybe_unused]] const ChunkID chunk_id,
                                       [[maybe_unused]] const ChunkOffset chunk_offset) {
   if constexpr (!std::is_same_v<AggregateKey, EmptyAggregateKey>) {
-    const auto& hash_keys = keys_per_chunk[chunk_id];
+    auto& hash_keys = keys_per_chunk[chunk_id];
 
     return hash_keys[chunk_offset];
   } else {
@@ -135,7 +184,7 @@ struct AggregateContext : public AggregateResultContext<ColumnDataType, aggregat
 template <typename ColumnDataType, AggregateFunction aggregate_function, typename AggregateKey>
 __attribute__((hot)) void AggregateHash::_aggregate_segment(ChunkID chunk_id, ColumnID column_index,
                                                             const AbstractSegment& abstract_segment,
-                                                            const KeysPerChunk<AggregateKey>& keys_per_chunk) {
+                                                            KeysPerChunk<AggregateKey>& keys_per_chunk) {
   using AggregateType = typename AggregateTraits<ColumnDataType, aggregate_function>::AggregateType;
 
   auto aggregator =
@@ -149,27 +198,35 @@ __attribute__((hot)) void AggregateHash::_aggregate_segment(ChunkID chunk_id, Co
 
   ChunkOffset chunk_offset{0};
 
-  segment_iterate<ColumnDataType>(abstract_segment, [&](const auto& position) {
+  // CacheResultIds is a boolean type parameter that is forwarded to get_or_add_result, see the documentation over there
+  // for details.
+  const auto process_position = [&](const auto cache_result_ids, const auto& position) {
     auto& result =
-        get_or_add_result(result_ids, results, get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
+        get_or_add_result(cache_result_ids, result_ids, results, get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
                           RowID{chunk_id, chunk_offset});
 
-    /**
-    * If the value is NULL, the current aggregate value does not change.
-    */
+    // If the value is NULL, the current aggregate value does not change.
     if (!position.is_null()) {
       if constexpr (aggregate_function == AggregateFunction::CountDistinct) {
         // For the case of CountDistinct, insert the current value into the set to keep track of distinct values
         result.accumulator.emplace(position.value());
       } else {
-        aggregator(position.value(), result.aggregate_count, result.accumulator);
+        aggregator(ColumnDataType{position.value()}, result.aggregate_count, result.accumulator);
       }
 
       ++result.aggregate_count;
     }
 
     ++chunk_offset;
-  });
+  };
+
+  // If we have more than one aggregate function (and thus more than one context), it makes sense to cache the results
+  // indexes, see get_or_add_result for details.
+  if (_contexts_per_column.size() > 1) {
+    segment_iterate<ColumnDataType>(abstract_segment, [&](const auto& position) {process_position(std::true_type{}, position);});
+  } else {
+    segment_iterate<ColumnDataType>(abstract_segment, [&](const auto& position) {process_position(std::false_type{}, position);});
+  }
 }
 
 /**
@@ -185,7 +242,6 @@ KeysPerChunk<AggregateKey> AggregateHash::_partition_by_groupby_keys() const {
     const auto chunk_count = input_table->chunk_count();
 
     // Create the actual data structure
-    keys_per_chunk = KeysPerChunk<AggregateKey>{};
     keys_per_chunk.reserve(chunk_count);
     for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
       const auto chunk = input_table->get_chunk(chunk_id);
@@ -415,7 +471,7 @@ void AggregateHash::_aggregate() {
   /**
    * PARTITIONING STEP
    */
-  const auto keys_per_chunk = _partition_by_groupby_keys<AggregateKey>();
+  auto keys_per_chunk = _partition_by_groupby_keys<AggregateKey>();
   step_performance_data.set_step_runtime(OperatorSteps::GroupByKeyPartitioning, timer.lap());
 
   /**
@@ -487,8 +543,9 @@ void AggregateHash::_aggregate() {
       auto& results = context->results;
 
       for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
-        // Make sure the value or combination of values is added to the list of distinct value(s)
-        get_or_add_result(result_ids, results, get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
+        // Make sure the value or combination of values is added to the list of distinct value(s). Do not cache result
+        // ids as there is no aggregate function that could reuse the cached indexes.
+        get_or_add_result(std::false_type{}, result_ids, results, get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
                           RowID{chunk_id, chunk_offset});
       }
     } else {
@@ -519,12 +576,22 @@ void AggregateHash::_aggregate() {
             results.resize(1);
             results[0].aggregate_count += input_chunk_size;
           } else {
-            // count occurrences for each group key
-            for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
-              auto& result = get_or_add_result(result_ids, results,
-                                               get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
-                                               RowID{chunk_id, chunk_offset});
-              ++result.aggregate_count;
+            // Count occurrences for each group key -  If we have more than one aggregate function (and thus more than
+            // one context), it makes sense to cache the results indexes, see get_or_add_result for details.
+            if (_contexts_per_column.size() > 1) {
+              for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
+                auto& result = get_or_add_result(std::true_type{}, result_ids, results,
+                                                 get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
+                                                 RowID{chunk_id, chunk_offset});
+                ++result.aggregate_count;
+              }
+            } else {
+              for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
+                auto& result = get_or_add_result(std::false_type{}, result_ids, results,
+                                                 get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
+                                                 RowID{chunk_id, chunk_offset});
+                ++result.aggregate_count;
+              }
             }
           }
 

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -62,13 +62,13 @@ typename Results::reference get_or_add_result(CacheResultIds _, ResultIds& resul
     // become larger than the maximum size of a table, which is 2^31 * 2^31 == 2^62.
     static_assert(std::is_same_v<AggregateKeyEntry, uint64_t>,
                   "Expected AggregateKeyEntry to be unsigned 64-bit value");
-    constexpr auto mask = AggregateKeyEntry{1} << 63;
+    constexpr auto MASK = AggregateKeyEntry{1} << 63u;
 
     // Check if the AggregateKey already contains a stored index.
     if constexpr (std::is_same_v<CacheResultIds, std::true_type>) {
-      if (*first_key_entry & mask) {
+      if (*first_key_entry & MASK) {
         // The most significant bit is a 1, remove it by xoring the mask gives us the index into the results vector.
-        const auto result_id = *first_key_entry ^ mask;
+        const auto result_id = *first_key_entry ^ MASK;
 
         // If we have not seen this index as part of the current aggregate function, the results vector may not yet have
         // the correct size. Resize it if necessary and write the current row_id so that we can recover the GroupBy
@@ -89,7 +89,7 @@ typename Results::reference get_or_add_result(CacheResultIds _, ResultIds& resul
       result_id = it->second;
       if constexpr (std::is_same_v<CacheResultIds, std::true_type>) {
         // If requested, store the index the the first_key_entry and set the most significant bit to 1.
-        *first_key_entry = mask | result_id;
+        *first_key_entry = MASK | result_id;
       }
       return results[result_id];
     }
@@ -101,7 +101,7 @@ typename Results::reference get_or_add_result(CacheResultIds _, ResultIds& resul
 
     if constexpr (std::is_same_v<CacheResultIds, std::true_type>) {
       // If requested, store the index the the first_key_entry and set the most significant bit to 1.
-      *first_key_entry = mask | result_id;
+      *first_key_entry = MASK | result_id;
     }
 
     return results[result_id];

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -174,7 +174,7 @@ class AggregateHash : public AbstractAggregateOperator {
 
   template <typename ColumnDataType, AggregateFunction aggregate_function, typename AggregateKey>
   void _aggregate_segment(ChunkID chunk_id, ColumnID column_index, const AbstractSegment& abstract_segment,
-                          const KeysPerChunk<AggregateKey>& keys_per_chunk);
+                          KeysPerChunk<AggregateKey>& keys_per_chunk);
 
   template <typename AggregateKey>
   std::shared_ptr<SegmentVisitorContext> _create_aggregate_context(const DataType data_type,


### PR DESCRIPTION
This is the first step of the AggregateHash optimizations. Currently, we perform a hash lookup for every row *and* every aggregate function. With this PR, we cache the result of that lookup so that we only need to look up every row once.

In a follow-up PR, we can use the same hack (masked AggregateKeyEntry) to forgo the hashmap lookup entirely in the case of more-or-less contiguous GROUP BY values (e.g., TPC-H Q 18).

----------------------------------------
**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.5TB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 7f8d50b44 | 23.12.2020 11:12 | TableScan: track number of chunks where all rows match (#2283) | real 303.28 user 2794.24 sys 130.78|
| 2245f66db | 27.12.2020 07:39 | emplace_hint | real 442.09 user 2964.50 sys 134.06|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_2245f66db38c3502cf4915644c58dc5639c19dbc_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                         | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2020-12-26 16:09:23                                                                                                                    | 2020-12-27 06:47:55                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||    641.2 |   490.1 |  -24%  ||     1.56 |     2.04 |  +31%  |  0.0000 |
 | TPC-H 02 ||      4.6 |     4.5 |   -2%  ||   219.51 |   224.03 |   +2%  |  0.0071 |
 | TPC-H 03 ||     76.2 |    78.1 |   +2%  ||    13.12 |    12.80 |   -2%  |  0.0000 |
 | TPC-H 04 ||     67.4 |    68.0 |   +1%  ||    14.83 |    14.71 |   -1%  |  0.0000 |
 | TPC-H 05 ||    213.2 |   208.9 |   -2%  ||     4.69 |     4.79 |   +2%  |  0.0000 |
 | TPC-H 06 ||      3.4 |     3.5 |   +0%  ||   290.30 |   289.25 |   -0%  |  0.0010 |
 | TPC-H 07 ||     54.3 |    54.8 |   +1%  ||    18.42 |    18.24 |   -1%  |  0.3422 |
 | TPC-H 08 ||     58.7 |    58.2 |   -1%  ||    17.04 |    17.18 |   +1%  |  0.1764 |
 | TPC-H 09 ||    447.8 |   455.5 |   +2%  ||     2.23 |     2.20 |   -2%  |  0.0000 |
 | TPC-H 10 ||    108.6 |   109.4 |   +1%  ||     9.21 |     9.14 |   -1%  |  0.0000 |
 | TPC-H 11 ||      8.1 |     8.1 |   +0%  ||   123.33 |   123.08 |   -0%  |  0.0335 |
 | TPC-H 12 ||     42.4 |    42.9 |   +1%  ||    23.58 |    23.31 |   -1%  |  0.0000 |
 | TPC-H 13 ||    331.0 |   327.3 |   -1%  ||     3.02 |     3.05 |   +1%  |  0.0000 |
 | TPC-H 14 ||     21.3 |    21.8 |   +2%  ||    47.04 |    45.92 |   -2%  |  0.0000 |
 | TPC-H 15 ||      6.6 |     6.8 |   +3%  ||   151.12 |   146.68 |   -3%  |  0.0000 |
 | TPC-H 16 ||     65.6 |    65.8 |   +0%  ||    15.23 |    15.20 |   -0%  |  0.0012 |
 | TPC-H 17 ||     15.2 |    14.8 |   -3%  ||    65.67 |    67.41 |   +3%  |  0.0000 |
 | TPC-H 18 ||    489.9 |   508.6 |   +4%  ||     2.04 |     1.97 |   -4%  |  0.0000 |
 | TPC-H 19 ||     27.8 |    27.4 |   -1%  ||    35.98 |    36.44 |   +1%  |  0.0000 |
 | TPC-H 20 ||     15.3 |    15.2 |   -1%  ||    65.24 |    65.79 |   +1%  |  0.0024 |
 | TPC-H 21 ||    337.5 |   346.0 |   +2%  ||     2.96 |     2.89 |   -2%  |  0.0000 |
 | TPC-H 22 ||     31.7 |    31.7 |   +0%  ||    31.54 |    31.53 |   -0%  |  0.7163 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   3067.9 |  2947.3 |   -4%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_st_s01.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_2245f66db38c3502cf4915644c58dc5639c19dbc_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                             | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 10.2                                                                                                                                   | gcc 10.2                                                                                                                                   |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-12-26 16:31:38                                                                                                                        | 2020-12-27 07:10:05                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||      6.4 |     4.9 |  -24%  ||   156.33 |   205.20 |  +31%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.5 |   +2%  ||  1855.41 |  1826.46 |   -2%  |  0.0003 |
 | TPC-H 03 ||      0.8 |     0.9 |   +0%  ||  1175.40 |  1169.88 |   -0%  |  0.0000 |
 | TPC-H 04 ||      0.5 |     0.5 |   -1%  ||  1952.84 |  1968.88 |   +1%  |  0.0000 |
 | TPC-H 05 ||      1.2 |     1.2 |   +1%  ||   812.59 |   804.95 |   -1%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   -2%  ||  8919.47 |  9069.83 |   +2%  |  0.0000 |
 | TPC-H 07 ||      1.3 |     1.2 |   -3%  ||   792.68 |   820.55 |   +4%  |  0.0034 |
 | TPC-H 08 ||     14.8 |    14.9 |   +0%  ||    67.43 |    67.18 |   -0%  |  0.6219 |
 | TPC-H 09 ||      2.3 |     2.3 |   +0%  ||   433.75 |   432.56 |   -0%  |  0.3002 |
 | TPC-H 10 ||      0.9 |     0.9 |   -1%  ||  1114.26 |  1123.07 |   +1%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   +1%  ||  3311.45 |  3286.34 |   -1%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   +0%  ||  1564.69 |  1559.01 |   -0%  |  0.0000 |
 | TPC-H 13 ||      2.2 |     2.2 |   +0%  ||   461.67 |   459.41 |   -0%  |  0.0000 |
 | TPC-H 14 ||      0.4 |     0.4 |   -1%  ||  2736.95 |  2763.08 |   +1%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   +0%  ||   890.97 |   890.94 |   -0%  |  0.8189 |
 | TPC-H 16 ||      1.9 |     1.9 |   +0%  ||   515.19 |   513.47 |   -0%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   -3%  ||  3451.61 |  3557.52 |   +3%  |  0.0000 |
 | TPC-H 18 ||      2.5 |     2.6 |   +3%  ||   403.23 |   391.02 |   -3%  |  0.0000 |
 | TPC-H 19 ||      5.5 |     5.5 |   -0%  ||   182.63 |   183.38 |   +0%  |  0.0000 |
 | TPC-H 20 ||      2.3 |     2.3 |   -1%  ||   428.94 |   431.55 |   +1%  |  0.0006 |
 | TPC-H 21 ||      1.6 |     1.7 |   +0%  ||   606.83 |   604.64 |   -0%  |  0.1408 |
 | TPC-H 22 ||      1.1 |     1.1 |   -0%  ||   904.11 |   906.42 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     48.8 |    47.3 |   -3%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_st_s10.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_2245f66db38c3502cf4915644c58dc5639c19dbc_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                             | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 10.2                                                                                                                                   | gcc 10.2                                                                                                                                   |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2020-12-26 16:53:42                                                                                                                        | 2020-12-27 07:32:09                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   6955.7 |  5352.1 |  -23%  ||     0.14 |     0.19 |  +30%  |       ˅ |
 | TPC-H 02 ||     48.3 |    47.1 |   -2%  ||    20.72 |    21.25 |   +3%  |  0.0000 |
 | TPC-H 03 ||   1352.7 |  1366.0 |   +1%  ||     0.74 |     0.73 |   -1%  |  0.1634 |
 | TPC-H 04 ||   1462.9 |  1460.6 |   -0%  ||     0.68 |     0.68 |   +0%  |  0.8471 |
 | TPC-H 05 ||   3016.6 |  3018.3 |   +0%  ||     0.33 |     0.33 |   -0%  |  0.9488 |
 | TPC-H 06 ||     37.0 |    36.5 |   -1%  ||    27.04 |    27.39 |   +1%  |  0.0013 |
 | TPC-H 07 ||    793.2 |   795.8 |   +0%  ||     1.26 |     1.26 |   -0%  |  0.1260 |
 | TPC-H 08 ||    529.2 |   530.5 |   +0%  ||     1.89 |     1.88 |   -0%  |  0.0044 |
 | TPC-H 09 ||   6491.6 |  6555.4 |   +1%  ||     0.15 |     0.15 |   -1%  |  0.1254 |
 | TPC-H 10 ||   1843.5 |  1853.1 |   +1%  ||     0.54 |     0.54 |   -1%  |  0.4289 |
 | TPC-H 11 ||    103.8 |   102.7 |   -1%  ||     9.64 |     9.73 |   +1%  |  0.0000 |
 | TPC-H 12 ||    673.5 |   670.0 |   -1%  ||     1.48 |     1.49 |   +1%  |  0.1098 |
+| TPC-H 13 ||   5341.1 |  4925.5 |   -8%  ||     0.19 |     0.20 |   +8%  |  0.0000 |
 | TPC-H 14 ||    230.3 |   230.0 |   -0%  ||     4.34 |     4.35 |   +0%  |  0.6030 |
 | TPC-H 15 ||     74.3 |    75.6 |   +2%  ||    13.46 |    13.22 |   -2%  |  0.0000 |
 | TPC-H 16 ||    666.9 |   652.3 |   -2%  ||     1.50 |     1.53 |   +2%  |  0.0000 |
 | TPC-H 17 ||    224.4 |   223.5 |   -0%  ||     4.46 |     4.47 |   +0%  |  0.0000 |
 | TPC-H 18 ||   9601.9 |  9667.2 |   +1%  ||     0.10 |     0.10 |   -1%  |       ˅ |
 | TPC-H 19 ||    279.6 |   279.1 |   -0%  ||     3.58 |     3.58 |   +0%  |  0.1273 |
 | TPC-H 20 ||    161.1 |   160.8 |   -0%  ||     6.21 |     6.22 |   +0%  |  0.5078 |
 | TPC-H 21 ||   5376.2 |  5411.4 |   +1%  ||     0.19 |     0.18 |   -1%  |  0.5724 |
 | TPC-H 22 ||    463.2 |   464.2 |   +0%  ||     2.16 |     2.15 |   -0%  |  0.0211 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  45727.0 | 43877.8 |   -4%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +2%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCH_2245f66db38c3502cf4915644c58dc5639c19dbc_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                         | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-12-26 17:18:51                                                                                                                    | 2020-12-27 07:56:14                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 56, 0]                                                                                                                          | [0, 0, 56, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   1751.7 |  1263.9 |  -28%  ||    27.90 |    38.50 |  +38%  |  0.0000 |
 | TPC-H 02 ||     16.6 |    16.6 |   +0%  ||  2266.44 |  2263.63 |   -0%  |  0.3077 |
 | TPC-H 03 ||    204.0 |   204.0 |   -0%  ||   238.20 |   238.30 |   +0%  |  0.9836 |
 | TPC-H 04 ||    148.8 |   148.5 |   -0%  ||   321.65 |   322.78 |   +0%  |  0.8542 |
 | TPC-H 05 ||    538.4 |   544.8 |   +1%  ||    90.42 |    90.10 |   -0%  |  0.5494 |
 | TPC-H 06 ||     10.2 |    10.1 |   -1%  ||  3330.03 |  3405.09 |   +2%  |  0.0000 |
 | TPC-H 07 ||    118.9 |   118.9 |   -0%  ||   402.42 |   403.03 |   +0%  |  0.9723 |
 | TPC-H 08 ||    132.9 |   131.9 |   -1%  ||   361.30 |   363.95 |   +1%  |  0.3418 |
 | TPC-H 09 ||   1063.4 |  1064.4 |   +0%  ||    45.75 |    45.99 |   +1%  |  0.9719 |
 | TPC-H 10 ||    291.1 |   290.6 |   -0%  ||   168.31 |   168.55 |   +0%  |  0.8627 |
 | TPC-H 11 ||     33.5 |    33.8 |   +1%  ||  1315.63 |  1304.88 |   -1%  |  0.0584 |
 | TPC-H 12 ||     97.6 |    97.2 |   -0%  ||   480.69 |   482.15 |   +0%  |  0.5449 |
 | TPC-H 13 ||    967.4 |   959.1 |   -1%  ||    50.53 |    51.03 |   +1%  |  0.6962 |
-| TPC-H 14 ||     67.0 |    83.5 |  +25%  ||   693.57 |   562.47 |  -19%  |  0.0000 |
 | TPC-H 15 ||     26.5 |    26.3 |   -0%  ||  1596.02 |  1603.62 |   +0%  |  0.1420 |
 | TPC-H 16 ||    218.8 |   219.8 |   +0%  ||   222.82 |   221.56 |   -1%  |  0.5865 |
 | TPC-H 17 ||     39.1 |    38.3 |   -2%  ||  1119.06 |  1144.28 |   +2%  |  0.0000 |
 | TPC-H 18 ||   2343.8 |  2367.9 |   +1%  ||    20.83 |    20.50 |   -2%  |  0.6560 |
 | TPC-H 19 ||     71.4 |    69.9 |   -2%  ||   651.45 |   663.08 |   +2%  |  0.0002 |
 | TPC-H 20 ||     44.0 |    44.2 |   +0%  ||  1034.18 |  1031.93 |   -0%  |  0.4743 |
 | TPC-H 21 ||    773.3 |   770.4 |   -0%  ||    63.51 |    63.58 |   +0%  |  0.8774 |
 | TPC-H 22 ||    115.4 |   110.4 |   -4%  ||   413.91 |   432.28 |   +4%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||   9073.7 |  8614.6 |   -5%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -4%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_2245f66db38c3502cf4915644c58dc5639c19dbc_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                          | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 10.2                                                                                                                                | gcc 10.2                                                                                                                                |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2020-12-26 17:41:12                                                                                                                     | 2020-12-27 08:18:34                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     26.5 |    26.5 |   -0%  ||    37.78 |    37.79 |   +0%  |  0.7236 |
+| 03      ||      6.3 |     5.9 |   -7%  ||   157.98 |   169.29 |   +7%  |  0.0000 |
 | 06      ||     17.9 |    17.6 |   -2%  ||    55.85 |    56.92 |   +2%  |  0.0000 |
+| 07      ||     31.0 |    29.2 |   -6%  ||    32.27 |    34.30 |   +6%  |  0.0000 |
 | 09      ||    115.2 |   111.2 |   -4%  ||     8.68 |     9.00 |   +4%  |  0.0000 |
+| 10      ||     18.6 |    17.8 |   -5%  ||    53.67 |    56.25 |   +5%  |  0.0000 |
 | 13      ||    115.6 |   114.6 |   -1%  ||     8.65 |     8.73 |   +1%  |  0.3647 |
 | 15      ||      9.9 |    10.0 |   +0%  ||   100.54 |   100.48 |   -0%  |  0.0859 |
 | 17      ||     27.6 |    27.4 |   -1%  ||    36.24 |    36.55 |   +1%  |  0.1872 |
 | 19      ||      9.6 |     9.3 |   -3%  ||   104.20 |   107.49 |   +3%  |  0.0000 |
 | 25      ||     15.1 |    14.8 |   -2%  ||    66.31 |    67.72 |   +2%  |  0.0009 |
 | 26      ||     15.1 |    14.9 |   -2%  ||    66.24 |    67.27 |   +2%  |  0.0000 |
 | 28      ||    951.0 |   930.7 |   -2%  ||     1.05 |     1.07 |   +2%  |  0.0000 |
 | 29      ||     25.3 |    24.9 |   -2%  ||    39.50 |    40.12 |   +2%  |  0.0145 |
 | 31      ||    112.7 |   112.4 |   -0%  ||     8.87 |     8.90 |   +0%  |  0.0126 |
 | 34      ||     16.6 |    16.3 |   -1%  ||    60.36 |    61.21 |   +1%  |  0.0000 |
+| 35      ||     85.7 |    75.9 |  -11%  ||    11.67 |    13.17 |  +13%  |  0.0000 |
+| 39a     ||    139.5 |   113.9 |  -18%  ||     7.17 |     8.78 |  +22%  |  0.0000 |
+| 39b     ||    139.0 |   114.5 |  -18%  ||     7.20 |     8.73 |  +21%  |  0.0000 |
 | 41      ||     25.6 |    25.5 |   -1%  ||    39.00 |    39.27 |   +1%  |  0.0000 |
 | 42      ||      7.6 |     7.3 |   -4%  ||   131.69 |   137.07 |   +4%  |  0.0000 |
+| 43      ||    230.6 |   204.1 |  -11%  ||     4.34 |     4.90 |  +13%  |  0.0000 |
 | 45      ||      9.7 |     9.6 |   -1%  ||   102.71 |   104.04 |   +1%  |  0.0000 |
 | 48      ||     78.8 |    77.5 |   -2%  ||    12.69 |    12.90 |   +2%  |  0.0000 |
+| 50      ||     10.9 |    10.3 |   -5%  ||    92.11 |    97.43 |   +6%  |  0.0000 |
 | 52      ||      7.7 |     7.4 |   -4%  ||   129.84 |   134.96 |   +4%  |  0.0000 |
 | 55      ||      7.5 |     7.2 |   -4%  ||   132.79 |   138.02 |   +4%  |  0.0000 |
+| 62      ||     59.5 |    51.6 |  -13%  ||    16.81 |    19.40 |  +15%  |  0.0000 |
 | 65      ||     53.8 |    54.2 |   +1%  ||    18.57 |    18.46 |   -1%  |  0.0000 |
 | 69      ||     18.0 |    17.4 |   -3%  ||    55.61 |    57.60 |   +4%  |  0.0000 |
 | 73      ||      9.7 |     9.4 |   -3%  ||   102.73 |   106.23 |   +3%  |  0.0000 |
+| 79      ||     39.2 |    36.8 |   -6%  ||    25.52 |    27.15 |   +6%  |  0.0000 |
 | 81      ||     18.4 |    18.4 |   +0%  ||    54.34 |    54.20 |   -0%  |  0.0000 |
 | 83      ||      9.2 |     9.1 |   -1%  ||   108.20 |   109.83 |   +2%  |  0.0000 |
 | 85      ||     52.5 |    51.4 |   -2%  ||    19.06 |    19.45 |   +2%  |  0.3214 |
 | 88      ||     65.6 |    63.7 |   -3%  ||    15.24 |    15.70 |   +3%  |  0.0000 |
 | 91      ||     18.3 |    17.9 |   -2%  ||    54.76 |    55.88 |   +2%  |  0.0000 |
-| 93      ||    245.1 |   259.7 |   +6%  ||     4.08 |     3.85 |   -6%  |  0.0000 |
 | 96      ||      7.0 |     6.8 |   -4%  ||   142.42 |   148.08 |   +4%  |  0.0000 |
 | 97      ||    311.4 |   302.6 |   -3%  ||     3.21 |     3.30 |   +3%  |  0.0000 |
+| 99      ||    116.0 |    98.9 |  -15%  ||     8.62 |    10.11 |  +17%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3280.4 |  3134.3 |   -4%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +4%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_2245f66db38c3502cf4915644c58dc5639c19dbc_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                          | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 10.2                                                                                                                                | gcc 10.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2020-12-26 18:22:24                                                                                                                     | 2020-12-27 08:59:38                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [0, 0, 56, 0]                                                                                                                           | [0, 0, 56, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     83.2 |    84.5 |   +2%  ||   567.05 |   558.27 |   -2%  |  0.0003 |
 | 03      ||     19.2 |    19.1 |   -1%  ||  2131.15 |  2141.23 |   +0%  |  0.0147 |
 | 06      ||     60.0 |    60.3 |   +0%  ||   769.16 |   766.66 |   -0%  |  0.4278 |
 | 07      ||     89.5 |    88.0 |   -2%  ||   529.28 |   537.48 |   +2%  |  0.0092 |
 | 09      ||    356.2 |   347.3 |   -3%  ||   137.55 |   140.19 |   +2%  |  0.2144 |
 | 10      ||     52.3 |    52.4 |   +0%  ||   871.34 |   871.44 |   +0%  |  0.8116 |
 | 13      ||    367.1 |   369.2 |   +1%  ||   133.56 |   132.97 |   -0%  |  0.6276 |
 | 15      ||     44.4 |    44.6 |   +1%  ||  1017.74 |  1013.01 |   -0%  |  0.2909 |
 | 17      ||     87.6 |    88.3 |   +1%  ||   540.83 |   537.74 |   -1%  |  0.3174 |
 | 19      ||     32.7 |    32.8 |   +0%  ||  1363.46 |  1360.27 |   -0%  |  0.5280 |
 | 25      ||     49.9 |    49.8 |   -0%  ||   920.18 |   920.30 |   +0%  |  0.8106 |
 | 26      ||     49.0 |    48.3 |   -1%  ||   927.86 |   939.14 |   +1%  |  0.0006 |
 | 28      ||   2167.6 |  2147.3 |   -1%  ||    16.83 |    17.15 |   +2%  |  0.7309 |
 | 29      ||     76.0 |    75.2 |   -1%  ||   618.26 |   624.07 |   +1%  |  0.1261 |
 | 31      ||    362.9 |   370.6 |   +2%  ||   132.83 |   132.36 |   -0%  |  0.2722 |
 | 34      ||     52.9 |    52.7 |   -0%  ||   867.13 |   870.67 |   +0%  |  0.4344 |
+| 35      ||    304.1 |   264.6 |  -13%  ||   160.72 |   184.78 |  +15%  |  0.0000 |
+| 39a     ||    531.5 |   434.6 |  -18%  ||    92.31 |   113.00 |  +22%  |  0.0000 |
+| 39b     ||    532.0 |   433.6 |  -19%  ||    92.49 |   113.07 |  +22%  |  0.0000 |
-| 41      ||    929.0 |   996.5 |   +7%  ||    52.07 |    48.62 |   -7%  |  0.1350 |
 | 42      ||     22.6 |    22.2 |   -2%  ||  1840.06 |  1860.27 |   +1%  |  0.0000 |
+| 43      ||    653.4 |   587.7 |  -10%  ||    74.76 |    83.36 |  +11%  |  0.0000 |
 | 45      ||     29.8 |    29.7 |   -0%  ||  1478.10 |  1483.04 |   +0%  |  0.1758 |
 | 48      ||    230.2 |   228.8 |   -1%  ||   211.59 |   212.88 |   +1%  |  0.6034 |
 | 50      ||     40.6 |    39.5 |   -3%  ||  1096.03 |  1125.42 |   +3%  |  0.0000 |
 | 52      ||     23.2 |    22.8 |   -1%  ||  1804.69 |  1825.82 |   +1%  |  0.0000 |
 | 55      ||     21.9 |    21.5 |   -2%  ||  1885.15 |  1908.96 |   +1%  |  0.0000 |
+| 62      ||    157.5 |   137.5 |  -13%  ||   306.86 |   350.22 |  +14%  |  0.0000 |
 | 65      ||    224.1 |   226.3 |   +1%  ||   217.74 |   215.71 |   -1%  |  0.2339 |
 | 69      ||     51.4 |    50.9 |   -1%  ||   877.71 |   886.77 |   +1%  |  0.0656 |
 | 73      ||     31.0 |    30.6 |   -1%  ||  1423.14 |  1438.08 |   +1%  |  0.0023 |
+| 79      ||    131.3 |   122.7 |   -7%  ||   366.24 |   390.92 |   +7%  |  0.0000 |
 | 81      ||     64.2 |    64.7 |   +1%  ||   721.58 |   716.82 |   -1%  |  0.1453 |
 | 83      ||     49.4 |    49.8 |   +1%  ||   921.84 |   917.12 |   -1%  |  0.3219 |
 | 85      ||    170.8 |   167.5 |   -2%  ||   284.17 |   289.34 |   +2%  |  0.0536 |
 | 88      ||    187.0 |   186.6 |   -0%  ||   238.61 |   240.39 |   +1%  |  0.8446 |
 | 91      ||     72.7 |    70.8 |   -3%  ||   646.10 |   662.27 |   +3%  |  0.0000 |
 | 93      ||    632.5 |   626.8 |   -1%  ||    77.52 |    78.13 |   +1%  |  0.6837 |
 | 96      ||     22.1 |    21.8 |   -2%  ||  1877.63 |  1900.40 |   +1%  |  0.0000 |
 | 97      ||    985.2 |   983.6 |   -0%  ||    50.01 |    50.08 |   +0%  |  0.9295 |
+| 99      ||    322.8 |   289.9 |  -10%  ||   151.88 |   168.56 |  +11%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  10370.8 | 10041.4 |   -3%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +3%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_2245f66db38c3502cf4915644c58dc5639c19dbc_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                         | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2020-12-26 19:03:40                                                                                                                    | 2020-12-27 09:40:52                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     29.1 |    28.7 |   -1%  ||     3.67 |     3.70 |   +1%  | (run time too short) |
 | New-Order    ||     18.8 |    18.5 |   -1%  ||    41.13 |    41.73 |   +1%  | (run time too short) |
 | Order-Status ||      1.2 |     1.2 |   -2%  ||     3.65 |     3.68 |   +1%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   -0%  ||    39.37 |    39.88 |   +1%  | (run time too short) |
 | Stock-Level  ||      4.2 |     4.0 |   -5%  ||     3.67 |     3.70 |   +1%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     55.8 |    55.0 |   -2%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   +1%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +6%
 ||
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkTPCC_2245f66db38c3502cf4915644c58dc5639c19dbc_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                         | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2020-12-26 19:04:44                                                                                                                    | 2020-12-27 09:41:56                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 56, 0]                                                                                                                          | [0, 0, 56, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    195.0 |   203.3 |   +4%  ||     4.97 |     4.75 |   -4%  | (run time too short) |
 |    unsucc.:  ||      4.5 |     4.4 |   -2%  ||   132.47 |   131.92 |   -0%  |                      |
-| New-Order    ||     81.4 |    88.8 |   +9%  ||   104.06 |    97.09 |   -7%  |               0.0000 |
 |    unsucc.:  ||      4.9 |     4.9 |   +1%  ||  1442.17 |  1440.45 |   -0%  |                      |
 | Order-Status ||      7.6 |     8.1 |   +6%  ||   137.46 |   136.70 |   -1%  |               0.0000 |
-| Payment      ||     15.2 |    16.1 |   +6%  ||     8.26 |     7.41 |  -10%  | (run time too short) |
 |    unsucc.:  ||      4.2 |     4.4 |   +5%  ||  1469.42 |  1461.99 |   -1%  |                      |
 | Stock-Level  ||     18.6 |    19.4 |   +4%  ||   137.41 |   136.70 |   -1%  |               0.0004 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
-| Sum          ||    317.9 |   335.7 |   +6%  ||          |          |        |                      |
-| Geomean      ||          |         |        ||          |          |   -5%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_st.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2245f66db38c3502cf4915644c58dc5639c19dbc_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                              | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 10.2                                                                                                                                    | gcc 10.2                                                                                                                                    |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2020-12-26 19:05:50                                                                                                                         | 2020-12-27 09:43:01                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    330.2 |    322.8 |   -2%  ||     3.03 |     3.10 |   +2%  |  0.0000 |
 | 10b     ||    320.1 |    311.6 |   -3%  ||     3.12 |     3.21 |   +3%  |  0.0000 |
 | 10c     ||    917.0 |    918.2 |   +0%  ||     1.09 |     1.09 |   -0%  |  0.7310 |
 | 11a     ||    142.4 |    139.4 |   -2%  ||     7.02 |     7.17 |   +2%  |  0.0280 |
 | 11b     ||    133.4 |    130.5 |   -2%  ||     7.49 |     7.66 |   +2%  |  0.0294 |
-| 11c     ||    478.0 |    502.9 |   +5%  ||     2.09 |     1.99 |   -5%  |  0.0000 |
-| 11d     ||   4693.9 |   5104.6 |   +9%  ||     0.21 |     0.20 |   -8%  |  0.0001 |
 | 12a     ||    290.2 |    286.4 |   -1%  ||     3.45 |     3.49 |   +1%  |  0.1591 |
 | 12b     ||    594.2 |    586.6 |   -1%  ||     1.68 |     1.70 |   +1%  |  0.1850 |
 | 12c     ||   3461.0 |   3419.0 |   -1%  ||     0.29 |     0.29 |   +1%  |  0.2214 |
 | 13a     ||    172.9 |    169.4 |   -2%  ||     5.78 |     5.90 |   +2%  |  0.0000 |
-| 13b     ||    234.5 |    245.8 |   +5%  ||     4.26 |     4.07 |   -5%  |  0.0000 |
 | 13c     ||    134.2 |    134.5 |   +0%  ||     7.45 |     7.44 |   -0%  |  0.0385 |
 | 13d     ||    172.7 |    169.3 |   -2%  ||     5.79 |     5.91 |   +2%  |  0.0000 |
 | 14a     ||   3955.3 |   3914.4 |   -1%  ||     0.25 |     0.26 |   +1%  |  0.2511 |
 | 14b     ||   4532.9 |   4483.8 |   -1%  ||     0.22 |     0.22 |   +1%  |  0.2451 |
 | 14c     ||   3955.9 |   3911.8 |   -1%  ||     0.25 |     0.26 |   +1%  |  0.2256 |
 | 15a     ||    180.6 |    187.9 |   +4%  ||     5.54 |     5.32 |   -4%  |  0.0000 |
 | 15b     ||    178.0 |    177.4 |   -0%  ||     5.62 |     5.64 |   +0%  |  0.3256 |
 | 15c     ||    139.4 |    143.1 |   +3%  ||     7.17 |     6.99 |   -3%  |  0.0000 |
-| 15d     ||    442.8 |    466.2 |   +5%  ||     2.26 |     2.15 |   -5%  |  0.0000 |
 | 16a     ||   4674.4 |   4625.5 |   -1%  ||     0.21 |     0.22 |   +1%  |  0.5751 |
 | 16b     ||   6105.3 |   6236.8 |   +2%  ||     0.16 |     0.16 |   -2%  |  0.1006 |
 | 16c     ||   4811.7 |   4816.8 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.9484 |
 | 16d     ||   4787.0 |   4720.9 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.3303 |
 | 17a     ||    906.9 |    903.9 |   -0%  ||     1.10 |     1.11 |   +0%  |  0.5869 |
 | 17b     ||    717.9 |    713.1 |   -1%  ||     1.39 |     1.40 |   +1%  |  0.2394 |
 | 17c     ||    674.8 |    671.9 |   -0%  ||     1.48 |     1.49 |   +0%  |  0.4539 |
 | 17d     ||    787.9 |    782.5 |   -1%  ||     1.27 |     1.28 |   +1%  |  0.2278 |
 | 17e     ||   2589.0 |   2640.9 |   +2%  ||     0.39 |     0.38 |   -2%  |  0.0050 |
 | 17f     ||   1458.6 |   1475.4 |   +1%  ||     0.69 |     0.68 |   -1%  |  0.0995 |
 | 18a     ||    580.1 |    579.7 |   -0%  ||     1.72 |     1.73 |   +0%  |  0.8855 |
 | 18b     ||    207.0 |    202.1 |   -2%  ||     4.83 |     4.95 |   +2%  |  0.0000 |
 | 18c     ||   3581.3 |   3554.5 |   -1%  ||     0.28 |     0.28 |   +1%  |  0.1962 |
 | 19a     ||   7206.0 |   7264.9 |   +1%  ||     0.14 |     0.14 |   -1%  |       ˅ |
 | 19b     ||   4319.8 |   4336.3 |   +0%  ||     0.23 |     0.23 |   -0%  |  0.2254 |
 | 19c     ||   6979.4 |   7039.8 |   +1%  ||     0.14 |     0.14 |   -1%  |       ˅ |
 | 19d     ||   5339.7 |   5516.1 |   +3%  ||     0.19 |     0.18 |   -3%  |  0.0008 |
 | 1a      ||     54.2 |     55.5 |   +2%  ||    18.43 |    18.01 |   -2%  |  0.0000 |
+| 1b      ||     20.2 |     19.1 |   -5%  ||    49.40 |    52.27 |   +6%  |  0.0000 |
+| 1c      ||     20.2 |     19.0 |   -6%  ||    49.48 |    52.50 |   +6%  |  0.0000 |
+| 1d      ||     20.0 |     18.8 |   -6%  ||    50.01 |    53.25 |   +6%  |  0.0000 |
 | 20a     ||   1169.6 |   1200.3 |   +3%  ||     0.86 |     0.83 |   -3%  |  0.0000 |
 | 20b     ||   1009.1 |   1045.3 |   +4%  ||     0.99 |     0.96 |   -3%  |  0.0000 |
 | 20c     ||   1012.4 |   1017.2 |   +0%  ||     0.99 |     0.98 |   -0%  |  0.0096 |
 | 21a     ||   3644.4 |   3601.5 |   -1%  ||     0.27 |     0.28 |   +1%  |  0.0008 |
 | 21b     ||    238.0 |    234.9 |   -1%  ||     4.20 |     4.26 |   +1%  |  0.0000 |
 | 21c     ||   3814.4 |   3764.5 |   -1%  ||     0.26 |     0.27 |   +1%  |  0.0003 |
 | 22a     ||   3264.1 |   3231.0 |   -1%  ||     0.31 |     0.31 |   +1%  |  0.2645 |
 | 22b     ||   3264.2 |   3231.2 |   -1%  ||     0.31 |     0.31 |   +1%  |  0.2708 |
 | 22c     ||   3976.4 |   3929.6 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.1326 |
 | 22d     ||   3995.8 |   3950.4 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.1357 |
 | 23a     ||    142.9 |    146.0 |   +2%  ||     7.00 |     6.85 |   -2%  |  0.0000 |
+| 23b     ||     97.7 |     92.6 |   -5%  ||    10.24 |    10.79 |   +5%  |  0.0000 |
 | 23c     ||    160.7 |    164.3 |   +2%  ||     6.22 |     6.09 |   -2%  |  0.0000 |
 | 24a     ||   4377.9 |   4413.4 |   +1%  ||     0.23 |     0.23 |   -1%  |  0.2415 |
 | 24b     ||   4353.1 |   4364.5 |   +0%  ||     0.23 |     0.23 |   -0%  |  0.8650 |
 | 25a     ||    210.3 |    203.1 |   -3%  ||     4.75 |     4.92 |   +4%  |  0.0000 |
 | 25b     ||    225.1 |    216.0 |   -4%  ||     4.44 |     4.63 |   +4%  |  0.0000 |
 | 25c     ||   3595.0 |   3564.2 |   -1%  ||     0.28 |     0.28 |   +1%  |  0.1029 |
 | 26a     ||    902.5 |    909.4 |   +1%  ||     1.11 |     1.10 |   -1%  |  0.0576 |
 | 26b     ||    892.1 |    900.1 |   +1%  ||     1.12 |     1.11 |   -1%  |  0.1939 |
 | 26c     ||    902.7 |    909.4 |   +1%  ||     1.11 |     1.10 |   -1%  |  0.1458 |
 | 27a     ||   3298.8 |   3255.4 |   -1%  ||     0.30 |     0.31 |   +1%  |  0.0203 |
 | 27b     ||   3273.4 |   3232.1 |   -1%  ||     0.31 |     0.31 |   +1%  |  0.0278 |
 | 27c     ||    188.0 |    180.9 |   -4%  ||     5.32 |     5.53 |   +4%  |  0.0000 |
 | 28a     ||   4019.4 |   3969.3 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.6004 |
 | 28b     ||   3211.3 |   3170.2 |   -1%  ||     0.31 |     0.32 |   +1%  |  0.6590 |
 | 28c     ||   4017.3 |   3968.3 |   -1%  ||     0.25 |     0.25 |   +1%  |  0.6042 |
 | 29a     ||   4277.4 |   4323.0 |   +1%  ||     0.23 |     0.23 |   -1%  |  0.7414 |
+| 29b     ||    176.0 |    166.4 |   -6%  ||     5.68 |     6.01 |   +6%  |  0.3006 |
 | 29c     ||   4382.8 |   4406.1 |   +1%  ||     0.23 |     0.23 |   -1%  |  0.8758 |
 | 2a      ||     94.8 |     92.7 |   -2%  ||    10.55 |    10.79 |   +2%  |  0.0000 |
 | 2b      ||     77.5 |     75.4 |   -3%  ||    12.90 |    13.26 |   +3%  |  0.0000 |
 | 2c      ||     49.7 |     47.7 |   -4%  ||    20.13 |    20.98 |   +4%  |  0.0000 |
 | 2d      ||    118.7 |    118.3 |   -0%  ||     8.42 |     8.45 |   +0%  |  0.0000 |
 | 30a     ||    224.5 |    217.7 |   -3%  ||     4.45 |     4.59 |   +3%  |  0.1095 |
 | 30b     ||   1022.6 |   1008.4 |   -1%  ||     0.98 |     0.99 |   +1%  |  0.4879 |
 | 30c     ||   3619.7 |   3589.5 |   -1%  ||     0.28 |     0.28 |   +1%  |  0.7034 |
+| 31a     ||    258.1 |    246.8 |   -4%  ||     3.87 |     4.05 |   +5%  |  0.0000 |
 | 31b     ||   1049.7 |   1030.9 |   -2%  ||     0.95 |     0.97 |   +2%  |  0.1144 |
+| 31c     ||    261.3 |    249.9 |   -4%  ||     3.83 |     4.00 |   +5%  |  0.0000 |
+| 32a     ||     33.7 |     31.5 |   -6%  ||    29.69 |    31.71 |   +7%  |  0.0000 |
 | 32b     ||    258.9 |    267.7 |   +3%  ||     3.86 |     3.74 |   -3%  |  0.0000 |
+| 33a     ||     63.6 |     60.8 |   -4%  ||    15.73 |    16.44 |   +5%  |  0.0000 |
+| 33b     ||     62.9 |     60.1 |   -4%  ||    15.90 |    16.63 |   +5%  |  0.0000 |
 | 33c     ||     78.0 |     75.3 |   -3%  ||    12.82 |    13.28 |   +4%  |  0.0000 |
 | 3a      ||   3723.1 |   3678.1 |   -1%  ||     0.27 |     0.27 |   +1%  |  0.0000 |
+| 3b      ||     32.2 |     30.4 |   -6%  ||    31.03 |    32.91 |   +6%  |  0.0000 |
 | 3c      ||   4671.4 |   4616.7 |   -1%  ||     0.21 |     0.22 |   +1%  |  0.0000 |
 | 4a      ||    110.4 |    109.5 |   -1%  ||     9.06 |     9.13 |   +1%  |  0.0000 |
+| 4b      ||     24.4 |     22.8 |   -7%  ||    40.94 |    43.82 |   +7%  |  0.0000 |
 | 4c      ||    122.3 |    121.5 |   -1%  ||     8.18 |     8.23 |   +1%  |  0.0000 |
 | 5a      ||   3595.2 |   3549.0 |   -1%  ||     0.28 |     0.28 |   +1%  |  0.0000 |
 | 5b      ||    277.5 |    275.6 |   -1%  ||     3.60 |     3.63 |   +1%  |  0.0000 |
 | 5c      ||   4275.6 |   4221.9 |   -1%  ||     0.23 |     0.24 |   +1%  |  0.0000 |
 | 6a      ||    202.2 |    194.7 |   -4%  ||     4.95 |     5.14 |   +4%  |  0.0000 |
 | 6b      ||    923.4 |    907.7 |   -2%  ||     1.08 |     1.10 |   +2%  |  0.0000 |
 | 6c      ||    202.2 |    194.6 |   -4%  ||     4.95 |     5.14 |   +4%  |  0.0000 |
 | 6d      ||    925.3 |    909.6 |   -2%  ||     1.08 |     1.10 |   +2%  |  0.0000 |
 | 6e      ||    202.5 |    195.0 |   -4%  ||     4.94 |     5.13 |   +4%  |  0.0000 |
 | 6f      ||   1390.1 |   1425.1 |   +3%  ||     0.72 |     0.70 |   -2%  |  0.0000 |
+| 7a      ||    257.5 |    244.5 |   -5%  ||     3.88 |     4.09 |   +5%  |  0.0000 |
+| 7b      ||    124.8 |    114.7 |   -8%  ||     8.01 |     8.72 |   +9%  |  0.0000 |
 | 7c      ||  10080.8 |  10293.9 |   +2%  ||     0.10 |     0.10 |   -2%  |       ˅ |
 | 8a      ||    103.7 |     99.9 |   -4%  ||     9.64 |    10.01 |   +4%  |  0.0000 |
 | 8b      ||    146.1 |    145.1 |   -1%  ||     6.84 |     6.89 |   +1%  |  0.0204 |
 | 8c      ||   3915.0 |   4034.0 |   +3%  ||     0.26 |     0.25 |   -3%  |  0.0001 |
 | 8d      ||   1263.8 |   1259.5 |   -0%  ||     0.79 |     0.79 |   +0%  |  0.2186 |
 | 9a      ||   3249.2 |   3247.8 |   -0%  ||     0.31 |     0.31 |   +0%  |  0.9310 |
 | 9b      ||    297.9 |    298.3 |   +0%  ||     3.36 |     3.35 |   -0%  |  0.7959 |
 | 9c      ||   3242.2 |   3238.7 |   -0%  ||     0.31 |     0.31 |   +0%  |  0.8351 |
 | 9d      ||   3808.3 |   3883.4 |   +2%  ||     0.26 |     0.26 |   -2%  |  0.0008 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 203834.4 | 204164.3 |   +0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +3%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_7f8d50b44eb8941f3a7e4c00ab72f5ee77920341_mt.json | /home/Markus.Dreseler/hyrise3/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_2245f66db38c3502cf4915644c58dc5639c19dbc_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f8d50b44eb8941f3a7e4c00ab72f5ee77920341-dirty                                                                                              | 2245f66db38c3502cf4915644c58dc5639c19dbc-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 10.2                                                                                                                                    | gcc 10.2                                                                                                                                    |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2020-12-26 21:00:55                                                                                                                         | 2020-12-27 11:37:52                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 0, 56, 0]                                                                                                                               | [0, 0, 56, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    672.3 |    668.6 |   -1%  ||    71.14 |    71.23 |   +0%  |  0.8179 |
 | 10b     ||    613.4 |    615.6 |   +0%  ||    74.62 |    74.66 |   +0%  |  0.8592 |
 | 10c     ||   2718.7 |   2724.0 |   +0%  ||    17.77 |    17.55 |   -1%  |  0.9668 |
 | 11a     ||    332.6 |    333.4 |   +0%  ||   146.48 |   146.53 |   +0%  |  0.8801 |
 | 11b     ||    312.5 |    310.6 |   -1%  ||   155.90 |   156.77 |   +1%  |  0.7007 |
-| 11c     ||   1290.0 |   1384.8 |   +7%  ||    38.08 |    35.20 |   -8%  |  0.0037 |
-| 11d     ||  12900.5 |  14711.5 |  +14%  ||     3.28 |     2.83 |  -14%  |  0.0069 |
 | 12a     ||    932.9 |    935.5 |   +0%  ||    51.95 |    52.23 |   +1%  |  0.9140 |
 | 12b     ||    870.4 |    860.8 |   -1%  ||    51.69 |    51.63 |   -0%  |  0.6528 |
 | 12c     ||   6965.3 |   7516.6 |   +8%  ||     5.20 |     5.20 |   -0%  |  0.3286 |
 | 13a     ||    429.6 |    427.7 |   -0%  ||   112.74 |   112.28 |   -0%  |  0.8187 |
-| 13b     ||    458.2 |    494.0 |   +8%  ||   103.20 |    95.29 |   -8%  |  0.0026 |
 | 13c     ||    354.2 |    362.3 |   +2%  ||   133.38 |   130.67 |   -2%  |  0.2428 |
 | 13d     ||    427.8 |    429.8 |   +0%  ||   113.00 |   112.68 |   -0%  |  0.7964 |
 | 14a     ||   8540.6 |   7604.6 |  -11%  ||     4.78 |     4.77 |   -0%  |  0.1821 |
 | 14b     ||   8918.4 |   9468.9 |   +6%  ||     4.32 |     4.30 |   -0%  |  0.4903 |
 | 14c     ||   8883.7 |   7256.8 |  -18%  ||     4.77 |     4.73 |   -1%  |  0.0312 |
 | 15a     ||    436.4 |    447.0 |   +2%  ||   111.78 |   108.86 |   -3%  |  0.1644 |
 | 15b     ||    426.5 |    435.6 |   +2%  ||   114.21 |   111.78 |   -2%  |  0.2608 |
-| 15c     ||    324.6 |    342.1 |   +5%  ||   148.63 |   141.05 |   -5%  |  0.0019 |
-| 15d     ||   1237.1 |   1297.4 |   +5%  ||    39.45 |    37.66 |   -5%  |  0.0438 |
 | 16a     ||  12569.3 |  12837.8 |   +2%  ||     3.18 |     3.17 |   -1%  |  0.7620 |
 | 16b     ||  15057.6 |  16393.6 |   +9%  ||     2.32 |     2.30 |   -1%  |  0.1919 |
 | 16c     ||  13313.4 |  13388.4 |   +1%  ||     3.08 |     3.03 |   -2%  |  0.9355 |
-| 16d     ||  12032.0 |  10856.7 |  -10%  ||     3.13 |     2.98 |   -5%  |  0.1145 |
 | 17a     ||   2367.9 |   2578.8 |   +9%  ||    18.96 |    18.77 |   -1%  |  0.0884 |
 | 17b     ||   1851.8 |   1885.2 |   +2%  ||    25.65 |    25.36 |   -1%  |  0.6501 |
 | 17c     ||   1714.2 |   1765.6 |   +3%  ||    27.12 |    27.05 |   -0%  |  0.4742 |
 | 17d     ||   1923.4 |   1898.6 |   -1%  ||    24.78 |    24.75 |   -0%  |  0.7294 |
 | 17e     ||   6103.1 |   6195.2 |   +2%  ||     7.42 |     7.30 |   -2%  |  0.7828 |
 | 17f     ||   3704.0 |   3804.0 |   +3%  ||    12.30 |    12.18 |   -1%  |  0.5976 |
 | 18a     ||   1426.4 |   1421.3 |   -0%  ||    33.65 |    33.65 |   +0%  |  0.9234 |
 | 18b     ||    520.2 |    519.7 |   -0%  ||    92.63 |    93.10 |   +1%  |  0.9700 |
 | 18c     ||   8100.3 |   7458.4 |   -8%  ||     5.33 |     5.27 |   -1%  |  0.3236 |
 | 19a     ||  12897.6 |  15090.9 |  +17%  ||     2.35 |     2.25 |   -4%  |  0.1198 |
 | 19b     ||   8697.4 |   7966.4 |   -8%  ||     5.00 |     4.83 |   -3%  |  0.3678 |
 | 19c     ||  14100.2 |  13250.1 |   -6%  ||     2.40 |     2.42 |   +1%  |  0.5634 |
 | 19d     ||  13962.6 |  14829.9 |   +6%  ||     2.72 |     2.62 |   -4%  |  0.4079 |
 | 1a      ||    139.3 |    142.9 |   +3%  ||   341.45 |   332.33 |   -3%  |  0.0066 |
 | 1b      ||     47.5 |     47.3 |   -0%  ||   924.24 |   926.36 |   +0%  |  0.6177 |
 | 1c      ||     50.1 |     49.9 |   -0%  ||   895.21 |   898.21 |   +0%  |  0.4490 |
 | 1d      ||     47.5 |     47.4 |   -0%  ||   924.88 |   926.34 |   +0%  |  0.8133 |
 | 20a     ||   2234.3 |   2332.1 |   +4%  ||    20.83 |    20.40 |   -2%  |  0.3697 |
 | 20b     ||   1926.5 |   1924.2 |   -0%  ||    24.72 |    24.18 |   -2%  |  0.9750 |
 | 20c     ||   1928.3 |   1984.5 |   +3%  ||    24.45 |    23.85 |   -2%  |  0.4997 |
 | 21a     ||   7676.2 |   7445.7 |   -3%  ||     5.20 |     5.15 |   -1%  |  0.7159 |
 | 21b     ||    563.3 |    563.0 |   -0%  ||    86.64 |    86.65 |   +0%  |  0.9833 |
 | 21c     ||   7795.9 |   7184.8 |   -8%  ||     5.00 |     4.90 |   -2%  |  0.3711 |
 | 22a     ||   6615.3 |   7605.1 |  +15%  ||     5.62 |     5.58 |   -1%  |  0.1007 |
 | 22b     ||   5259.0 |   7360.5 |  +40%  ||     5.60 |     5.62 |   +0%  |  0.0010 |
 | 22c     ||   8284.2 |   8283.0 |   -0%  ||     4.75 |     4.78 |   +1%  |  0.9987 |
 | 22d     ||   8329.1 |   8272.6 |   -1%  ||     4.73 |     4.68 |   -1%  |  0.9390 |
 | 23a     ||    335.9 |    351.7 |   +5%  ||   143.97 |   137.56 |   -4%  |  0.0094 |
 | 23b     ||    271.2 |    267.2 |   -1%  ||   179.54 |   181.81 |   +1%  |  0.3621 |
 | 23c     ||    374.6 |    390.2 |   +4%  ||   129.49 |   123.93 |   -4%  |  0.0195 |
 | 24a     ||   8023.5 |   9120.6 |  +14%  ||     4.90 |     4.82 |   -2%  |  0.0907 |
 | 24b     ||   8346.2 |   8998.5 |   +8%  ||     4.90 |     4.77 |   -3%  |  0.3494 |
 | 25a     ||    528.3 |    522.7 |   -1%  ||    92.13 |    92.63 |   +1%  |  0.6600 |
 | 25b     ||    518.7 |    516.7 |   -0%  ||    87.02 |    87.68 |   +1%  |  0.8561 |
 | 25c     ||   6390.0 |   7926.6 |  +24%  ||     5.28 |     5.28 |   -0%  |  0.0161 |
 | 26a     ||   1648.3 |   1696.4 |   +3%  ||    28.33 |    27.66 |   -2%  |  0.4505 |
 | 26b     ||   1635.3 |   1680.7 |   +3%  ||    28.90 |    27.97 |   -3%  |  0.4211 |
 | 26c     ||   1607.8 |   1659.8 |   +3%  ||    28.43 |    27.60 |   -3%  |  0.3588 |
 | 27a     ||   7705.9 |   5899.4 |  -23%  ||     5.68 |     5.68 |   +0%  |  0.0010 |
 | 27b     ||   6693.5 |   6982.2 |   +4%  ||     5.77 |     5.75 |   -0%  |  0.6330 |
 | 27c     ||    461.2 |    455.8 |   -1%  ||   105.83 |   106.86 |   +1%  |  0.5662 |
 | 28a     ||   8031.3 |   7970.8 |   -1%  ||     4.62 |     4.63 |   +0%  |  0.9315 |
 | 28b     ||   6455.8 |   6292.9 |   -3%  ||     5.78 |     5.68 |   -2%  |  0.7658 |
 | 28c     ||   7990.3 |   8453.3 |   +6%  ||     4.63 |     4.67 |   +1%  |  0.5169 |
 | 29a     ||   8381.8 |   8037.7 |   -4%  ||     4.87 |     4.77 |   -2%  |  0.6031 |
 | 29b     ||    492.9 |    489.1 |   -1%  ||    98.70 |    99.84 |   +1%  |  0.7891 |
 | 29c     ||   8802.5 |   8770.0 |   -0%  ||     4.92 |     4.77 |   -3%  |  0.9610 |
 | 2a      ||    277.2 |    276.9 |   -0%  ||   175.82 |   175.60 |   -0%  |  0.9401 |
 | 2b      ||    229.5 |    229.9 |   +0%  ||   211.87 |   211.43 |   -0%  |  0.8911 |
 | 2c      ||    133.4 |    133.2 |   -0%  ||   348.97 |   350.66 |   +0%  |  0.8234 |
 | 2d      ||    336.5 |    340.6 |   +1%  ||   145.13 |   143.08 |   -1%  |  0.4310 |
 | 30a     ||    575.7 |    566.8 |   -2%  ||    84.19 |    84.38 |   +0%  |  0.5463 |
 | 30b     ||   1650.2 |   1662.9 |   +1%  ||    28.33 |    28.28 |   -0%  |  0.8522 |
 | 30c     ||   7645.4 |   7815.9 |   +2%  ||     5.18 |     5.15 |   -1%  |  0.8116 |
 | 31a     ||    622.1 |    613.9 |   -1%  ||    75.74 |    76.40 |   +1%  |  0.5781 |
 | 31b     ||   1472.8 |   1506.6 |   +2%  ||    27.71 |    27.83 |   +0%  |  0.4354 |
 | 31c     ||    640.0 |    636.9 |   -0%  ||    74.74 |    75.57 |   +1%  |  0.8501 |
 | 32a     ||     58.1 |     59.5 |   +2%  ||   525.64 |   528.26 |   +0%  |  0.0000 |
-| 32b     ||    706.4 |    746.7 |   +6%  ||    69.79 |    65.98 |   -5%  |  0.0026 |
 | 33a     ||    172.3 |    171.3 |   -1%  ||   280.43 |   282.30 |   +1%  |  0.5960 |
 | 33b     ||    170.9 |    169.2 |   -1%  ||   282.61 |   284.84 |   +1%  |  0.3841 |
 | 33c     ||    218.8 |    218.4 |   -0%  ||   222.48 |   223.02 |   +0%  |  0.8907 |
 | 3a      ||   7275.8 |   7262.7 |   -0%  ||     5.05 |     5.05 |   -0%  |  0.9864 |
 | 3b      ||     97.3 |     96.4 |   -1%  ||   464.65 |   468.36 |   +1%  |  0.2722 |
 | 3c      ||  10079.0 |   9982.4 |   -1%  ||     3.82 |     3.90 |   +2%  |  0.9084 |
 | 4a      ||    353.9 |    355.8 |   +1%  ||   137.71 |   137.40 |   -0%  |  0.7641 |
 | 4b      ||     62.3 |     61.3 |   -2%  ||   716.76 |   728.82 |   +2%  |  0.0159 |
 | 4c      ||    406.5 |    406.1 |   -0%  ||   119.90 |   119.77 |   -0%  |  0.9583 |
 | 5a      ||   6070.1 |   7527.5 |  +24%  ||     5.33 |     5.30 |   -1%  |  0.0168 |
 | 5b      ||    592.4 |    589.2 |   -1%  ||    79.28 |    79.11 |   -0%  |  0.8196 |
 | 5c      ||   8848.6 |   8362.7 |   -5%  ||     4.43 |     4.50 |   +2%  |  0.5257 |
 | 6a      ||    476.2 |    472.5 |   -1%  ||    99.16 |   100.24 |   +1%  |  0.6879 |
 | 6b      ||   2069.8 |   2112.4 |   +2%  ||    22.48 |    22.28 |   -1%  |  0.6558 |
 | 6c      ||    479.6 |    473.5 |   -1%  ||    98.50 |    99.96 |   +1%  |  0.5374 |
 | 6d      ||   2147.6 |   2110.8 |   -2%  ||    22.13 |    22.31 |   +1%  |  0.6804 |
 | 6e      ||    479.9 |    475.0 |   -1%  ||    98.56 |    99.76 |   +1%  |  0.6329 |
 | 6f      ||   3286.4 |   3366.1 |   +2%  ||    14.50 |    14.17 |   -2%  |  0.5486 |
 | 7a      ||    879.1 |    855.1 |   -3%  ||    55.68 |    57.38 |   +3%  |  0.1903 |
 | 7b      ||    343.3 |    335.0 |   -2%  ||   140.23 |   143.89 |   +3%  |  0.2351 |
 | 7c      ||  24629.1 |  27742.0 |  +13%  ||     1.22 |     1.17 |   -4%  |  0.0669 |
 | 8a      ||    335.5 |    331.7 |   -1%  ||   142.68 |   144.58 |   +1%  |  0.4871 |
 | 8b      ||    366.0 |    365.4 |   -0%  ||   129.62 |   130.08 |   +0%  |  0.9342 |
 | 8c      ||  10024.0 |  10505.8 |   +5%  ||     4.22 |     4.03 |   -4%  |  0.4665 |
 | 8d      ||   3438.1 |   3504.5 |   +2%  ||    13.35 |    13.22 |   -1%  |  0.6733 |
 | 9a      ||   8010.3 |   7297.6 |   -9%  ||     4.95 |     4.88 |   -1%  |  0.2090 |
 | 9b      ||    861.3 |    878.7 |   +2%  ||    56.18 |    55.58 |   -1%  |  0.5354 |
 | 9c      ||   7834.7 |   8057.6 |   +3%  ||     4.82 |     4.80 |   -0%  |  0.7624 |
 | 9d      ||   8923.0 |   9374.6 |   +5%  ||     4.02 |     3.97 |   -1%  |  0.4879 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 447257.5 | 458544.5 |   +3%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -1%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>