### PR TITLE
Fix live reporting of latency

### DIFF
--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -169,8 +169,8 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
     new_successful_durations = np.array([run["duration"] for run in new["successful_runs"]], dtype=np.float64)
     old_unsuccessful_durations = np.array([run["duration"] for run in old["unsuccessful_runs"]], dtype=np.float64)
     new_unsuccessful_durations = np.array([run["duration"] for run in new["unsuccessful_runs"]], dtype=np.float64)
-    old_avg_successful_duration = np.mean(old_successful_durations)  # defaults to np.float64 for int input
-    new_avg_successful_duration = np.mean(new_successful_durations)
+    old_avg_successful_duration = np.mean(old_successful_durations) / 1000  # defaults to np.float64 for int input
+    new_avg_successful_duration = np.mean(new_successful_durations) / 1000
 
     total_runtime_old += old_avg_successful_duration if not math.isnan(old_avg_successful_duration) else 0.0
     total_runtime_new += new_avg_successful_duration if not math.isnan(new_avg_successful_duration) else 0.0
@@ -210,8 +210,8 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
     table_data.append(
         [
             name,
-            f"{(old_avg_successful_duration / 1e6):>7.1f}" if old_avg_successful_duration else "nan",
-            f"{(new_avg_successful_duration / 1e6):>7.1f}" if new_avg_successful_duration else "nan",
+            f"{(old_avg_successful_duration / 1e6):>3.4f}" if old_avg_successful_duration else "nan",
+            f"{(new_avg_successful_duration / 1e6):>3.4f}" if new_avg_successful_duration else "nan",
             diff_duration_formatted + note if not math.isnan(diff_duration) else "",
             f'{old["items_per_second"]:>8.2f}',
             f'{new["items_per_second"]:>8.2f}',
@@ -243,10 +243,10 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
 
         unsuccessful_info = [
             "   unsucc.:",
-            f"{(old_avg_unsuccessful_duration / 1e6):>7.1f}"
+            f"{(old_avg_unsuccessful_duration / 1e6):>3.4f}"
             if not math.isnan(old_avg_unsuccessful_duration)
             else "nan",
-            f"{(new_avg_unsuccessful_duration / 1e6):>7.1f}"
+            f"{(new_avg_unsuccessful_duration / 1e6):>3.4f}"
             if not math.isnan(new_avg_unsuccessful_duration)
             else "nan",
             format_diff(diff_duration_unsuccessful) + " " if not math.isnan(diff_duration_unsuccessful) else " ",
@@ -263,8 +263,8 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
 table_data.append(
     [
         "Sum",
-        f"{(total_runtime_old / 1e6):>7.1f}",
-        f"{(total_runtime_new / 1e6):>7.1f}",
+        f"{(total_runtime_old / 1e6):>3.4f}",
+        f"{(total_runtime_new / 1e6):>3.4f}",
         color_diff(total_runtime_new / total_runtime_old, True) + " ",
     ]
 )
@@ -289,7 +289,7 @@ lines = double_vertical_separators(lines, [1, 4])
 # holder with the actual full descriptions.
 for (placeholder, final) in [
     ("$thrghpt", "Throughput (iter/s)"),
-    ("$latency", "Latency (ms/iter)"),
+    ("$latency", "Latency (s/iter)"),
 ]:
     header_strings = lines[1].split("|")
     for column_id, text in enumerate(header_strings):

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -169,8 +169,8 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
     new_successful_durations = np.array([run["duration"] for run in new["successful_runs"]], dtype=np.float64)
     old_unsuccessful_durations = np.array([run["duration"] for run in old["unsuccessful_runs"]], dtype=np.float64)
     new_unsuccessful_durations = np.array([run["duration"] for run in new["unsuccessful_runs"]], dtype=np.float64)
-    old_avg_successful_duration = np.mean(old_successful_durations) / 1000  # defaults to np.float64 for int input
-    new_avg_successful_duration = np.mean(new_successful_durations) / 1000
+    old_avg_successful_duration = np.mean(old_successful_durations)  # defaults to np.float64 for int input
+    new_avg_successful_duration = np.mean(new_successful_durations)
 
     total_runtime_old += old_avg_successful_duration if not math.isnan(old_avg_successful_duration) else 0.0
     total_runtime_new += new_avg_successful_duration if not math.isnan(new_avg_successful_duration) else 0.0
@@ -210,8 +210,8 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
     table_data.append(
         [
             name,
-            f"{(old_avg_successful_duration / 1e6):>3.4f}" if old_avg_successful_duration else "nan",
-            f"{(new_avg_successful_duration / 1e6):>3.4f}" if new_avg_successful_duration else "nan",
+            f"{(old_avg_successful_duration / 1e6):>7.1f}" if old_avg_successful_duration else "nan",
+            f"{(new_avg_successful_duration / 1e6):>7.1f}" if new_avg_successful_duration else "nan",
             diff_duration_formatted + note if not math.isnan(diff_duration) else "",
             f'{old["items_per_second"]:>8.2f}',
             f'{new["items_per_second"]:>8.2f}',
@@ -243,10 +243,10 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
 
         unsuccessful_info = [
             "   unsucc.:",
-            f"{(old_avg_unsuccessful_duration / 1e6):>3.4f}"
+            f"{(old_avg_unsuccessful_duration / 1e6):>7.1f}"
             if not math.isnan(old_avg_unsuccessful_duration)
             else "nan",
-            f"{(new_avg_unsuccessful_duration / 1e6):>3.4f}"
+            f"{(new_avg_unsuccessful_duration / 1e6):>7.1f}"
             if not math.isnan(new_avg_unsuccessful_duration)
             else "nan",
             format_diff(diff_duration_unsuccessful) + " " if not math.isnan(diff_duration_unsuccessful) else " ",
@@ -263,8 +263,8 @@ for old, new in zip(old_data["benchmarks"], new_data["benchmarks"]):
 table_data.append(
     [
         "Sum",
-        f"{(total_runtime_old / 1e6):>3.4f}",
-        f"{(total_runtime_new / 1e6):>3.4f}",
+        f"{(total_runtime_old / 1e6):>7.1f}",
+        f"{(total_runtime_new / 1e6):>7.1f}",
         color_diff(total_runtime_new / total_runtime_old, True) + " ",
     ]
 )
@@ -289,7 +289,7 @@ lines = double_vertical_separators(lines, [1, 4])
 # holder with the actual full descriptions.
 for (placeholder, final) in [
     ("$thrghpt", "Throughput (iter/s)"),
-    ("$latency", "Latency (s/iter)"),
+    ("$latency", "Latency (ms/iter)"),
 ]:
     header_strings = lines[1].split("|")
     for column_id, text in enumerate(header_strings):

--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -99,14 +99,10 @@ class CompareBenchmarkScriptTest:
 
             # Check the latency values for both JSON files
             assert_latency_equals(
-                len(old_successful_runs),
-                [run["duration"] for run in old_successful_runs],
-                fields[3],
+                len(old_successful_runs), [run["duration"] for run in old_successful_runs], fields[3],
             )
             assert_latency_equals(
-                len(new_successful_runs),
-                [run["duration"] for run in new_successful_runs],
-                fields[4],
+                len(new_successful_runs), [run["duration"] for run in new_successful_runs], fields[4],
             )
 
             # Get the divisors for both benchmark files. They differ for Ordered and Shuffled mode.
@@ -137,9 +133,7 @@ class CompareBenchmarkScriptTest:
 
                 if len(old_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(old_unsuccessful_runs),
-                        [run["duration"] for run in old_unsuccessful_runs],
-                        fields[3],
+                        len(old_unsuccessful_runs), [run["duration"] for run in old_unsuccessful_runs], fields[3],
                     )
                     assert_throughput_equals(len(old_unsuccessful_runs), divisors[0], fields[7])
                 else:
@@ -148,9 +142,7 @@ class CompareBenchmarkScriptTest:
 
                 if len(new_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(new_unsuccessful_runs),
-                        [run["duration"] for run in new_unsuccessful_runs],
-                        fields[4],
+                        len(new_unsuccessful_runs), [run["duration"] for run in new_unsuccessful_runs], fields[4],
                     )
                     assert_throughput_equals(len(new_unsuccessful_runs), divisors[1], fields[8])
                 else:

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -277,8 +277,8 @@ void BenchmarkRunner::_benchmark_ordered() {
       auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
       accumulator(static_cast<double>(duration.count()));
     }
-    auto mean_in_milliseconds = boost::accumulators::mean(accumulator);
-    auto mean_in_seconds = mean_in_milliseconds / 1'000'000'000;
+    auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);
+    auto mean_in_seconds = mean_in_nanoseconds / 1'000'000'000;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -278,6 +278,7 @@ void BenchmarkRunner::_benchmark_ordered() {
       accumulator(static_cast<double>(duration.count()));
     }
     auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);
+    // For readability and to be consistent with compare_benchmarks.py SQL queries should be in milliseconds
     auto mean_in_milliseconds = mean_in_nanoseconds / 1'000'000;
 
     if (!_config.verify && !_config.enable_visualization) {

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -2,6 +2,7 @@
 
 #include <fstream>
 #include <random>
+#include <chrono>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptors.hpp>
@@ -264,13 +265,29 @@ void BenchmarkRunner::_benchmark_ordered() {
         static_cast<float>(std::chrono::duration_cast<std::chrono::nanoseconds>(_state.benchmark_duration).count());
     const auto duration_seconds = duration_of_all_runs_ns / 1'000'000'000.f;
     const auto items_per_second = static_cast<float>(result.successful_runs.size()) / duration_seconds;
+
+    // Compute geometric mean with splitting exponent and mantissa
+    double m = 1.0;
+    long long ex = 0;
+    double invN = 1.0 / result.successful_runs.size();
+
+    for (auto entry : result.successful_runs) {
+      double duration = std::chrono::duration_cast<std::chrono::seconds>(entry.duration)
+      int i;
+      double f1 = std::frexp(x,&i);
+      m*=f1;
+      ex+=i;
+    }
+
+    auto geo_mean = std::pow( std::numeric_limits<double>::radix,ex * invN) * std::pow(m,invN);
+
     const auto num_successful_runs = result.successful_runs.size();
-    const auto duration_per_item =
-        num_successful_runs > 0 ? static_cast<float>(duration_seconds) / static_cast<float>(num_successful_runs) : NAN;
+    // const auto duration_per_item =
+    //     num_successful_runs > 0 ? static_cast<float>(duration_seconds) / static_cast<float>(num_successful_runs) : NAN;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds ("
-                << items_per_second << " iter/s, " << duration_per_item << " s/iter)" << std::endl;
+                << items_per_second << " iter/s, " << geo_mean << " s/iter)" << std::endl;
       if (!result.unsuccessful_runs.empty()) {
         std::cout << "  -> " << result.unsuccessful_runs.size() << " additional runs failed" << std::endl;
       }

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -274,11 +274,11 @@ void BenchmarkRunner::_benchmark_ordered() {
     boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>>
         accumulator;
     for (const auto& entry : result.successful_runs) {
-      auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(entry.duration);
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
       accumulator(static_cast<double>(duration.count()));
     }
     auto mean_in_milliseconds = boost::accumulators::mean(accumulator);
-    auto mean_in_seconds = mean_in_milliseconds / 1000;
+    auto mean_in_seconds = mean_in_milliseconds / 1'000'000'000;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -273,7 +273,7 @@ void BenchmarkRunner::_benchmark_ordered() {
     // Compute mean by using accumulators
     boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>>
         accumulator;
-    for (const auto& entry : result.successful_runs) {
+    for (const auto entry : result.successful_runs) {
       const auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
       accumulator(static_cast<double>(duration.count()));
     }

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -265,7 +265,7 @@ void BenchmarkRunner::_benchmark_ordered() {
     _state.set_done();
 
     // Wait for the rest of the tasks that didn't make it in time - they will not count toward the results
-    std::cout << "  -> Waiting for clients that are still running" << std::endl;
+    if (_currently_running_clients > 0) std::cout << "  -> Waiting for clients that are still running" << std::endl;
     Hyrise::get().scheduler()->wait_for_all_tasks();
     Assert(_currently_running_clients == 0, "All runs must be finished at this point");
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -274,12 +274,12 @@ void BenchmarkRunner::_benchmark_ordered() {
     boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>>
         accumulator;
     for (const auto& entry : result.successful_runs) {
-      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
+      const auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
       accumulator(static_cast<double>(duration.count()));
     }
-    auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);
+    const auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);
     // For readability and to be consistent with compare_benchmarks.py SQL queries should be in milliseconds
-    auto mean_in_milliseconds = mean_in_nanoseconds / 1'000'000;
+    const auto mean_in_milliseconds = mean_in_nanoseconds / 1'000'000;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -278,12 +278,12 @@ void BenchmarkRunner::_benchmark_ordered() {
       accumulator(static_cast<double>(duration.count()));
     }
     auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);
-    auto mean_in_seconds = mean_in_nanoseconds / 1'000'000'000;
+    auto mean_in_milliseconds = mean_in_nanoseconds / 1'000'000;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds
-                << " seconds (Latency: " << mean_in_seconds << " s/iter, Throughput: " << items_per_second << " iter/s)"
-                << std::endl;
+                << " seconds (Latency: " << mean_in_milliseconds << " ms/iter, Throughput: " << items_per_second
+                << " iter/s)" << std::endl;
       if (!result.unsuccessful_runs.empty()) {
         std::cout << "  -> " << result.unsuccessful_runs.size() << " additional runs failed" << std::endl;
       }

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -1,12 +1,12 @@
 #include "benchmark_runner.hpp"
 
+#include <chrono>
 #include <fstream>
 #include <random>
-#include <chrono>
 
 #include <boost/accumulators/accumulators.hpp>
-#include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
+#include <boost/accumulators/statistics/stats.hpp>
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/range/adaptors.hpp>
@@ -276,13 +276,12 @@ void BenchmarkRunner::_benchmark_ordered() {
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(entry.duration);
       acc(static_cast<double>(duration.count()));
     }
-
-    auto mean_ms = boost::accumulators::mean(acc);
-    auto mean_s = mean_ms / 1000;
+    auto mean_in_milliseconds = boost::accumulators::mean(acc);
+    auto mean_in_seconds = mean_in_milliseconds / 1000;
 
     if (!_config.verify && !_config.enable_visualization) {
       std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds ("
-                << items_per_second << " iter/s, " << mean_s << " s/iter)" << std::endl;
+                << items_per_second << " iter/s, " << mean_in_seconds << " s/iter)" << std::endl;
       if (!result.unsuccessful_runs.empty()) {
         std::cout << "  -> " << result.unsuccessful_runs.size() << " additional runs failed" << std::endl;
       }

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -271,17 +271,19 @@ void BenchmarkRunner::_benchmark_ordered() {
     const auto items_per_second = static_cast<float>(result.successful_runs.size()) / duration_seconds;
 
     // Compute mean by using accumulators
-    boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>> acc;
-    for (auto entry : result.successful_runs) {
+    boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>>
+        accumulator;
+    for (const auto& entry : result.successful_runs) {
       auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(entry.duration);
-      acc(static_cast<double>(duration.count()));
+      accumulator(static_cast<double>(duration.count()));
     }
-    auto mean_in_milliseconds = boost::accumulators::mean(acc);
+    auto mean_in_milliseconds = boost::accumulators::mean(accumulator);
     auto mean_in_seconds = mean_in_milliseconds / 1000;
 
     if (!_config.verify && !_config.enable_visualization) {
-      std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds (Latency: "
-                << mean_in_seconds << " s/iter, Throughput: " << items_per_second << " iter/s)" << std::endl;
+      std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds
+                << " seconds (Latency: " << mean_in_seconds << " s/iter, Throughput: " << items_per_second << " iter/s)"
+                << std::endl;
       if (!result.unsuccessful_runs.empty()) {
         std::cout << "  -> " << result.unsuccessful_runs.size() << " additional runs failed" << std::endl;
       }

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -273,8 +273,8 @@ void BenchmarkRunner::_benchmark_ordered() {
     // Compute mean by using accumulators
     boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>>
         accumulator;
-    for (auto entry : result.successful_runs) {
-      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
+    for (const auto& entry : result.successful_runs) {
+      const duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
       accumulator(static_cast<double>(duration.count()));
     }
     const auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -273,8 +273,8 @@ void BenchmarkRunner::_benchmark_ordered() {
     // Compute mean by using accumulators
     boost::accumulators::accumulator_set<double, boost::accumulators::stats<boost::accumulators::tag::mean>>
         accumulator;
-    for (const auto entry : result.successful_runs) {
-      const auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
+    for (auto entry : result.successful_runs) {
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(entry.duration);
       accumulator(static_cast<double>(duration.count()));
     }
     const auto mean_in_nanoseconds = boost::accumulators::mean(accumulator);

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -280,8 +280,8 @@ void BenchmarkRunner::_benchmark_ordered() {
     auto mean_in_seconds = mean_in_milliseconds / 1000;
 
     if (!_config.verify && !_config.enable_visualization) {
-      std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds ("
-                << items_per_second << " iter/s, " << mean_in_seconds << " s/iter)" << std::endl;
+      std::cout << "  -> Executed " << result.successful_runs.size() << " times in " << duration_seconds << " seconds (Latency: "
+                << mean_in_seconds << " s/iter, Throughput: " << items_per_second << " iter/s)" << std::endl;
       if (!result.unsuccessful_runs.empty()) {
         std::cout << "  -> " << result.unsuccessful_runs.size() << " additional runs failed" << std::endl;
       }


### PR DESCRIPTION
This PR fixes #2226

It solves the problem the following way:

* The `benchmark_runner` now reports the latency as the arithmetic mean of iterations.
* The output latency in the benchmark_runner is now in `ms` like in the `compare_benchmarks.py`
* The order of latency and throughput are now harmonized between the live-reporting of benchmarks and the `compare_benchmarks.py` script.

Example output TPC-H 01: 

Single-Threaded:

```
- Benchmarking TPC-H 01
  -> Executed 41 times in 60.0047 seconds (Latency: 1463.1 ms/iter, Throughput: 0.68328 iter/s)
```

Multi-Threaded:
```
- Benchmarking TPC-H 01
  -> Executed 1189 times in 60.0058 seconds (Latency: 2446.3 ms/iter, Throughput: 19.8148 iter/s)
```

`compare_benchmarks.py` :

```
+----------++----------+---------+---------++----------+----------+---------+---------+
| Item     ||  Latency (ms/iter)  |  Change || Throughput (iter/s) |  Change | p-value |
|          ||      old |     new |         ||      old |      new |         |         |
+----------++----------+---------+---------++----------+----------+---------+---------+
| TPC-H 01 ||    1463.5 |  2446.7 |  +67%  ||     0.68 |    19.81 | +2800%  |  0.0000 |
```