### PR TITLE
Override destructor in segment accessors (clang11)

### DIFF
--- a/src/lib/storage/segment_accessor.hpp
+++ b/src/lib/storage/segment_accessor.hpp
@@ -53,7 +53,7 @@ class SegmentAccessor final : public AbstractSegmentAccessor<T> {
     return _segment.get_typed_value(offset);
   }
 
-  ~SegmentAccessor() { _segment.access_counter[SegmentAccessCounter::AccessType::Random] += _accesses; }
+  ~SegmentAccessor() override { _segment.access_counter[SegmentAccessCounter::AccessType::Random] += _accesses; }
 
  protected:
   mutable uint64_t _accesses{0};
@@ -114,7 +114,7 @@ class SingleChunkReferenceSegmentAccessor final : public AbstractSegmentAccessor
     return _segment.get_typed_value(referenced_chunk_offset);
   }
 
-  ~SingleChunkReferenceSegmentAccessor() {
+  ~SingleChunkReferenceSegmentAccessor() override {
     _segment.access_counter[SegmentAccessCounter::AccessType::Random] += _accesses;
   }
 


### PR DESCRIPTION
Fixes builds on MacOS with Clang11. The destructors in the segment accessors have not been marked as `override`, which is required even when the base destructor is marked as virtual.

C++ core discussion: https://github.com/isocpp/CppCoreGuidelines/issues/721 & https://github.com/isocpp/CppCoreGuidelines/pull/1448

I don't know why clang on Linux does not complain.

PS: I first upgraded several components on my laptop (Big Sur) and got various `boost` issues. Might be required to upgrade all Hyrise-related components together. But I haven't looked at it any further.