### PR TITLE
BenchmarkRunner: Write report idempotently

### DIFF
--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -453,7 +453,7 @@ void BenchmarkRunner::write_report_to_file() const {
                         {"summary", std::move(summary)},
                         {"table_generation", _table_generator->metrics}};
 
-  // Add information that was gathered asynchronously to the output data
+  // Add information that was temporarily stored in the `benchmark_...` tables during the benchmark execution
   if (Hyrise::get().storage_manager.has_table("benchmark_system_utilization_log")) {
     report["system_utilization"] = _sql_to_json("SELECT * FROM benchmark_system_utilization_log");
   }

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -295,8 +295,6 @@ void BenchmarkRunner::_benchmark_ordered() {
     // into account, too. In light of the significant amount of data added by the snapshots to the JSON file and the
     // unclear advantage of excluding those runs, we only take one snapshot here.
     _snapshot_segment_access_counters(name);
-
-    write_report_to_file();
   }
 }
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -133,14 +133,10 @@ void BenchmarkRunner::run() {
     }
   }
 
-  auto benchmark_end = std::chrono::system_clock::now();
-  _total_run_duration = benchmark_end - _benchmark_start;
-
   // Create report
   if (_config.output_file_path) {
     if (!_config.verify && !_config.enable_visualization) {
-      std::ofstream output_file(*_config.output_file_path);
-      _create_report(output_file);
+      write_report_to_file();
     } else {
       std::cout << "- Not writing JSON result as either verification or visualization are activated." << std::endl;
       std::cout << "  These options make the results meaningless." << std::endl;
@@ -299,6 +295,8 @@ void BenchmarkRunner::_benchmark_ordered() {
     // into account, too. In light of the significant amount of data added by the snapshots to the JSON file and the
     // unclear advantage of excluding those runs, we only take one snapshot here.
     _snapshot_segment_access_counters(name);
+
+    write_report_to_file();
   }
 }
 
@@ -365,7 +363,9 @@ void BenchmarkRunner::_warmup(const BenchmarkItemID item_id) {
   Assert(_currently_running_clients == 0, "All runs must be finished at this point");
 }
 
-void BenchmarkRunner::_create_report(std::ostream& stream) const {
+void BenchmarkRunner::write_report_to_file() const {
+  const auto total_duration = std::chrono::system_clock::now() - _benchmark_start;
+
   nlohmann::json benchmarks;
 
   for (const auto& item_id : _benchmark_item_runner->items()) {
@@ -419,11 +419,12 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     // duration of the entire benchmark. This means that items_per_second of ordered and shuffled runs are not
     // comparable.
     const auto reported_item_duration =
-        _config.benchmark_mode == BenchmarkMode::Shuffled ? _total_run_duration : result.duration;
+        _config.benchmark_mode == BenchmarkMode::Shuffled ? total_duration : result.duration;
     const auto reported_item_duration_ns =
         static_cast<double>(std::chrono::duration_cast<std::chrono::nanoseconds>(reported_item_duration).count());
     const auto duration_seconds = reported_item_duration_ns / 1'000'000'000.0;
-    const auto items_per_second = static_cast<double>(result.successful_runs.size()) / duration_seconds;
+    const auto items_per_second =
+        duration_seconds > 0 ? (static_cast<double>(result.successful_runs.size()) / duration_seconds) : 0;
 
     // The field items_per_second is relied upon by a number of visualization scripts. Carefully consider if you really
     // want to touch this and potentially break the comparability across commits. Note that items_per_second only
@@ -441,7 +442,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
 
   nlohmann::json summary{
       {"table_size_in_bytes", table_size},
-      {"total_duration", std::chrono::duration_cast<std::chrono::nanoseconds>(_total_run_duration).count()}};
+      {"total_duration", std::chrono::duration_cast<std::chrono::nanoseconds>(total_duration).count()}};
 
   const auto benchmark_start_ns =
       std::chrono::duration_cast<std::chrono::nanoseconds>(_benchmark_start.time_since_epoch()).count();
@@ -454,6 +455,7 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
                         {"summary", std::move(summary)},
                         {"table_generation", _table_generator->metrics}};
 
+  // Add information that was gathered asynchronously to the output data
   if (Hyrise::get().storage_manager.has_table("benchmark_system_utilization_log")) {
     report["system_utilization"] = _sql_to_json("SELECT * FROM benchmark_system_utilization_log");
   }
@@ -462,7 +464,8 @@ void BenchmarkRunner::_create_report(std::ostream& stream) const {
     report["segments"] = _sql_to_json("SELECT * FROM benchmark_segments_log");
   }
 
-  stream << std::setw(2) << report << std::endl;
+  // Write the output file
+  std::ofstream{_config.output_file_path.value()} << std::setw(2) << report << std::endl;
 }
 
 cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& benchmark_name) {

--- a/src/benchmarklib/benchmark_runner.hpp
+++ b/src/benchmarklib/benchmark_runner.hpp
@@ -52,8 +52,8 @@ class BenchmarkRunner : public Noncopyable {
   std::shared_ptr<SQLiteWrapper> sqlite_wrapper;
 
   // Create a report in roughly the same format as google benchmarks do when run with --benchmark_format=json.
-  // This is idempotent, i.e., you can call it multiple times and the result will be updated. Be aware that this may
-  // affect the performance of concurrently running queries.
+  // This is idempotent, i.e., you can call it multiple times and the resulting file will be overwritten. Be aware
+  // writing the file may affect the performance of concurrently running queries.
   void write_report_to_file() const;
 
  private:

--- a/src/benchmarklib/benchmark_runner.hpp
+++ b/src/benchmarklib/benchmark_runner.hpp
@@ -51,6 +51,11 @@ class BenchmarkRunner : public Noncopyable {
   // If the query execution should be validated, this stores a pointer to the used SQLite instance
   std::shared_ptr<SQLiteWrapper> sqlite_wrapper;
 
+  // Create a report in roughly the same format as google benchmarks do when run with --benchmark_format=json.
+  // This is idempotent, i.e., you can call it multiple times and the result will be updated. Be aware that this may
+  // affect the performance of concurrently running queries.
+  void write_report_to_file() const;
+
  private:
   // Run benchmark in BenchmarkMode::Shuffled mode
   void _benchmark_shuffled();
@@ -64,9 +69,6 @@ class BenchmarkRunner : public Noncopyable {
   // Schedules a run of the specified for execution. After execution, the result is updated. If the scheduler is
   // disabled, the item is executed immediately.
   void _schedule_item_run(const BenchmarkItemID item_id);
-
-  // Create a report in roughly the same format as google benchmarks do when run with --benchmark_format=json
-  void _create_report(std::ostream& stream) const;
 
   // Converts the result of a SQL query into a JSON object
   static nlohmann::json _sql_to_json(const std::string& sql);
@@ -90,7 +92,6 @@ class BenchmarkRunner : public Noncopyable {
   std::optional<PerformanceWarningDisabler> _performance_warning_disabler;
 
   std::chrono::system_clock::time_point _benchmark_start;
-  Duration _total_run_duration{};
 
   // The atomic uints are modified by other threads when finishing an item, to keep track of when we can
   // let a simulated client schedule the next item, as well as the total number of finished items so far


### PR DESCRIPTION
I am currently running multi-hour benchmarks. Waiting until the end to realize that something is wrong sucks. With this PR, `BenchmarkRunner::write_report_to_file` can be
* called more than once, with the resulting file simply being overwritten, and
* called from the outside so that my plugin can generate a report when something has been done.

This PR does not change the default behavior of the BenchmarkRunner. I decided against generating a report after each executed item in the `Ordered` mode as this may incur significant costs with `--metrics`. If you want to profit from this change, you thus need to call `Hyrise::get().benchmark_runner.lock()->write_report_to_file()` yourself.