### PR TITLE
wait_for_tasks: Execute own tasks first

### DIFF
--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -51,6 +51,8 @@ void AbstractTask::set_node_id(NodeID node_id) { _node_id = node_id; }
 
 bool AbstractTask::try_mark_as_enqueued() { return !_is_enqueued.exchange(true); }
 
+bool AbstractTask::try_mark_as_enqueued() { return !_is_assigned_to_worker.exchange(true); }
+
 void AbstractTask::set_done_callback(const std::function<void()>& done_callback) {
   DebugAssert((!_is_scheduled), "Possible race: Don't set callback after the Task was scheduled");
 

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -51,7 +51,7 @@ void AbstractTask::set_node_id(NodeID node_id) { _node_id = node_id; }
 
 bool AbstractTask::try_mark_as_enqueued() { return !_is_enqueued.exchange(true); }
 
-bool AbstractTask::try_mark_as_enqueued() { return !_is_assigned_to_worker.exchange(true); }
+bool AbstractTask::try_mark_as_assigned_to_worker() { return !_is_assigned_to_worker.exchange(true); }
 
 void AbstractTask::set_done_callback(const std::function<void()>& done_callback) {
   DebugAssert((!_is_scheduled), "Possible race: Don't set callback after the Task was scheduled");

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -110,6 +110,11 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
    */
   void execute();
 
+  /**
+   * What an awful name.
+   */
+  std::atomic_bool about_to_be_executed{false};
+
  protected:
   virtual void _on_execute() = 0;
 

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -106,14 +106,15 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
   bool try_mark_as_enqueued();
 
   /**
+   * returns true whether the caller is atomically the first to try to assign this task to a worker,
+   * false otherwise.
+   */
+  bool try_mark_as_assigned_to_worker();
+
+  /**
    * Executes the task in the current Thread, blocks until all operations are finished
    */
   void execute();
-
-  /**
-   * What an awful name.
-   */
-  std::atomic_bool about_to_be_executed{false};
 
  protected:
   virtual void _on_execute() = 0;
@@ -149,9 +150,12 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
 
   // For making sure a task gets only scheduled and enqueued once, respectively
   // A Task is scheduled once schedule() is called and enqueued, which is an internal process, once it has been added
-  // to a TaskQueue
+  // to a TaskQueue. Once a worker has chosen to execute this task (and it is thus can no longer be executed by anyone
+  // else), _is_assigned_to_worker is set to true.
+  // TODO(anyone): Change this into proper state transitions, see TransactionContext as an example.
   std::atomic_bool _is_enqueued{false};
   std::atomic_bool _is_scheduled{false};
+  std::atomic_bool _is_assigned_to_worker{false};
 
   // For making Tasks join()-able
   std::condition_variable _done_condition_variable;

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -36,8 +36,8 @@ Worker::Worker(const std::shared_ptr<TaskQueue>& queue, WorkerID id, CpuID cpu_i
     : _queue(queue), _id(id), _cpu_id(cpu_id) {
   // Generate a random distribution from 0-99 for later use, see below
   _random.resize(100);
-  std::iota(_random.begin(), _random.end());
-  std::shuffle(_random.begin(), _random.end(), std::default_random_engine{std::random_device{}});
+  std::iota(_random.begin(), _random.end(), 0);
+  std::shuffle(_random.begin(), _random.end(), std::default_random_engine{std::random_device{}()});
 }
 
 WorkerID Worker::id() const { return _id; }

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -68,7 +68,8 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   std::thread _thread;
   std::atomic<uint64_t> _num_finished_tasks{0};
 
-  std::default_random_engine _random{std::random_device{}()};
+  std::vector<int> _random{};
+  int _next_random{};
 };
 
 }  // namespace opossum

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -68,7 +68,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   std::thread _thread;
   std::atomic<uint64_t> _num_finished_tasks{0};
 
-  std::mt19937 _random{std::random_device{}()};
+  std::default_random_engine _random{std::random_device{}()};
 };
 
 }  // namespace opossum

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -66,6 +67,8 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   CpuID _cpu_id;
   std::thread _thread;
   std::atomic<uint64_t> _num_finished_tasks{0};
+
+  std::mt19937 _random{std::random_device{}()};
 };
 
 }  // namespace opossum

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -69,7 +69,7 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   std::atomic<uint64_t> _num_finished_tasks{0};
 
   std::vector<int> _random{};
-  int _next_random{};
+  size_t _next_random{};
 };
 
 }  // namespace opossum


### PR DESCRIPTION
Currently, `Worker::wait_for_tasks` checks if all tasks are completed. If they are not, the worker pulls tasks from the queue and executes them until all tasks that we wait on are done. This, however, leads to a problem if one of the pulled tasks calls `wait_for_tasks` itself. Over time, the worker builds a stack of `wait_for_tasks` calls and the first task has to wait until all tasks that the worker started because it was bored are completed.

<details>

<summary>Demo Code - click to expand</summary>

```cpp
int main() {
  const auto scheduler = std::make_shared<NodeQueueScheduler>();
  Hyrise::get().topology.use_non_numa_topology(3);
  Hyrise::get().set_scheduler(scheduler);

  // Start with some busy workers
  for (auto i = 0; i < 2; ++i) {
    std::make_shared<JobTask>([i] {
      sleep(i + 1);
      std::cout << "Adding one worker" << std::endl;
    })->schedule();
  }

  // Spawn 10 long-running tasks
  auto schedule_timer = Timer{};
  for (auto i = 0; i < 5; ++i) {
    std::make_shared<JobTask>([schedule_timer, i]() mutable {
      auto run_timer = Timer{};
      std::cout << std::string{"Started query "} + std::to_string(i) + "\n";

      auto a = std::make_shared<JobTask>([i] {
        std::cout << std::string{"Started left input "} + std::to_string(i) + "\n";
        sleep(i + 1);
        std::cout << std::string{"Finished left input "} + std::to_string(i) + "\n";
      });

      auto b = std::make_shared<JobTask>([i] {
        std::cout << std::string{"Started right input "} + std::to_string(i) + "\n";
        sleep(i + 1);
        std::cout << std::string{"Finished right input "} + std::to_string(i) + "\n";
      });

      auto c = std::make_shared<JobTask>([i] { std::cout << std::string{"Joined "} + std::to_string(i) + "\n"; });

      a->set_as_predecessor_of(c);
      b->set_as_predecessor_of(c);

      Hyrise::get().scheduler()->schedule_and_wait_for_tasks({a, b, c});

      std::cout << std::string{"Finished query "} + std::to_string(i) + " - " + schedule_timer.lap_formatted() +
                       " after being scheduled, execution took " + run_timer.lap_formatted() + "\n";
    })->schedule();
  }

  Hyrise::get().scheduler()->finish();

  return 0;
}
```
</details>

Results in the current master:
```
Finished query 4 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 3 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 2 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 1 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 0 - 13 s 1 ms after being scheduled, execution took 13 s 1 ms
```

With this PR:
```
Finished query 0 - 2 s 1 ms after being scheduled, execution took 2 s 0 ms
Finished query 1 - 5 s 1 ms after being scheduled, execution took 4 s 0 ms
Finished query 2 - 8 s 1 ms after being scheduled, execution took 6 s 0 ms
Finished query 3 - 10 s 1 ms after being scheduled, execution took 8 s 0 ms
Finished query 4 - 13 s 1 ms after being scheduled, execution took 8 s 0 ms
```

<details>
<summary>Full results</summary>

Master:
```
Started query 0
Started query 1
Started query 2
Started query 3
Started query 4
Started left input 0
Adding one worker
Started right input 0
Finished left input 0
Started left input 1
Adding one worker
Started right input 1
Finished right input 0
Joined 0
Started left input 2
Finished left input 1
Started right input 2
Finished right input 1
Joined 1
Started left input 3
Finished left input 2
Started right input 3
Finished right input 2
Joined 2
Started left input 4
Finished left input 3
Started right input 4
Finished right input 3
Joined 3
Finished left input 4
Finished right input 4
Joined 4
Finished query 4 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 3 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 2 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 1 - 13 s 1 ms after being scheduled, execution took 13 s 0 ms
Finished query 0 - 13 s 1 ms after being scheduled, execution took 13 s 1 ms
```

New:
```
Started query 0
Started left input 0
Adding one worker
Started query 1
Started left input 1
Finished left input 0
Started right input 0
Adding one worker
Started query 2
Started left input 2
Finished right input 0
Joined 0
Finished query 0 - 2 s 1 ms after being scheduled, execution took 2 s 0 ms
Started query 3
Started left input 3
Finished left input 1
Started right input 1
Finished left input 2
Started right input 2
Finished right input 1
Joined 1
Finished query 1 - 5 s 1 ms after being scheduled, execution took 4 s 0 ms
Started query 4
Started left input 4
Finished left input 3
Started right input 3
Finished right input 2
Joined 2
Finished query 2 - 8 s 1 ms after being scheduled, execution took 6 s 0 ms
Started right input 4
Finished left input 4
Finished right input 3
Joined 3
Finished query 3 - 10 s 1 ms after being scheduled, execution took 8 s 0 ms
Finished right input 4
Joined 4
Finished query 4 - 13 s 1 ms after being scheduled, execution took 8 s 0 ms
```

</details>

This increases the performance for the analytical benchmarks quite a bit. For 200 clients (i.e., an overcommitted system), it also drastically reduces the latency.

TPC-C has a slight regression, but given that we have not looked into OLTP scheduling yet, I would keep that for another day. In a follow-up project, one could also look at how this affects the fairness. As we have no metrics for that yet, I would leave that for another day, too.

Also, this finally makes htop look like it is supposed to (node 0 is this branch, node 3 is master):

<img width="300" alt="Screenshot 2021-01-25 at 18 02 42" src="https://user-images.githubusercontent.com/575106/105767016-c9aa2b00-5f5a-11eb-8657-9df2cb3b5bd1.png">

===========

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.3TB |
| numactl | nodebind: 1  |
| numactl | membind: 1  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 3b2f4c148 | 24.01.2021 12:16 | Update README.md (#2309) | real 447.40 user 2952.27 sys 142.88|
| c80fd32cb | 25.01.2021 21:59 | Change random engine | real 450.04 user 2939.22 sys 143.85|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2021-01-26 02:14:15                                                                                                                    | 2021-01-26 10:16:33                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    518.5 |   509.1 |   -2%  ||     1.93 |     1.96 |   +2%  |  0.0037 |
+| TPC-H 02 ||      4.2 |     3.9 |   -7%  ||   235.65 |   253.42 |   +8%  |  0.0000 |
 | TPC-H 03 ||     71.4 |    70.7 |   -1%  ||    14.01 |    14.14 |   +1%  |  0.0000 |
 | TPC-H 04 ||     63.3 |    61.9 |   -2%  ||    15.79 |    16.17 |   +2%  |  0.0000 |
 | TPC-H 05 ||    194.1 |   198.7 |   +2%  ||     5.15 |     5.03 |   -2%  |  0.0000 |
 | TPC-H 06 ||      3.4 |     3.4 |   -2%  ||   292.14 |   296.93 |   +2%  |  0.0000 |
 | TPC-H 07 ||     50.7 |    50.7 |   +0%  ||    19.73 |    19.72 |   -0%  |  0.9736 |
 | TPC-H 08 ||     54.7 |    55.2 |   +1%  ||    18.27 |    18.11 |   -1%  |  0.1561 |
 | TPC-H 09 ||    442.3 |   447.5 |   +1%  ||     2.26 |     2.23 |   -1%  |  0.0010 |
 | TPC-H 10 ||    102.4 |   102.3 |   -0%  ||     9.76 |     9.78 |   +0%  |  0.4459 |
+| TPC-H 11 ||      8.1 |     7.6 |   -7%  ||   123.41 |   132.13 |   +7%  |  0.0000 |
 | TPC-H 12 ||     41.0 |    40.6 |   -1%  ||    24.36 |    24.61 |   +1%  |  0.0000 |
 | TPC-H 13 ||    329.5 |   335.1 |   +2%  ||     3.03 |     2.98 |   -2%  |  0.0000 |
 | TPC-H 14 ||     17.8 |    18.1 |   +1%  ||    56.16 |    55.35 |   -1%  |  0.0000 |
 | TPC-H 15 ||      6.8 |     6.9 |   +1%  ||   147.06 |   145.75 |   -1%  |  0.0000 |
 | TPC-H 16 ||     63.2 |    63.9 |   +1%  ||    15.82 |    15.64 |   -1%  |  0.0000 |
+| TPC-H 17 ||     15.4 |    14.6 |   -5%  ||    65.13 |    68.70 |   +5%  |  0.0000 |
-| TPC-H 18 ||    503.4 |   528.4 |   +5%  ||     1.99 |     1.89 |   -5%  |  0.0000 |
 | TPC-H 19 ||     27.8 |    27.1 |   -2%  ||    36.03 |    36.94 |   +3%  |  0.0000 |
 | TPC-H 20 ||     14.3 |    13.9 |   -3%  ||    70.05 |    71.91 |   +3%  |  0.0000 |
 | TPC-H 21 ||    337.3 |   336.8 |   -0%  ||     2.96 |     2.97 |   +0%  |  0.7048 |
 | TPC-H 22 ||     31.3 |    31.0 |   -1%  ||    31.94 |    32.24 |   +1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   2900.9 |  2927.3 |   +1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st_s01.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                             | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 10.2                                                                                                                                   | gcc 10.2                                                                                                                                   |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2021-01-26 02:36:26                                                                                                                        | 2021-01-26 10:38:43                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      4.8 |     4.9 |   +2%  ||   206.83 |   202.46 |   -2%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.5 |   +2%  ||  1889.51 |  1847.17 |   -2%  |  0.0000 |
 | TPC-H 03 ||      0.7 |     0.7 |   -3%  ||  1340.14 |  1377.50 |   +3%  |  0.0000 |
 | TPC-H 04 ||      0.4 |     0.4 |   -3%  ||  2290.36 |  2363.34 |   +3%  |  0.0000 |
 | TPC-H 05 ||      1.0 |     1.0 |   +2%  ||  1015.27 |   999.91 |   -2%  |  0.0000 |
-| TPC-H 06 ||      0.1 |     0.1 |   +7%  ||  8981.41 |  8385.82 |   -7%  |  0.0000 |
-| TPC-H 07 ||      1.1 |     1.2 |   +6%  ||   878.71 |   832.53 |   -5%  |  0.0000 |
 | TPC-H 08 ||     14.8 |    14.9 |   +1%  ||    67.36 |    66.97 |   -1%  |  0.4412 |
 | TPC-H 09 ||      2.1 |     2.1 |   -1%  ||   475.82 |   479.18 |   +1%  |  0.0080 |
 | TPC-H 10 ||      0.8 |     0.8 |   -0%  ||  1236.83 |  1242.56 |   +0%  |  0.0000 |
-| TPC-H 11 ||      0.3 |     0.3 |   +7%  ||  3434.55 |  3214.98 |   -6%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   -2%  ||  1642.99 |  1674.03 |   +2%  |  0.0000 |
 | TPC-H 13 ||      2.0 |     2.0 |   +1%  ||   496.36 |   491.57 |   -1%  |  0.0000 |
 | TPC-H 14 ||      0.3 |     0.3 |   +2%  ||  3289.20 |  3213.50 |   -2%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   +1%  ||   888.23 |   882.82 |   -1%  |  0.0000 |
 | TPC-H 16 ||      1.9 |     1.9 |   +1%  ||   525.92 |   519.04 |   -1%  |  0.0000 |
+| TPC-H 17 ||      0.3 |     0.3 |   -7%  ||  3478.26 |  3756.96 |   +8%  |  0.0000 |
 | TPC-H 18 ||      2.5 |     2.5 |   +1%  ||   397.40 |   395.09 |   -1%  |  0.0000 |
 | TPC-H 19 ||      5.5 |     5.5 |   -0%  ||   182.78 |   183.34 |   +0%  |  0.0000 |
 | TPC-H 20 ||      2.3 |     2.3 |   -1%  ||   432.57 |   434.85 |   +1%  |  0.0030 |
 | TPC-H 21 ||      1.4 |     1.5 |   +3%  ||   689.22 |   670.99 |   -3%  |  0.0000 |
 | TPC-H 22 ||      1.1 |     1.1 |   -0%  ||   920.41 |   924.16 |   +0%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     45.9 |    46.2 |   +1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st_s10.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                             | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 10.2                                                                                                                                   | gcc 10.2                                                                                                                                   |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2021-01-26 02:58:30                                                                                                                        | 2021-01-26 11:00:47                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   5586.4 |  5598.3 |   +0%  ||     0.18 |     0.18 |   -0%  |  0.9480 |
+| TPC-H 02 ||     44.8 |    41.6 |   -7%  ||    22.31 |    24.02 |   +8%  |  0.0000 |
 | TPC-H 03 ||   1311.5 |  1325.2 |   +1%  ||     0.76 |     0.75 |   -1%  |  0.1497 |
 | TPC-H 04 ||   1390.6 |  1449.9 |   +4%  ||     0.72 |     0.69 |   -4%  |  0.0000 |
 | TPC-H 05 ||   2923.0 |  2931.5 |   +0%  ||     0.34 |     0.34 |   -0%  |  0.7781 |
 | TPC-H 06 ||     36.9 |    35.7 |   -3%  ||    27.09 |    28.00 |   +3%  |  0.0000 |
 | TPC-H 07 ||    755.3 |   755.7 |   +0%  ||     1.32 |     1.32 |   -0%  |  0.7924 |
 | TPC-H 08 ||    513.8 |   517.0 |   +1%  ||     1.95 |     1.93 |   -1%  |  0.0000 |
 | TPC-H 09 ||   6414.1 |  6409.0 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.8721 |
 | TPC-H 10 ||   1797.6 |  1793.2 |   -0%  ||     0.56 |     0.56 |   +0%  |  0.6925 |
+| TPC-H 11 ||    102.4 |    96.4 |   -6%  ||     9.76 |    10.37 |   +6%  |  0.0000 |
 | TPC-H 12 ||    663.5 |   658.4 |   -1%  ||     1.51 |     1.52 |   +1%  |  0.0018 |
 | TPC-H 13 ||   4947.0 |  4977.5 |   +1%  ||     0.20 |     0.20 |   -1%  |  0.4353 |
 | TPC-H 14 ||    221.8 |   222.2 |   +0%  ||     4.51 |     4.50 |   -0%  |  0.3579 |
 | TPC-H 15 ||     73.3 |    73.5 |   +0%  ||    13.63 |    13.60 |   -0%  |  0.1872 |
 | TPC-H 16 ||    643.4 |   643.4 |   -0%  ||     1.55 |     1.55 |   +0%  |  0.9993 |
 | TPC-H 17 ||    223.5 |   223.6 |   +0%  ||     4.47 |     4.47 |   -0%  |  0.8049 |
 | TPC-H 18 ||   9530.7 |  9514.1 |   -0%  ||     0.10 |     0.11 |   +0%  |       ˅ |
 | TPC-H 19 ||    280.8 |   279.2 |   -1%  ||     3.56 |     3.58 |   +1%  |  0.0000 |
 | TPC-H 20 ||    148.1 |   144.1 |   -3%  ||     6.75 |     6.94 |   +3%  |  0.0000 |
 | TPC-H 21 ||   5174.2 |  5307.4 |   +3%  ||     0.19 |     0.19 |   -3%  |  0.0755 |
 | TPC-H 22 ||    439.7 |   448.1 |   +2%  ||     2.27 |     2.23 |   -2%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  43222.5 | 43445.0 |   +1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -8%
 ||
Geometric mean of throughput changes: +11%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2021-01-26 03:22:31                                                                                                                    | 2021-01-26 11:24:51                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                          | [0, 56, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   1304.5 |  1126.2 |  -14%  ||    37.65 |    43.53 |  +16%  |  0.0000 |
+| TPC-H 02 ||     10.8 |     7.1 |  -35%  ||  3505.14 |  4334.16 |  +24%  |  0.0000 |
+| TPC-H 03 ||    176.5 |   163.4 |   -7%  ||   273.66 |   293.73 |   +7%  |  0.0000 |
+| TPC-H 04 ||    131.0 |   115.3 |  -12%  ||   363.27 |   394.32 |   +9%  |  0.0000 |
+| TPC-H 05 ||    501.0 |   477.8 |   -5%  ||    97.76 |   102.33 |   +5%  |  0.0141 |
+| TPC-H 06 ||     10.2 |     8.0 |  -21%  ||  3413.22 |  4356.10 |  +28%  |  0.0000 |
+| TPC-H 07 ||    103.4 |    88.9 |  -14%  ||   460.80 |   525.24 |  +14%  |  0.0000 |
+| TPC-H 08 ||    115.9 |   104.3 |  -10%  ||   411.51 |   448.05 |   +9%  |  0.0000 |
 | TPC-H 09 ||   1017.9 |   979.9 |   -4%  ||    47.90 |    49.87 |   +4%  |  0.1192 |
+| TPC-H 10 ||    262.6 |   239.2 |   -9%  ||   186.32 |   203.76 |   +9%  |  0.0000 |
+| TPC-H 11 ||     28.4 |    19.5 |  -31%  ||  1508.04 |  2052.21 |  +36%  |  0.0000 |
+| TPC-H 12 ||     89.0 |    61.0 |  -31%  ||   520.18 |   577.08 |  +11%  |  0.0000 |
+| TPC-H 13 ||    947.4 |   881.5 |   -7%  ||    51.79 |    55.58 |   +7%  |  0.0001 |
 | TPC-H 14 ||     55.8 |    54.4 |   -3%  ||   824.09 |   840.59 |   +2%  |  0.0000 |
+| TPC-H 15 ||     24.1 |    21.6 |  -10%  ||  1721.02 |  1877.28 |   +9%  |  0.0000 |
 | TPC-H 16 ||    208.3 |   200.5 |   -4%  ||   233.70 |   242.77 |   +4%  |  0.0000 |
+| TPC-H 17 ||     36.6 |    29.6 |  -19%  ||  1180.61 |  1352.53 |  +15%  |  0.0000 |
 | TPC-H 18 ||   2277.6 |  2187.0 |   -4%  ||    21.37 |    22.31 |   +4%  |  0.0439 |
+| TPC-H 19 ||     63.4 |    58.4 |   -8%  ||   715.63 |   759.04 |   +6%  |  0.0000 |
+| TPC-H 20 ||     39.5 |    35.8 |   -9%  ||  1127.79 |  1217.23 |   +8%  |  0.0000 |
+| TPC-H 21 ||    720.8 |   631.7 |  -12%  ||    68.01 |    74.38 |   +9%  |  0.0000 |
+| TPC-H 22 ||    105.4 |    97.9 |   -7%  ||   451.20 |   484.87 |   +7%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||   8230.3 |  7589.1 |   -8%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |  +11%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -2%
 ||
Geometric mean of throughput changes: +4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                          | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 10.2                                                                                                                                | gcc 10.2                                                                                                                                |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2021-01-26 03:44:52                                                                                                                     | 2021-01-26 11:47:12                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     22.8 |    23.1 |   +1%  ||    43.80 |    43.35 |   -1%  |  0.0000 |
+| 03      ||      6.1 |     5.1 |  -16%  ||   163.21 |   194.18 |  +19%  |  0.0000 |
+| 06      ||     16.5 |    15.5 |   -6%  ||    60.50 |    64.38 |   +6%  |  0.0000 |
 | 07      ||     28.2 |    28.2 |   -0%  ||    35.40 |    35.47 |   +0%  |  0.0438 |
+| 09      ||    111.2 |   105.8 |   -5%  ||     8.99 |     9.45 |   +5%  |  0.0000 |
+| 10      ||     18.0 |    16.7 |   -8%  ||    55.49 |    59.99 |   +8%  |  0.0000 |
+| 13      ||    112.9 |   105.8 |   -6%  ||     8.86 |     9.45 |   +7%  |  0.0000 |
-| 15      ||      8.8 |     9.6 |   +9%  ||   113.45 |   103.80 |   -9%  |  0.0000 |
+| 17      ||     26.7 |    25.2 |   -6%  ||    37.44 |    39.64 |   +6%  |  0.0000 |
+| 19      ||      9.1 |     8.0 |  -12%  ||   109.37 |   124.34 |  +14%  |  0.0000 |
 | 25      ||     14.4 |    14.1 |   -2%  ||    69.54 |    71.16 |   +2%  |  0.0003 |
-| 26      ||     13.9 |    15.1 |   +9%  ||    71.95 |    66.21 |   -8%  |  0.0000 |
+| 28      ||    932.9 |   870.0 |   -7%  ||     1.07 |     1.15 |   +7%  |  0.0000 |
+| 29      ||     23.8 |    22.5 |   -5%  ||    42.10 |    44.41 |   +5%  |  0.0000 |
 | 31      ||    104.8 |   102.0 |   -3%  ||     9.54 |     9.81 |   +3%  |  0.0000 |
 | 34      ||     15.8 |    15.3 |   -3%  ||    63.30 |    65.55 |   +4%  |  0.0000 |
 | 35      ||     61.7 |    61.7 |   -0%  ||    16.21 |    16.21 |   +0%  |  0.9972 |
-| 39a     ||    114.1 |   127.1 |  +11%  ||     8.76 |     7.87 |  -10%  |  0.0000 |
-| 39b     ||    113.3 |   125.9 |  +11%  ||     8.82 |     7.94 |  -10%  |  0.0000 |
 | 41      ||     25.4 |    26.3 |   +4%  ||    39.45 |    37.95 |   -4%  |  0.0000 |
+| 42      ||      7.4 |     6.3 |  -14%  ||   134.82 |   157.55 |  +17%  |  0.0000 |
 | 43      ||    201.9 |   203.0 |   +1%  ||     4.95 |     4.93 |   -1%  |  0.0000 |
 | 45      ||      8.5 |     8.2 |   -3%  ||   118.22 |   121.49 |   +3%  |  0.0000 |
 | 48      ||     76.1 |    74.0 |   -3%  ||    13.14 |    13.52 |   +3%  |  0.0000 |
+| 50      ||     10.2 |     9.1 |  -11%  ||    97.61 |   110.23 |  +13%  |  0.0000 |
+| 52      ||      7.5 |     6.5 |  -14%  ||   132.86 |   154.66 |  +16%  |  0.0000 |
+| 55      ||      7.4 |     6.3 |  -14%  ||   135.60 |   158.53 |  +17%  |  0.0000 |
 | 62      ||     50.6 |    51.1 |   +1%  ||    19.75 |    19.57 |   -1%  |  0.0000 |
 | 65      ||     52.5 |    52.3 |   -0%  ||    19.05 |    19.10 |   +0%  |  0.0087 |
+| 69      ||     16.7 |    15.5 |   -7%  ||    59.81 |    64.44 |   +8%  |  0.0000 |
+| 73      ||      9.5 |     8.4 |  -11%  ||   105.79 |   118.70 |  +12%  |  0.0000 |
 | 79      ||     35.8 |    35.3 |   -1%  ||    27.91 |    28.33 |   +2%  |  0.0000 |
 | 81      ||     14.8 |    14.9 |   +0%  ||    67.33 |    67.26 |   -0%  |  0.0014 |
 | 83      ||      8.1 |     8.0 |   -1%  ||   123.90 |   124.87 |   +1%  |  0.0000 |
+| 85      ||     51.0 |    48.3 |   -5%  ||    19.59 |    20.71 |   +6%  |  0.0059 |
+| 88      ||     63.7 |    55.5 |  -13%  ||    15.70 |    18.02 |  +15%  |  0.0000 |
 | 91      ||     17.7 |    17.0 |   -4%  ||    56.36 |    58.86 |   +4%  |  0.0000 |
 | 93      ||    249.7 |   248.5 |   -0%  ||     4.00 |     4.02 |   +0%  |  0.0164 |
+| 96      ||      6.8 |     5.8 |  -16%  ||   145.98 |   173.41 |  +19%  |  0.0000 |
 | 97      ||    306.3 |   309.5 |   +1%  ||     3.26 |     3.23 |   -1%  |  0.0132 |
 | 99      ||     98.8 |    98.5 |   -0%  ||    10.12 |    10.15 |   +0%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3081.8 |  3005.0 |   -2%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +4%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -20%
 ||
Geometric mean of throughput changes: +18%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                          | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 10.2                                                                                                                                | gcc 10.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2021-01-26 04:25:57                                                                                                                     | 2021-01-26 12:28:16                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                           | [0, 56, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     71.2 |    68.5 |   -4%  ||   657.35 |   680.65 |   +4%  |  0.0000 |
+| 03      ||     17.9 |    15.5 |  -13%  ||  2247.38 |  2377.77 |   +6%  |  0.0000 |
+| 06      ||     51.8 |    40.9 |  -21%  ||   884.30 |  1058.71 |  +20%  |  0.0000 |
+| 07      ||     81.1 |    62.0 |  -24%  ||   579.97 |   723.47 |  +25%  |  0.0000 |
+| 09      ||    345.6 |   295.3 |  -15%  ||   141.41 |   165.57 |  +17%  |  0.0000 |
+| 10      ||     47.9 |    32.6 |  -32%  ||   925.64 |  1132.75 |  +22%  |  0.0000 |
+| 13      ||    349.4 |   274.8 |  -21%  ||   140.38 |   177.53 |  +26%  |  0.0000 |
+| 15      ||     41.2 |    31.6 |  -23%  ||  1092.18 |  1393.94 |  +28%  |  0.0000 |
+| 17      ||     79.0 |    58.1 |  -27%  ||   597.09 |   742.87 |  +24%  |  0.0000 |
+| 19      ||     30.0 |    22.8 |  -24%  ||  1452.24 |  1859.26 |  +28%  |  0.0000 |
+| 25      ||     45.9 |    37.8 |  -18%  ||   989.58 |  1142.57 |  +15%  |  0.0000 |
+| 26      ||     44.1 |    38.9 |  -12%  ||  1016.55 |  1127.26 |  +11%  |  0.0000 |
+| 28      ||   2101.1 |  1106.8 |  -47%  ||    17.41 |    22.83 |  +31%  |  0.0000 |
+| 29      ||     66.9 |    49.9 |  -25%  ||   694.71 |   835.35 |  +20%  |  0.0000 |
+| 31      ||    342.1 |   154.2 |  -55%  ||   143.20 |   173.69 |  +21%  |  0.0000 |
+| 34      ||     49.2 |    35.8 |  -27%  ||   925.85 |  1186.64 |  +28%  |  0.0000 |
+| 35      ||    208.4 |   190.3 |   -9%  ||   233.93 |   255.09 |   +9%  |  0.0000 |
 | 39a     ||    429.9 |   430.2 |   +0%  ||   114.21 |   112.49 |   -2%  |  0.9600 |
 | 39b     ||    429.5 |   430.6 |   +0%  ||   114.26 |   112.63 |   -1%  |  0.8740 |
-| 41      ||    542.4 |   635.8 |  +17%  ||    90.34 |    76.89 |  -15%  |  0.0000 |
+| 42      ||     21.4 |    16.3 |  -24%  ||  1927.81 |  2336.38 |  +21%  |  0.0000 |
+| 43      ||    536.3 |   476.3 |  -11%  ||    90.92 |    98.50 |   +8%  |  0.0000 |
+| 45      ||     23.6 |    19.5 |  -17%  ||  1723.59 |  1971.79 |  +14%  |  0.0000 |
+| 48      ||    215.5 |   161.6 |  -25%  ||   225.37 |   276.02 |  +22%  |  0.0000 |
+| 50      ||     32.6 |    26.0 |  -20%  ||  1346.15 |  1652.61 |  +23%  |  0.0000 |
+| 52      ||     21.9 |    16.6 |  -24%  ||  1903.61 |  2328.59 |  +22%  |  0.0000 |
+| 55      ||     20.6 |    15.8 |  -23%  ||  1988.10 |  2395.79 |  +21%  |  0.0000 |
+| 62      ||    135.2 |   126.2 |   -7%  ||   355.66 |   379.01 |   +7%  |  0.0000 |
+| 65      ||    212.6 |   194.1 |   -9%  ||   229.09 |   250.84 |   +9%  |  0.0000 |
+| 69      ||     46.6 |    30.9 |  -34%  ||   948.45 |  1186.58 |  +25%  |  0.0000 |
+| 73      ||     28.3 |    19.9 |  -30%  ||  1533.58 |  1955.25 |  +27%  |  0.0000 |
+| 79      ||    118.9 |    96.1 |  -19%  ||   402.85 |   492.65 |  +22%  |  0.0000 |
+| 81      ||     54.7 |    47.6 |  -13%  ||   838.58 |   954.13 |  +14%  |  0.0000 |
+| 83      ||     37.0 |    20.2 |  -45%  ||  1197.48 |  1969.62 |  +64%  |  0.0000 |
+| 85      ||    156.7 |   123.0 |  -21%  ||   308.40 |   385.71 |  +25%  |  0.0000 |
+| 88      ||    170.7 |    84.7 |  -50%  ||   253.89 |   347.25 |  +37%  |  0.0000 |
+| 91      ||     64.5 |    47.4 |  -27%  ||   722.81 |   953.42 |  +32%  |  0.0000 |
+| 93      ||    618.2 |   567.0 |   -8%  ||    79.59 |    85.99 |   +8%  |  0.0000 |
+| 96      ||     19.9 |    15.9 |  -20%  ||  2030.09 |  2410.73 |  +19%  |  0.0000 |
 | 97      ||    972.5 |   943.3 |   -3%  ||    50.39 |    52.19 |   +4%  |  0.0882 |
 | 99      ||    286.2 |   277.6 |   -3%  ||   171.40 |   176.15 |   +3%  |  0.0036 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||   9168.6 |  7338.5 |  -20%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |  +18%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +4%
 ||
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2021-01-26 05:07:12                                                                                                                    | 2021-01-26 13:09:31                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
-| Delivery     ||     28.7 |    29.7 |   +4%  ||     3.73 |     3.55 |   -5%  | (run time too short) |
-| New-Order    ||     18.5 |    19.4 |   +5%  ||    41.79 |    39.91 |   -5%  | (run time too short) |
 | Order-Status ||      1.2 |     1.3 |   +4%  ||     3.72 |     3.55 |   -4%  | (run time too short) |
 | Payment      ||      2.5 |     2.6 |   +3%  ||    39.83 |    38.17 |   -4%  | (run time too short) |
 | Stock-Level  ||      4.1 |     4.1 |   -1%  ||     3.72 |     3.55 |   -4%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     55.0 |    57.1 |   +4%  ||          |          |        |                      |
-| Geomean      ||          |         |        ||          |          |   -5%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +8%
 ||
Geometric mean of throughput changes: -8%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2021-01-26 05:08:15                                                                                                                    | 2021-01-26 13:10:35                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                          | [0, 56, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
-| Delivery     ||    131.4 |   141.2 |   +7%  ||     7.26 |     6.74 |   -7%  | (run time too short) |
 |    unsucc.:  ||      4.0 |     3.7 |   -7%  ||   133.80 |   133.68 |   -0%  |                      |
-| New-Order    ||     69.8 |    77.0 |  +10%  ||   121.50 |   110.67 |   -9%  |               0.0000 |
 |    unsucc.:  ||      4.0 |     3.9 |   -2%  ||  1465.16 |  1469.03 |   +0%  |                      |
 | Order-Status ||      6.3 |     6.5 |   +4%  ||   141.04 |   140.43 |   -0%  | (run time too short) |
-| Payment      ||     11.2 |    12.4 |  +11%  ||    10.70 |     8.21 |  -23%  | (run time too short) |
 |    unsucc.:  ||      3.7 |     3.7 |   -2%  ||  1505.67 |  1501.46 |   -0%  |                      |
 | Stock-Level  ||     17.5 |    17.4 |   -1%  ||   141.02 |   140.38 |   -0%  |               0.4717 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
-| Sum          ||    236.2 |   254.5 |   +8%  ||          |          |        |                      |
-| Geomean      ||          |         |        ||          |          |   -8%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                              | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 10.2                                                                                                                                    | gcc 10.2                                                                                                                                    |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2021-01-26 05:09:20                                                                                                                         | 2021-01-26 13:11:40                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    325.8 |    314.6 |   -3%  ||     3.07 |     3.18 |   +4%  |  0.0000 |
 | 10b     ||    319.6 |    308.5 |   -3%  ||     3.13 |     3.24 |   +4%  |  0.0000 |
 | 10c     ||    890.4 |    887.4 |   -0%  ||     1.12 |     1.13 |   +0%  |  0.3633 |
 | 11a     ||    137.8 |    132.7 |   -4%  ||     7.26 |     7.54 |   +4%  |  0.0002 |
 | 11b     ||    130.1 |    124.9 |   -4%  ||     7.69 |     8.01 |   +4%  |  0.0001 |
 | 11c     ||    501.6 |    490.9 |   -2%  ||     1.99 |     2.04 |   +2%  |  0.0318 |
 | 11d     ||   5109.1 |   5031.6 |   -2%  ||     0.20 |     0.20 |   +2%  |  0.4399 |
 | 12a     ||    276.4 |    275.4 |   -0%  ||     3.62 |     3.63 |   +0%  |  0.7256 |
 | 12b     ||    594.7 |    582.4 |   -2%  ||     1.68 |     1.72 |   +2%  |  0.0322 |
 | 12c     ||   3444.0 |   3450.3 |   +0%  ||     0.29 |     0.29 |   -0%  |  0.8504 |
+| 13a     ||    164.1 |    152.6 |   -7%  ||     6.09 |     6.55 |   +8%  |  0.0000 |
+| 13b     ||    246.1 |    221.8 |  -10%  ||     4.06 |     4.51 |  +11%  |  0.0000 |
+| 13c     ||    138.4 |    127.7 |   -8%  ||     7.23 |     7.83 |   +8%  |  0.0000 |
+| 13d     ||    163.7 |    152.5 |   -7%  ||     6.11 |     6.56 |   +7%  |  0.0000 |
 | 14a     ||   3937.5 |   3959.9 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.5587 |
 | 14b     ||   4515.9 |   4539.8 |   +1%  ||     0.22 |     0.22 |   -1%  |  0.5716 |
 | 14c     ||   3926.9 |   3951.3 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.4962 |
 | 15a     ||    178.0 |    185.8 |   +4%  ||     5.62 |     5.38 |   -4%  |  0.0000 |
 | 15b     ||    174.6 |    180.3 |   +3%  ||     5.73 |     5.54 |   -3%  |  0.0000 |
+| 15c     ||    140.0 |    128.4 |   -8%  ||     7.14 |     7.79 |   +9%  |  0.0000 |
 | 15d     ||    451.3 |    462.9 |   +3%  ||     2.22 |     2.16 |   -3%  |  0.0000 |
 | 16a     ||   4633.0 |   4606.8 |   -1%  ||     0.22 |     0.22 |   +1%  |  0.7659 |
 | 16b     ||   6167.9 |   6198.2 |   +0%  ||     0.16 |     0.16 |   -0%  |  0.6869 |
 | 16c     ||   4710.5 |   4771.4 |   +1%  ||     0.21 |     0.21 |   -1%  |  0.3791 |
 | 16d     ||   4653.8 |   4773.8 |   +3%  ||     0.21 |     0.21 |   -3%  |  0.0603 |
 | 17a     ||    895.5 |    884.5 |   -1%  ||     1.12 |     1.13 |   +1%  |  0.0490 |
 | 17b     ||    697.5 |    692.6 |   -1%  ||     1.43 |     1.44 |   +1%  |  0.2322 |
 | 17c     ||    659.5 |    652.9 |   -1%  ||     1.52 |     1.53 |   +1%  |  0.0827 |
 | 17d     ||    775.2 |    767.2 |   -1%  ||     1.29 |     1.30 |   +1%  |  0.0765 |
 | 17e     ||   2617.5 |   2612.9 |   -0%  ||     0.38 |     0.38 |   +0%  |  0.8257 |
 | 17f     ||   1466.9 |   1471.3 |   +0%  ||     0.68 |     0.68 |   -0%  |  0.6586 |
 | 18a     ||    553.8 |    559.3 |   +1%  ||     1.81 |     1.79 |   -1%  |  0.0738 |
+| 18b     ||    207.9 |    196.9 |   -5%  ||     4.81 |     5.08 |   +6%  |  0.0000 |
 | 18c     ||   3603.7 |   3605.8 |   +0%  ||     0.28 |     0.28 |   -0%  |  0.9221 |
 | 19a     ||   5484.5 |   5451.8 |   -1%  ||     0.18 |     0.18 |   +1%  |  0.1406 |
 | 19b     ||   2551.1 |   2523.4 |   -1%  ||     0.39 |     0.40 |   +1%  |  0.0129 |
 | 19c     ||   5237.3 |   5219.1 |   -0%  ||     0.19 |     0.19 |   +0%  |  0.2425 |
 | 19d     ||   5557.3 |   5576.0 |   +0%  ||     0.18 |     0.18 |   -0%  |  0.7537 |
+| 1a      ||     55.9 |     53.5 |   -4%  ||    17.88 |    18.70 |   +5%  |  0.0000 |
+| 1b      ||     20.2 |     18.2 |  -10%  ||    49.38 |    55.00 |  +11%  |  0.0000 |
+| 1c      ||     20.2 |     18.2 |  -10%  ||    49.55 |    55.06 |  +11%  |  0.0000 |
+| 1d      ||     20.0 |     17.9 |  -10%  ||    50.07 |    55.71 |  +11%  |  0.0000 |
 | 20a     ||   1176.3 |   1159.2 |   -1%  ||     0.85 |     0.86 |   +1%  |  0.0000 |
 | 20b     ||   1018.3 |    998.9 |   -2%  ||     0.98 |     1.00 |   +2%  |  0.0000 |
+| 20c     ||    662.7 |    630.9 |   -5%  ||     1.51 |     1.59 |   +5%  |  0.0000 |
 | 21a     ||   3629.0 |   3636.8 |   +0%  ||     0.28 |     0.27 |   -0%  |  0.5127 |
 | 21b     ||    227.1 |    222.7 |   -2%  ||     4.40 |     4.49 |   +2%  |  0.0000 |
 | 21c     ||   3793.7 |   3809.5 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.2081 |
 | 22a     ||   3258.8 |   3258.5 |   -0%  ||     0.31 |     0.31 |   +0%  |  0.9931 |
 | 22b     ||   3257.8 |   3265.9 |   +0%  ||     0.31 |     0.31 |   -0%  |  0.7779 |
 | 22c     ||   3949.4 |   3972.5 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.4372 |
 | 22d     ||   3964.3 |   3989.5 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.3900 |
+| 23a     ||    140.8 |    130.0 |   -8%  ||     7.10 |     7.69 |   +8%  |  0.0000 |
+| 23b     ||     97.3 |     84.9 |  -13%  ||    10.28 |    11.77 |  +15%  |  0.0000 |
+| 23c     ||    154.6 |    144.3 |   -7%  ||     6.47 |     6.93 |   +7%  |  0.0000 |
 | 24a     ||   2621.1 |   2646.8 |   +1%  ||     0.38 |     0.38 |   -1%  |  0.1768 |
 | 24b     ||   2573.4 |   2493.3 |   -3%  ||     0.39 |     0.40 |   +3%  |  0.0518 |
+| 25a     ||    210.5 |    195.9 |   -7%  ||     4.75 |     5.10 |   +7%  |  0.0000 |
+| 25b     ||    226.8 |    203.4 |  -10%  ||     4.41 |     4.92 |  +11%  |  0.0000 |
 | 25c     ||   3610.7 |   3617.3 |   +0%  ||     0.28 |     0.28 |   -0%  |  0.7286 |
+| 26a     ||    554.2 |    520.8 |   -6%  ||     1.80 |     1.92 |   +6%  |  0.0000 |
+| 26b     ||    543.5 |    510.6 |   -6%  ||     1.84 |     1.96 |   +6%  |  0.0000 |
+| 26c     ||    554.7 |    521.0 |   -6%  ||     1.80 |     1.92 |   +6%  |  0.0000 |
 | 27a     ||   3287.2 |   3289.9 |   +0%  ||     0.30 |     0.30 |   -0%  |  0.8830 |
 | 27b     ||   3266.2 |   3268.3 |   +0%  ||     0.31 |     0.31 |   -0%  |  0.9102 |
+| 27c     ||    185.2 |    169.5 |   -8%  ||     5.40 |     5.90 |   +9%  |  0.0000 |
 | 28a     ||   3983.0 |   4021.3 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.6828 |
 | 28b     ||   3199.0 |   3203.2 |   +0%  ||     0.31 |     0.31 |   -0%  |  0.9631 |
 | 28c     ||   3981.8 |   4014.7 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.7191 |
 | 29a     ||   2540.1 |   2550.5 |   +0%  ||     0.39 |     0.39 |   -0%  |  0.9471 |
+| 29b     ||    175.9 |    153.7 |  -13%  ||     5.69 |     6.51 |  +14%  |  0.0138 |
 | 29c     ||   2602.4 |   2557.7 |   -2%  ||     0.38 |     0.39 |   +2%  |  0.7742 |
+| 2a      ||     86.5 |     81.9 |   -5%  ||    11.56 |    12.22 |   +6%  |  0.0000 |
+| 2b      ||     70.0 |     65.4 |   -7%  ||    14.28 |    15.29 |   +7%  |  0.0000 |
+| 2c      ||     46.8 |     42.0 |  -10%  ||    21.37 |    23.80 |  +11%  |  0.0000 |
 | 2d      ||    110.4 |    106.2 |   -4%  ||     9.06 |     9.42 |   +4%  |  0.0000 |
+| 30a     ||    225.3 |    209.9 |   -7%  ||     4.44 |     4.76 |   +7%  |  0.0002 |
 | 30b     ||   1020.9 |   1020.8 |   -0%  ||     0.98 |     0.98 |   +0%  |  0.9957 |
 | 30c     ||   3630.1 |   3642.8 |   +0%  ||     0.28 |     0.27 |   -0%  |  0.8681 |
+| 31a     ||    259.4 |    231.6 |  -11%  ||     3.85 |     4.32 |  +12%  |  0.0000 |
 | 31b     ||   1047.9 |   1033.0 |   -1%  ||     0.95 |     0.97 |   +1%  |  0.2101 |
+| 31c     ||    262.8 |    234.3 |  -11%  ||     3.81 |     4.27 |  +12%  |  0.0000 |
+| 32a     ||     33.8 |     28.9 |  -15%  ||    29.54 |    34.64 |  +17%  |  0.0000 |
 | 32b     ||    257.9 |    252.7 |   -2%  ||     3.88 |     3.96 |   +2%  |  0.0000 |
+| 33a     ||     61.8 |     56.2 |   -9%  ||    16.19 |    17.79 |  +10%  |  0.0000 |
+| 33b     ||     61.3 |     55.6 |   -9%  ||    16.32 |    18.00 |  +10%  |  0.0000 |
+| 33c     ||     73.1 |     67.6 |   -8%  ||    13.67 |    14.79 |   +8%  |  0.0000 |
 | 3a      ||   3699.6 |   3707.2 |   +0%  ||     0.27 |     0.27 |   -0%  |  0.0009 |
+| 3b      ||     31.5 |     27.9 |  -12%  ||    31.72 |    35.89 |  +13%  |  0.0000 |
 | 3c      ||   4620.6 |   4666.4 |   +1%  ||     0.22 |     0.21 |   -1%  |  0.0000 |
 | 4a      ||    107.3 |    106.2 |   -1%  ||     9.32 |     9.42 |   +1%  |  0.0000 |
+| 4b      ||     24.4 |     20.5 |  -16%  ||    41.06 |    48.86 |  +19%  |  0.0000 |
 | 4c      ||    118.5 |    117.9 |   -0%  ||     8.44 |     8.48 |   +0%  |  0.0004 |
 | 5a      ||   3574.7 |   3591.3 |   +0%  ||     0.28 |     0.28 |   -0%  |  0.0000 |
 | 5b      ||    254.7 |    258.2 |   +1%  ||     3.93 |     3.87 |   -1%  |  0.0000 |
 | 5c      ||   4234.3 |   4256.5 |   +1%  ||     0.24 |     0.23 |   -1%  |  0.0000 |
+| 6a      ||    203.2 |    188.5 |   -7%  ||     4.92 |     5.30 |   +8%  |  0.0000 |
 | 6b      ||    891.1 |    888.6 |   -0%  ||     1.12 |     1.13 |   +0%  |  0.2811 |
+| 6c      ||    203.4 |    188.6 |   -7%  ||     4.92 |     5.30 |   +8%  |  0.0000 |
 | 6d      ||    893.9 |    894.1 |   +0%  ||     1.12 |     1.12 |   -0%  |  0.8661 |
+| 6e      ||    203.3 |    189.4 |   -7%  ||     4.92 |     5.28 |   +7%  |  0.0000 |
 | 6f      ||   1418.4 |   1406.4 |   -1%  ||     0.71 |     0.71 |   +1%  |  0.0001 |
+| 7a      ||    343.1 |    304.0 |  -11%  ||     2.91 |     3.29 |  +13%  |  0.0000 |
+| 7b      ||    124.5 |     98.1 |  -21%  ||     8.03 |    10.19 |  +27%  |  0.0000 |
 | 7c      ||  10234.0 |  10252.5 |   +0%  ||     0.10 |     0.10 |   -0%  |       ˅ |
 | 8a      ||     95.6 |     98.2 |   +3%  ||    10.45 |    10.18 |   -3%  |  0.0000 |
 | 8b      ||    147.1 |    148.8 |   +1%  ||     6.80 |     6.72 |   -1%  |  0.0002 |
 | 8c      ||   4011.0 |   4048.8 |   +1%  ||     0.25 |     0.25 |   -1%  |  0.1726 |
 | 8d      ||   1233.0 |   1273.2 |   +3%  ||     0.81 |     0.79 |   -3%  |  0.0000 |
 | 9a      ||   3260.3 |   3264.2 |   +0%  ||     0.31 |     0.31 |   -0%  |  0.8334 |
 | 9b      ||    319.4 |    317.6 |   -1%  ||     3.13 |     3.15 |   +1%  |  0.2791 |
 | 9c      ||   3244.9 |   3265.0 |   +1%  ||     0.31 |     0.31 |   -1%  |  0.2454 |
 | 9d      ||   3891.4 |   3901.8 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.6198 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 190432.3 | 190183.7 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +3%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -20%
 ||
Geometric mean of throughput changes: +10%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_c80fd32cbb795d17e5b0f492200a1e6ab60f19a6_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                              | c80fd32cbb795d17e5b0f492200a1e6ab60f19a6-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 10.2                                                                                                                                    | gcc 10.2                                                                                                                                    |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2021-01-26 07:04:12                                                                                                                         | 2021-01-26 15:06:43                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                               | [0, 56, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
+| 10a     ||    629.7 |    437.4 |  -31%  ||    75.23 |    80.18 |   +7%  |  0.0000 |
+| 10b     ||    588.6 |    400.7 |  -32%  ||    76.88 |    81.54 |   +6%  |  0.0000 |
 | 10c     ||   2456.6 |   2297.1 |   -6%  ||    19.50 |    20.36 |   +4%  |  0.0881 |
+| 11a     ||    313.5 |    199.7 |  -36%  ||   155.09 |   185.05 |  +19%  |  0.0000 |
+| 11b     ||    292.3 |    180.5 |  -38%  ||   165.64 |   196.20 |  +18%  |  0.0000 |
+| 11c     ||   1278.4 |   1197.9 |   -6%  ||    38.31 |    40.97 |   +7%  |  0.0027 |
 | 11d     ||  13348.6 |  13572.7 |   +2%  ||     3.05 |     3.13 |   +3%  |  0.7246 |
 | 12a     ||    804.7 |    703.9 |  -13%  ||    60.71 |    62.06 |   +2%  |  0.0000 |
 | 12b     ||    405.6 |    287.4 |  -29%  ||    52.81 |    53.86 |   +2%  |  0.0000 |
 | 12c     ||   6834.6 |   5755.5 |  -16%  ||     5.33 |     5.55 |   +4%  |  0.0334 |
+| 13a     ||    353.5 |    279.6 |  -21%  ||   127.44 |   138.66 |   +9%  |  0.0000 |
+| 13b     ||    430.2 |    173.7 |  -60%  ||   101.81 |   115.40 |  +13%  |  0.0000 |
+| 13c     ||    301.8 |    159.6 |  -47%  ||   132.77 |   139.35 |   +5%  |  0.0000 |
+| 13d     ||    350.7 |    274.0 |  -22%  ||   127.33 |   138.73 |   +9%  |  0.0000 |
 | 14a     ||   7932.7 |   6314.3 |  -20%  ||     4.92 |     5.10 |   +4%  |  0.0027 |
 | 14b     ||   9175.7 |   6759.6 |  -26%  ||     4.42 |     4.60 |   +4%  |  0.0000 |
 | 14c     ||   8537.3 |   6551.0 |  -23%  ||     4.95 |     5.02 |   +1%  |  0.0006 |
 | 15a     ||    419.0 |    370.6 |  -12%  ||   116.19 |   116.87 |   +1%  |  0.0000 |
 | 15b     ||    397.8 |    334.9 |  -16%  ||   121.16 |   120.25 |   -1%  |  0.0000 |
+| 15c     ||    322.2 |    245.2 |  -24%  ||   149.56 |   169.93 |  +14%  |  0.0000 |
+| 15d     ||   1207.4 |   1051.4 |  -13%  ||    40.43 |    46.03 |  +14%  |  0.0000 |
+| 16a     ||  10867.1 |  10995.4 |   +1%  ||     3.55 |     4.03 |  +14%  |  0.8483 |
+| 16b     ||  14916.2 |  14029.5 |   -6%  ||     2.57 |     2.87 |  +12%  |  0.2901 |
+| 16c     ||  12453.8 |  11634.3 |   -7%  ||     3.47 |     3.73 |   +8%  |  0.2766 |
+| 16d     ||  12302.9 |  11164.5 |   -9%  ||     3.45 |     3.73 |   +8%  |  0.1056 |
+| 17a     ||   2262.8 |   1890.6 |  -16%  ||    20.10 |    23.56 |  +17%  |  0.0000 |
+| 17b     ||   1719.6 |   1116.1 |  -35%  ||    27.66 |    31.10 |  +12%  |  0.0000 |
+| 17c     ||   1642.2 |   1109.1 |  -32%  ||    29.28 |    32.63 |  +11%  |  0.0000 |
+| 17d     ||   1778.2 |   1153.3 |  -35%  ||    26.77 |    29.50 |  +10%  |  0.0000 |
+| 17e     ||   5906.3 |   5531.1 |   -6%  ||     7.63 |     8.25 |   +8%  |  0.1578 |
+| 17f     ||   3596.5 |   3018.9 |  -16%  ||    12.88 |    15.00 |  +16%  |  0.0000 |
 | 18a     ||   1302.3 |   1129.4 |  -13%  ||    37.23 |    38.38 |   +3%  |  0.0000 |
+| 18b     ||    470.9 |    341.4 |  -28%  ||    97.18 |   104.31 |   +7%  |  0.0000 |
+| 18c     ||   7093.0 |   4705.2 |  -34%  ||     5.38 |     5.78 |   +7%  |  0.0000 |
+| 19a     ||  11781.3 |   7691.0 |  -35%  ||     2.95 |     3.55 |  +20%  |  0.0000 |
+| 19b     ||   5461.8 |   2665.5 |  -51%  ||     7.85 |     8.23 |   +5%  |  0.0000 |
 | 19c     ||  12537.8 |   8845.8 |  -29%  ||     3.17 |     3.27 |   +3%  |  0.0000 |
+| 19d     ||  13603.2 |  13051.5 |   -4%  ||     2.78 |     2.93 |   +5%  |  0.4887 |
+| 1a      ||    109.4 |     62.4 |  -43%  ||   355.78 |   384.87 |   +8%  |  0.0000 |
+| 1b      ||     29.5 |     21.6 |  -27%  ||   966.36 |  1097.56 |  +14%  |  0.0000 |
+| 1c      ||     30.3 |     22.0 |  -27%  ||   958.41 |  1087.71 |  +13%  |  0.0000 |
+| 1d      ||     29.3 |     21.5 |  -27%  ||   967.92 |  1098.42 |  +13%  |  0.0000 |
+| 20a     ||   2183.9 |   1239.2 |  -43%  ||    21.36 |    22.41 |   +5%  |  0.0000 |
+| 20b     ||   1874.1 |   1013.1 |  -46%  ||    25.21 |    26.47 |   +5%  |  0.0000 |
+| 20c     ||   1283.9 |    751.3 |  -41%  ||    36.68 |    40.98 |  +12%  |  0.0000 |
+| 21a     ||   7732.7 |   3820.5 |  -51%  ||     5.30 |     5.87 |  +11%  |  0.0000 |
+| 21b     ||    509.2 |    439.4 |  -14%  ||    96.12 |   107.43 |  +12%  |  0.0000 |
+| 21c     ||   8169.0 |   3822.4 |  -53%  ||     5.12 |     5.68 |  +11%  |  0.0000 |
+| 22a     ||   6287.1 |   5766.1 |   -8%  ||     5.80 |     6.10 |   +5%  |  0.2241 |
+| 22b     ||   7157.5 |   5406.6 |  -24%  ||     5.78 |     6.08 |   +5%  |  0.0001 |
 | 22c     ||   5597.7 |   6528.3 |  +17%  ||     4.92 |     5.05 |   +3%  |  0.0229 |
+| 22d     ||   7898.5 |   7401.7 |   -6%  ||     4.87 |     5.17 |   +6%  |  0.3752 |
+| 23a     ||    323.6 |    204.9 |  -37%  ||   148.48 |   169.20 |  +14%  |  0.0000 |
+| 23b     ||    253.8 |    156.5 |  -38%  ||   190.31 |   239.13 |  +26%  |  0.0000 |
+| 23c     ||    355.9 |    233.9 |  -34%  ||   135.73 |   156.17 |  +15%  |  0.0000 |
 | 24a     ||   5941.3 |   3837.3 |  -35%  ||     7.45 |     7.75 |   +4%  |  0.0000 |
 | 24b     ||   4994.1 |   2819.2 |  -44%  ||     7.78 |     8.08 |   +4%  |  0.0000 |
+| 25a     ||    490.8 |    338.0 |  -31%  ||    96.99 |   105.62 |   +9%  |  0.0000 |
+| 25b     ||    353.0 |    267.7 |  -24%  ||    89.11 |   100.59 |  +13%  |  0.0000 |
+| 25c     ||   7502.3 |   5327.2 |  -29%  ||     5.42 |     5.70 |   +5%  |  0.0000 |
+| 26a     ||    943.7 |    482.8 |  -49%  ||    45.55 |    50.14 |  +10%  |  0.0000 |
+| 26b     ||    918.0 |    465.8 |  -49%  ||    46.40 |    51.39 |  +11%  |  0.0000 |
+| 26c     ||    999.6 |    483.3 |  -52%  ||    45.38 |    50.04 |  +10%  |  0.0000 |
 | 27a     ||   5729.2 |   5953.4 |   +4%  ||     5.78 |     5.80 |   +0%  |  0.5976 |
+| 27b     ||   7024.6 |   4383.3 |  -38%  ||     5.90 |     6.27 |   +6%  |  0.0000 |
+| 27c     ||    442.7 |    271.8 |  -39%  ||   110.13 |   134.99 |  +23%  |  0.0000 |
 | 28a     ||   7886.1 |   6855.9 |  -13%  ||     4.75 |     4.80 |   +1%  |  0.0786 |
+| 28b     ||   7000.4 |   4031.8 |  -42%  ||     5.92 |     6.30 |   +6%  |  0.0000 |
+| 28c     ||   7688.7 |   7048.7 |   -8%  ||     4.75 |     5.05 |   +6%  |  0.2722 |
 | 29a     ||   6201.7 |   3255.4 |  -48%  ||     7.32 |     7.58 |   +4%  |  0.0000 |
+| 29b     ||    454.9 |    371.3 |  -18%  ||   101.27 |   115.33 |  +14%  |  0.0000 |
 | 29c     ||   6012.1 |   3527.5 |  -41%  ||     7.15 |     7.40 |   +3%  |  0.0000 |
+| 2a      ||    242.5 |    175.5 |  -28%  ||   200.46 |   242.47 |  +21%  |  0.0000 |
+| 2b      ||    200.3 |    137.1 |  -32%  ||   241.58 |   299.21 |  +24%  |  0.0000 |
+| 2c      ||    115.5 |     69.6 |  -40%  ||   381.85 |   472.94 |  +24%  |  0.0000 |
+| 2d      ||    300.2 |    226.8 |  -24%  ||   162.56 |   196.88 |  +21%  |  0.0000 |
+| 30a     ||    549.9 |    407.0 |  -26%  ||    86.71 |    95.03 |  +10%  |  0.0000 |
 | 30b     ||   1595.7 |    836.7 |  -48%  ||    28.65 |    29.65 |   +4%  |  0.0000 |
+| 30c     ||   7461.1 |   5256.2 |  -30%  ||     5.25 |     5.50 |   +5%  |  0.0001 |
+| 31a     ||    576.0 |    340.1 |  -41%  ||    77.16 |    88.22 |  +14%  |  0.0000 |
 | 31b     ||    941.6 |    625.3 |  -34%  ||    28.26 |    29.38 |   +4%  |  0.0000 |
+| 31c     ||    580.6 |    339.0 |  -42%  ||    76.38 |    87.21 |  +14%  |  0.0000 |
+| 32a     ||     58.4 |     43.0 |  -26%  ||   530.78 |   631.88 |  +19%  |  0.0000 |
+| 32b     ||    678.5 |    529.3 |  -22%  ||    72.68 |    91.22 |  +26%  |  0.0000 |
+| 33a     ||    144.8 |    115.4 |  -20%  ||   309.24 |   362.59 |  +17%  |  0.0000 |
+| 33b     ||    142.9 |    114.5 |  -20%  ||   312.46 |   365.29 |  +17%  |  0.0000 |
+| 33c     ||    188.8 |    141.1 |  -25%  ||   253.44 |   301.79 |  +19%  |  0.0000 |
+| 3a      ||   7527.4 |   5775.3 |  -23%  ||     5.20 |     5.55 |   +7%  |  0.0013 |
+| 3b      ||     82.3 |     62.2 |  -24%  ||   539.91 |   645.20 |  +20%  |  0.0000 |
+| 3c      ||   9666.5 |   8050.0 |  -17%  ||     4.08 |     4.30 |   +5%  |  0.0013 |
 | 4a      ||    317.5 |    282.1 |  -11%  ||   153.50 |   160.25 |   +4%  |  0.0000 |
+| 4b      ||     48.4 |     33.4 |  -31%  ||   769.89 |   962.00 |  +25%  |  0.0000 |
 | 4c      ||    358.6 |    294.1 |  -18%  ||   135.50 |   138.94 |   +3%  |  0.0000 |
+| 5a      ||   7093.4 |   4111.1 |  -42%  ||     5.43 |     5.97 |  +10%  |  0.0000 |
 | 5b      ||    460.3 |    348.4 |  -24%  ||    93.27 |    92.00 |   -1%  |  0.0000 |
+| 5c      ||   7982.6 |   5782.8 |  -28%  ||     4.63 |     4.93 |   +6%  |  0.0000 |
+| 6a      ||    401.2 |    230.6 |  -43%  ||   103.50 |   113.00 |   +9%  |  0.0000 |
+| 6b      ||   1896.8 |   1328.4 |  -30%  ||    24.26 |    26.26 |   +8%  |  0.0000 |
+| 6c      ||    404.5 |    225.9 |  -44%  ||   103.17 |   112.68 |   +9%  |  0.0000 |
+| 6d      ||   1907.7 |   1318.1 |  -31%  ||    24.36 |    26.36 |   +8%  |  0.0000 |
+| 6e      ||    403.9 |    237.2 |  -41%  ||   102.91 |   112.48 |   +9%  |  0.0000 |
+| 6f      ||   3263.2 |   2659.1 |  -19%  ||    14.53 |    16.98 |  +17%  |  0.0000 |
+| 7a      ||    842.7 |    573.0 |  -32%  ||    57.71 |    78.83 |  +37%  |  0.0000 |
+| 7b      ||    291.1 |    170.0 |  -42%  ||   145.84 |   188.71 |  +29%  |  0.0000 |
+| 7c      ||  24934.8 |  24052.1 |   -4%  ||     1.25 |     1.35 |   +8%  |  0.5023 |
+| 8a      ||    265.7 |    227.4 |  -14%  ||   175.51 |   191.36 |   +9%  |  0.0000 |
+| 8b      ||    278.7 |    190.5 |  -32%  ||   150.63 |   160.60 |   +7%  |  0.0000 |
+| 8c      ||  10244.0 |   9186.5 |  -10%  ||     4.17 |     4.67 |  +12%  |  0.0769 |
 | 8d      ||   3207.1 |   3075.1 |   -4%  ||    14.40 |    14.93 |   +4%  |  0.2832 |
+| 9a      ||   7219.1 |   5390.9 |  -25%  ||     5.02 |     5.40 |   +8%  |  0.0001 |
+| 9b      ||    789.7 |    511.4 |  -35%  ||    61.44 |    69.05 |  +12%  |  0.0000 |
 | 9c      ||   6897.0 |   7682.4 |  +11%  ||     4.97 |     5.02 |   +1%  |  0.1423 |
+| 9d      ||   8677.4 |   8571.7 |   -1%  ||     4.02 |     4.48 |  +12%  |  0.8440 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
+| Sum     || 415723.5 | 333977.0 |  -20%  ||          |          |        |         |
+| Geomean ||          |          |        ||          |          |  +10%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, 20 clients, shuffled**
<details>
<summary>
Sum of avg. item runtimes: -5%
 ||
Geometric mean of throughput changes: +5%
</summary>
```diff
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
+| TPC-H 01 ||    686.6 |   667.2 |   -3%  ||     3.62 |     3.80 |   +5%  |               0.0196 |
+| TPC-H 02 ||     40.3 |    39.3 |   -3%  ||     3.62 |     3.80 |   +5%  |               0.7083 |
+| TPC-H 03 ||    157.1 |   132.3 |  -16%  ||     3.62 |     3.80 |   +5%  |               0.0004 |
+| TPC-H 04 ||    114.4 |    94.4 |  -17%  ||     3.61 |     3.80 |   +5%  |               0.0015 |
+| TPC-H 05 ||    338.2 |   284.5 |  -16%  ||     3.61 |     3.80 |   +5%  |               0.0000 |
+| TPC-H 06 ||      8.0 |     7.3 |   -9%  ||     3.62 |     3.80 |   +5%  | (run time too short) |
+| TPC-H 07 ||    136.5 |   135.7 |   -1%  ||     3.62 |     3.80 |   +5%  |               0.8965 |
+| TPC-H 08 ||    110.2 |   108.7 |   -1%  ||     3.62 |     3.80 |   +5%  |               0.7772 |
+| TPC-H 09 ||    531.8 |   488.1 |   -8%  ||     3.62 |     3.80 |   +5%  |               0.0002 |
+| TPC-H 10 ||    208.0 |   206.5 |   -1%  ||     3.61 |     3.80 |   +5%  |               0.8457 |
+| TPC-H 11 ||     26.7 |    30.5 |  +14%  ||     3.62 |     3.80 |   +5%  | (run time too short) |
+| TPC-H 12 ||     85.9 |    70.6 |  -18%  ||     3.62 |     3.80 |   +5%  |               0.0013 |
+| TPC-H 13 ||    583.0 |   560.2 |   -4%  ||     3.61 |     3.80 |   +5%  |               0.0152 |
+| TPC-H 14 ||     52.9 |    54.7 |   +3%  ||     3.61 |     3.80 |   +5%  |               0.6380 |
+| TPC-H 15 ||     31.1 |    27.9 |  -10%  ||     3.62 |     3.80 |   +5%  |               0.2005 |
+| TPC-H 16 ||    180.6 |   166.4 |   -8%  ||     3.62 |     3.80 |   +5%  |               0.0405 |
+| TPC-H 17 ||     39.9 |    37.3 |   -6%  ||     3.62 |     3.80 |   +5%  |               0.4772 |
+| TPC-H 18 ||   1407.4 |  1408.2 |   +0%  ||     3.61 |     3.79 |   +5%  |               0.9384 |
+| TPC-H 19 ||     69.7 |    62.1 |  -11%  ||     3.62 |     3.80 |   +5%  |               0.0583 |
+| TPC-H 20 ||     62.5 |    53.5 |  -14%  ||     3.62 |     3.80 |   +5%  |               0.0309 |
+| TPC-H 21 ||    452.1 |   429.4 |   -5%  ||     3.61 |     3.79 |   +5%  |               0.0628 |
+| TPC-H 22 ||     88.7 |    82.0 |   -8%  ||     3.62 |     3.80 |   +5%  |               0.2004 |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
+| Sum      ||   5411.3 |  5146.6 |   -5%  ||          |          |        |                      |
+| Geomean  ||          |         |        ||          |          |   +5%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>

**hyriseBenchmarkTPCH - multi-threaded, 50 clients, shuffled**
<details>
<summary>
Sum of avg. item runtimes: -9%
 ||
Geometric mean of throughput changes: +9%
</summary>

```diff
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
+| TPC-H 01 ||    961.2 |   853.4 |  -11%  ||     5.70 |     6.23 |   +9%  |               0.0000 |
+| TPC-H 02 ||     62.6 |    53.3 |  -15%  ||     5.71 |     6.24 |   +9%  |               0.0615 |
+| TPC-H 03 ||    257.0 |   218.8 |  -15%  ||     5.71 |     6.24 |   +9%  |               0.0016 |
+| TPC-H 04 ||    187.5 |   140.8 |  -25%  ||     5.71 |     6.24 |   +9%  |               0.0000 |
+| TPC-H 05 ||    561.0 |   473.3 |  -16%  ||     5.70 |     6.23 |   +9%  |               0.0000 |
+| TPC-H 06 ||     15.3 |    11.0 |  -28%  ||     5.71 |     6.24 |   +9%  | (run time too short) |
+| TPC-H 07 ||    263.3 |   221.3 |  -16%  ||     5.71 |     6.24 |   +9%  |               0.0006 |
+| TPC-H 08 ||    173.8 |   160.6 |   -8%  ||     5.71 |     6.24 |   +9%  |               0.1253 |
+| TPC-H 09 ||    897.2 |   794.7 |  -11%  ||     5.70 |     6.23 |   +9%  |               0.0000 |
+| TPC-H 10 ||    384.5 |   343.2 |  -11%  ||     5.71 |     6.23 |   +9%  |               0.0015 |
+| TPC-H 11 ||     67.3 |    73.5 |   +9%  ||     5.71 |     6.24 |   +9%  |               0.3782 |
+| TPC-H 12 ||    176.8 |   130.3 |  -26%  ||     5.71 |     6.24 |   +9%  |               0.0000 |
+| TPC-H 13 ||    928.7 |   936.5 |   +1%  ||     5.70 |     6.23 |   +9%  |               0.6383 |
+| TPC-H 14 ||    110.1 |    96.5 |  -12%  ||     5.71 |     6.24 |   +9%  |               0.1020 |
+| TPC-H 15 ||     54.8 |    34.4 |  -37%  ||     5.71 |     6.24 |   +9%  |               0.0000 |
+| TPC-H 16 ||    330.1 |   287.0 |  -13%  ||     5.71 |     6.23 |   +9%  |               0.0007 |
+| TPC-H 17 ||     74.3 |    65.4 |  -12%  ||     5.71 |     6.24 |   +9%  |               0.1815 |
+| TPC-H 18 ||   1912.7 |  1971.2 |   +3%  ||     5.69 |     6.22 |   +9%  |               0.0006 |
+| TPC-H 19 ||    109.3 |   101.0 |   -8%  ||     5.71 |     6.24 |   +9%  |               0.2784 |
+| TPC-H 20 ||    103.9 |    96.7 |   -7%  ||     5.71 |     6.24 |   +9%  |               0.3845 |
+| TPC-H 21 ||    801.4 |   665.4 |  -17%  ||     5.70 |     6.23 |   +9%  |               0.0000 |
+| TPC-H 22 ||    196.6 |   157.0 |  -20%  ||     5.71 |     6.24 |   +9%  |               0.0004 |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
+| Sum      ||   8629.7 |  7885.4 |   -9%  ||          |          |        |                      |
+| Geomean  ||          |         |        ||          |          |   +9%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>

**hyriseBenchmarkTPCH - multi-threaded, 200 clients, shuffled**
<details>
<summary>
Sum of avg. item runtimes: -48%
 ||
Geometric mean of throughput changes: +10%
</summary>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   2569.6 |  1031.9 |  -60%  ||     6.35 |     7.01 |  +11%  |  0.0000 |
+| TPC-H 02 ||    342.9 |   114.5 |  -67%  ||     6.38 |     7.02 |  +10%  |  0.0000 |
+| TPC-H 03 ||   1250.2 |   652.1 |  -48%  ||     6.36 |     7.01 |  +10%  |  0.0000 |
+| TPC-H 04 ||    816.7 |   586.6 |  -28%  ||     6.37 |     7.01 |  +10%  |  0.0008 |
+| TPC-H 05 ||   2384.3 |  1489.7 |  -38%  ||     6.34 |     7.01 |  +10%  |  0.0000 |
+| TPC-H 06 ||    134.8 |   105.8 |  -22%  ||     6.38 |     7.02 |  +10%  |  0.1452 |
+| TPC-H 07 ||   1263.8 |   949.1 |  -25%  ||     6.36 |     7.00 |  +10%  |  0.0004 |
+| TPC-H 08 ||    853.0 |   483.9 |  -43%  ||     6.37 |     7.02 |  +10%  |  0.0000 |
+| TPC-H 09 ||   3221.4 |  2041.4 |  -37%  ||     6.35 |     7.00 |  +10%  |  0.0000 |
+| TPC-H 10 ||   1503.6 |   822.3 |  -45%  ||     6.36 |     7.01 |  +10%  |  0.0000 |
+| TPC-H 11 ||    432.0 |   207.1 |  -52%  ||     6.38 |     7.02 |  +10%  |  0.0000 |
+| TPC-H 12 ||    868.9 |   462.9 |  -47%  ||     6.37 |     7.02 |  +10%  |  0.0000 |
+| TPC-H 13 ||   3045.7 |  1357.4 |  -55%  ||     6.34 |     7.01 |  +11%  |  0.0000 |
+| TPC-H 14 ||    379.4 |   265.3 |  -30%  ||     6.38 |     7.02 |  +10%  |  0.0050 |
+| TPC-H 15 ||    214.4 |    63.0 |  -71%  ||     6.38 |     7.03 |  +10%  |  0.0000 |
+| TPC-H 16 ||   1207.9 |   517.7 |  -57%  ||     6.37 |     7.02 |  +10%  |  0.0000 |
+| TPC-H 17 ||    295.6 |   205.1 |  -31%  ||     6.38 |     7.02 |  +10%  |  0.0022 |
+| TPC-H 18 ||   4352.9 |  1990.8 |  -54%  ||     6.33 |     7.00 |  +11%  |  0.0000 |
+| TPC-H 19 ||    526.5 |   315.2 |  -40%  ||     6.37 |     7.02 |  +10%  |  0.0002 |
+| TPC-H 20 ||    593.2 |   291.6 |  -51%  ||     6.38 |     7.02 |  +10%  |  0.0000 |
+| TPC-H 21 ||   3352.2 |  1766.5 |  -47%  ||     6.33 |     7.01 |  +11%  |  0.0000 |
+| TPC-H 22 ||   1077.5 |   390.2 |  -64%  ||     6.37 |     7.02 |  +10%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||  30686.6 | 16109.8 |  -48%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |  +10%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>