### PR TITLE
Fix benchmark_all.sh script

### DIFF
--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -76,6 +76,9 @@ do
     echo "Running $benchmark for $commit... (single-threaded)"
     ( ${build_folder}/$benchmark -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
 
+    echo "Running $benchmark for $commit... (multi-threaded)"
+    ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
+
     if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
       echo "Running $benchmark for $commit... (single-threaded, SF 0.01)"
       ( ${build_folder}/$benchmark -s .01 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
@@ -83,12 +86,11 @@ do
       echo "Running $benchmark for $commit... (single-threaded, SF 1.0)"
       ( ${build_folder}/$benchmark -s 1 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s1.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s1.log"
 
+      # This run needs to be executed last as loading unclustered binary data works for the Pruning clustering (tables
+      # will be sorted), but not loading clustered for the unclustered case.
       echo "Running $benchmark for $commit... (multi-threaded, SF 10.0, clustered for pruning)"
       ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -s 10 --clustering=Pruning -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.log"
     fi
-
-    echo "Running $benchmark for $commit... (multi-threaded)"
-    ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
   done
   cd "${build_folder}"
 

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -76,9 +76,6 @@ do
     echo "Running $benchmark for $commit... (single-threaded)"
     ( ${build_folder}/$benchmark -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
 
-    echo "Running $benchmark for $commit... (multi-threaded)"
-    ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
-
     if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
       echo "Running $benchmark for $commit... (single-threaded, SF 0.01)"
       ( ${build_folder}/$benchmark -s .01 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
@@ -86,11 +83,12 @@ do
       echo "Running $benchmark for $commit... (single-threaded, SF 1.0)"
       ( ${build_folder}/$benchmark -s 1 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s1.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s1.log"
 
-      # This run needs to be executed last as loading unclustered binary data works for the Pruning clustering (tables
-      # will be sorted), but not loading clustered for the unclustered case.
       echo "Running $benchmark for $commit... (multi-threaded, SF 10.0, clustered for pruning)"
-      ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -s 10 --clustering=Pruning -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.log"
+      ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -s 10 --dont_cache_binary_tables --clustering=Pruning -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.log"
     fi
+
+    echo "Running $benchmark for $commit... (multi-threaded)"
+    ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
   done
   cd "${build_folder}"
 

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -83,8 +83,8 @@ do
       echo "Running $benchmark for $commit... (single-threaded, SF 1.0)"
       ( ${build_folder}/$benchmark -s 1 -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s1.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s1.log"
 
-      echo "Running $benchmark for $commit... (multi-threaded, SF 10.0, clustered for pruning)"
-      ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -s 10 --dont_cache_binary_tables --clustering=Pruning -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_s10_clustered.log"
+      echo "Running $benchmark for $commit... (multi-threaded, clustered for pruning)"
+      ( ${build_folder}/$benchmark --scheduler --clients ${num_mt_clients} -s 10 --dont_cache_binary_tables --clustering=Pruning -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_clustered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_clustered.log"
     fi
 
     echo "Running $benchmark for $commit... (multi-threaded)"
@@ -144,7 +144,7 @@ for benchmark in $benchmarks
 do
   configs="st mt"
   if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
-    configs="st st_s01 st_s10 mt"
+    configs="st st_s01 st_s1 mt_clustered mt"
   fi
 
   for config in $configs


### PR DESCRIPTION
Currently, not all TPC-H runs execute properly as the binary cached data is sorted in a clustered run (using `--clustering=Pruning`) which fails in the next non-clustered run.

This PR changes the clustered run to use `--dont_cache_binary_tables`. We could move the run to the very end, but that would probably crash with the next `benchmark_all.sh` run.

- [x] Output of clustered config