### PR TITLE
wait_for_tasks: Execute own tasks first

### DIFF
--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -8,8 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
-
 #include "aggregate/aggregate_traits.hpp"
 #include "constant_mappings.hpp"
 #include "expression/pqp_column_expression.hpp"

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -93,8 +93,7 @@ size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t
       optimizer could identify these cases of potentially inefficient hash joins and switch to other join algorithms.
     */
     std::stringstream performance_warning;
-    performance_warning << "Build side larger than probe side in hash join (join mode: " // << magic_enum::enum_name(mode)
-                        << ").";
+    performance_warning << "Build side larger than probe side in hash join.";
     PerformanceWarning(performance_warning.str());
   }
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -92,9 +92,7 @@ size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t
       other join operators might be more efficient. We emit performance warning in this case. In the future, the
       optimizer could identify these cases of potentially inefficient hash joins and switch to other join algorithms.
     */
-    std::stringstream performance_warning;
-    performance_warning << "Build side larger than probe side in hash join.";
-    PerformanceWarning(performance_warning.str());
+    PerformanceWarning("Build side larger than probe side in hash join");
   }
 
   // We assume a cache of 1024 KB for an Intel Xeon Platinum 8180. For local deployments or other CPUs, this size might

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -93,7 +93,7 @@ size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t
       optimizer could identify these cases of potentially inefficient hash joins and switch to other join algorithms.
     */
     std::stringstream performance_warning;
-    performance_warning << "Build side larger than probe side in hash join (join mode: " << magic_enum::enum_name(mode)
+    performance_warning << "Build side larger than probe side in hash join (join mode: " // << magic_enum::enum_name(mode)
                         << ").";
     PerformanceWarning(performance_warning.str());
   }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -9,8 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
-
 #include "bytell_hash_map.hpp"
 #include "hyrise.hpp"
 #include "join_hash/join_hash_steps.hpp"

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -8,8 +8,6 @@
 #include <utility>
 #include <vector>
 
-#include <magic_enum.hpp>
-
 #include "all_type_variant.hpp"
 #include "join_nested_loop.hpp"
 #include "multi_predicate_join/multi_predicate_join_evaluator.hpp"

--- a/src/lib/operators/operator_performance_data.hpp
+++ b/src/lib/operators/operator_performance_data.hpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 
+// Warning: In the past, magic_enum has led to problems with TSan. See #2154 for details.
 #include <magic_enum.hpp>
 
 #include "types.hpp"

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -51,6 +51,8 @@ void AbstractTask::set_node_id(NodeID node_id) { _node_id = node_id; }
 
 bool AbstractTask::try_mark_as_enqueued() { return !_is_enqueued.exchange(true); }
 
+bool AbstractTask::try_mark_as_assigned_to_worker() { return !_is_assigned_to_worker.exchange(true); }
+
 void AbstractTask::set_done_callback(const std::function<void()>& done_callback) {
   DebugAssert((!_is_scheduled), "Possible race: Don't set callback after the Task was scheduled");
 

--- a/src/lib/scheduler/abstract_task.hpp
+++ b/src/lib/scheduler/abstract_task.hpp
@@ -106,6 +106,12 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
   bool try_mark_as_enqueued();
 
   /**
+   * returns true whether the caller is atomically the first to try to assign this task to a worker,
+   * false otherwise.
+   */
+  bool try_mark_as_assigned_to_worker();
+
+  /**
    * Executes the task in the current Thread, blocks until all operations are finished
    */
   void execute();
@@ -144,9 +150,12 @@ class AbstractTask : public std::enable_shared_from_this<AbstractTask> {
 
   // For making sure a task gets only scheduled and enqueued once, respectively
   // A Task is scheduled once schedule() is called and enqueued, which is an internal process, once it has been added
-  // to a TaskQueue
+  // to a TaskQueue. Once a worker has chosen to execute this task (and it is thus can no longer be executed by anyone
+  // else), _is_assigned_to_worker is set to true.
+  // TODO(anyone): Change this into proper state transitions, see TransactionContext as an example.
   std::atomic_bool _is_enqueued{false};
   std::atomic_bool _is_scheduled{false};
+  std::atomic_bool _is_assigned_to_worker{false};
 
   // For making Tasks join()-able
   std::condition_variable _done_condition_variable;

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -158,9 +158,10 @@ void Worker::_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& t
         continue;
       }
 
-      // Give other tasks a certain chance of being executed, too. Anectotal evidence says that this is a good idea.
-      // For some reason, this keeps the memory consumption of TPC-H Q6 low even if the scheduler is overcommitted.
-      // Because generating random numbers is somewhat expensive, we keep a list of random numbers and reuse them.
+      // Give other tasks, i.e., tasks that are unrelated to what we are currently waiting on, a certain chance of being
+      // executed, too. Anectotal evidence says that this is a good idea. For some reason, this keeps the memory
+      // consumption of TPC-H Q6 low even if the scheduler is overcommitted. Because generating random numbers is
+      // somewhat expensive, we keep a list of random numbers and reuse them.
       // TODO(anyone): Look deeper into scheduling theory and make this theoretically sound.
       _next_random = (_next_random + 1) % _random.size();
       if (_random[_next_random] <= 20) {

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <memory>
 #include <mutex>
+#include <random>
 #include <thread>
 #include <vector>
 

--- a/src/lib/scheduler/worker.cpp
+++ b/src/lib/scheduler/worker.cpp
@@ -33,7 +33,12 @@ namespace opossum {
 std::shared_ptr<Worker> Worker::get_this_thread_worker() { return ::this_thread_worker.lock(); }
 
 Worker::Worker(const std::shared_ptr<TaskQueue>& queue, WorkerID id, CpuID cpu_id)
-    : _queue(queue), _id(id), _cpu_id(cpu_id) {}
+    : _queue(queue), _id(id), _cpu_id(cpu_id) {
+  // Generate a random distribution from 0-99 for later use, see below
+  _random.resize(100);
+  std::iota(_random.begin(), _random.end(), 0);
+  std::shuffle(_random.begin(), _random.end(), std::default_random_engine{std::random_device{}()});
+}
 
 WorkerID Worker::id() const { return _id; }
 
@@ -90,6 +95,12 @@ void Worker::_work() {
     }
   }
 
+  const auto successfully_assigned = task->try_mark_as_assigned_to_worker();
+  if (!successfully_assigned) {
+    // Some other worker has already started to work on this task - pick a different one.
+    return;
+  }
+
   task->execute();
 
   // This is part of the Scheduler shutdown system. Count the number of tasks a Worker executed to allow the
@@ -114,7 +125,7 @@ void Worker::execute_next(const std::shared_ptr<AbstractTask>& task) {
     Assert(successfully_enqueued, "Task was already enqueued, expected to be solely responsible for execution");
     _next_task = task;
   } else {
-    _queue->push(task, static_cast<uint32_t>(SchedulePriority::High));
+    _queue->push(task, static_cast<uint32_t>(SchedulePriority::Default));
   }
 }
 
@@ -128,17 +139,58 @@ void Worker::join() {
 uint64_t Worker::num_finished_tasks() const { return _num_finished_tasks; }
 
 void Worker::_wait_for_tasks(const std::vector<std::shared_ptr<AbstractTask>>& tasks) {
-  auto tasks_completed = [&tasks]() {
-    // Reversely iterate through the list of tasks, because unfinished tasks are likely at the end of the list.
-    for (auto it = tasks.rbegin(); it != tasks.rend(); ++it) {
-      if (!(*it)->is_done()) {
+  // This lambda checks if all tasks from the vector have been executed. If they are, it causes _wait_for_tasks to
+  // return. If there are remaining tasks, it primarily tries to execute these. If they cannot be executed, the
+  // worker performs work for others (i.e., executes tasks from the queue).
+  auto check_own_tasks = [&]() {
+    auto all_done = true;
+    // Note: If we found a task that has not yet been executed, we reset this loop and start from the beginning.
+    // As such, both all_done and it may be reset outside of the following line.
+    for (auto it = tasks.begin(); it != tasks.end(); ++it) {
+      const auto& task = *it;
+      if (task->is_done()) {
+        continue;
+      }
+
+      // Task is not yet done - check if it is ready for execution
+      if (!task->is_ready()) {
+        all_done = false;
+        continue;
+      }
+
+      // Give other tasks a certain chance of being executed, too. Anectotal evidence says that this is a good idea.
+      // For some reason, this keeps the memory consumption of TPC-H Q6 low even if the scheduler is overcommitted.
+      // Because generating random numbers is somewhat expensive, we keep a list of random numbers and reuse them.
+      // TODO(anyone): Look deeper into scheduling theory and make this theoretically sound.
+      _next_random = (_next_random + 1) % _random.size();
+      if (_random[_next_random] <= 20) {
         return false;
       }
+
+      // Run one of our own tasks. First, let everyone know that we are about to execute it. This is necessary because
+      // the task is already in a queue and some other worker might pull it at the same time.
+      const auto successfully_assigned = task->try_mark_as_assigned_to_worker();
+      if (!successfully_assigned) {
+        // Some other worker has already started to work on this task - pick a different one.
+        all_done = false;
+        continue;
+      }
+
+      // Actually execute it.
+      task->execute();
+      ++_num_finished_tasks;
+
+      // Reset loop so that we re-visit tasks that may have finished in the meantime. We need to decrement `it` because
+      // it will be incremented when the loop iteration finishes.
+      all_done = true;
+      it = tasks.begin() - 1;
     }
-    return true;
+    return all_done;
   };
 
-  while (!tasks_completed()) {
+  while (!check_own_tasks()) {
+    // Run any job. this could be any job that is currently enqueued. Note: This job may internally call wait_for_tasks
+    // again, in which case we would first wait for the inner task before the outer task has a chance to proceed.
     _work();
   }
 }

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include <random>
 #include <thread>
 #include <vector>
 
@@ -66,6 +67,9 @@ class Worker : public std::enable_shared_from_this<Worker>, private Noncopyable 
   CpuID _cpu_id;
   std::thread _thread;
   std::atomic<uint64_t> _num_finished_tasks{0};
+
+  std::vector<int> _random{};
+  size_t _next_random{};
 };
 
 }  // namespace opossum

--- a/src/lib/scheduler/worker.hpp
+++ b/src/lib/scheduler/worker.hpp
@@ -2,7 +2,6 @@
 
 #include <atomic>
 #include <memory>
-#include <random>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
(This PR replaces #2311. Something is amiss with Jenkins in a way that we have not seen before. Assuming that this is a freak accident, I simply reopened the PR. If this reoccurs, we have to look into it.)

- [x] Fix join_hash.cpp
- [x] Decide how to progress with magic_enum, document in #2154 

Currently, `Worker::wait_for_tasks` checks if all tasks are completed. If they are not, the worker pulls tasks from the queue and executes them until all tasks that we wait on are done. This, however, leads to a problem if one of the pulled tasks calls `wait_for_tasks` itself. Over time, the worker builds a stack of `wait_for_tasks` calls and the first task has to wait until all tasks that the worker started because it was bored are completed.

**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.4TB |
| numactl | nodebind: 0  |
| numactl | membind: 0  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 3b2f4c148 | 24.01.2021 12:16 | Update README.md (#2309) | real 447.40 user 2952.27 sys 142.88|
| 72331c3a8 | 06.02.2021 12:14 | Get it to compile | real 446.63 user 2952.24 sys 134.77|


**hyriseBenchmarkTPCH - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_72331c3a86447303c4f45d935ec2f7a7162d7921_st.json |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                         |
 |  benchmark_mode          | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type              | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size              | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler                | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                   | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                    | 2021-01-26 02:14:15                                                                                                                    | 2021-02-06 11:22:55                                                                                                                    |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                 | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration            | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor            | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit               | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler         | False                                                                                                                                  | False                                                                                                                                  |
 |  verify                  | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration         | 0                                                                                                                                      | 0                                                                                                                                      |
 +--------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||    518.5 |   503.2 |   -3%  ||     1.93 |     1.99 |   +3%  |  0.0000 |
 | TPC-H 02 ||      4.2 |     4.2 |   -2%  ||   235.65 |   240.68 |   +2%  |  0.0049 |
 | TPC-H 03 ||     71.4 |    71.8 |   +1%  ||    14.01 |    13.92 |   -1%  |  0.0000 |
 | TPC-H 04 ||     63.3 |    63.1 |   -0%  ||    15.79 |    15.84 |   +0%  |  0.0000 |
 | TPC-H 05 ||    194.1 |   196.2 |   +1%  ||     5.15 |     5.10 |   -1%  |  0.0000 |
 | TPC-H 06 ||      3.4 |     3.5 |   +1%  ||   292.14 |   289.50 |   -1%  |  0.0000 |
 | TPC-H 07 ||     50.7 |    50.5 |   -0%  ||    19.73 |    19.81 |   +0%  |  0.6665 |
 | TPC-H 08 ||     54.7 |    54.6 |   -0%  ||    18.27 |    18.32 |   +0%  |  0.6371 |
 | TPC-H 09 ||    442.3 |   445.7 |   +1%  ||     2.26 |     2.24 |   -1%  |  0.0312 |
 | TPC-H 10 ||    102.4 |   102.1 |   -0%  ||     9.76 |     9.80 |   +0%  |  0.0510 |
 | TPC-H 11 ||      8.1 |     7.8 |   -3%  ||   123.41 |   127.65 |   +3%  |  0.0000 |
 | TPC-H 12 ||     41.0 |    41.1 |   +0%  ||    24.36 |    24.32 |   -0%  |  0.1575 |
 | TPC-H 13 ||    329.5 |   331.1 |   +0%  ||     3.03 |     3.02 |   -1%  |  0.1414 |
 | TPC-H 14 ||     17.8 |    17.8 |   +0%  ||    56.16 |    56.05 |   -0%  |  0.0076 |
 | TPC-H 15 ||      6.8 |     6.8 |   +0%  ||   147.06 |   147.03 |   -0%  |  0.7447 |
 | TPC-H 16 ||     63.2 |    63.3 |   +0%  ||    15.82 |    15.79 |   -0%  |  0.0087 |
+| TPC-H 17 ||     15.4 |    14.7 |   -4%  ||    65.13 |    68.19 |   +5%  |  0.0000 |
 | TPC-H 18 ||    503.4 |   519.4 |   +3%  ||     1.99 |     1.93 |   -3%  |  0.0000 |
 | TPC-H 19 ||     27.8 |    27.2 |   -2%  ||    36.03 |    36.82 |   +2%  |  0.0000 |
 | TPC-H 20 ||     14.3 |    14.1 |   -1%  ||    70.05 |    70.78 |   +1%  |  0.0002 |
 | TPC-H 21 ||    337.3 |   341.5 |   +1%  ||     2.96 |     2.93 |   -1%  |  0.0078 |
 | TPC-H 22 ||     31.3 |    31.3 |   +0%  ||    31.94 |    31.93 |   -0%  |  0.7498 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||   2900.9 |  2911.0 |   +0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +0%
 ||
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st_s01.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_72331c3a86447303c4f45d935ec2f7a7162d7921_st_s01.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                             | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 10.2                                                                                                                                   | gcc 10.2                                                                                                                                   |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2021-01-26 02:36:26                                                                                                                        | 2021-02-06 11:45:06                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 0.009999999776482582                                                                                                                       | 0.009999999776482582                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      4.8 |     5.0 |   +4%  ||   206.83 |   199.32 |   -4%  |  0.0000 |
 | TPC-H 02 ||      0.5 |     0.5 |   -0%  ||  1889.51 |  1897.58 |   +0%  |  0.3233 |
 | TPC-H 03 ||      0.7 |     0.7 |   -3%  ||  1340.14 |  1377.87 |   +3%  |  0.0000 |
 | TPC-H 04 ||      0.4 |     0.4 |   -2%  ||  2290.36 |  2327.22 |   +2%  |  0.0000 |
 | TPC-H 05 ||      1.0 |     1.0 |   -1%  ||  1015.27 |  1028.92 |   +1%  |  0.0000 |
 | TPC-H 06 ||      0.1 |     0.1 |   +1%  ||  8981.41 |  8916.48 |   -1%  |  0.0000 |
 | TPC-H 07 ||      1.1 |     1.1 |   -2%  ||   878.71 |   896.08 |   +2%  |  0.0961 |
 | TPC-H 08 ||     14.8 |    14.8 |   -0%  ||    67.36 |    67.62 |   +0%  |  0.6198 |
 | TPC-H 09 ||      2.1 |     2.1 |   -1%  ||   475.82 |   479.39 |   +1%  |  0.0047 |
 | TPC-H 10 ||      0.8 |     0.8 |   -1%  ||  1236.83 |  1244.49 |   +1%  |  0.0000 |
 | TPC-H 11 ||      0.3 |     0.3 |   +1%  ||  3434.55 |  3415.46 |   -1%  |  0.0000 |
 | TPC-H 12 ||      0.6 |     0.6 |   -0%  ||  1642.99 |  1646.91 |   +0%  |  0.0000 |
 | TPC-H 13 ||      2.0 |     2.1 |   +3%  ||   496.36 |   479.68 |   -3%  |  0.0000 |
 | TPC-H 14 ||      0.3 |     0.3 |   +1%  ||  3289.20 |  3248.13 |   -1%  |  0.0000 |
 | TPC-H 15 ||      1.1 |     1.1 |   -1%  ||   888.23 |   893.13 |   +1%  |  0.0000 |
 | TPC-H 16 ||      1.9 |     1.9 |   +0%  ||   525.92 |   524.55 |   -0%  |  0.0000 |
 | TPC-H 17 ||      0.3 |     0.3 |   -3%  ||  3478.26 |  3584.26 |   +3%  |  0.0000 |
 | TPC-H 18 ||      2.5 |     2.5 |   +0%  ||   397.40 |   396.32 |   -0%  |  0.0000 |
 | TPC-H 19 ||      5.5 |     5.4 |   -1%  ||   182.78 |   184.19 |   +1%  |  0.0000 |
 | TPC-H 20 ||      2.3 |     2.3 |   -0%  ||   432.57 |   433.83 |   +0%  |  0.1029 |
 | TPC-H 21 ||      1.4 |     1.4 |   -1%  ||   689.22 |   696.88 |   +1%  |  0.0000 |
 | TPC-H 22 ||      1.1 |     1.1 |   -1%  ||   920.41 |   925.85 |   +1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     45.9 |    45.9 |   +0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 10**
<details>
<summary>
Sum of avg. item runtimes: +2%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st_s10.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_72331c3a86447303c4f45d935ec2f7a7162d7921_st_s10.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                             | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler                | gcc 10.2                                                                                                                                   | gcc 10.2                                                                                                                                   |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2021-01-26 02:58:30                                                                                                                        | 2021-02-06 12:07:10                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   5586.4 |  5573.1 |   -0%  ||     0.18 |     0.18 |   +0%  |  0.9411 |
 | TPC-H 02 ||     44.8 |    44.0 |   -2%  ||    22.31 |    22.73 |   +2%  |  0.0001 |
 | TPC-H 03 ||   1311.5 |  1314.5 |   +0%  ||     0.76 |     0.76 |   -0%  |  0.7353 |
 | TPC-H 04 ||   1390.6 |  1411.3 |   +1%  ||     0.72 |     0.71 |   -1%  |  0.0706 |
 | TPC-H 05 ||   2923.0 |  2950.7 |   +1%  ||     0.34 |     0.34 |   -1%  |  0.3183 |
 | TPC-H 06 ||     36.9 |    37.0 |   +0%  ||    27.09 |    27.04 |   -0%  |  0.6377 |
 | TPC-H 07 ||    755.3 |   766.7 |   +2%  ||     1.32 |     1.30 |   -1%  |  0.0000 |
 | TPC-H 08 ||    513.8 |   518.5 |   +1%  ||     1.95 |     1.93 |   -1%  |  0.0000 |
 | TPC-H 09 ||   6414.1 |  6523.4 |   +2%  ||     0.16 |     0.15 |   -2%  |  0.0026 |
 | TPC-H 10 ||   1797.6 |  1825.3 |   +2%  ||     0.56 |     0.55 |   -2%  |  0.0154 |
 | TPC-H 11 ||    102.4 |   100.6 |   -2%  ||     9.76 |     9.94 |   +2%  |  0.0000 |
 | TPC-H 12 ||    663.5 |   669.6 |   +1%  ||     1.51 |     1.49 |   -1%  |  0.0001 |
-| TPC-H 13 ||   4947.0 |  5195.3 |   +5%  ||     0.20 |     0.19 |   -5%  |  0.0000 |
 | TPC-H 14 ||    221.8 |   225.0 |   +1%  ||     4.51 |     4.45 |   -1%  |  0.0000 |
 | TPC-H 15 ||     73.3 |    76.7 |   +5%  ||    13.63 |    13.04 |   -4%  |  0.0000 |
 | TPC-H 16 ||    643.4 |   664.0 |   +3%  ||     1.55 |     1.51 |   -3%  |  0.0000 |
 | TPC-H 17 ||    223.5 |   224.6 |   +0%  ||     4.47 |     4.45 |   -0%  |  0.0000 |
 | TPC-H 18 ||   9530.7 |  9741.5 |   +2%  ||     0.10 |     0.10 |   -2%  |       ˅ |
 | TPC-H 19 ||    280.8 |   281.6 |   +0%  ||     3.56 |     3.55 |   -0%  |  0.0431 |
 | TPC-H 20 ||    148.1 |   148.4 |   +0%  ||     6.75 |     6.74 |   -0%  |  0.3038 |
 | TPC-H 21 ||   5174.2 |  5381.8 |   +4%  ||     0.19 |     0.19 |   -4%  |  0.0089 |
 | TPC-H 22 ||    439.7 |   453.2 |   +3%  ||     2.27 |     2.21 |   -3%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  43222.5 | 44126.7 |   +2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -7%
 ||
Geometric mean of throughput changes: +10%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCH_72331c3a86447303c4f45d935ec2f7a7162d7921_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2021-01-26 03:22:31                                                                                                                    | 2021-02-06 12:31:13                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1.0                                                                                                                                    | 1.0                                                                                                                                    |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  use_prepared_statements      | False                                                                                                                                  | False                                                                                                                                  |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                          | [0, 56, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||   1304.5 |  1136.5 |  -13%  ||    37.65 |    43.19 |  +15%  |  0.0000 |
+| TPC-H 02 ||     10.8 |     7.5 |  -31%  ||  3505.14 |  4212.31 |  +20%  |  0.0000 |
+| TPC-H 03 ||    176.5 |   162.2 |   -8%  ||   273.66 |   295.18 |   +8%  |  0.0000 |
+| TPC-H 04 ||    131.0 |   117.9 |  -10%  ||   363.27 |   385.79 |   +6%  |  0.0000 |
+| TPC-H 05 ||    501.0 |   477.1 |   -5%  ||    97.76 |   102.45 |   +5%  |  0.0111 |
+| TPC-H 06 ||     10.2 |     8.4 |  -18%  ||  3413.22 |  4176.83 |  +22%  |  0.0000 |
+| TPC-H 07 ||    103.4 |    89.4 |  -14%  ||   460.80 |   522.29 |  +13%  |  0.0000 |
+| TPC-H 08 ||    115.9 |   105.7 |   -9%  ||   411.51 |   441.60 |   +7%  |  0.0000 |
 | TPC-H 09 ||   1017.9 |   978.9 |   -4%  ||    47.90 |    49.98 |   +4%  |  0.1142 |
+| TPC-H 10 ||    262.6 |   237.8 |   -9%  ||   186.32 |   204.86 |  +10%  |  0.0000 |
+| TPC-H 11 ||     28.4 |    20.4 |  -28%  ||  1508.04 |  2000.51 |  +33%  |  0.0000 |
+| TPC-H 12 ||     89.0 |    62.4 |  -30%  ||   520.18 |   564.31 |   +8%  |  0.0000 |
+| TPC-H 13 ||    947.4 |   887.8 |   -6%  ||    51.79 |    55.15 |   +6%  |  0.0007 |
 | TPC-H 14 ||     55.8 |    54.3 |   -3%  ||   824.09 |   841.58 |   +2%  |  0.0000 |
+| TPC-H 15 ||     24.1 |    21.4 |  -11%  ||  1721.02 |  1894.55 |  +10%  |  0.0000 |
+| TPC-H 16 ||    208.3 |   196.9 |   -5%  ||   233.70 |   246.77 |   +6%  |  0.0000 |
+| TPC-H 17 ||     36.6 |    30.3 |  -17%  ||  1180.61 |  1312.33 |  +11%  |  0.0000 |
 | TPC-H 18 ||   2277.6 |  2237.6 |   -2%  ||    21.37 |    21.70 |   +2%  |  0.4016 |
 | TPC-H 19 ||     63.4 |    59.5 |   -6%  ||   715.63 |   746.82 |   +4%  |  0.0000 |
+| TPC-H 20 ||     39.5 |    36.3 |   -8%  ||  1127.79 |  1213.94 |   +8%  |  0.0000 |
+| TPC-H 21 ||    720.8 |   618.7 |  -14%  ||    68.01 |    74.79 |  +10%  |  0.0000 |
+| TPC-H 22 ||    105.4 |    97.2 |   -8%  ||   451.20 |   487.99 |   +8%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
+| Sum      ||   8230.3 |  7644.1 |   -7%  ||          |          |        |         |
+| Geomean  ||          |         |        ||          |          |  +10%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview--------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_72331c3a86447303c4f45d935ec2f7a7162d7921_st.json |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                          | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                          |
 |  benchmark_mode  | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type      | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size      | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients         | 1                                                                                                                                       | 1                                                                                                                                       |
 |  compiler        | gcc 10.2                                                                                                                                | gcc 10.2                                                                                                                                |
 |  cores           | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date            | 2021-01-26 03:44:52                                                                                                                     | 2021-02-06 12:53:34                                                                                                                     |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes         | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration    | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs        | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler | False                                                                                                                                   | False                                                                                                                                   |
 |  verify          | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration | 0                                                                                                                                       | 0                                                                                                                                       |
 +------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     22.8 |    22.8 |   -0%  ||    43.80 |    43.88 |   +0%  |  0.0091 |
+| 03      ||      6.1 |     5.8 |   -6%  ||   163.21 |   173.10 |   +6%  |  0.0000 |
 | 06      ||     16.5 |    16.2 |   -2%  ||    60.50 |    61.69 |   +2%  |  0.0000 |
+| 07      ||     28.2 |    25.4 |  -10%  ||    35.40 |    39.33 |  +11%  |  0.0000 |
 | 09      ||    111.2 |   112.4 |   +1%  ||     8.99 |     8.90 |   -1%  |  0.0000 |
+| 10      ||     18.0 |    17.1 |   -5%  ||    55.49 |    58.49 |   +5%  |  0.0000 |
 | 13      ||    112.9 |   113.5 |   +1%  ||     8.86 |     8.81 |   -1%  |  0.5769 |
 | 15      ||      8.8 |     8.8 |   -0%  ||   113.45 |   113.94 |   +0%  |  0.0000 |
 | 17      ||     26.7 |    26.2 |   -2%  ||    37.44 |    38.18 |   +2%  |  0.0027 |
+| 19      ||      9.1 |     8.6 |   -6%  ||   109.37 |   115.88 |   +6%  |  0.0000 |
+| 25      ||     14.4 |    13.7 |   -5%  ||    69.54 |    73.10 |   +5%  |  0.0000 |
+| 26      ||     13.9 |    12.8 |   -8%  ||    71.95 |    77.82 |   +8%  |  0.0000 |
 | 28      ||    932.9 |   949.5 |   +2%  ||     1.07 |     1.05 |   -2%  |  0.0000 |
 | 29      ||     23.8 |    23.0 |   -3%  ||    42.10 |    43.43 |   +3%  |  0.0000 |
 | 31      ||    104.8 |   103.6 |   -1%  ||     9.54 |     9.66 |   +1%  |  0.0000 |
+| 34      ||     15.8 |    14.7 |   -7%  ||    63.30 |    68.04 |   +7%  |  0.0000 |
 | 35      ||     61.7 |    61.2 |   -1%  ||    16.21 |    16.35 |   +1%  |  0.0000 |
 | 39a     ||    114.1 |   114.4 |   +0%  ||     8.76 |     8.74 |   -0%  |  0.1175 |
 | 39b     ||    113.3 |   112.8 |   -0%  ||     8.82 |     8.87 |   +1%  |  0.0000 |
 | 41      ||     25.4 |    25.6 |   +1%  ||    39.45 |    39.07 |   -1%  |  0.0000 |
+| 42      ||      7.4 |     7.0 |   -6%  ||   134.82 |   142.84 |   +6%  |  0.0000 |
 | 43      ||    201.9 |   205.7 |   +2%  ||     4.95 |     4.86 |   -2%  |  0.0000 |
 | 45      ||      8.5 |     8.3 |   -2%  ||   118.22 |   120.27 |   +2%  |  0.0000 |
 | 48      ||     76.1 |    75.0 |   -2%  ||    13.14 |    13.34 |   +2%  |  0.0000 |
+| 50      ||     10.2 |     9.8 |   -4%  ||    97.61 |   102.09 |   +5%  |  0.0000 |
+| 52      ||      7.5 |     7.1 |   -6%  ||   132.86 |   140.64 |   +6%  |  0.0000 |
+| 55      ||      7.4 |     7.0 |   -6%  ||   135.60 |   143.73 |   +6%  |  0.0000 |
 | 62      ||     50.6 |    50.2 |   -1%  ||    19.75 |    19.92 |   +1%  |  0.0000 |
 | 65      ||     52.5 |    51.1 |   -3%  ||    19.05 |    19.56 |   +3%  |  0.0000 |
 | 69      ||     16.7 |    16.1 |   -4%  ||    59.81 |    62.17 |   +4%  |  0.0000 |
+| 73      ||      9.5 |     8.9 |   -6%  ||   105.79 |   112.17 |   +6%  |  0.0000 |
 | 79      ||     35.8 |    34.8 |   -3%  ||    27.91 |    28.70 |   +3%  |  0.0000 |
 | 81      ||     14.8 |    14.6 |   -2%  ||    67.33 |    68.38 |   +2%  |  0.0000 |
 | 83      ||      8.1 |     8.0 |   -0%  ||   123.90 |   124.23 |   +0%  |  0.0000 |
 | 85      ||     51.0 |    50.5 |   -1%  ||    19.59 |    19.79 |   +1%  |  0.6197 |
+| 88      ||     63.7 |    59.3 |   -7%  ||    15.70 |    16.86 |   +7%  |  0.0000 |
 | 91      ||     17.7 |    17.7 |   -0%  ||    56.36 |    56.44 |   +0%  |  0.1051 |
 | 93      ||    249.7 |   252.0 |   +1%  ||     4.00 |     3.97 |   -1%  |  0.0000 |
+| 96      ||      6.8 |     6.5 |   -6%  ||   145.98 |   154.87 |   +6%  |  0.0000 |
-| 97      ||    306.3 |   336.7 |  +10%  ||     3.26 |     2.97 |   -9%  |  0.0000 |
 | 99      ||     98.8 |    96.7 |   -2%  ||    10.12 |    10.34 |   +2%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   3081.8 |  3111.1 |   +1%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +2%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -16%
 ||
Geometric mean of throughput changes: +13%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCDS_72331c3a86447303c4f45d935ec2f7a7162d7921_mt.json |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                          | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                          |
 |  benchmark_mode               | Ordered                                                                                                                                 | Ordered                                                                                                                                 |
 |  build_type                   | release                                                                                                                                 | release                                                                                                                                 |
 |  chunk_size                   | 65535                                                                                                                                   | 65535                                                                                                                                   |
 |  clients                      | 50                                                                                                                                      | 50                                                                                                                                      |
 |  compiler                     | gcc 10.2                                                                                                                                | gcc 10.2                                                                                                                                |
 |  cores                        | 0                                                                                                                                       | 0                                                                                                                                       |
 |  date                         | 2021-01-26 04:25:57                                                                                                                     | 2021-02-06 13:34:38                                                                                                                     |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                 | {'default': {'encoding': 'Dictionary'}}                                                                                                 |
 |  indexes                      | False                                                                                                                                   | False                                                                                                                                   |
 |  max_duration                 | 60000000000                                                                                                                             | 60000000000                                                                                                                             |
 |  max_runs                     | -1                                                                                                                                      | -1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                      | ns                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                    | True                                                                                                                                    |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                           | [0, 56, 0, 0]                                                                                                                           |
 |  verify                       | False                                                                                                                                   | False                                                                                                                                   |
 |  warmup_duration              | 0                                                                                                                                       | 0                                                                                                                                       |
 +-------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     71.2 |    68.4 |   -4%  ||   657.35 |   681.45 |   +4%  |  0.0000 |
+| 03      ||     17.9 |    16.3 |   -9%  ||  2247.38 |  2386.37 |   +6%  |  0.0000 |
+| 06      ||     51.8 |    42.0 |  -19%  ||   884.30 |  1029.57 |  +16%  |  0.0000 |
+| 07      ||     81.1 |    60.1 |  -26%  ||   579.97 |   736.54 |  +27%  |  0.0000 |
+| 09      ||    345.6 |   285.6 |  -17%  ||   141.41 |   170.50 |  +21%  |  0.0000 |
+| 10      ||     47.9 |    33.7 |  -30%  ||   925.64 |  1074.08 |  +16%  |  0.0000 |
 | 13      ||    349.4 |   334.7 |   -4%  ||   140.38 |   146.31 |   +4%  |  0.0001 |
+| 15      ||     41.2 |    32.2 |  -22%  ||  1092.18 |  1372.77 |  +26%  |  0.0000 |
+| 17      ||     79.0 |    60.4 |  -24%  ||   597.09 |   711.48 |  +19%  |  0.0000 |
+| 19      ||     30.0 |    24.8 |  -18%  ||  1452.24 |  1722.96 |  +19%  |  0.0000 |
+| 25      ||     45.9 |    37.7 |  -18%  ||   989.58 |  1143.80 |  +16%  |  0.0000 |
+| 26      ||     44.1 |    34.8 |  -21%  ||  1016.55 |  1232.27 |  +21%  |  0.0000 |
 | 28      ||   2101.1 |  1408.7 |  -33%  ||    17.41 |    17.08 |   -2%  |  0.0000 |
+| 29      ||     66.9 |    52.1 |  -22%  ||   694.71 |   798.09 |  +15%  |  0.0000 |
+| 31      ||    342.1 |   156.6 |  -54%  ||   143.20 |   169.34 |  +18%  |  0.0000 |
+| 34      ||     49.2 |    35.6 |  -28%  ||   925.85 |  1177.42 |  +27%  |  0.0000 |
+| 35      ||    208.4 |   190.2 |   -9%  ||   233.93 |   255.33 |   +9%  |  0.0000 |
 | 39a     ||    429.9 |   419.4 |   -2%  ||   114.21 |   116.27 |   +2%  |  0.0977 |
 | 39b     ||    429.5 |   418.2 |   -3%  ||   114.26 |   116.62 |   +2%  |  0.0823 |
-| 41      ||    542.4 |   603.0 |  +11%  ||    90.34 |    80.71 |  -11%  |  0.0000 |
+| 42      ||     21.4 |    17.8 |  -17%  ||  1927.81 |  2216.17 |  +15%  |  0.0000 |
+| 43      ||    536.3 |   476.9 |  -11%  ||    90.92 |    97.61 |   +7%  |  0.0000 |
+| 45      ||     23.6 |    20.0 |  -15%  ||  1723.59 |  1939.30 |  +13%  |  0.0000 |
+| 48      ||    215.5 |   173.5 |  -20%  ||   225.37 |   251.03 |  +11%  |  0.0000 |
+| 50      ||     32.6 |    27.7 |  -15%  ||  1346.15 |  1492.62 |  +11%  |  0.0000 |
+| 52      ||     21.9 |    17.9 |  -18%  ||  1903.61 |  2189.46 |  +15%  |  0.0000 |
+| 55      ||     20.6 |    17.1 |  -17%  ||  1988.10 |  2271.16 |  +14%  |  0.0000 |
+| 62      ||    135.2 |   124.7 |   -8%  ||   355.66 |   383.59 |   +8%  |  0.0000 |
+| 65      ||    212.6 |   192.8 |   -9%  ||   229.09 |   252.28 |  +10%  |  0.0000 |
+| 69      ||     46.6 |    32.3 |  -31%  ||   948.45 |  1116.96 |  +18%  |  0.0000 |
+| 73      ||     28.3 |    21.1 |  -25%  ||  1533.58 |  1857.29 |  +21%  |  0.0000 |
+| 79      ||    118.9 |    96.2 |  -19%  ||   402.85 |   492.33 |  +22%  |  0.0000 |
+| 81      ||     54.7 |    46.7 |  -15%  ||   838.58 |   970.14 |  +16%  |  0.0000 |
+| 83      ||     37.0 |    21.0 |  -43%  ||  1197.48 |  1922.46 |  +61%  |  0.0000 |
+| 85      ||    156.7 |   145.5 |   -7%  ||   308.40 |   329.22 |   +7%  |  0.0000 |
+| 88      ||    170.7 |    94.6 |  -45%  ||   253.89 |   311.15 |  +23%  |  0.0000 |
+| 91      ||     64.5 |    55.4 |  -14%  ||   722.81 |   827.26 |  +14%  |  0.0000 |
+| 93      ||    618.2 |   561.1 |   -9%  ||    79.59 |    86.61 |   +9%  |  0.0000 |
+| 96      ||     19.9 |    17.2 |  -14%  ||  2030.09 |  2330.40 |  +15%  |  0.0000 |
 | 97      ||    972.5 |   937.3 |   -4%  ||    50.39 |    52.45 |   +4%  |  0.0323 |
 | 99      ||    286.2 |   273.6 |   -4%  ||   171.40 |   178.76 |   +4%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||   9168.6 |  7684.7 |  -16%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |  +13%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 ||
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_72331c3a86447303c4f45d935ec2f7a7162d7921_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                         |
 |  benchmark_mode  | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2021-01-26 05:07:12                                                                                                                    | 2021-02-06 14:15:52                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor    | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     28.7 |    28.9 |   +1%  ||     3.73 |     3.68 |   -1%  | (run time too short) |
 | New-Order    ||     18.5 |    18.5 |   +0%  ||    41.79 |    41.68 |   -0%  | (run time too short) |
 | Order-Status ||      1.2 |     1.3 |   +2%  ||     3.72 |     3.72 |   +0%  | (run time too short) |
 | Payment      ||      2.5 |     2.5 |   -0%  ||    39.83 |    39.92 |   +0%  | (run time too short) |
 | Stock-Level  ||      4.1 |     4.1 |   +1%  ||     3.72 |     3.70 |   -0%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||     55.0 |    55.3 |   +1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -0%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +9%
 ||
Geometric mean of throughput changes: -9%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkTPCC_72331c3a86447303c4f45d935ec2f7a7162d7921_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                         | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                         |
 |  benchmark_mode               | Shuffled                                                                                                                               | Shuffled                                                                                                                               |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | gcc 10.2                                                                                                                               | gcc 10.2                                                                                                                               |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2021-01-26 05:08:15                                                                                                                    | 2021-02-06 14:16:56                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  scale_factor                 | 1                                                                                                                                      | 1                                                                                                                                      |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                          | [0, 56, 0, 0]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
-| Delivery     ||    131.4 |   144.9 |  +10%  ||     7.26 |     6.56 |  -10%  | (run time too short) |
 |    unsucc.:  ||      4.0 |     3.7 |   -7%  ||   133.80 |   133.71 |   -0%  |                      |
-| New-Order    ||     69.8 |    76.4 |  +10%  ||   121.50 |   112.02 |   -8%  |               0.0000 |
 |    unsucc.:  ||      4.0 |     3.9 |   -2%  ||  1465.16 |  1466.13 |   +0%  |                      |
 | Order-Status ||      6.3 |     6.5 |   +4%  ||   141.04 |   140.30 |   -1%  | (run time too short) |
-| Payment      ||     11.2 |    13.1 |  +17%  ||    10.70 |     7.97 |  -25%  | (run time too short) |
 |    unsucc.:  ||      3.7 |     3.7 |   +0%  ||  1505.67 |  1500.24 |   -0%  |                      |
 | Stock-Level  ||     17.5 |    17.5 |   -0%  ||   141.02 |   140.27 |   -1%  |               0.8297 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
-| Sum          ||    236.2 |   258.4 |   +9%  ||          |          |        |                      |
-| Geomean      ||          |         |        ||          |          |   -9%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 ||
Geometric mean of throughput changes: +2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_st.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_72331c3a86447303c4f45d935ec2f7a7162d7921_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                              | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 10.2                                                                                                                                    | gcc 10.2                                                                                                                                    |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2021-01-26 05:09:20                                                                                                                         | 2021-02-06 14:18:01                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    325.8 |    320.3 |   -2%  ||     3.07 |     3.12 |   +2%  |  0.0000 |
 | 10b     ||    319.6 |    314.6 |   -2%  ||     3.13 |     3.18 |   +2%  |  0.0000 |
 | 10c     ||    890.4 |    882.6 |   -1%  ||     1.12 |     1.13 |   +1%  |  0.0341 |
 | 11a     ||    137.8 |    134.4 |   -2%  ||     7.26 |     7.44 |   +3%  |  0.0102 |
 | 11b     ||    130.1 |    126.8 |   -3%  ||     7.69 |     7.89 |   +3%  |  0.0119 |
 | 11c     ||    501.6 |    490.0 |   -2%  ||     1.99 |     2.04 |   +2%  |  0.0183 |
 | 11d     ||   5109.1 |   5014.3 |   -2%  ||     0.20 |     0.20 |   +2%  |  0.3334 |
 | 12a     ||    276.4 |    275.4 |   -0%  ||     3.62 |     3.63 |   +0%  |  0.7103 |
 | 12b     ||    594.7 |    590.2 |   -1%  ||     1.68 |     1.69 |   +1%  |  0.4232 |
 | 12c     ||   3444.0 |   3456.2 |   +0%  ||     0.29 |     0.29 |   -0%  |  0.7097 |
 | 13a     ||    164.1 |    159.3 |   -3%  ||     6.09 |     6.28 |   +3%  |  0.0000 |
+| 13b     ||    246.1 |    234.9 |   -5%  ||     4.06 |     4.26 |   +5%  |  0.0000 |
+| 13c     ||    138.4 |    128.2 |   -7%  ||     7.23 |     7.80 |   +8%  |  0.0000 |
 | 13d     ||    163.7 |    158.7 |   -3%  ||     6.11 |     6.30 |   +3%  |  0.0000 |
 | 14a     ||   3937.5 |   3934.1 |   -0%  ||     0.25 |     0.25 |   +0%  |  0.9252 |
 | 14b     ||   4515.9 |   4516.8 |   +0%  ||     0.22 |     0.22 |   -0%  |  0.9834 |
 | 14c     ||   3926.9 |   3934.4 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.8312 |
+| 15a     ||    178.0 |    163.4 |   -8%  ||     5.62 |     6.12 |   +9%  |  0.0000 |
+| 15b     ||    174.6 |    160.3 |   -8%  ||     5.73 |     6.24 |   +9%  |  0.0000 |
+| 15c     ||    140.0 |    130.5 |   -7%  ||     7.14 |     7.66 |   +7%  |  0.0000 |
 | 15d     ||    451.3 |    440.1 |   -2%  ||     2.22 |     2.27 |   +3%  |  0.0000 |
 | 16a     ||   4633.0 |   4527.1 |   -2%  ||     0.22 |     0.22 |   +2%  |  0.2362 |
 | 16b     ||   6167.9 |   6096.6 |   -1%  ||     0.16 |     0.16 |   +1%  |  0.3144 |
 | 16c     ||   4710.5 |   4686.1 |   -1%  ||     0.21 |     0.21 |   +1%  |  0.7004 |
 | 16d     ||   4653.8 |   4694.5 |   +1%  ||     0.21 |     0.21 |   -1%  |  0.5442 |
 | 17a     ||    895.5 |    882.3 |   -1%  ||     1.12 |     1.13 |   +1%  |  0.0152 |
 | 17b     ||    697.5 |    691.6 |   -1%  ||     1.43 |     1.45 |   +1%  |  0.1455 |
 | 17c     ||    659.5 |    653.6 |   -1%  ||     1.52 |     1.53 |   +1%  |  0.1110 |
 | 17d     ||    775.2 |    765.8 |   -1%  ||     1.29 |     1.31 |   +1%  |  0.0289 |
 | 17e     ||   2617.5 |   2572.1 |   -2%  ||     0.38 |     0.39 |   +2%  |  0.0369 |
 | 17f     ||   1466.9 |   1458.6 |   -1%  ||     0.68 |     0.69 |   +1%  |  0.4123 |
 | 18a     ||    553.8 |    552.8 |   -0%  ||     1.81 |     1.81 |   +0%  |  0.7202 |
 | 18b     ||    207.9 |    200.3 |   -4%  ||     4.81 |     4.99 |   +4%  |  0.0000 |
 | 18c     ||   3603.7 |   3589.3 |   -0%  ||     0.28 |     0.28 |   +0%  |  0.4870 |
 | 19a     ||   5484.5 |   5533.9 |   +1%  ||     0.18 |     0.18 |   -1%  |  0.0502 |
 | 19b     ||   2551.1 |   2596.2 |   +2%  ||     0.39 |     0.39 |   -2%  |  0.0000 |
 | 19c     ||   5237.3 |   5299.1 |   +1%  ||     0.19 |     0.19 |   -1%  |  0.0007 |
 | 19d     ||   5557.3 |   5550.8 |   -0%  ||     0.18 |     0.18 |   +0%  |  0.9070 |
 | 1a      ||     55.9 |     54.5 |   -3%  ||    17.88 |    18.35 |   +3%  |  0.0000 |
+| 1b      ||     20.2 |     19.0 |   -6%  ||    49.38 |    52.62 |   +7%  |  0.0000 |
+| 1c      ||     20.2 |     18.9 |   -6%  ||    49.55 |    52.85 |   +7%  |  0.0000 |
+| 1d      ||     20.0 |     18.7 |   -6%  ||    50.07 |    53.43 |   +7%  |  0.0000 |
 | 20a     ||   1176.3 |   1159.0 |   -1%  ||     0.85 |     0.86 |   +1%  |  0.0000 |
 | 20b     ||   1018.3 |   1004.6 |   -1%  ||     0.98 |     1.00 |   +1%  |  0.0000 |
 | 20c     ||    662.7 |    652.3 |   -2%  ||     1.51 |     1.53 |   +2%  |  0.0000 |
 | 21a     ||   3629.0 |   3658.5 |   +1%  ||     0.28 |     0.27 |   -1%  |  0.0163 |
 | 21b     ||    227.1 |    224.8 |   -1%  ||     4.40 |     4.45 |   +1%  |  0.0002 |
 | 21c     ||   3793.7 |   3813.0 |   +1%  ||     0.26 |     0.26 |   -1%  |  0.1233 |
 | 22a     ||   3258.8 |   3280.9 |   +1%  ||     0.31 |     0.30 |   -1%  |  0.4212 |
 | 22b     ||   3257.8 |   3280.7 |   +1%  ||     0.31 |     0.30 |   -1%  |  0.4158 |
 | 22c     ||   3949.4 |   3952.7 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.9082 |
 | 22d     ||   3964.3 |   3969.3 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.8580 |
+| 23a     ||    140.8 |    131.3 |   -7%  ||     7.10 |     7.62 |   +7%  |  0.0000 |
+| 23b     ||     97.3 |     92.6 |   -5%  ||    10.28 |    10.80 |   +5%  |  0.0000 |
+| 23c     ||    154.6 |    145.3 |   -6%  ||     6.47 |     6.88 |   +6%  |  0.0000 |
 | 24a     ||   2621.1 |   2711.3 |   +3%  ||     0.38 |     0.37 |   -3%  |  0.0000 |
 | 24b     ||   2573.4 |   2586.8 |   +1%  ||     0.39 |     0.39 |   -1%  |  0.7417 |
 | 25a     ||    210.5 |    202.0 |   -4%  ||     4.75 |     4.95 |   +4%  |  0.0000 |
+| 25b     ||    226.8 |    216.1 |   -5%  ||     4.41 |     4.63 |   +5%  |  0.0000 |
 | 25c     ||   3610.7 |   3595.8 |   -0%  ||     0.28 |     0.28 |   +0%  |  0.3897 |
 | 26a     ||    554.2 |    544.3 |   -2%  ||     1.80 |     1.84 |   +2%  |  0.0000 |
 | 26b     ||    543.5 |    533.8 |   -2%  ||     1.84 |     1.87 |   +2%  |  0.0093 |
 | 26c     ||    554.7 |    544.8 |   -2%  ||     1.80 |     1.84 |   +2%  |  0.0004 |
 | 27a     ||   3287.2 |   3305.1 |   +1%  ||     0.30 |     0.30 |   -1%  |  0.3143 |
 | 27b     ||   3266.2 |   3283.5 |   +1%  ||     0.31 |     0.30 |   -1%  |  0.3261 |
 | 27c     ||    185.2 |    178.5 |   -4%  ||     5.40 |     5.60 |   +4%  |  0.0000 |
 | 28a     ||   3983.0 |   3991.5 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.9226 |
 | 28b     ||   3199.0 |   3215.9 |   +1%  ||     0.31 |     0.31 |   -1%  |  0.8478 |
 | 28c     ||   3981.8 |   3986.7 |   +0%  ||     0.25 |     0.25 |   -0%  |  0.9537 |
 | 29a     ||   2540.1 |   2573.5 |   +1%  ||     0.39 |     0.39 |   -1%  |  0.8346 |
+| 29b     ||    175.9 |    166.5 |   -5%  ||     5.69 |     6.01 |   +6%  |  0.3124 |
 | 29c     ||   2602.4 |   2654.8 |   +2%  ||     0.38 |     0.38 |   -2%  |  0.7398 |
 | 2a      ||     86.5 |     84.0 |   -3%  ||    11.56 |    11.91 |   +3%  |  0.0000 |
 | 2b      ||     70.0 |     67.3 |   -4%  ||    14.28 |    14.87 |   +4%  |  0.0000 |
+| 2c      ||     46.8 |     44.5 |   -5%  ||    21.37 |    22.47 |   +5%  |  0.0000 |
 | 2d      ||    110.4 |    107.8 |   -2%  ||     9.06 |     9.28 |   +2%  |  0.0000 |
 | 30a     ||    225.3 |    216.4 |   -4%  ||     4.44 |     4.62 |   +4%  |  0.0280 |
 | 30b     ||   1020.9 |   1028.1 |   +1%  ||     0.98 |     0.97 |   -1%  |  0.7158 |
 | 30c     ||   3630.1 |   3621.5 |   -0%  ||     0.28 |     0.28 |   +0%  |  0.9077 |
+| 31a     ||    259.4 |    246.4 |   -5%  ||     3.85 |     4.06 |   +5%  |  0.0000 |
 | 31b     ||   1047.9 |   1052.8 |   +0%  ||     0.95 |     0.95 |   -0%  |  0.6851 |
+| 31c     ||    262.8 |    249.4 |   -5%  ||     3.81 |     4.01 |   +5%  |  0.0000 |
+| 32a     ||     33.8 |     31.3 |   -7%  ||    29.54 |    31.94 |   +8%  |  0.0000 |
 | 32b     ||    257.9 |    252.9 |   -2%  ||     3.88 |     3.95 |   +2%  |  0.0000 |
+| 33a     ||     61.8 |     58.1 |   -6%  ||    16.19 |    17.20 |   +6%  |  0.0000 |
+| 33b     ||     61.3 |     57.5 |   -6%  ||    16.32 |    17.40 |   +7%  |  0.0000 |
+| 33c     ||     73.1 |     69.4 |   -5%  ||    13.67 |    14.41 |   +5%  |  0.0000 |
 | 3a      ||   3699.6 |   3723.9 |   +1%  ||     0.27 |     0.27 |   -1%  |  0.0000 |
+| 3b      ||     31.5 |     29.7 |   -6%  ||    31.72 |    33.70 |   +6%  |  0.0000 |
 | 3c      ||   4620.6 |   4634.2 |   +0%  ||     0.22 |     0.22 |   -0%  |  0.1142 |
 | 4a      ||    107.3 |    104.4 |   -3%  ||     9.32 |     9.58 |   +3%  |  0.0000 |
+| 4b      ||     24.4 |     22.7 |   -7%  ||    41.06 |    44.15 |   +8%  |  0.0000 |
 | 4c      ||    118.5 |    115.5 |   -3%  ||     8.44 |     8.66 |   +3%  |  0.0000 |
 | 5a      ||   3574.7 |   3605.5 |   +1%  ||     0.28 |     0.28 |   -1%  |  0.0000 |
 | 5b      ||    254.7 |    254.4 |   -0%  ||     3.93 |     3.93 |   +0%  |  0.4476 |
 | 5c      ||   4234.3 |   4233.5 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.7565 |
 | 6a      ||    203.2 |    194.5 |   -4%  ||     4.92 |     5.14 |   +4%  |  0.0000 |
 | 6b      ||    891.1 |    886.8 |   -0%  ||     1.12 |     1.13 |   +0%  |  0.0546 |
+| 6c      ||    203.4 |    194.4 |   -4%  ||     4.92 |     5.14 |   +5%  |  0.0000 |
 | 6d      ||    893.9 |    888.8 |   -1%  ||     1.12 |     1.13 |   +1%  |  0.0000 |
 | 6e      ||    203.3 |    194.8 |   -4%  ||     4.92 |     5.13 |   +4%  |  0.0000 |
 | 6f      ||   1418.4 |   1406.4 |   -1%  ||     0.71 |     0.71 |   +1%  |  0.0000 |
 | 7a      ||    343.1 |    332.8 |   -3%  ||     2.91 |     3.00 |   +3%  |  0.0075 |
+| 7b      ||    124.5 |    114.7 |   -8%  ||     8.03 |     8.72 |   +9%  |  0.0000 |
 | 7c      ||  10234.0 |  10145.1 |   -1%  ||     0.10 |     0.10 |   +1%  |       ˅ |
 | 8a      ||     95.6 |     93.8 |   -2%  ||    10.45 |    10.66 |   +2%  |  0.0000 |
 | 8b      ||    147.1 |    143.8 |   -2%  ||     6.80 |     6.95 |   +2%  |  0.0000 |
 | 8c      ||   4011.0 |   3934.4 |   -2%  ||     0.25 |     0.25 |   +2%  |  0.0042 |
 | 8d      ||   1233.0 |   1221.4 |   -1%  ||     0.81 |     0.82 |   +1%  |  0.0010 |
 | 9a      ||   3260.3 |   3282.8 |   +1%  ||     0.31 |     0.30 |   -1%  |  0.2163 |
 | 9b      ||    319.4 |    314.7 |   -1%  ||     3.13 |     3.18 |   +1%  |  0.0043 |
 | 9c      ||   3244.9 |   3269.8 |   +1%  ||     0.31 |     0.31 |   -1%  |  0.1464 |
 | 9d      ||   3891.4 |   3901.0 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.6382 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 190432.3 | 190114.1 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   +2%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -20%
 ||
Geometric mean of throughput changes: +7%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_3b2f4c1487617e8cffd00f0c1f888e4a5442165a_mt.json | /home/Markus.Dreseler/hyrise4/build-release/benchmark_all_results/hyriseBenchmarkJoinOrder_72331c3a86447303c4f45d935ec2f7a7162d7921_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 3b2f4c1487617e8cffd00f0c1f888e4a5442165a-dirty                                                                                              | 72331c3a86447303c4f45d935ec2f7a7162d7921-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 10.2                                                                                                                                    | gcc 10.2                                                                                                                                    |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2021-01-26 07:04:12                                                                                                                         | 2021-02-06 16:13:06                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 56, 0, 0]                                                                                                                               | [0, 56, 0, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    629.7 |    446.7 |  -29%  ||    75.23 |    76.56 |   +2%  |  0.0000 |
 | 10b     ||    588.6 |    399.4 |  -32%  ||    76.88 |    78.04 |   +2%  |  0.0000 |
+| 10c     ||   2456.6 |   2268.5 |   -8%  ||    19.50 |    20.53 |   +5%  |  0.0368 |
+| 11a     ||    313.5 |    212.8 |  -32%  ||   155.09 |   173.13 |  +12%  |  0.0000 |
+| 11b     ||    292.3 |    188.8 |  -35%  ||   165.64 |   182.74 |  +10%  |  0.0000 |
+| 11c     ||   1278.4 |   1185.0 |   -7%  ||    38.31 |    41.20 |   +8%  |  0.0002 |
 | 11d     ||  13348.6 |  12646.2 |   -5%  ||     3.05 |     2.98 |   -2%  |  0.2545 |
 | 12a     ||    804.7 |    702.0 |  -13%  ||    60.71 |    62.46 |   +3%  |  0.0000 |
 | 12b     ||    405.6 |    274.3 |  -32%  ||    52.81 |    52.09 |   -1%  |  0.0000 |
 | 12c     ||   6834.6 |   6552.1 |   -4%  ||     5.33 |     5.57 |   +4%  |  0.5903 |
 | 13a     ||    353.5 |    295.8 |  -16%  ||   127.44 |   128.67 |   +1%  |  0.0000 |
 | 13b     ||    430.2 |    179.3 |  -58%  ||   101.81 |   104.75 |   +3%  |  0.0000 |
 | 13c     ||    301.8 |    169.7 |  -44%  ||   132.77 |   132.73 |   -0%  |  0.0000 |
 | 13d     ||    350.7 |    293.6 |  -16%  ||   127.33 |   128.70 |   +1%  |  0.0000 |
+| 14a     ||   7932.7 |   6137.6 |  -23%  ||     4.92 |     5.17 |   +5%  |  0.0007 |
+| 14b     ||   9175.7 |   7194.7 |  -22%  ||     4.42 |     4.77 |   +8%  |  0.0010 |
 | 14c     ||   8537.3 |   5957.5 |  -30%  ||     4.95 |     5.08 |   +3%  |  0.0000 |
+| 15a     ||    419.0 |    344.5 |  -18%  ||   116.19 |   125.50 |   +8%  |  0.0000 |
+| 15b     ||    397.8 |    283.3 |  -29%  ||   121.16 |   129.64 |   +7%  |  0.0000 |
+| 15c     ||    322.2 |    252.7 |  -22%  ||   149.56 |   163.82 |  +10%  |  0.0000 |
+| 15d     ||   1207.4 |    996.4 |  -17%  ||    40.43 |    48.34 |  +20%  |  0.0000 |
+| 16a     ||  10867.1 |  10899.8 |   +0%  ||     3.55 |     4.05 |  +14%  |  0.9597 |
+| 16b     ||  14916.2 |  14434.7 |   -3%  ||     2.57 |     2.90 |  +13%  |  0.6119 |
+| 16c     ||  12453.8 |  11396.6 |   -8%  ||     3.47 |     3.78 |   +9%  |  0.1562 |
+| 16d     ||  12302.9 |  10508.9 |  -15%  ||     3.45 |     3.73 |   +8%  |  0.0111 |
+| 17a     ||   2262.8 |   1850.4 |  -18%  ||    20.10 |    23.46 |  +17%  |  0.0000 |
+| 17b     ||   1719.6 |   1114.7 |  -35%  ||    27.66 |    30.58 |  +11%  |  0.0000 |
+| 17c     ||   1642.2 |   1091.2 |  -34%  ||    29.28 |    32.20 |  +10%  |  0.0000 |
+| 17d     ||   1778.2 |   1216.9 |  -32%  ||    26.77 |    29.30 |   +9%  |  0.0000 |
+| 17e     ||   5906.3 |   5520.6 |   -7%  ||     7.63 |     8.33 |   +9%  |  0.1658 |
+| 17f     ||   3596.5 |   2952.3 |  -18%  ||    12.88 |    15.12 |  +17%  |  0.0000 |
 | 18a     ||   1302.3 |   1120.4 |  -14%  ||    37.23 |    38.35 |   +3%  |  0.0000 |
 | 18b     ||    470.9 |    353.7 |  -25%  ||    97.18 |    99.17 |   +2%  |  0.0000 |
+| 18c     ||   7093.0 |   4452.5 |  -37%  ||     5.38 |     5.92 |  +10%  |  0.0000 |
+| 19a     ||  11781.3 |   7255.9 |  -38%  ||     2.95 |     3.42 |  +16%  |  0.0000 |
+| 19b     ||   5461.8 |   3055.5 |  -44%  ||     7.85 |     8.45 |   +8%  |  0.0000 |
+| 19c     ||  12537.8 |   9120.0 |  -27%  ||     3.17 |     3.65 |  +15%  |  0.0000 |
+| 19d     ||  13603.2 |  13522.0 |   -1%  ||     2.78 |     2.93 |   +5%  |  0.9231 |
+| 1a      ||    109.4 |     68.4 |  -37%  ||   355.78 |   375.49 |   +6%  |  0.0000 |
 | 1b      ||     29.5 |     25.3 |  -14%  ||   966.36 |  1001.83 |   +4%  |  0.0000 |
 | 1c      ||     30.3 |     25.6 |  -16%  ||   958.41 |  1000.73 |   +4%  |  0.0000 |
 | 1d      ||     29.3 |     25.1 |  -14%  ||   967.92 |  1003.52 |   +4%  |  0.0000 |
 | 20a     ||   2183.9 |   1298.6 |  -41%  ||    21.36 |    22.01 |   +3%  |  0.0000 |
 | 20b     ||   1874.1 |   1021.9 |  -45%  ||    25.21 |    25.65 |   +2%  |  0.0000 |
+| 20c     ||   1283.9 |    771.0 |  -40%  ||    36.68 |    38.40 |   +5%  |  0.0000 |
+| 21a     ||   7732.7 |   3606.7 |  -53%  ||     5.30 |     5.92 |  +12%  |  0.0000 |
+| 21b     ||    509.2 |    445.5 |  -13%  ||    96.12 |   105.22 |   +9%  |  0.0000 |
+| 21c     ||   8169.0 |   4329.9 |  -47%  ||     5.12 |     5.52 |   +8%  |  0.0000 |
+| 22a     ||   6287.1 |   5331.0 |  -15%  ||     5.80 |     6.12 |   +5%  |  0.0218 |
 | 22b     ||   7157.5 |   5672.1 |  -21%  ||     5.78 |     5.95 |   +3%  |  0.0010 |
 | 22c     ||   5597.7 |   7404.1 |  +32%  ||     4.92 |     5.13 |   +4%  |  0.0001 |
+| 22d     ||   7898.5 |   6810.2 |  -14%  ||     4.87 |     5.10 |   +5%  |  0.0298 |
+| 23a     ||    323.6 |    214.4 |  -34%  ||   148.48 |   163.35 |  +10%  |  0.0000 |
+| 23b     ||    253.8 |    173.9 |  -31%  ||   190.31 |   208.48 |  +10%  |  0.0000 |
+| 23c     ||    355.9 |    241.1 |  -32%  ||   135.73 |   151.23 |  +11%  |  0.0000 |
 | 24a     ||   5941.3 |   3551.6 |  -40%  ||     7.45 |     7.72 |   +4%  |  0.0000 |
 | 24b     ||   4994.1 |   2812.5 |  -44%  ||     7.78 |     8.07 |   +4%  |  0.0000 |
 | 25a     ||    490.8 |    358.7 |  -27%  ||    96.99 |    98.72 |   +2%  |  0.0000 |
 | 25b     ||    353.0 |    285.5 |  -19%  ||    89.11 |    90.39 |   +1%  |  0.0000 |
+| 25c     ||   7502.3 |   4853.0 |  -35%  ||     5.42 |     5.72 |   +6%  |  0.0000 |
 | 26a     ||    943.7 |    510.8 |  -46%  ||    45.55 |    45.94 |   +1%  |  0.0000 |
 | 26b     ||    918.0 |    493.4 |  -46%  ||    46.40 |    46.96 |   +1%  |  0.0000 |
 | 26c     ||    999.6 |    515.4 |  -48%  ||    45.38 |    45.79 |   +1%  |  0.0000 |
 | 27a     ||   5729.2 |   5545.8 |   -3%  ||     5.78 |     5.97 |   +3%  |  0.6515 |
+| 27b     ||   7024.6 |   4255.1 |  -39%  ||     5.90 |     6.35 |   +8%  |  0.0000 |
+| 27c     ||    442.7 |    291.6 |  -34%  ||   110.13 |   120.26 |   +9%  |  0.0000 |
+| 28a     ||   7886.1 |   6706.5 |  -15%  ||     4.75 |     5.28 |  +11%  |  0.0381 |
+| 28b     ||   7000.4 |   4161.3 |  -41%  ||     5.92 |     6.33 |   +7%  |  0.0000 |
+| 28c     ||   7688.7 |   6541.4 |  -15%  ||     4.75 |     5.02 |   +6%  |  0.0479 |
+| 29a     ||   6201.7 |   3058.0 |  -51%  ||     7.32 |     7.68 |   +5%  |  0.0000 |
 | 29b     ||    454.9 |    399.1 |  -12%  ||   101.27 |   103.44 |   +2%  |  0.0000 |
 | 29c     ||   6012.1 |   3681.9 |  -39%  ||     7.15 |     7.45 |   +4%  |  0.0000 |
+| 2a      ||    242.5 |    181.3 |  -25%  ||   200.46 |   233.27 |  +16%  |  0.0000 |
+| 2b      ||    200.3 |    144.5 |  -28%  ||   241.58 |   283.85 |  +17%  |  0.0000 |
+| 2c      ||    115.5 |     75.6 |  -34%  ||   381.85 |   430.87 |  +13%  |  0.0000 |
+| 2d      ||    300.2 |    233.0 |  -22%  ||   162.56 |   190.79 |  +17%  |  0.0000 |
 | 30a     ||    549.9 |    427.9 |  -22%  ||    86.71 |    89.48 |   +3%  |  0.0000 |
 | 30b     ||   1595.7 |    863.0 |  -46%  ||    28.65 |    28.53 |   -0%  |  0.0000 |
+| 30c     ||   7461.1 |   5735.1 |  -23%  ||     5.25 |     5.57 |   +6%  |  0.0022 |
 | 31a     ||    576.0 |    367.8 |  -36%  ||    77.16 |    79.01 |   +2%  |  0.0000 |
 | 31b     ||    941.6 |    677.4 |  -28%  ||    28.26 |    27.80 |   -2%  |  0.0000 |
 | 31c     ||    580.6 |    366.6 |  -37%  ||    76.38 |    78.21 |   +2%  |  0.0000 |
 | 32a     ||     58.4 |     48.7 |  -17%  ||   530.78 |   547.34 |   +3%  |  0.0000 |
+| 32b     ||    678.5 |    526.5 |  -22%  ||    72.68 |    90.88 |  +25%  |  0.0000 |
+| 33a     ||    144.8 |    124.2 |  -14%  ||   309.24 |   331.49 |   +7%  |  0.0000 |
+| 33b     ||    142.9 |    124.3 |  -13%  ||   312.46 |   332.74 |   +6%  |  0.0000 |
+| 33c     ||    188.8 |    150.1 |  -21%  ||   253.44 |   281.14 |  +11%  |  0.0000 |
+| 3a      ||   7527.4 |   6173.0 |  -18%  ||     5.20 |     5.63 |   +8%  |  0.0154 |
+| 3b      ||     82.3 |     68.6 |  -17%  ||   539.91 |   581.47 |   +8%  |  0.0000 |
 | 3c      ||   9666.5 |   7400.1 |  -23%  ||     4.08 |     4.20 |   +3%  |  0.0000 |
+| 4a      ||    317.5 |    279.2 |  -12%  ||   153.50 |   160.87 |   +5%  |  0.0000 |
+| 4b      ||     48.4 |     37.7 |  -22%  ||   769.89 |   819.17 |   +6%  |  0.0000 |
 | 4c      ||    358.6 |    291.2 |  -19%  ||   135.50 |   139.33 |   +3%  |  0.0000 |
+| 5a      ||   7093.4 |   3951.1 |  -44%  ||     5.43 |     5.97 |  +10%  |  0.0000 |
 | 5b      ||    460.3 |    348.9 |  -24%  ||    93.27 |    92.30 |   -1%  |  0.0000 |
+| 5c      ||   7982.6 |   5548.3 |  -30%  ||     4.63 |     4.97 |   +7%  |  0.0000 |
 | 6a      ||    401.2 |    246.5 |  -39%  ||   103.50 |   105.65 |   +2%  |  0.0000 |
+| 6b      ||   1896.8 |   1344.6 |  -29%  ||    24.26 |    26.03 |   +7%  |  0.0000 |
 | 6c      ||    404.5 |    238.9 |  -41%  ||   103.17 |   105.11 |   +2%  |  0.0000 |
+| 6d      ||   1907.7 |   1343.9 |  -30%  ||    24.36 |    25.95 |   +6%  |  0.0000 |
 | 6e      ||    403.9 |    239.9 |  -41%  ||   102.91 |   104.90 |   +2%  |  0.0000 |
+| 6f      ||   3263.2 |   2650.1 |  -19%  ||    14.53 |    16.77 |  +15%  |  0.0000 |
+| 7a      ||    842.7 |    708.0 |  -16%  ||    57.71 |    63.88 |  +11%  |  0.0000 |
 | 7b      ||    291.1 |    203.6 |  -30%  ||   145.84 |   150.90 |   +3%  |  0.0000 |
+| 7c      ||  24934.8 |  24445.2 |   -2%  ||     1.25 |     1.33 |   +7%  |  0.7157 |
+| 8a      ||    265.7 |    228.6 |  -14%  ||   175.51 |   193.82 |  +10%  |  0.0000 |
+| 8b      ||    278.7 |    184.1 |  -34%  ||   150.63 |   160.63 |   +7%  |  0.0000 |
+| 8c      ||  10244.0 |   8553.6 |  -17%  ||     4.17 |     4.72 |  +13%  |  0.0029 |
+| 8d      ||   3207.1 |   3035.4 |   -5%  ||    14.40 |    15.18 |   +5%  |  0.1654 |
+| 9a      ||   7219.1 |   5975.6 |  -17%  ||     5.02 |     5.28 |   +5%  |  0.0090 |
+| 9b      ||    789.7 |    534.0 |  -32%  ||    61.44 |    69.03 |  +12%  |  0.0000 |
 | 9c      ||   6897.0 |   6920.9 |   +0%  ||     4.97 |     5.10 |   +3%  |  0.9613 |
+| 9d      ||   8677.4 |   8761.8 |   +1%  ||     4.02 |     4.43 |  +10%  |  0.8796 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
+| Sum     || 415723.5 | 332092.4 |  -20%  ||          |          |        |         |
+| Geomean ||          |          |        ||          |          |   +7%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>