### PR TITLE
Fix docker pull in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,7 @@ try {
       sh "hostname"
     }
   
+    // The empty '' results in using the default registry: https://index.docker.io/v1/
     docker.withRegistry('', 'docker') {
       def oppossumCI = docker.image('hyrise/opossum-ci:20.04');
       oppossumCI.pull()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ try {
       sh "hostname"
     }
   
-    docker.withRegistry('https://registry.hub.docker.com', 'docker') {
+    docker.withRegistry('', 'docker') {
       def oppossumCI = docker.image('hyrise/opossum-ci:20.04');
       oppossumCI.pull()
 


### PR DESCRIPTION
I noticed that our PRs suddenly fail early before anything is being actually built. Apparently, the login to docker is [failing](https://hyrise-ci.epic-hpi.de/blue/rest/organizations/jenkins/pipelines/hyrise/pipelines/hyrise/branches/PR-2374/runs/13/log/?start=0). I don't know the exact reason, they might have deactivated this endpoint. Apparently, by not specifying a registry, the default (and working) registry is used.