### PR TITLE
Fix all values zero in SegmentEncodingTests

### DIFF
--- a/src/test/lib/storage/encoded_segment_test.cpp
+++ b/src/test/lib/storage/encoded_segment_test.cpp
@@ -57,6 +57,7 @@ class EncodedSegmentTest : public BaseTestWithParam<SegmentEncodingSpec> {
     auto counter = 0u;
     for (auto& elem : values) {
       elem = _generated_value_pool[counter % _generated_value_pool.size()];
+      ++counter;
     }
 
     return std::make_shared<ValueSegment<int32_t>>(std::move(values));


### PR DESCRIPTION
Thanks to @benrobby for pointing at it. Currently, we unintentionally create a vector of zeros.