### PR TITLE
sql-parser: Fix unary minus

### DIFF
--- a/resources/benchmark/tpcds/query_blacklist.cfg
+++ b/resources/benchmark/tpcds/query_blacklist.cfg
@@ -1,5 +1,5 @@
 #01.sql
-02.sql
+#02.sql
 #03.sql
 04.sql
 05.sql
@@ -60,7 +60,7 @@
 56.sql
 57.sql
 58.sql
-59.sql
+#59.sql
 60.sql
 61.sql
 #62.sql

--- a/resources/test_data/sqlite_testrunner_queries.sql
+++ b/resources/test_data/sqlite_testrunner_queries.sql
@@ -8,7 +8,7 @@ SELECT * FROM mixed_null;
 
 -- No FROM clause
 SELECT 1;
-SELECT -1;
+SELECT -1 AS negative;
 SELECT (1 + 3.0) * 13.0 as some_arithmetics;
 SELECT 22 / 5 AS col;
 


### PR DESCRIPTION
In the sql-parser, we changed `-10` to be handled as `-(10)`. This fixes things like `1 + -10`.

- [ ] Run benchmarks
- [ ] Change sql-parser submodule to master once the feature is merged over there