### PR TITLE
Fix compilation of release cmake build type for ppc64le

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FLAGS_ALL}")
 # https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
 # We check specifically for arm64 (e.g., Apple's M1) or aarch64 (e.g., Raspberry Pi 4), as these are the two ARM architectures we have tested so far.
 # Match for "arm" on your own risk to include other ARM architures.
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64|ppc64le")
     set(FLAGS_RELEASE "-mcpu=native")
 else()
     set(FLAGS_RELEASE "-march=native")  


### PR DESCRIPTION
This extra tiny modification of CMakeLists.txt is necessary so Hyrise can compile successfully for ppc64le arch and ```-DCMAKE_BUILD_TYPE=RelWithDebInfo```. Otherwise compilation fails with this message

```console
unrecognized command line option '-march=native'; did you mean '-mcpu=native'
```