### PR TITLE
Add pure virtual function name() in AbstractRule

### DIFF
--- a/src/lib/operators/change_meta_table.cpp
+++ b/src/lib/operators/change_meta_table.cpp
@@ -17,7 +17,7 @@ ChangeMetaTable::ChangeMetaTable(const std::string& table_name, const MetaTableC
       _change_type(change_type) {}
 
 const std::string& ChangeMetaTable::name() const {
-  static const auto name = std::string{"Change Meta Table"};
+  static const auto name = std::string{"ChangeMetaTable"};
   return name;
 }
 

--- a/src/lib/optimizer/optimizer.cpp
+++ b/src/lib/optimizer/optimizer.cpp
@@ -131,9 +131,7 @@ std::shared_ptr<AbstractLQPNode> Optimizer::optimize(
     auto rule_duration = rule_timer.lap();
 
     if (rule_durations) {
-      auto& rule_reference = *rule;
-      auto rule_name = std::string(typeid(rule_reference).name());
-      rule_durations->emplace_back(OptimizerRuleMetrics{rule_name, rule_duration});
+      rule_durations->emplace_back(OptimizerRuleMetrics{rule->name(), rule_duration});
     }
 
     if constexpr (HYRISE_DEBUG) validate_lqp(root_node);

--- a/src/lib/optimizer/strategy/abstract_rule.hpp
+++ b/src/lib/optimizer/strategy/abstract_rule.hpp
@@ -42,6 +42,8 @@ class AbstractRule {
    */
   virtual void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp_root) const;
 
+  virtual std::string name() const = 0;
+
   std::shared_ptr<AbstractCostEstimator> cost_estimator;
 
  protected:

--- a/src/lib/optimizer/strategy/between_composition_rule.cpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.cpp
@@ -36,6 +36,11 @@ PredicateCondition get_between_predicate_condition(bool left_inclusive, bool rig
 
 namespace opossum {
 
+std::string BetweenCompositionRule::name() const {
+  static const auto name = std::string{"BetweenCompositionRule"};
+  return name;
+}
+
 /**
  * Distinction from the ChunkPruningRule:
  *  Both rules search for predicate chains, but of different types:

--- a/src/lib/optimizer/strategy/between_composition_rule.hpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.hpp
@@ -26,6 +26,9 @@ class PredicateNode;
  * after the substitution.
  */
 class BetweenCompositionRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -131,6 +131,11 @@ std::vector<PredicatePruningChain> find_predicate_pruning_chains_by_stored_table
 
 namespace opossum {
 
+std::string ChunkPruningRule::name() const {
+  static const auto name = std::string{"ChunkPruningRule"};
+  return name;
+}
+
 void ChunkPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   std::unordered_map<std::shared_ptr<StoredTableNode>, std::vector<PredicatePruningChain>>
       predicate_pruning_chains_by_stored_table_node;

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -25,6 +25,9 @@ class Table;
  * The resulting pruning information is stored inside the StoredTableNode objects.
  */
 class ChunkPruningRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -19,11 +19,11 @@
 #include "logical_query_plan/union_node.hpp"
 #include "logical_query_plan/update_node.hpp"
 
+namespace {
+
+using namespace opossum;                         // NOLINT
 using namespace opossum::expression_functional;  // NOLINT
 
-namespace opossum {
-
-namespace {
 void gather_expressions_not_computed_by_expression_evaluator(
     const std::shared_ptr<AbstractExpression>& expression,
     const std::vector<std::shared_ptr<AbstractExpression>>& input_expressions,
@@ -324,6 +324,13 @@ void prune_projection_node(
 }
 
 }  // namespace
+
+namespace opossum {
+
+std::string ColumnPruningRule::name() const {
+  static const auto name = std::string{"ColumnPruningRule"};
+  return name;
+}
 
 void ColumnPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // For each node, required_expressions_by_node will hold the expressions either needed by this node or by one of its

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -19,6 +19,9 @@ class AbstractLQPNode;
 //     information about which columns are needed and which ones are not. That information is gathered here and not
 //     exported.
 class ColumnPruningRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
@@ -68,6 +68,11 @@ bool remove_dependent_group_by_columns(const FunctionalDependency& fd, Aggregate
 
 namespace opossum {
 
+std::string DependentGroupByReductionRule::name() const {
+  static const auto name = std::string{"DependentGroupByReductionRule"};
+  return name;
+}
+
 void DependentGroupByReductionRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   visit_lqp(lqp_root, [&](const auto& node) {

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
@@ -40,6 +40,9 @@ class StoredTableNode;
  * However, not all queries listed in the paper can be optimized yet, since Hyrise lacks foreign key support.
  */
 class DependentGroupByReductionRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -18,6 +18,11 @@ namespace opossum {
 
 using namespace opossum::expression_functional;  // NOLINT
 
+std::string ExpressionReductionRule::name() const {
+  static const auto name = std::string{"ExpressionReductionRule"};
+  return name;
+}
+
 void ExpressionReductionRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto");

--- a/src/lib/optimizer/strategy/expression_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.hpp
@@ -34,6 +34,8 @@ class AbstractLQPNode;
  */
 class ExpressionReductionRule : public AbstractRule {
  public:
+  std::string name() const override;
+
   /**
    * Use the law of boolean distributivity to reduce an expression
    * `(a AND b) OR (a AND c)` becomes `a AND (b OR c)`

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
@@ -99,6 +99,11 @@ void rewrite_to_disjunction(const std::shared_ptr<AbstractLQPNode>& node,
 
 namespace opossum {
 
+std::string InExpressionRewriteRule::name() const {
+  static const auto name = std::string{"InExpressionRewriteRule"};
+  return name;
+}
+
 void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   if (strategy == Strategy::ExpressionEvaluator) {

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.hpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.hpp
@@ -18,6 +18,8 @@ class PredicateNode;
 
 class InExpressionRewriteRule : public AbstractRule {
  public:
+  std::string name() const override;
+
   // With the auto strategy, IN expressions with up to MAX_ELEMENTS_FOR_DISJUNCTION on the right side are rewritten
   // into disjunctive predicates. This value was chosen conservatively, also to keep the LQPs easy to read.
   constexpr static auto MAX_ELEMENTS_FOR_DISJUNCTION = 3;

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -17,8 +17,7 @@
 #include "statistics/cardinality_estimator.hpp"
 #include "utils/assert.hpp"
 
-namespace opossum {
-
+namespace {
 // Only if we expect num_output_rows <= num_input_rows * selectivity_threshold, the ScanType can be set to IndexScan.
 // This value is kind of arbitrarily chosen, but the following paper suggests something similar:
 // Access Path Selection in Main-Memory Optimized Data Systems: Should I Scan or Should I Probe?
@@ -27,6 +26,14 @@ constexpr float INDEX_SCAN_SELECTIVITY_THRESHOLD = 0.01f;
 // Only if the number of input rows exceeds num_input_rows, the ScanType can be set to IndexScan.
 // The number is taken from: Fast Lookups for In-Memory Column Stores: Group-Key Indices, Lookup and Maintenance.
 constexpr float INDEX_SCAN_ROW_COUNT_THRESHOLD = 1000.0f;
+}  // namespace
+
+namespace opossum {
+
+std::string IndexScanRule::name() const {
+  static const auto name = std::string{"IndexScanRule"};
+  return name;
+}
 
 void IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "IndexScanRule requires cost estimator to be set");

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -26,6 +26,9 @@ class PredicateNode;
  */
 
 class IndexScanRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
   bool _is_index_scan_applicable(const IndexStatistics& index_statistics,

--- a/src/lib/optimizer/strategy/join_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.cpp
@@ -13,6 +13,11 @@
 
 namespace opossum {
 
+std::string JoinOrderingRule::name() const {
+  static const auto name = std::string{"JoinOrderingRule"};
+  return name;
+}
+
 void JoinOrderingRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "JoinOrderingRule requires cost estimator to be set");
 

--- a/src/lib/optimizer/strategy/join_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.hpp
@@ -13,6 +13,9 @@ class AbstractCostEstimator;
  * Currently only the order of inner joins is modified using a single underlying algorithm, DpCcp.
  */
 class JoinOrderingRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 

--- a/src/lib/optimizer/strategy/join_predicate_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_predicate_ordering_rule.cpp
@@ -11,6 +11,11 @@
 
 namespace opossum {
 
+std::string JoinPredicateOrderingRule::name() const {
+  static const auto name = std::string{"JoinPredicateOrderingRule"};
+  return name;
+}
+
 void JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   visit_lqp(lqp_root, [&](const auto& node) {

--- a/src/lib/optimizer/strategy/join_predicate_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_predicate_ordering_rule.hpp
@@ -20,6 +20,9 @@ namespace opossum {
  * for why we have that duplication.
  */
 class JoinPredicateOrderingRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -23,6 +23,11 @@
 
 namespace opossum {
 
+std::string NullScanRemovalRule::name() const {
+  static const auto name = std::string{"NullScanRemovalRule"};
+  return name;
+}
+
 void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const {
   Assert(root->type == LQPNodeType::Root, "NullScanRemovalRule needs root to hold onto");
 

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -16,6 +16,7 @@ class PredicateNode;
 class NullScanRemovalRule : public AbstractRule {
  public:
   void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
+  std::string name() const override;
 
  private:
   static void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes);

--- a/src/lib/optimizer/strategy/predicate_merge_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_merge_rule.cpp
@@ -9,6 +9,11 @@ using namespace opossum::expression_functional;  // NOLINT
 
 namespace opossum {
 
+std::string PredicateMergeRule::name() const {
+  static const auto name = std::string{"PredicateMergeRule"};
+  return name;
+}
+
 /**
  * Merge subplans that only consists of PredicateNodes and UnionNodes (with SetOperationMode::Positions) into a single
  * PredicateNode. A subplan consists of linear "chain" and forked "diamond" parts.

--- a/src/lib/optimizer/strategy/predicate_merge_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_merge_rule.hpp
@@ -20,6 +20,8 @@ namespace opossum {
  */
 class PredicateMergeRule : public AbstractRule {
  public:
+  std::string name() const override;
+
   size_t minimum_union_count{4};
 
  protected:

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -17,6 +17,11 @@
 
 namespace opossum {
 
+std::string PredicatePlacementRule::name() const {
+  static const auto name = std::string{"PredicatePlacementRule"};
+  return name;
+}
+
 void PredicatePlacementRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // The traversal functions require the existence of a root of the LQP, so make sure we have that
   const auto root_node = lqp_root->type == LQPNodeType::Root ? lqp_root : LogicalPlanRootNode::make(lqp_root);

--- a/src/lib/optimizer/strategy/predicate_placement_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.hpp
@@ -19,6 +19,9 @@ class PredicateNode;
  * predicates involving a correlated subquery as "expensive" and all other predicates as non-expensive.
  */
 class PredicatePlacementRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -45,6 +45,11 @@ bool is_predicate_style_node(const std::shared_ptr<AbstractLQPNode>& node) {
 
 namespace opossum {
 
+std::string PredicateReorderingRule::name() const {
+  static const auto name = std::string{"PredicateReorderingRule"};
+  return name;
+}
+
 void PredicateReorderingRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "PredicateReorderingRule requires cost estimator to be set");

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
@@ -24,6 +24,9 @@ class PredicateNode;
  * others, such as JoinNode or UnionNode.
  */
 class PredicateReorderingRule : public AbstractRule {
+ public:
+  std::string name() const override;
+
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -7,9 +7,10 @@
 #include "logical_query_plan/lqp_utils.hpp"
 #include "logical_query_plan/union_node.hpp"
 
-namespace opossum {
-
 namespace {
+
+using namespace opossum;  // NOLINT
+
 bool predicates_are_mutually_exclusive(const std::vector<std::shared_ptr<AbstractExpression>>& predicates) {
   // Optimization: The ExpressionReductionRule transforms `x NOT LIKE 'foo%'` into `x < 'foo' OR x >= 'fop'`. For this
   // special case, we know that the two OR arguments are mutually exclusive. In this case, we do not need to use
@@ -66,7 +67,14 @@ bool predicates_are_mutually_exclusive(const std::vector<std::shared_ptr<Abstrac
 }
 }  // namespace
 
+namespace opossum {
+
 PredicateSplitUpRule::PredicateSplitUpRule(const bool split_disjunctions) : _split_disjunctions(split_disjunctions) {}
+
+std::string PredicateSplitUpRule::name() const {
+  static const auto name = std::string{"PredicateSplitUpRule"};
+  return name;
+}
 
 void PredicateSplitUpRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateSplitUpRule needs root to hold onto");

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
@@ -27,6 +27,7 @@ namespace opossum {
 class PredicateSplitUpRule : public AbstractRule {
  public:
   explicit PredicateSplitUpRule(const bool split_disjunctions = true);
+  std::string name() const override;
 
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -8,6 +8,12 @@
 #include "statistics/abstract_cardinality_estimator.hpp"
 
 namespace opossum {
+
+std::string SemiJoinReductionRule::name() const {
+  static const auto name = std::string{"SemiJoinReductionRule"};
+  return name;
+}
+
 void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "Rule needs root to hold onto");
 

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.hpp
@@ -45,6 +45,8 @@ class PredicateNode;
 
 class SemiJoinReductionRule : public AbstractRule {
  public:
+  std::string name() const override;
+
   // Defines the minimum selectivity for a semi join reduction to be added. For a candidate location in the LQP with an
   // input cardinality `i`, the output cardinality of the semi join has to be lower than `i * MINIMUM_SELECTIVITY`.
   constexpr static auto MINIMUM_SELECTIVITY = .25;

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -95,6 +95,11 @@ void align_pruned_column_ids(const ColumnPruningAgnosticMultiSet& grouped_stored
 
 namespace opossum {
 
+std::string StoredTableColumnAlignmentRule::name() const {
+  static const auto name = std::string{"StoredTableColumnAlignmentRule"};
+  return name;
+}
+
 /**
  * The default implementation of this function optimizes a given LQP and all of its subquery LQPs individually.
  * However, as we do not want to align StoredTableNodes per plan but across all plans, we override it accordingly.

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -63,6 +63,7 @@ namespace opossum {
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
   void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const override;
+  std::string name() const override;
 
  protected:
   void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -229,6 +229,11 @@ void push_arithmetic_expression_into_subquery(const std::shared_ptr<BinaryPredic
 
 namespace opossum {
 
+std::string SubqueryToJoinRule::name() const {
+  static const auto name = std::string{"SubqueryToJoinRule"};
+  return name;
+}
+
 std::optional<SubqueryToJoinRule::PredicateNodeInfo> SubqueryToJoinRule::is_predicate_node_join_candidate(
     const PredicateNode& predicate_node) {
   PredicateNodeInfo result;

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
@@ -30,6 +30,8 @@ class ProjectionNode;
  */
 class SubqueryToJoinRule : public AbstractRule {
  public:
+  std::string name() const override;
+
   struct PredicateNodeInfo {
     /**
      * Join predicate to achieve the semantic of the input expression type (IN, comparison, ...) in the created join.

--- a/src/test/lib/optimizer/optimizer_test.cpp
+++ b/src/test/lib/optimizer/optimizer_test.cpp
@@ -224,8 +224,8 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
     explicit MockRule(size_t& init_counter) : counter(init_counter) {}
     std::string name() const override { return "MockRule"; }
 
-   protected:
     size_t& counter;
+   protected:
     void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       ++counter;
     }

--- a/src/test/lib/optimizer/optimizer_test.cpp
+++ b/src/test/lib/optimizer/optimizer_test.cpp
@@ -109,7 +109,9 @@ TEST_F(OptimizerTest, VerifiesResults) {
    public:
     explicit LQPBreakingRule(const std::shared_ptr<AbstractExpression>& init_out_of_plan_expression)
         : out_of_plan_expression(init_out_of_plan_expression) {}
+    std::string name() const override { return "LQPBreakingRule"; }
 
+   protected:
     void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       // Change the `b` expression in the projection to `x`, which is not part of the input LQP
       const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(lqp_root->left_input());
@@ -117,7 +119,6 @@ TEST_F(OptimizerTest, VerifiesResults) {
       projection_node->node_expressions[0] = out_of_plan_expression;
     }
 
-    std::string name() const override { return "LQPBreakingRule"; }
 
     std::shared_ptr<AbstractExpression> out_of_plan_expression;
   };
@@ -210,7 +211,7 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
     EXPECT_NE(subquery_a_a->lqp, subquery_a_b->lqp);
   }
 
-  /**q
+  /**
    * 2. Optimize the LQP with a telemetric Rule
    */
 
@@ -221,10 +222,10 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
   class MockRule : public AbstractRule {
    public:
     explicit MockRule(size_t& init_counter) : counter(init_counter) {}
-
-    size_t& counter;
+    std::string name() const override { return "MockRule"; }
 
    protected:
+    size_t& counter;
     void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       ++counter;
     }

--- a/src/test/lib/optimizer/optimizer_test.cpp
+++ b/src/test/lib/optimizer/optimizer_test.cpp
@@ -117,6 +117,8 @@ TEST_F(OptimizerTest, VerifiesResults) {
       projection_node->node_expressions[0] = out_of_plan_expression;
     }
 
+    std::string name() const override { return "LQPBreakingRule"; }
+
     std::shared_ptr<AbstractExpression> out_of_plan_expression;
   };
 
@@ -136,6 +138,7 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
   class MockRule : public AbstractRule {
    public:
     explicit MockRule(std::unordered_set<std::shared_ptr<AbstractLQPNode>>& init_nodes) : nodes(init_nodes) {}
+    std::string name() const override { return "MockRule"; }
 
    protected:
     void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {

--- a/src/test/lib/optimizer/optimizer_test.cpp
+++ b/src/test/lib/optimizer/optimizer_test.cpp
@@ -119,7 +119,6 @@ TEST_F(OptimizerTest, VerifiesResults) {
       projection_node->node_expressions[0] = out_of_plan_expression;
     }
 
-
     std::shared_ptr<AbstractExpression> out_of_plan_expression;
   };
 
@@ -225,6 +224,7 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
     std::string name() const override { return "MockRule"; }
 
     size_t& counter;
+
    protected:
     void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       ++counter;


### PR DESCRIPTION
This PR adds `AbstractRule::name`, similar to `AbstractOperator::name`. 

It replaces 

```cpp
auto& rule_reference = *rule;
std::string(typeid(rule_reference).name());
```

with

```cpp
rule->name();
```