### PR TITLE
Enable binary exports/imports for TPC-C

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,7 @@ try {
               sh "./scripts/test/hyriseServer_test.py clang-release"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-              sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate visualization
+              sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
               sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
             } else {
@@ -218,7 +218,7 @@ try {
               sh "./scripts/test/hyriseServer_test.py gcc-release"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-              sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate visualization
+              sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
               sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
             }
           } else {
@@ -231,7 +231,7 @@ try {
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-              sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate visualization
+              sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
             } else {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,7 +131,7 @@ try {
               sh "./scripts/test/hyriseServer_test.py clang-release"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-release"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-release"
-              sh "./scripts/test/hyriseBenchmarkTPCC_test.py clang-release"
+              sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate visualization
               sh "cd clang-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
 
             } else {
@@ -218,7 +218,7 @@ try {
               sh "./scripts/test/hyriseServer_test.py gcc-release"
               sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
               sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-              sh "./scripts/test/hyriseBenchmarkTPCC_test.py gcc-release"
+              sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate visualization
               sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
             }
           } else {
@@ -231,7 +231,7 @@ try {
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
               sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-              sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./scripts/test/hyriseBenchmarkTPCC_test.py clang-release-addr-ub-sanitizers"
+              sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate visualization
             } else {
               Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
             }

--- a/scripts/plot_operator_breakdown.py
+++ b/scripts/plot_operator_breakdown.py
@@ -76,7 +76,7 @@ df.iloc[:, 0:] = df.iloc[:, 0:].apply(lambda x: x / x.sum(), axis=1)
 print(df)
 
 # Drop all operators that do not exceed 1% in any query
-df = df[df > 0.01].dropna(axis="columns", how="all")
+df = df[df >= 0.01].dropna(axis="columns", how="all")
 
 # Setup colorscheme - using cubehelix, which provides a color mapping that gracefully degrades to grayscale
 colors = sns.cubehelix_palette(n_colors=len(df), rot=2, reverse=True, light=0.9, dark=0.1, hue=1)

--- a/scripts/plot_operator_breakdown.py
+++ b/scripts/plot_operator_breakdown.py
@@ -76,7 +76,7 @@ df.iloc[:, 0:] = df.iloc[:, 0:].apply(lambda x: x / x.sum(), axis=1)
 print(df)
 
 # Drop all operators that do not exceed 1% in any query
-df = df[df >= 0.01].dropna(axis="columns", how="all")
+df = df[df > 0.01].dropna(axis="columns", how="all")
 
 # Setup colorscheme - using cubehelix, which provides a color mapping that gracefully degrades to grayscale
 colors = sns.cubehelix_palette(n_colors=len(df), rot=2, reverse=True, light=0.9, dark=0.1, hue=1)

--- a/scripts/test/hyriseBenchmarkTPCC_test.py
+++ b/scripts/test/hyriseBenchmarkTPCC_test.py
@@ -21,6 +21,7 @@ def main():
 
     benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
     benchmark.expect_exact("TPC-C scale factor (number of warehouses) is 2")
+    benchmark.expect_exact("Writing 'NEW_ORDER' into binary file")
     benchmark.expect_exact("Consistency checks passed")
 
     close_benchmark(benchmark)
@@ -41,6 +42,7 @@ def main():
     benchmark.expect_exact("10 simulated clients are scheduling items in parallel")
     benchmark.expect_exact("Running benchmark in 'Shuffled' mode")
     benchmark.expect_exact("TPC-C scale factor (number of warehouses) is 1")
+    benchmark.expect_exact("Writing 'NEW_ORDER' into binary file")
     benchmark.expect_exact("Results for Delivery")
     benchmark.expect_exact("-> Executed")
     benchmark.expect_exact("Results for New-Order")
@@ -66,6 +68,7 @@ def main():
 
     benchmark = run_benchmark(build_dir, arguments, "hyriseBenchmarkTPCC", True)
     benchmark.expect_exact(f"Writing benchmark results to '{output_filename_2}'")
+    benchmark.expect_exact("Loading table 'NEW_ORDER' from cached binary")
 
     close_benchmark(benchmark)
     check_exit_status(benchmark)

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -356,7 +356,8 @@ bool AbstractTableGenerator::_all_chunks_sorted_by(const std::shared_ptr<Table>&
   return true;
 }
 
-std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_load_binary_tables_from_path(std::string cache_directory) {
+std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_load_binary_tables_from_path(
+    std::string cache_directory) {
   std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
 
   for (const auto& table_file : list_directory(cache_directory)) {

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -3,6 +3,7 @@
 #include "benchmark_config.hpp"
 #include "benchmark_table_encoder.hpp"
 #include "hyrise.hpp"
+#include "import_export/binary/binary_parser.hpp"
 #include "import_export/binary/binary_writer.hpp"
 #include "operators/sort.hpp"
 #include "operators/table_wrapper.hpp"
@@ -10,6 +11,7 @@
 #include "storage/index/group_key/group_key_index.hpp"
 #include "storage/segment_iterate.hpp"
 #include "utils/format_duration.hpp"
+#include "utils/list_directory.hpp"
 #include "utils/timer.hpp"
 
 namespace opossum {
@@ -352,6 +354,26 @@ bool AbstractTableGenerator::_all_chunks_sorted_by(const std::shared_ptr<Table>&
     if (!chunk_sorted) return false;
   }
   return true;
+}
+
+std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_load_binary_tables_from_path(std::string cache_directory) {
+  std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
+
+  for (const auto& table_file : list_directory(cache_directory)) {
+    const auto table_name = table_file.stem();
+    std::cout << "-  Loading table '" << table_name.string() << "' from cached binary " << table_file.relative_path();
+
+    Timer timer;
+    BenchmarkTableInfo table_info;
+    table_info.table = BinaryParser::parse(table_file);
+    table_info.loaded_from_binary = true;
+    table_info.binary_file_path = table_file;
+    table_info_by_name[table_name] = table_info;
+
+    std::cout << " (" << timer.lap_formatted() << ")" << std::endl;
+  }
+
+  return table_info_by_name;
 }
 
 }  // namespace opossum

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -357,7 +357,7 @@ bool AbstractTableGenerator::_all_chunks_sorted_by(const std::shared_ptr<Table>&
 }
 
 std::unordered_map<std::string, BenchmarkTableInfo> AbstractTableGenerator::_load_binary_tables_from_path(
-    std::string cache_directory) {
+    const std::string& cache_directory) {
   std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
 
   for (const auto& table_file : list_directory(cache_directory)) {

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -80,7 +80,8 @@ class AbstractTableGenerator {
 
   static bool _all_chunks_sorted_by(const std::shared_ptr<Table>& table, const SortColumnDefinition& sort_column);
 
-  static std::unordered_map<std::string, BenchmarkTableInfo> _load_binary_tables_from_path(std::string cache_directory);
+  static std::unordered_map<std::string, BenchmarkTableInfo> _load_binary_tables_from_path(
+      const std::string& cache_directory);
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/abstract_table_generator.hpp
+++ b/src/benchmarklib/abstract_table_generator.hpp
@@ -79,6 +79,8 @@ class AbstractTableGenerator {
   const std::shared_ptr<BenchmarkConfig> _benchmark_config;
 
   static bool _all_chunks_sorted_by(const std::shared_ptr<Table>& table, const SortColumnDefinition& sort_column);
+
+  static std::unordered_map<std::string, BenchmarkTableInfo> _load_binary_tables_from_path(std::string cache_directory);
 };
 
 }  // namespace opossum

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -480,9 +480,6 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
   // benchmarks interact with the BenchmarkRunner. At this moment, that does not seem to be worth the effort.
   const auto* const default_mode = (benchmark_name == "TPC-C Benchmark" ? "Shuffled" : "Ordered");
 
-  // TPC-C does not support binary caching
-  const auto* const default_dont_cache_binary_tables = (benchmark_name == "TPC-C Benchmark" ? "true" : "false");
-
   // clang-format off
   cli_options.add_options()
     ("help", "print a summary of CLI options")
@@ -501,7 +498,7 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("clients", "Specify how many items should run in parallel if the scheduler is active", cxxopts::value<uint32_t>()->default_value("1")) // NOLINT
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value(default_dont_cache_binary_tables)) // NOLINT
+    ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("metrics", "Track more metrics (steps in SQL pipeline, system utilization, etc.) and add them to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")); // NOLINT
   // clang-format on
 

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -524,15 +524,16 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCCTableGenerator::generate
   auto order_table = generate_order_table(order_line_counts);
   auto order_line_table = generate_order_line_table(order_line_counts);
 
-  auto table_info_by_name = std::unordered_map<std::string, BenchmarkTableInfo>({{"ITEM", BenchmarkTableInfo{item_table}},
-                                                              {"WAREHOUSE", BenchmarkTableInfo{warehouse_table}},
-                                                              {"STOCK", BenchmarkTableInfo{stock_table}},
-                                                              {"DISTRICT", BenchmarkTableInfo{district_table}},
-                                                              {"CUSTOMER", BenchmarkTableInfo{customer_table}},
-                                                              {"HISTORY", BenchmarkTableInfo{history_table}},
-                                                              {"ORDER", BenchmarkTableInfo{order_table}},
-                                                              {"ORDER_LINE", BenchmarkTableInfo{order_line_table}},
-                                                              {"NEW_ORDER", BenchmarkTableInfo{new_order_table}}});
+  auto table_info_by_name =
+      std::unordered_map<std::string, BenchmarkTableInfo>({{"ITEM", BenchmarkTableInfo{item_table}},
+                                                           {"WAREHOUSE", BenchmarkTableInfo{warehouse_table}},
+                                                           {"STOCK", BenchmarkTableInfo{stock_table}},
+                                                           {"DISTRICT", BenchmarkTableInfo{district_table}},
+                                                           {"CUSTOMER", BenchmarkTableInfo{customer_table}},
+                                                           {"HISTORY", BenchmarkTableInfo{history_table}},
+                                                           {"ORDER", BenchmarkTableInfo{order_table}},
+                                                           {"ORDER_LINE", BenchmarkTableInfo{order_line_table}},
+                                                           {"NEW_ORDER", BenchmarkTableInfo{new_order_table}}});
 
   if (_benchmark_config->cache_binary_tables) {
     std::filesystem::create_directories(cache_directory);

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -10,11 +10,9 @@ extern "C" {
 #include <utility>
 
 #include "benchmark_config.hpp"
-#include "import_export/binary/binary_parser.hpp"
 #include "storage/chunk.hpp"
 #include "storage/table_key_constraint.hpp"
 #include "table_builder.hpp"
-#include "utils/list_directory.hpp"
 #include "utils/timer.hpp"
 
 extern char** asc_date;
@@ -131,23 +129,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCHTableGenerator::generate
 
   const auto cache_directory = std::string{"tpch_cached_tables/sf-"} + std::to_string(_scale_factor);  // NOLINT
   if (_benchmark_config->cache_binary_tables && std::filesystem::is_directory(cache_directory)) {
-    std::unordered_map<std::string, BenchmarkTableInfo> table_info_by_name;
-
-    for (const auto& table_file : list_directory(cache_directory)) {
-      const auto table_name = table_file.stem();
-      Timer timer;
-      std::cout << "-  Loading table " << table_name << " from cached binary " << table_file.relative_path();
-
-      BenchmarkTableInfo table_info;
-      table_info.table = BinaryParser::parse(table_file);
-      table_info.loaded_from_binary = true;
-      table_info.binary_file_path = table_file;
-      table_info_by_name[table_name] = table_info;
-
-      std::cout << " (" << timer.lap_formatted() << ")" << std::endl;
-    }
-
-    return table_info_by_name;
+    return _load_binary_tables_from_path(cache_directory);
   }
 
   // Init tpch_dbgen - it is important this is done before any data structures from tpch_dbgen are read.


### PR DESCRIPTION
Enable binary exports/imports for TPC-C, which was the only benchmark left that did not support binary export and imports.

The data creation for TPC-H does not scale linearly and larger tests with 10 warehouses, take a good amount of time.

| Warehouse count | Time to generate data (s) |
| --:            | --: |
| 1 |   6 |
| 2 |  19 |
| 3 |  36 |
| 5 |  86 |
| 10 | 312 |