### PR TITLE
Build on Raspberry Pi 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,8 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FLAGS_ALL}")
 # Build the binary optimized for the current system, ignoring older systems. For x86 systems, we use -march=native.
 # Clang does not support -march=native on ARM. ARM recommends setting -mcpu for both GCC and Clang instead of march:
 # https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
-if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
+message(${CMAKE_SYSTEM_PROCESSOR}) 
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
     set(FLAGS_RELEASE "-mcpu=native")
 else()
     set(FLAGS_RELEASE "-march=native")  

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FLAGS_ALL}")
 # Build the binary optimized for the current system, ignoring older systems. For x86 systems, we use -march=native.
 # Clang does not support -march=native on ARM. ARM recommends setting -mcpu for both GCC and Clang instead of march:
 # https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
-message(${CMAKE_SYSTEM_PROCESSOR}) 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch64")
+# We check specifically for arm64 (e.g., Apple's M1) or aarch64 (e.g., Raspberry Pi 4), as these are the two ARM architectures we have tested so far.
+# Match for "arm" on your own risk to include other ARM architures.
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
     set(FLAGS_RELEASE "-mcpu=native")
 else()
     set(FLAGS_RELEASE "-march=native")  


### PR DESCRIPTION
Turns out that the CPU architecture of a Raspberry Pi 4 is not `arm64` but rather `aarch64`. We now check for both to use `-mcpu=native` over `-march=native` for Clang on ARM.