### PR TITLE
Fix CI problems with the hyrise server test

### DIFF
--- a/scripts/test/hyriseServer_test.py
+++ b/scripts/test/hyriseServer_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import pexpect
+import re
 
 from hyriseBenchmarkCore import initialize
 
@@ -11,13 +12,15 @@ def main():
     arguments = {}
     arguments["--benchmark_data"] = "tpc-h:0.01"
 
-    benchmark = pexpect.spawn(f"{build_dir}/hyriseServer --benchmark_data=tpc-h:0.01", timeout=10)
+    benchmark = pexpect.spawn(f"{build_dir}/hyriseServer --benchmark_data=tpc-h:0.01 -p 0", timeout=10)
 
     benchmark.expect_exact("Loading/Generating tables", timeout=120)
     benchmark.expect_exact("Encoding 'lineitem'", timeout=120)
-    benchmark.expect_exact("Server started at 0.0.0.0 and port 5432", timeout=120)
+    search_regex = r"Server started at 0.0.0.0 and port (\d+)"
+    benchmark.expect(search_regex, timeout=120)
 
-    client = pexpect.spawn("psql -h localhost -p 5432", timeout=10)
+    server_port = int(re.search(search_regex, str(benchmark.after)).group(1))
+    client = pexpect.spawn(f"psql -h localhost -p {server_port}", timeout=10)
 
     client.sendline("select count(*) from region;")
     client.expect_exact("COUNT(*)")


### PR DESCRIPTION
Currently, the server starts with the default port which might crash if there is a parallel server running in the CI.
This PR starts with the server port 0 to let the OS assign a port, parses the output to obtain the port, and connects the client to this port.

Resolves #2320 