### PR TITLE
stateless

### DIFF
--- a/src/benchmarklib/abstract_benchmark_item_runner.cpp
+++ b/src/benchmarklib/abstract_benchmark_item_runner.cpp
@@ -9,8 +9,9 @@
 
 namespace opossum {
 
-AbstractBenchmarkItemRunner::AbstractBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config)
-    : _config(config) {}
+AbstractBenchmarkItemRunner::AbstractBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                                         const std::shared_ptr<BenchmarkConfig>& config)
+    : _hyrise_env(hyrise_env), _config(config) {}
 
 void AbstractBenchmarkItemRunner::load_dedicated_expected_results(
     const std::filesystem::path& expected_results_directory_path) {
@@ -64,7 +65,7 @@ std::tuple<bool, std::vector<SQLPipelineMetrics>, bool> AbstractBenchmarkItemRun
     visualize_prefix = std::move(name);
   }
 
-  BenchmarkSQLExecutor sql_executor(_sqlite_wrapper, visualize_prefix);
+  BenchmarkSQLExecutor sql_executor(_sqlite_wrapper, _hyrise_env, visualize_prefix);
   auto success = _on_execute_item(item_id, sql_executor);
   return {success, std::move(sql_executor.metrics), sql_executor.any_verification_failed};
 }

--- a/src/benchmarklib/abstract_benchmark_item_runner.hpp
+++ b/src/benchmarklib/abstract_benchmark_item_runner.hpp
@@ -19,7 +19,8 @@ namespace opossum {
 // Parameters can be randomized for some benchmarks (e.g., TPC-H).
 class AbstractBenchmarkItemRunner {
  public:
-  explicit AbstractBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config);
+  explicit AbstractBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                       const std::shared_ptr<BenchmarkConfig>& config);
 
   virtual ~AbstractBenchmarkItemRunner() = default;
 
@@ -59,6 +60,7 @@ class AbstractBenchmarkItemRunner {
   // Returns true if the execution was successful (see execute_item)
   virtual bool _on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) = 0;
 
+  std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   std::shared_ptr<BenchmarkConfig> _config;
   std::vector<std::shared_ptr<const Table>> _dedicated_expected_results;
   std::shared_ptr<SQLiteWrapper> _sqlite_wrapper;

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -11,6 +11,7 @@
 namespace opossum {
 
 class BenchmarkConfig;
+class HyriseEnvironmentRef;
 
 struct BenchmarkTableInfo {
   BenchmarkTableInfo() = default;
@@ -52,7 +53,7 @@ class AbstractTableGenerator {
   explicit AbstractTableGenerator(const std::shared_ptr<BenchmarkConfig>& benchmark_config);
   virtual ~AbstractTableGenerator() = default;
 
-  void generate_and_store();
+  void generate_and_store(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   /**
    * @return A table_name -> TableEntry mapping

--- a/src/benchmarklib/benchmark_runner.hpp
+++ b/src/benchmarklib/benchmark_runner.hpp
@@ -39,7 +39,8 @@ class BenchmarkRunner : public Noncopyable {
   // Defines the interval in which the system utilization is collected
   static constexpr auto SYSTEM_UTILIZATION_TRACKING_INTERVAL = std::chrono::milliseconds{1000};
 
-  BenchmarkRunner(const BenchmarkConfig& config, std::unique_ptr<AbstractBenchmarkItemRunner> benchmark_item_runner,
+  BenchmarkRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const BenchmarkConfig& config,
+                  std::unique_ptr<AbstractBenchmarkItemRunner> benchmark_item_runner,
                   std::unique_ptr<AbstractTableGenerator> table_generator, const nlohmann::json& context);
 
   void run();
@@ -75,6 +76,7 @@ class BenchmarkRunner : public Noncopyable {
   // to identify a certain point in the benchmark, e.g., when an item is finished in the ordered mode.
   void _snapshot_segment_access_counters(const std::string& moment = "");
 
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const BenchmarkConfig _config;
 
   std::unique_ptr<AbstractBenchmarkItemRunner> _benchmark_item_runner;

--- a/src/benchmarklib/benchmark_sql_executor.cpp
+++ b/src/benchmarklib/benchmark_sql_executor.cpp
@@ -8,9 +8,12 @@
 
 namespace opossum {
 BenchmarkSQLExecutor::BenchmarkSQLExecutor(const std::shared_ptr<SQLiteWrapper>& sqlite_wrapper,
+
+                                           const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
                                            const std::optional<std::string>& visualize_prefix)
     : _sqlite_connection(sqlite_wrapper ? std::optional<SQLiteWrapper::Connection>{sqlite_wrapper->new_connection()}
                                         : std::optional<SQLiteWrapper::Connection>{}),
+      _hyrise_env(hyrise_env),
       _visualize_prefix(visualize_prefix) {
   if (_sqlite_connection) {
     _sqlite_connection->raw_execute_query("BEGIN TRANSACTION");
@@ -22,6 +25,7 @@ std::pair<SQLPipelineStatus, std::shared_ptr<const Table>> BenchmarkSQLExecutor:
     const std::string& sql, const std::shared_ptr<const Table>& expected_result_table) {
   auto pipeline_builder = SQLPipelineBuilder{sql};
   if (transaction_context) pipeline_builder.with_transaction_context(transaction_context);
+  pipeline_builder.with_hyrise_env(_hyrise_env);
 
   auto pipeline = pipeline_builder.create_pipeline();
 

--- a/src/benchmarklib/benchmark_sql_executor.hpp
+++ b/src/benchmarklib/benchmark_sql_executor.hpp
@@ -15,6 +15,7 @@ class BenchmarkSQLExecutor {
   // @param visualize_prefix    Prefix for the filename of the generated query plans (e.g., "TPC-H_6-").
   //                            The suffix will be "LQP/PQP-<statement_idx>.<extension>"
   BenchmarkSQLExecutor(const std::shared_ptr<SQLiteWrapper>& sqlite_wrapper,
+                       const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
                        const std::optional<std::string>& visualize_prefix);
 
   ~BenchmarkSQLExecutor();
@@ -45,6 +46,7 @@ class BenchmarkSQLExecutor {
   void _visualize(SQLPipeline& pipeline);
 
   std::optional<SQLiteWrapper::Connection> _sqlite_connection;
+  std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   bool _sqlite_transaction_open{false};
 
   const std::optional<std::string> _visualize_prefix;

--- a/src/benchmarklib/file_based_benchmark_item_runner.cpp
+++ b/src/benchmarklib/file_based_benchmark_item_runner.cpp
@@ -13,10 +13,10 @@
 namespace opossum {
 
 FileBasedBenchmarkItemRunner::FileBasedBenchmarkItemRunner(
-    const std::shared_ptr<BenchmarkConfig>& config, const std::string& query_path,
-    const std::unordered_set<std::string>& filename_blacklist,
+    const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::shared_ptr<BenchmarkConfig>& config,
+    const std::string& query_path, const std::unordered_set<std::string>& filename_blacklist,
     const std::optional<std::unordered_set<std::string>>& query_subset)
-    : AbstractBenchmarkItemRunner(config) {
+    : AbstractBenchmarkItemRunner(hyrise_env, config) {
   const auto is_sql_file = [](const std::string& filename) { return boost::algorithm::ends_with(filename, ".sql"); };
 
   std::filesystem::path path{query_path};

--- a/src/benchmarklib/file_based_benchmark_item_runner.hpp
+++ b/src/benchmarklib/file_based_benchmark_item_runner.hpp
@@ -15,7 +15,8 @@ class FileBasedBenchmarkItemRunner : public AbstractBenchmarkItemRunner {
   //                              generated. If "q7.sql" contains a single query, the query has the name "q7". If
   //                              it contains multiple queries, they are called "q7.0", "q7.1", ...
 
-  FileBasedBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config, const std::string& query_path,
+  FileBasedBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                               const std::shared_ptr<BenchmarkConfig>& config, const std::string& query_path,
                                const std::unordered_set<std::string>& filename_blacklist = {},
                                const std::optional<std::unordered_set<std::string>>& query_subset = {});
 

--- a/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
@@ -11,9 +11,10 @@ namespace opossum {
 
 JCCHBenchmarkItemRunner::JCCHBenchmarkItemRunner(const bool skewed, const std::string& dbgen_path,
                                                  const std::string& data_path,
+                                                 const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
                                                  const std::shared_ptr<BenchmarkConfig>& config,
                                                  bool use_prepared_statements, float scale_factor)
-    : TPCHBenchmarkItemRunner(config, use_prepared_statements, scale_factor),
+    : TPCHBenchmarkItemRunner(hyrise_env, config, use_prepared_statements, scale_factor),
       _skewed(skewed),
       _dbgen_path(dbgen_path),
       _data_path(data_path) {
@@ -22,10 +23,11 @@ JCCHBenchmarkItemRunner::JCCHBenchmarkItemRunner(const bool skewed, const std::s
 
 JCCHBenchmarkItemRunner::JCCHBenchmarkItemRunner(const bool skewed, const std::string& dbgen_path,
                                                  const std::string& data_path,
+                                                 const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
                                                  const std::shared_ptr<BenchmarkConfig>& config,
                                                  bool use_prepared_statements, float scale_factor,
                                                  const std::vector<BenchmarkItemID>& items)
-    : TPCHBenchmarkItemRunner(config, use_prepared_statements, scale_factor, items),
+    : TPCHBenchmarkItemRunner(hyrise_env, config, use_prepared_statements, scale_factor, items),
       _skewed(skewed),
       _dbgen_path(dbgen_path),
       _data_path(data_path) {

--- a/src/benchmarklib/jcch/jcch_benchmark_item_runner.hpp
+++ b/src/benchmarklib/jcch/jcch_benchmark_item_runner.hpp
@@ -13,11 +13,13 @@ class JCCHBenchmarkItemRunner : public TPCHBenchmarkItemRunner {
  public:
   // Constructor for a JCCHBenchmarkItemRunner containing all TPC-H queries
   JCCHBenchmarkItemRunner(const bool skewed, const std::string& dbgen_path, const std::string& data_path,
+                          const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
                           const std::shared_ptr<BenchmarkConfig>& config, bool use_prepared_statements,
                           float scale_factor);
 
   // Constructor for a JCCHBenchmarkItemRunner containing a subset of TPC-H queries
   JCCHBenchmarkItemRunner(const bool skewed, const std::string& dbgen_path, const std::string& data_path,
+                          const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
                           const std::shared_ptr<BenchmarkConfig>& config, bool use_prepared_statements,
                           float scale_factor, const std::vector<BenchmarkItemID>& items);
 

--- a/src/benchmarklib/tpcc/tpcc_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpcc/tpcc_benchmark_item_runner.cpp
@@ -8,8 +8,9 @@
 
 namespace opossum {
 
-TPCCBenchmarkItemRunner::TPCCBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config, int num_warehouses)
-    : AbstractBenchmarkItemRunner(config), _num_warehouses(num_warehouses) {}
+TPCCBenchmarkItemRunner::TPCCBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                                 const std::shared_ptr<BenchmarkConfig>& config, int num_warehouses)
+    : AbstractBenchmarkItemRunner(hyrise_env, config), _num_warehouses(num_warehouses) {}
 
 const std::vector<BenchmarkItemID>& TPCCBenchmarkItemRunner::items() const {
   static const std::vector<BenchmarkItemID> items{BenchmarkItemID{0}, BenchmarkItemID{1}, BenchmarkItemID{2},

--- a/src/benchmarklib/tpcc/tpcc_benchmark_item_runner.hpp
+++ b/src/benchmarklib/tpcc/tpcc_benchmark_item_runner.hpp
@@ -8,7 +8,8 @@ namespace opossum {
 
 class TPCCBenchmarkItemRunner : public AbstractBenchmarkItemRunner {
  public:
-  TPCCBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config, int num_warehouses);
+  TPCCBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                          const std::shared_ptr<BenchmarkConfig>& config, int num_warehouses);
 
   std::string item_name(const BenchmarkItemID item_id) const override;
   const std::vector<BenchmarkItemID>& items() const override;

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.cpp
@@ -20,19 +20,21 @@ extern "C" {
 
 namespace opossum {
 
-TPCHBenchmarkItemRunner::TPCHBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config,
+TPCHBenchmarkItemRunner::TPCHBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                                 const std::shared_ptr<BenchmarkConfig>& config,
                                                  bool use_prepared_statements, float scale_factor)
-    : AbstractBenchmarkItemRunner(config),
+    : AbstractBenchmarkItemRunner(hyrise_env, config),
       _use_prepared_statements(use_prepared_statements),
       _scale_factor(scale_factor) {
   _items.resize(22);
   std::iota(_items.begin(), _items.end(), BenchmarkItemID{0});
 }
 
-TPCHBenchmarkItemRunner::TPCHBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config,
+TPCHBenchmarkItemRunner::TPCHBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                                 const std::shared_ptr<BenchmarkConfig>& config,
                                                  bool use_prepared_statements, float scale_factor,
                                                  const std::vector<BenchmarkItemID>& items)
-    : AbstractBenchmarkItemRunner(config),
+    : AbstractBenchmarkItemRunner(hyrise_env, config),
       _use_prepared_statements(use_prepared_statements),
       _scale_factor(scale_factor),
       _items(items) {
@@ -69,7 +71,7 @@ std::string TPCHBenchmarkItemRunner::_calculate_date(boost::gregorian::date date
 
 void TPCHBenchmarkItemRunner::on_tables_loaded() {
   // Make sure that sort order, indexes, and constraints have made it all the way up to here
-  const auto orders_table = Hyrise::get().storage_manager.get_table("orders");
+  const auto orders_table = _hyrise_env->storage_manager()->get_table("orders");
   const auto first_chunk = orders_table->get_chunk(ChunkID{0});
   Assert(!first_chunk->individually_sorted_by().empty(), "Sorting information was lost");
   if (_config->indexes) {

--- a/src/benchmarklib/tpch/tpch_benchmark_item_runner.hpp
+++ b/src/benchmarklib/tpch/tpch_benchmark_item_runner.hpp
@@ -14,11 +14,13 @@ namespace opossum {
 class TPCHBenchmarkItemRunner : public AbstractBenchmarkItemRunner {
  public:
   // Constructor for a TPCHBenchmarkItemRunner containing all TPC-H queries
-  TPCHBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config, bool use_prepared_statements,
+  TPCHBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                          const std::shared_ptr<BenchmarkConfig>& config, bool use_prepared_statements,
                           float scale_factor);
 
   // Constructor for a TPCHBenchmarkItemRunner containing a subset of TPC-H queries
-  TPCHBenchmarkItemRunner(const std::shared_ptr<BenchmarkConfig>& config, bool use_prepared_statements,
+  TPCHBenchmarkItemRunner(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                          const std::shared_ptr<BenchmarkConfig>& config, bool use_prepared_statements,
                           float scale_factor, const std::vector<BenchmarkItemID>& items);
 
   void on_tables_loaded() override;

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -557,6 +557,7 @@ set(
     types.cpp
     types.hpp
     uid_allocator.hpp
+    utils/abstract_plugin.cpp
     utils/abstract_plugin.hpp
     utils/aligned_size.hpp
     utils/assert.hpp

--- a/src/lib/expression/lqp_column_expression.cpp
+++ b/src/lib/expression/lqp_column_expression.cpp
@@ -39,7 +39,8 @@ std::string LQPColumnExpression::description(const DescriptionMode mode) const {
   switch (original_node_locked->type) {
     case LQPNodeType::StoredTable: {
       const auto stored_table_node = std::static_pointer_cast<const StoredTableNode>(original_node_locked);
-      const auto table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
+      const auto storage_manager = stored_table_node->hyrise_env->storage_manager();
+      const auto table = storage_manager->get_table(stored_table_node->table_name);
       output << table->column_name(original_column_id);
       return output.str();
     }
@@ -75,7 +76,8 @@ DataType LQPColumnExpression::data_type() const {
   switch (original_node_locked->type) {
     case LQPNodeType::StoredTable: {
       const auto stored_table_node = std::static_pointer_cast<const StoredTableNode>(original_node_locked);
-      const auto table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
+      const auto storage_manager = stored_table_node->hyrise_env->storage_manager();
+      const auto table = storage_manager->get_table(stored_table_node->table_name);
       return table->column_data_type(original_column_id);
     }
 

--- a/src/lib/expression/lqp_column_expression.hpp
+++ b/src/lib/expression/lqp_column_expression.hpp
@@ -21,6 +21,7 @@ class LQPColumnExpression : public AbstractExpression {
   // StoredTableNode::output_expressions). If the original_node is not referenced by any shared_ptr anymore, it is
   // deleted. As a result, the weak_ptr expires. It should not be accessed anymore. Thus, if original_node.lock() is
   // a nullptr, the LQP is defective.
+
   const std::weak_ptr<const AbstractLQPNode> original_node;
   const ColumnID original_column_id;
 

--- a/src/lib/hyrise.cpp
+++ b/src/lib/hyrise.cpp
@@ -13,10 +13,7 @@ Hyrise::Hyrise() {
   // destructed last.
   boost::container::pmr::get_default_resource();
 
-  storage_manager = StorageManager{};
-  plugin_manager = PluginManager{};
   transaction_manager = TransactionManager{};
-  meta_table_manager = MetaTableManager{};
   settings_manager = SettingsManager{};
   log_manager = LogManager{};
   topology = Topology{};
@@ -38,6 +35,38 @@ void Hyrise::set_scheduler(const std::shared_ptr<AbstractScheduler>& new_schedul
   _scheduler->finish();
   _scheduler = new_scheduler;
   _scheduler->begin();
+}
+
+std::shared_ptr<StorageManager> HyriseEnvironmentRef::storage_manager() const {
+  auto ret = _storage_manager.lock();
+  if (!ret) Fail("Missing storage manager");
+  return ret;
+}
+
+std::shared_ptr<PluginManager> HyriseEnvironmentRef::plugin_manager() const {
+  auto ret = _plugin_manager.lock();
+  if (!ret) Fail("Missing plugin manager");
+  return ret;
+}
+
+std::shared_ptr<MetaTableManager> HyriseEnvironmentRef::meta_table_manager() const {
+  auto ret = _meta_table_manager.lock();
+  if (!ret) Fail("Missing meta table manager");
+  return ret;
+}
+
+HyriseEnvironmentRef::HyriseEnvironmentRef() noexcept {}
+
+const std::shared_ptr<HyriseEnvironmentRef>& HyriseEnvironmentHolder::hyrise_env_ref() { return _hyrise_env_ref; }
+
+HyriseEnvironmentHolder::HyriseEnvironmentHolder() {
+  _hyrise_env_ref = std::shared_ptr<HyriseEnvironmentRef>(new HyriseEnvironmentRef());
+  _storage_manager = std::make_shared<StorageManager>();
+  _hyrise_env_ref->_storage_manager = std::weak_ptr<StorageManager>(_storage_manager);
+  _plugin_manager = std::make_shared<PluginManager>(_hyrise_env_ref);
+  _hyrise_env_ref->_plugin_manager = std::weak_ptr<PluginManager>(_plugin_manager);
+  _meta_table_manager = std::make_shared<MetaTableManager>(_hyrise_env_ref);
+  _hyrise_env_ref->_meta_table_manager = std::weak_ptr<MetaTableManager>(_meta_table_manager);
 }
 
 }  // namespace opossum

--- a/src/lib/hyrise.hpp
+++ b/src/lib/hyrise.hpp
@@ -39,10 +39,10 @@ class Hyrise : public Singleton<Hyrise> {
   // For example, the StorageManager's destructor should not be called before the PluginManager's destructor.
   // The latter stops all plugins which, in turn, might access tables during their shutdown procedure. This
   // could not work without the StorageManager still in place.
-  StorageManager storage_manager;
-  PluginManager plugin_manager;
+  // StorageManager storage_manager; - removed
+  // PluginManager plugin_manager; - removed
   TransactionManager transaction_manager;
-  MetaTableManager meta_table_manager;
+  // MetaTableManager meta_table_manager; - removed
   SettingsManager settings_manager;
   LogManager log_manager;
   Topology topology;
@@ -63,6 +63,35 @@ class Hyrise : public Singleton<Hyrise> {
   // (Re-)setting the scheduler requires more than just replacing the pointer. To make sure that set_scheduler is used,
   // the scheduler is private.
   std::shared_ptr<AbstractScheduler> _scheduler;
+};
+
+class HyriseEnvironmentRef {
+  friend class HyriseEnvironmentHolder;
+
+ public:
+  std::shared_ptr<StorageManager> storage_manager() const;
+  std::shared_ptr<PluginManager> plugin_manager() const;
+  std::shared_ptr<MetaTableManager> meta_table_manager() const;
+
+ private:
+  HyriseEnvironmentRef() noexcept;
+
+  std::weak_ptr<StorageManager> _storage_manager;
+  std::weak_ptr<PluginManager> _plugin_manager;
+  std::weak_ptr<MetaTableManager> _meta_table_manager;
+};
+
+class HyriseEnvironmentHolder {
+ public:
+  HyriseEnvironmentHolder();
+  const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env_ref();
+
+ private:
+  // We do not allow users to retrieve these pointers in order to preserve destruction order.
+  std::shared_ptr<HyriseEnvironmentRef> _hyrise_env_ref;
+  std::shared_ptr<StorageManager> _storage_manager;
+  std::shared_ptr<PluginManager> _plugin_manager;
+  std::shared_ptr<MetaTableManager> _meta_table_manager;
 };
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/change_meta_table_node.cpp
+++ b/src/lib/logical_query_plan/change_meta_table_node.cpp
@@ -2,9 +2,13 @@
 
 namespace opossum {
 
-ChangeMetaTableNode::ChangeMetaTableNode(const std::string& init_table_name,
+ChangeMetaTableNode::ChangeMetaTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                                         const std::string& init_table_name,
                                          const MetaTableChangeType& init_change_type)
-    : AbstractNonQueryNode(LQPNodeType::ChangeMetaTable), table_name(init_table_name), change_type(init_change_type) {}
+    : AbstractNonQueryNode(LQPNodeType::ChangeMetaTable),
+      hyrise_env(init_hyrise_env),
+      table_name(init_table_name),
+      change_type(init_change_type) {}
 
 std::string ChangeMetaTableNode::description(const DescriptionMode mode) const {
   std::ostringstream desc;
@@ -15,18 +19,20 @@ std::string ChangeMetaTableNode::description(const DescriptionMode mode) const {
 }
 
 std::shared_ptr<AbstractLQPNode> ChangeMetaTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return ChangeMetaTableNode::make(table_name, change_type);
+  return ChangeMetaTableNode::make(hyrise_env, table_name, change_type);
 }
 
 size_t ChangeMetaTableNode::_on_shallow_hash() const {
-  auto hash = boost::hash_value(table_name);
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, table_name);
   boost::hash_combine(hash, change_type);
   return hash;
 }
 
 bool ChangeMetaTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& change_meta_table_node = static_cast<const ChangeMetaTableNode&>(rhs);
-  return table_name == change_meta_table_node.table_name && change_type == change_meta_table_node.change_type;
+  return hyrise_env == change_meta_table_node.hyrise_env && table_name == change_meta_table_node.table_name &&
+         change_type == change_meta_table_node.change_type;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/change_meta_table_node.hpp
+++ b/src/lib/logical_query_plan/change_meta_table_node.hpp
@@ -9,6 +9,7 @@
 namespace opossum {
 
 class AbstractExpression;
+class HyriseEnvironmentRef;
 
 /*
  * Node type to represent modifications of a meta table.
@@ -19,10 +20,12 @@ class AbstractExpression;
  */
 class ChangeMetaTableNode : public EnableMakeForLQPNode<ChangeMetaTableNode>, public AbstractNonQueryNode {
  public:
-  explicit ChangeMetaTableNode(const std::string& init_table_name, const MetaTableChangeType& init_change_type);
+  explicit ChangeMetaTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                               const std::string& init_table_name, const MetaTableChangeType& init_change_type);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
   const MetaTableChangeType change_type;
 

--- a/src/lib/logical_query_plan/create_prepared_plan_node.cpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.cpp
@@ -6,9 +6,13 @@
 
 namespace opossum {
 
-CreatePreparedPlanNode::CreatePreparedPlanNode(const std::string& init_name,
+CreatePreparedPlanNode::CreatePreparedPlanNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                                               const std::string& init_name,
                                                const std::shared_ptr<PreparedPlan>& init_prepared_plan)
-    : AbstractNonQueryNode(LQPNodeType::CreatePreparedPlan), name(init_name), prepared_plan(init_prepared_plan) {}
+    : AbstractNonQueryNode(LQPNodeType::CreatePreparedPlan),
+      hyrise_env(init_hyrise_env),
+      name(init_name),
+      prepared_plan(init_prepared_plan) {}
 
 std::string CreatePreparedPlanNode::description(const DescriptionMode mode) const {
   std::stringstream stream;
@@ -21,17 +25,19 @@ std::string CreatePreparedPlanNode::description(const DescriptionMode mode) cons
 
 size_t CreatePreparedPlanNode::_on_shallow_hash() const {
   auto hash = prepared_plan->hash();
+  boost::hash_combine(hash, hyrise_env);
   boost::hash_combine(hash, name);
   return hash;
 }
 
 std::shared_ptr<AbstractLQPNode> CreatePreparedPlanNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return CreatePreparedPlanNode::make(name, prepared_plan);
+  return CreatePreparedPlanNode::make(hyrise_env, name, prepared_plan);
 }
 
 bool CreatePreparedPlanNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& create_prepared_plan_node = static_cast<const CreatePreparedPlanNode&>(rhs);
-  return name == create_prepared_plan_node.name && *prepared_plan == *create_prepared_plan_node.prepared_plan;
+  return hyrise_env == create_prepared_plan_node.hyrise_env && name == create_prepared_plan_node.name &&
+         *prepared_plan == *create_prepared_plan_node.prepared_plan;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/create_prepared_plan_node.hpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.hpp
@@ -4,6 +4,7 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class PreparedPlan;
 
 /**
@@ -11,10 +12,12 @@ class PreparedPlan;
  */
 class CreatePreparedPlanNode : public EnableMakeForLQPNode<CreatePreparedPlanNode>, public AbstractNonQueryNode {
  public:
-  CreatePreparedPlanNode(const std::string& init_name, const std::shared_ptr<PreparedPlan>& init_prepared_plan);
+  CreatePreparedPlanNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_name,
+                         const std::shared_ptr<PreparedPlan>& init_prepared_plan);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   std::string name;
   std::shared_ptr<PreparedPlan> prepared_plan;
 

--- a/src/lib/logical_query_plan/create_table_node.cpp
+++ b/src/lib/logical_query_plan/create_table_node.cpp
@@ -7,8 +7,12 @@
 
 namespace opossum {
 
-CreateTableNode::CreateTableNode(const std::string& init_table_name, const bool init_if_not_exists)
-    : AbstractNonQueryNode(LQPNodeType::CreateTable), table_name(init_table_name), if_not_exists(init_if_not_exists) {}
+CreateTableNode::CreateTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                                 const std::string& init_table_name, const bool init_if_not_exists)
+    : AbstractNonQueryNode(LQPNodeType::CreateTable),
+      hyrise_env(init_hyrise_env),
+      table_name(init_table_name),
+      if_not_exists(init_if_not_exists) {}
 
 std::string CreateTableNode::description(const DescriptionMode mode) const {
   std::ostringstream stream;
@@ -20,18 +24,20 @@ std::string CreateTableNode::description(const DescriptionMode mode) const {
 }
 
 size_t CreateTableNode::_on_shallow_hash() const {
-  auto hash = boost::hash_value(table_name);
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, table_name);
   boost::hash_combine(hash, if_not_exists);
   return hash;
 }
 
 std::shared_ptr<AbstractLQPNode> CreateTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return CreateTableNode::make(table_name, if_not_exists, left_input());
+  return CreateTableNode::make(hyrise_env, table_name, if_not_exists, left_input());
 }
 
 bool CreateTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& create_table_node = static_cast<const CreateTableNode&>(rhs);
-  return table_name == create_table_node.table_name && if_not_exists == create_table_node.if_not_exists;
+  return hyrise_env == create_table_node.hyrise_env && table_name == create_table_node.table_name &&
+         if_not_exists == create_table_node.if_not_exists;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/create_table_node.hpp
+++ b/src/lib/logical_query_plan/create_table_node.hpp
@@ -8,15 +8,19 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This node type represents the CREATE TABLE management command.
  */
 class CreateTableNode : public EnableMakeForLQPNode<CreateTableNode>, public AbstractNonQueryNode {
  public:
-  CreateTableNode(const std::string& init_table_name, const bool init_if_not_exists);
+  CreateTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name,
+                  const bool init_if_not_exists);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
   const bool if_not_exists;
 

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -7,9 +7,11 @@
 
 namespace opossum {
 
-CreateViewNode::CreateViewNode(const std::string& init_view_name, const std::shared_ptr<LQPView>& init_view,
+CreateViewNode::CreateViewNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                               const std::string& init_view_name, const std::shared_ptr<LQPView>& init_view,
                                const bool init_if_not_exists)
     : AbstractNonQueryNode(LQPNodeType::CreateView),
+      hyrise_env(init_hyrise_env),
       view_name(init_view_name),
       view(init_view),
       if_not_exists(init_if_not_exists) {}
@@ -29,21 +31,22 @@ std::string CreateViewNode::description(const DescriptionMode mode) const {
 }
 
 size_t CreateViewNode::_on_shallow_hash() const {
-  auto hash = boost::hash_value(view_name);
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, view_name);
   boost::hash_combine(hash, view);
   boost::hash_combine(hash, if_not_exists);
   return hash;
 }
 
 std::shared_ptr<AbstractLQPNode> CreateViewNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return CreateViewNode::make(view_name, view->deep_copy(), if_not_exists);
+  return CreateViewNode::make(hyrise_env, view_name, view->deep_copy(), if_not_exists);
 }
 
 bool CreateViewNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& create_view_node_rhs = static_cast<const CreateViewNode&>(rhs);
 
-  return view_name == create_view_node_rhs.view_name && view->deep_equals(*create_view_node_rhs.view) &&
-         if_not_exists == create_view_node_rhs.if_not_exists;
+  return hyrise_env == create_view_node_rhs.hyrise_env && view_name == create_view_node_rhs.view_name &&
+         view->deep_equals(*create_view_node_rhs.view) && if_not_exists == create_view_node_rhs.if_not_exists;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -8,15 +8,19 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This node type represents the CREATE VIEW management command.
  */
 class CreateViewNode : public EnableMakeForLQPNode<CreateViewNode>, public AbstractNonQueryNode {
  public:
-  CreateViewNode(const std::string& init_view_name, const std::shared_ptr<LQPView>& init_view, bool init_if_not_exists);
+  CreateViewNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_view_name,
+                 const std::shared_ptr<LQPView>& init_view, bool init_if_not_exists);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string view_name;
   const std::shared_ptr<LQPView> view;
   const bool if_not_exists;

--- a/src/lib/logical_query_plan/drop_table_node.cpp
+++ b/src/lib/logical_query_plan/drop_table_node.cpp
@@ -2,26 +2,32 @@
 
 namespace opossum {
 
-DropTableNode::DropTableNode(const std::string& init_table_name, const bool init_if_exists)
-    : AbstractNonQueryNode(LQPNodeType::DropTable), table_name(init_table_name), if_exists(init_if_exists) {}
+DropTableNode::DropTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                             const std::string& init_table_name, const bool init_if_exists)
+    : AbstractNonQueryNode(LQPNodeType::DropTable),
+      hyrise_env(init_hyrise_env),
+      table_name(init_table_name),
+      if_exists(init_if_exists) {}
 
 std::string DropTableNode::description(const DescriptionMode mode) const {
   return std::string("[DropTable] Name: '") + table_name + "'";
 }
 
 size_t DropTableNode::_on_shallow_hash() const {
-  auto hash = boost::hash_value(table_name);
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, table_name);
   boost::hash_combine(hash, if_exists);
   return hash;
 }
 
 std::shared_ptr<AbstractLQPNode> DropTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return DropTableNode::make(table_name, if_exists);
+  return DropTableNode::make(hyrise_env, table_name, if_exists);
 }
 
 bool DropTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& drop_table_node = static_cast<const DropTableNode&>(rhs);
-  return table_name == drop_table_node.table_name && if_exists == drop_table_node.if_exists;
+  return hyrise_env == drop_table_node.hyrise_env && table_name == drop_table_node.table_name &&
+         if_exists == drop_table_node.if_exists;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/drop_table_node.hpp
+++ b/src/lib/logical_query_plan/drop_table_node.hpp
@@ -5,12 +5,16 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 class DropTableNode : public EnableMakeForLQPNode<DropTableNode>, public AbstractNonQueryNode {
  public:
-  DropTableNode(const std::string& init_table_name, bool init_if_exists);
+  DropTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name,
+                bool init_if_exists);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
   const bool if_exists;
 

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -11,24 +11,30 @@ using namespace std::string_literals;  // NOLINT
 
 namespace opossum {
 
-DropViewNode::DropViewNode(const std::string& init_view_name, const bool init_if_exists)
-    : AbstractNonQueryNode(LQPNodeType::DropView), view_name(init_view_name), if_exists(init_if_exists) {}
+DropViewNode::DropViewNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                           const std::string& init_view_name, const bool init_if_exists)
+    : AbstractNonQueryNode(LQPNodeType::DropView),
+      hyrise_env(init_hyrise_env),
+      view_name(init_view_name),
+      if_exists(init_if_exists) {}
 
 std::string DropViewNode::description(const DescriptionMode mode) const { return "[Drop] View: '"s + view_name + "'"; }
 
 size_t DropViewNode::_on_shallow_hash() const {
-  auto hash = boost::hash_value(view_name);
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, view_name);
   boost::hash_combine(hash, if_exists);
   return hash;
 }
 
 std::shared_ptr<AbstractLQPNode> DropViewNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return DropViewNode::make(view_name, if_exists);
+  return DropViewNode::make(hyrise_env, view_name, if_exists);
 }
 
 bool DropViewNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& drop_view_node = static_cast<const DropViewNode&>(rhs);
-  return view_name == drop_view_node.view_name && if_exists == drop_view_node.if_exists;
+  return hyrise_env == drop_view_node.hyrise_env && view_name == drop_view_node.view_name &&
+         if_exists == drop_view_node.if_exists;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -7,15 +7,19 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * Node type to represent deleting a view from the StorageManager
  */
 class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public AbstractNonQueryNode {
  public:
-  DropViewNode(const std::string& init_view_name, bool init_if_exists);
+  DropViewNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_view_name,
+               bool init_if_exists);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string view_name;
   const bool if_exists;
 

--- a/src/lib/logical_query_plan/import_node.cpp
+++ b/src/lib/logical_query_plan/import_node.cpp
@@ -6,9 +6,10 @@
 
 namespace opossum {
 
-ImportNode::ImportNode(const std::string& init_table_name, const std::string& init_file_name,
-                       const FileType init_file_type)
+ImportNode::ImportNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name,
+                       const std::string& init_file_name, const FileType init_file_type)
     : AbstractNonQueryNode(LQPNodeType::Import),
+      hyrise_env(init_hyrise_env),
       table_name(init_table_name),
       file_name(init_file_name),
       file_type(init_file_type) {}
@@ -20,20 +21,21 @@ std::string ImportNode::description(const DescriptionMode mode) const {
 }
 
 size_t ImportNode::_on_shallow_hash() const {
-  auto hash = boost::hash_value(table_name);
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, table_name);
   boost::hash_combine(hash, file_name);
   boost::hash_combine(hash, file_type);
   return hash;
 }
 
 std::shared_ptr<AbstractLQPNode> ImportNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return ImportNode::make(table_name, file_name, file_type);
+  return ImportNode::make(hyrise_env, table_name, file_name, file_type);
 }
 
 bool ImportNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& import_node = static_cast<const ImportNode&>(rhs);
-  return table_name == import_node.table_name && file_name == import_node.file_name &&
-         file_type == import_node.file_type;
+  return hyrise_env == import_node.hyrise_env && table_name == import_node.table_name &&
+         file_name == import_node.file_name && file_type == import_node.file_type;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/import_node.hpp
+++ b/src/lib/logical_query_plan/import_node.hpp
@@ -9,15 +9,19 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This node type represents the IMPORT / COPY FROM management command.
  */
 class ImportNode : public EnableMakeForLQPNode<ImportNode>, public AbstractNonQueryNode {
  public:
-  ImportNode(const std::string& init_table_name, const std::string& init_file_name, const FileType init_file_type);
+  ImportNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name,
+             const std::string& init_file_name, const FileType init_file_type);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
   const std::string file_name;
   const FileType file_type;

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -10,8 +10,8 @@
 
 namespace opossum {
 
-InsertNode::InsertNode(const std::string& init_table_name)
-    : AbstractNonQueryNode(LQPNodeType::Insert), table_name(init_table_name) {}
+InsertNode::InsertNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name)
+    : AbstractNonQueryNode(LQPNodeType::Insert), hyrise_env(init_hyrise_env), table_name(init_table_name) {}
 
 std::string InsertNode::description(const DescriptionMode mode) const {
   std::ostringstream desc;
@@ -24,12 +24,12 @@ std::string InsertNode::description(const DescriptionMode mode) const {
 size_t InsertNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
 
 std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return InsertNode::make(table_name);
+  return InsertNode::make(hyrise_env, table_name);
 }
 
 bool InsertNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& insert_node_rhs = static_cast<const InsertNode&>(rhs);
-  return table_name == insert_node_rhs.table_name;
+  return hyrise_env == insert_node_rhs.hyrise_env && table_name == insert_node_rhs.table_name;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -8,15 +8,18 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * Node type to represent insertion of rows into a table.
  */
 class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractNonQueryNode {
  public:
-  explicit InsertNode(const std::string& init_table_name);
+  explicit InsertNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
 
  protected:

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -10,6 +10,7 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class LQPColumnExpression;
 class TableStatistics;
 
@@ -20,7 +21,8 @@ class TableStatistics;
  */
 class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public AbstractLQPNode {
  public:
-  explicit StoredTableNode(const std::string& init_table_name);
+  explicit StoredTableNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env,
+                           const std::string& init_table_name);
 
   std::shared_ptr<LQPColumnExpression> get_column(const std::string& name) const;
 
@@ -46,6 +48,7 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
   // Generates unique constraints from table's key constraints and pays respect to pruned columns.
   std::shared_ptr<LQPUniqueConstraints> unique_constraints() const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
 
   // By default, the StoredTableNode takes its statistics from the table. This field can be used to overwrite these

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -10,8 +10,8 @@
 
 namespace opossum {
 
-UpdateNode::UpdateNode(const std::string& init_table_name)
-    : AbstractNonQueryNode(LQPNodeType::Update), table_name(init_table_name) {}
+UpdateNode::UpdateNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name)
+    : AbstractNonQueryNode(LQPNodeType::Update), hyrise_env(init_hyrise_env), table_name(init_table_name) {}
 
 std::string UpdateNode::description(const DescriptionMode mode) const {
   std::ostringstream desc;
@@ -22,18 +22,22 @@ std::string UpdateNode::description(const DescriptionMode mode) const {
 }
 
 std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  return UpdateNode::make(table_name);
+  return UpdateNode::make(hyrise_env, table_name);
 }
 
 bool UpdateNode::is_column_nullable(const ColumnID column_id) const { Fail("Update does not output any colums"); }
 
 std::vector<std::shared_ptr<AbstractExpression>> UpdateNode::output_expressions() const { return {}; }
 
-size_t UpdateNode::_on_shallow_hash() const { return boost::hash_value(table_name); }
+size_t UpdateNode::_on_shallow_hash() const {
+  auto hash = boost::hash_value(hyrise_env);
+  boost::hash_combine(hash, table_name);
+  return hash;
+}
 
 bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& update_node_rhs = static_cast<const UpdateNode&>(rhs);
-  return table_name == update_node_rhs.table_name;
+  return hyrise_env == update_node_rhs.hyrise_env && table_name == update_node_rhs.table_name;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -9,18 +9,20 @@
 namespace opossum {
 
 class AbstractExpression;
+class HyriseEnvironmentRef;
 
 /**
  * Node type to represent updates (i.e., invalidation and inserts) in a table.
  */
 class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public AbstractNonQueryNode {
  public:
-  explicit UpdateNode(const std::string& init_table_name);
+  explicit UpdateNode(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   bool is_column_nullable(const ColumnID column_id) const override;
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
 
  protected:

--- a/src/lib/operators/change_meta_table.cpp
+++ b/src/lib/operators/change_meta_table.cpp
@@ -9,10 +9,14 @@
 
 namespace opossum {
 
-ChangeMetaTable::ChangeMetaTable(const std::string& table_name, const MetaTableChangeType& change_type,
+class HyriseEnvironmentRef;
+
+ChangeMetaTable::ChangeMetaTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& table_name,
+                                 const MetaTableChangeType& change_type,
                                  const std::shared_ptr<const AbstractOperator>& values_to_modify,
                                  const std::shared_ptr<const AbstractOperator>& modification_values)
     : AbstractReadWriteOperator(OperatorType::ChangeMetaTable, values_to_modify, modification_values),
+      _hyrise_env(hyrise_env),
       _meta_table_name(table_name.substr(MetaTableManager::META_PREFIX.size())),
       _change_type(change_type) {}
 
@@ -26,13 +30,13 @@ std::shared_ptr<const Table> ChangeMetaTable::_on_execute(std::shared_ptr<Transa
 
   switch (_change_type) {
     case MetaTableChangeType::Insert:
-      Hyrise::get().meta_table_manager.insert_into(_meta_table_name, right_input_table());
+      _hyrise_env->meta_table_manager()->insert_into(_meta_table_name, right_input_table());
       break;
     case MetaTableChangeType::Update:
-      Hyrise::get().meta_table_manager.update(_meta_table_name, left_input_table(), right_input_table());
+      _hyrise_env->meta_table_manager()->update(_meta_table_name, left_input_table(), right_input_table());
       break;
     case MetaTableChangeType::Delete:
-      Hyrise::get().meta_table_manager.delete_from(_meta_table_name, left_input_table());
+      _hyrise_env->meta_table_manager()->delete_from(_meta_table_name, left_input_table());
       break;
   }
 
@@ -42,7 +46,8 @@ std::shared_ptr<const Table> ChangeMetaTable::_on_execute(std::shared_ptr<Transa
 std::shared_ptr<AbstractOperator> ChangeMetaTable::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input) const {
-  return std::make_shared<ChangeMetaTable>(_meta_table_name, _change_type, copied_left_input, copied_right_input);
+  return std::make_shared<ChangeMetaTable>(_hyrise_env, _meta_table_name, _change_type, copied_left_input,
+                                           copied_right_input);
 }
 
 void ChangeMetaTable::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}

--- a/src/lib/operators/change_meta_table.hpp
+++ b/src/lib/operators/change_meta_table.hpp
@@ -8,6 +8,7 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class TransactionContext;
 
 /**
@@ -27,7 +28,8 @@ class TransactionContext;
  */
 class ChangeMetaTable : public AbstractReadWriteOperator {
  public:
-  explicit ChangeMetaTable(const std::string& table_name, const MetaTableChangeType& change_type,
+  explicit ChangeMetaTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& table_name,
+                           const MetaTableChangeType& change_type,
                            const std::shared_ptr<const AbstractOperator>& values_to_modify,
                            const std::shared_ptr<const AbstractOperator>& modification_values);
 
@@ -43,6 +45,7 @@ class ChangeMetaTable : public AbstractReadWriteOperator {
   void _on_rollback_records() override {}
 
  private:
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _meta_table_name;
   const MetaTableChangeType _change_type;
 };

--- a/src/lib/operators/get_table.hpp
+++ b/src/lib/operators/get_table.hpp
@@ -10,6 +10,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // Operator to retrieve a table from the StorageManager by specifying its name. Depending on how the operator was
 // constructed, chunks and columns may be pruned if they are irrelevant for the final result. The returned table is NOT
 // the same table as stored in the StorageManager. If that stored table is changed (most importantly: if a chunk is
@@ -21,11 +23,11 @@ namespace opossum {
 class GetTable : public AbstractReadOnlyOperator {
  public:
   // Convenience constructor without pruning info
-  explicit GetTable(const std::string& name);
+  explicit GetTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& name);
 
   // Constructor with pruning info
-  GetTable(const std::string& name, const std::vector<ChunkID>& pruned_chunk_ids,
-           const std::vector<ColumnID>& pruned_column_ids);
+  GetTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& name,
+           const std::vector<ChunkID>& pruned_chunk_ids, const std::vector<ColumnID>& pruned_column_ids);
 
   const std::string& name() const override;
   std::string description(DescriptionMode description_mode) const override;
@@ -43,6 +45,7 @@ class GetTable : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
 
   // name of the table to retrieve
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _name;
   const std::vector<ChunkID> _pruned_chunk_ids;
   const std::vector<ColumnID> _pruned_column_ids;

--- a/src/lib/operators/import.hpp
+++ b/src/lib/operators/import.hpp
@@ -12,6 +12,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /*
  * This operator reads a file, creates a table from that input and adds it to the storage manager.
  * Supported file types are .tbl, .csv and Opossum .bin files.
@@ -27,9 +29,9 @@ class Import : public AbstractReadOnlyOperator {
    * @param file_type      Optional. Type indicating the file format. If not present, it is guessed by the filename.
    * @param csv_meta       Optional. A specific meta config, used instead of filename + '.json'
    */
-  explicit Import(const std::string& init_filename, const std::string& tablename,
-                  const ChunkOffset chunk_size = Chunk::DEFAULT_SIZE, const FileType file_type = FileType::Auto,
-                  const std::optional<CsvMeta>& csv_meta = std::nullopt);
+  explicit Import(const std::string& init_filename, const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                  const std::string& tablename, const ChunkOffset chunk_size = Chunk::DEFAULT_SIZE,
+                  const FileType file_type = FileType::Auto, const std::optional<CsvMeta>& csv_meta = std::nullopt);
 
   const std::string& name() const final;
   const std::string filename;
@@ -44,6 +46,7 @@ class Import : public AbstractReadOnlyOperator {
 
  private:
   // Name for adding the table to the StorageManager
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _tablename;
   const ChunkOffset _chunk_size;
   FileType _file_type;

--- a/src/lib/operators/insert.hpp
+++ b/src/lib/operators/insert.hpp
@@ -10,6 +10,7 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class TransactionContext;
 
 /**
@@ -21,7 +22,7 @@ class TransactionContext;
  */
 class Insert : public AbstractReadWriteOperator {
  public:
-  explicit Insert(const std::string& target_table_name,
+  explicit Insert(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& target_table_name,
                   const std::shared_ptr<const AbstractOperator>& values_to_insert);
 
   const std::string& name() const override;
@@ -36,6 +37,7 @@ class Insert : public AbstractReadWriteOperator {
   void _on_rollback_records() override;
 
  private:
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _target_table_name;
 
   // Ranges of rows to which the inserted values are written

--- a/src/lib/operators/maintenance/create_prepared_plan.cpp
+++ b/src/lib/operators/maintenance/create_prepared_plan.cpp
@@ -5,9 +5,11 @@
 
 namespace opossum {
 
-CreatePreparedPlan::CreatePreparedPlan(const std::string& prepared_plan_name,
+CreatePreparedPlan::CreatePreparedPlan(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                       const std::string& prepared_plan_name,
                                        const std::shared_ptr<PreparedPlan>& prepared_plan)
     : AbstractReadOnlyOperator(OperatorType::CreatePreparedPlan),
+      _hyrise_env(hyrise_env),
       _prepared_plan_name(prepared_plan_name),
       _prepared_plan(prepared_plan) {}
 
@@ -30,7 +32,7 @@ std::shared_ptr<PreparedPlan> CreatePreparedPlan::prepared_plan() const { return
 const std::string& CreatePreparedPlan::prepared_plan_name() const { return _prepared_plan_name; }
 
 std::shared_ptr<const Table> CreatePreparedPlan::_on_execute() {
-  Hyrise::get().storage_manager.add_prepared_plan(_prepared_plan_name, _prepared_plan);
+  _hyrise_env->storage_manager()->add_prepared_plan(_prepared_plan_name, _prepared_plan);
   return nullptr;
 }
 
@@ -39,7 +41,7 @@ void CreatePreparedPlan::_on_set_parameters(const std::unordered_map<ParameterID
 std::shared_ptr<AbstractOperator> CreatePreparedPlan::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input) const {
-  return std::make_shared<CreatePreparedPlan>(_prepared_plan_name, _prepared_plan->deep_copy());
+  return std::make_shared<CreatePreparedPlan>(_hyrise_env, _prepared_plan_name, _prepared_plan->deep_copy());
 }
 
 }  // namespace opossum

--- a/src/lib/operators/maintenance/create_prepared_plan.hpp
+++ b/src/lib/operators/maintenance/create_prepared_plan.hpp
@@ -5,9 +5,12 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 class CreatePreparedPlan : public AbstractReadOnlyOperator {
  public:
-  CreatePreparedPlan(const std::string& prepared_plan_name, const std::shared_ptr<PreparedPlan>& prepared_plan);
+  CreatePreparedPlan(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& prepared_plan_name,
+                     const std::shared_ptr<PreparedPlan>& prepared_plan);
 
   const std::string& name() const override;
   std::string description(DescriptionMode description_mode) const override;
@@ -25,6 +28,7 @@ class CreatePreparedPlan : public AbstractReadOnlyOperator {
       const std::shared_ptr<AbstractOperator>& copied_right_input) const override;
 
  private:
+  const std::shared_ptr<HyriseEnvironmentRef>& _hyrise_env;
   const std::string _prepared_plan_name;
   const std::shared_ptr<PreparedPlan> _prepared_plan;
 };

--- a/src/lib/operators/maintenance/create_table.hpp
+++ b/src/lib/operators/maintenance/create_table.hpp
@@ -2,20 +2,24 @@
 
 #include "operators/abstract_read_write_operator.hpp"
 #include "operators/insert.hpp"
+#include "storage/storage_manager.hpp"
 #include "storage/table_column_definition.hpp"
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // maintenance operator for the "CREATE TABLE" sql statement
 class CreateTable : public AbstractReadWriteOperator {
  public:
-  CreateTable(const std::string& init_table_name, bool init_if_not_exists,
-              const std::shared_ptr<const AbstractOperator>& input_operator);
+  CreateTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& init_table_name,
+              bool init_if_not_exists, const std::shared_ptr<const AbstractOperator>& input_operator);
 
   const std::string& name() const override;
   std::string description(DescriptionMode description_mode) const override;
   const TableColumnDefinitions& column_definitions() const;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
   const bool if_not_exists;
 

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -10,8 +10,10 @@
 
 namespace opossum {
 
-CreateView::CreateView(const std::string& view_name, const std::shared_ptr<LQPView>& view, const bool if_not_exists)
+CreateView::CreateView(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& view_name,
+                       const std::shared_ptr<LQPView>& view, const bool if_not_exists)
     : AbstractReadOnlyOperator(OperatorType::CreateView),
+      _hyrise_env(hyrise_env),
       _view_name(view_name),
       _view(view),
       _if_not_exists(if_not_exists) {}
@@ -27,15 +29,15 @@ bool CreateView::if_not_exists() const { return _if_not_exists; }
 std::shared_ptr<AbstractOperator> CreateView::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input) const {
-  return std::make_shared<CreateView>(_view_name, _view->deep_copy(), _if_not_exists);
+  return std::make_shared<CreateView>(_hyrise_env, _view_name, _view->deep_copy(), _if_not_exists);
 }
 
 void CreateView::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<const Table> CreateView::_on_execute() {
   // If IF NOT EXISTS is not set and the view already exists, StorageManager throws an exception
-  if (!_if_not_exists || !Hyrise::get().storage_manager.has_view(_view_name)) {
-    Hyrise::get().storage_manager.add_view(_view_name, _view);
+  if (!_if_not_exists || !_hyrise_env->storage_manager()->has_view(_view_name)) {
+    _hyrise_env->storage_manager()->add_view(_view_name, _view);
   }
   return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
 }

--- a/src/lib/operators/maintenance/create_view.hpp
+++ b/src/lib/operators/maintenance/create_view.hpp
@@ -8,12 +8,14 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class LQPView;
 
 // maintenance operator for the "CREATE VIEW" sql statement
 class CreateView : public AbstractReadOnlyOperator {
  public:
-  CreateView(const std::string& view_name, const std::shared_ptr<LQPView>& view, bool if_not_exists);
+  CreateView(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& view_name,
+             const std::shared_ptr<LQPView>& view, bool if_not_exists);
 
   const std::string& name() const override;
 
@@ -29,6 +31,7 @@ class CreateView : public AbstractReadOnlyOperator {
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
  private:
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _view_name;
   const std::shared_ptr<LQPView> _view;
   const bool _if_not_exists;

--- a/src/lib/operators/maintenance/drop_table.cpp
+++ b/src/lib/operators/maintenance/drop_table.cpp
@@ -4,8 +4,12 @@
 
 namespace opossum {
 
-DropTable::DropTable(const std::string& init_table_name, const bool init_if_exists)
-    : AbstractReadOnlyOperator(OperatorType::DropTable), table_name(init_table_name), if_exists(init_if_exists) {}
+DropTable::DropTable(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name,
+                     const bool init_if_exists)
+    : AbstractReadOnlyOperator(OperatorType::DropTable),
+      hyrise_env(init_hyrise_env),
+      table_name(init_table_name),
+      if_exists(init_if_exists) {}
 
 const std::string& DropTable::name() const {
   static const auto name = std::string{"DropTable"};
@@ -16,8 +20,8 @@ std::string DropTable::description(DescriptionMode description_mode) const { ret
 
 std::shared_ptr<const Table> DropTable::_on_execute() {
   // If IF EXISTS is not set and the table is not found, StorageManager throws an exception
-  if (!if_exists || Hyrise::get().storage_manager.has_table(table_name)) {
-    Hyrise::get().storage_manager.drop_table(table_name);
+  if (!if_exists || hyrise_env->storage_manager()->has_table(table_name)) {
+    hyrise_env->storage_manager()->drop_table(table_name);
   }
 
   return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
@@ -26,7 +30,7 @@ std::shared_ptr<const Table> DropTable::_on_execute() {
 std::shared_ptr<AbstractOperator> DropTable::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input) const {
-  return std::make_shared<DropTable>(table_name, if_exists);
+  return std::make_shared<DropTable>(hyrise_env, table_name, if_exists);
 }
 
 void DropTable::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {

--- a/src/lib/operators/maintenance/drop_table.hpp
+++ b/src/lib/operators/maintenance/drop_table.hpp
@@ -4,14 +4,18 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // maintenance operator for the "DROP TABLE" sql statement
 class DropTable : public AbstractReadOnlyOperator {
  public:
-  DropTable(const std::string& init_table_name, bool init_if_exists);
+  DropTable(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_table_name,
+            bool init_if_exists);
 
   const std::string& name() const override;
   std::string description(DescriptionMode description_mode) const override;
 
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string table_name;
   const bool if_exists;
 

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -9,8 +9,12 @@
 
 namespace opossum {
 
-DropView::DropView(const std::string& init_view_name, const bool init_if_exists)
-    : AbstractReadOnlyOperator(OperatorType::DropView), view_name(init_view_name), if_exists(init_if_exists) {}
+DropView::DropView(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_view_name,
+                   const bool init_if_exists)
+    : AbstractReadOnlyOperator(OperatorType::DropView),
+      hyrise_env(init_hyrise_env),
+      view_name(init_view_name),
+      if_exists(init_if_exists) {}
 
 const std::string& DropView::name() const {
   static const auto name = std::string{"DropView"};
@@ -20,15 +24,15 @@ const std::string& DropView::name() const {
 std::shared_ptr<AbstractOperator> DropView::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input) const {
-  return std::make_shared<DropView>(view_name, if_exists);
+  return std::make_shared<DropView>(hyrise_env, view_name, if_exists);
 }
 
 void DropView::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<const Table> DropView::_on_execute() {
   // If IF EXISTS is not set and the view is not found, StorageManager throws an exception
-  if (!if_exists || Hyrise::get().storage_manager.has_view(view_name)) {
-    Hyrise::get().storage_manager.drop_view(view_name);
+  if (!if_exists || hyrise_env->storage_manager()->has_view(view_name)) {
+    hyrise_env->storage_manager()->drop_view(view_name);
   }
 
   return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table

--- a/src/lib/operators/maintenance/drop_view.hpp
+++ b/src/lib/operators/maintenance/drop_view.hpp
@@ -9,12 +9,17 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // maintenance operator for the "CREATE VIEW" sql statement
 class DropView : public AbstractReadOnlyOperator {
  public:
-  DropView(const std::string& init_view_name, bool init_if_exists);
+  DropView(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env, const std::string& init_view_name,
+           bool init_if_exists);
 
   const std::string& name() const override;
+
+  const std::shared_ptr<HyriseEnvironmentRef> hyrise_env;
   const std::string view_name;
   const bool if_exists;
 

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -60,8 +60,9 @@ void Print::print(const std::shared_ptr<const AbstractOperator>& in, const Print
   Print(in, flags, out).execute();
 }
 
-void Print::print(const std::string& sql, const PrintFlags flags, std::ostream& out) {
-  auto pipeline = SQLPipelineBuilder{sql}.create_pipeline();
+void Print::print(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& sql,
+                  const PrintFlags flags, std::ostream& out) {
+  auto pipeline = SQLPipelineBuilder{sql}.with_hyrise_env(hyrise_env).create_pipeline();
   const auto [status, result_tables] = pipeline.get_result_tables();
   Assert(status == SQLPipelineStatus::Success, "SQL execution was unsuccessful");
   Assert(result_tables.size() == 1, "Expected exactly one result table");

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -9,6 +9,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * PrintFlags::Mvcc:                   If set, print begin commit id and end commit id and transaction id for each tuple
  * PrintFlags::IgnoreChunkBoundaries:  If set, print a logical view of the Table, i.e., do not print info about Chunks or
@@ -32,7 +34,8 @@ class Print : public AbstractReadOnlyOperator {
                     std::ostream& out = std::cout);
 
   // Convenience method to print the result of an SQL query
-  static void print(const std::string& sql, const PrintFlags flags = PrintFlags::None, std::ostream& out = std::cout);
+  static void print(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& sql,
+                    const PrintFlags flags = PrintFlags::None, std::ostream& out = std::cout);
 
  protected:
   std::vector<uint16_t> _column_string_widths(uint16_t min, uint16_t max,

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -15,9 +15,11 @@
 
 namespace opossum {
 
-Update::Update(const std::string& table_to_update_name, const std::shared_ptr<AbstractOperator>& fields_to_update_op,
+Update::Update(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& table_to_update_name,
+               const std::shared_ptr<AbstractOperator>& fields_to_update_op,
                const std::shared_ptr<AbstractOperator>& update_values_op)
     : AbstractReadWriteOperator(OperatorType::Update, fields_to_update_op, update_values_op),
+      _hyrise_env{hyrise_env},
       _table_to_update_name{table_to_update_name} {}
 
 const std::string& Update::name() const {
@@ -26,7 +28,7 @@ const std::string& Update::name() const {
 }
 
 std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionContext> context) {
-  const auto table_to_update = Hyrise::get().storage_manager.get_table(_table_to_update_name);
+  const auto table_to_update = _hyrise_env->storage_manager()->get_table(_table_to_update_name);
 
   // 0. Validate input
   DebugAssert(context, "Update needs a transaction context");
@@ -49,7 +51,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
   }
 
   // 2. Insert new data with the Insert operator.
-  _insert = std::make_shared<Insert>(_table_to_update_name, _right_input);
+  _insert = std::make_shared<Insert>(_hyrise_env, _table_to_update_name, _right_input);
   _insert->set_transaction_context(context);
   _insert->execute();
   // Insert cannot fail in the MVCC sense, no check necessary
@@ -60,7 +62,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
 std::shared_ptr<AbstractOperator> Update::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input) const {
-  return std::make_shared<Update>(_table_to_update_name, copied_left_input, copied_right_input);
+  return std::make_shared<Update>(_hyrise_env, _table_to_update_name, copied_left_input, copied_right_input);
 }
 
 void Update::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}

--- a/src/lib/operators/update.hpp
+++ b/src/lib/operators/update.hpp
@@ -10,6 +10,7 @@
 namespace opossum {
 
 class Delete;
+class HyriseEnvironmentRef;
 class Insert;
 
 /**
@@ -26,7 +27,8 @@ class Insert;
  */
 class Update : public AbstractReadWriteOperator {
  public:
-  explicit Update(const std::string& table_to_update_name, const std::shared_ptr<AbstractOperator>& fields_to_update_op,
+  explicit Update(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& table_to_update_name,
+                  const std::shared_ptr<AbstractOperator>& fields_to_update_op,
                   const std::shared_ptr<AbstractOperator>& update_values_op);
 
   const std::string& name() const override;
@@ -45,6 +47,7 @@ class Update : public AbstractReadWriteOperator {
   void _on_rollback_records() override {}
 
  protected:
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _table_to_update_name;
   std::shared_ptr<Delete> _delete;
   std::shared_ptr<Insert> _insert;

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -59,7 +59,7 @@ void ChunkPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<A
   /**
    * A chain of predicates followed by a stored table node was found.
    */
-  auto table = Hyrise::get().storage_manager.get_table(stored_table->table_name);
+  auto table = stored_table->hyrise_env->storage_manager()->get_table(stored_table->table_name);
 
   std::set<ChunkID> pruned_chunk_ids;
   for (auto& predicate : predicate_nodes) {

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -58,7 +58,7 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
     if (!stored_table_node) return LQPVisitation::VisitInputs;
 
     // Checks for condition 6
-    const auto& table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
+    const auto& table = stored_table_node->hyrise_env->storage_manager()->get_table(stored_table_node->table_name);
     const auto original_column_id = column->original_column_id;
     const auto table_column_definition = table->column_definitions()[original_column_id];
     if (table_column_definition.nullable == true) return LQPVisitation::VisitInputs;

--- a/src/lib/server/query_handler.hpp
+++ b/src/lib/server/query_handler.hpp
@@ -26,11 +26,14 @@ class QueryHandler {
  public:
   static std::pair<ExecutionInformation, std::shared_ptr<TransactionContext>> execute_pipeline(
       const std::string& query, const SendExecutionInfo send_execution_info,
+      const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
       const std::shared_ptr<TransactionContext>& transaction_context);
 
-  static void setup_prepared_plan(const std::string& statement_name, const std::string& query);
+  static void setup_prepared_plan(const std::string& statement_name, const std::string& query,
+                                  const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
-  static std::shared_ptr<AbstractOperator> bind_prepared_plan(const PreparedStatementDetails& statement_details);
+  static std::shared_ptr<AbstractOperator> bind_prepared_plan(const PreparedStatementDetails& statement_details,
+                                                              const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   static std::shared_ptr<const Table> execute_prepared_plan(const std::shared_ptr<AbstractOperator>& physical_plan);
 

--- a/src/lib/server/server.cpp
+++ b/src/lib/server/server.cpp
@@ -12,8 +12,10 @@ namespace opossum {
 
 // Specified port (default: 5432) will be opened after initializing the _acceptor
 Server::Server(const boost::asio::ip::address& address, const uint16_t port,
-               const SendExecutionInfo send_execution_info)
-    : _acceptor(_io_service, boost::asio::ip::tcp::endpoint(address, port)), _send_execution_info(send_execution_info) {
+               const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const SendExecutionInfo send_execution_info)
+    : _hyrise_env(hyrise_env),
+      _acceptor(_io_service, boost::asio::ip::tcp::endpoint(address, port)),
+      _send_execution_info(send_execution_info) {
   std::cout << "Server started at " << server_address() << " and port " << server_port() << std::endl
             << "Run 'psql -h localhost " << server_address() << "' to connect to the server" << std::endl;
 }
@@ -37,7 +39,7 @@ void Server::_accept_new_session() {
   // Create a new session. This will also open a new data socket in order to communicate with the client
   // For more information on TCP ports + Asio see:
   // https://www.gamedev.net/forums/topic/586557-boostasio-allowing-multiple-connections-to-a-single-server-socket/
-  auto new_session = std::make_shared<Session>(_io_service, _send_execution_info);
+  auto new_session = std::make_shared<Session>(_io_service, _hyrise_env, _send_execution_info);
   _acceptor.async_accept(*(new_session->socket()),
                          boost::bind(&Server::_start_session, this, new_session, boost::asio::placeholders::error));
 }

--- a/src/lib/server/server.hpp
+++ b/src/lib/server/server.hpp
@@ -29,7 +29,8 @@ namespace opossum {
 
 class Server {
  public:
-  Server(const boost::asio::ip::address& address, const uint16_t port, const SendExecutionInfo send_execution_info);
+  Server(const boost::asio::ip::address& address, const uint16_t port,
+         const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const SendExecutionInfo send_execution_info);
 
   // Start server to accept new sessions.
   void run();
@@ -53,6 +54,8 @@ class Server {
 
   std::atomic<uint64_t> _num_running_sessions{0};
   boost::asio::io_service _io_service;
+  const std::shared_ptr<HyriseEnvironmentRef>
+      _hyrise_env;  // TODO: User should be allowed to have several of these to choose from.
   boost::asio::ip::tcp::acceptor _acceptor;
   const SendExecutionInfo _send_execution_info;
   std::atomic_bool _is_initialized{false};

--- a/src/lib/server/session.hpp
+++ b/src/lib/server/session.hpp
@@ -7,6 +7,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // The session class implements the communication flow and stores session-specific information such as portals. Those
 // portals are required by the PostgreSQL message protocol for the execution of prepared statements. However, named
 // portals used for CURSOR operations are currently not supported by Hyrise. For further documentation see here:
@@ -14,7 +16,8 @@ namespace opossum {
 // Example usage can be found here: https://stackoverflow.com/questions/52479293/postgresql-refcursor-and-portal-name
 class Session {
  public:
-  explicit Session(boost::asio::io_service& io_service, const SendExecutionInfo send_execution_info);
+  explicit Session(boost::asio::io_service& io_service, const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                   const SendExecutionInfo send_execution_info);
 
   // Start new session.
   void run();
@@ -48,6 +51,7 @@ class Session {
 
   const std::shared_ptr<Socket> _socket;
   const std::shared_ptr<PostgresProtocolHandler<Socket>> _postgres_protocol_handler;
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const SendExecutionInfo _send_execution_info;
   bool _terminate_session = false;
   bool _sync_send_after_error = false;

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -15,13 +15,15 @@
 
 namespace opossum {
 
-SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<TransactionContext>& transaction_context,
-                         const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
+SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                         const std::shared_ptr<TransactionContext>& transaction_context, const UseMvcc use_mvcc,
+                         const std::shared_ptr<Optimizer>& optimizer,
                          const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
                          const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache)
     : pqp_cache(init_pqp_cache),
       lqp_cache(init_lqp_cache),
       _sql(sql),
+      _hyrise_env(hyrise_env),
       _transaction_context(transaction_context),
       _optimizer(optimizer) {
   DebugAssert(!_transaction_context || _transaction_context->phase() == TransactionPhase::Active,
@@ -82,8 +84,8 @@ SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Transacti
     const auto statement_string = boost::trim_copy(sql.substr(sql_string_offset, statement_string_length));
     sql_string_offset += statement_string_length;
 
-    auto pipeline_statement = std::make_shared<SQLPipelineStatement>(statement_string, std::move(parsed_statement),
-                                                                     use_mvcc, optimizer, pqp_cache, lqp_cache);
+    auto pipeline_statement = std::make_shared<SQLPipelineStatement>(
+        statement_string, std::move(parsed_statement), use_mvcc, _hyrise_env, optimizer, pqp_cache, lqp_cache);
     _sql_pipeline_statements.emplace_back(std::move(pipeline_statement));
   }
 

--- a/src/lib/sql/sql_pipeline.hpp
+++ b/src/lib/sql/sql_pipeline.hpp
@@ -32,9 +32,9 @@ std::ostream& operator<<(std::ostream& stream, const SQLPipelineMetrics& metrics
 class SQLPipeline : public Noncopyable {
  public:
   // Prefer using the SQLPipelineBuilder interface for constructing SQLPipelines conveniently
-  SQLPipeline(const std::string& sql, const std::shared_ptr<TransactionContext>& transaction_context,
-              const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
-              const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
+  SQLPipeline(const std::string& sql, const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+              const std::shared_ptr<TransactionContext>& transaction_context, const UseMvcc use_mvcc,
+              const std::shared_ptr<Optimizer>& optimizer, const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
               const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache);
 
   // Returns the original SQL string
@@ -105,6 +105,8 @@ class SQLPipeline : public Noncopyable {
   std::string _sql;
 
   std::vector<std::shared_ptr<SQLPipelineStatement>> _sql_pipeline_statements;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 
   // Either created during execution (if auto-commit) or set by set_transaction_context
   std::shared_ptr<TransactionContext> _transaction_context;

--- a/src/lib/sql/sql_pipeline_builder.cpp
+++ b/src/lib/sql/sql_pipeline_builder.cpp
@@ -17,6 +17,11 @@ SQLPipelineBuilder& SQLPipelineBuilder::with_optimizer(const std::shared_ptr<Opt
   return *this;
 }
 
+SQLPipelineBuilder& SQLPipelineBuilder::with_hyrise_env(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env) {
+  _hyrise_env = hyrise_env;
+  return *this;
+}
+
 SQLPipelineBuilder& SQLPipelineBuilder::with_transaction_context(
     const std::shared_ptr<TransactionContext>& transaction_context) {
   _transaction_context = transaction_context;
@@ -40,7 +45,7 @@ SQLPipelineBuilder& SQLPipelineBuilder::disable_mvcc() { return with_mvcc(UseMvc
 SQLPipeline SQLPipelineBuilder::create_pipeline() const {
   DTRACE_PROBE1(HYRISE, CREATE_PIPELINE, reinterpret_cast<uintptr_t>(this));
   auto optimizer = _optimizer ? _optimizer : Optimizer::create_default_optimizer();
-  auto pipeline = SQLPipeline(_sql, _transaction_context, _use_mvcc, optimizer, _pqp_cache, _lqp_cache);
+  auto pipeline = SQLPipeline(_sql, _hyrise_env, _transaction_context, _use_mvcc, optimizer, _pqp_cache, _lqp_cache);
   DTRACE_PROBE3(HYRISE, PIPELINE_CREATION_DONE, pipeline.get_sql_per_statement().size(), _sql.c_str(),
                 reinterpret_cast<uintptr_t>(this));
   return pipeline;

--- a/src/lib/sql/sql_pipeline_builder.hpp
+++ b/src/lib/sql/sql_pipeline_builder.hpp
@@ -39,6 +39,7 @@ class SQLPipelineBuilder final {
 
   SQLPipelineBuilder& with_mvcc(const UseMvcc use_mvcc);
   SQLPipelineBuilder& with_optimizer(const std::shared_ptr<Optimizer>& optimizer);
+  SQLPipelineBuilder& with_hyrise_env(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
   SQLPipelineBuilder& with_transaction_context(const std::shared_ptr<TransactionContext>& transaction_context);
   SQLPipelineBuilder& with_pqp_cache(const std::shared_ptr<SQLPhysicalPlanCache>& pqp_cache);
   SQLPipelineBuilder& with_lqp_cache(const std::shared_ptr<SQLLogicalPlanCache>& lqp_cache);
@@ -54,6 +55,7 @@ class SQLPipelineBuilder final {
   const std::string _sql;
 
   UseMvcc _use_mvcc{UseMvcc::Yes};
+  std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   std::shared_ptr<TransactionContext> _transaction_context;
   std::shared_ptr<Optimizer> _optimizer;
   std::shared_ptr<SQLPhysicalPlanCache> _pqp_cache;

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -55,7 +55,8 @@ class SQLPipelineStatement : public Noncopyable {
  public:
   // Prefer using the SQLPipelineBuilder for constructing SQLPipelineStatements conveniently
   SQLPipelineStatement(const std::string& sql, std::shared_ptr<hsql::SQLParserResult> parsed_sql,
-                       const UseMvcc use_mvcc, const std::shared_ptr<Optimizer>& optimizer,
+                       const UseMvcc use_mvcc, const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                       const std::shared_ptr<Optimizer>& optimizer,
                        const std::shared_ptr<SQLPhysicalPlanCache>& init_pqp_cache,
                        const std::shared_ptr<SQLLogicalPlanCache>& init_lqp_cache);
 
@@ -112,11 +113,12 @@ class SQLPipelineStatement : public Noncopyable {
   // Performs a sanity check in order to prevent an execution of a predictably failing DDL operator (e.g., creating a
   // table that already exists).
   // Throws an InvalidInputException if an invalid PQP is detected.
-  static void _precheck_ddl_operators(const std::shared_ptr<AbstractOperator>& pqp);
+  void _precheck_ddl_operators(const std::shared_ptr<AbstractOperator>& pqp);
 
   const std::string _sql_string;
   const UseMvcc _use_mvcc;
 
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::shared_ptr<Optimizer> _optimizer;
 
   // Execution results

--- a/src/lib/sql/sql_translator.hpp
+++ b/src/lib/sql/sql_translator.hpp
@@ -18,6 +18,7 @@
 namespace opossum {
 
 class AggregateNode;
+class HyriseEnvironmentRef;
 class LQPSubqueryExpression;
 class Table;
 
@@ -54,7 +55,7 @@ class SQLTranslator final {
   /**
    * @param use_mvcc  Whether ValidateNodes should be compiled into the plan
    */
-  explicit SQLTranslator(const UseMvcc use_mvcc);
+  explicit SQLTranslator(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const UseMvcc use_mvcc);
 
   /**
    * Main entry point. Translate an AST produced by the SQLParser into LQPs, one for each SQL statement
@@ -121,7 +122,7 @@ class SQLTranslator final {
    * @param _meta_tables                            Contains a map of meta table names to meta tables that have already
    *                                                been loaded by other subqueries
    */
-  SQLTranslator(const UseMvcc use_mvcc,
+  SQLTranslator(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const UseMvcc use_mvcc,
                 const std::shared_ptr<SQLIdentifierResolverProxy>& external_sql_identifier_resolver_proxy,
                 const std::shared_ptr<ParameterIDAllocator>& parameter_id_allocator,
                 const std::unordered_map<std::string, std::shared_ptr<LQPView>>& with_descriptions,
@@ -133,7 +134,7 @@ class SQLTranslator final {
   * @param meta_tables  Contains a map of meta table names to meta tables that have already
   *                     been loaded by other subqueries
   */
-  SQLTranslator(const UseMvcc use_mvcc,
+  SQLTranslator(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const UseMvcc use_mvcc,
                 const std::shared_ptr<std::unordered_map<std::string, std::shared_ptr<Table>>>& meta_tables);
 
   std::shared_ptr<AbstractLQPNode> _translate_statement(const hsql::SQLStatement& statement);
@@ -204,6 +205,7 @@ class SQLTranslator final {
   static std::string _trim_meta_table_name(const std::string& name);
 
  private:
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const UseMvcc _use_mvcc;
 
   std::shared_ptr<AbstractLQPNode> _current_lqp;

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -171,7 +171,8 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_statistics(
     case LQPNodeType::StoredTable: {
       const auto stored_table_node = std::dynamic_pointer_cast<const StoredTableNode>(lqp);
 
-      const auto stored_table = Hyrise::get().storage_manager.get_table(stored_table_node->table_name);
+      const auto stored_table =
+          stored_table_node->hyrise_env->storage_manager()->get_table(stored_table_node->table_name);
       Assert(stored_table->table_statistics(), "Stored Table should have cardinality estimation statistics");
 
       if (stored_table_node->table_statistics) {

--- a/src/lib/storage/storage_manager.hpp
+++ b/src/lib/storage/storage_manager.hpp
@@ -17,10 +17,12 @@ namespace opossum {
 
 class Table;
 class AbstractLQPNode;
+class MetaTableManager;
+class PluginManager;
 
 // The StorageManager is a class that maintains all tables
 // by mapping table names to table instances.
-class StorageManager : public Noncopyable {
+class StorageManager : public std::enable_shared_from_this<StorageManager> {
  public:
   /**
    * @defgroup Manage Tables, this is only thread-safe for operations on tables with different names
@@ -60,8 +62,11 @@ class StorageManager : public Noncopyable {
   // For debugging purposes mostly, dump all tables as csv
   void export_all_tables_as_csv(const std::string& path);
 
- protected:
   StorageManager() = default;
+  StorageManager(const StorageManager&) = delete;
+  void operator=(const StorageManager&) = delete;
+
+ protected:
   friend class Hyrise;
 
   // We preallocate maps to prevent costly re-allocation.

--- a/src/lib/tasks/chunk_compression_task.cpp
+++ b/src/lib/tasks/chunk_compression_task.cpp
@@ -13,14 +13,16 @@
 
 namespace opossum {
 
-ChunkCompressionTask::ChunkCompressionTask(const std::string& table_name, const ChunkID chunk_id)
-    : ChunkCompressionTask{table_name, std::vector<ChunkID>{chunk_id}} {}
+ChunkCompressionTask::ChunkCompressionTask(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                           const std::string& table_name, const ChunkID chunk_id)
+    : ChunkCompressionTask{hyrise_env, table_name, std::vector<ChunkID>{chunk_id}} {}
 
-ChunkCompressionTask::ChunkCompressionTask(const std::string& table_name, const std::vector<ChunkID>& chunk_ids)
-    : _table_name{table_name}, _chunk_ids{chunk_ids} {}
+ChunkCompressionTask::ChunkCompressionTask(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                           const std::string& table_name, const std::vector<ChunkID>& chunk_ids)
+    : _hyrise_env{hyrise_env}, _table_name{table_name}, _chunk_ids{chunk_ids} {}
 
 void ChunkCompressionTask::_on_execute() {
-  auto table = Hyrise::get().storage_manager.get_table(_table_name);
+  auto table = _hyrise_env->storage_manager()->get_table(_table_name);
 
   Assert(table, "Table does not exist.");
 

--- a/src/lib/tasks/chunk_compression_task.hpp
+++ b/src/lib/tasks/chunk_compression_task.hpp
@@ -8,6 +8,7 @@
 namespace opossum {
 
 class Chunk;
+class HyriseEnvironmentRef;
 
 /**
  * @brief Compresses a chunk of a table using the default encoding
@@ -32,8 +33,10 @@ class Chunk;
  */
 class ChunkCompressionTask : public AbstractTask {
  public:
-  explicit ChunkCompressionTask(const std::string& table_name, const ChunkID chunk_id);
-  explicit ChunkCompressionTask(const std::string& table_name, const std::vector<ChunkID>& chunk_ids);
+  explicit ChunkCompressionTask(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& table_name,
+                                const ChunkID chunk_id);
+  explicit ChunkCompressionTask(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& table_name,
+                                const std::vector<ChunkID>& chunk_ids);
 
  protected:
   void _on_execute() override;
@@ -47,6 +50,7 @@ class ChunkCompressionTask : public AbstractTask {
   static bool _chunk_is_completed(const std::shared_ptr<Chunk>& chunk, const uint32_t target_chunk_size);
 
  private:
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
   const std::string _table_name;
   const std::vector<ChunkID> _chunk_ids;
 };

--- a/src/lib/utils/abstract_plugin.hpp
+++ b/src/lib/utils/abstract_plugin.hpp
@@ -7,16 +7,22 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // This is necessary to make the plugin instantiable, it leads to plain C linkage to avoid
 // ugly mangled names. Use EXPORT in the implementation file of your plugin.
-#define EXPORT_PLUGIN(PluginName) \
-  extern "C" AbstractPlugin* factory() { return new PluginName(); }
+#define EXPORT_PLUGIN(PluginName)                                                               \
+  extern "C" AbstractPlugin* factory(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env) { \
+    return new PluginName(hyrise_env);                                                          \
+  }
 
 // AbstractPlugin is the abstract super class for all plugins. An example implementation can be found
 // under test/utils/test_plugin.cpp. Usually plugins are implemented as singletons because there
 // shouldn't be multiple instances of them as they would compete against each other.
 class AbstractPlugin {
  public:
+  AbstractPlugin(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env);
+
   virtual ~AbstractPlugin() = default;
 
   virtual std::string description() const = 0;
@@ -24,6 +30,10 @@ class AbstractPlugin {
   virtual void start() = 0;
 
   virtual void stop() = 0;
+
+ protected:
+  // Raw pointer is used since storage manager is the owner of plugin manager
+  std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/log_manager.cpp
+++ b/src/lib/utils/log_manager.cpp
@@ -5,7 +5,7 @@ namespace opossum {
 void LogManager::add_message(const std::string& reporter, const std::string& message, const LogLevel log_level) {
   const auto now = std::chrono::system_clock::now();
   const LogEntry log_entry{now, log_level, reporter, message};
-  _log_entries.emplace_back(log_entry);
+  _log_entries.push_back(log_entry);
 }
 
 const tbb::concurrent_vector<LogEntry>& LogManager::log_entries() const { return _log_entries; }

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -1,5 +1,6 @@
 #include "meta_table_manager.hpp"
 
+#include "hyrise.hpp"
 #include "utils/meta_tables/meta_chunk_sort_orders_table.hpp"
 #include "utils/meta_tables/meta_chunks_table.hpp"
 #include "utils/meta_tables/meta_columns_table.hpp"
@@ -14,18 +15,19 @@
 
 namespace opossum {
 
-MetaTableManager::MetaTableManager() {
-  const std::vector<std::shared_ptr<AbstractMetaTable>> meta_tables = {std::make_shared<MetaTablesTable>(),
-                                                                       std::make_shared<MetaColumnsTable>(),
-                                                                       std::make_shared<MetaChunksTable>(),
-                                                                       std::make_shared<MetaChunkSortOrdersTable>(),
-                                                                       std::make_shared<MetaLogTable>(),
-                                                                       std::make_shared<MetaSegmentsTable>(),
-                                                                       std::make_shared<MetaSegmentsAccurateTable>(),
-                                                                       std::make_shared<MetaPluginsTable>(),
-                                                                       std::make_shared<MetaSettingsTable>(),
-                                                                       std::make_shared<MetaSystemInformationTable>(),
-                                                                       std::make_shared<MetaSystemUtilizationTable>()};
+MetaTableManager::MetaTableManager(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env) {
+  const std::vector<std::shared_ptr<AbstractMetaTable>> meta_tables = {
+      std::make_shared<MetaTablesTable>(hyrise_env),
+      std::make_shared<MetaColumnsTable>(hyrise_env),
+      std::make_shared<MetaChunksTable>(hyrise_env),
+      std::make_shared<MetaChunkSortOrdersTable>(hyrise_env),
+      std::make_shared<MetaLogTable>(),
+      std::make_shared<MetaSegmentsTable>(hyrise_env),
+      std::make_shared<MetaSegmentsAccurateTable>(hyrise_env),
+      std::make_shared<MetaPluginsTable>(hyrise_env),
+      std::make_shared<MetaSettingsTable>(),
+      std::make_shared<MetaSystemInformationTable>(),
+      std::make_shared<MetaSystemUtilizationTable>()};
 
   _table_names.reserve(_meta_tables.size());
   for (const auto& table : meta_tables) {

--- a/src/lib/utils/meta_table_manager.hpp
+++ b/src/lib/utils/meta_table_manager.hpp
@@ -8,6 +8,7 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class Table;
 
 class MetaTableManager : public Noncopyable {
@@ -15,6 +16,8 @@ class MetaTableManager : public Noncopyable {
   static inline const auto META_PREFIX = std::string{"meta_"};
 
   static bool is_meta_table_name(const std::string& name);
+
+  MetaTableManager(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   // Returns a sorted list of all meta table names (without prefix)
   const std::vector<std::string>& table_names() const;
@@ -37,8 +40,6 @@ class MetaTableManager : public Noncopyable {
 
  protected:
   friend class Hyrise;
-
-  MetaTableManager();
 
   static std::string _trim_table_name(const std::string& table_name);
 

--- a/src/lib/utils/meta_tables/meta_chunk_sort_orders_table.cpp
+++ b/src/lib/utils/meta_tables/meta_chunk_sort_orders_table.cpp
@@ -4,11 +4,12 @@
 
 namespace opossum {
 
-MetaChunkSortOrdersTable::MetaChunkSortOrdersTable()
+MetaChunkSortOrdersTable::MetaChunkSortOrdersTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env)
     : AbstractMetaTable(TableColumnDefinitions{{"table_name", DataType::String, false},
                                                {"chunk_id", DataType::Int, false},
                                                {"column_id", DataType::Int, false},
-                                               {"order_mode", DataType::String, false}}) {}
+                                               {"order_mode", DataType::String, false}}),
+      _hyrise_env(hyrise_env) {}
 
 const std::string& MetaChunkSortOrdersTable::name() const {
   static const auto name = std::string{"chunk_sort_orders"};
@@ -21,8 +22,7 @@ const std::string& MetaChunkSortOrdersTable::name() const {
  */
 std::shared_ptr<Table> MetaChunkSortOrdersTable::_on_generate() const {
   auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
-
-  for (const auto& [table_name, table] : Hyrise::get().storage_manager.tables()) {
+  for (const auto& [table_name, table] : _hyrise_env->storage_manager()->tables()) {
     for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
       const auto& chunk = table->get_chunk(chunk_id);
       if (!chunk) continue;  // Skip physically deleted chunks

--- a/src/lib/utils/meta_tables/meta_chunk_sort_orders_table.hpp
+++ b/src/lib/utils/meta_tables/meta_chunk_sort_orders_table.hpp
@@ -4,16 +4,20 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for showing all sort orders of stored chunks via a meta table.
  */
 class MetaChunkSortOrdersTable : public AbstractMetaTable {
  public:
-  MetaChunkSortOrdersTable();
+  explicit MetaChunkSortOrdersTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   const std::string& name() const final;
 
  protected:
   std::shared_ptr<Table> _on_generate() const final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_chunks_table.hpp
+++ b/src/lib/utils/meta_tables/meta_chunks_table.hpp
@@ -4,17 +4,21 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for showing all stored chunks via a meta table.
  */
 class MetaChunksTable : public AbstractMetaTable {
  public:
-  MetaChunksTable();
+  explicit MetaChunksTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   const std::string& name() const final;
 
  protected:
   std::shared_ptr<Table> _on_generate() const final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_columns_table.cpp
+++ b/src/lib/utils/meta_tables/meta_columns_table.cpp
@@ -4,11 +4,12 @@
 
 namespace opossum {
 
-MetaColumnsTable::MetaColumnsTable()
+MetaColumnsTable::MetaColumnsTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env)
     : AbstractMetaTable(TableColumnDefinitions{{"table_name", DataType::String, false},
                                                {"column_name", DataType::String, false},
                                                {"data_type", DataType::String, false},
-                                               {"nullable", DataType::Int, false}}) {}
+                                               {"nullable", DataType::Int, false}}),
+      _hyrise_env(hyrise_env) {}
 
 const std::string& MetaColumnsTable::name() const {
   static const auto name = std::string{"columns"};
@@ -18,7 +19,7 @@ const std::string& MetaColumnsTable::name() const {
 std::shared_ptr<Table> MetaColumnsTable::_on_generate() const {
   auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
 
-  for (const auto& [table_name, table] : Hyrise::get().storage_manager.tables()) {
+  for (const auto& [table_name, table] : _hyrise_env->storage_manager()->tables()) {
     for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {
       output_table->append({pmr_string{table_name}, static_cast<pmr_string>(table->column_name(column_id)),
                             static_cast<pmr_string>(data_type_to_string.left.at(table->column_data_type(column_id))),

--- a/src/lib/utils/meta_tables/meta_columns_table.hpp
+++ b/src/lib/utils/meta_tables/meta_columns_table.hpp
@@ -4,17 +4,21 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for showing all stored columns via a meta table.
  */
 class MetaColumnsTable : public AbstractMetaTable {
  public:
-  MetaColumnsTable();
+  explicit MetaColumnsTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   const std::string& name() const final;
 
  protected:
   std::shared_ptr<Table> _on_generate() const final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_log_table.hpp
+++ b/src/lib/utils/meta_tables/meta_log_table.hpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 class MetaLogTable : public AbstractMetaTable {
  public:
-  MetaLogTable();
+  explicit MetaLogTable();
 
   const std::string& name() const final;
 

--- a/src/lib/utils/meta_tables/meta_plugins_table.hpp
+++ b/src/lib/utils/meta_tables/meta_plugins_table.hpp
@@ -4,13 +4,15 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for plugin control via a meta table.
  * Inserting loads a plugin, deleting unloads it.
  */
 class MetaPluginsTable : public AbstractMetaTable {
  public:
-  MetaPluginsTable();
+  explicit MetaPluginsTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   const std::string& name() const final;
 
@@ -22,6 +24,8 @@ class MetaPluginsTable : public AbstractMetaTable {
 
   void _on_insert(const std::vector<AllTypeVariant>& values) final;
   void _on_remove(const std::vector<AllTypeVariant>& values) final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_segments_accurate_table.cpp
+++ b/src/lib/utils/meta_tables/meta_segments_accurate_table.cpp
@@ -5,7 +5,7 @@
 
 namespace opossum {
 
-MetaSegmentsAccurateTable::MetaSegmentsAccurateTable()
+MetaSegmentsAccurateTable::MetaSegmentsAccurateTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env)
     : AbstractMetaTable(TableColumnDefinitions{{"table_name", DataType::String, false},
                                                {"chunk_id", DataType::Int, false},
                                                {"column_id", DataType::Int, false},
@@ -19,7 +19,8 @@ MetaSegmentsAccurateTable::MetaSegmentsAccurateTable()
                                                {"sequential_accesses", DataType::Long, false},
                                                {"monotonic_accesses", DataType::Long, false},
                                                {"random_accesses", DataType::Long, false},
-                                               {"dictionary_accesses", DataType::Long, false}}) {}
+                                               {"dictionary_accesses", DataType::Long, false}}),
+      _hyrise_env(hyrise_env) {}
 
 const std::string& MetaSegmentsAccurateTable::name() const {
   static const auto name = std::string{"segments_accurate"};
@@ -30,7 +31,7 @@ std::shared_ptr<Table> MetaSegmentsAccurateTable::_on_generate() const {
   PerformanceWarning("Accurate segment information are expensive to gather. Use with caution.");
 
   auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
-  gather_segment_meta_data(output_table, MemoryUsageCalculationMode::Full);
+  gather_segment_meta_data(_hyrise_env, output_table, MemoryUsageCalculationMode::Full);
 
   return output_table;
 }

--- a/src/lib/utils/meta_tables/meta_segments_accurate_table.hpp
+++ b/src/lib/utils/meta_tables/meta_segments_accurate_table.hpp
@@ -4,6 +4,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for showing information of all stored segments via a meta table.
  * Here, we provide the distinct value count per segment.
@@ -12,12 +14,14 @@ namespace opossum {
  */
 class MetaSegmentsAccurateTable : public AbstractMetaTable {
  public:
-  MetaSegmentsAccurateTable();
+  explicit MetaSegmentsAccurateTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   const std::string& name() const final;
 
  protected:
   std::shared_ptr<Table> _on_generate() const final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_segments_table.cpp
+++ b/src/lib/utils/meta_tables/meta_segments_table.cpp
@@ -5,7 +5,7 @@
 
 namespace opossum {
 
-MetaSegmentsTable::MetaSegmentsTable()
+MetaSegmentsTable::MetaSegmentsTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env)
     : AbstractMetaTable(TableColumnDefinitions{{"table_name", DataType::String, false},
                                                {"chunk_id", DataType::Int, false},
                                                {"column_id", DataType::Int, false},
@@ -18,7 +18,8 @@ MetaSegmentsTable::MetaSegmentsTable()
                                                {"sequential_accesses", DataType::Long, false},
                                                {"monotonic_accesses", DataType::Long, false},
                                                {"random_accesses", DataType::Long, false},
-                                               {"dictionary_accesses", DataType::Long, false}}) {}
+                                               {"dictionary_accesses", DataType::Long, false}}),
+      _hyrise_env(hyrise_env) {}
 
 const std::string& MetaSegmentsTable::name() const {
   static const auto name = std::string{"segments"};
@@ -27,7 +28,7 @@ const std::string& MetaSegmentsTable::name() const {
 
 std::shared_ptr<Table> MetaSegmentsTable::_on_generate() const {
   auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
-  gather_segment_meta_data(output_table, MemoryUsageCalculationMode::Sampled);
+  gather_segment_meta_data(_hyrise_env, output_table, MemoryUsageCalculationMode::Sampled);
 
   return output_table;
 }

--- a/src/lib/utils/meta_tables/meta_segments_table.hpp
+++ b/src/lib/utils/meta_tables/meta_segments_table.hpp
@@ -4,6 +4,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for showing information of all stored segments via a meta table.
  * Here, we do not provide the distinct value count per segment.
@@ -11,12 +13,14 @@ namespace opossum {
  */
 class MetaSegmentsTable : public AbstractMetaTable {
  public:
-  MetaSegmentsTable();
+  explicit MetaSegmentsTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
 
   const std::string& name() const final;
 
  protected:
   std::shared_ptr<Table> _on_generate() const final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_settings_table.hpp
+++ b/src/lib/utils/meta_tables/meta_settings_table.hpp
@@ -9,7 +9,7 @@ namespace opossum {
  */
 class MetaSettingsTable : public AbstractMetaTable {
  public:
-  MetaSettingsTable();
+  explicit MetaSettingsTable();
 
   const std::string& name() const final;
 

--- a/src/lib/utils/meta_tables/meta_system_information_table.hpp
+++ b/src/lib/utils/meta_tables/meta_system_information_table.hpp
@@ -9,7 +9,7 @@ namespace opossum {
  */
 class MetaSystemInformationTable : public AbstractMetaTable {
  public:
-  MetaSystemInformationTable();
+  explicit MetaSystemInformationTable();
 
   const std::string& name() const final;
 

--- a/src/lib/utils/meta_tables/meta_system_utilization_table.hpp
+++ b/src/lib/utils/meta_tables/meta_system_utilization_table.hpp
@@ -9,7 +9,7 @@ namespace opossum {
  */
 class MetaSystemUtilizationTable : public AbstractMetaTable {
  public:
-  MetaSystemUtilizationTable();
+  explicit MetaSystemUtilizationTable();
 
   const std::string& name() const final;
 

--- a/src/lib/utils/meta_tables/meta_tables_table.cpp
+++ b/src/lib/utils/meta_tables/meta_tables_table.cpp
@@ -4,12 +4,15 @@
 
 namespace opossum {
 
-MetaTablesTable::MetaTablesTable()
+MetaTablesTable::MetaTablesTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env)
     : AbstractMetaTable(TableColumnDefinitions{{"table_name", DataType::String, false},
                                                {"column_count", DataType::Int, false},
                                                {"row_count", DataType::Long, false},
                                                {"chunk_count", DataType::Int, false},
-                                               {"target_chunk_size", DataType::Long, false}}) {}
+                                               {"target_chunk_size", DataType::Long, false}}),
+      _hyrise_env(hyrise_env) {
+  Assert(hyrise_env, "Created without environment");
+}
 
 const std::string& MetaTablesTable::name() const {
   static const auto name = std::string{"tables"};
@@ -19,7 +22,7 @@ const std::string& MetaTablesTable::name() const {
 std::shared_ptr<Table> MetaTablesTable::_on_generate() const {
   auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
 
-  for (const auto& [table_name, table] : Hyrise::get().storage_manager.tables()) {
+  for (const auto& [table_name, table] : _hyrise_env->storage_manager()->tables()) {
     output_table->append({pmr_string{table_name}, static_cast<int32_t>(table->column_count()),
                           static_cast<int64_t>(table->row_count()), static_cast<int32_t>(table->chunk_count()),
                           static_cast<int64_t>(table->target_chunk_size())});

--- a/src/lib/utils/meta_tables/meta_tables_table.hpp
+++ b/src/lib/utils/meta_tables/meta_tables_table.hpp
@@ -4,18 +4,22 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /**
  * This is a class for showing all stored tables via a meta table.
  */
 class MetaTablesTable : public AbstractMetaTable {
  public:
-  MetaTablesTable();
+  explicit MetaTablesTable(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env);
   const std::string& name() const final;
 
  protected:
   friend class MetaTableManager;
 
   std::shared_ptr<Table> _on_generate() const final;
+
+  const std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 };
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/segment_meta_data.cpp
+++ b/src/lib/utils/meta_tables/segment_meta_data.cpp
@@ -9,8 +9,10 @@
 
 namespace opossum {
 
-void gather_segment_meta_data(const std::shared_ptr<Table>& meta_table, const MemoryUsageCalculationMode mode) {
-  for (const auto& [table_name, table] : Hyrise::get().storage_manager.tables()) {
+void gather_segment_meta_data(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                              const std::shared_ptr<Table>& meta_table, const MemoryUsageCalculationMode mode) {
+  auto storage_manager = hyrise_env->storage_manager();
+  for (const auto& [table_name, table] : storage_manager->tables()) {
     for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
       const auto& chunk = table->get_chunk(chunk_id);
       if (!chunk) continue;  // Skip physically deleted chunks

--- a/src/lib/utils/meta_tables/segment_meta_data.hpp
+++ b/src/lib/utils/meta_tables/segment_meta_data.hpp
@@ -4,6 +4,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 // Methods for collecting information about all stored segments,
 // used at MetaSegmentsTable and MetaSegmentsAccurateTable.
 
@@ -11,7 +13,8 @@ namespace opossum {
  * Fills the table with table name, chunk and column ID, column name, data type,
  * encoding, compression and estimated size. With full mode, also the number of disctinct values is included.
  */
-void gather_segment_meta_data(const std::shared_ptr<Table>& meta_table, const MemoryUsageCalculationMode mode);
+void gather_segment_meta_data(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                              const std::shared_ptr<Table>& meta_table, const MemoryUsageCalculationMode mode);
 
 size_t get_distinct_value_count(const std::shared_ptr<AbstractSegment>& segment);
 

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -9,6 +9,8 @@
 
 namespace opossum {
 
+PluginManager::PluginManager(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env) : _hyrise_env(hyrise_env) {}
+
 bool PluginManager::_is_duplicate(const std::unique_ptr<AbstractPlugin>& plugin) const {
   const auto& plugin_ref = *plugin;
   for (const auto& [_, plugin_handle_wrapper] : _plugins) {
@@ -49,10 +51,10 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
          "Instantiating plugin failed: Use the EXPORT_PLUGIN (abstract_plugin.hpp) macro to export a factory method "
          "for your plugin!");
 
-  using PluginGetter = AbstractPlugin* (*)();
+  using PluginGetter = AbstractPlugin* (*)(const std::shared_ptr<HyriseEnvironmentRef>&);
   auto plugin_get = reinterpret_cast<PluginGetter>(factory);
 
-  auto plugin = std::unique_ptr<AbstractPlugin>(plugin_get());
+  auto plugin = std::unique_ptr<AbstractPlugin>(plugin_get(_hyrise_env));
   PluginHandleWrapper plugin_handle_wrapper = {plugin_handle, std::move(plugin)};
   plugin = nullptr;
 

--- a/src/lib/utils/plugin_manager.hpp
+++ b/src/lib/utils/plugin_manager.hpp
@@ -23,6 +23,8 @@ class PluginManager : public Noncopyable {
   friend class SingletonTest;
 
  public:
+  PluginManager(const std::shared_ptr<HyriseEnvironmentRef>&);
+
   void load_plugin(const std::filesystem::path& path);
   void unload_plugin(const PluginName& name);
 
@@ -31,13 +33,13 @@ class PluginManager : public Noncopyable {
   ~PluginManager();
 
  protected:
-  PluginManager() = default;
   friend class Hyrise;
 
   const PluginManager& operator=(const PluginManager&) = delete;
   PluginManager& operator=(PluginManager&&) = default;
 
   std::unordered_map<PluginName, PluginHandleWrapper> _plugins;
+  std::shared_ptr<HyriseEnvironmentRef> _hyrise_env;
 
   // This method is called during destruction and stops and unloads all currently loaded plugions.
   void _clean_up();

--- a/src/lib/utils/sqlite_add_indices.cpp
+++ b/src/lib/utils/sqlite_add_indices.cpp
@@ -13,16 +13,19 @@
 
 namespace opossum {
 
-void add_indices_to_sqlite(const std::string& schema_file_path, const std::string& create_indices_file_path,
+void add_indices_to_sqlite(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env, const std::string& schema_file_path,
+                           const std::string& create_indices_file_path,
                            std::shared_ptr<SQLiteWrapper>& sqlite_wrapper) {
   Assert(sqlite_wrapper, "sqlite_wrapper should be set");
+
+  auto storage_manager = hyrise_env->storage_manager();
 
   std::cout << "- Adding indexes to SQLite" << std::endl;
   Timer timer;
 
   // SQLite does not support adding primary keys to non-empty tables, so we rename the table, create an empty one from
   // the provided schema and copy the data.
-  for (const auto& table_name : Hyrise::get().storage_manager.table_names()) {
+  for (const auto& table_name : storage_manager->table_names()) {
     // SQLite doesn't like an unescaped "ORDER" as a table name, thus we escape it. No need to escape the
     // "..._unindexed" name.
     const auto escaped_table_name = std::string{"\""} + table_name + "\"";
@@ -48,7 +51,7 @@ void add_indices_to_sqlite(const std::string& schema_file_path, const std::strin
   }
 
   // Copy over data
-  for (const auto& table_name : Hyrise::get().storage_manager.table_names()) {
+  for (const auto& table_name : storage_manager->table_names()) {
     Timer per_table_time;
     std::cout << "-  Adding indexes to SQLite table " << table_name << std::flush;
 

--- a/src/lib/utils/sqlite_add_indices.hpp
+++ b/src/lib/utils/sqlite_add_indices.hpp
@@ -5,6 +5,7 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
 class SQLiteWrapper;
 
 /**
@@ -17,11 +18,13 @@ class SQLiteWrapper;
  * Finally, the data from the corresponding renamed tables is copied over to the newly created indexed tables.
  * 
  *
+ * @param hyrise_en                     hyrise environment to use
  * @param schema_file_path              the path to an SQL file which creates the data schema
  * @param create_indices_file_path      the path to an SQL file which creates indices (if separate, else "")
  * @param sqlite_wrapper                the used sqlite_wrapper
  */
-void add_indices_to_sqlite(const std::string& schema_file_path, const std::string& create_indices_file_path,
+void add_indices_to_sqlite(const std::shared_ptr<HyriseEnvironmentRef>& storage_manager,
+                           const std::string& schema_file_path, const std::string& create_indices_file_path,
                            std::shared_ptr<SQLiteWrapper>& sqlite_wrapper);
 
 }  // namespace opossum

--- a/src/lib/utils/sqlite_wrapper.cpp
+++ b/src/lib/utils/sqlite_wrapper.cpp
@@ -140,7 +140,8 @@ namespace opossum {
 // See also https://www.sqlite.org/inmemorydb.html, starting at "If two or more distinct but shareable
 // in-memory databases"
 SQLiteWrapper::SQLiteWrapper()
-    : _uri{std::string{"file:sqlitewrapper_"} + std::to_string(reinterpret_cast<uintptr_t>(this)) +  // NOLINT
+    : _uri{std::string{"file:sqlitewrapper_"} + std::to_string(reinterpret_cast<uintptr_t>(this)) + "+" +
+           std::to_string(time(nullptr)) +  // NOLINT
            "?mode=memory&cache=shared"},
       main_connection{_uri} {
   Assert(sqlite3_threadsafe(), "Expected sqlite to be compiled with thread-safety");
@@ -148,9 +149,9 @@ SQLiteWrapper::SQLiteWrapper()
 
 SQLiteWrapper::Connection::Connection(const std::string& uri) {
   // Explicity set parallel mode. On Linux it seems to be the default, on Mac, it seems to make a difference.
-  const auto ret =
-      sqlite3_open_v2(uri.c_str(), &db, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,  // NOLINT
-                      nullptr);
+  const auto ret = sqlite3_open_v2(uri.c_str(), &db,
+                                   SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,  // NOLINT
+                                   nullptr);
   if (ret != SQLITE_OK) {
     sqlite3_close(db);
     Fail("Cannot open database: " + std::string(sqlite3_errmsg(db)));
@@ -330,7 +331,7 @@ void SQLiteWrapper::create_sqlite_table(const Table& table, const std::string& t
               // clang-tidy doesn't like SQLITE_TRANSIENT
               // clang-format off
               sqlite3_bind_return_code = sqlite3_bind_text(insert_into_statement, sqlite_column_id, string_value.c_str(), static_cast<int>(string_value.size()), SQLITE_TRANSIENT);  // NOLINT
-              // clang-format on
+                  // clang-format on
             } break;
             case DataType::Null:
               Fail("SQLiteWrapper: column type not supported.");

--- a/src/lib/utils/sqlite_wrapper.hpp
+++ b/src/lib/utils/sqlite_wrapper.hpp
@@ -9,6 +9,8 @@
 
 namespace opossum {
 
+class HyriseEnvironmentRef;
+
 /*
  * This class wraps the sqlite3 library for opossum. It creates an in-memory sqlite database on construction.
  * When executing a sql query, the wrapper converts the result into an opossum Table.
@@ -34,7 +36,7 @@ class SQLiteWrapper final {
 
   class Connection final {
    public:
-    explicit Connection(const std::string& uri);
+    Connection(const std::string& uri);
 
     Connection(const Connection&) = delete;
     Connection(Connection&&) noexcept;

--- a/src/plugins/mvcc_delete_plugin.hpp
+++ b/src/plugins/mvcc_delete_plugin.hpp
@@ -32,6 +32,8 @@ class MvccDeletePlugin : public AbstractPlugin {
   friend class MvccDeletePluginSystemTest;
 
  public:
+  MvccDeletePlugin(const std::shared_ptr<HyriseEnvironmentRef>&);
+
   std::string description() const final;
 
   void start() final;
@@ -57,7 +59,8 @@ class MvccDeletePlugin : public AbstractPlugin {
   void _logical_delete_loop();
   void _physical_delete_loop();
 
-  static bool _try_logical_delete(const std::string& table_name, ChunkID chunk_id,
+  static bool _try_logical_delete(const std::shared_ptr<HyriseEnvironmentRef>& hyrise_env,
+                                  const std::string& table_name, ChunkID chunk_id,
                                   const std::shared_ptr<TransactionContext>& transaction_context);
   static void _delete_chunk_physically(const std::shared_ptr<Table>& table, ChunkID chunk_id);
 

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -11,10 +11,10 @@ void TestPlugin::start() {
   column_definitions.emplace_back("col_1", DataType::Int, false);
   auto table = std::make_shared<Table>(column_definitions, TableType::Data);
 
-  storage_manager.add_table("DummyTable", table);
+  _hyrise_env->storage_manager()->add_table("DummyTable", table);
 }
 
-void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
+void TestPlugin::stop() { _hyrise_env->storage_manager()->drop_table("DummyTable"); }
 
 EXPORT_PLUGIN(TestPlugin)
 

--- a/src/plugins/test_plugin.hpp
+++ b/src/plugins/test_plugin.hpp
@@ -8,15 +8,13 @@ namespace opossum {
 
 class TestPlugin : public AbstractPlugin {
  public:
-  TestPlugin() : storage_manager(Hyrise::get().storage_manager) {}
+  TestPlugin(const std::shared_ptr<HyriseEnvironmentRef>& init_hyrise_env) : AbstractPlugin(init_hyrise_env) {}
 
   std::string description() const final;
 
   void start() final;
 
   void stop() final;
-
-  StorageManager& storage_manager;
 };
 
 }  // namespace opossum

--- a/src/test/base_test.hpp
+++ b/src/test/base_test.hpp
@@ -38,12 +38,22 @@ template <typename ParamType>
 class BaseTestWithParam
     : public std::conditional_t<std::is_same_v<ParamType, void>, ::testing::Test, ::testing::TestWithParam<ParamType>> {
  public:
+  BaseTestWithParam() {
+    _hyrise_env_holder = std::make_shared<HyriseEnvironmentHolder>();
+    _hyrise_env = _hyrise_env_holder->hyrise_env_ref();
+  }
+
   /**
    * Base test uses its destructor instead of TearDown() to clean up. This way, derived test classes can override TearDown()
    * safely without preventing the BaseTest-cleanup from happening.
    * GTest runs the destructor right after TearDown(): https://github.com/abseil/googletest/blob/master/googletest/docs/faq.md#should-i-use-the-constructordestructor-of-the-test-fixture-or-setupteardown
    */
   ~BaseTestWithParam() override { Hyrise::reset(); }
+
+ protected:
+  static inline std::shared_ptr<HyriseEnvironmentHolder> _hyrise_env_holder =
+      std::make_shared<HyriseEnvironmentHolder>();
+  static inline std::shared_ptr<HyriseEnvironmentRef> _hyrise_env = _hyrise_env_holder->hyrise_env_ref();
 };
 
 using BaseTest = BaseTestWithParam<void>;

--- a/src/test/benchmarklib/sqlite_add_indices_test.cpp
+++ b/src/test/benchmarklib/sqlite_add_indices_test.cpp
@@ -16,9 +16,10 @@ class SQLiteAddIndicesTest : public BaseTest {
     TableColumnDefinitions column_definitions;
     column_definitions.emplace_back("column_1", DataType::Int, false);
     column_definitions.emplace_back("column_2", DataType::String, false);
-    Hyrise::get().storage_manager.add_table("table_1", std::make_shared<Table>(column_definitions, TableType::Data, 2));
+    _hyrise_env->storage_manager()->add_table("table_1",
+                                              std::make_shared<Table>(column_definitions, TableType::Data, 2));
 
-    stored_table = Hyrise::get().storage_manager.get_table("table_1");
+    stored_table = _hyrise_env->storage_manager()->get_table("table_1");
     stored_table->append({13, "Hello,"});
     stored_table->append({37, "world"});
 
@@ -37,7 +38,7 @@ TEST_F(SQLiteAddIndicesTest, AddIndexTest) {
   EXPECT_TABLE_EQ_ORDERED(stored_table, sqlite_table);
   const auto schema_file_path = "resources/test_data/sqlite_add_index_schema.sql";
   const auto create_index_file_path = "resources/test_data/sqlite_add_index_create_index.sql";
-  add_indices_to_sqlite(schema_file_path, create_index_file_path, sqlite_wrapper);
+  add_indices_to_sqlite(_hyrise_env, schema_file_path, create_index_file_path, sqlite_wrapper);
   sqlite_table = sqlite_wrapper->main_connection.execute_query("SELECT * FROM table_1");
   EXPECT_TABLE_EQ_ORDERED(stored_table, sqlite_table);
   sqlite_wrapper->main_connection.raw_execute_query("DROP INDEX index_1;");

--- a/src/test/benchmarklib/tpcds/tpcds_db_generator_test.cpp
+++ b/src/test/benchmarklib/tpcds/tpcds_db_generator_test.cpp
@@ -99,13 +99,13 @@ TEST_F(TPCDSTableGeneratorTest, GenerateAndStoreRowCounts) {
                                                               {"web_sales", 719620},
                                                               {"web_site", 30}};
 
-  EXPECT_EQ(Hyrise::get().storage_manager.tables().size(), 0);
+  EXPECT_EQ(_hyrise_env->storage_manager()->tables().size(), 0);
 
-  TPCDSTableGenerator(1, Chunk::DEFAULT_SIZE, 0).generate_and_store();
+  TPCDSTableGenerator(1, Chunk::DEFAULT_SIZE, 0).generate_and_store(_hyrise_env);
 
   for (const auto& [name, size] : expected_sizes) {
     SCOPED_TRACE("checking table " + std::string{name});
-    EXPECT_EQ(Hyrise::get().storage_manager.get_table(name)->row_count(), size);
+    EXPECT_EQ(_hyrise_env->storage_manager()->get_table(name)->row_count(), size);
   }
 
   Hyrise::reset();

--- a/src/test/benchmarklib/tpch/tpch_db_generator_test.cpp
+++ b/src/test/benchmarklib/tpch/tpch_db_generator_test.cpp
@@ -76,24 +76,24 @@ TEST_F(TPCHTableGeneratorTest, RowCountsMediumScaleFactor) {
 }
 
 TEST_F(TPCHTableGeneratorTest, GenerateAndStore) {
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("part"));
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("supplier"));
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("partsupp"));
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("customer"));
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("orders"));
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("nation"));
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("region"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("part"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("supplier"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("partsupp"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("customer"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("orders"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("nation"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("region"));
 
   // Small scale factor
-  TPCHTableGenerator(0.01f, Chunk::DEFAULT_SIZE).generate_and_store();
+  TPCHTableGenerator(0.01f, Chunk::DEFAULT_SIZE).generate_and_store(_hyrise_env);
 
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("part"));
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("supplier"));
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("partsupp"));
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("customer"));
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("orders"));
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("nation"));
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_table("region"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("part"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("supplier"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("partsupp"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("customer"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("orders"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("nation"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("region"));
 
   Hyrise::reset();
 }

--- a/src/test/lib/concurrency/transaction_context_test.cpp
+++ b/src/test/lib/concurrency/transaction_context_test.cpp
@@ -26,7 +26,7 @@ class TransactionContextTest : public BaseTest {
   void SetUp() override {
     auto t = load_table("resources/test_data/tbl/float_int.tbl");
     // Insert Operator works with the Storage Manager, so the test table must also be known to the StorageManager
-    Hyrise::get().storage_manager.add_table(table_name, t);
+    _hyrise_env->storage_manager()->add_table(table_name, t);
   }
 
   TransactionManager& manager() { return Hyrise::get().transaction_manager; }
@@ -102,7 +102,7 @@ TEST_F(TransactionContextTest, CommitShouldIncreaseCommitIDIfReadWrite) {
 
   const auto prev_last_commit_id = manager().last_commit_id();
 
-  const auto get_table_op = std::make_shared<GetTable>(table_name);
+  const auto get_table_op = std::make_shared<GetTable>(_hyrise_env, table_name);
   const auto validate_op = std::make_shared<Validate>(get_table_op);
   const auto delete_op = std::make_shared<Delete>(validate_op);
   delete_op->set_transaction_context_recursively(context);
@@ -120,7 +120,7 @@ TEST_F(TransactionContextTest, CommitShouldNotIncreaseCommitIDIfReadOnly) {
 
   const auto prev_last_commit_id = manager().last_commit_id();
 
-  const auto get_table_op = std::make_shared<GetTable>(table_name);
+  const auto get_table_op = std::make_shared<GetTable>(_hyrise_env, table_name);
   const auto validate_op = std::make_shared<Validate>(get_table_op);
   validate_op->set_transaction_context_recursively(context);
   get_table_op->execute();

--- a/src/test/lib/expression/expression_test.cpp
+++ b/src/test/lib/expression/expression_test.cpp
@@ -28,14 +28,14 @@ class ExpressionTest : public BaseTest {
   void SetUp() override {
     table_int_float = load_table("resources/test_data/tbl/int_float.tbl");
     table_int_float_with_null = load_table("resources/test_data/tbl/int_float_with_null.tbl");
-    Hyrise::get().storage_manager.add_table("int_float", table_int_float);
-    Hyrise::get().storage_manager.add_table("int_float_with_null", table_int_float_with_null);
+    _hyrise_env->storage_manager()->add_table("int_float", table_int_float);
+    _hyrise_env->storage_manager()->add_table("int_float_with_null", table_int_float_with_null);
 
-    int_float_node = StoredTableNode::make("int_float");
+    int_float_node = StoredTableNode::make(_hyrise_env, "int_float");
     a = int_float_node->get_column("a");
     b = int_float_node->get_column("b");
 
-    int_float_node_nullable = StoredTableNode::make("int_float_with_null");
+    int_float_node_nullable = StoredTableNode::make(_hyrise_env, "int_float_with_null");
     a_nullable = int_float_node_nullable->get_column("a");
     b_nullable = int_float_node_nullable->get_column("b");
   }
@@ -139,7 +139,7 @@ TEST_F(ExpressionTest, RequiresCalculation) {
   EXPECT_TRUE(in_(5, subquery_expression)->requires_computation());
   EXPECT_TRUE(not_in_(5, subquery_expression)->requires_computation());
 
-  const auto get_table = std::make_shared<GetTable>("int_float");
+  const auto get_table = std::make_shared<GetTable>(_hyrise_env, "int_float");
   const auto pqp_subquery_expression = std::make_shared<PQPSubqueryExpression>(get_table);
 
   EXPECT_TRUE(pqp_subquery_expression->requires_computation());
@@ -400,12 +400,15 @@ TEST_F(ExpressionTest, EqualsAndHash) {
   expressions.emplace_back(__LINE__, pqp_column_(ColumnID{1}, DataType::Int, true, "alias"));
 
   // PQPSubqueryExpression
-  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>("a"), DataType::Int, false));
-  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>("b"), DataType::Int, false));
-  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>("b"), DataType::Float, false));
-  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>("b"), DataType::Float, true));
+  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>(_hyrise_env, "a"), DataType::Int, false));
+  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>(_hyrise_env, "b"), DataType::Int, false));
+  expressions.emplace_back(__LINE__,
+                           pqp_subquery_(std::make_shared<GetTable>(_hyrise_env, "b"), DataType::Float, false));
+  expressions.emplace_back(__LINE__,
+                           pqp_subquery_(std::make_shared<GetTable>(_hyrise_env, "b"), DataType::Float, true));
   const auto parameter = std::make_pair(ParameterID{0}, ColumnID{0});
-  expressions.emplace_back(__LINE__, pqp_subquery_(std::make_shared<GetTable>("b"), DataType::Float, true, parameter));
+  expressions.emplace_back(
+      __LINE__, pqp_subquery_(std::make_shared<GetTable>(_hyrise_env, "b"), DataType::Float, true, parameter));
 
   // UnaryMinusExpression
   expressions.emplace_back(__LINE__, unary_minus_(3));

--- a/src/test/lib/expression/lqp_subquery_expression_test.cpp
+++ b/src/test/lib/expression/lqp_subquery_expression_test.cpp
@@ -22,13 +22,13 @@ namespace opossum {
 class LQPSubqueryExpressionTest : public BaseTest {
  public:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
+    _hyrise_env->storage_manager()->add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
 
-    int_float_node_a = StoredTableNode::make("int_float");
+    int_float_node_a = StoredTableNode::make(_hyrise_env, "int_float");
     a = int_float_node_a->get_column("a");
     b = int_float_node_a->get_column("b");
 
-    int_float_node_a_2 = StoredTableNode::make("int_float");
+    int_float_node_a_2 = StoredTableNode::make(_hyrise_env, "int_float");
     a_2 = int_float_node_a_2->get_column("a");
 
     // clang-format off

--- a/src/test/lib/expression/pqp_subquery_expression_test.cpp
+++ b/src/test/lib/expression/pqp_subquery_expression_test.cpp
@@ -23,13 +23,13 @@ class PQPSubqueryExpressionTest : public BaseTest {
  public:
   void SetUp() override {
     table_a = load_table("resources/test_data/tbl/int_float.tbl");
-    Hyrise::get().storage_manager.add_table("int_float", table_a);
+    _hyrise_env->storage_manager()->add_table("int_float", table_a);
     a_a = PQPColumnExpression::from_table(*table_a, "a");
     a_b = PQPColumnExpression::from_table(*table_a, "b");
 
     // Build a Subquery returning a SINGLE NON-NULLABLE VALUE and taking ONE PARAMETER
     const auto parameter_a = placeholder_(ParameterID{2});
-    const auto get_table_a = std::make_shared<GetTable>("int_float");
+    const auto get_table_a = std::make_shared<GetTable>(_hyrise_env, "int_float");
     const auto projection_a = std::make_shared<Projection>(get_table_a, expression_vector(add_(a_a, parameter_a)));
     const auto limit_a = std::make_shared<Limit>(projection_a, value_(1));
     pqp_single_value_one_parameter = limit_a;
@@ -38,7 +38,7 @@ class PQPSubqueryExpressionTest : public BaseTest {
         std::make_shared<PQPSubqueryExpression>(pqp_single_value_one_parameter, DataType::Int, false, parameters_a);
 
     // Build a Subquery returning a TABLE and taking NO PARAMETERS
-    const auto get_table_b = std::make_shared<GetTable>("int_float");
+    const auto get_table_b = std::make_shared<GetTable>(_hyrise_env, "int_float");
     const auto table_scan_b = std::make_shared<TableScan>(get_table_b, greater_than_(a_a, 5));
     pqp_table = table_scan_b;
     subquery_table = std::make_shared<PQPSubqueryExpression>(pqp_table);

--- a/src/test/lib/hyrise_test.cpp
+++ b/src/test/lib/hyrise_test.cpp
@@ -19,9 +19,9 @@ class HyriseTest : public BaseTest {
 
   // This wrapper method is needed to access the plugins vector since it is a private member of PluginManager
   std::unordered_map<PluginName, PluginHandleWrapper>& get_plugins() {
-    auto& pm = Hyrise::get().plugin_manager;
+    auto pm = _hyrise_env->plugin_manager();
 
-    return pm._plugins;
+    return pm->_plugins;
   }
 };
 
@@ -29,20 +29,20 @@ TEST_F(HyriseTest, GetAndResetHyrise) {
   auto& hyrise = Hyrise::get();
 
   EXPECT_EQ(get_plugins().size(), 0);
-  hyrise.plugin_manager.load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin"));
   EXPECT_EQ(get_plugins().size(), 1);
 
   const auto table_name = "test_table";
 
-  EXPECT_EQ(hyrise.storage_manager.has_table(table_name), false);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_table(table_name), false);
   const auto table = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
-  hyrise.storage_manager.add_table(table_name, table);
-  EXPECT_EQ(hyrise.storage_manager.has_table(table_name), true);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_table(table_name), true);
 
   EXPECT_EQ(hyrise.transaction_manager.last_commit_id(), CommitID{1});
 
   // We need to do some honest work so that the commit id is actually incremented
-  const auto get_table = std::make_shared<GetTable>(table_name);
+  const auto get_table = std::make_shared<GetTable>(_hyrise_env, table_name);
   const auto validate = std::make_shared<Validate>(get_table);
   const auto delete_op = std::make_shared<Delete>(validate);
   const auto transaction_context = hyrise.transaction_manager.new_transaction_context(AutoCommit::No);
@@ -55,9 +55,11 @@ TEST_F(HyriseTest, GetAndResetHyrise) {
   EXPECT_EQ(hyrise.transaction_manager.last_commit_id(), CommitID{2});
 
   Hyrise::reset();
+  _hyrise_env_holder = std::make_shared<HyriseEnvironmentHolder>();
+  _hyrise_env = _hyrise_env_holder->hyrise_env_ref();
 
   EXPECT_EQ(get_plugins().size(), 0);
-  EXPECT_EQ(hyrise.storage_manager.has_table(table_name), false);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_table(table_name), false);
   EXPECT_EQ(hyrise.transaction_manager.last_commit_id(), CommitID{1});
 }
 

--- a/src/test/lib/logical_query_plan/change_meta_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/change_meta_table_node_test.cpp
@@ -13,7 +13,7 @@ class ChangeMetaTableNodeTest : public BaseTest {
   void SetUp() override {
     _mock_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::String, "foo"}}));
     _change_meta_table_node =
-        ChangeMetaTableNode::make("meta_table", MetaTableChangeType::Insert, _mock_node, _mock_node);
+        ChangeMetaTableNode::make(_hyrise_env, "meta_table", MetaTableChangeType::Insert, _mock_node, _mock_node);
   }
 
   std::shared_ptr<ChangeMetaTableNode> _change_meta_table_node;
@@ -26,7 +26,7 @@ TEST_F(ChangeMetaTableNodeTest, Description) {
 
 TEST_F(ChangeMetaTableNodeTest, HashingAndEqualityCheck) {
   const auto another_change_meta_table_node =
-      ChangeMetaTableNode::make("meta_table", MetaTableChangeType::Insert, _mock_node, _mock_node);
+      ChangeMetaTableNode::make(_hyrise_env, "meta_table", MetaTableChangeType::Insert, _mock_node, _mock_node);
   EXPECT_EQ(*_change_meta_table_node, *another_change_meta_table_node);
 
   EXPECT_EQ(_change_meta_table_node->hash(), another_change_meta_table_node->hash());

--- a/src/test/lib/logical_query_plan/create_prepared_plan_node_test.cpp
+++ b/src/test/lib/logical_query_plan/create_prepared_plan_node_test.cpp
@@ -13,7 +13,7 @@ class CreatePreparedPlanNodeTest : public BaseTest {
   void SetUp() override {
     lqp = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
     prepared_plan = std::make_shared<PreparedPlan>(lqp, std::vector<ParameterID>{});
-    create_prepared_plan_node = CreatePreparedPlanNode::make("some_prepared_plan", prepared_plan);
+    create_prepared_plan_node = CreatePreparedPlanNode::make(_hyrise_env, "some_prepared_plan", prepared_plan);
   }
 
   std::shared_ptr<CreatePreparedPlanNode> create_prepared_plan_node;
@@ -33,13 +33,14 @@ TEST_F(CreatePreparedPlanNodeTest, HashingAndEqualityCheck) {
   const auto deep_copied_node = create_prepared_plan_node->deep_copy();
   EXPECT_EQ(*create_prepared_plan_node, *deep_copied_node);
 
-  const auto different_prepared_plan_node_a = CreatePreparedPlanNode::make("some_prepared_plan2", prepared_plan);
+  const auto different_prepared_plan_node_a =
+      CreatePreparedPlanNode::make(_hyrise_env, "some_prepared_plan2", prepared_plan);
 
   const auto different_lqp = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "b"}}));
   const auto different_prepared_plan =
       std::make_shared<PreparedPlan>(different_lqp, std::vector<ParameterID>{ParameterID{1}});
   const auto different_prepared_plan_node_b =
-      CreatePreparedPlanNode::make("some_prepared_plan", different_prepared_plan);
+      CreatePreparedPlanNode::make(_hyrise_env, "some_prepared_plan", different_prepared_plan);
 
   EXPECT_NE(*different_prepared_plan_node_a, *create_prepared_plan_node);
   EXPECT_NE(*different_prepared_plan_node_b, *create_prepared_plan_node);

--- a/src/test/lib/logical_query_plan/create_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/create_table_node_test.cpp
@@ -15,7 +15,7 @@ class CreateTableNodeTest : public BaseTest {
     column_definitions.emplace_back("a", DataType::Int, false);
     column_definitions.emplace_back("b", DataType::Float, true);
     input_node = std::make_shared<StaticTableNode>(Table::create_dummy_table(column_definitions));
-    create_table_node = CreateTableNode::make("some_table", false, input_node);
+    create_table_node = CreateTableNode::make(_hyrise_env, "some_table", false, input_node);
   }
 
   TableColumnDefinitions column_definitions;
@@ -25,7 +25,7 @@ class CreateTableNodeTest : public BaseTest {
 
 TEST_F(CreateTableNodeTest, Description) {
   EXPECT_EQ(create_table_node->description(), "[CreateTable] Name: 'some_table'");
-  auto create_table_node_2 = CreateTableNode::make("some_table", true, input_node);
+  auto create_table_node_2 = CreateTableNode::make(_hyrise_env, "some_table", true, input_node);
   EXPECT_EQ(create_table_node_2->description(), "[CreateTable] IfNotExists Name: 'some_table'");
 }
 
@@ -35,14 +35,15 @@ TEST_F(CreateTableNodeTest, HashingAndEqualityCheck) {
   const auto deep_copy_node = create_table_node->deep_copy();
   EXPECT_EQ(*create_table_node, *deep_copy_node);
 
-  const auto different_create_table_node_a = CreateTableNode::make("some_table2", false, input_node);
-  const auto different_create_table_node_b = CreateTableNode::make("some_table", true, input_node);
+  const auto different_create_table_node_a = CreateTableNode::make(_hyrise_env, "some_table2", false, input_node);
+  const auto different_create_table_node_b = CreateTableNode::make(_hyrise_env, "some_table", true, input_node);
 
   TableColumnDefinitions different_column_definitions;
   different_column_definitions.emplace_back("a", DataType::Int, false);
   const auto different_input_node =
       std::make_shared<StaticTableNode>(Table::create_dummy_table(different_column_definitions));
-  const auto different_create_table_node_c = CreateTableNode::make("some_table", false, different_input_node);
+  const auto different_create_table_node_c =
+      CreateTableNode::make(_hyrise_env, "some_table", false, different_input_node);
 
   EXPECT_NE(*different_create_table_node_a, *create_table_node);
   EXPECT_NE(*different_create_table_node_b, *create_table_node);

--- a/src/test/lib/logical_query_plan/create_view_node_test.cpp
+++ b/src/test/lib/logical_query_plan/create_view_node_test.cpp
@@ -12,7 +12,7 @@ class CreateViewNodeTest : public BaseTest {
   void SetUp() override {
     _view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
     _view = std::make_shared<LQPView>(_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, {"a"}}});
-    _create_view_node = CreateViewNode::make("some_view", _view, false);
+    _create_view_node = CreateViewNode::make(_hyrise_env, "some_view", _view, false);
   }
 
   std::shared_ptr<CreateViewNode> _create_view_node;
@@ -27,7 +27,7 @@ TEST_F(CreateViewNodeTest, Description) {
             "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns @ 0x00000000\n"
             ")");
 
-  const auto _create_view_node_2 = CreateViewNode::make("some_view", _view, true);
+  const auto _create_view_node_2 = CreateViewNode::make(_hyrise_env, "some_view", _view, true);
   EXPECT_EQ(replace_addresses(_create_view_node_2->description(AbstractLQPNode::DescriptionMode::Short)),
             "[CreateView] IfNotExists Name: some_view, Columns: a FROM (\n"
             "[0] [MockNode 'Unnamed'] Columns: a | pruned: 0/1 columns @ 0x00000000\n"
@@ -38,13 +38,13 @@ TEST_F(CreateViewNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_create_view_node, *_create_view_node);
   EXPECT_EQ(*_create_view_node, *_create_view_node->deep_copy());
 
-  const auto different_create_view_node_a = CreateViewNode::make("some_view2", _view, false);
+  const auto different_create_view_node_a = CreateViewNode::make(_hyrise_env, "some_view2", _view, false);
 
   const auto different_view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "b"}}));
   const auto different_view =
       std::make_shared<LQPView>(different_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, {"b"}}});
-  const auto different_create_view_node_b = CreateViewNode::make("some_view", different_view, false);
-  const auto different_create_view_node_c = CreateViewNode::make("some_view", _view, true);
+  const auto different_create_view_node_b = CreateViewNode::make(_hyrise_env, "some_view", different_view, false);
+  const auto different_create_view_node_c = CreateViewNode::make(_hyrise_env, "some_view", _view, true);
 
   EXPECT_NE(*different_create_view_node_a, *_create_view_node);
   EXPECT_NE(*different_create_view_node_b, *_create_view_node);
@@ -59,7 +59,7 @@ TEST_F(CreateViewNodeTest, Copy) {
   const auto same_view_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
   const auto same_view =
       std::make_shared<LQPView>(_view_node, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, "a"}});
-  const auto same_create_view_node = CreateViewNode::make("some_view", _view, false);
+  const auto same_create_view_node = CreateViewNode::make(_hyrise_env, "some_view", _view, false);
 
   EXPECT_EQ(*same_create_view_node, *_create_view_node->deep_copy());
 }

--- a/src/test/lib/logical_query_plan/drop_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/drop_table_node_test.cpp
@@ -6,7 +6,7 @@ namespace opossum {
 
 class DropTableNodeTest : public BaseTest {
  public:
-  void SetUp() override { drop_table_node = DropTableNode::make("some_table", false); }
+  void SetUp() override { drop_table_node = DropTableNode::make(_hyrise_env, "some_table", false); }
 
   std::shared_ptr<DropTableNode> drop_table_node;
 };
@@ -16,7 +16,7 @@ TEST_F(DropTableNodeTest, Description) { EXPECT_EQ(drop_table_node->description(
 TEST_F(DropTableNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*drop_table_node, *drop_table_node);
 
-  const auto different_drop_table_node = DropTableNode::make("some_table2", false);
+  const auto different_drop_table_node = DropTableNode::make(_hyrise_env, "some_table2", false);
   EXPECT_NE(*different_drop_table_node, *drop_table_node);
   EXPECT_NE(different_drop_table_node->hash(), drop_table_node->hash());
 }

--- a/src/test/lib/logical_query_plan/drop_view_node_test.cpp
+++ b/src/test/lib/logical_query_plan/drop_view_node_test.cpp
@@ -8,7 +8,7 @@ namespace opossum {
 
 class DropViewNodeTest : public BaseTest {
  public:
-  void SetUp() override { _drop_view_node = DropViewNode::make("some_view", false); }
+  void SetUp() override { _drop_view_node = DropViewNode::make(_hyrise_env, "some_view", false); }
 
   std::shared_ptr<DropViewNode> _drop_view_node;
 };
@@ -18,8 +18,8 @@ TEST_F(DropViewNodeTest, Description) { EXPECT_EQ(_drop_view_node->description()
 TEST_F(DropViewNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_drop_view_node, *_drop_view_node);
 
-  const auto same_drop_view_node = DropViewNode::make("some_view", false);
-  const auto different_drop_view_node = DropViewNode::make("some_view2", false);
+  const auto same_drop_view_node = DropViewNode::make(_hyrise_env, "some_view", false);
+  const auto different_drop_view_node = DropViewNode::make(_hyrise_env, "some_view2", false);
 
   EXPECT_EQ(*_drop_view_node, *same_drop_view_node);
   EXPECT_NE(*_drop_view_node, *different_drop_view_node);

--- a/src/test/lib/logical_query_plan/import_node_test.cpp
+++ b/src/test/lib/logical_query_plan/import_node_test.cpp
@@ -10,7 +10,7 @@ namespace opossum {
 
 class ImportNodeTest : public BaseTest {
  protected:
-  void SetUp() override { _import_node = ImportNode::make("table_name", "file_name", FileType::Csv); }
+  void SetUp() override { _import_node = ImportNode::make(_hyrise_env, "table_name", "file_name", FileType::Csv); }
 
   std::shared_ptr<ImportNode> _import_node;
 };
@@ -18,7 +18,7 @@ class ImportNodeTest : public BaseTest {
 TEST_F(ImportNodeTest, Description) { EXPECT_EQ(_import_node->description(), "[Import] Name: 'table_name'"); }
 
 TEST_F(ImportNodeTest, HashingAndEqualityCheck) {
-  const auto another_import_node = ImportNode::make("table_name", "file_name", FileType::Csv);
+  const auto another_import_node = ImportNode::make(_hyrise_env, "table_name", "file_name", FileType::Csv);
   EXPECT_EQ(*_import_node, *another_import_node);
 
   EXPECT_EQ(_import_node->hash(), another_import_node->hash());

--- a/src/test/lib/logical_query_plan/insert_node_test.cpp
+++ b/src/test/lib/logical_query_plan/insert_node_test.cpp
@@ -9,7 +9,7 @@ namespace opossum {
 
 class InsertNodeTest : public BaseTest {
  protected:
-  void SetUp() override { _insert_node = InsertNode::make("table_a"); }
+  void SetUp() override { _insert_node = InsertNode::make(_hyrise_env, "table_a"); }
 
   std::shared_ptr<InsertNode> _insert_node;
 };
@@ -20,11 +20,11 @@ TEST_F(InsertNodeTest, TableName) { EXPECT_EQ(_insert_node->table_name, "table_a
 
 TEST_F(InsertNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_insert_node, *_insert_node);
-  EXPECT_EQ(*_insert_node, *InsertNode::make("table_a"));
-  EXPECT_NE(*_insert_node, *InsertNode::make("table_b"));
+  EXPECT_EQ(*_insert_node, *InsertNode::make(_hyrise_env, "table_a"));
+  EXPECT_NE(*_insert_node, *InsertNode::make(_hyrise_env, "table_b"));
 
-  EXPECT_EQ(_insert_node->hash(), InsertNode::make("table_a")->hash());
-  EXPECT_NE(_insert_node->hash(), InsertNode::make("table_b")->hash());
+  EXPECT_EQ(_insert_node->hash(), InsertNode::make(_hyrise_env, "table_a")->hash());
+  EXPECT_NE(_insert_node->hash(), InsertNode::make(_hyrise_env, "table_b")->hash());
 }
 
 TEST_F(InsertNodeTest, NodeExpressions) { EXPECT_TRUE(_insert_node->node_expressions.empty()); }

--- a/src/test/lib/logical_query_plan/logical_query_plan_test.cpp
+++ b/src/test/lib/logical_query_plan/logical_query_plan_test.cpp
@@ -21,14 +21,14 @@ namespace opossum {
 class LogicalQueryPlanTest : public BaseTest {
  public:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("int_int", load_table("resources/test_data/tbl/int_int.tbl"));
-    Hyrise::get().storage_manager.add_table("int_int_int", load_table("resources/test_data/tbl/int_int_int.tbl"));
+    _hyrise_env->storage_manager()->add_table("int_int", load_table("resources/test_data/tbl/int_int.tbl"));
+    _hyrise_env->storage_manager()->add_table("int_int_int", load_table("resources/test_data/tbl/int_int_int.tbl"));
 
-    node_int_int = StoredTableNode::make("int_int");
+    node_int_int = StoredTableNode::make(_hyrise_env, "int_int");
     a1 = node_int_int->get_column("a");
     b1 = node_int_int->get_column("b");
 
-    node_int_int_int = StoredTableNode::make("int_int_int");
+    node_int_int_int = StoredTableNode::make(_hyrise_env, "int_int_int");
     a2 = node_int_int_int->get_column("a");
     b2 = node_int_int_int->get_column("b");
     c2 = node_int_int_int->get_column("c");
@@ -107,8 +107,8 @@ class LogicalQueryPlanTest : public BaseTest {
 };
 
 TEST_F(LogicalQueryPlanTest, LQPColumnExpressionHash) {
-  const auto node_int_int_1 = StoredTableNode::make("int_int");
-  const auto node_int_int_2 = StoredTableNode::make("int_int");
+  const auto node_int_int_1 = StoredTableNode::make(_hyrise_env, "int_int");
+  const auto node_int_int_2 = StoredTableNode::make(_hyrise_env, "int_int");
 
   const auto expression_a = std::make_shared<LQPColumnExpression>(node_int_int_1, ColumnID{0});
   const auto expression_a_1 = std::make_shared<LQPColumnExpression>(node_int_int_1, ColumnID{0});

--- a/src/test/lib/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_find_subplan_mismatch_test.cpp
@@ -50,14 +50,14 @@ class LQPFindSubplanMismatchTest : public BaseTest {
   };
 
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("table_a", load_table("resources/test_data/tbl/int_int.tbl", 2));
+    _hyrise_env->storage_manager()->add_table("table_a", load_table("resources/test_data/tbl/int_int.tbl", 2));
 
     _init_query_nodes(_query_nodes_lhs);
     _init_query_nodes(_query_nodes_rhs);
   }
 
   void _init_query_nodes(QueryNodes& query_nodes) const {
-    query_nodes.stored_table_node_a = StoredTableNode::make("table_a");
+    query_nodes.stored_table_node_a = StoredTableNode::make(_hyrise_env, "table_a");
     query_nodes.validate_node = ValidateNode::make();
     query_nodes.mock_node_a = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}});
     query_nodes.mock_node_b = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "b"}, {DataType::Int, "c"}});

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -196,7 +196,7 @@ TEST_F(LQPUtilsTest, LQPFindModifiedTables) {
 
   // clang-format off
   const auto insert_lqp =
-  InsertNode::make("insert_table_name",
+  InsertNode::make(_hyrise_env, "insert_table_name",
     PredicateNode::make(greater_than_(a_a, 5),
       node_a));
   // clang-format on

--- a/src/test/lib/logical_query_plan/predicate_node_test.cpp
+++ b/src/test/lib/logical_query_plan/predicate_node_test.cpp
@@ -13,10 +13,10 @@ namespace opossum {
 class PredicateNodeTest : public BaseTest {
  protected:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("table_a",
-                                            load_table("resources/test_data/tbl/int_float_double_string.tbl", 2));
+    _hyrise_env->storage_manager()->add_table("table_a",
+                                              load_table("resources/test_data/tbl/int_float_double_string.tbl", 2));
 
-    _table_node = StoredTableNode::make("table_a");
+    _table_node = StoredTableNode::make(_hyrise_env, "table_a");
     _i = lqp_column_(_table_node, ColumnID{0});
     _f = lqp_column_(_table_node, ColumnID{1});
 
@@ -32,7 +32,7 @@ TEST_F(PredicateNodeTest, Descriptions) { EXPECT_EQ(_predicate_node->description
 
 TEST_F(PredicateNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_predicate_node, *_predicate_node);
-  const auto equal_table_node = StoredTableNode::make("table_a");
+  const auto equal_table_node = StoredTableNode::make(_hyrise_env, "table_a");
   const auto equal_i = equal_table_node->get_column("i");
 
   const auto other_predicate_node_a = PredicateNode::make(equals_(_i, 5), _table_node);

--- a/src/test/lib/logical_query_plan/sort_node_test.cpp
+++ b/src/test/lib/logical_query_plan/sort_node_test.cpp
@@ -14,10 +14,10 @@ namespace opossum {
 class SortNodeTest : public BaseTest {
  protected:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("table_a",
-                                            load_table("resources/test_data/tbl/int_float_double_string.tbl", 2));
+    _hyrise_env->storage_manager()->add_table("table_a",
+                                              load_table("resources/test_data/tbl/int_float_double_string.tbl", 2));
 
-    _table_node = StoredTableNode::make("table_a");
+    _table_node = StoredTableNode::make(_hyrise_env, "table_a");
 
     _a_i = _table_node->get_column("i");
     _a_f = _table_node->get_column("f");

--- a/src/test/lib/logical_query_plan/update_node_test.cpp
+++ b/src/test/lib/logical_query_plan/update_node_test.cpp
@@ -16,7 +16,7 @@ class UpdateNodeTest : public BaseTest {
  protected:
   void SetUp() override {
     _mock_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Int, "a"}}));
-    _update_node = UpdateNode::make("table_a", _mock_node, _mock_node);
+    _update_node = UpdateNode::make(_hyrise_env, "table_a", _mock_node, _mock_node);
   }
 
   std::shared_ptr<UpdateNode> _update_node;
@@ -32,11 +32,11 @@ TEST_F(UpdateNodeTest, HashingAndEqualityCheck) {
 
   const auto other_mock_node = MockNode::make(MockNode::ColumnDefinitions({{DataType::Long, "a"}}));
 
-  const auto other_update_node_a = UpdateNode::make("table_a", _mock_node, _mock_node);
-  const auto other_update_node_b = UpdateNode::make("table_b", _mock_node, _mock_node);
-  const auto other_update_node_c = UpdateNode::make("table_a", other_mock_node, _mock_node);
-  const auto other_update_node_d = UpdateNode::make("table_a", _mock_node, other_mock_node);
-  const auto other_update_node_e = UpdateNode::make("table_a", other_mock_node, other_mock_node);
+  const auto other_update_node_a = UpdateNode::make(_hyrise_env, "table_a", _mock_node, _mock_node);
+  const auto other_update_node_b = UpdateNode::make(_hyrise_env, "table_b", _mock_node, _mock_node);
+  const auto other_update_node_c = UpdateNode::make(_hyrise_env, "table_a", other_mock_node, _mock_node);
+  const auto other_update_node_d = UpdateNode::make(_hyrise_env, "table_a", _mock_node, other_mock_node);
+  const auto other_update_node_e = UpdateNode::make(_hyrise_env, "table_a", other_mock_node, other_mock_node);
 
   EXPECT_EQ(*_update_node, *other_update_node_a);
   EXPECT_NE(*_update_node, *other_update_node_b);

--- a/src/test/lib/operators/change_meta_table_test.cpp
+++ b/src/test/lib/operators/change_meta_table_test.cpp
@@ -29,7 +29,7 @@ class ChangeMetaTableTest : public BaseTest {
     right_input->execute();
 
     meta_mock_table = std::make_shared<MetaMockTable>();
-    Hyrise::get().meta_table_manager.add_table(meta_mock_table);
+    _hyrise_env->meta_table_manager()->add_table(meta_mock_table);
 
     context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::Yes);
   }
@@ -44,7 +44,7 @@ class ChangeMetaTableTest : public BaseTest {
 
 TEST_F(ChangeMetaTableTest, Insert) {
   auto change_meta_table =
-      std::make_shared<ChangeMetaTable>("meta_mock", MetaTableChangeType::Insert, left_input, right_input);
+      std::make_shared<ChangeMetaTable>(_hyrise_env, "meta_mock", MetaTableChangeType::Insert, left_input, right_input);
 
   change_meta_table->set_transaction_context(context);
   change_meta_table->execute();
@@ -57,7 +57,7 @@ TEST_F(ChangeMetaTableTest, Insert) {
 
 TEST_F(ChangeMetaTableTest, Delete) {
   auto change_meta_table =
-      std::make_shared<ChangeMetaTable>("meta_mock", MetaTableChangeType::Delete, left_input, right_input);
+      std::make_shared<ChangeMetaTable>(_hyrise_env, "meta_mock", MetaTableChangeType::Delete, left_input, right_input);
 
   change_meta_table->set_transaction_context(context);
   change_meta_table->execute();
@@ -70,7 +70,7 @@ TEST_F(ChangeMetaTableTest, Delete) {
 
 TEST_F(ChangeMetaTableTest, Update) {
   auto change_meta_table =
-      std::make_shared<ChangeMetaTable>("meta_mock", MetaTableChangeType::Update, left_input, right_input);
+      std::make_shared<ChangeMetaTable>(_hyrise_env, "meta_mock", MetaTableChangeType::Update, left_input, right_input);
 
   change_meta_table->set_transaction_context(context);
   change_meta_table->execute();
@@ -84,7 +84,7 @@ TEST_F(ChangeMetaTableTest, Update) {
 
 TEST_F(ChangeMetaTableTest, OnlyAllowsAutoCommit) {
   auto change_meta_table =
-      std::make_shared<ChangeMetaTable>("meta_mock", MetaTableChangeType::Insert, left_input, right_input);
+      std::make_shared<ChangeMetaTable>(_hyrise_env, "meta_mock", MetaTableChangeType::Insert, left_input, right_input);
 
   auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
 

--- a/src/test/lib/operators/get_table_test.cpp
+++ b/src/test/lib/operators/get_table_test.cpp
@@ -16,10 +16,10 @@ namespace opossum {
 class OperatorsGetTableTest : public BaseTest {
  protected:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("int_int_float",
-                                            load_table("resources/test_data/tbl/int_int_float.tbl", 1u));
+    _hyrise_env->storage_manager()->add_table("int_int_float",
+                                              load_table("resources/test_data/tbl/int_int_float.tbl", 1u));
 
-    const auto& table = Hyrise::get().storage_manager.get_table("int_int_float");
+    const auto& table = _hyrise_env->storage_manager()->get_table("int_int_float");
     ChunkEncoder::encode_all_chunks(table);
     table->create_index<GroupKeyIndex>({ColumnID{0}}, "i_a");
     table->create_index<GroupKeyIndex>({ColumnID{1}}, "i_b1");
@@ -28,19 +28,19 @@ class OperatorsGetTableTest : public BaseTest {
 };
 
 TEST_F(OperatorsGetTableTest, GetOutput) {
-  auto get_table = std::make_shared<GetTable>("int_int_float");
+  auto get_table = std::make_shared<GetTable>(_hyrise_env, "int_int_float");
   get_table->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(get_table->get_output(), load_table("resources/test_data/tbl/int_int_float.tbl", 1u));
 }
 
 TEST_F(OperatorsGetTableTest, OutputDoesNotChangeChunkSize) {
-  auto get_table = std::make_shared<GetTable>("int_int_float");
+  auto get_table = std::make_shared<GetTable>(_hyrise_env, "int_int_float");
   get_table->execute();
 
   EXPECT_TABLE_EQ_UNORDERED(get_table->get_output(), load_table("resources/test_data/tbl/int_int_float.tbl", 1u));
 
-  const auto table = Hyrise::get().storage_manager.get_table("int_int_float");
+  const auto table = _hyrise_env->storage_manager()->get_table("int_int_float");
   table->append({1, 2, 10.0f});
   EXPECT_GT(table->chunk_count(), get_table->get_output()->chunk_count());
 
@@ -48,26 +48,26 @@ TEST_F(OperatorsGetTableTest, OutputDoesNotChangeChunkSize) {
 }
 
 TEST_F(OperatorsGetTableTest, ThrowsUnknownTableName) {
-  auto get_table = std::make_shared<GetTable>("anUglyTestTable");
+  auto get_table = std::make_shared<GetTable>(_hyrise_env, "anUglyTestTable");
 
   EXPECT_THROW(get_table->execute(), std::exception) << "Should throw unknown table name exception";
 }
 
 TEST_F(OperatorsGetTableTest, OperatorName) {
-  auto get_table = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
 
   EXPECT_EQ(get_table->name(), "GetTable");
 }
 
 TEST_F(OperatorsGetTableTest, Description) {
-  auto get_table_a = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table_a = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   EXPECT_EQ(get_table_a->description(DescriptionMode::SingleLine),
             "GetTable (int_int_float) pruned: 0/4 chunk(s), 0/3 column(s)");
   EXPECT_EQ(get_table_a->description(DescriptionMode::MultiLine),
             "GetTable\n(int_int_float)\npruned:\n0/4 chunk(s)\n0/3 column(s)");
 
-  auto get_table_b =
-      std::make_shared<opossum::GetTable>("int_int_float", std::vector{ChunkID{0}}, std::vector{ColumnID{1}});
+  auto get_table_b = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector{ChunkID{0}},
+                                                         std::vector{ColumnID{1}});
   EXPECT_EQ(get_table_b->description(DescriptionMode::SingleLine),
             "GetTable (int_int_float) pruned: 1/4 chunk(s), 1/3 column(s)");
   EXPECT_EQ(get_table_b->description(DescriptionMode::MultiLine),
@@ -75,7 +75,7 @@ TEST_F(OperatorsGetTableTest, Description) {
 }
 
 TEST_F(OperatorsGetTableTest, PassThroughInvalidRowCount) {
-  auto get_table_1 = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table_1 = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   get_table_1->execute();
 
   auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
@@ -91,7 +91,7 @@ TEST_F(OperatorsGetTableTest, PassThroughInvalidRowCount) {
 
   transaction_context->commit();
 
-  auto get_table_2 = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table_2 = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   get_table_2->execute();
   const auto result_table = get_table_2->get_output();
 
@@ -104,12 +104,12 @@ TEST_F(OperatorsGetTableTest, PassThroughInvalidRowCount) {
 }
 
 TEST_F(OperatorsGetTableTest, PrunedChunks) {
-  auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector{ChunkID{0}, ChunkID{2}},
-                                                       std::vector<ColumnID>{});
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float",
+                                                       std::vector{ChunkID{0}, ChunkID{2}}, std::vector<ColumnID>{});
 
   get_table->execute();
 
-  auto original_table = Hyrise::get().storage_manager.get_table("int_int_float");
+  auto original_table = _hyrise_env->storage_manager()->get_table("int_int_float");
   auto table = get_table->get_output();
   EXPECT_EQ(table->chunk_count(), ChunkID(2));
   EXPECT_EQ(table->get_value<int32_t>(ColumnID(0), 0u), original_table->get_value<int32_t>(ColumnID(0), 1u));
@@ -123,8 +123,8 @@ TEST_F(OperatorsGetTableTest, PrunedChunks) {
 }
 
 TEST_F(OperatorsGetTableTest, PrunedColumns) {
-  auto get_table =
-      std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector{ColumnID{1}});
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector<ChunkID>{},
+                                                       std::vector{ColumnID{1}});
 
   get_table->execute();
 
@@ -145,8 +145,8 @@ TEST_F(OperatorsGetTableTest, PrunedColumns) {
 }
 
 TEST_F(OperatorsGetTableTest, PrunedColumnsAndChunks) {
-  auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector{ChunkID{0}, ChunkID{2}},
-                                                       std::vector{ColumnID{0}});
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float",
+                                                       std::vector{ChunkID{0}, ChunkID{2}}, std::vector{ColumnID{0}});
 
   get_table->execute();
 
@@ -164,10 +164,10 @@ TEST_F(OperatorsGetTableTest, PrunedColumnsAndChunks) {
 }
 
 TEST_F(OperatorsGetTableTest, ExcludeCleanedUpChunk) {
-  auto get_table = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   auto context = std::make_shared<TransactionContext>(1u, 3u, AutoCommit::No);
 
-  auto original_table = Hyrise::get().storage_manager.get_table("int_int_float");
+  auto original_table = _hyrise_env->storage_manager()->get_table("int_int_float");
   auto chunk = original_table->get_chunk(ChunkID{0});
 
   chunk->set_cleanup_commit_id(CommitID{2u});
@@ -181,12 +181,12 @@ TEST_F(OperatorsGetTableTest, ExcludeCleanedUpChunk) {
 }
 
 TEST_F(OperatorsGetTableTest, ExcludePhysicallyDeletedChunks) {
-  auto original_table = Hyrise::get().storage_manager.get_table("int_int_float");
+  auto original_table = _hyrise_env->storage_manager()->get_table("int_int_float");
   EXPECT_EQ(original_table->chunk_count(), 4);
 
   // Invalidate all records to be able to call remove_chunk()
   auto context = std::make_shared<TransactionContext>(1u, 1u, AutoCommit::No);
-  auto get_table = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   get_table->set_transaction_context(context);
   get_table->execute();
   EXPECT_EQ(get_table->get_output()->chunk_count(), 4);
@@ -214,7 +214,7 @@ TEST_F(OperatorsGetTableTest, ExcludePhysicallyDeletedChunks) {
 
   // Check GetTable filtering
   auto context2 = std::make_shared<TransactionContext>(2u, 1u, AutoCommit::No);
-  auto get_table_2 = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table_2 = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   get_table_2->set_transaction_context(context2);
 
   get_table_2->execute();
@@ -223,12 +223,12 @@ TEST_F(OperatorsGetTableTest, ExcludePhysicallyDeletedChunks) {
 
 TEST_F(OperatorsGetTableTest, PrunedChunksCombined) {
   // 1. --- Physical deletion of a chunk
-  auto original_table = Hyrise::get().storage_manager.get_table("int_int_float");
+  auto original_table = _hyrise_env->storage_manager()->get_table("int_int_float");
   EXPECT_EQ(original_table->chunk_count(), 4);
 
   // Invalidate all records to be able to call remove_chunk()
   auto context = std::make_shared<TransactionContext>(1u, 1u, AutoCommit::No);
-  auto get_table = std::make_shared<opossum::GetTable>("int_int_float");
+  auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float");
   get_table->set_transaction_context(context);
   get_table->execute();
   EXPECT_EQ(get_table->get_output()->chunk_count(), 4);
@@ -253,12 +253,12 @@ TEST_F(OperatorsGetTableTest, PrunedChunksCombined) {
   EXPECT_FALSE(original_table->get_chunk(ChunkID{2}));
 
   // 2. --- Logical deletion of a chunk
-  auto get_table_2 =
-      std::make_shared<opossum::GetTable>("int_int_float", std::vector{ChunkID{0}}, std::vector<ColumnID>{});
+  auto get_table_2 = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector{ChunkID{0}},
+                                                         std::vector<ColumnID>{});
 
   auto context2 = std::make_shared<TransactionContext>(1u, 3u, AutoCommit::No);
 
-  auto modified_table = Hyrise::get().storage_manager.get_table("int_int_float");
+  auto modified_table = _hyrise_env->storage_manager()->get_table("int_int_float");
   auto chunk = modified_table->get_chunk(ChunkID{1});
 
   chunk->set_cleanup_commit_id(CommitID{2u});
@@ -271,14 +271,14 @@ TEST_F(OperatorsGetTableTest, PrunedChunksCombined) {
 }
 
 TEST_F(OperatorsGetTableTest, Copy) {
-  const auto get_table_a = std::make_shared<GetTable>("int_int_float");
+  const auto get_table_a = std::make_shared<GetTable>(_hyrise_env, "int_int_float");
   const auto get_table_a_copy = std::dynamic_pointer_cast<GetTable>(get_table_a->deep_copy());
   EXPECT_EQ(get_table_a_copy->table_name(), "int_int_float");
   EXPECT_TRUE(get_table_a_copy->pruned_chunk_ids().empty());
   EXPECT_TRUE(get_table_a_copy->pruned_column_ids().empty());
 
   const auto get_table_b =
-      std::make_shared<GetTable>("int_int_float", std::vector{ChunkID{1}}, std::vector{ColumnID{0}});
+      std::make_shared<GetTable>(_hyrise_env, "int_int_float", std::vector{ChunkID{1}}, std::vector{ColumnID{0}});
   const auto get_table_b_copy = std::dynamic_pointer_cast<GetTable>(get_table_b->deep_copy());
   EXPECT_EQ(get_table_b_copy->table_name(), "int_int_float");
   EXPECT_EQ(get_table_b_copy->pruned_chunk_ids(), std::vector{ChunkID{1}});
@@ -286,7 +286,7 @@ TEST_F(OperatorsGetTableTest, Copy) {
 }
 
 TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
-  auto table = Hyrise::get().storage_manager.get_table("int_int_float");
+  auto table = _hyrise_env->storage_manager()->get_table("int_int_float");
   table->get_chunk(ChunkID{0})->set_individually_sorted_by(SortColumnDefinition(ColumnID{0}, SortMode::Ascending));
   table->get_chunk(ChunkID{1})
       ->set_individually_sorted_by({SortColumnDefinition(ColumnID{1}, SortMode::Ascending),
@@ -294,8 +294,8 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
   // single column pruned
   {
-    auto get_table =
-        std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector{ColumnID{1}});
+    auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector<ChunkID>{},
+                                                         std::vector{ColumnID{1}});
     get_table->execute();
 
     const auto& get_table_output = get_table->get_output();
@@ -310,7 +310,7 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
   // multiple columns pruned
   {
-    auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{},
+    auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector<ChunkID>{},
                                                          std::vector{ColumnID{0}, ColumnID{1}});
     get_table->execute();
 
@@ -324,8 +324,8 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
   // no columns pruned
   {
-    auto get_table =
-        std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{}, std::vector<ColumnID>{});
+    auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector<ChunkID>{},
+                                                         std::vector<ColumnID>{});
     get_table->execute();
 
     const auto& get_table_output = get_table->get_output();
@@ -338,7 +338,7 @@ TEST_F(OperatorsGetTableTest, AdaptOrderByInformation) {
 
   // pruning the columns on which chunks are sorted
   {
-    auto get_table = std::make_shared<opossum::GetTable>("int_int_float", std::vector<ChunkID>{},
+    auto get_table = std::make_shared<opossum::GetTable>(_hyrise_env, "int_int_float", std::vector<ChunkID>{},
                                                          std::vector{ColumnID{0}, ColumnID{2}});
     get_table->execute();
 

--- a/src/test/lib/operators/index_scan_test.cpp
+++ b/src/test/lib/operators/index_scan_test.cpp
@@ -65,7 +65,7 @@ class OperatorsIndexScanTest : public BaseTest {
     ChunkEncoder::encode_all_chunks(partially_indexed_table);
     const auto second_chunk = partially_indexed_table->get_chunk(ChunkID{1});
     second_chunk->template create_index<DerivedIndex>(std::vector<ColumnID>{ColumnID{0}});
-    Hyrise::get().storage_manager.add_table("index_test_table", partially_indexed_table);
+    BaseTest::_hyrise_env->storage_manager()->add_table("index_test_table", partially_indexed_table);
   }
 
   void ASSERT_COLUMN_EQ(std::shared_ptr<const Table> table, const ColumnID& column_id,
@@ -272,7 +272,7 @@ TYPED_TEST(OperatorsIndexScanTest, InvalidIndexTypeThrows) {
 TYPED_TEST(OperatorsIndexScanTest, AddedChunk) {
   // We want to make sure that all chunks are covered even if they have been added after SQL translation
 
-  const auto stored_table_node = StoredTableNode::make("index_test_table");
+  const auto stored_table_node = StoredTableNode::make(BaseTest::_hyrise_env, "index_test_table");
   auto predicate_node = PredicateNode::make(equals_(stored_table_node->get_column("a"), 4), stored_table_node);
   predicate_node->scan_type = ScanType::IndexScan;
 
@@ -294,7 +294,7 @@ TYPED_TEST(OperatorsIndexScanTest, AddedChunk) {
   ASSERT_TRUE(get_table);
 
   // Add values:
-  const auto table = Hyrise::get().storage_manager.get_table("index_test_table");
+  const auto table = BaseTest::_hyrise_env->storage_manager()->get_table("index_test_table");
   table->append({4, 5});
   EXPECT_EQ(table->chunk_count(), 3);
 

--- a/src/test/lib/operators/insert_test.cpp
+++ b/src/test/lib/operators/insert_test.cpp
@@ -28,12 +28,12 @@ TEST_F(OperatorsInsertTest, SelfInsert) {
   auto table_name = "test_table";
   auto table = load_table("resources/test_data/tbl/float_int.tbl");
   // Insert Operator works with the Storage Manager, so the test table must also be known to the StorageManager
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
-  auto get_table = std::make_shared<GetTable>(table_name);
+  auto get_table = std::make_shared<GetTable>(_hyrise_env, table_name);
   get_table->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
 
@@ -62,16 +62,16 @@ TEST_F(OperatorsInsertTest, InsertRespectChunkSize) {
 
   // 3 Rows, chunk_size = 4
   auto table = load_table("resources/test_data/tbl/int.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   // 10 Rows
   auto table2 = load_table("resources/test_data/tbl/10_ints.tbl");
-  Hyrise::get().storage_manager.add_table(table_name2, table2);
+  _hyrise_env->storage_manager()->add_table(table_name2, table2);
 
-  auto get_table2 = std::make_shared<GetTable>(table_name2);
+  auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name2);
   get_table2->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table2);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table2);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();
@@ -89,16 +89,16 @@ TEST_F(OperatorsInsertTest, MultipleChunks) {
 
   // 3 Rows
   auto table = load_table("resources/test_data/tbl/int.tbl", 2u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   // 10 Rows
   auto table2 = load_table("resources/test_data/tbl/10_ints.tbl", 3u);
-  Hyrise::get().storage_manager.add_table(table_name2, table2);
+  _hyrise_env->storage_manager()->add_table(table_name2, table2);
 
-  auto get_table2 = std::make_shared<GetTable>(table_name2);
+  auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name2);
   get_table2->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table2);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table2);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();
@@ -116,17 +116,17 @@ TEST_F(OperatorsInsertTest, CompressedChunks) {
 
   // 3 Rows
   auto table = load_table("resources/test_data/tbl/int.tbl", 2u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
   opossum::ChunkEncoder::encode_all_chunks(table);
 
   // 10 Rows
   auto table2 = load_table("resources/test_data/tbl/10_ints.tbl");
-  Hyrise::get().storage_manager.add_table(table_name2, table2);
+  _hyrise_env->storage_manager()->add_table(table_name2, table2);
 
-  auto get_table2 = std::make_shared<GetTable>(table_name2);
+  auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name2);
   get_table2->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table2);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table2);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();
@@ -141,18 +141,18 @@ TEST_F(OperatorsInsertTest, Rollback) {
   auto table_name = "test3";
 
   auto table = load_table("resources/test_data/tbl/int.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
-  auto get_table1 = std::make_shared<GetTable>(table_name);
+  auto get_table1 = std::make_shared<GetTable>(_hyrise_env, table_name);
   get_table1->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table1);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table1);
   auto context1 = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context1);
   insert->execute();
 
   const auto check = [&]() {
-    auto get_table2 = std::make_shared<GetTable>(table_name);
+    auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name);
     get_table2->execute();
     auto validate = std::make_shared<Validate>(get_table2);
     auto context2 = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
@@ -171,29 +171,29 @@ TEST_F(OperatorsInsertTest, RollbackIncreaseInvalidRowCount) {
 
   // Set Up
   auto t = load_table("resources/test_data/tbl/int.tbl", 10u);
-  Hyrise::get().storage_manager.add_table(t_name, t);
+  _hyrise_env->storage_manager()->add_table(t_name, t);
   auto row_count = t->row_count();
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->chunk_count(), 1);
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->chunk_count(), 1);
 
   // Insert rows again
-  auto gt1 = std::make_shared<GetTable>(t_name);
+  auto gt1 = std::make_shared<GetTable>(_hyrise_env, t_name);
   gt1->execute();
-  auto ins = std::make_shared<Insert>(t_name, gt1);
+  auto ins = std::make_shared<Insert>(_hyrise_env, t_name, gt1);
   auto context1 = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   ins->set_transaction_context(context1);
   ins->execute();
 
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->row_count(), row_count * 2);
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->chunk_count(),
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->row_count(), row_count * 2);
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->chunk_count(),
             2);  // load_table() has finalized first chunk
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->get_chunk(ChunkID{0})->invalid_row_count(), uint32_t{0});
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->get_chunk(ChunkID{1})->invalid_row_count(), uint32_t{0});
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->get_chunk(ChunkID{0})->invalid_row_count(), uint32_t{0});
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->get_chunk(ChunkID{1})->invalid_row_count(), uint32_t{0});
 
   // Rollback Insert - invalidate inserted rows
   context1->rollback(RollbackReason::User);
 
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->get_chunk(ChunkID{0})->invalid_row_count(), uint32_t{0});
-  EXPECT_EQ(Hyrise::get().storage_manager.get_table(t_name)->get_chunk(ChunkID{1})->invalid_row_count(), uint32_t{3});
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->get_chunk(ChunkID{0})->invalid_row_count(), uint32_t{0});
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_table(t_name)->get_chunk(ChunkID{1})->invalid_row_count(), uint32_t{3});
 }
 
 TEST_F(OperatorsInsertTest, InsertStringNullValue) {
@@ -201,15 +201,15 @@ TEST_F(OperatorsInsertTest, InsertStringNullValue) {
   auto table_name2 = "test2";
 
   auto table = load_table("resources/test_data/tbl/string_with_null.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   auto table2 = load_table("resources/test_data/tbl/string_with_null.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name2, table2);
+  _hyrise_env->storage_manager()->add_table(table_name2, table2);
 
-  auto get_table2 = std::make_shared<GetTable>(table_name2);
+  auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name2);
   get_table2->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table2);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table2);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();
@@ -227,15 +227,15 @@ TEST_F(OperatorsInsertTest, InsertIntFloatNullValues) {
   auto table_name2 = "test2";
 
   auto table = load_table("resources/test_data/tbl/int_float_with_null.tbl", 3u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   auto table2 = load_table("resources/test_data/tbl/int_float_with_null.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name2, table2);
+  _hyrise_env->storage_manager()->add_table(table_name2, table2);
 
-  auto get_table2 = std::make_shared<GetTable>(table_name2);
+  auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name2);
   get_table2->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table2);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table2);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();
@@ -256,15 +256,15 @@ TEST_F(OperatorsInsertTest, InsertNullIntoNonNull) {
   auto table_name2 = "test2";
 
   auto table = load_table("resources/test_data/tbl/int_float.tbl", 3u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   auto table2 = load_table("resources/test_data/tbl/int_float_with_null.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name2, table2);
+  _hyrise_env->storage_manager()->add_table(table_name2, table2);
 
-  auto get_table2 = std::make_shared<GetTable>(table_name2);
+  auto get_table2 = std::make_shared<GetTable>(_hyrise_env, table_name2);
   get_table2->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table2);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table2);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   EXPECT_THROW(insert->execute(), std::logic_error);
@@ -275,7 +275,7 @@ TEST_F(OperatorsInsertTest, InsertSingleNullFromDummyProjection) {
   auto table_name = "test1";
 
   auto table = load_table("resources/test_data/tbl/float_with_null.tbl", 4u);
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   auto dummy_wrapper = std::make_shared<TableWrapper>(Projection::dummy_table());
   dummy_wrapper->execute();
@@ -284,7 +284,7 @@ TEST_F(OperatorsInsertTest, InsertSingleNullFromDummyProjection) {
   auto projection = std::make_shared<Projection>(dummy_wrapper, expression_vector(add_(0.0f, null_())));
   projection->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, projection);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, projection);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();
@@ -304,14 +304,14 @@ TEST_F(OperatorsInsertTest, InsertIntoEmptyTable) {
 
   const auto target_table =
       std::make_shared<Table>(column_definitions, TableType::Data, Chunk::DEFAULT_SIZE, UseMvcc::Yes);
-  Hyrise::get().storage_manager.add_table("target_table", target_table);
+  _hyrise_env->storage_manager()->add_table("target_table", target_table);
 
   const auto table_int_float = load_table("resources/test_data/tbl/int_float.tbl");
 
   const auto table_wrapper = std::make_shared<TableWrapper>(table_int_float);
   table_wrapper->execute();
 
-  const auto insert = std::make_shared<Insert>("target_table", table_wrapper);
+  const auto insert = std::make_shared<Insert>(_hyrise_env, "target_table", table_wrapper);
   auto context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
   insert->set_transaction_context(context);
   insert->execute();

--- a/src/test/lib/operators/maintenance/create_prepared_plan_test.cpp
+++ b/src/test/lib/operators/maintenance/create_prepared_plan_test.cpp
@@ -15,7 +15,7 @@ class CreatePreparedPlanTest : public BaseTest {
  protected:
   void SetUp() override {
     prepared_plan = std::make_shared<PreparedPlan>(DummyTableNode::make(), std::vector<ParameterID>{});
-    create_prepared_plan = std::make_shared<CreatePreparedPlan>("prepared_plan_a", prepared_plan);
+    create_prepared_plan = std::make_shared<CreatePreparedPlan>(_hyrise_env, "prepared_plan_a", prepared_plan);
   }
 
   std::shared_ptr<PreparedPlan> prepared_plan;
@@ -38,11 +38,10 @@ TEST_F(CreatePreparedPlanTest, DeepCopy) {
 }
 
 TEST_F(CreatePreparedPlanTest, Execute) {
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_prepared_plan("prepared_plan_a"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_prepared_plan("prepared_plan_a"));
   create_prepared_plan->execute();
-  const auto& sm = Hyrise::get().storage_manager;
-  EXPECT_TRUE(sm.has_prepared_plan("prepared_plan_a"));
-  EXPECT_EQ(sm.get_prepared_plan("prepared_plan_a"), prepared_plan);
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_prepared_plan("prepared_plan_a"));
+  EXPECT_EQ(_hyrise_env->storage_manager()->get_prepared_plan("prepared_plan_a"), prepared_plan);
 
   const auto copy = create_prepared_plan->deep_copy();
   EXPECT_ANY_THROW(copy->execute());

--- a/src/test/lib/operators/maintenance/create_view_test.cpp
+++ b/src/test/lib/operators/maintenance/create_view_test.cpp
@@ -15,10 +15,9 @@ namespace opossum {
 class CreateViewTest : public BaseTest {
  protected:
   void SetUp() override {
-    auto& sm = Hyrise::get().storage_manager;
     auto t1 = std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data);
 
-    sm.add_table("first_table", t1);
+    _hyrise_env->storage_manager()->add_table("first_table", t1);
   }
 };
 
@@ -26,7 +25,7 @@ TEST_F(CreateViewTest, OperatorName) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view, false);
+  auto cv = std::make_shared<CreateView>(_hyrise_env, "view_name", view, false);
 
   EXPECT_EQ(cv->name(), "CreateView");
 }
@@ -35,7 +34,7 @@ TEST_F(CreateViewTest, DeepCopy) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view, false);
+  auto cv = std::make_shared<CreateView>(_hyrise_env, "view_name", view, false);
 
   cv->execute();
   EXPECT_NE(cv->get_output(), nullptr);
@@ -48,17 +47,17 @@ TEST_F(CreateViewTest, Execute) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view_in, false);
+  auto cv = std::make_shared<CreateView>(_hyrise_env, "view_name", view_in, false);
   cv->execute();
 
   EXPECT_EQ(cv->get_output()->row_count(), 0u);
 
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_view("view_name"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_view("view_name"));
 
-  auto view_out = Hyrise::get().storage_manager.get_view("view_name");
+  auto view_out = _hyrise_env->storage_manager()->get_view("view_name");
   EXPECT_EQ(view_out->lqp->type, LQPNodeType::Mock);
 
-  auto cv_2 = std::make_shared<CreateView>("view_name", view_in, false);
+  auto cv_2 = std::make_shared<CreateView>(_hyrise_env, "view_name", view_in, false);
   EXPECT_ANY_THROW(cv_2->execute());
 }
 
@@ -66,17 +65,17 @@ TEST_F(CreateViewTest, ExecuteWithIfNotExists) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view_in, true);
+  auto cv = std::make_shared<CreateView>(_hyrise_env, "view_name", view_in, true);
   cv->execute();
 
   EXPECT_EQ(cv->get_output()->row_count(), 0u);
 
-  EXPECT_TRUE(Hyrise::get().storage_manager.has_view("view_name"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_view("view_name"));
 
-  auto view_out = Hyrise::get().storage_manager.get_view("view_name");
+  auto view_out = _hyrise_env->storage_manager()->get_view("view_name");
   EXPECT_EQ(view_out->lqp->type, LQPNodeType::Mock);
 
-  auto cv_2 = std::make_shared<CreateView>("view_name", view_in, true);
+  auto cv_2 = std::make_shared<CreateView>(_hyrise_env, "view_name", view_in, true);
   EXPECT_NO_THROW(cv_2->execute());
 }
 

--- a/src/test/lib/operators/maintenance/drop_table_test.cpp
+++ b/src/test/lib/operators/maintenance/drop_table_test.cpp
@@ -13,7 +13,7 @@ namespace opossum {
 class DropTableTest : public BaseTest {
  public:
   void SetUp() override {
-    drop_table = std::make_shared<DropTable>("t", false);
+    drop_table = std::make_shared<DropTable>(_hyrise_env, "t", false);
 
     TableColumnDefinitions column_definitions;
     column_definitions.emplace_back("a", DataType::Int, false);
@@ -32,22 +32,22 @@ TEST_F(DropTableTest, NameAndDescription) {
 }
 
 TEST_F(DropTableTest, Execute) {
-  Hyrise::get().storage_manager.add_table("t", table);
+  _hyrise_env->storage_manager()->add_table("t", table);
   drop_table->execute();
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("t"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("t"));
 }
 
 TEST_F(DropTableTest, NoSuchTable) { EXPECT_THROW(drop_table->execute(), std::logic_error); }
 
 TEST_F(DropTableTest, ExecuteWithIfExists) {
-  Hyrise::get().storage_manager.add_table("t", table);
-  auto drop_table_if_exists_1 = std::make_shared<DropTable>("t", true);
+  _hyrise_env->storage_manager()->add_table("t", table);
+  auto drop_table_if_exists_1 = std::make_shared<DropTable>(_hyrise_env, "t", true);
   drop_table_if_exists_1->execute();
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("t"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("t"));
 
-  auto drop_table_if_exists_2 = std::make_shared<DropTable>("t", true);
+  auto drop_table_if_exists_2 = std::make_shared<DropTable>(_hyrise_env, "t", true);
   EXPECT_NO_THROW(drop_table_if_exists_2->execute());
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_table("t"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("t"));
 }
 
 }  // namespace opossum

--- a/src/test/lib/operators/maintenance/drop_view_test.cpp
+++ b/src/test/lib/operators/maintenance/drop_view_test.cpp
@@ -14,26 +14,25 @@ namespace opossum {
 class DropViewTest : public BaseTest {
  protected:
   void SetUp() override {
-    auto& sm = Hyrise::get().storage_manager;
     auto t1 = std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data);
 
-    sm.add_table("first_table", t1);
+    _hyrise_env->storage_manager()->add_table("first_table", t1);
 
-    const auto view_lqp = StoredTableNode::make("first_table");
+    const auto view_lqp = StoredTableNode::make(_hyrise_env, "first_table");
     const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-    sm.add_view("view_name", view);
+    _hyrise_env->storage_manager()->add_view("view_name", view);
   }
 };
 
 TEST_F(DropViewTest, OperatorName) {
-  auto dv = std::make_shared<DropView>("view_name", false);
+  auto dv = std::make_shared<DropView>(_hyrise_env, "view_name", false);
 
   EXPECT_EQ(dv->name(), "DropView");
 }
 
 TEST_F(DropViewTest, DeepCopy) {
-  auto dv = std::make_shared<DropView>("view_name", false);
+  auto dv = std::make_shared<DropView>(_hyrise_env, "view_name", false);
 
   dv->execute();
   EXPECT_NE(dv->get_output(), nullptr);
@@ -43,27 +42,27 @@ TEST_F(DropViewTest, DeepCopy) {
 }
 
 TEST_F(DropViewTest, Execute) {
-  auto dv = std::make_shared<DropView>("view_name", false);
+  auto dv = std::make_shared<DropView>(_hyrise_env, "view_name", false);
   dv->execute();
 
   EXPECT_EQ(dv->get_output()->row_count(), 0u);
 
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_view("view_name"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_view("view_name"));
 }
 
 TEST_F(DropViewTest, ExecuteWithIfExists) {
-  auto dv_1 = std::make_shared<DropView>("view_name", true);
+  auto dv_1 = std::make_shared<DropView>(_hyrise_env, "view_name", true);
   dv_1->execute();
 
   EXPECT_EQ(dv_1->get_output()->row_count(), 0u);
 
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_view("view_name"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_view("view_name"));
 
-  auto dv_2 = std::make_shared<DropView>("view_name", true);
+  auto dv_2 = std::make_shared<DropView>(_hyrise_env, "view_name", true);
 
   EXPECT_NO_THROW(dv_2->execute());
 
-  EXPECT_FALSE(Hyrise::get().storage_manager.has_view("view_name"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_view("view_name"));
 }
 
 }  // namespace opossum

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -280,11 +280,11 @@ TEST_F(OperatorPerformanceDataTest, OperatorPerformanceDataHasOutputMarkerSet) {
   const auto table = load_table("resources/test_data/tbl/int_float.tbl");
 
   // Delete Operator works with the Storage Manager, so the test table must also be known to the StorageManager
-  Hyrise::get().storage_manager.add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
 
   auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::Yes);
 
-  auto gt = std::make_shared<GetTable>(table_name);
+  auto gt = std::make_shared<GetTable>(_hyrise_env, table_name);
   gt->execute();
 
   auto table_scan_1 = create_table_scan(gt, ColumnID{0}, PredicateCondition::Equals, "123");

--- a/src/test/lib/operators/pqp_utils_test.cpp
+++ b/src/test/lib/operators/pqp_utils_test.cpp
@@ -10,12 +10,12 @@ namespace opossum {
 
 class PQPUtilsTest : public BaseTest {
  public:
-  void SetUp() override { node_a = std::make_shared<GetTable>("foo"); }
+  void SetUp() override { node_a = std::make_shared<GetTable>(_hyrise_env, "foo"); }
   std::shared_ptr<AbstractOperator> node_a;
 };
 
 TEST_F(PQPUtilsTest, VisitPQPStreamlinePQP) {
-  auto node_b = std::make_shared<GetTable>("bar");
+  auto node_b = std::make_shared<GetTable>(_hyrise_env, "bar");
   auto node_c = std::make_shared<JoinHash>(
       node_b, node_a, JoinMode::Inner,
       OperatorJoinPredicate{ColumnIDPair{ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals});
@@ -64,7 +64,7 @@ TEST_F(PQPUtilsTest, VisitPQPNonConstOperators) {
 }
 
 TEST_F(PQPUtilsTest, VisitPQPConstOperators) {
-  auto node_b = std::make_shared<const GetTable>("bar");
+  auto node_b = std::make_shared<const GetTable>(_hyrise_env, "bar");
   auto node_c = std::make_shared<const Limit>(node_b, to_expression(int64_t{1}));
   const auto expected_nodes = std::vector<std::shared_ptr<const AbstractOperator>>{node_c, node_b};
 

--- a/src/test/lib/operators/union_positions_test.cpp
+++ b/src/test/lib/operators/union_positions_test.cpp
@@ -19,11 +19,11 @@ class UnionPositionsTest : public BaseTest {
  public:
   void SetUp() override {
     _table_10_ints = load_table("resources/test_data/tbl/10_ints.tbl", 3);
-    Hyrise::get().storage_manager.add_table("10_ints", _table_10_ints);
+    _hyrise_env->storage_manager()->add_table("10_ints", _table_10_ints);
 
     _table_int_float4 = load_table("resources/test_data/tbl/int_float4.tbl", 3);
-    Hyrise::get().storage_manager.add_table("int_float4", _table_int_float4);
-    Hyrise::get().storage_manager.add_table("int_int", load_table("resources/test_data/tbl/int_int.tbl", 2));
+    _hyrise_env->storage_manager()->add_table("int_float4", _table_int_float4);
+    _hyrise_env->storage_manager()->add_table("int_int", load_table("resources/test_data/tbl/int_int.tbl", 2));
 
     _int_column_0_non_nullable = pqp_column_(ColumnID{0}, DataType::Int, false, "");
     _float_column_1_non_nullable = pqp_column_(ColumnID{1}, DataType::Float, false, "");
@@ -39,7 +39,7 @@ TEST_F(UnionPositionsTest, SelfUnionSimple) {
    * Scan '10_ints' so that some values get excluded. UnionPositions the result with itself, and it should not change
    */
 
-  auto get_table_op = std::make_shared<GetTable>("10_ints");
+  auto get_table_op = std::make_shared<GetTable>(_hyrise_env, "10_ints");
   auto table_scan_a_op = std::make_shared<TableScan>(get_table_op, greater_than_(_int_column_0_non_nullable, 24));
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_op, greater_than_(_int_column_0_non_nullable, 24));
 
@@ -63,7 +63,7 @@ TEST_F(UnionPositionsTest, SelfUnionExlusiveRanges) {
    * should be discarded
    */
 
-  auto get_table_op = std::make_shared<GetTable>("10_ints");
+  auto get_table_op = std::make_shared<GetTable>(_hyrise_env, "10_ints");
   auto table_scan_a_op = std::make_shared<TableScan>(get_table_op, less_than_(_int_column_0_non_nullable, 10));
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_op, greater_than_(_int_column_0_non_nullable, 200));
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
@@ -81,7 +81,7 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRanges) {
    * This tests the actual functionality UnionPositions is intended for.
    */
 
-  auto get_table_op = std::make_shared<GetTable>("10_ints");
+  auto get_table_op = std::make_shared<GetTable>(_hyrise_env, "10_ints");
   auto table_scan_a_op = std::make_shared<TableScan>(get_table_op, greater_than_(_int_column_0_non_nullable, 20));
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_op, less_than_(_int_column_0_non_nullable, 100));
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
@@ -96,7 +96,7 @@ TEST_F(UnionPositionsTest, EarlyResultLeft) {
    * If one of the input tables is empty, an early result should be produced
    */
 
-  auto get_table_op = std::make_shared<GetTable>("int_float4");
+  auto get_table_op = std::make_shared<GetTable>(_hyrise_env, "int_float4");
   auto table_scan_a_op = std::make_shared<TableScan>(get_table_op, less_than_(_int_column_0_non_nullable, 12346));
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_op, less_than_(_int_column_0_non_nullable, 0));
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
@@ -112,7 +112,7 @@ TEST_F(UnionPositionsTest, EarlyResultRight) {
    * If one of the input tables is empty, an early result should be produced
    */
 
-  auto get_table_op = std::make_shared<GetTable>("int_float4");
+  auto get_table_op = std::make_shared<GetTable>(_hyrise_env, "int_float4");
   auto table_scan_a_op = std::make_shared<TableScan>(get_table_op, less_than_(_int_column_0_non_nullable, 0));
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_op, less_than_(_int_column_0_non_nullable, 12346));
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
@@ -130,7 +130,7 @@ TEST_F(UnionPositionsTest, SelfUnionOverlappingRangesMultipleSegments) {
    * This tests the actual functionality UnionPositions is intended for.
    */
 
-  auto get_table_op = std::make_shared<GetTable>("int_float4");
+  auto get_table_op = std::make_shared<GetTable>(_hyrise_env, "int_float4");
   auto table_scan_a_op = std::make_shared<TableScan>(get_table_op, greater_than_(_int_column_0_non_nullable, 12345));
   auto table_scan_b_op = std::make_shared<TableScan>(get_table_op, less_than_(_float_column_1_non_nullable, 400));
   auto union_unique_op = std::make_shared<UnionPositions>(table_scan_a_op, table_scan_b_op);
@@ -173,8 +173,8 @@ TEST_F(UnionPositionsTest, MultipleReferencedTables) {
    *
    */
 
-  auto get_table_a_op = std::make_shared<GetTable>("int_float4");
-  auto get_table_b_op = std::make_shared<GetTable>("int_int");
+  auto get_table_a_op = std::make_shared<GetTable>(_hyrise_env, "int_float4");
+  auto get_table_b_op = std::make_shared<GetTable>(_hyrise_env, "int_int");
   auto join =
       std::make_shared<JoinNestedLoop>(get_table_a_op, get_table_b_op, JoinMode::Inner,
                                        OperatorJoinPredicate{{ColumnID{0}, ColumnID{0}}, PredicateCondition::Equals});

--- a/src/test/lib/operators/validate_test.cpp
+++ b/src/test/lib/operators/validate_test.cpp
@@ -32,9 +32,9 @@ class OperatorsValidateTest : public BaseTest {
     const auto _test_table2 = load_table("resources/test_data/tbl/int_int3.tbl", 3);
 
     // Delete Operator works with the Storage Manager, so the test table must also be known to the StorageManager
-    Hyrise::get().storage_manager.add_table(_table2_name, _test_table2);
+    _hyrise_env->storage_manager()->add_table(_table2_name, _test_table2);
 
-    _gt = std::make_shared<GetTable>(_table2_name);
+    _gt = std::make_shared<GetTable>(_hyrise_env, _table2_name);
     _gt->execute();
 
     _table_wrapper = std::make_shared<TableWrapper>(_test_table);

--- a/src/test/lib/operators/validate_visibility_test.cpp
+++ b/src/test/lib/operators/validate_visibility_test.cpp
@@ -21,9 +21,9 @@ class OperatorsValidateVisibilityTest : public BaseTest {
     t = std::make_shared<Table>(column_definitions, TableType::Data, chunk_size, UseMvcc::Yes);
     t->append({123, 456});
 
-    Hyrise::get().storage_manager.add_table(table_name, t);
+    _hyrise_env->storage_manager()->add_table(table_name, t);
 
-    gt = std::make_shared<GetTable>(table_name);
+    gt = std::make_shared<GetTable>(_hyrise_env, table_name);
     gt->execute();
 
     validate = std::make_shared<Validate>(gt);

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -340,13 +340,12 @@ TEST_F(ColumnPruningRuleTest, InnerJoinToSemiJoin) {
     column_definitions.emplace_back("column0", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
 
     table->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::UNIQUE});
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
 
   // clang-format off
@@ -382,13 +381,12 @@ TEST_F(ColumnPruningRuleTest, MultiPredicateInnerJoinToSemiJoinWithSingleEqui) {
     column_definitions.emplace_back("column1", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
 
     table->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::UNIQUE});
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
   const auto column1 = stored_table_node->get_column("column1");
 
@@ -428,13 +426,12 @@ TEST_F(ColumnPruningRuleTest, MultiPredicateInnerJoinToSemiJoinWithMultiEqui) {
     column_definitions.emplace_back("column1", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
 
     table->add_soft_key_constraint({{ColumnID{0}, ColumnID{1}}, KeyConstraintType::UNIQUE});
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
   const auto column1 = stored_table_node->get_column("column1");
 
@@ -468,13 +465,12 @@ TEST_F(ColumnPruningRuleTest, DoNotTouchInnerJoinWithNonEqui) {
     column_definitions.emplace_back("column0", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
 
     table->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::UNIQUE});
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
 
   // clang-format off
@@ -509,11 +505,10 @@ TEST_F(ColumnPruningRuleTest, DoNotTouchInnerJoinWithoutUniqueConstraint) {
     column_definitions.emplace_back("column0", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
 
   // clang-format off
@@ -555,13 +550,12 @@ TEST_F(ColumnPruningRuleTest, DoNotTouchInnerJoinWithoutMatchingUniqueConstraint
     column_definitions.emplace_back("column1", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
 
     table->add_soft_key_constraint({{ColumnID{0}, ColumnID{1}}, KeyConstraintType::UNIQUE});
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
 
   // clang-format off
@@ -595,13 +589,12 @@ TEST_F(ColumnPruningRuleTest, DoNotTouchNonInnerJoin) {
     column_definitions.emplace_back("column0", DataType::Int, false);
     auto table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-    auto& sm = Hyrise::get().storage_manager;
-    sm.add_table("table", table);
+    _hyrise_env->storage_manager()->add_table("table", table);
 
     table->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY});
   }
 
-  const auto stored_table_node = StoredTableNode::make("table");
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "table");
   const auto column0 = stored_table_node->get_column("column0");
 
   // clang-format off
@@ -637,7 +630,7 @@ TEST_F(ColumnPruningRuleTest, DoNotPruneUpdateInputs) {
     node_a);
 
   const auto lqp =
-  UpdateNode::make("dummy",
+  UpdateNode::make(_hyrise_env, "dummy",
     select_rows_lqp,
     ProjectionNode::make(expression_vector(a, add_(b, 1), c),
       select_rows_lqp));
@@ -653,7 +646,7 @@ TEST_F(ColumnPruningRuleTest, DoNotPruneInsertInputs) {
 
   // clang-format off
   const auto lqp =
-  InsertNode::make("dummy",
+  InsertNode::make(_hyrise_env, "dummy",
     PredicateNode::make(greater_than_(a, 5),
       node_a));
   // clang-format on
@@ -702,7 +695,7 @@ TEST_F(ColumnPruningRuleTest, DoNotPruneChangeMetaTableInputs) {
     node_a);
 
   const auto lqp =
-  ChangeMetaTableNode::make("dummy", MetaTableChangeType::Update,
+	ChangeMetaTableNode::make(_hyrise_env, "dummy", MetaTableChangeType::Update,
     select_rows_lqp,
     ProjectionNode::make(expression_vector(a, add_(b, 1), c),
       select_rows_lqp));

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -17,46 +17,44 @@ namespace opossum {
 class DependentGroupByReductionRuleTest : public StrategyBaseTest {
  public:
   void SetUp() override {
-    auto& storage_manager = Hyrise::get().storage_manager;
-
     TableColumnDefinitions column_definitions{
         {"column0", DataType::Int, false}, {"column1", DataType::Int, false}, {"column2", DataType::Int, false}};
 
     table_a = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
     table_a->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY});
-    storage_manager.add_table("table_a", table_a);
-    stored_table_node_a = StoredTableNode::make("table_a");
+    _hyrise_env->storage_manager()->add_table("table_a", table_a);
+    stored_table_node_a = StoredTableNode::make(_hyrise_env, "table_a");
     column_a_0 = stored_table_node_a->get_column("column0");
     column_a_1 = stored_table_node_a->get_column("column1");
     column_a_2 = stored_table_node_a->get_column("column2");
 
     table_b = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
     table_b->add_soft_key_constraint({{ColumnID{0}, ColumnID{1}}, KeyConstraintType::UNIQUE});
-    storage_manager.add_table("table_b", table_b);
-    stored_table_node_b = StoredTableNode::make("table_b");
+    _hyrise_env->storage_manager()->add_table("table_b", table_b);
+    stored_table_node_b = StoredTableNode::make(_hyrise_env, "table_b");
     column_b_0 = stored_table_node_b->get_column("column0");
     column_b_1 = stored_table_node_b->get_column("column1");
     column_b_2 = stored_table_node_b->get_column("column2");
 
     table_c = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
     table_c->add_soft_key_constraint({{ColumnID{0}, ColumnID{2}}, KeyConstraintType::PRIMARY_KEY});
-    storage_manager.add_table("table_c", table_c);
-    stored_table_node_c = StoredTableNode::make("table_c");
+    _hyrise_env->storage_manager()->add_table("table_c", table_c);
+    stored_table_node_c = StoredTableNode::make(_hyrise_env, "table_c");
     column_c_0 = stored_table_node_c->get_column("column0");
     column_c_1 = stored_table_node_c->get_column("column1");
     column_c_2 = stored_table_node_c->get_column("column2");
 
     table_d = std::make_shared<Table>(TableColumnDefinitions{{"column0", DataType::Int, false}}, TableType::Data, 2,
                                       UseMvcc::Yes);
-    storage_manager.add_table("table_d", table_d);
-    stored_table_node_d = StoredTableNode::make("table_d");
+    _hyrise_env->storage_manager()->add_table("table_d", table_d);
+    stored_table_node_d = StoredTableNode::make(_hyrise_env, "table_d");
     column_d_0 = stored_table_node_d->get_column("column0");
 
     table_e = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
     table_e->add_soft_key_constraint({{ColumnID{0}, ColumnID{1}}, KeyConstraintType::PRIMARY_KEY});
     table_e->add_soft_key_constraint({{ColumnID{2}}, KeyConstraintType::UNIQUE});
-    storage_manager.add_table("table_e", table_e);
-    stored_table_node_e = StoredTableNode::make("table_e");
+    _hyrise_env->storage_manager()->add_table("table_e", table_e);
+    stored_table_node_e = StoredTableNode::make(_hyrise_env, "table_e");
     column_e_0 = stored_table_node_e->get_column("column0");
     column_e_1 = stored_table_node_e->get_column("column1");
     column_e_2 = stored_table_node_e->get_column("column2");

--- a/src/test/lib/optimizer/strategy/expression_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/expression_reduction_rule_test.cpp
@@ -150,8 +150,8 @@ TEST_F(ExpressionReductionRuleTest, RewriteLikePrefixWildcard) {
 TEST_F(ExpressionReductionRuleTest, RemoveDuplicateAggregate) {
   const auto table_definition = TableColumnDefinitions{{"a", DataType::Int, false}, {"b", DataType::Int, true}};
   const auto table = Table::create_dummy_table(table_definition);
-  Hyrise::get().storage_manager.add_table("agg_table", table);
-  const auto stored_table_node = StoredTableNode::make("agg_table");
+  _hyrise_env->storage_manager()->add_table("agg_table", table);
+  const auto stored_table_node = StoredTableNode::make(_hyrise_env, "agg_table");
 
   const auto col_a = lqp_column_(stored_table_node, ColumnID{0});
   const auto col_b = lqp_column_(stored_table_node, ColumnID{1});

--- a/src/test/lib/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/index_scan_rule_test.cpp
@@ -31,12 +31,12 @@ class IndexScanRuleTest : public StrategyBaseTest {
  public:
   void SetUp() override {
     table = load_table("resources/test_data/tbl/int_int_int.tbl");
-    Hyrise::get().storage_manager.add_table("a", table);
-    ChunkEncoder::encode_all_chunks(Hyrise::get().storage_manager.get_table("a"));
+    _hyrise_env->storage_manager()->add_table("a", table);
+    ChunkEncoder::encode_all_chunks(_hyrise_env->storage_manager()->get_table("a"));
 
     rule = std::make_shared<IndexScanRule>();
 
-    stored_table_node = StoredTableNode::make("a");
+    stored_table_node = StoredTableNode::make(_hyrise_env, "a");
     a = stored_table_node->get_column("a");
     b = stored_table_node->get_column("b");
     c = stored_table_node->get_column("c");

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -18,11 +18,11 @@ class NullScanRemovalRuleTest : public StrategyBaseTest {
     mock_node = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}, {DataType::Float, "b"}});
     mock_node_column = mock_node->get_column("a");
 
-    Hyrise::get().storage_manager.add_table("nullable_table",
-                                            load_table("resources/test_data/tbl/int_float_null_1.tbl", 2));
-    Hyrise::get().storage_manager.add_table("table", load_table("resources/test_data/tbl/int_float4_or_1.tbl", 2));
-    nullable_table_node = StoredTableNode::make("nullable_table");
-    table_node = StoredTableNode::make("table");
+    _hyrise_env->storage_manager()->add_table("nullable_table",
+                                              load_table("resources/test_data/tbl/int_float_null_1.tbl", 2));
+    _hyrise_env->storage_manager()->add_table("table", load_table("resources/test_data/tbl/int_float4_or_1.tbl", 2));
+    nullable_table_node = StoredTableNode::make(_hyrise_env, "nullable_table");
+    table_node = StoredTableNode::make(_hyrise_env, "table");
     nullable_table_node_column = lqp_column_(nullable_table_node, ColumnID{0});
     table_node_column = lqp_column_(table_node, ColumnID{0});
   }

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -31,28 +31,28 @@ class PredicatePlacementRuleTest : public StrategyBaseTest {
   }
 
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("a", _table_a);
-    _stored_table_a = StoredTableNode::make("a");
+    _hyrise_env->storage_manager()->add_table("a", _table_a);
+    _stored_table_a = StoredTableNode::make(_hyrise_env, "a");
     _a_a = _stored_table_a->get_column("a");
     _a_b = _stored_table_a->get_column("b");
 
-    Hyrise::get().storage_manager.add_table("b", _table_b);
-    _stored_table_b = StoredTableNode::make("b");
+    _hyrise_env->storage_manager()->add_table("b", _table_b);
+    _stored_table_b = StoredTableNode::make(_hyrise_env, "b");
     _b_a = _stored_table_b->get_column("a");
     _b_b = _stored_table_b->get_column("b");
 
-    Hyrise::get().storage_manager.add_table("c", _table_c);
-    _stored_table_c = StoredTableNode::make("c");
+    _hyrise_env->storage_manager()->add_table("c", _table_c);
+    _stored_table_c = StoredTableNode::make(_hyrise_env, "c");
     _c_a = _stored_table_c->get_column("a");
     _c_b = _stored_table_c->get_column("b");
 
-    Hyrise::get().storage_manager.add_table("d", _table_d);
-    _stored_table_d = StoredTableNode::make("d");
+    _hyrise_env->storage_manager()->add_table("d", _table_d);
+    _stored_table_d = StoredTableNode::make(_hyrise_env, "d");
     _d_a = _stored_table_d->get_column("a");
     _d_b = _stored_table_d->get_column("b");
 
-    Hyrise::get().storage_manager.add_table("e", _table_e);
-    _stored_table_e = StoredTableNode::make("e");
+    _hyrise_env->storage_manager()->add_table("e", _table_e);
+    _stored_table_e = StoredTableNode::make(_hyrise_env, "e");
     _e_a = _stored_table_e->get_column("a");
 
     _rule = std::make_shared<PredicatePlacementRule>();
@@ -163,7 +163,7 @@ TEST_F(PredicatePlacementRuleTest, DiamondPushdownInputRecoveryTest) {
       _stored_table_a));
 
   const auto input_lqp =
-  UpdateNode::make("int_float",
+  UpdateNode::make(_hyrise_env, "int_float",
     input_sub_lqp,
     ProjectionNode::make(expression_vector(_a_a, cast_(3.2, DataType::Float)),
       input_sub_lqp));
@@ -174,7 +174,7 @@ TEST_F(PredicatePlacementRuleTest, DiamondPushdownInputRecoveryTest) {
       _stored_table_a));
 
   const auto expected_lqp =
-  UpdateNode::make("int_float",
+  UpdateNode::make(_hyrise_env, "int_float",
     expected_sub_lqp,
     ProjectionNode::make(expression_vector(_a_a, cast_(3.2, DataType::Float)),
       expected_sub_lqp));

--- a/src/test/lib/optimizer/strategy/predicate_reordering_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_reordering_rule_test.cpp
@@ -110,9 +110,9 @@ TEST_F(PredicateReorderingTest, ComplexReorderingTest) {
 
 TEST_F(PredicateReorderingTest, SameOrderingForStoredTable) {
   std::shared_ptr<Table> table_a = load_table("resources/test_data/tbl/int_float4.tbl", 2);
-  Hyrise::get().storage_manager.add_table("table_a", std::move(table_a));
+  _hyrise_env->storage_manager()->add_table("table_a", std::move(table_a));
 
-  auto stored_table_node = StoredTableNode::make("table_a");
+  auto stored_table_node = StoredTableNode::make(_hyrise_env, "table_a");
 
   {
     // clang-format off

--- a/src/test/lib/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
@@ -11,10 +11,10 @@ namespace opossum {
 class StoredTableColumnAlignmentRuleTest : public StrategyBaseTest {
  public:
   void SetUp() override {
-    Hyrise::get().storage_manager.add_table("t_a", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
-    Hyrise::get().storage_manager.add_table("t_b", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
+    _hyrise_env->storage_manager()->add_table("t_a", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
+    _hyrise_env->storage_manager()->add_table("t_b", load_table("resources/test_data/tbl/int_int_float.tbl", 1));
 
-    _stored_table_node_left = StoredTableNode::make("t_a");
+    _stored_table_node_left = StoredTableNode::make(_hyrise_env, "t_a");
     _stored_table_node_left->set_pruned_chunk_ids({ChunkID{2}});
     _stored_table_node_left->set_pruned_column_ids({ColumnID{0}});
     _stored_table_node_right = std::static_pointer_cast<StoredTableNode>(_stored_table_node_left->deep_copy());
@@ -66,7 +66,7 @@ TEST_F(StoredTableColumnAlignmentRuleTest, EqualTableDifferentChunksDifferentCol
 }
 
 TEST_F(StoredTableColumnAlignmentRuleTest, DifferentTableEqualChunksDifferentColumns) {
-  _stored_table_node_right = StoredTableNode::make("t_b");
+  _stored_table_node_right = StoredTableNode::make(_hyrise_env, "t_b");
   _stored_table_node_right->set_pruned_chunk_ids({ChunkID{2}});
   _stored_table_node_right->set_pruned_column_ids({ColumnID{0}, ColumnID{1}});
   _union_node->set_right_input(_stored_table_node_right);

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -226,9 +226,9 @@ TEST_F(SchedulerTest, MultipleOperators) {
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
 
   auto test_table = load_table("resources/test_data/tbl/int_float.tbl", 2);
-  Hyrise::get().storage_manager.add_table("table", test_table);
+  _hyrise_env->storage_manager()->add_table("table", test_table);
 
-  auto gt = std::make_shared<GetTable>("table");
+  auto gt = std::make_shared<GetTable>(_hyrise_env, "table");
   auto a = PQPColumnExpression::from_table(*test_table, ColumnID{0});
   auto ts = std::make_shared<TableScan>(gt, greater_than_equals_(a, 1234));
 

--- a/src/test/lib/server/result_serializer_test.cpp
+++ b/src/test/lib/server/result_serializer_test.cpp
@@ -10,7 +10,7 @@ class ResultSerializerTest : public BaseTest {
  protected:
   void SetUp() override {
     _test_table = load_table("resources/test_data/tbl/all_data_types_sorted.tbl", 2);
-    Hyrise::get().storage_manager.add_table("_test_table", _test_table);
+    _hyrise_env->storage_manager()->add_table("_test_table", _test_table);
 
     _mocked_socket = std::make_shared<MockSocket>();
     _protocol_handler =

--- a/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner.cpp
+++ b/src/test/lib/sql/sqlite_testrunner/sqlite_testrunner.cpp
@@ -131,11 +131,11 @@ void SQLiteTestRunner::SetUp() {
         ChunkEncoder::encode_all_chunks(reloaded_table, table_cache_entry.chunk_encoding_spec);
       }
 
-      Hyrise::get().storage_manager.add_table(table_name, reloaded_table);
+      _hyrise_env->storage_manager()->add_table(table_name, reloaded_table);
       table_cache_entry.table = reloaded_table;
 
     } else {
-      Hyrise::get().storage_manager.add_table(table_name, table_cache_entry.table);
+      _hyrise_env->storage_manager()->add_table(table_name, table_cache_entry.table);
     }
   }
 }
@@ -168,7 +168,7 @@ TEST_P(SQLiteTestRunner, CompareToSQLite) {
   SCOPED_TRACE("Query '" + sql + "' from line " + std::to_string(line) + " with encoding " +
                encoding_type_to_string.left.at(encoding_type));
 
-  auto sql_pipeline = SQLPipelineBuilder{sql}.create_pipeline();
+  auto sql_pipeline = SQLPipelineBuilder{sql}.with_hyrise_env(_hyrise_env).create_pipeline();
 
   // Execute query in Hyrise and SQLite
   const auto [pipeline_status, result_table] = sql_pipeline.get_result_table();

--- a/src/test/lib/statistics/cardinality_estimator_test.cpp
+++ b/src/test/lib/statistics/cardinality_estimator_test.cpp
@@ -842,8 +842,8 @@ TEST_F(CardinalityEstimatorTest, Sort) {
 }
 
 TEST_F(CardinalityEstimatorTest, StoredTable) {
-  Hyrise::get().storage_manager.add_table("t", load_table("resources/test_data/tbl/int.tbl"));
-  EXPECT_EQ(estimator.estimate_cardinality(StoredTableNode::make("t")), 3);
+  _hyrise_env->storage_manager()->add_table("t", load_table("resources/test_data/tbl/int.tbl"));
+  EXPECT_EQ(estimator.estimate_cardinality(StoredTableNode::make(_hyrise_env, "t")), 3);
 }
 
 TEST_F(CardinalityEstimatorTest, Validate) {
@@ -886,27 +886,27 @@ TEST_F(CardinalityEstimatorTest, NonQueryNodes) {
   // Test that, basically, the CardinalityEstimator doesn't crash when processing non-query nodes. There is not much
   // more to test here
 
-  const auto create_table_lqp = CreateTableNode::make("t", false, node_a);
+  const auto create_table_lqp = CreateTableNode::make(_hyrise_env, "t", false, node_a);
   EXPECT_EQ(estimator.estimate_cardinality(create_table_lqp), 0.0f);
 
   const auto prepared_plan = std::make_shared<PreparedPlan>(node_a, std::vector<ParameterID>{});
-  const auto create_prepared_plan_lqp = CreatePreparedPlanNode::make("t", prepared_plan);
+  const auto create_prepared_plan_lqp = CreatePreparedPlanNode::make(_hyrise_env, "t", prepared_plan);
   EXPECT_EQ(estimator.estimate_cardinality(create_prepared_plan_lqp), 0.0f);
 
   const auto lqp_view = std::make_shared<LQPView>(
       node_a, std::unordered_map<ColumnID, std::string>{{ColumnID{0}, "x"}, {ColumnID{1}, "y"}});
-  const auto create_view_lqp = CreateViewNode::make("v", lqp_view, false);
+  const auto create_view_lqp = CreateViewNode::make(_hyrise_env, "v", lqp_view, false);
   EXPECT_EQ(estimator.estimate_cardinality(create_view_lqp), 0.0f);
 
-  const auto update_lqp = UpdateNode::make("t", node_a, node_b);
+  const auto update_lqp = UpdateNode::make(_hyrise_env, "t", node_a, node_b);
   EXPECT_EQ(estimator.estimate_cardinality(update_lqp), 0.0f);
 
-  const auto insert_lqp = InsertNode::make("t", node_a);
+  const auto insert_lqp = InsertNode::make(_hyrise_env, "t", node_a);
   EXPECT_EQ(estimator.estimate_cardinality(insert_lqp), 0.0f);
 
   EXPECT_EQ(estimator.estimate_cardinality(DeleteNode::make(node_a)), 0.0f);
-  EXPECT_EQ(estimator.estimate_cardinality(DropViewNode::make("v", false)), 0.0f);
-  EXPECT_EQ(estimator.estimate_cardinality(DropTableNode::make("t", false)), 0.0f);
+  EXPECT_EQ(estimator.estimate_cardinality(DropViewNode::make(_hyrise_env, "v", false)), 0.0f);
+  EXPECT_EQ(estimator.estimate_cardinality(DropTableNode::make(_hyrise_env, "t", false)), 0.0f);
   EXPECT_EQ(estimator.estimate_cardinality(DummyTableNode::make()), 0.0f);
 }
 

--- a/src/test/lib/storage/pos_lists/entire_chunk_pos_list_test.cpp
+++ b/src/test/lib/storage/pos_lists/entire_chunk_pos_list_test.cpp
@@ -16,7 +16,7 @@ class EntireChunkPosListTest : public BaseTest {
     dummy_table_wrapper = std::make_shared<TableWrapper>(Table::create_dummy_table(column_definitions));
     dummy_table_wrapper->execute();
 
-    create_table = std::make_shared<CreateTable>("t", false, dummy_table_wrapper);
+    create_table = std::make_shared<CreateTable>(_hyrise_env, "t", false, dummy_table_wrapper);
   }
 
   TableColumnDefinitions column_definitions;
@@ -34,20 +34,20 @@ TEST_F(EntireChunkPosListTest, AddAfterMatchedAllTest) {
   auto table_to_add_name = "test_table_to_add";
   auto table_to_add = load_table("resources/test_data/tbl/float_int.tbl", 10);
   // Insert Operator works with the Storage Manager, so the test table must also be known to the StorageManager
-  Hyrise::get().storage_manager.add_table(table_name, table);
-  Hyrise::get().storage_manager.add_table(table_to_add_name, table_to_add);
+  _hyrise_env->storage_manager()->add_table(table_name, table);
+  _hyrise_env->storage_manager()->add_table(table_to_add_name, table_to_add);
 
-  auto get_table = std::make_shared<GetTable>(table_name);
+  auto get_table = std::make_shared<GetTable>(_hyrise_env, table_name);
   get_table->execute();
   const auto chunk_id = ChunkID{0};
   const auto chunk_size = get_table->get_output()->get_chunk(chunk_id)->size();
   const auto entire_chunk_pos_list = std::make_shared<const EntireChunkPosList>(chunk_id, chunk_size);
 
   const auto insert_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
-  auto get_table_to_add = std::make_shared<GetTable>(table_to_add_name);
+  auto get_table_to_add = std::make_shared<GetTable>(_hyrise_env, table_to_add_name);
   get_table_to_add->execute();
 
-  auto insert = std::make_shared<Insert>(table_name, get_table_to_add);
+  auto insert = std::make_shared<Insert>(_hyrise_env, table_name, get_table_to_add);
   insert->set_transaction_context(insert_context);
   insert->execute();
   insert_context->commit();

--- a/src/test/lib/storage/reference_segment_test.cpp
+++ b/src/test/lib/storage/reference_segment_test.cpp
@@ -41,7 +41,7 @@ class ReferenceSegmentTest : public BaseTest {
 
     ChunkEncoder::encode_chunks(_test_table_dict, {ChunkID{0}, ChunkID{1}});
 
-    Hyrise::get().storage_manager.add_table("test_table_dict", _test_table_dict);
+    _hyrise_env->storage_manager()->add_table("test_table_dict", _test_table_dict);
   }
 
  public:

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -15,21 +15,20 @@ namespace opossum {
 class StorageManagerTest : public BaseTest {
  protected:
   void SetUp() override {
-    auto& sm = Hyrise::get().storage_manager;
     auto t1 = std::make_shared<Table>(TableColumnDefinitions{{"a", DataType::Int, false}}, TableType::Data);
     auto t2 = std::make_shared<Table>(TableColumnDefinitions{{"b", DataType::Int, false}}, TableType::Data, 4);
 
-    sm.add_table("first_table", t1);
-    sm.add_table("second_table", t2);
+    _hyrise_env->storage_manager()->add_table("first_table", t1);
+    _hyrise_env->storage_manager()->add_table("second_table", t2);
 
-    const auto v1_lqp = StoredTableNode::make("first_table");
+    const auto v1_lqp = StoredTableNode::make(_hyrise_env, "first_table");
     const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::string>{});
 
-    const auto v2_lqp = StoredTableNode::make("second_table");
+    const auto v2_lqp = StoredTableNode::make(_hyrise_env, "second_table");
     const auto v2 = std::make_shared<LQPView>(v2_lqp, std::unordered_map<ColumnID, std::string>{});
 
-    sm.add_view("first_view", std::move(v1));
-    sm.add_view("second_view", std::move(v2));
+    _hyrise_env->storage_manager()->add_view("first_view", std::move(v1));
+    _hyrise_env->storage_manager()->add_view("second_view", std::move(v2));
 
     const auto pp1_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}}, "a");
     const auto pp1 = std::make_shared<PreparedPlan>(pp1_lqp, std::vector<ParameterID>{});
@@ -37,24 +36,24 @@ class StorageManagerTest : public BaseTest {
     const auto pp2_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Float, "b"}}, "b");
     const auto pp2 = std::make_shared<PreparedPlan>(pp2_lqp, std::vector<ParameterID>{});
 
-    sm.add_prepared_plan("first_prepared_plan", std::move(pp1));
-    sm.add_prepared_plan("second_prepared_plan", std::move(pp2));
+    _hyrise_env->storage_manager()->add_prepared_plan("first_prepared_plan", std::move(pp1));
+    _hyrise_env->storage_manager()->add_prepared_plan("second_prepared_plan", std::move(pp2));
   }
 };
 
 TEST_F(StorageManagerTest, AddTableTwice) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_THROW(sm.add_table("first_table", std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data)),
+  EXPECT_THROW(_hyrise_env->storage_manager()->add_table(
+                   "first_table", std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data)),
                std::exception);
-  EXPECT_THROW(sm.add_table("first_view", std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data)),
+  EXPECT_THROW(_hyrise_env->storage_manager()->add_table(
+                   "first_view", std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data)),
                std::exception);
 }
 
 TEST_F(StorageManagerTest, StatisticCreationOnAddTable) {
-  auto& sm = Hyrise::get().storage_manager;
-  sm.add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
+  _hyrise_env->storage_manager()->add_table("int_float", load_table("resources/test_data/tbl/int_float.tbl"));
 
-  const auto table = sm.get_table("int_float");
+  const auto table = _hyrise_env->storage_manager()->get_table("int_float");
   EXPECT_EQ(table->table_statistics()->row_count, 3.0f);
   const auto chunk = table->get_chunk(ChunkID{0});
   EXPECT_TRUE(chunk->pruning_statistics().has_value());
@@ -63,89 +62,77 @@ TEST_F(StorageManagerTest, StatisticCreationOnAddTable) {
 }
 
 TEST_F(StorageManagerTest, GetTable) {
-  auto& sm = Hyrise::get().storage_manager;
-  auto t3 = sm.get_table("first_table");
-  auto t4 = sm.get_table("second_table");
-  EXPECT_THROW(sm.get_table("third_table"), std::exception);
+  auto t3 = _hyrise_env->storage_manager()->get_table("first_table");
+  auto t4 = _hyrise_env->storage_manager()->get_table("second_table");
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_table("third_table"), std::exception);
   auto names = std::vector<std::string>{"first_table", "second_table"};
-  auto sm_names = sm.table_names();
+  auto sm_names = _hyrise_env->storage_manager()->table_names();
   std::sort(sm_names.begin(), sm_names.end());
   EXPECT_EQ(sm_names, names);
 }
 
 TEST_F(StorageManagerTest, DropTable) {
-  auto& sm = Hyrise::get().storage_manager;
-  sm.drop_table("first_table");
-  EXPECT_THROW(sm.get_table("first_table"), std::exception);
-  EXPECT_THROW(sm.drop_table("first_table"), std::exception);
+  _hyrise_env->storage_manager()->drop_table("first_table");
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_table("first_table"), std::exception);
+  EXPECT_THROW(_hyrise_env->storage_manager()->drop_table("first_table"), std::exception);
 
-  const auto& tables = sm.tables();
+  const auto& tables = _hyrise_env->storage_manager()->tables();
   EXPECT_EQ(tables.size(), 1);
 
-  sm.add_table("first_table", std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data));
-  EXPECT_TRUE(sm.has_table("first_table"));
+  _hyrise_env->storage_manager()->add_table("first_table",
+                                            std::make_shared<Table>(TableColumnDefinitions{}, TableType::Data));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("first_table"));
 }
 
 TEST_F(StorageManagerTest, DoesNotHaveTable) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_EQ(sm.has_table("third_table"), false);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_table("third_table"), false);
 }
 
-TEST_F(StorageManagerTest, HasTable) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_EQ(sm.has_table("first_table"), true);
-}
+TEST_F(StorageManagerTest, HasTable) { EXPECT_EQ(_hyrise_env->storage_manager()->has_table("first_table"), true); }
 
 TEST_F(StorageManagerTest, AddViewTwice) {
-  const auto v1_lqp = StoredTableNode::make("first_table");
+  const auto v1_lqp = StoredTableNode::make(_hyrise_env, "first_table");
   const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_THROW(sm.add_view("first_table", v1), std::exception);
-  EXPECT_THROW(sm.add_view("first_view", v1), std::exception);
+  EXPECT_THROW(_hyrise_env->storage_manager()->add_view("first_table", v1), std::exception);
+  EXPECT_THROW(_hyrise_env->storage_manager()->add_view("first_view", v1), std::exception);
 }
 
 TEST_F(StorageManagerTest, GetView) {
-  auto& sm = Hyrise::get().storage_manager;
-  auto v3 = sm.get_view("first_view");
-  auto v4 = sm.get_view("second_view");
-  EXPECT_THROW(sm.get_view("third_view"), std::exception);
+  auto v3 = _hyrise_env->storage_manager()->get_view("first_view");
+  auto v4 = _hyrise_env->storage_manager()->get_view("second_view");
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_view("third_view"), std::exception);
 }
 
 TEST_F(StorageManagerTest, DropView) {
-  auto& sm = Hyrise::get().storage_manager;
-  sm.drop_view("first_view");
-  EXPECT_THROW(sm.get_view("first_view"), std::exception);
-  EXPECT_THROW(sm.drop_view("first_view"), std::exception);
+  _hyrise_env->storage_manager()->drop_view("first_view");
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_view("first_view"), std::exception);
+  EXPECT_THROW(_hyrise_env->storage_manager()->drop_view("first_view"), std::exception);
 
-  const auto& views = sm.views();
+  const auto& views = _hyrise_env->storage_manager()->views();
   EXPECT_EQ(views.size(), 1);
 
-  const auto v1_lqp = StoredTableNode::make("first_table");
+  const auto v1_lqp = StoredTableNode::make(_hyrise_env, "first_table");
   const auto v1 = std::make_shared<LQPView>(v1_lqp, std::unordered_map<ColumnID, std::string>{});
-  sm.add_view("first_view", v1);
-  EXPECT_TRUE(sm.has_view("first_view"));
+  _hyrise_env->storage_manager()->add_view("first_view", v1);
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_view("first_view"));
 }
 
 TEST_F(StorageManagerTest, ResetView) {
   Hyrise::reset();
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_THROW(sm.get_view("first_view"), std::exception);
+  _hyrise_env_holder = std::make_shared<HyriseEnvironmentHolder>();
+  _hyrise_env = _hyrise_env_holder->hyrise_env_ref();
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_view("first_view"), std::exception);
 }
 
 TEST_F(StorageManagerTest, DoesNotHaveView) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_EQ(sm.has_view("third_view"), false);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_view("third_view"), false);
 }
 
-TEST_F(StorageManagerTest, HasView) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_EQ(sm.has_view("first_view"), true);
-}
+TEST_F(StorageManagerTest, HasView) { EXPECT_EQ(_hyrise_env->storage_manager()->has_view("first_view"), true); }
 
 TEST_F(StorageManagerTest, ListViewNames) {
-  auto& sm = Hyrise::get().storage_manager;
-  const auto view_names = sm.view_names();
+  const auto view_names = _hyrise_env->storage_manager()->view_names();
 
   EXPECT_EQ(view_names.size(), 2u);
 
@@ -154,11 +141,10 @@ TEST_F(StorageManagerTest, ListViewNames) {
 }
 
 TEST_F(StorageManagerTest, OutputToStream) {
-  auto& sm = Hyrise::get().storage_manager;
-  sm.add_table("third_table", load_table("resources/test_data/tbl/int_int2.tbl", 2));
+  _hyrise_env->storage_manager()->add_table("third_table", load_table("resources/test_data/tbl/int_int2.tbl", 2));
 
   std::ostringstream output;
-  output << sm;
+  output << *_hyrise_env->storage_manager();
   auto output_string = output.str();
 
   EXPECT_TRUE(output_string.find("===== Tables =====") != std::string::npos);
@@ -173,16 +159,15 @@ TEST_F(StorageManagerTest, OutputToStream) {
 
 TEST_F(StorageManagerTest, ExportTables) {
   std::ostringstream output;
-  auto& sm = Hyrise::get().storage_manager;
 
   // first, we remove empty test tables
-  sm.drop_table("first_table");
-  sm.drop_table("second_table");
+  _hyrise_env->storage_manager()->drop_table("first_table");
+  _hyrise_env->storage_manager()->drop_table("second_table");
 
   // add a non-empty table
-  sm.add_table("third_table", load_table("resources/test_data/tbl/int_float.tbl"));
+  _hyrise_env->storage_manager()->add_table("third_table", load_table("resources/test_data/tbl/int_float.tbl"));
 
-  sm.export_all_tables_as_csv(opossum::test_data_path);
+  _hyrise_env->storage_manager()->export_all_tables_as_csv(opossum::test_data_path);
 
   const std::string filename = opossum::test_data_path + "/third_table.csv";
   EXPECT_TRUE(std::filesystem::exists(filename));
@@ -190,45 +175,39 @@ TEST_F(StorageManagerTest, ExportTables) {
 }
 
 TEST_F(StorageManagerTest, AddPreparedPlanTwice) {
-  auto& sm = Hyrise::get().storage_manager;
-
   const auto pp1_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}}, "a");
   const auto pp1 = std::make_shared<PreparedPlan>(pp1_lqp, std::vector<ParameterID>{});
 
-  EXPECT_THROW(sm.add_prepared_plan("first_prepared_plan", pp1), std::exception);
+  EXPECT_THROW(_hyrise_env->storage_manager()->add_prepared_plan("first_prepared_plan", pp1), std::exception);
 }
 
 TEST_F(StorageManagerTest, GetPreparedPlan) {
-  auto& sm = Hyrise::get().storage_manager;
-  auto pp3 = sm.get_prepared_plan("first_prepared_plan");
-  auto pp4 = sm.get_prepared_plan("second_prepared_plan");
-  EXPECT_THROW(sm.get_prepared_plan("third_prepared_plan"), std::exception);
+  auto pp3 = _hyrise_env->storage_manager()->get_prepared_plan("first_prepared_plan");
+  auto pp4 = _hyrise_env->storage_manager()->get_prepared_plan("second_prepared_plan");
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_prepared_plan("third_prepared_plan"), std::exception);
 }
 
 TEST_F(StorageManagerTest, DropPreparedPlan) {
-  auto& sm = Hyrise::get().storage_manager;
-  sm.drop_prepared_plan("first_prepared_plan");
-  EXPECT_THROW(sm.get_prepared_plan("first_prepared_plan"), std::exception);
-  EXPECT_THROW(sm.drop_prepared_plan("first_prepared_plan"), std::exception);
+  _hyrise_env->storage_manager()->drop_prepared_plan("first_prepared_plan");
+  EXPECT_THROW(_hyrise_env->storage_manager()->get_prepared_plan("first_prepared_plan"), std::exception);
+  EXPECT_THROW(_hyrise_env->storage_manager()->drop_prepared_plan("first_prepared_plan"), std::exception);
 
-  const auto& prepared_plans = sm.prepared_plans();
+  const auto& prepared_plans = _hyrise_env->storage_manager()->prepared_plans();
   EXPECT_EQ(prepared_plans.size(), 1);
 
   const auto pp_lqp = MockNode::make(MockNode::ColumnDefinitions{{DataType::Int, "a"}}, "a");
   const auto pp = std::make_shared<PreparedPlan>(pp_lqp, std::vector<ParameterID>{});
 
-  sm.add_prepared_plan("first_prepared_plan", pp);
-  EXPECT_TRUE(sm.has_prepared_plan("first_prepared_plan"));
+  _hyrise_env->storage_manager()->add_prepared_plan("first_prepared_plan", pp);
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_prepared_plan("first_prepared_plan"));
 }
 
 TEST_F(StorageManagerTest, DoesNotHavePreparedPlan) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_EQ(sm.has_prepared_plan("third_prepared_plan"), false);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_prepared_plan("third_prepared_plan"), false);
 }
 
 TEST_F(StorageManagerTest, HasPreparedPlan) {
-  auto& sm = Hyrise::get().storage_manager;
-  EXPECT_EQ(sm.has_prepared_plan("first_prepared_plan"), true);
+  EXPECT_EQ(_hyrise_env->storage_manager()->has_prepared_plan("first_prepared_plan"), true);
 }
 
 }  // namespace opossum

--- a/src/test/lib/storage/table_key_constraint_test.cpp
+++ b/src/test/lib/storage/table_key_constraint_test.cpp
@@ -11,7 +11,6 @@ namespace opossum {
 class TableKeyConstraintTest : public BaseTest {
  protected:
   void SetUp() override {
-    auto& sm = Hyrise::get().storage_manager;
     {
       TableColumnDefinitions column_definitions;
       column_definitions.emplace_back("column0", DataType::Int, false);
@@ -20,7 +19,7 @@ class TableKeyConstraintTest : public BaseTest {
       column_definitions.emplace_back("column3", DataType::Int, false);
       _table = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-      sm.add_table("table", _table);
+      _hyrise_env->storage_manager()->add_table("table", _table);
     }
 
     {
@@ -29,7 +28,7 @@ class TableKeyConstraintTest : public BaseTest {
       column_definitions.emplace_back("column1", DataType::Int, true);
       _table_nullable = std::make_shared<Table>(column_definitions, TableType::Data, 2, UseMvcc::Yes);
 
-      sm.add_table("table_nullable", _table_nullable);
+      _hyrise_env->storage_manager()->add_table("table_nullable", _table_nullable);
     }
   }
 

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -8,25 +8,16 @@ namespace opossum {
 
 class PluginManagerTest : public BaseTest {
  protected:
-  std::unordered_map<PluginName, PluginHandleWrapper>& get_plugins() {
-    auto& pm = Hyrise::get().plugin_manager;
+  std::unordered_map<PluginName, PluginHandleWrapper>& get_plugins() { return _hyrise_env->plugin_manager()->_plugins; }
 
-    return pm._plugins;
-  }
-
-  void call_clean_up() {
-    auto& pm = Hyrise::get().plugin_manager;
-    pm._clean_up();
-  }
+  void call_clean_up() { _hyrise_env->plugin_manager()->_clean_up(); }
 };
 
 TEST_F(PluginManagerTest, LoadUnloadPlugin) {
-  auto& sm = Hyrise::get().storage_manager;
-  auto& pm = Hyrise::get().plugin_manager;
   auto& plugins = get_plugins();
 
   EXPECT_EQ(plugins.size(), 0u);
-  pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin"));
 
   EXPECT_EQ(plugins.count("hyriseTestPlugin"), 1u);
   EXPECT_EQ(plugins["hyriseTestPlugin"].plugin->description(), "This is the Hyrise TestPlugin");
@@ -34,23 +25,21 @@ TEST_F(PluginManagerTest, LoadUnloadPlugin) {
   EXPECT_NE(plugins["hyriseTestPlugin"].plugin, nullptr);
 
   // The test plugin creates a dummy table when it is started
-  EXPECT_TRUE(sm.has_table("DummyTable"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("DummyTable"));
 
-  pm.unload_plugin("hyriseTestPlugin");
+  _hyrise_env->plugin_manager()->unload_plugin("hyriseTestPlugin");
 
   // The test plugin removes the dummy table from the storage manager when it is unloaded
-  EXPECT_FALSE(sm.has_table("DummyTable"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("DummyTable"));
   EXPECT_EQ(plugins.count("hyriseTestPlugin"), 0u);
 }
 
 // Plugins are unloaded when the PluginManager's destructor is called, this is simulated and tested here.
 TEST_F(PluginManagerTest, LoadPluginAutomaticUnload) {
-  auto& sm = Hyrise::get().storage_manager;
-  auto& pm = Hyrise::get().plugin_manager;
   auto& plugins = get_plugins();
 
   EXPECT_EQ(plugins.size(), 0u);
-  pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin"));
 
   EXPECT_EQ(plugins.count("hyriseTestPlugin"), 1u);
   EXPECT_EQ(plugins["hyriseTestPlugin"].plugin->description(), "This is the Hyrise TestPlugin");
@@ -58,7 +47,7 @@ TEST_F(PluginManagerTest, LoadPluginAutomaticUnload) {
   EXPECT_NE(plugins["hyriseTestPlugin"].plugin, nullptr);
 
   // The test plugin creates a dummy table when it is started
-  EXPECT_TRUE(sm.has_table("DummyTable"));
+  EXPECT_TRUE(_hyrise_env->storage_manager()->has_table("DummyTable"));
 
   // The PluginManager's destructor calls _clean_up(), we call it here explicitly to simulate the destructor
   // being called, which in turn should unload all loaded plugins.
@@ -66,57 +55,50 @@ TEST_F(PluginManagerTest, LoadPluginAutomaticUnload) {
 
   // The test plugin removes the dummy table from the storage manager when it is unloaded
   // (implicitly by the destructor of the PluginManager).
-  EXPECT_FALSE(sm.has_table("DummyTable"));
+  EXPECT_FALSE(_hyrise_env->storage_manager()->has_table("DummyTable"));
 }
 
 TEST_F(PluginManagerTest, LoadingSameName) {
-  auto& pm = Hyrise::get().plugin_manager;
   auto& plugins = get_plugins();
 
   EXPECT_EQ(plugins.size(), 0u);
-  pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin"));
 
-  EXPECT_THROW(pm.load_plugin(build_dylib_path("libhyriseTestPlugin")), std::exception);
+  EXPECT_THROW(_hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin")), std::exception);
 }
 
 TEST_F(PluginManagerTest, LoadingNotExistingLibrary) {
-  auto& pm = Hyrise::get().plugin_manager;
-
-  EXPECT_THROW(pm.load_plugin(build_dylib_path("libNotExisting")), std::exception);
+  EXPECT_THROW(_hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libNotExisting")), std::exception);
 }
 
 TEST_F(PluginManagerTest, LoadingNonInstantiableLibrary) {
-  auto& pm = Hyrise::get().plugin_manager;
-
-  EXPECT_THROW(pm.load_plugin(build_dylib_path("libhyriseTestNonInstantiablePlugin")), std::exception);
+  EXPECT_THROW(_hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestNonInstantiablePlugin")),
+               std::exception);
 }
 
 TEST_F(PluginManagerTest, LoadingDifferentPlugins) {
-  auto& pm = Hyrise::get().plugin_manager;
   auto& plugins = get_plugins();
 
   EXPECT_EQ(plugins.size(), 0u);
-  pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
-  pm.load_plugin(build_dylib_path("libhyriseMvccDeletePlugin"));
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseMvccDeletePlugin"));
   EXPECT_EQ(plugins.size(), 2u);
 }
 
 TEST_F(PluginManagerTest, LoadingTwoInstancesOfSamePlugin) {
-  auto& pm = Hyrise::get().plugin_manager;
   auto& plugins = get_plugins();
 
   EXPECT_EQ(plugins.size(), 0u);
-  pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
-  EXPECT_THROW(pm.load_plugin(build_dylib_path("libhyriseTestPlugin")), std::exception);
+  _hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  EXPECT_THROW(_hyrise_env->plugin_manager()->load_plugin(build_dylib_path("libhyriseTestPlugin")), std::exception);
 }
 
 TEST_F(PluginManagerTest, UnloadNotLoadedPlugin) {
-  auto& pm = Hyrise::get().plugin_manager;
   auto& plugins = get_plugins();
 
   EXPECT_EQ(plugins.size(), 0u);
 
-  EXPECT_THROW(pm.unload_plugin("NotLoadedPlugin"), std::exception);
+  EXPECT_THROW(_hyrise_env->plugin_manager()->unload_plugin("NotLoadedPlugin"), std::exception);
 }
 
 }  // namespace opossum

--- a/src/test/lib/utils/singleton_test.cpp
+++ b/src/test/lib/utils/singleton_test.cpp
@@ -10,11 +10,7 @@ namespace opossum {
 
 class SingletonTest : public BaseTest {
  protected:
-  std::unordered_map<PluginName, PluginHandleWrapper>& get_plugins() {
-    auto& pm = Hyrise::get().plugin_manager;
-
-    return pm._plugins;
-  }
+  std::unordered_map<PluginName, PluginHandleWrapper>& get_plugins() { return _hyrise_env->plugin_manager()->_plugins; }
 };
 
 TEST_F(SingletonTest, SingleInstance) {


### PR DESCRIPTION
A PR that allows Hyrise to run with the StorageManager and other objects given as parameters. This removes the dependence on a global object, possibly allowing different namespaces/schemas, an alternate transaction model, and several different implementations of StorageManager.

Note: While most tests pass, a few still don't. I am posting this PR to see if you are interested, if you are, I will fix the few tests that do not pass.