### PR TITLE
Fix Jenkins, allow admin override

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,7 @@ try {
           withCredentials([usernamePassword(credentialsId: '5fe8ede9-bbdb-4803-a307-6924d4b4d9b5', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN')]) {
             env.PR_CREATED_BY = pullRequest.createdBy
             sh '''
-              curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY}
-              curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY} | head -n 1 | grep "HTTP/1.1 204 No Content"
+              curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY} | head -n 1 | grep "204"
             '''
           }
         } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,15 +3,14 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
-def cause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]
-def jenkinsUserName = cause ? cause['userId'] : null
-echo jenkinsUserName
-
 try {
   node {
     stage ("Start") {
-      // Check if the user who opened the PR is a known collaborator (i.e., has been added to a hyrise/hyrise team)
-      if (env.CHANGE_ID) {
+      // Check if the user who opened the PR is a known collaborator (i.e., has been added to a hyrise/hyrise team) or the Jenkins admin user
+      def cause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]
+      def jenkinsUserName = cause ? cause['userId'] : null
+
+      if (jenkinsUserName != "admin") {
         try {
           withCredentials([usernamePassword(credentialsId: '5fe8ede9-bbdb-4803-a307-6924d4b4d9b5', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN')]) {
             env.PR_CREATED_BY = pullRequest.createdBy

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,9 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
-def userName = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]['userId']
-echo userName
+def cause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]
+def jenkinsUserName = cause ? ['userId'] : null
+echo jenkinsUserName
 
 try {
   node {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
 def cause = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]
-def jenkinsUserName = cause ? ['userId'] : null
+def jenkinsUserName = cause ? cause['userId'] : null
 echo jenkinsUserName
 
 try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ try {
           withCredentials([usernamePassword(credentialsId: '5fe8ede9-bbdb-4803-a307-6924d4b4d9b5', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_TOKEN')]) {
             env.PR_CREATED_BY = pullRequest.createdBy
             sh '''
+              curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY}
               curl -s -I -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/repos/hyrise/hyrise/collaborators/${PR_CREATED_BY} | head -n 1 | grep "HTTP/1.1 204 No Content"
             '''
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
-def userName = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]?['userId']
+def userName = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]['userId']
 echo userName
 
 try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,9 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 full_ci = env.BRANCH_NAME == 'master' || pullRequest.labels.contains('FullCI')
 tests_excluded_in_sanitizer_builds = '--gtest_filter=-SQLiteTestRunnerEncodings/*:TPCDSTableGeneratorTest.GenerateAndStoreRowCounts:TPCHTableGeneratorTest.RowCountsMediumScaleFactor'
 
+def userName = currentBuild.getBuildCauses('hudson.model.Cause$UserIdCause')[0]?['userId']
+echo userName
+
 try {
   node {
     stage ("Start") {


### PR DESCRIPTION
Github changed from HTTP/1.1 to HTTP/2 so the header check failed. Fixing that and also adding a quick hack that allows the Jenkins admin to run PRs of non-members.