### PR TITLE
Use boost's pdqsort in union positions operators

### DIFF
--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -11,7 +11,7 @@ then
   exit 1
 fi
 
-benchmarks='hyriseBenchmarkTPCDS'
+benchmarks='hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkTPCC hyriseBenchmarkJoinOrder'
 num_mt_clients=50
 
 # Retrieve SHA-1 hashes from arguments (e.g., translate "master" into an actual hash)

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -11,7 +11,7 @@ then
   exit 1
 fi
 
-benchmarks='hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkTPCC hyriseBenchmarkJoinOrder'
+benchmarks='hyriseBenchmarkTPCDS'
 num_mt_clients=50
 
 # Retrieve SHA-1 hashes from arguments (e.g., translate "master" into an actual hash)

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -99,7 +99,12 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
   /**
    * Sort the virtual pos lists so that they bring the rows in their respective ReferenceMatrix into order.
    * This is necessary for merging them.
-   * PERFORMANCE NOTE: These sorts take the vast majority of time spend in this Operator
+   * Performance note: These sorts take the vast majority of time spend in this operator. Using boost's pdqsort helps
+   * a lot over std::sort, but there is probably still room for improvement (see comment above about other data
+   * structures). The reason why pdqsort can be much faster than std::sort is that is more efficient for already sorted
+   * data, which happens when no "shuffling" operators (e.g., inner joins) occur before the UnionPosition so the
+   * position lists are already sorted. For cases where the input is not sorted, pdqsort is usually still more than 20%
+   * faster than std::sort.
    */
   boost::sort::pdqsort(virtual_pos_list_left.begin(), virtual_pos_list_left.end(),
                        VirtualPosListCmpContext{reference_matrix_left});

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -8,6 +8,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/sort/sort.hpp>
+
 #include "storage/chunk.hpp"
 #include "storage/reference_segment.hpp"
 #include "storage/table.hpp"
@@ -99,10 +101,10 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
    * This is necessary for merging them.
    * PERFORMANCE NOTE: These sorts take the vast majority of time spend in this Operator
    */
-  std::sort(virtual_pos_list_left.begin(), virtual_pos_list_left.end(),
-            VirtualPosListCmpContext{reference_matrix_left});
-  std::sort(virtual_pos_list_right.begin(), virtual_pos_list_right.end(),
-            VirtualPosListCmpContext{reference_matrix_right});
+  boost::sort::pdqsort(virtual_pos_list_left.begin(), virtual_pos_list_left.end(),
+                       VirtualPosListCmpContext{reference_matrix_left});
+  boost::sort::pdqsort(virtual_pos_list_right.begin(), virtual_pos_list_right.end(),
+                       VirtualPosListCmpContext{reference_matrix_right});
 
   /**
    * Build result table
@@ -242,7 +244,7 @@ std::shared_ptr<const Table> UnionPositions::_prepare_operator() {
   add(left_input_table());
   add(right_input_table());
 
-  std::sort(_column_cluster_offsets.begin(), _column_cluster_offsets.end());
+  boost::sort::pdqsort(_column_cluster_offsets.begin(), _column_cluster_offsets.end());
   const auto unique_end_iter = std::unique(_column_cluster_offsets.begin(), _column_cluster_offsets.end());
   _column_cluster_offsets.resize(std::distance(_column_cluster_offsets.begin(), unique_end_iter));
 

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -99,7 +99,7 @@ std::shared_ptr<const Table> UnionPositions::_on_execute() {
   /**
    * Sort the virtual pos lists so that they bring the rows in their respective ReferenceMatrix into order.
    * This is necessary for merging them.
-   * Performance note: These sorts take the vast majority of time spend in this operator. Using boost's pdqsort helps
+   * Performance note: These sorts take the vast majority of time spent in this operator. Using boost's pdqsort helps
    * a lot over std::sort, but there is probably still room for improvement (see comment above about other data
    * structures). The reason why pdqsort can be much faster than std::sort is that is more efficient for already sorted
    * data, which happens when no "shuffling" operators (e.g., inner joins) occur before the UnionPosition so the


### PR DESCRIPTION
@aloeser and @dey4ss found that the union positions operator takes a surprising large share of the overall runtime of the DS benchmark. For TPC-H or JOB, the union positions operators mostly does not matter (TPC-H is microseconds, JOB is more for two queries, but both are too fast to make an impact).

This PR simply changes `std::sort` to boost's `pdqsort` (see #2271 for a related discussion on sorting).

The results look good so far. The main reason fo the slow runtimes is Q28 and this query improve significantly. The noise is reproducible. I can't really tell where it comes from. The union positions operator is not used in many queries, which change quite a lot.

### Clang
**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.3TB |
| numactl | nodebind: 3  |
| numactl | membind: 3  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| b2cdc796e | 19.02.2021 22:41 | Fix all values zero (#2327) | real 382.39 user 2979.22 sys 92.90|
| b80341b54 | 03.03.2021 20:46 | Temporarily disable all benchmarks but DS | real 380.29 user 2983.58 sys 92.79|


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -8%
 ||
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Martin.Boissier/hyrise_wip/rel_clang/benchmark_all_results/hyriseBenchmarkTPCDS_b2cdc796e34a52dd038be3208d382750c9952413_st.json | /home/Martin.Boissier/hyrise_wip/rel_clang/benchmark_all_results/hyriseBenchmarkTPCDS_b80341b54482d6d5e353a3c2a0f2b9ff3f313280_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | b2cdc796e34a52dd038be3208d382750c9952413-dirty                                                                                         | b80341b54482d6d5e353a3c2a0f2b9ff3f313280-dirty                                                                                         |
 |  benchmark_mode  | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type      | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size      | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients         | 1                                                                                                                                      | 1                                                                                                                                      |
 |  compiler        | clang 11.0.0                                                                                                                           | clang 11.0.0                                                                                                                           |
 |  cores           | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date            | 2021-03-03 20:54:30                                                                                                                    | 2021-03-03 22:23:10                                                                                                                    |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes         | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration    | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs        | -1                                                                                                                                     | -1                                                                                                                                     |
 |  time_unit       | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler | False                                                                                                                                  | False                                                                                                                                  |
 |  verify          | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration | 0                                                                                                                                      | 0                                                                                                                                      |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     22.4 |    22.5 |   +1%  ||    44.67 |    44.40 |   -1%  |  0.0000 |
-| 03      ||      4.8 |     6.4 |  +34%  ||   208.27 |   155.40 |  -25%  |  0.0000 |
-| 06      ||     15.0 |    17.3 |  +15%  ||    66.76 |    57.86 |  -13%  |  0.0000 |
-| 07      ||     28.0 |    30.7 |  +10%  ||    35.76 |    32.60 |   -9%  |  0.0000 |
-| 09      ||     89.8 |    99.6 |  +11%  ||    11.14 |    10.04 |  -10%  |  0.0000 |
-| 10      ||     15.8 |    19.5 |  +23%  ||    63.28 |    51.33 |  -19%  |  0.0000 |
+| 13      ||     66.7 |    45.5 |  -32%  ||    14.99 |    21.97 |  +47%  |  0.0000 |
 | 15      ||      9.4 |     9.1 |   -3%  ||   106.22 |   109.33 |   +3%  |  0.0000 |
-| 17      ||     23.6 |    26.8 |  +13%  ||    42.33 |    37.32 |  -12%  |  0.0000 |
-| 19      ||      7.5 |     9.5 |  +26%  ||   132.81 |   105.10 |  -21%  |  0.0000 |
-| 25      ||     13.4 |    15.2 |  +14%  ||    74.68 |    65.66 |  -12%  |  0.0000 |
+| 26      ||     14.9 |    14.2 |   -5%  ||    67.30 |    70.56 |   +5%  |  0.0000 |
+| 28      ||    453.3 |   230.6 |  -49%  ||     2.21 |     4.34 |  +97%  |  0.0000 |
-| 29      ||     21.1 |    24.2 |  +15%  ||    47.42 |    41.36 |  -13%  |  0.0000 |
-| 31      ||    100.3 |   107.3 |   +7%  ||     9.97 |     9.32 |   -7%  |  0.0000 |
-| 34      ||     13.8 |    15.8 |  +14%  ||    72.34 |    63.34 |  -12%  |  0.0000 |
-| 35      ||     60.6 |    63.4 |   +5%  ||    16.51 |    15.76 |   -5%  |  0.0000 |
+| 39a     ||    122.0 |   114.6 |   -6%  ||     8.20 |     8.73 |   +6%  |  0.0000 |
+| 39b     ||    120.7 |   113.6 |   -6%  ||     8.28 |     8.81 |   +6%  |  0.0000 |
 | 41      ||     23.6 |    23.5 |   -0%  ||    42.43 |    42.55 |   +0%  |  0.0000 |
-| 42      ||      5.9 |     7.8 |  +32%  ||   168.34 |   127.67 |  -24%  |  0.0000 |
 | 43      ||    199.8 |   204.5 |   +2%  ||     5.01 |     4.89 |   -2%  |  0.0000 |
-| 45      ||      8.3 |     8.8 |   +6%  ||   120.86 |   113.67 |   -6%  |  0.0000 |
+| 48      ||     57.9 |    51.6 |  -11%  ||    17.28 |    19.38 |  +12%  |  0.0000 |
-| 50      ||      8.6 |    10.7 |  +24%  ||   115.83 |    93.34 |  -19%  |  0.0000 |
-| 52      ||      6.1 |     8.0 |  +31%  ||   164.98 |   125.71 |  -24%  |  0.0000 |
-| 55      ||      5.9 |     7.8 |  +32%  ||   169.88 |   128.44 |  -24%  |  0.0000 |
 | 62      ||     48.5 |    48.7 |   +1%  ||    20.63 |    20.51 |   -1%  |  0.0000 |
 | 65      ||     42.7 |    44.4 |   +4%  ||    23.41 |    22.52 |   -4%  |  0.0000 |
-| 69      ||     14.7 |    18.0 |  +22%  ||    67.82 |    55.41 |  -18%  |  0.0000 |
-| 73      ||      7.6 |     9.5 |  +26%  ||   132.09 |   104.94 |  -21%  |  0.0000 |
-| 79      ||     32.8 |    34.6 |   +6%  ||    30.50 |    28.87 |   -5%  |  0.0000 |
 | 81      ||     13.9 |    14.0 |   +1%  ||    72.12 |    71.25 |   -1%  |  0.0000 |
-| 83      ||      7.9 |     8.3 |   +5%  ||   126.25 |   120.34 |   -5%  |  0.0000 |
+| 85      ||     35.2 |    29.1 |  -18%  ||    28.38 |    34.40 |  +21%  |  0.0000 |
-| 88      ||     51.2 |    66.2 |  +29%  ||    19.53 |    15.10 |  -23%  |  0.0000 |
+| 91      ||     13.0 |    10.0 |  -23%  ||    76.89 |    99.99 |  +30%  |  0.0000 |
 | 93      ||    212.4 |   211.1 |   -1%  ||     4.71 |     4.74 |   +1%  |  0.0017 |
-| 96      ||      5.3 |     7.2 |  +35%  ||   188.56 |   139.26 |  -26%  |  0.0000 |
 | 97      ||    252.9 |   258.1 |   +2%  ||     3.95 |     3.87 |   -2%  |  0.0000 |
 | 99      ||     94.1 |    94.3 |   +0%  ||    10.62 |    10.60 |   -0%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||   2351.1 |  2162.2 |   -8%  ||          |          |        |         |
-| Geomean ||          |         |        ||          |          |   -5%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -3%
 ||
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Martin.Boissier/hyrise_wip/rel_clang/benchmark_all_results/hyriseBenchmarkTPCDS_b2cdc796e34a52dd038be3208d382750c9952413_mt.json | /home/Martin.Boissier/hyrise_wip/rel_clang/benchmark_all_results/hyriseBenchmarkTPCDS_b80341b54482d6d5e353a3c2a0f2b9ff3f313280_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | b2cdc796e34a52dd038be3208d382750c9952413-dirty                                                                                         | b80341b54482d6d5e353a3c2a0f2b9ff3f313280-dirty                                                                                         |
 |  benchmark_mode               | Ordered                                                                                                                                | Ordered                                                                                                                                |
 |  build_type                   | release                                                                                                                                | release                                                                                                                                |
 |  chunk_size                   | 65535                                                                                                                                  | 65535                                                                                                                                  |
 |  clients                      | 50                                                                                                                                     | 50                                                                                                                                     |
 |  compiler                     | clang 11.0.0                                                                                                                           | clang 11.0.0                                                                                                                           |
 |  cores                        | 0                                                                                                                                      | 0                                                                                                                                      |
 |  date                         | 2021-03-03 21:35:34                                                                                                                    | 2021-03-03 23:04:14                                                                                                                    |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                | {'default': {'encoding': 'Dictionary'}}                                                                                                |
 |  indexes                      | False                                                                                                                                  | False                                                                                                                                  |
 |  max_duration                 | 60000000000                                                                                                                            | 60000000000                                                                                                                            |
 |  max_runs                     | -1                                                                                                                                     | -1                                                                                                                                     |
 |  time_unit                    | ns                                                                                                                                     | ns                                                                                                                                     |
 |  using_scheduler              | True                                                                                                                                   | True                                                                                                                                   |
 |  utilized_cores_per_numa_node | [0, 0, 0, 56]                                                                                                                          | [0, 0, 0, 56]                                                                                                                          |
 |  verify                       | False                                                                                                                                  | False                                                                                                                                  |
 |  warmup_duration              | 0                                                                                                                                      | 0                                                                                                                                      |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     63.9 |    64.7 |   +1%  ||   725.31 |   717.10 |   -1%  |  0.0007 |
 | 03      ||     15.0 |    16.0 |   +7%  ||  2380.72 |  2400.86 |   +1%  |  0.0000 |
 | 06      ||     38.7 |    39.9 |   +3%  ||  1107.52 |  1077.29 |   -3%  |  0.0000 |
 | 07      ||     59.8 |    61.1 |   +2%  ||   746.16 |   722.97 |   -3%  |  0.0000 |
-| 09      ||    210.5 |   221.8 |   +5%  ||   229.38 |   215.30 |   -6%  |  0.0000 |
-| 10      ||     29.5 |    32.1 |   +9%  ||  1248.99 |  1120.43 |  -10%  |  0.0000 |
+| 13      ||    186.5 |   137.6 |  -26%  ||   259.43 |   347.26 |  +34%  |  0.0000 |
 | 15      ||     31.1 |    31.7 |   +2%  ||  1417.69 |  1392.31 |   -2%  |  0.0000 |
-| 17      ||     54.3 |    57.9 |   +7%  ||   795.70 |   748.15 |   -6%  |  0.0000 |
-| 19      ||     20.1 |    23.8 |  +18%  ||  2067.35 |  1784.71 |  -14%  |  0.0000 |
-| 25      ||     33.6 |    36.3 |   +8%  ||  1244.38 |  1173.56 |   -6%  |  0.0000 |
 | 26      ||     37.3 |    36.3 |   -2%  ||  1159.31 |  1192.47 |   +3%  |  0.0000 |
+| 28      ||    670.5 |   434.1 |  -35%  ||    36.45 |    56.38 |  +55%  |  0.0000 |
-| 29      ||     46.2 |    49.8 |   +8%  ||   896.82 |   831.99 |   -7%  |  0.0000 |
 | 31      ||    142.7 |   145.2 |   +2%  ||   181.72 |   175.86 |   -3%  |  0.0056 |
-| 34      ||     31.7 |    34.2 |   +8%  ||  1310.15 |  1211.38 |   -8%  |  0.0000 |
 | 35      ||    183.8 |   186.4 |   +1%  ||   264.11 |   260.25 |   -1%  |  0.0983 |
 | 39a     ||    412.4 |   408.9 |   -1%  ||   117.85 |   119.13 |   +1%  |  0.5603 |
 | 39b     ||    412.0 |   407.0 |   -1%  ||   117.85 |   119.17 |   +1%  |  0.3953 |
 | 41      ||    609.9 |   621.6 |   +2%  ||    80.37 |    78.82 |   -2%  |  0.5209 |
-| 42      ||     15.3 |    17.4 |  +13%  ||  2374.96 |  2248.18 |   -5%  |  0.0000 |
 | 43      ||    437.4 |   452.7 |   +3%  ||   107.22 |   105.36 |   -2%  |  0.0067 |
 | 45      ||     18.5 |    19.5 |   +5%  ||  2005.26 |  1959.61 |   -2%  |  0.0000 |
+| 48      ||    135.3 |   127.6 |   -6%  ||   327.93 |   355.57 |   +8%  |  0.0000 |
-| 50      ||     24.0 |    26.8 |  +12%  ||  1792.08 |  1565.59 |  -13%  |  0.0000 |
-| 52      ||     15.4 |    17.7 |  +15%  ||  2387.89 |  2225.10 |   -7%  |  0.0000 |
 | 55      ||     15.1 |    16.9 |  +12%  ||  2398.47 |  2297.18 |   -4%  |  0.0000 |
 | 62      ||    115.0 |   115.7 |   +1%  ||   414.53 |   412.16 |   -1%  |  0.3119 |
 | 65      ||    167.5 |   168.0 |   +0%  ||   289.66 |   288.79 |   -0%  |  0.6078 |
-| 69      ||     27.7 |    30.9 |  +12%  ||  1309.51 |  1163.51 |  -11%  |  0.0000 |
-| 73      ||     17.0 |    20.1 |  +18%  ||  2129.53 |  1926.66 |  -10%  |  0.0000 |
 | 79      ||     89.6 |    91.1 |   +2%  ||   526.56 |   518.06 |   -2%  |  0.0013 |
 | 81      ||     43.6 |    43.4 |   -1%  ||  1029.07 |  1033.97 |   +0%  |  0.1774 |
 | 83      ||     18.3 |    19.0 |   +4%  ||  2087.52 |  2041.27 |   -2%  |  0.0000 |
+| 85      ||     91.8 |    73.3 |  -20%  ||   501.83 |   604.57 |  +20%  |  0.0000 |
-| 88      ||     75.8 |    92.0 |  +21%  ||   386.78 |   316.89 |  -18%  |  0.0000 |
+| 91      ||     35.7 |    27.1 |  -24%  ||  1228.82 |  1437.61 |  +17%  |  0.0000 |
 | 93      ||    568.7 |   570.3 |   +0%  ||    86.23 |    85.95 |   -0%  |  0.8674 |
 | 96      ||     15.4 |    17.0 |  +10%  ||  2395.88 |  2354.31 |   -2%  |  0.0000 |
 | 97      ||    856.9 |   859.6 |   +0%  ||    57.54 |    57.33 |   -0%  |  0.8469 |
 | 99      ||    256.9 |   258.3 |   +1%  ||   189.93 |   189.08 |   -0%  |  0.5601 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   6330.7 |  6111.3 |   -3%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


### GCC
**System**
<details>
<summary>nemea - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | nemea |
| CPU | Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz |
| Memory | 1.3TB |
| numactl | nodebind: 3  |
| numactl | membind: 3  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| b2cdc796e | 19.02.2021 22:41 | Fix all values zero (#2327) | real 440.17 user 2816.16 sys 132.99|
| b80341b54 | 03.03.2021 20:46 | Temporarily disable all benchmarks but DS | real 439.93 user 2812.59 sys 132.80|


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -23%
 ||
Geometric mean of throughput changes: +15%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Martin.Boissier/hyrise_wip/rel/benchmark_all_results/hyriseBenchmarkTPCDS_b2cdc796e34a52dd038be3208d382750c9952413_st.json | /home/Martin.Boissier/hyrise_wip/rel/benchmark_all_results/hyriseBenchmarkTPCDS_b80341b54482d6d5e353a3c2a0f2b9ff3f313280_st.json |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | b2cdc796e34a52dd038be3208d382750c9952413-dirty                                                                                   | b80341b54482d6d5e353a3c2a0f2b9ff3f313280-dirty                                                                                   |
 |  benchmark_mode  | Ordered                                                                                                                          | Ordered                                                                                                                          |
 |  build_type      | release                                                                                                                          | release                                                                                                                          |
 |  chunk_size      | 65535                                                                                                                            | 65535                                                                                                                            |
 |  clients         | 1                                                                                                                                | 1                                                                                                                                |
 |  compiler        | gcc 10.2                                                                                                                         | gcc 10.2                                                                                                                         |
 |  cores           | 0                                                                                                                                | 0                                                                                                                                |
 |  date            | 2021-03-03 23:53:08                                                                                                              | 2021-03-04 01:22:47                                                                                                              |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                          | {'default': {'encoding': 'Dictionary'}}                                                                                          |
 |  indexes         | False                                                                                                                            | False                                                                                                                            |
 |  max_duration    | 60000000000                                                                                                                      | 60000000000                                                                                                                      |
 |  max_runs        | -1                                                                                                                               | -1                                                                                                                               |
 |  time_unit       | ns                                                                                                                               | ns                                                                                                                               |
 |  using_scheduler | False                                                                                                                            | False                                                                                                                            |
 |  verify          | False                                                                                                                            | False                                                                                                                            |
 |  warmup_duration | 0                                                                                                                                | 0                                                                                                                                |
 +------------------+----------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     23.2 |    22.8 |   -2%  ||    43.14 |    43.93 |   +2%  |  0.0000 |
+| 03      ||      6.2 |     5.0 |  -19%  ||   160.79 |   198.08 |  +23%  |  0.0000 |
+| 06      ||     16.6 |    15.3 |   -8%  ||    60.35 |    65.40 |   +8%  |  0.0000 |
+| 07      ||     28.4 |    24.7 |  -13%  ||    35.24 |    40.55 |  +15%  |  0.0000 |
-| 09      ||    105.1 |   111.7 |   +6%  ||     9.52 |     8.95 |   -6%  |  0.0000 |
+| 10      ||     18.0 |    16.4 |   -9%  ||    55.53 |    60.93 |  +10%  |  0.0000 |
+| 13      ||    106.5 |    54.1 |  -49%  ||     9.39 |    18.48 |  +97%  |  0.0000 |
-| 15      ||      8.8 |     9.4 |   +7%  ||   113.55 |   106.05 |   -7%  |  0.0000 |
+| 17      ||     26.7 |    24.3 |   -9%  ||    37.44 |    41.20 |  +10%  |  0.0000 |
+| 19      ||      9.2 |     7.7 |  -16%  ||   109.01 |   129.31 |  +19%  |  0.0000 |
+| 25      ||     14.4 |    13.4 |   -7%  ||    69.41 |    74.55 |   +7%  |  0.0000 |
 | 26      ||     14.1 |    13.6 |   -4%  ||    71.00 |    73.63 |   +4%  |  0.0000 |
+| 28      ||    877.5 |   292.6 |  -67%  ||     1.14 |     3.42 | +200%  |  0.0000 |
+| 29      ||     23.7 |    21.4 |  -10%  ||    42.24 |    46.76 |  +11%  |  0.0000 |
+| 31      ||    110.1 |   104.7 |   -5%  ||     9.08 |     9.55 |   +5%  |  0.0000 |
+| 34      ||     15.9 |    14.0 |  -12%  ||    62.73 |    71.37 |  +14%  |  0.0000 |
 | 35      ||     61.7 |    59.2 |   -4%  ||    16.20 |    16.89 |   +4%  |  0.0000 |
-| 39a     ||    114.9 |   126.0 |  +10%  ||     8.70 |     7.94 |   -9%  |  0.0000 |
-| 39b     ||    114.1 |   125.8 |  +10%  ||     8.77 |     7.95 |   -9%  |  0.0000 |
 | 41      ||     26.7 |    25.6 |   -4%  ||    37.51 |    39.12 |   +4%  |  0.0000 |
+| 42      ||      7.4 |     6.1 |  -17%  ||   134.47 |   162.59 |  +21%  |  0.0000 |
 | 43      ||    201.4 |   200.6 |   -0%  ||     4.97 |     4.98 |   +0%  |  0.0000 |
+| 45      ||      8.5 |     8.0 |   -5%  ||   118.25 |   124.71 |   +5%  |  0.0000 |
+| 48      ||     74.5 |    52.9 |  -29%  ||    13.42 |    18.89 |  +41%  |  0.0000 |
+| 50      ||     10.3 |     8.9 |  -13%  ||    97.47 |   112.47 |  +15%  |  0.0000 |
+| 52      ||      7.5 |     6.3 |  -17%  ||   132.44 |   159.68 |  +21%  |  0.0000 |
+| 55      ||      7.4 |     6.1 |  -17%  ||   135.02 |   163.42 |  +21%  |  0.0000 |
 | 62      ||     50.9 |    50.3 |   -1%  ||    19.66 |    19.88 |   +1%  |  0.0000 |
+| 65      ||     54.1 |    51.4 |   -5%  ||    18.49 |    19.45 |   +5%  |  0.0000 |
+| 69      ||     16.8 |    15.2 |   -9%  ||    59.66 |    65.59 |  +10%  |  0.0000 |
+| 73      ||      9.5 |     8.0 |  -16%  ||   105.09 |   124.86 |  +19%  |  0.0000 |
+| 79      ||     36.3 |    34.1 |   -6%  ||    27.51 |    29.36 |   +7%  |  0.0000 |
 | 81      ||     15.0 |    14.6 |   -2%  ||    66.54 |    68.26 |   +3%  |  0.0000 |
+| 83      ||      8.3 |     7.8 |   -6%  ||   120.29 |   127.45 |   +6%  |  0.0000 |
+| 85      ||     49.1 |    29.7 |  -40%  ||    20.35 |    33.71 |  +66%  |  0.0000 |
+| 88      ||     63.4 |    53.4 |  -16%  ||    15.78 |    18.73 |  +19%  |  0.0000 |
+| 91      ||     17.1 |    10.8 |  -37%  ||    58.31 |    92.77 |  +59%  |  0.0000 |
 | 93      ||    236.2 |   235.2 |   -0%  ||     4.23 |     4.25 |   +0%  |  0.0422 |
+| 96      ||      6.8 |     5.7 |  -17%  ||   146.29 |   176.85 |  +21%  |  0.0000 |
-| 97      ||    304.3 |   331.7 |   +9%  ||     3.29 |     3.01 |   -8%  |  0.0000 |
 | 99      ||     97.1 |    97.8 |   +1%  ||    10.30 |    10.23 |   -1%  |  0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||   3003.6 |  2322.3 |  -23%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |  +15%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -9%
 ||
Geometric mean of throughput changes: +8%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Martin.Boissier/hyrise_wip/rel/benchmark_all_results/hyriseBenchmarkTPCDS_b2cdc796e34a52dd038be3208d382750c9952413_mt.json | /home/Martin.Boissier/hyrise_wip/rel/benchmark_all_results/hyriseBenchmarkTPCDS_b80341b54482d6d5e353a3c2a0f2b9ff3f313280_mt.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | b2cdc796e34a52dd038be3208d382750c9952413-dirty                                                                                   | b80341b54482d6d5e353a3c2a0f2b9ff3f313280-dirty                                                                                   |
 |  benchmark_mode               | Ordered                                                                                                                          | Ordered                                                                                                                          |
 |  build_type                   | release                                                                                                                          | release                                                                                                                          |
 |  chunk_size                   | 65535                                                                                                                            | 65535                                                                                                                            |
 |  clients                      | 50                                                                                                                               | 50                                                                                                                               |
 |  compiler                     | gcc 10.2                                                                                                                         | gcc 10.2                                                                                                                         |
 |  cores                        | 0                                                                                                                                | 0                                                                                                                                |
 |  date                         | 2021-03-04 00:34:12                                                                                                              | 2021-03-04 02:03:52                                                                                                              |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                          | {'default': {'encoding': 'Dictionary'}}                                                                                          |
 |  indexes                      | False                                                                                                                            | False                                                                                                                            |
 |  max_duration                 | 60000000000                                                                                                                      | 60000000000                                                                                                                      |
 |  max_runs                     | -1                                                                                                                               | -1                                                                                                                               |
 |  time_unit                    | ns                                                                                                                               | ns                                                                                                                               |
 |  using_scheduler              | True                                                                                                                             | True                                                                                                                             |
 |  utilized_cores_per_numa_node | [0, 0, 0, 56]                                                                                                                    | [0, 0, 0, 56]                                                                                                                    |
 |  verify                       | False                                                                                                                            | False                                                                                                                            |
 |  warmup_duration              | 0                                                                                                                                | 0                                                                                                                                |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     68.8 |    68.2 |   -1%  ||   678.57 |   684.14 |   +1%  |  0.0296 |
 | 03      ||     16.2 |    15.4 |   -5%  ||  2392.38 |  2366.79 |   -1%  |  0.0000 |
 | 06      ||     40.9 |    39.5 |   -3%  ||  1051.77 |  1087.50 |   +3%  |  0.0000 |
+| 07      ||     61.8 |    57.8 |   -7%  ||   722.42 |   768.65 |   +6%  |  0.0000 |
 | 09      ||    291.1 |   285.8 |   -2%  ||   168.06 |   170.44 |   +1%  |  0.3120 |
+| 10      ||     33.1 |    31.0 |   -6%  ||  1093.36 |  1188.73 |   +9%  |  0.0000 |
+| 13      ||    264.5 |   174.7 |  -34%  ||   184.31 |   275.79 |  +50%  |  0.0000 |
 | 15      ||     32.4 |    31.6 |   -2%  ||  1366.11 |  1398.50 |   +2%  |  0.0000 |
+| 17      ||     58.8 |    55.4 |   -6%  ||   730.65 |   775.34 |   +6%  |  0.0000 |
+| 19      ||     24.4 |    21.2 |  -13%  ||  1746.37 |  1986.16 |  +14%  |  0.0000 |
 | 25      ||     36.6 |    35.3 |   -4%  ||  1170.10 |  1202.55 |   +3%  |  0.0000 |
 | 26      ||     35.8 |    35.7 |   -0%  ||  1208.49 |  1205.24 |   -0%  |  0.5655 |
+| 28      ||   1023.6 |   545.1 |  -47%  ||    23.68 |    44.83 |  +89%  |  0.0000 |
+| 29      ||     50.8 |    47.7 |   -6%  ||   819.72 |   870.37 |   +6%  |  0.0000 |
 | 31      ||    149.8 |   145.3 |   -3%  ||   172.43 |   177.99 |   +3%  |  0.0000 |
+| 34      ||     36.2 |    33.6 |   -7%  ||  1167.21 |  1257.83 |   +8%  |  0.0000 |
 | 35      ||    186.0 |   184.8 |   -1%  ||   261.16 |   262.85 |   +1%  |  0.4379 |
 | 39a     ||    417.2 |   427.6 |   +2%  ||   116.72 |   113.31 |   -3%  |  0.1092 |
 | 39b     ||    416.7 |   427.4 |   +3%  ||   117.05 |   113.62 |   -3%  |  0.1094 |
 | 41      ||    651.8 |   646.7 |   -1%  ||    75.08 |    75.51 |   +1%  |  0.7880 |
+| 42      ||     17.5 |    15.8 |   -9%  ||  2235.93 |  2369.79 |   +6%  |  0.0000 |
 | 43      ||    450.2 |   447.1 |   -1%  ||   103.23 |   103.61 |   +0%  |  0.5681 |
 | 45      ||     19.2 |    18.3 |   -5%  ||  1985.48 |  2025.22 |   +2%  |  0.0000 |
+| 48      ||    156.6 |   133.8 |  -15%  ||   283.67 |   337.55 |  +19%  |  0.0000 |
+| 50      ||     27.5 |    25.0 |   -9%  ||  1527.11 |  1730.51 |  +13%  |  0.0000 |
+| 52      ||     17.7 |    15.9 |  -10%  ||  2215.73 |  2370.89 |   +7%  |  0.0000 |
+| 55      ||     17.0 |    15.5 |   -8%  ||  2286.69 |  2413.21 |   +6%  |  0.0000 |
 | 62      ||    121.5 |   121.6 |   +0%  ||   393.36 |   393.02 |   -0%  |  0.9223 |
 | 65      ||    197.9 |   194.7 |   -2%  ||   246.04 |   250.09 |   +2%  |  0.0107 |
+| 69      ||     31.8 |    29.4 |   -8%  ||  1141.91 |  1239.26 |   +9%  |  0.0000 |
+| 73      ||     21.2 |    18.5 |  -13%  ||  1865.34 |  2046.24 |  +10%  |  0.0000 |
 | 79      ||     95.5 |    93.2 |   -2%  ||   496.02 |   507.66 |   +2%  |  0.0000 |
 | 81      ||     47.5 |    47.0 |   -1%  ||   956.79 |   965.42 |   +1%  |  0.0117 |
 | 83      ||     20.3 |    19.2 |   -5%  ||  1964.10 |  2039.28 |   +4%  |  0.0000 |
+| 85      ||    119.8 |    83.2 |  -31%  ||   395.11 |   548.27 |  +39%  |  0.0000 |
+| 88      ||     93.3 |    81.4 |  -13%  ||   314.69 |   367.05 |  +17%  |  0.0000 |
+| 91      ||     45.1 |    33.7 |  -25%  ||   987.74 |  1283.95 |  +30%  |  0.0000 |
 | 93      ||    631.4 |   634.3 |   +0%  ||    77.96 |    77.35 |   -1%  |  0.8061 |
 | 96      ||     17.0 |    15.8 |   -7%  ||  2346.08 |  2401.57 |   +2%  |  0.0000 |
 | 97      ||    930.5 |   940.6 |   +1%  ||    52.67 |    52.21 |   -1%  |  0.5005 |
 | 99      ||    267.8 |   269.4 |   +1%  ||   182.37 |   181.33 |   -1%  |  0.5050 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||   7242.6 |  6563.1 |   -9%  ||          |          |        |         |
+| Geomean ||          |         |        ||          |          |   +8%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>
