### PR TITLE
Hash join: keep track of skipped values from Bloom filtering

### DIFF
--- a/scripts/plot_operator_breakdown.py
+++ b/scripts/plot_operator_breakdown.py
@@ -187,6 +187,11 @@ if paper_mode:
             bar.set_linewidth(0)
 
 handles, labels = ax_relative_queries.get_legend_handles_labels()
-fig.legend(reversed(handles), reversed(labels), loc='upper center', ncol=10,)
+fig.legend(
+    reversed(handles),
+    reversed(labels),
+    loc="upper center",
+    ncol=10,
+)
 fig.subplots_adjust(wspace=0.5)  # add a little horizontal margin between the charts (0.2 is the default)
 fig.savefig("operator_breakdown.pdf", bbox_inches="tight")

--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -99,10 +99,14 @@ class CompareBenchmarkScriptTest:
 
             # Check the latency values for both JSON files
             assert_latency_equals(
-                len(old_successful_runs), [run["duration"] for run in old_successful_runs], fields[3],
+                len(old_successful_runs),
+                [run["duration"] for run in old_successful_runs],
+                fields[3],
             )
             assert_latency_equals(
-                len(new_successful_runs), [run["duration"] for run in new_successful_runs], fields[4],
+                len(new_successful_runs),
+                [run["duration"] for run in new_successful_runs],
+                fields[4],
             )
 
             # Get the divisors for both benchmark files. They differ for Ordered and Shuffled mode.
@@ -133,7 +137,9 @@ class CompareBenchmarkScriptTest:
 
                 if len(old_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(old_unsuccessful_runs), [run["duration"] for run in old_unsuccessful_runs], fields[3],
+                        len(old_unsuccessful_runs),
+                        [run["duration"] for run in old_unsuccessful_runs],
+                        fields[3],
                     )
                     assert_throughput_equals(len(old_unsuccessful_runs), divisors[0], fields[7])
                 else:
@@ -142,7 +148,9 @@ class CompareBenchmarkScriptTest:
 
                 if len(new_unsuccessful_runs) > 0:
                     assert_latency_equals(
-                        len(new_unsuccessful_runs), [run["duration"] for run in new_unsuccessful_runs], fields[4],
+                        len(new_unsuccessful_runs),
+                        [run["duration"] for run in new_unsuccessful_runs],
+                        fields[4],
                     )
                     assert_throughput_equals(len(new_unsuccessful_runs), divisors[1], fields[8])
                 else:

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -719,8 +719,10 @@ if(NOT APPLE)
     target_link_libraries(hyrise_impl PUBLIC custom_jemalloc -rdynamic)
     target_compile_definitions(hyrise_impl PUBLIC HYRISE_WITH_JEMALLOC)
 
-    # Add the jemalloc headers to Hyrise so that we can use jemalloc-specific functions
-    target_include_directories(hyrise_impl PUBLIC ${CMAKE_BINARY_DIR}/third_party/jemalloc/include)
+    # Add the jemalloc headers to Hyrise so that we can use jemalloc-specific functions.
+    # We need to use a path relative to CMAKE_CURRENT_BINARY_DIR instead of using CMAKE_BINARY_DIR because Hyrise might
+    # not be the top-level CMake project (e.g., if it is used as a submodule in a Hyrise plugin repository).
+    target_include_directories(hyrise_impl PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../../third_party/jemalloc/include)
 endif()
 
 target_link_libraries_system(hyrise_impl nlohmann_json::nlohmann_json)

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -366,8 +366,8 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
       _performance_data.set_step_runtime(OperatorSteps::ProbeSideMaterializing, timer_materialization.lap());
     } else {
       // Here, we first materialize the probe side and use the resulting Bloom filter in the materialization of the
-      // build side. Consequently, the passed Bloom filter in build() will have no effect as it has been already used
-      // during the materialization to filter non-matching values.
+      // build side. Consequently, the Bloom filter later passed into build() will have no effect as it has already
+      // been used here to filter non-matching values.
       materialize_probe_side(ALL_TRUE_BLOOM_FILTER);
       _performance_data.set_step_runtime(OperatorSteps::ProbeSideMaterializing, timer_materialization.lap());
       materialize_build_side(probe_side_bloom_filter);

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -458,7 +458,14 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
       if (!hash_table) continue;
 
       _performance_data.hash_tables_distinct_value_count += hash_table->distinct_value_count();
-      _performance_data.hash_tables_position_count += hash_table->position_count() ? *hash_table->position_count() : 0;
+      const auto position_count = hash_table->position_count();
+      if (position_count) {
+        // Update or set hash_tables_position_count when hash table stores positions.
+        _performance_data.hash_tables_position_count =
+            _performance_data.hash_tables_position_count
+                ? *_performance_data.hash_tables_position_count + *position_count
+                : *position_count;
+      }
     }
 
     /**

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -460,11 +460,9 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
       _performance_data.hash_tables_distinct_value_count += hash_table->distinct_value_count();
       const auto position_count = hash_table->position_count();
       if (position_count) {
-        // Update or set hash_tables_position_count when hash table stores positions.
+        // Update or set hash_tables_position_count if hash table stores positions.
         _performance_data.hash_tables_position_count =
-            _performance_data.hash_tables_position_count
-                ? *_performance_data.hash_tables_position_count + *position_count
-                : *position_count;
+            _performance_data.hash_tables_position_count.value_or(0) + *position_count;
       }
     }
 

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -64,7 +64,7 @@ class JoinHash : public AbstractJoinOperator {
     // Note, depending on the order of materialization, build_side_materialized_value_count is not necessarily equal to
     // build_side_position_count (see order of materialization in hash_join.cpp).
     size_t hash_tables_distinct_value_count{0};
-    size_t hash_tables_position_count{0};
+    std::optional<size_t> hash_tables_position_count;
   };
 
  protected:

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -52,6 +52,13 @@ class JoinHash : public AbstractJoinOperator {
     size_t radix_bits{0};
     // Initially, the left input is the build side and the right side is the probe side.
     bool left_input_is_build_side{true};
+
+    // Due to the used Bloom filters, the number of actually joined tuples can significantly differ from the sizes of
+    // the input tables. For the build side, the bloom filter reduces the number of values in the hash table (i.e., the
+    // size of the hash table) and potentially the number of rows (in case of non-semi/anti* joins).
+    size_t probe_side_materialized_values{0};
+    size_t build_side_hash_table_size{0};
+    size_t build_side_position_count{0};
   };
 
  protected:

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -54,11 +54,17 @@ class JoinHash : public AbstractJoinOperator {
     bool left_input_is_build_side{true};
 
     // Due to the used Bloom filters, the number of actually joined tuples can significantly differ from the sizes of
-    // the input tables. For the build side, the Bloom filter reduces the number of values in the hash table (i.e., the
-    // size of the hash table) and potentially the number of rows (in case of non-semi/anti* joins).
-    size_t probe_side_materialized_values{0};
-    size_t build_side_hash_table_size{0};
-    size_t build_side_position_count{0};
+    // the input tables. To enable analyses of the Bloom filter efficiency, we stored number of values that were
+    // eventually materialized; i.e., "input_row_count - filtered_values_by_Bloom_filter".
+    size_t build_side_materialized_value_count{0};
+    size_t probe_side_materialized_value_count{0};
+
+    // For the build side, the Bloom filter reduces the distinct values in the hash table (i.e., the size of the hash
+    // table) and potentially the number of rows (in case of non-semi/anti* joins).
+    // Note, depending on the order of materialization, build_side_materialized_value_count is not necessarily equal to
+    // build_side_position_count (see order of materialization in hash_join.cpp).
+    size_t hash_table_distinct_value_count{0};
+    size_t hash_table_position_count{0};
   };
 
  protected:

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -54,7 +54,7 @@ class JoinHash : public AbstractJoinOperator {
     bool left_input_is_build_side{true};
 
     // Due to the used Bloom filters, the number of actually joined tuples can significantly differ from the sizes of
-    // the input tables. For the build side, the bloom filter reduces the number of values in the hash table (i.e., the
+    // the input tables. For the build side, the Bloom filter reduces the number of values in the hash table (i.e., the
     // size of the hash table) and potentially the number of rows (in case of non-semi/anti* joins).
     size_t probe_side_materialized_values{0};
     size_t build_side_hash_table_size{0};

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -54,17 +54,17 @@ class JoinHash : public AbstractJoinOperator {
     bool left_input_is_build_side{true};
 
     // Due to the used Bloom filters, the number of actually joined tuples can significantly differ from the sizes of
-    // the input tables. To enable analyses of the Bloom filter efficiency, we stored number of values that were
+    // the input tables. To enable analyses of the Bloom filter efficiency, we store the number of values that were
     // eventually materialized; i.e., "input_row_count - filtered_values_by_Bloom_filter".
     size_t build_side_materialized_value_count{0};
     size_t probe_side_materialized_value_count{0};
 
-    // For the build side, the Bloom filter reduces the distinct values in the hash table (i.e., the size of the hash
-    // table) and potentially the number of rows (in case of non-semi/anti* joins).
+    // In build(), the Bloom filter potentially reduces the distinct values in the hash table (i.e., the size of the
+    // hash table) and the number of rows (in case of non-semi/anti* joins).
     // Note, depending on the order of materialization, build_side_materialized_value_count is not necessarily equal to
     // build_side_position_count (see order of materialization in hash_join.cpp).
-    size_t hash_table_distinct_value_count{0};
-    size_t hash_table_position_count{0};
+    size_t hash_tables_distinct_value_count{0};
+    size_t hash_tables_position_count{0};
   };
 
  protected:

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -192,9 +192,7 @@ class PosHashTable {
   }
 
   // Return the number of distinct values (i.e., the size of the hash table).
-  size_t distinct_value_count() const {
-    return _offset_hash_table.size();
-  }
+  size_t distinct_value_count() const { return _offset_hash_table.size(); }
 
   // Return the number of positions stored in the hash table. For semi/anti joins, no positions are stored in the hash
   // table. For other join types, we return the size of the unified position list that is created in finalize().

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -192,7 +192,7 @@ class PosHashTable {
   }
 
   // Return the number of distinct values (i.e., the size of the hash table).
-  size_t get_distinct_values_count() const {
+  size_t get_distinct_value_count() const {
     return _offset_hash_table.size();
   }
 

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -191,6 +191,16 @@ class PosHashTable {
     return _offset_hash_table.find(casted_value) != _offset_hash_table.end();
   }
 
+  // Return the size of the hash table and the number of positions stored (in case the mode is AllPositions). We use
+  // the unified position list that is created in finalize(). For semi/anti* joins the number of positions is 0.
+  std::pair<size_t, size_t> get_hash_table_size_and_position_count() const {
+    const auto hash_table_size = _offset_hash_table.size();
+    if (_mode == JoinHashBuildMode::AllPositions) {
+      return {hash_table_size, _unified_pos_list->pos_list.size()};
+    }
+    return {hash_table_size, 0ul};
+  }
+
  private:
   // During the build phase, the small_vectors cause many small allocations. Instead of going to malloc every time,
   // we create our own pool, which is discarded once finalize() is called. The pool is unsynchronized (i.e., non-thread-

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -192,18 +192,18 @@ class PosHashTable {
   }
 
   // Return the number of distinct values (i.e., the size of the hash table).
-  size_t get_distinct_value_count() const {
+  size_t distinct_value_count() const {
     return _offset_hash_table.size();
   }
 
-  // Return the number of positions stored. For semi/anti joins, no positions are stored and thus 0 is returned.
-  // Otherwise, we use the unified position list that is created in finalize().
-  size_t get_position_count() const {
+  // Return the number of positions stored in the hash table. For semi/anti joins, no positions are stored in the hash
+  // table. For other join types, we return the size of the unified position list that is created in finalize().
+  std::optional<size_t> position_count() const {
     if (_mode == JoinHashBuildMode::AllPositions) {
-      Assert(_unified_pos_list, "");
+      Assert(_unified_pos_list, "Expected unified position list to be set (i.e., finalize() has been called).");
       return _unified_pos_list->pos_list.size();
     }
-    return 0ul;
+    return std::nullopt;
   }
 
  private:

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -213,34 +213,39 @@ TEST_F(OperatorPerformanceDataTest, JoinHashBloomFilterReductions) {
   table_wrapper_b->never_clear_output();
   table_wrapper_b->execute();
 
-  // Inner join case: checking that the number of stored positions (required for all join types except semi/anti) is
-  // larger than zero. Depending on the Bloom filter implementation (which is currently depending on the
-  // implementation of std::hash), we might store values and positions in the hash map that do not have a matching
-  // partner. Thus, we only check for the existence of the minimum number of values and positions.
+  // Check that std's hash for integer values is still the identity funtion. This assumption might break in the future.
+  // In this case, some of the following tests might break as well.
+  ASSERT_EQ(std::hash<uint32_t>{}(17), 17);
+
+  // Inner join case: We check that the number of stored positions (required for all join types except semi/anti).
+  // Depending on the Bloom filter implementation (which is currently depending on the implementation of std::hash),
+  // we might store values and positions in the hash map that do not have a matching partner.
   const auto inner_join = std::make_shared<JoinHash>(
       table_wrapper_a, table_wrapper_b, JoinMode::Inner,
       OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
   inner_join->execute();
 
   const auto& inner_perf = dynamic_cast<JoinHash::PerformanceData&>(*inner_join->performance_data);
-  EXPECT_GE(inner_perf.probe_side_materialized_values, 3ul);  // values 2,6,2
-  EXPECT_GE(inner_perf.build_side_hash_table_size, 2ul);      // values 2,6
-  EXPECT_GE(inner_perf.build_side_position_count, 3ul);       // positions 1,2,3
+  EXPECT_EQ(inner_perf.build_side_materialized_value_count, 4ul);  // matching values 2,6,2
+  EXPECT_EQ(inner_perf.probe_side_materialized_value_count, 4ul);  // matching values 2,6,2
+  EXPECT_EQ(inner_perf.hash_table_distinct_value_count, 2ul);      // values 2,6
+  EXPECT_EQ(inner_perf.hash_table_position_count, 3ul);            // positions 1,2,3
   EXPECT_TRUE(inner_perf.left_input_is_build_side);
 
-  // Semi join case: we check that no positions are stored (see explanation for "AllPositions" mode in hash map).
+  // Semi join case: We check that no positions are stored (see explanation for "AllPositions" mode in hash map).
   // Further, we force the larger input to be the build side. As we first materialize the smaller side (i.e., the probe
   // side in this case) and create the initial bloom filter with that, there will be no reduction due to bloom
   // filtering on the probe side.
   const auto semi_join = std::make_shared<JoinHash>(
-      table_wrapper_b, table_wrapper_a, JoinMode::Semi,
+      table_wrapper_a, table_wrapper_b, JoinMode::Semi,
       OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
   semi_join->execute();
 
   const auto& semi_perf = dynamic_cast<JoinHash::PerformanceData&>(*semi_join->performance_data);
-  EXPECT_EQ(semi_perf.probe_side_materialized_values, table_a->row_count());
-  EXPECT_GE(semi_perf.build_side_hash_table_size, 2ul);
-  EXPECT_EQ(semi_perf.build_side_position_count, 0ul);
+  EXPECT_EQ(semi_perf.build_side_materialized_value_count, 4ul);
+  EXPECT_EQ(semi_perf.probe_side_materialized_value_count, table_a->row_count());
+  EXPECT_EQ(semi_perf.hash_table_distinct_value_count, 2ul);
+  EXPECT_EQ(semi_perf.hash_table_position_count, 0ul);
   EXPECT_FALSE(semi_perf.left_input_is_build_side);
 }
 

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -202,6 +202,48 @@ TEST_F(OperatorPerformanceDataTest, JoinHashStepRuntimes) {
   }
 }
 
+TEST_F(OperatorPerformanceDataTest, JoinHashBloomFilterReductions) {
+  const auto table_a = load_table("resources/test_data/tbl/int_int2.tbl", 2);
+  const auto table_wrapper_a = std::make_shared<TableWrapper>(table_a);
+  table_wrapper_a->never_clear_output();
+  table_wrapper_a->execute();
+
+  const auto table_b = load_table("resources/test_data/tbl/int_int_shuffled.tbl", 2);  // larger than int_int.tbl
+  const auto table_wrapper_b = std::make_shared<TableWrapper>(table_b);
+  table_wrapper_b->never_clear_output();
+  table_wrapper_b->execute();
+
+  // Inner join case: checking that the number of stored positions (required for all join types except semi/anti) is
+  // larger than zero. Depending on the Bloom filter implementation (which is currently depending on the
+  // implementation of std::hash), we might store values and positions in the hash map that do not have a matching
+  // partner. Thus, we only check for the existence of the minimum number of values and positions.
+  const auto inner_join = std::make_shared<JoinHash>(
+      table_wrapper_a, table_wrapper_b, JoinMode::Inner,
+      OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
+  inner_join->execute();
+
+  const auto& inner_perf = dynamic_cast<JoinHash::PerformanceData&>(*inner_join->performance_data);
+  EXPECT_GE(inner_perf.probe_side_materialized_values, 3ul);  // values 2,6,2
+  EXPECT_GE(inner_perf.build_side_hash_table_size, 2ul);      // values 2,6
+  EXPECT_GE(inner_perf.build_side_position_count, 3ul);       // positions 1,2,3
+  EXPECT_TRUE(inner_perf.left_input_is_build_side);
+
+  // Semi join case: we check that no positions are stored (see explanation for "AllPositions" mode in hash map).
+  // Further, we force the larger input to be the build side. As we first materialize the smaller side (i.e., the probe
+  // side in this case) and create the initial bloom filter with that, there will be no reduction due to bloom
+  // filtering on the probe side.
+  const auto semi_join = std::make_shared<JoinHash>(
+      table_wrapper_b, table_wrapper_a, JoinMode::Semi,
+      OperatorJoinPredicate{ColumnIDPair(ColumnID{0}, ColumnID{0}), PredicateCondition::Equals});
+  semi_join->execute();
+
+  const auto& semi_perf = dynamic_cast<JoinHash::PerformanceData&>(*semi_join->performance_data);
+  EXPECT_EQ(semi_perf.probe_side_materialized_values, table_a->row_count());
+  EXPECT_GE(semi_perf.build_side_hash_table_size, 2ul);
+  EXPECT_EQ(semi_perf.build_side_position_count, 0ul);
+  EXPECT_FALSE(semi_perf.left_input_is_build_side);
+}
+
 // Check that steps of IndexJoin (indexed chunks/unindexed chunks) are executed as expected.
 TEST_F(OperatorPerformanceDataTest, JoinIndexStepRuntimes) {
   // This test modifies a table. Hence, we create a new one for this test only.

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -228,8 +228,8 @@ TEST_F(OperatorPerformanceDataTest, JoinHashBloomFilterReductions) {
   const auto& inner_perf = dynamic_cast<JoinHash::PerformanceData&>(*inner_join->performance_data);
   EXPECT_EQ(inner_perf.build_side_materialized_value_count, 4ul);  // matching values 2,6,2
   EXPECT_EQ(inner_perf.probe_side_materialized_value_count, 4ul);  // matching values 2,6,2
-  EXPECT_EQ(inner_perf.hash_tables_distinct_value_count, 2ul);      // values 2,6
-  EXPECT_EQ(inner_perf.hash_tables_position_count, 3ul);            // positions 1,2,3
+  EXPECT_EQ(inner_perf.hash_tables_distinct_value_count, 2ul);     // values 2,6
+  EXPECT_EQ(inner_perf.hash_tables_position_count, 3ul);           // positions 1,2,3
   EXPECT_TRUE(inner_perf.left_input_is_build_side);
 
   // Semi join case: We check that no positions are stored (see explanation for "AllPositions" mode in hash map).
@@ -245,7 +245,7 @@ TEST_F(OperatorPerformanceDataTest, JoinHashBloomFilterReductions) {
   EXPECT_EQ(semi_perf.build_side_materialized_value_count, 4ul);
   EXPECT_EQ(semi_perf.probe_side_materialized_value_count, table_a->row_count());
   EXPECT_EQ(semi_perf.hash_tables_distinct_value_count, 2ul);
-  EXPECT_EQ(semi_perf.hash_tables_position_count, 0ul);
+  EXPECT_FALSE(semi_perf.hash_tables_position_count);
   EXPECT_FALSE(semi_perf.left_input_is_build_side);
 }
 

--- a/src/test/lib/operators/operator_performance_data_test.cpp
+++ b/src/test/lib/operators/operator_performance_data_test.cpp
@@ -228,8 +228,8 @@ TEST_F(OperatorPerformanceDataTest, JoinHashBloomFilterReductions) {
   const auto& inner_perf = dynamic_cast<JoinHash::PerformanceData&>(*inner_join->performance_data);
   EXPECT_EQ(inner_perf.build_side_materialized_value_count, 4ul);  // matching values 2,6,2
   EXPECT_EQ(inner_perf.probe_side_materialized_value_count, 4ul);  // matching values 2,6,2
-  EXPECT_EQ(inner_perf.hash_table_distinct_value_count, 2ul);      // values 2,6
-  EXPECT_EQ(inner_perf.hash_table_position_count, 3ul);            // positions 1,2,3
+  EXPECT_EQ(inner_perf.hash_tables_distinct_value_count, 2ul);      // values 2,6
+  EXPECT_EQ(inner_perf.hash_tables_position_count, 3ul);            // positions 1,2,3
   EXPECT_TRUE(inner_perf.left_input_is_build_side);
 
   // Semi join case: We check that no positions are stored (see explanation for "AllPositions" mode in hash map).
@@ -244,8 +244,8 @@ TEST_F(OperatorPerformanceDataTest, JoinHashBloomFilterReductions) {
   const auto& semi_perf = dynamic_cast<JoinHash::PerformanceData&>(*semi_join->performance_data);
   EXPECT_EQ(semi_perf.build_side_materialized_value_count, 4ul);
   EXPECT_EQ(semi_perf.probe_side_materialized_value_count, table_a->row_count());
-  EXPECT_EQ(semi_perf.hash_table_distinct_value_count, 2ul);
-  EXPECT_EQ(semi_perf.hash_table_position_count, 0ul);
+  EXPECT_EQ(semi_perf.hash_tables_distinct_value_count, 2ul);
+  EXPECT_EQ(semi_perf.hash_tables_position_count, 0ul);
   EXPECT_FALSE(semi_perf.left_input_is_build_side);
 }
 


### PR DESCRIPTION
This PR adds three integers to the hash join's performance operator struct. They keep track of the "success" of the bloom filtering:
 * size of materialized probe side (might or might not be filtered by a bloom filter, see added test)
 * size of hash table
 * size of positions stored for hash table (can be empty for certain joins)

The reason to add these counters is to enable better join runtime predictions (might be of interest for @dey4ss, @aloeser, and @Bensk1; even though it does not interact with clustering decisions). For certain joins, the bloom filters remove 90% of the data, almost removing the runtime of the probe phase from join.

I thought about adding these values to the visualization as well. But for now I have not, because:
- a sole number is cumbersome, to calculate percentage (input table vs. materialized) we would need the input size, which we don't have
- this number works for the probe side and a "normal" join, where we can count the positions stored for the hash table
- BUT I have no idea what to print for semi/anti joins; ideally we could compare the number of distinct values of the input table and the size of the hash table after the build phase, but we don't have the distinct count at hand