### PR TITLE
Move BetweenCompositionRule behind PredicateSplitUpRule

### DIFF
--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -53,11 +53,11 @@ std::shared_ptr<Optimizer> Optimizer::create_default_optimizer() {
   // (FDs) used by the DependentGroupByReductionRule.
   optimizer->add_rule(std::make_unique<DependentGroupByReductionRule>());
 
-  optimizer->add_rule(std::make_unique<BetweenCompositionRule>());
-
   optimizer->add_rule(std::make_unique<PredicatePlacementRule>());
 
   optimizer->add_rule(std::make_unique<PredicateSplitUpRule>());
+
+  optimizer->add_rule(std::make_unique<BetweenCompositionRule>());
 
   optimizer->add_rule(std::make_unique<NullScanRemovalRule>());
 


### PR DESCRIPTION
- [x] Run benchmark_all.sh
 
--- 

Fixes #2274

## Benchmark Results

**System**
<details>
<summary>pella - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | pella |
| CPU | Intel(R) Xeon(R) CPU E7- 8870  @ 2.40GHz |
| Memory | 1.3TB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 7f102c819 | 11.03.2021 20:51 | Optimizer: Run BetweenComposition and ChunkPruning rules bottom-up (#2284) | real 826.35 user 4919.55 sys 222.61|
| 3eedda59d | 11.03.2021 22:04 | Move BetweenCompositionRule behind PredicateSplitUpRule | real 817.53 user 4479.62 sys 185.04|


**hyriseBenchmarkTPCH - single-threaded, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +6%
 || 
Geometric mean of throughput changes: -4%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_7f102c819ef58675cce062d2dff039d215842a17_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_3eedda59d0745047abafe049bca149f337feeaa3_st.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                             | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  clustering              | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2021-03-11 22:33:11                                                                                                                        | 2021-03-12 06:50:00                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 0                                                                                                                                          | 0                                                                                                                                          |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||  10926.6 | 11089.2 |   +1%  ||     0.09 |     0.09 |   -1%  |       ˅ |
 | TPC-H 02 ||     83.2 |    83.3 |   +0%  ||    12.02 |    12.00 |   -0%  |  0.8700 |
 | TPC-H 03 ||   4238.3 |  4204.4 |   -1%  ||     0.24 |     0.24 |   +1%  |  0.3841 |
-| TPC-H 04 ||   3083.5 |  7921.6 | +157%  ||     0.32 |     0.13 |  -61%  |       ˅ |
 | TPC-H 05 ||   6778.5 |  6797.2 |   +0%  ||     0.15 |     0.15 |   -0%  |       ˅ |
 | TPC-H 06 ||    367.8 |   376.5 |   +2%  ||     2.72 |     2.66 |   -2%  |  0.0004 |
 | TPC-H 07 ||   1852.0 |  1843.9 |   -0%  ||     0.54 |     0.54 |   +0%  |  0.1423 |
 | TPC-H 08 ||   1533.8 |  1536.4 |   +0%  ||     0.65 |     0.65 |   -0%  |  0.2986 |
 | TPC-H 09 ||  11838.4 | 11779.5 |   -0%  ||     0.08 |     0.08 |   +1%  |       ˅ |
 | TPC-H 10 ||   4834.6 |  4819.2 |   -0%  ||     0.21 |     0.21 |   +0%  |  0.6362 |
 | TPC-H 11 ||    197.2 |   195.8 |   -1%  ||     5.07 |     5.11 |   +1%  |  0.0176 |
 | TPC-H 12 ||   2072.5 |  2050.5 |   -1%  ||     0.48 |     0.49 |   +1%  |  0.0004 |
 | TPC-H 13 ||  10984.8 | 10989.6 |   +0%  ||     0.09 |     0.09 |   -0%  |       ˅ |
 | TPC-H 14 ||    948.4 |   948.8 |   +0%  ||     1.05 |     1.05 |   -0%  |  0.9143 |
 | TPC-H 15 ||    498.8 |   497.8 |   -0%  ||     2.00 |     2.01 |   +0%  |  0.2344 |
 | TPC-H 16 ||   1328.3 |  1345.0 |   +1%  ||     0.75 |     0.74 |   -1%  |  0.0370 |
 | TPC-H 17 ||    571.9 |   571.0 |   -0%  ||     1.75 |     1.75 |   +0%  |  0.4945 |
 | TPC-H 18 ||   5059.1 |  5177.1 |   +2%  ||     0.20 |     0.19 |   -2%  |  0.0124 |
 | TPC-H 19 ||    670.6 |   669.5 |   -0%  ||     1.49 |     1.49 |   +0%  |  0.6585 |
 | TPC-H 20 ||    918.8 |   924.4 |   +1%  ||     1.09 |     1.08 |   -1%  |  0.5545 |
 | TPC-H 21 ||  10411.4 | 10368.2 |   -0%  ||     0.10 |     0.10 |   +0%  |       ˅ |
 | TPC-H 22 ||    940.1 |   942.5 |   +0%  ||     1.06 |     1.06 |   -0%  |  0.0392 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
-| Sum      ||  80138.6 | 85131.7 |   +6%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -4%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +5%
 || 
Geometric mean of throughput changes: -7%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_7f102c819ef58675cce062d2dff039d215842a17_st_s01.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_3eedda59d0745047abafe049bca149f337feeaa3_st_s01.json |
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                                 | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                                 |
 |  benchmark_mode          | Ordered                                                                                                                                        | Ordered                                                                                                                                        |
 |  build_type              | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_size              | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                 | 1                                                                                                                                              | 1                                                                                                                                              |
 |  clustering              | None                                                                                                                                           | None                                                                                                                                           |
 |  compiler                | gcc 9.2                                                                                                                                        | gcc 9.2                                                                                                                                        |
 |  cores                   | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                    | 2021-03-11 22:58:53                                                                                                                            | 2021-03-12 07:15:44                                                                                                                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                        | {'default': {'encoding': 'Dictionary'}}                                                                                                        |
 |  indexes                 | False                                                                                                                                          | False                                                                                                                                          |
 |  max_duration            | 60000000000                                                                                                                                    | 60000000000                                                                                                                                    |
 |  max_runs                | -1                                                                                                                                             | -1                                                                                                                                             |
 |  scale_factor            | 0.009999999776482582                                                                                                                           | 0.009999999776482582                                                                                                                           |
 |  time_unit               | ns                                                                                                                                             | ns                                                                                                                                             |
 |  use_prepared_statements | False                                                                                                                                          | False                                                                                                                                          |
 |  using_scheduler         | False                                                                                                                                          | False                                                                                                                                          |
 |  verify                  | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration         | 0                                                                                                                                              | 0                                                                                                                                              |
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      9.3 |     9.7 |   +5%  ||   107.78 |   103.00 |   -4%  |  0.0000 |
 | TPC-H 02 ||      1.7 |     1.7 |   +0%  ||   579.93 |   579.91 |   -0%  |  0.9965 |
 | TPC-H 03 ||      1.4 |     1.4 |   +0%  ||   734.85 |   734.76 |   -0%  |  0.8337 |
-| TPC-H 04 ||      0.9 |     4.9 | +438%  ||  1102.55 |   205.87 |  -81%  |  0.0000 |
 | TPC-H 05 ||      2.2 |     2.2 |   -0%  ||   462.71 |   463.14 |   +0%  |  0.6741 |
 | TPC-H 06 ||      0.4 |     0.4 |   -1%  ||  2233.27 |  2245.29 |   +1%  |  0.0000 |
-| TPC-H 07 ||      3.1 |     3.3 |   +6%  ||   320.38 |   303.39 |   -5%  |  0.0016 |
 | TPC-H 08 ||     25.0 |    25.3 |   +1%  ||    39.93 |    39.50 |   -1%  |  0.2799 |
 | TPC-H 09 ||      4.0 |     4.0 |   +0%  ||   247.45 |   247.07 |   -0%  |  0.7206 |
 | TPC-H 10 ||      1.6 |     1.6 |   -0%  ||   625.73 |   627.77 |   +0%  |  0.0000 |
 | TPC-H 11 ||      0.6 |     0.6 |   -0%  ||  1674.17 |  1677.39 |   +0%  |  0.0000 |
 | TPC-H 12 ||      1.3 |     1.3 |   -0%  ||   756.30 |   758.14 |   +0%  |  0.0152 |
 | TPC-H 13 ||      3.5 |     3.5 |   +1%  ||   286.56 |   284.24 |   -1%  |  0.0000 |
 | TPC-H 14 ||      0.7 |     0.7 |   +0%  ||  1417.09 |  1414.22 |   -0%  |  0.0000 |
 | TPC-H 15 ||      2.4 |     2.4 |   +0%  ||   421.01 |   419.29 |   -0%  |  0.0000 |
 | TPC-H 16 ||      3.7 |     3.8 |   +1%  ||   267.86 |   266.26 |   -1%  |  0.0000 |
 | TPC-H 17 ||      0.7 |     0.7 |   -2%  ||  1391.99 |  1422.03 |   +2%  |  0.0000 |
 | TPC-H 18 ||      3.0 |     3.0 |   +0%  ||   335.08 |   334.65 |   -0%  |  0.0001 |
+| TPC-H 19 ||     10.1 |     9.4 |   -7%  ||    98.98 |   106.43 |   +8%  |  0.0000 |
 | TPC-H 20 ||      4.8 |     4.8 |   +0%  ||   210.28 |   209.73 |   -0%  |  0.2691 |
 | TPC-H 21 ||      7.4 |     7.4 |   -0%  ||   135.34 |   135.75 |   +0%  |  0.1104 |
 | TPC-H 22 ||      2.2 |     2.2 |   +1%  ||   456.84 |   453.76 |   -1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
-| Sum      ||     89.9 |    94.1 |   +5%  ||          |          |        |         |
-| Geomean  ||          |         |        ||          |          |   -7%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 1.0**
<details>
<summary>
Sum of avg. item runtimes: +9%
 || 
Geometric mean of throughput changes: -7%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+-----------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_7f102c819ef58675cce062d2dff039d215842a17_st_s1.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_3eedda59d0745047abafe049bca149f337feeaa3_st_s1.json |
 +--------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                                | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                                |
 |  benchmark_mode          | Ordered                                                                                                                                       | Ordered                                                                                                                                       |
 |  build_type              | release                                                                                                                                       | release                                                                                                                                       |
 |  chunk_size              | 65535                                                                                                                                         | 65535                                                                                                                                         |
 |  clients                 | 1                                                                                                                                             | 1                                                                                                                                             |
 |  clustering              | None                                                                                                                                          | None                                                                                                                                          |
 |  compiler                | gcc 9.2                                                                                                                                       | gcc 9.2                                                                                                                                       |
 |  cores                   | 0                                                                                                                                             | 0                                                                                                                                             |
 |  date                    | 2021-03-11 23:20:56                                                                                                                           | 2021-03-12 07:37:47                                                                                                                           |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                       | {'default': {'encoding': 'Dictionary'}}                                                                                                       |
 |  indexes                 | False                                                                                                                                         | False                                                                                                                                         |
 |  max_duration            | 60000000000                                                                                                                                   | 60000000000                                                                                                                                   |
 |  max_runs                | -1                                                                                                                                            | -1                                                                                                                                            |
 |  scale_factor            | 1.0                                                                                                                                           | 1.0                                                                                                                                           |
 |  time_unit               | ns                                                                                                                                            | ns                                                                                                                                            |
 |  use_prepared_statements | False                                                                                                                                         | False                                                                                                                                         |
 |  using_scheduler         | False                                                                                                                                         | False                                                                                                                                         |
 |  verify                  | False                                                                                                                                         | False                                                                                                                                         |
 |  warmup_duration         | 0                                                                                                                                             | 0                                                                                                                                             |
 +--------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||   1035.4 |  1057.8 |   +2%  ||     0.97 |     0.95 |   -2%  |  0.0754 |
 | TPC-H 02 ||      9.3 |     9.5 |   +2%  ||   107.42 |   105.19 |   -2%  |  0.0929 |
 | TPC-H 03 ||    180.8 |   180.3 |   -0%  ||     5.53 |     5.55 |   +0%  |  0.1033 |
-| TPC-H 04 ||    109.4 |   556.4 | +408%  ||     9.14 |     1.80 |  -80%  |  0.0000 |
 | TPC-H 05 ||    365.5 |   362.2 |   -1%  ||     2.74 |     2.76 |   +1%  |  0.0508 |
 | TPC-H 06 ||     33.4 |    33.5 |   +0%  ||    29.90 |    29.85 |   -0%  |  0.4002 |
 | TPC-H 07 ||    144.9 |   148.4 |   +2%  ||     6.90 |     6.74 |   -2%  |  0.0133 |
 | TPC-H 08 ||    123.3 |   121.7 |   -1%  ||     8.11 |     8.22 |   +1%  |  0.0208 |
 | TPC-H 09 ||    799.0 |   800.8 |   +0%  ||     1.25 |     1.25 |   -0%  |  0.6232 |
 | TPC-H 10 ||    221.6 |   222.5 |   +0%  ||     4.51 |     4.49 |   -0%  |  0.0760 |
 | TPC-H 11 ||     10.7 |    10.7 |   +0%  ||    93.68 |    93.32 |   -0%  |  0.0073 |
 | TPC-H 12 ||    136.5 |   136.4 |   -0%  ||     7.33 |     7.33 |   +0%  |  0.9293 |
 | TPC-H 13 ||    661.6 |   656.1 |   -1%  ||     1.51 |     1.52 |   +1%  |  0.0000 |
 | TPC-H 14 ||     70.2 |    70.3 |   +0%  ||    14.24 |    14.22 |   -0%  |  0.4720 |
 | TPC-H 15 ||     41.6 |    41.6 |   -0%  ||    24.03 |    24.04 |   +0%  |  0.7965 |
 | TPC-H 16 ||    123.4 |   123.3 |   -0%  ||     8.10 |     8.11 |   +0%  |  0.5707 |
 | TPC-H 17 ||     43.2 |    43.1 |   -0%  ||    23.16 |    23.19 |   +0%  |  0.5494 |
 | TPC-H 18 ||    509.5 |   509.3 |   -0%  ||     1.96 |     1.96 |   +0%  |  0.9273 |
+| TPC-H 19 ||     66.2 |    61.8 |   -7%  ||    15.10 |    16.18 |   +7%  |  0.0000 |
 | TPC-H 20 ||     76.3 |    76.4 |   +0%  ||    13.10 |    13.09 |   -0%  |  0.8726 |
 | TPC-H 21 ||    504.3 |   521.8 |   +3%  ||     1.98 |     1.92 |   -3%  |  0.0723 |
 | TPC-H 22 ||     65.7 |    66.4 |   +1%  ||    15.21 |    15.06 |   -1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
-| Sum      ||   5331.9 |  5810.2 |   +9%  ||          |          |        |         |
-| Geomean  ||          |         |        ||          |          |   -7%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, clustering config 'Pruning', SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +1%
 || 
Geometric mean of throughput changes: -3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_7f102c819ef58675cce062d2dff039d215842a17_mt_clustered.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_3eedda59d0745047abafe049bca149f337feeaa3_mt_clustered.json |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                                       | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                                       |
 |  benchmark_mode               | Ordered                                                                                                                                              | Ordered                                                                                                                                              |
 |  build_type                   | release                                                                                                                                              | release                                                                                                                                              |
 |  chunk_size                   | 65535                                                                                                                                                | 65535                                                                                                                                                |
 |  clients                      | 50                                                                                                                                                   | 50                                                                                                                                                   |
 |  clustering                   | Pruning                                                                                                                                              | Pruning                                                                                                                                              |
 |  compiler                     | gcc 9.2                                                                                                                                              | gcc 9.2                                                                                                                                              |
 |  cores                        | 0                                                                                                                                                    | 0                                                                                                                                                    |
 |  date                         | 2021-03-11 23:43:17                                                                                                                                  | 2021-03-12 08:00:06                                                                                                                                  |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                              | {'default': {'encoding': 'Dictionary'}}                                                                                                              |
 |  indexes                      | False                                                                                                                                                | False                                                                                                                                                |
 |  max_duration                 | 60000000000                                                                                                                                          | 60000000000                                                                                                                                          |
 |  max_runs                     | -1                                                                                                                                                   | -1                                                                                                                                                   |
 |  scale_factor                 | 10.0                                                                                                                                                 | 10.0                                                                                                                                                 |
 |  time_unit                    | ns                                                                                                                                                   | ns                                                                                                                                                   |
 |  use_prepared_statements      | False                                                                                                                                                | False                                                                                                                                                |
 |  using_scheduler              | True                                                                                                                                                 | True                                                                                                                                                 |
 |  utilized_cores_per_numa_node | [0, 0, 20, 0]                                                                                                                                        | [0, 0, 20, 0]                                                                                                                                        |
 |  verify                       | False                                                                                                                                                | False                                                                                                                                                |
 |  warmup_duration              | 0                                                                                                                                                    | 0                                                                                                                                                    |
 +-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |      new |        ||      old |      new |        |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||  22961.3 |  21414.0 |   -7%  ||     0.67 |     0.67 |   +0%  |  0.2145 |
 | TPC-H 02 ||    165.8 |    159.7 |   -4%  ||   139.68 |   140.41 |   +1%  |  0.0013 |
 | TPC-H 03 ||   9575.5 |   8900.8 |   -7%  ||     2.57 |     2.60 |   +1%  |  0.4415 |
-| TPC-H 04 ||   9351.4 |  10923.8 |  +17%  ||     2.22 |     1.03 |  -53%  |  0.1236 |
-| TPC-H 05 ||  13546.1 |  15215.9 |  +12%  ||     1.03 |     0.98 |   -5%  |  0.1159 |
 | TPC-H 06 ||    102.8 |    104.1 |   +1%  ||   123.30 |   123.30 |   -0%  |  0.0562 |
 | TPC-H 07 ||   2748.1 |   2883.5 |   +5%  ||     7.20 |     7.27 |   +1%  |  0.2501 |
 | TPC-H 08 ||   2313.5 |   2086.5 |  -10%  ||     8.65 |     8.70 |   +1%  |  0.0038 |
-| TPC-H 09 ||  25301.3 |  25678.3 |   +1%  ||     0.48 |     0.43 |  -10%  |  0.8301 |
+| TPC-H 10 ||   8529.6 |  10411.3 |  +22%  ||     1.77 |     1.88 |   +7%  |  0.0385 |
 | TPC-H 11 ||    556.7 |    570.9 |   +3%  ||    48.51 |    48.75 |   +0%  |  0.2258 |
 | TPC-H 12 ||   2527.9 |   2483.5 |   -2%  ||     7.38 |     7.33 |   -1%  |  0.7048 |
 | TPC-H 13 ||  18141.4 |  17595.8 |   -3%  ||     0.77 |     0.78 |   +2%  |  0.3760 |
 | TPC-H 14 ||   1028.9 |    913.7 |  -11%  ||    16.77 |    16.70 |   -0%  |  0.0154 |
 | TPC-H 15 ||    467.9 |    468.6 |   +0%  ||    51.46 |    51.57 |   +0%  |  0.9019 |
 | TPC-H 16 ||   5684.4 |   5854.5 |   +3%  ||     6.78 |     6.92 |   +2%  |  0.7171 |
 | TPC-H 17 ||    949.3 |    853.2 |  -10%  ||    17.03 |    17.20 |   +1%  |  0.0013 |
+| TPC-H 18 ||  30316.2 |  30826.7 |   +2%  ||     0.30 |     0.32 |   +6%  |  0.0009 |
 | TPC-H 19 ||   1282.9 |   1208.1 |   -6%  ||    15.00 |    15.12 |   +1%  |  0.1344 |
 | TPC-H 20 ||    785.0 |    731.0 |   -7%  ||    31.83 |    31.93 |   +0%  |  0.0004 |
 | TPC-H 21 ||  16747.5 |  16331.3 |   -2%  ||     0.80 |     0.83 |   +4%  |  0.7461 |
 | TPC-H 22 ||   1353.9 |   1378.9 |   +2%  ||    10.00 |    10.07 |   +1%  |  0.4846 |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Sum      || 174437.7 | 176994.1 |   +1%  ||          |          |        |         |
 | Geomean  ||          |          |        ||          |          |   -3%  |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded (50 clients), SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +2%
 || 
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_7f102c819ef58675cce062d2dff039d215842a17_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_3eedda59d0745047abafe049bca149f337feeaa3_mt.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                             | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                             |
 |  benchmark_mode               | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type                   | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                      | 50                                                                                                                                         | 50                                                                                                                                         |
 |  clustering                   | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                     | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                        | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                         | 2021-03-12 00:23:30                                                                                                                        | 2021-03-12 08:40:39                                                                                                                        |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                      | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration                 | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                     | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor                 | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit                    | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements      | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                       | True                                                                                                                                       |
 |  utilized_cores_per_numa_node | [0, 0, 20, 0]                                                                                                                              | [0, 0, 20, 0]                                                                                                                              |
 |  verify                       | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration              | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |      new |        ||      old |      new |        |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
+| TPC-H 01 ||  21475.7 |  20918.6 |   -3%  ||     0.68 |     0.75 |  +10%  |  0.5874 |
 | TPC-H 02 ||    158.9 |    160.1 |   +1%  ||   141.11 |   141.43 |   +0%  |  0.5618 |
 | TPC-H 03 ||  10730.0 |  11222.8 |   +5%  ||     2.02 |     1.97 |   -2%  |  0.6202 |
-| TPC-H 04 ||   5117.4 |   9942.4 |  +94%  ||     3.30 |     1.22 |  -63%  |  0.0000 |
+| TPC-H 05 ||  10510.5 |  10127.3 |   -4%  ||     1.22 |     1.38 |  +14%  |  0.6009 |
 | TPC-H 06 ||    504.0 |    501.8 |   -0%  ||    30.16 |    30.03 |   -0%  |  0.7431 |
 | TPC-H 07 ||   4240.5 |   4846.5 |  +14%  ||     4.72 |     4.70 |   -0%  |  0.0233 |
 | TPC-H 08 ||   3290.1 |   3319.9 |   +1%  ||     6.43 |     6.43 |   +0%  |  0.8490 |
-| TPC-H 09 ||  25031.8 |  23596.8 |   -6%  ||     0.53 |     0.45 |  -16%  |  0.4624 |
-| TPC-H 10 ||   9797.3 |   9976.5 |   +2%  ||     1.73 |     1.62 |   -7%  |  0.8197 |
 | TPC-H 11 ||    553.6 |    573.6 |   +4%  ||    48.69 |    48.78 |   +0%  |  0.0737 |
 | TPC-H 12 ||   3289.8 |   3450.5 |   +5%  ||     5.15 |     5.13 |   -0%  |  0.2683 |
 | TPC-H 13 ||  16468.5 |  16101.3 |   -2%  ||     0.90 |     0.88 |   -2%  |  0.5554 |
 | TPC-H 14 ||   1598.0 |   1595.2 |   -0%  ||     9.65 |     9.65 |   -0%  |  0.9654 |
 | TPC-H 15 ||    995.4 |    990.9 |   -0%  ||    19.88 |    19.93 |   +0%  |  0.7688 |
 | TPC-H 16 ||   5294.4 |   4878.6 |   -8%  ||     6.87 |     6.83 |   -0%  |  0.2614 |
 | TPC-H 17 ||    917.7 |    872.8 |   -5%  ||    17.22 |    17.30 |   +0%  |  0.0818 |
 | TPC-H 18 ||  11343.0 |  12313.8 |   +9%  ||     1.67 |     1.63 |   -2%  |  0.1594 |
 | TPC-H 19 ||   1100.4 |   1181.5 |   +7%  ||    14.92 |    15.18 |   +2%  |  0.0143 |
 | TPC-H 20 ||   1706.0 |   1698.1 |   -0%  ||    10.83 |    10.86 |   +0%  |  0.8618 |
+| TPC-H 21 ||  13284.8 |  12349.4 |   -7%  ||     1.05 |     1.10 |   +5%  |  0.3267 |
 | TPC-H 22 ||   1332.7 |   1336.7 |   +0%  ||    10.10 |     9.93 |   -2%  |  0.9080 |
 +----------++----------+----------+--------++----------+----------+--------+---------+
 | Sum      || 148740.5 | 151955.3 |   +2%  ||          |          |        |         |
-| Geomean  ||          |          |        ||          |          |   -5%  |         |
 +----------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 || 
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_7f102c819ef58675cce062d2dff039d215842a17_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_3eedda59d0745047abafe049bca149f337feeaa3_st.json |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                              | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                              |
 |  benchmark_mode  | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type      | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size      | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients         | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler        | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores           | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date            | 2021-03-12 00:54:31                                                                                                                         | 2021-03-12 09:12:25                                                                                                                         |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes         | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration    | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs        | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler | False                                                                                                                                       | False                                                                                                                                       |
 |  verify          | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration | 0                                                                                                                                           | 0                                                                                                                                           |
 +------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||     42.6 |    43.0 |   +1%  ||    23.48 |    23.25 |   -1%  |  0.0000 |
 | 03      ||     10.9 |    10.9 |   -0%  ||    92.00 |    92.09 |   +0%  |  0.0083 |
 | 06      ||     29.9 |    29.8 |   -0%  ||    33.43 |    33.56 |   +0%  |  0.0007 |
 | 07      ||     58.6 |    58.4 |   -0%  ||    17.08 |    17.12 |   +0%  |  0.0082 |
 | 09      ||    156.6 |   155.4 |   -1%  ||     6.39 |     6.43 |   +1%  |  0.0001 |
 | 10      ||     35.3 |    35.6 |   +1%  ||    28.35 |    28.05 |   -1%  |  0.0000 |
 | 13      ||    105.5 |   105.2 |   -0%  ||     9.48 |     9.50 |   +0%  |  0.8931 |
 | 15      ||     17.7 |    17.7 |   -0%  ||    56.43 |    56.51 |   +0%  |  0.0298 |
 | 17      ||     52.3 |    52.5 |   +0%  ||    19.12 |    19.05 |   -0%  |  0.7556 |
 | 19      ||     15.1 |    15.1 |   -0%  ||    66.17 |    66.23 |   +0%  |  0.5690 |
 | 25      ||     25.7 |    25.6 |   -0%  ||    38.91 |    39.04 |   +0%  |  0.7627 |
 | 26      ||     27.2 |    27.1 |   -0%  ||    36.73 |    36.86 |   +0%  |  0.0046 |
 | 28      ||    591.5 |   594.7 |   +1%  ||     1.69 |     1.68 |   -1%  |  0.0008 |
 | 29      ||     44.7 |    45.1 |   +1%  ||    22.38 |    22.14 |   -1%  |  0.3225 |
 | 31      ||    216.7 |   217.2 |   +0%  ||     4.61 |     4.60 |   -0%  |  0.2890 |
 | 34      ||     28.9 |    29.0 |   +0%  ||    34.59 |    34.51 |   -0%  |  0.0062 |
 | 35      ||    123.8 |   123.6 |   -0%  ||     8.08 |     8.09 |   +0%  |  0.0890 |
 | 39a     ||    247.7 |   246.2 |   -1%  ||     4.04 |     4.06 |   +1%  |  0.0018 |
 | 39b     ||    244.9 |   242.9 |   -1%  ||     4.08 |     4.12 |   +1%  |  0.0000 |
 | 41      ||     62.2 |    60.6 |   -3%  ||    16.07 |    16.50 |   +3%  |  0.0000 |
 | 42      ||     12.0 |    12.0 |   -0%  ||    83.52 |    83.52 |   +0%  |  0.8926 |
 | 43      ||    407.4 |   407.5 |   +0%  ||     2.45 |     2.45 |   -0%  |  0.7557 |
 | 45      ||     16.4 |    16.5 |   +0%  ||    60.82 |    60.54 |   -0%  |  0.0000 |
 | 48      ||    114.5 |   114.9 |   +0%  ||     8.73 |     8.70 |   -0%  |  0.2674 |
 | 50      ||     16.8 |    16.8 |   +0%  ||    59.58 |    59.48 |   -0%  |  0.2119 |
 | 52      ||     12.2 |    12.2 |   +0%  ||    82.17 |    82.15 |   -0%  |  0.3792 |
 | 55      ||     11.8 |    11.9 |   +0%  ||    84.37 |    84.35 |   -0%  |  0.5674 |
 | 62      ||     95.7 |    95.4 |   -0%  ||    10.45 |    10.48 |   +0%  |  0.0079 |
 | 65      ||    114.0 |   113.8 |   -0%  ||     8.77 |     8.78 |   +0%  |  0.1172 |
 | 69      ||     31.2 |    31.3 |   +0%  ||    32.07 |    31.99 |   -0%  |  0.0042 |
 | 73      ||     15.6 |    15.6 |   -0%  ||    63.98 |    64.17 |   +0%  |  0.0000 |
 | 79      ||     75.0 |    75.0 |   +0%  ||    13.34 |    13.33 |   -0%  |  0.5084 |
 | 81      ||     27.4 |    27.5 |   +0%  ||    36.46 |    36.32 |   -0%  |  0.0000 |
 | 83      ||     14.8 |    14.9 |   +1%  ||    67.33 |    66.87 |   -1%  |  0.0000 |
 | 85      ||     62.9 |    63.0 |   +0%  ||    15.90 |    15.86 |   -0%  |  0.9489 |
 | 88      ||    104.4 |   104.2 |   -0%  ||     9.58 |     9.60 |   +0%  |  0.3310 |
 | 91      ||     20.0 |    19.9 |   -1%  ||    49.92 |    50.29 |   +1%  |  0.0000 |
 | 93      ||    460.0 |   462.1 |   +0%  ||     2.17 |     2.16 |   -0%  |  0.0324 |
 | 96      ||     11.1 |    11.1 |   -0%  ||    90.18 |    90.27 |   +0%  |  0.0219 |
 | 97      ||    631.9 |   615.3 |   -3%  ||     1.58 |     1.63 |   +3%  |  0.0000 |
 | 99      ||    198.7 |   198.4 |   -0%  ||     5.03 |     5.04 |   +0%  |  0.3064 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||   4591.6 |  4574.8 |   -0%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +0%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -1%
 || 
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_7f102c819ef58675cce062d2dff039d215842a17_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_3eedda59d0745047abafe049bca149f337feeaa3_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                              | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                              |
 |  benchmark_mode               | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 50                                                                                                                                          | 50                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2021-03-12 01:35:37                                                                                                                         | 2021-03-12 09:53:31                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 0, 20, 0]                                                                                                                               | [0, 0, 20, 0]                                                                                                                               |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    214.4 |   215.3 |   +0%  ||   199.99 |   199.66 |   -0%  |  0.7571 |
 | 03      ||     29.9 |    30.4 |   +2%  ||   735.04 |   735.52 |   +0%  |  0.0008 |
 | 06      ||    128.9 |   128.9 |   +0%  ||   263.78 |   263.64 |   -0%  |  0.9775 |
 | 07      ||    123.9 |   124.7 |   +1%  ||   181.08 |   180.85 |   -0%  |  0.4108 |
 | 09      ||    281.2 |   276.4 |   -2%  ||    85.16 |    85.21 |   +0%  |  0.0942 |
 | 10      ||     76.7 |    77.6 |   +1%  ||   266.28 |   265.79 |   -0%  |  0.1905 |
 | 13      ||    735.2 |   713.8 |   -3%  ||    60.91 |    60.94 |   +0%  |  0.3605 |
 | 15      ||    118.7 |   118.5 |   -0%  ||   396.36 |   397.92 |   +0%  |  0.9186 |
 | 17      ||    132.1 |   133.3 |   +1%  ||   172.71 |   172.70 |   -0%  |  0.3651 |
 | 19      ||     51.4 |    50.5 |   -2%  ||   549.22 |   548.74 |   -0%  |  0.0175 |
 | 25      ||    127.6 |   126.1 |   -1%  ||   313.81 |   313.91 |   +0%  |  0.3949 |
 | 26      ||     78.5 |    78.9 |   +0%  ||   322.97 |   322.97 |   +0%  |  0.5787 |
 | 28      ||   1177.5 |  1160.0 |   -1%  ||     8.73 |     8.77 |   +0%  |  0.6673 |
 | 29      ||    127.4 |   123.5 |   -3%  ||   192.72 |   192.23 |   -0%  |  0.0035 |
 | 31      ||    262.6 |   263.2 |   +0%  ||    40.22 |    40.15 |   -0%  |  0.8798 |
 | 34      ||     68.4 |    69.0 |   +1%  ||   299.16 |   299.14 |   -0%  |  0.1174 |
 | 35      ||    716.8 |   720.8 |   +1%  ||    64.70 |    64.61 |   -0%  |  0.8678 |
 | 39a     ||   1535.5 |  1492.9 |   -3%  ||    27.63 |    27.58 |   -0%  |  0.6357 |
 | 39b     ||   1472.1 |  1437.8 |   -2%  ||    27.62 |    27.86 |   +1%  |  0.6805 |
 | 41      ||    116.7 |   116.3 |   -0%  ||   151.59 |   152.17 |   +0%  |  0.0002 |
 | 42      ||     29.0 |    28.9 |   -0%  ||   675.51 |   674.74 |   -0%  |  0.7026 |
 | 43      ||   1083.1 |  1058.2 |   -2%  ||    23.62 |    23.60 |   -0%  |  0.4426 |
 | 45      ||     75.1 |    73.8 |   -2%  ||   500.02 |   500.87 |   +0%  |  0.1081 |
 | 48      ||    311.5 |   321.6 |   +3%  ||    76.75 |    76.83 |   +0%  |  0.0576 |
 | 50      ||     50.8 |    51.3 |   +1%  ||   430.25 |   430.02 |   -0%  |  0.0401 |
 | 52      ||     29.3 |    29.7 |   +1%  ||   667.04 |   665.75 |   -0%  |  0.0018 |
 | 55      ||     26.0 |    26.4 |   +2%  ||   686.01 |   683.80 |   -0%  |  0.0001 |
 | 62      ||    397.3 |   402.8 |   +1%  ||    89.84 |    89.83 |   -0%  |  0.4855 |
 | 65      ||    641.1 |   637.5 |   -1%  ||    66.98 |    66.91 |   -0%  |  0.7893 |
 | 69      ||     73.6 |    75.1 |   +2%  ||   294.21 |   293.66 |   -0%  |  0.0337 |
 | 73      ||     36.8 |    36.9 |   +0%  ||   525.88 |   525.06 |   -0%  |  0.5554 |
 | 79      ||    287.5 |   288.9 |   +0%  ||   131.93 |   131.82 |   -0%  |  0.7591 |
 | 81      ||    140.6 |   139.8 |   -1%  ||   311.59 |   310.99 |   -0%  |  0.6624 |
 | 83      ||     38.2 |    38.7 |   +1%  ||   550.05 |   549.40 |   -0%  |  0.0285 |
 | 85      ||    195.0 |   195.1 |   +0%  ||   116.90 |   117.04 |   +0%  |  0.9892 |
 | 88      ||    214.4 |   203.6 |   -5%  ||    75.83 |    75.64 |   -0%  |  0.0000 |
 | 91      ||     98.5 |    98.3 |   -0%  ||   295.20 |   294.67 |   -0%  |  0.7943 |
 | 93      ||   2149.5 |  2171.5 |   +1%  ||    20.08 |    20.23 |   +1%  |  0.8418 |
 | 96      ||     23.0 |    23.0 |   +0%  ||   696.32 |   695.29 |   -0%  |  0.7796 |
 | 97      ||   1777.9 |  1758.7 |   -1%  ||    14.15 |    14.10 |   -0%  |  0.7429 |
 | 99      ||    887.3 |   886.8 |   -0%  ||    42.06 |    42.25 |   +0%  |  0.9832 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  16141.1 | 16004.7 |   -1%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   -0%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 || 
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview-----------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_7f102c819ef58675cce062d2dff039d215842a17_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_3eedda59d0745047abafe049bca149f337feeaa3_st.json |
 +------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                             | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                             |
 |  benchmark_mode  | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type      | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size      | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients         | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler        | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores           | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date            | 2021-03-12 02:17:08                                                                                                                        | 2021-03-12 10:35:03                                                                                                                        |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes         | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration    | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs        | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor    | 1                                                                                                                                          | 1                                                                                                                                          |
 |  time_unit       | ns                                                                                                                                         | ns                                                                                                                                         |
 |  using_scheduler | False                                                                                                                                      | False                                                                                                                                      |
 |  verify          | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration | 0                                                                                                                                          | 0                                                                                                                                          |
 +------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||     64.5 |    64.8 |   +0%  ||     1.66 |     1.65 |   -1%  | (run time too short) |
 | New-Order    ||     41.3 |    41.7 |   +1%  ||    18.70 |    18.55 |   -1%  | (run time too short) |
 | Order-Status ||      2.8 |     2.8 |   -0%  ||     1.66 |     1.65 |   -1%  | (run time too short) |
 | Payment      ||      5.7 |     5.7 |   -0%  ||    17.85 |    17.72 |   -1%  | (run time too short) |
 | Stock-Level  ||      7.9 |     7.9 |   +0%  ||     1.65 |     1.63 |   -1%  | (run time too short) |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    122.2 |   122.9 |   +1%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -1%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: +3%
 || 
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_7f102c819ef58675cce062d2dff039d215842a17_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_3eedda59d0745047abafe049bca149f337feeaa3_mt.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                             | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                             |
 |  benchmark_mode               | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type                   | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                      | 50                                                                                                                                         | 50                                                                                                                                         |
 |  compiler                     | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                        | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                         | 2021-03-12 02:18:20                                                                                                                        | 2021-03-12 10:36:15                                                                                                                        |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                      | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration                 | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                     | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                         | ns                                                                                                                                         |
 |  using_scheduler              | True                                                                                                                                       | True                                                                                                                                       |
 |  utilized_cores_per_numa_node | [0, 0, 20, 0]                                                                                                                              | [0, 0, 20, 0]                                                                                                                              |
 |  verify                       | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration              | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |              ||      old |     new |        ||      old |      new |        |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Delivery     ||    143.3 |   149.5 |   +4%  ||     6.69 |     6.42 |   -4%  | (run time too short) |
 |    unsucc.:  ||      2.3 |     2.2 |   -6%  ||   139.60 |   139.21 |   -0%  |                      |
 | New-Order    ||     83.5 |    84.2 |   +1%  ||   106.01 |   105.50 |   -0%  |               0.3314 |
 |    unsucc.:  ||      1.7 |     1.7 |   -1%  ||  1539.88 |  1532.87 |   -0%  |                      |
 | Order-Status ||      6.0 |     6.3 |   +5%  ||   146.31 |   145.65 |   -0%  | (run time too short) |
 | Payment      ||     10.2 |    10.2 |   -0%  ||     9.92 |     9.68 |   -2%  | (run time too short) |
 |    unsucc.:  ||      2.1 |     2.2 |   +2%  ||  1562.97 |  1556.01 |   -0%  |                      |
 | Stock-Level  ||     12.8 |    13.3 |   +4%  ||   146.31 |   145.62 |   -0%  |               0.0094 |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum          ||    255.8 |   263.4 |   +3%  ||          |          |        |                      |
 | Geomean      ||          |         |        ||          |          |   -2%  |                      |
 +--------------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 || 
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter        | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_7f102c819ef58675cce062d2dff039d215842a17_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_3eedda59d0745047abafe049bca149f337feeaa3_st.json |
 +------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH        | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                                  | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                                  |
 |  benchmark_mode  | Ordered                                                                                                                                         | Ordered                                                                                                                                         |
 |  build_type      | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_size      | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients         | 1                                                                                                                                               | 1                                                                                                                                               |
 |  compiler        | gcc 9.2                                                                                                                                         | gcc 9.2                                                                                                                                         |
 |  cores           | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date            | 2021-03-12 02:19:34                                                                                                                             | 2021-03-12 10:37:29                                                                                                                             |
 |  encoding        | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  indexes         | False                                                                                                                                           | False                                                                                                                                           |
 |  max_duration    | 60000000000                                                                                                                                     | 60000000000                                                                                                                                     |
 |  max_runs        | -1                                                                                                                                              | -1                                                                                                                                              |
 |  time_unit       | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler | False                                                                                                                                           | False                                                                                                                                           |
 |  verify          | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration | 0                                                                                                                                               | 0                                                                                                                                               |
 +------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    727.1 |    727.6 |   +0%  ||     1.38 |     1.37 |   -0%  |  0.9124 |
 | 10b     ||    710.8 |    708.8 |   -0%  ||     1.41 |     1.41 |   +0%  |  0.2774 |
 | 10c     ||   1639.6 |   1644.7 |   +0%  ||     0.61 |     0.61 |   -0%  |  0.5167 |
 | 11a     ||    267.2 |    267.2 |   -0%  ||     3.74 |     3.74 |   +0%  |  0.9830 |
 | 11b     ||    256.9 |    254.1 |   -1%  ||     3.89 |     3.94 |   +1%  |  0.5147 |
 | 11c     ||   1013.4 |   1028.9 |   +2%  ||     0.99 |     0.97 |   -2%  |  0.3636 |
 | 11d     ||  11062.8 |  11192.9 |   +1%  ||     0.09 |     0.09 |   -1%  |       ˅ |
 | 12a     ||    586.7 |    587.0 |   +0%  ||     1.70 |     1.70 |   -0%  |  0.9764 |
-| 12b     ||    349.8 |   1086.1 | +210%  ||     2.86 |     0.92 |  -68%  |  0.0000 |
 | 12c     ||   6627.3 |   6614.5 |   -0%  ||     0.15 |     0.15 |   +0%  |  0.9041 |
 | 13a     ||    329.9 |    329.7 |   -0%  ||     3.03 |     3.03 |   +0%  |  0.7517 |
 | 13b     ||    425.4 |    427.6 |   +1%  ||     2.35 |     2.34 |   -1%  |  0.0395 |
 | 13c     ||    313.2 |    312.4 |   -0%  ||     3.19 |     3.20 |   +0%  |  0.3354 |
 | 13d     ||    330.3 |    329.6 |   -0%  ||     3.03 |     3.03 |   +0%  |  0.3027 |
 | 14a     ||   8022.5 |   8023.0 |   +0%  ||     0.12 |     0.12 |   -0%  |       ˅ |
-| 14b     ||   8377.1 |   9065.8 |   +8%  ||     0.12 |     0.11 |   -8%  |       ˅ |
 | 14c     ||   8027.7 |   8019.2 |   -0%  ||     0.12 |     0.12 |   +0%  |       ˅ |
 | 15a     ||    403.5 |    391.7 |   -3%  ||     2.48 |     2.55 |   +3%  |  0.0018 |
 | 15b     ||    396.4 |    383.5 |   -3%  ||     2.52 |     2.61 |   +3%  |  0.0000 |
 | 15c     ||    302.8 |    302.8 |   +0%  ||     3.30 |     3.30 |   -0%  |  0.9894 |
 | 15d     ||    940.8 |    923.3 |   -2%  ||     1.06 |     1.08 |   +2%  |  0.0018 |
 | 16a     ||  10121.9 |  10098.0 |   -0%  ||     0.10 |     0.10 |   +0%  |       ˅ |
 | 16b     ||  13325.9 |  13271.9 |   -0%  ||     0.08 |     0.08 |   +0%  |       ˅ |
 | 16c     ||  10449.2 |  10525.0 |   +1%  ||     0.10 |     0.10 |   -1%  |       ˅ |
 | 16d     ||  10357.7 |  10342.5 |   -0%  ||     0.10 |     0.10 |   +0%  |       ˅ |
 | 17a     ||   1882.8 |   1881.2 |   -0%  ||     0.53 |     0.53 |   +0%  |  0.9374 |
 | 17b     ||   1523.7 |   1518.0 |   -0%  ||     0.66 |     0.66 |   +0%  |  0.7203 |
 | 17c     ||   1456.3 |   1444.8 |   -1%  ||     0.69 |     0.69 |   +1%  |  0.4260 |
 | 17d     ||   1648.9 |   1633.8 |   -1%  ||     0.61 |     0.61 |   +1%  |  0.3619 |
 | 17e     ||   5423.9 |   5419.8 |   -0%  ||     0.18 |     0.18 |   +0%  |  0.9481 |
 | 17f     ||   3036.3 |   3036.3 |   +0%  ||     0.33 |     0.33 |   -0%  |  0.9998 |
 | 18a     ||   1173.6 |   1176.0 |   +0%  ||     0.85 |     0.85 |   -0%  |  0.8302 |
 | 18b     ||    528.8 |    529.3 |   +0%  ||     1.89 |     1.89 |   -0%  |  0.9229 |
 | 18c     ||   6956.6 |   6954.5 |   -0%  ||     0.14 |     0.14 |   +0%  |       ˅ |
 | 19a     ||  10419.9 |  10414.9 |   -0%  ||     0.10 |     0.10 |   +0%  |       ˅ |
 | 19b     ||   4862.3 |   4865.3 |   +0%  ||     0.21 |     0.21 |   -0%  |  0.9124 |
 | 19c     ||  10097.0 |  10056.8 |   -0%  ||     0.10 |     0.10 |   +0%  |       ˅ |
 | 19d     ||  10935.1 |  10869.1 |   -1%  ||     0.09 |     0.09 |   +1%  |       ˅ |
 | 1a      ||    113.4 |    116.1 |   +2%  ||     8.82 |     8.61 |   -2%  |  0.0000 |
 | 1b      ||     48.6 |     48.8 |   +0%  ||    20.57 |    20.49 |   -0%  |  0.0000 |
 | 1c      ||     48.6 |     48.8 |   +0%  ||    20.56 |    20.49 |   -0%  |  0.0000 |
 | 1d      ||     48.5 |     48.8 |   +0%  ||    20.60 |    20.51 |   -0%  |  0.0000 |
 | 20a     ||   2211.1 |   2207.2 |   -0%  ||     0.45 |     0.45 |   +0%  |  0.6012 |
 | 20b     ||   1886.7 |   1877.1 |   -1%  ||     0.53 |     0.53 |   +1%  |  0.1290 |
 | 20c     ||   1222.4 |   1223.0 |   +0%  ||     0.82 |     0.82 |   -0%  |  0.8814 |
 | 21a     ||   7329.7 |   7330.2 |   +0%  ||     0.14 |     0.14 |   -0%  |       ˅ |
 | 21b     ||    408.4 |    407.9 |   -0%  ||     2.45 |     2.45 |   +0%  |  0.8042 |
 | 21c     ||   7651.3 |   7642.2 |   -0%  ||     0.13 |     0.13 |   +0%  |       ˅ |
 | 22a     ||   6292.4 |   6281.9 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.9121 |
 | 22b     ||   6296.9 |   6280.8 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.8719 |
 | 22c     ||   8032.1 |   8029.6 |   -0%  ||     0.12 |     0.12 |   +0%  |       ˅ |
 | 22d     ||   8063.1 |   8062.9 |   -0%  ||     0.12 |     0.12 |   +0%  |       ˅ |
 | 23a     ||    302.1 |    301.6 |   -0%  ||     3.31 |     3.32 |   +0%  |  0.7897 |
 | 23b     ||    214.7 |    215.7 |   +0%  ||     4.66 |     4.64 |   -0%  |  0.4231 |
 | 23c     ||    322.5 |    322.1 |   -0%  ||     3.10 |     3.10 |   +0%  |  0.8387 |
 | 24a     ||   5013.1 |   5010.2 |   -0%  ||     0.20 |     0.20 |   +0%  |  0.9597 |
 | 24b     ||   4875.9 |   4881.5 |   +0%  ||     0.21 |     0.20 |   -0%  |  0.9636 |
 | 25a     ||    533.0 |    534.4 |   +0%  ||     1.88 |     1.87 |   -0%  |  0.6755 |
 | 25b     ||    560.5 |    561.3 |   +0%  ||     1.78 |     1.78 |   -0%  |  0.7969 |
 | 25c     ||   6959.9 |   6962.2 |   +0%  ||     0.14 |     0.14 |   -0%  |       ˅ |
 | 26a     ||   1045.1 |   1046.5 |   +0%  ||     0.96 |     0.96 |   -0%  |  0.8791 |
 | 26b     ||   1015.9 |   1015.9 |   -0%  ||     0.98 |     0.98 |   +0%  |  0.9961 |
 | 26c     ||   1044.5 |   1045.9 |   +0%  ||     0.96 |     0.96 |   -0%  |  0.8786 |
 | 27a     ||   6215.2 |   6210.4 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.9382 |
 | 27b     ||   6175.5 |   6167.0 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.8929 |
 | 27c     ||    361.5 |    362.2 |   +0%  ||     2.77 |     2.76 |   -0%  |  0.8804 |
 | 28a     ||   8167.0 |   8162.6 |   -0%  ||     0.12 |     0.12 |   +0%  |       ˅ |
 | 28b     ||   6163.8 |   6162.5 |   -0%  ||     0.16 |     0.16 |   +0%  |  0.9968 |
 | 28c     ||   8166.7 |   8164.8 |   -0%  ||     0.12 |     0.12 |   +0%  |       ˅ |
 | 29a     ||   5002.9 |   4949.7 |   -1%  ||     0.20 |     0.20 |   +1%  |  0.9181 |
 | 29b     ||    344.5 |    343.0 |   -0%  ||     2.90 |     2.91 |   +0%  |  0.9674 |
 | 29c     ||   5265.3 |   5239.4 |   -0%  ||     0.19 |     0.19 |   +0%  |  0.9599 |
 | 2a      ||    179.5 |    180.2 |   +0%  ||     5.57 |     5.55 |   -0%  |  0.0029 |
 | 2b      ||    149.4 |    149.8 |   +0%  ||     6.69 |     6.68 |   -0%  |  0.0216 |
 | 2c      ||    102.9 |    103.2 |   +0%  ||     9.72 |     9.69 |   -0%  |  0.0002 |
 | 2d      ||    223.2 |    222.8 |   -0%  ||     4.48 |     4.49 |   +0%  |  0.1534 |
 | 30a     ||    570.7 |    569.2 |   -0%  ||     1.75 |     1.76 |   +0%  |  0.9350 |
-| 30b     ||    890.2 |   1984.9 | +123%  ||     1.12 |     0.50 |  -55%  |  0.0000 |
 | 30c     ||   7075.6 |   7075.3 |   -0%  ||     0.14 |     0.14 |   +0%  |       ˅ |
 | 31a     ||    633.2 |    632.7 |   -0%  ||     1.58 |     1.58 |   +0%  |  0.9640 |
-| 31b     ||    949.8 |   2035.4 | +114%  ||     1.05 |     0.49 |  -53%  |  0.0000 |
 | 31c     ||    638.9 |    640.6 |   +0%  ||     1.57 |     1.56 |   -0%  |  0.8711 |
 | 32a     ||     90.4 |     90.2 |   -0%  ||    11.06 |    11.09 |   +0%  |  0.0307 |
 | 32b     ||    506.7 |    504.8 |   -0%  ||     1.97 |     1.98 |   +0%  |  0.0064 |
 | 33a     ||    142.4 |    142.8 |   +0%  ||     7.02 |     7.00 |   -0%  |  0.8309 |
 | 33b     ||    141.4 |    141.7 |   +0%  ||     7.07 |     7.06 |   -0%  |  0.8322 |
 | 33c     ||    163.8 |    164.1 |   +0%  ||     6.10 |     6.09 |   -0%  |  0.8795 |
 | 3a      ||   7510.0 |   7504.5 |   -0%  ||     0.13 |     0.13 |   +0%  |       ˅ |
 | 3b      ||     67.5 |     67.7 |   +0%  ||    14.82 |    14.77 |   -0%  |  0.0001 |
 | 3c      ||   9595.3 |   9592.1 |   -0%  ||     0.10 |     0.10 |   +0%  |       ˅ |
 | 4a      ||    247.6 |    247.1 |   -0%  ||     4.04 |     4.05 |   +0%  |  0.1685 |
 | 4b      ||     53.8 |     53.8 |   +0%  ||    18.59 |    18.57 |   -0%  |  0.2424 |
 | 4c      ||    282.5 |    281.2 |   -0%  ||     3.54 |     3.56 |   +0%  |  0.0348 |
 | 5a      ||   7224.5 |   7239.4 |   +0%  ||     0.14 |     0.14 |   -0%  |       ˅ |
 | 5b      ||    481.3 |    480.9 |   -0%  ||     2.08 |     2.08 |   +0%  |  0.6934 |
 | 5c      ||   8434.3 |   8431.3 |   -0%  ||     0.12 |     0.12 |   +0%  |       ˅ |
 | 6a      ||    522.9 |    522.1 |   -0%  ||     1.91 |     1.92 |   +0%  |  0.1232 |
 | 6b      ||   1919.8 |   1899.9 |   -1%  ||     0.52 |     0.53 |   +1%  |  0.0036 |
 | 6c      ||    523.2 |    524.1 |   +0%  ||     1.91 |     1.91 |   -0%  |  0.1208 |
 | 6d      ||   1915.7 |   1906.1 |   -1%  ||     0.52 |     0.52 |   +1%  |  0.0803 |
 | 6e      ||    524.3 |    522.1 |   -0%  ||     1.91 |     1.92 |   +0%  |  0.0000 |
 | 6f      ||   2926.5 |   2917.7 |   -0%  ||     0.34 |     0.34 |   +0%  |  0.1228 |
 | 7a      ||    424.9 |    424.9 |   +0%  ||     2.35 |     2.35 |   -0%  |  0.9981 |
 | 7b      ||    247.7 |    247.2 |   -0%  ||     4.04 |     4.04 |   +0%  |  0.9295 |
 | 7c      ||  22315.7 |  22280.4 |   -0%  ||     0.04 |     0.04 |   +0%  |       ˅ |
 | 8a      ||    196.8 |    198.0 |   +1%  ||     5.08 |     5.05 |   -1%  |  0.2029 |
 | 8b      ||    275.3 |    277.2 |   +1%  ||     3.63 |     3.61 |   -1%  |  0.1086 |
 | 8c      ||   7698.8 |   7731.5 |   +0%  ||     0.13 |     0.13 |   -0%  |       ˅ |
 | 8d      ||   2276.9 |   2274.6 |   -0%  ||     0.44 |     0.44 |   +0%  |  0.8307 |
 | 9a      ||   6237.6 |   6202.0 |   -1%  ||     0.16 |     0.16 |   +1%  |  0.5422 |
 | 9b      ||    567.4 |    568.8 |   +0%  ||     1.76 |     1.76 |   -0%  |  0.7871 |
 | 9c      ||   6407.6 |   6366.6 |   -1%  ||     0.16 |     0.16 |   +1%  |  0.4731 |
 | 9d      ||   7697.8 |   7640.1 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 381747.9 | 384960.3 |   +1%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -2%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 |         || ˅ Insufficient number of runs for p-value calculation                  |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded (50 clients)**
<details>
<summary>
Sum of avg. item runtimes: -0%
 || 
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_7f102c819ef58675cce062d2dff039d215842a17_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_3eedda59d0745047abafe049bca149f337feeaa3_mt.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 7f102c819ef58675cce062d2dff039d215842a17-dirty                                                                                                  | 3eedda59d0745047abafe049bca149f337feeaa3-dirty                                                                                                  |
 |  benchmark_mode               | Ordered                                                                                                                                         | Ordered                                                                                                                                         |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 50                                                                                                                                              | 50                                                                                                                                              |
 |  compiler                     | gcc 9.2                                                                                                                                         | gcc 9.2                                                                                                                                         |
 |  cores                        | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2021-03-12 04:16:22                                                                                                                             | 2021-03-12 12:34:15                                                                                                                             |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  indexes                      | False                                                                                                                                           | False                                                                                                                                           |
 |  max_duration                 | 60000000000                                                                                                                                     | 60000000000                                                                                                                                     |
 |  max_runs                     | -1                                                                                                                                              | -1                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 20, 0]                                                                                                                                   | [0, 0, 20, 0]                                                                                                                                   |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 0                                                                                                                                               | 0                                                                                                                                               |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |      new |        ||      old |      new |        |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | 10a     ||    941.7 |    972.6 |   +3%  ||    15.65 |    15.67 |   +0%  |  0.2117 |
 | 10b     ||    914.2 |    837.2 |   -8%  ||    16.02 |    16.05 |   +0%  |  0.0021 |
 | 10c     ||   3559.4 |   3443.3 |   -3%  ||     4.98 |     4.98 |   +0%  |  0.5205 |
 | 11a     ||    456.3 |    475.5 |   +4%  ||    40.61 |    40.68 |   +0%  |  0.0418 |
 | 11b     ||    408.8 |    428.7 |   +5%  ||    43.15 |    43.26 |   +0%  |  0.0161 |
 | 11c     ||   3853.0 |   3770.2 |   -2%  ||     9.55 |     9.58 |   +0%  |  0.7394 |
+| 11d     ||  25577.3 |  24426.6 |   -4%  ||     0.57 |     0.63 |  +12%  |  0.1261 |
 | 12a     ||   1967.1 |   2304.4 |  +17%  ||    13.67 |    13.82 |   +1%  |  0.0066 |
-| 12b     ||    246.5 |    627.8 | +155%  ||    33.56 |    12.45 |  -63%  |  0.0000 |
 | 12c     ||  10886.3 |  10511.8 |   -3%  ||     1.28 |     1.23 |   -4%  |  0.6826 |
 | 13a     ||    672.5 |    671.3 |   -0%  ||    29.43 |    29.51 |   +0%  |  0.9450 |
 | 13b     ||    362.9 |    358.6 |   -1%  ||    27.00 |    27.03 |   +0%  |  0.5173 |
 | 13c     ||    297.5 |    298.4 |   +0%  ||    34.00 |    34.00 |   +0%  |  0.8493 |
 | 13d     ||    706.5 |    680.0 |   -4%  ||    29.45 |    29.43 |   -0%  |  0.2743 |
+| 14a     ||  11682.2 |  10806.8 |   -7%  ||     1.10 |     1.15 |   +5%  |  0.3768 |
+| 14b     ||  12636.0 |  12036.1 |   -5%  ||     0.93 |     1.05 |  +12%  |  0.6434 |
 | 14c     ||  12378.0 |  10745.8 |  -13%  ||     1.12 |     1.17 |   +4%  |  0.1640 |
 | 15a     ||    716.7 |    680.0 |   -5%  ||    27.25 |    27.48 |   +1%  |  0.0155 |
 | 15b     ||    601.5 |    585.4 |   -3%  ||    27.95 |    27.96 |   +0%  |  0.2338 |
 | 15c     ||    528.6 |    551.2 |   +4%  ||    37.26 |    37.18 |   -0%  |  0.0622 |
 | 15d     ||   2383.9 |   2474.6 |   +4%  ||    10.78 |    10.87 |   +1%  |  0.3782 |
-| 16a     ||  20899.4 |  20589.3 |   -1%  ||     0.57 |     0.52 |   -9%  |  0.7744 |
 | 16b     ||  29047.4 |  28365.8 |   -2%  ||     0.37 |     0.37 |   +0%  |  0.7663 |
-| 16c     ||  20902.5 |  22464.6 |   +7%  ||     0.60 |     0.48 |  -19%  |  0.1314 |
+| 16d     ||  21732.3 |  20709.8 |   -5%  ||     0.52 |     0.58 |  +13%  |  0.2161 |
 | 17a     ||   3903.5 |   3439.6 |  -12%  ||     5.03 |     5.07 |   +1%  |  0.0108 |
 | 17b     ||   2612.5 |   2543.2 |   -3%  ||     6.43 |     6.32 |   -2%  |  0.5592 |
 | 17c     ||   2482.0 |   2299.6 |   -7%  ||     6.73 |     6.65 |   -1%  |  0.0807 |
 | 17d     ||   2919.8 |   2702.4 |   -7%  ||     6.07 |     6.22 |   +2%  |  0.1638 |
 | 17e     ||  13488.4 |  13471.3 |   -0%  ||     1.58 |     1.55 |   -2%  |  0.9890 |
-| 17f     ||   9690.3 |   6829.9 |  -30%  ||     3.05 |     2.90 |   -5%  |  0.0001 |
 | 18a     ||   2891.2 |   3091.4 |   +7%  ||     8.77 |     8.77 |   -0%  |  0.2757 |
 | 18b     ||    718.0 |    728.9 |   +2%  ||    20.06 |    20.15 |   +0%  |  0.5022 |
-| 18c     ||  10090.4 |   8990.8 |  -11%  ||     1.38 |     1.28 |   -7%  |  0.1529 |
+| 19a     ||  14927.7 |  15878.5 |   +6%  ||     0.65 |     0.68 |   +5%  |  0.5661 |
 | 19b     ||   7924.2 |   7347.1 |   -7%  ||     2.07 |     2.00 |   -3%  |  0.5038 |
-| 19c     ||  16327.4 |  17507.7 |   +7%  ||     0.85 |     0.68 |  -20%  |  0.5659 |
 | 19d     ||  22762.7 |  22690.1 |   -0%  ||     0.53 |     0.55 |   +3%  |  0.9305 |
 | 1a      ||     97.3 |     97.0 |   -0%  ||    97.63 |    97.97 |   +0%  |  0.7905 |
 | 1b      ||     48.1 |     47.4 |   -2%  ||   217.75 |   217.55 |   -0%  |  0.0090 |
 | 1c      ||     49.2 |     49.2 |   +0%  ||   216.15 |   216.22 |   +0%  |  0.9089 |
 | 1d      ||     48.1 |     47.3 |   -2%  ||   217.69 |   217.49 |   -0%  |  0.0029 |
 | 20a     ||   2602.0 |   2702.3 |   +4%  ||     5.10 |     5.17 |   +1%  |  0.3477 |
 | 20b     ||   2081.8 |   2108.1 |   +1%  ||     5.95 |     6.05 |   +2%  |  0.7208 |
 | 20c     ||   1539.2 |   1550.4 |   +1%  ||     8.95 |     8.93 |   -0%  |  0.7954 |
 | 21a     ||   7485.7 |   7269.2 |   -3%  ||     1.33 |     1.32 |   -1%  |  0.7955 |
 | 21b     ||   1539.7 |   1693.0 |  +10%  ||    24.65 |    24.73 |   +0%  |  0.1739 |
 | 21c     ||   8021.1 |   8112.1 |   +1%  ||     1.27 |     1.28 |   +1%  |  0.9135 |
 | 22a     ||  10012.6 |  10797.2 |   +8%  ||     1.32 |     1.35 |   +3%  |  0.3977 |
 | 22b     ||  11896.9 |  10047.4 |  -16%  ||     1.38 |     1.37 |   -1%  |  0.0437 |
+| 22c     ||  12266.9 |  12553.3 |   +2%  ||     1.07 |     1.12 |   +5%  |  0.7985 |
+| 22d     ||  12518.8 |  15234.3 |  +22%  ||     1.00 |     1.08 |   +8%  |  0.0735 |
 | 23a     ||    417.6 |    424.9 |   +2%  ||    37.18 |    37.00 |   -0%  |  0.3771 |
 | 23b     ||    310.8 |    298.7 |   -4%  ||    48.72 |    48.60 |   -0%  |  0.0385 |
 | 23c     ||    494.1 |    497.4 |   +1%  ||    34.16 |    34.03 |   -0%  |  0.7325 |
 | 24a     ||   6350.5 |   6307.4 |   -1%  ||     1.87 |     1.85 |   -1%  |  0.9290 |
 | 24b     ||   4920.5 |   5104.2 |   +4%  ||     2.00 |     1.95 |   -2%  |  0.6581 |
 | 25a     ||    803.6 |    799.1 |   -1%  ||    20.00 |    20.03 |   +0%  |  0.8276 |
 | 25b     ||    626.0 |    642.6 |   +3%  ||    19.15 |    19.13 |   -0%  |  0.2195 |
-| 25c     ||  10375.7 |  10559.5 |   +2%  ||     1.23 |     1.17 |   -5%  |  0.8545 |
 | 26a     ||   1077.0 |   1140.2 |   +6%  ||    10.63 |    10.63 |   +0%  |  0.0652 |
 | 26b     ||   1035.8 |   1001.1 |   -3%  ||    10.95 |    10.93 |   -0%  |  0.2732 |
 | 26c     ||   1084.8 |   1132.5 |   +4%  ||    10.70 |    10.70 |   -0%  |  0.1641 |
 | 27a     ||   9219.2 |  11106.6 |  +20%  ||     1.40 |     1.37 |   -2%  |  0.0842 |
 | 27b     ||   7426.2 |   8697.1 |  +17%  ||     1.48 |     1.48 |   +0%  |  0.1042 |
 | 27c     ||    560.3 |    571.4 |   +2%  ||    29.28 |    29.40 |   +0%  |  0.4160 |
 | 28a     ||  14236.9 |  13750.1 |   -3%  ||     1.03 |     1.07 |   +3%  |  0.7329 |
 | 28b     ||   7471.7 |   7484.0 |   +0%  ||     1.43 |     1.43 |   +0%  |  0.9885 |
-| 28c     ||  11768.9 |  12090.4 |   +3%  ||     1.08 |     1.00 |   -8%  |  0.7856 |
 | 29a     ||   5723.1 |   6133.7 |   +7%  ||     1.90 |     1.83 |   -4%  |  0.5924 |
 | 29b     ||    625.3 |    653.9 |   +5%  ||    27.12 |    27.16 |   +0%  |  0.3938 |
 | 29c     ||   7514.0 |   7559.1 |   +1%  ||     1.70 |     1.68 |   -1%  |  0.9554 |
 | 2a      ||    455.5 |    435.3 |   -4%  ||    52.78 |    52.71 |   -0%  |  0.0466 |
 | 2b      ||    309.7 |    305.2 |   -1%  ||    63.35 |    63.34 |   -0%  |  0.2744 |
 | 2c      ||    150.7 |    151.2 |   +0%  ||    95.27 |    95.46 |   +0%  |  0.7386 |
 | 2d      ||    599.5 |    581.6 |   -3%  ||    43.32 |    43.27 |   -0%  |  0.2164 |
 | 30a     ||    982.5 |    952.6 |   -3%  ||    18.23 |    18.23 |   -0%  |  0.2326 |
-| 30b     ||   1122.7 |   1579.6 |  +41%  ||    12.43 |     6.53 |  -47%  |  0.0000 |
 | 30c     ||  10595.7 |  10958.0 |   +3%  ||     1.23 |     1.25 |   +1%  |  0.7368 |
 | 31a     ||    773.8 |    780.2 |   +1%  ||    16.62 |    16.65 |   +0%  |  0.7618 |
-| 31b     ||    835.4 |   1361.6 |  +63%  ||    11.90 |     6.43 |  -46%  |  0.0000 |
 | 31c     ||    781.1 |    787.0 |   +1%  ||    16.47 |    16.36 |   -1%  |  0.7957 |
 | 32a     ||     97.1 |     96.9 |   -0%  ||   111.33 |   111.59 |   +0%  |  0.7928 |
 | 32b     ||   1255.6 |   1290.4 |   +3%  ||    20.08 |    20.23 |   +1%  |  0.4259 |
 | 33a     ||    278.0 |    279.4 |   +1%  ||    71.45 |    71.67 |   +0%  |  0.6903 |
 | 33b     ||    279.2 |    273.3 |   -2%  ||    71.88 |    71.73 |   -0%  |  0.0932 |
 | 33c     ||    340.9 |    342.1 |   +0%  ||    60.90 |    60.73 |   -0%  |  0.8140 |
 | 3a      ||  10166.9 |   9059.5 |  -11%  ||     1.17 |     1.13 |   -3%  |  0.2911 |
 | 3b      ||    167.3 |    163.6 |   -2%  ||   148.36 |   148.44 |   +0%  |  0.0926 |
+| 3c      ||  14629.7 |  14151.8 |   -3%  ||     0.85 |     0.97 |  +14%  |  0.6494 |
 | 4a      ||    868.8 |    882.0 |   +2%  ||    38.05 |    38.16 |   +0%  |  0.6967 |
 | 4b      ||    101.4 |     99.4 |   -2%  ||   198.13 |   198.38 |   +0%  |  0.0570 |
 | 4c      ||    988.9 |   1047.3 |   +6%  ||    32.20 |    32.33 |   +0%  |  0.1899 |
 | 5a      ||   7181.4 |   7447.5 |   +4%  ||     1.38 |     1.35 |   -2%  |  0.7166 |
 | 5b      ||    744.9 |    733.3 |   -2%  ||    20.98 |    20.90 |   -0%  |  0.5557 |
+| 5c      ||  11964.5 |  12885.3 |   +8%  ||     1.10 |     1.15 |   +5%  |  0.4306 |
 | 6a      ||    569.7 |    545.2 |   -4%  ||    20.60 |    20.61 |   +0%  |  0.1829 |
 | 6b      ||   2942.2 |   2907.0 |   -1%  ||     5.52 |     5.57 |   +1%  |  0.7994 |
 | 6c      ||    588.0 |    551.9 |   -6%  ||    20.65 |    20.62 |   -0%  |  0.0378 |
 | 6d      ||   2736.6 |   2931.0 |   +7%  ||     5.52 |     5.52 |   -0%  |  0.1043 |
 | 6e      ||    587.1 |    548.0 |   -7%  ||    20.62 |    20.65 |   +0%  |  0.0185 |
 | 6f      ||   5857.3 |   5305.1 |   -9%  ||     3.58 |     3.62 |   +1%  |  0.0732 |
 | 7a      ||    727.4 |    754.3 |   +4%  ||    23.58 |    23.60 |   +0%  |  0.2448 |
 | 7b      ||    373.4 |    372.4 |   -0%  ||    40.04 |    40.05 |   +0%  |  0.8944 |
 | 7c      ||  50412.9 |  50348.4 |   -0%  ||     0.33 |     0.33 |   +0%  |  0.6007 |
 | 8a      ||    435.5 |    422.7 |   -3%  ||    51.13 |    51.17 |   +0%  |  0.0948 |
 | 8b      ||    319.1 |    324.9 |   +2%  ||    43.10 |    42.93 |   -0%  |  0.2443 |
 | 8c      ||  14513.2 |  14303.3 |   -1%  ||     1.07 |     1.05 |   -2%  |  0.8077 |
 | 8d      ||   6174.9 |   7922.2 |  +28%  ||     3.57 |     3.62 |   +1%  |  0.0118 |
 | 9a      ||  10666.2 |  11372.4 |   +7%  ||     1.17 |     1.18 |   +1%  |  0.4204 |
 | 9b      ||   1077.9 |   1049.3 |   -3%  ||    17.23 |    17.26 |   +0%  |  0.3527 |
-| 9c      ||  15755.8 |  13408.1 |  -15%  ||     1.15 |     0.87 |  -25%  |  0.1656 |
-| 9d      ||  15554.4 |  14618.2 |   -6%  ||     0.83 |     0.78 |   -6%  |  0.3484 |
 +---------++----------+----------+--------++----------+----------+--------+---------+
 | Sum     || 652308.9 | 649926.6 |   -0%  ||          |          |        |         |
 | Geomean ||          |          |        ||          |          |   -2%  |         |
 +---------++----------+----------+--------++----------+----------+--------+---------+
```
</details>
