### PR TITLE
Move definition of JoinHash::calculate_radix_bits() to .hpp

### DIFF
--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -63,51 +63,6 @@ std::shared_ptr<AbstractOperator> JoinHash::_on_deep_copy(
 
 void JoinHash::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
-template <typename T>
-size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode) {
-  /*
-    The number of radix bits is used to determine the number of build partitions. The idea is to size the partitions in
-    a way that keeps the whole hash map cache resident. We aim for the largest unshared cache (for most Intel systems
-    that's the L2 cache, for Apple's M1 the L1 cache). This calculation should include hardware knowledge, once
-    available in Hyrise. As of now, we assume a cache size of 1024 KB, of which we use 75 %.
-
-    We estimate the size the following way:
-      - we assume each key appears once (that is an overestimation space-wise, but we
-        aim rather for a hash map that is slightly smaller than the cache than slightly larger)
-      - each entry in the hash map is a pair of the actual hash key and the SmallPosList storing uint32_t offsets (see
-        hash_join_steps.hpp)
-  */
-  if (build_side_size > probe_side_size) {
-    /*
-      Hash joins perform best when the build side is small. For inner joins, we can simply select the smaller input
-      table as the build side. For other joins, such as semi or outer joins, the build side is fixed. In this case,
-      other join operators might be more efficient. We emit performance warning in this case. In the future, the
-      optimizer could identify these cases of potentially inefficient hash joins and switch to other join algorithms.
-    */
-    PerformanceWarning("Build side larger than probe side in hash join");
-  }
-
-  // We assume a cache of 1024 KB for an Intel Xeon Platinum 8180. For local deployments or other CPUs, this size might
-  // be different (e.g., an AMD EPYC 7F72 CPU has an L2 cache size of 512 KB and Apple's M1 has 128 KB).
-  constexpr auto L2_CACHE_SIZE = 1'024'000;                   // bytes
-  constexpr auto L2_CACHE_MAX_USABLE = L2_CACHE_SIZE * 0.75;  // use 75% of the L2 cache size
-
-  // For information about the sizing of the bytell hash map, see the comments:
-  // https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
-  // Bytell hash map has a maximum fill factor of 0.9375. Since it's hard to estimate the number of distinct values in
-  // a radix partition (and thus the size of each hash table), we accomodate a little bit extra space for
-  // slightly skewed data distributions and aim for a fill level of 80%.
-  const auto complete_hash_map_size =
-      // number of items in map
-      static_cast<double>(build_side_size) *
-      // key + value (and one byte overhead, see link above)
-      static_cast<double>(sizeof(uint32_t)) / 0.8;
-
-  const auto cluster_count = std::max(1.0, complete_hash_map_size / L2_CACHE_MAX_USABLE);
-
-  return static_cast<size_t>(std::ceil(std::log2(cluster_count)));
-}
-
 std::shared_ptr<const Table> JoinHash::_on_execute() {
   Assert(supports({_mode, _primary_predicate.predicate_condition,
                    left_input_table()->column_data_type(_primary_predicate.column_ids.first),

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -85,4 +85,49 @@ class JoinHash : public AbstractJoinOperator {
   friend class JoinHashImpl;
 };
 
+template <typename T>
+size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode) {
+  /*
+    The number of radix bits is used to determine the number of build partitions. The idea is to size the partitions in
+    a way that keeps the whole hash map cache resident. We aim for the largest unshared cache (for most Intel systems
+    that's the L2 cache, for Apple's M1 the L1 cache). This calculation should include hardware knowledge, once
+    available in Hyrise. As of now, we assume a cache size of 1024 KB, of which we use 75 %.
+
+    We estimate the size the following way:
+      - we assume each key appears once (that is an overestimation space-wise, but we
+        aim rather for a hash map that is slightly smaller than the cache than slightly larger)
+      - each entry in the hash map is a pair of the actual hash key and the SmallPosList storing uint32_t offsets (see
+        hash_join_steps.hpp)
+  */
+  if (build_side_size > probe_side_size) {
+    /*
+      Hash joins perform best when the build side is small. For inner joins, we can simply select the smaller input
+      table as the build side. For other joins, such as semi or outer joins, the build side is fixed. In this case,
+      other join operators might be more efficient. We emit performance warning in this case. In the future, the
+      optimizer could identify these cases of potentially inefficient hash joins and switch to other join algorithms.
+    */
+    PerformanceWarning("Build side larger than probe side in hash join");
+  }
+
+  // We assume a cache of 1024 KB for an Intel Xeon Platinum 8180. For local deployments or other CPUs, this size might
+  // be different (e.g., an AMD EPYC 7F72 CPU has an L2 cache size of 512 KB and Apple's M1 has 128 KB).
+  constexpr auto L2_CACHE_SIZE = 1'024'000;                   // bytes
+  constexpr auto L2_CACHE_MAX_USABLE = L2_CACHE_SIZE * 0.75;  // use 75% of the L2 cache size
+
+  // For information about the sizing of the bytell hash map, see the comments:
+  // https://probablydance.com/2018/05/28/a-new-fast-hash-table-in-response-to-googles-new-fast-hash-table/
+  // Bytell hash map has a maximum fill factor of 0.9375. Since it's hard to estimate the number of distinct values in
+  // a radix partition (and thus the size of each hash table), we accomodate a little bit extra space for
+  // slightly skewed data distributions and aim for a fill level of 80%.
+  const auto complete_hash_map_size =
+      // number of items in map
+      static_cast<double>(build_side_size) *
+      // key + value (and one byte overhead, see link above)
+      static_cast<double>(sizeof(uint32_t)) / 0.8;
+
+  const auto cluster_count = std::max(1.0, complete_hash_map_size / L2_CACHE_MAX_USABLE);
+
+  return static_cast<size_t>(std::ceil(std::log2(cluster_count)));
+}
+
 }  // namespace opossum


### PR DESCRIPTION
Without moving the definition, the linker throws several errors for release builds under g++ >= 10.2. Apparently, for older compilers these problems do not occur, but I don't even know why that was working before.