### PR TITLE
Fix jemalloc includes for Plugin builds on Linux

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -719,7 +719,9 @@ if(NOT APPLE)
     target_link_libraries(hyrise_impl PUBLIC custom_jemalloc -rdynamic)
     target_compile_definitions(hyrise_impl PUBLIC HYRISE_WITH_JEMALLOC)
 
-    # Add the jemalloc headers to Hyrise so that we can use jemalloc-specific functions
+    # Add the jemalloc headers to Hyrise so that we can use jemalloc-specific functions.
+    # We need to use a path relative to CMAKE_CURRENT_BINARY_DIR instead of using CMAKE_BINARY_DIR because Hyrise might
+    # not be the top-level CMake project (e.g., if it is used as a submodule in a Hyrise plugin repository).
     target_include_directories(hyrise_impl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../../third_party/jemalloc/include)
 endif()
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -720,7 +720,7 @@ if(NOT APPLE)
     target_compile_definitions(hyrise_impl PUBLIC HYRISE_WITH_JEMALLOC)
 
     # Add the jemalloc headers to Hyrise so that we can use jemalloc-specific functions
-    target_include_directories(hyrise_impl PUBLIC ${CMAKE_BINARY_DIR}/third_party/jemalloc/include)
+    target_include_directories(hyrise_impl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../../third_party/jemalloc/include)
 endif()
 
 target_link_libraries_system(hyrise_impl nlohmann_json::nlohmann_json)


### PR DESCRIPTION
Currently, we cannot build Hyrise's example plugin on Linux. In general, we build jemalloc first and then link and include the generated files.

Now, if we have import hyrise from the path `hyrise`, we do no longer find the jemalloc includes under `third_party/jemalloc/include` but rather `hyrise/third_party/jemalloc/include`.

This PR solves this issue by using `CMAKE_CURRENT_BINARY_DIR` to obtain the path `cmake-build-debug/hyrise/third_party` from which we can simply go upwards. `CMAKE_BINARY_DIR` does not tell us that Hyrise lives within the `hyrise` folder.
I have not found a nicer way to obtain the information, that we need to add `hyrise` to the include path.

This error does not occur on MaOS as we do not use jemalloc on MacOS.