### PR TITLE
Fix -march=native once and for all (?)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,15 +79,13 @@ set(FLAGS_ALL "-fopenmp-simd")  # enables loop vectorization hints, but does not
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${FLAGS_ALL}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FLAGS_ALL}")
 
-# Build the binary optimized for the current system, ignoring older systems. For x86 systems, we use -march=native.
-# Clang does not support -march=native on ARM. ARM recommends setting -mcpu for both GCC and Clang instead of march:
-# https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
-# We check specifically for arm64 (e.g., Apple's M1) or aarch64 (e.g., Raspberry Pi 4), as these are the two ARM architectures we have tested so far.
-# Match for "arm" on your own risk to include other ARM architures.
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
-    set(FLAGS_RELEASE "-mcpu=native")
-else()
-    set(FLAGS_RELEASE "-march=native")  
+# Build the binary optimized for the current system, ignoring older systems.
+# Not all environments support march=native - check before we use it.
+set(FLAGS_RELEASE "-mcpu=native -mtune=native")
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+if(COMPILER_SUPPORTS_MARCH_NATIVE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
 endif()
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${FLAGS_ALL} ${FLAGS_RELEASE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,12 +80,13 @@ set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} ${FLAGS_ALL}")
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${FLAGS_ALL}")
 
 # Build the binary optimized for the current system, ignoring older systems.
-# Not all environments support march=native - check before we use it.
-set(FLAGS_RELEASE "-mcpu=native -mtune=native")
+# Not all environments support march=native - check before we use it. Otherwise use mcpu.
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
 if(COMPILER_SUPPORTS_MARCH_NATIVE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    set(FLAGS_RELEASE "${FLAGS_RELEASE} -march=native")
+else()
+    set(FLAGS_RELEASE "${FLAGS_RELEASE} -mcpu=native")
 endif()
 
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${FLAGS_ALL} ${FLAGS_RELEASE}")


### PR DESCRIPTION
This should enable `-march=native` for exactly those architecture/compiler combinations that support it:

https://github.com/hyrise/hyrise/pull/2306#issuecomment-767388729

- [x]  M1: builds with clang and no performance regression
- [x]  Raspberry PI: builds with clang/gcc and no performance regressions
