### PR TITLE
lint.sh: Work even if only a single file is present

### DIFF
--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -15,35 +15,35 @@ let "exitcode |= $?"
 #             Finds all .cpp and .hpp files, separated by \0
 
 # All disabled tests should have an issue number
-output=$(grep -rn 'DISABLED_' src/test | grep -v '#[0-9]\+' | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Disabled tests should be documented with their issue number (e.g. \/* #123 *\/)/')
+output=$(grep -rHn 'DISABLED_' src/test | grep -v '#[0-9]\+' | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Disabled tests should be documented with their issue number (e.g. \/* #123 *\/)/')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1
 fi
 
 # Gtest's TEST() should not be used. Use TEST_F() instead. This might require additional test classes but ensures that state is cleaned up properly.
-output=$(grep -rn '^TEST(' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  TEST() should not be used as it does not clean up global state (e.g., the Hyrise singleton)./')
+output=$(grep -rHn '^TEST(' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  TEST() should not be used as it does not clean up global state (e.g., the Hyrise singleton)./')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1
 fi
 
 # Tests should inherit from BaseTest or BaseTestWithParams of base_test.hpp to ensure proper destruction.
-output=$(grep -rEn ':[[:space:]]*(public|protected|private)?[[:space:]]+::testing::Test' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Tests should inherit from BaseTest\/BaseTestWithParams to ensure a proper clean up./')
+output=$(grep -rHEn ':[[:space:]]*(public|protected|private)?[[:space:]]+::testing::Test' src/test | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Tests should inherit from BaseTest\/BaseTestWithParams to ensure a proper clean up./')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1
 fi
 
 # The singleton pattern should not be manually implemented
-output=$(grep -rn 'static[^:]*instance;' --exclude singleton.hpp src | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Singletons should not be implemented manually. Have a look at src\/lib\/utils\/singleton.hpp/')
+output=$(grep -rHn 'static[^:]*instance;' --exclude singleton.hpp src | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Singletons should not be implemented manually. Have a look at src\/lib\/utils\/singleton.hpp/')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1
 fi
 
 # Tests should not include any type of random behavior, see #1321.
-output=$(grep -rEn '#include <random>|std::random|std::[a-z_]+_engine|std::[a-z_]+_distribution' src/test | grep -v std::random_access_iterator_tag | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Tests should not include any type of random behavior, see #1321./')
+output=$(grep -rHEn '#include <random>|std::random|std::[a-z_]+_engine|std::[a-z_]+_distribution' src/test | grep -v std::random_access_iterator_tag | sed 's/^\([a-zA-Z/._]*:[0-9]*\).*/\1  Tests should not include any type of random behavior, see #1321./')
 if [ ! -z "$output" ]; then
 	echo "$output"
 	exitcode=1
@@ -51,7 +51,7 @@ fi
 
 # Check for included cpp files. You would think that this is not necessary, but history proves you wrong.
 regex='#include .*\.cpp'
-namecheck=$(find src \( -iname "*.cpp" -o -iname "*.hpp" \) -print0 | xargs -0 grep -rn "$regex" | grep -v NOLINT)
+namecheck=$(find src \( -iname "*.cpp" -o -iname "*.hpp" \) -print0 | xargs -0 grep -rHn "$regex" | grep -v NOLINT)
 
 let "exitcode |= ! $?"
 while IFS= read -r line


### PR DESCRIPTION
I was just using this as a base for something else and realized that our custom lint scripts expect at least two cpp files. Adding `-H` makes grep print the file name even if there is just a single file.