### PR TITLE
Finalize chunks in AbstractTableGenerator before setting sortedness information

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -37,6 +37,18 @@ void AbstractTableGenerator::generate_and_store() {
   std::cout << "- Loading/Generating tables done (" << format_duration(metrics.generation_duration) << ")" << std::endl;
 
   /**
+   * Finalizing all chunks of all tables that are still mutable.
+   */
+  // TODO(any): Finalization might trigger encoding in the future.
+  for (auto& [table_name, table_info] : table_info_by_name) {
+    auto& table = table_info_by_name[table_name].table;
+    for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
+      const auto chunk = table->get_chunk(chunk_id);
+      if (chunk->is_mutable()) chunk->finalize();
+    }
+  }
+
+  /**
    * Sort tables if a sort order was defined by the benchmark
    */
   {
@@ -158,18 +170,6 @@ void AbstractTableGenerator::generate_and_store() {
    * Add constraints if defined by the benchmark
    */
   _add_constraints(table_info_by_name);
-
-  /**
-   * Finalizing all chunks of all tables that are still mutable.
-   */
-  // TODO(any): Finalization might trigger encoding in the future.
-  for (auto& [table_name, table_info] : table_info_by_name) {
-    auto& table = table_info_by_name[table_name].table;
-    for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
-      const auto chunk = table->get_chunk(chunk_id);
-      if (chunk->is_mutable()) chunk->finalize();
-    }
-  }
 
   /**
    * Encode the tables


### PR DESCRIPTION
Fixes #2297 

In the AbstractTableGenerator, there is a case where sortedness information may be set on mutable chunks (for details see #2297), which causes Hyrise to crash.
This PR fixes the crash by finalizing chunks before the benchmark tables are sorted