### PR TITLE
Let CI build JOB query plans

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,8 +140,7 @@ try {
                 Utils.markStageSkippedForConditional("clangRelease")
               }
             }
-          }
-          , debugSystemTests: {
+          }, debugSystemTests: {
             stage("system-tests") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,139 +141,139 @@ try {
               }
             }
           }
-          // , debugSystemTests: {
-          //   stage("system-tests") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-          //       sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-          //       sh "./scripts/test/hyriseConsole_test.py clang-debug"
-          //       sh "./scripts/test/hyriseServer_test.py clang-debug"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
-          //       sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-          //       sh "./scripts/test/hyriseServer_test.py gcc-debug"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
+          , debugSystemTests: {
+            stage("system-tests") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+                sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+                sh "./scripts/test/hyriseConsole_test.py clang-debug"
+                sh "./scripts/test/hyriseServer_test.py clang-debug"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
+                sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+                sh "./scripts/test/hyriseServer_test.py gcc-debug"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
 
-          //     } else {
-          //       Utils.markStageSkippedForConditional("debugSystemTests")
-          //     }
-          //   }
-          // }, clangDebugRunShuffled: {
-          //   stage("clang-debug:test-shuffle") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "mkdir ./clang-debug/run-shuffled"
-          //       sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-          //       sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-          //     }
-          //   }
-          // }, clangDebugUnityODR: {
-          //   stage("clang-debug-unity-odr") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-          //       sh "cd clang-debug-unity-odr && make all -j \$(( \$(nproc) / 3))"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugUnityODR")
-          //     }
-          //   }
-          // }, clangDebugTidy: {
-          //   stage("clang-debug:tidy") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-          //       sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugTidy")
-          //     }
-          //   }
-          // }, clangDebugDisablePrecompileHeaders: {
-          //   stage("clang-debug:disable-precompile-headers") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-          //       sh "cd clang-debug-disable-precompile-headers && make hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-          //     }
-          //   }
-          // }, clangDebugAddrUBSanitizers: {
-          //   stage("clang-debug:addr-ub-sanitizers") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugAddrUBSanitizers")
-          //     }
-          //   }
-          // }, gccRelease: {
-          //   if (env.BRANCH_NAME == 'master' || full_ci) {
-          //     stage("gcc-release") {
-          //       sh "cd gcc-release && make all -j \$(( \$(nproc) / 6))"
-          //       sh "./gcc-release/hyriseTest gcc-release"
-          //       sh "./gcc-release/hyriseSystemTest gcc-release"
-          //       sh "./scripts/test/hyriseConsole_test.py gcc-release"
-          //       sh "./scripts/test/hyriseServer_test.py gcc-release"
-          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-          //     }
-          //   } else {
-          //       Utils.markStageSkippedForConditional("gccRelease")
-          //   }
-          // }, clangReleaseAddrUBSanitizers: {
-          //   stage("clang-release:addr-ub-sanitizers") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
-          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-          //       sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
-          //     }
-          //   }
-          // }, clangRelWithDebInfoThreadSanitizer: {
-          //   stage("clang-relwithdebinfo:thread-sanitizer") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(nproc) / 6))"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-          //     }
-          //   }
-          // }, clangDebugCoverage: {
-          //   stage("clang-debug-coverage") {
-          //     if (env.BRANCH_NAME == 'master' || full_ci) {
-          //       sh "./scripts/coverage.sh --generate_badge=true"
-          //       sh "find coverage -type d -exec chmod +rx {} \\;"
-          //       archive 'coverage_badge.svg'
-          //       archive 'coverage_percent.txt'
-          //       publishHTML (target: [
-          //         allowMissing: false,
-          //         alwaysLinkToLastBuild: false,
-          //         keepAll: true,
-          //         reportDir: 'coverage',
-          //         reportFiles: 'index.html',
-          //         reportName: "Llvm-cov_Report"
-          //       ])
-          //       script {
-          //         coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-          //         githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-          //       }
-          //     } else {
-          //       Utils.markStageSkippedForConditional("clangDebugCoverage")
-          //     }
-          //   }
-          // }
+              } else {
+                Utils.markStageSkippedForConditional("debugSystemTests")
+              }
+            }
+          }, clangDebugRunShuffled: {
+            stage("clang-debug:test-shuffle") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir ./clang-debug/run-shuffled"
+                sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+              }
+            }
+          }, clangDebugUnityODR: {
+            stage("clang-debug-unity-odr") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+                sh "cd clang-debug-unity-odr && make all -j \$(( \$(nproc) / 3))"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugUnityODR")
+              }
+            }
+          }, clangDebugTidy: {
+            stage("clang-debug:tidy") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+                sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugTidy")
+              }
+            }
+          }, clangDebugDisablePrecompileHeaders: {
+            stage("clang-debug:disable-precompile-headers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+                sh "cd clang-debug-disable-precompile-headers && make hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+              }
+            }
+          }, clangDebugAddrUBSanitizers: {
+            stage("clang-debug:addr-ub-sanitizers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugAddrUBSanitizers")
+              }
+            }
+          }, gccRelease: {
+            if (env.BRANCH_NAME == 'master' || full_ci) {
+              stage("gcc-release") {
+                sh "cd gcc-release && make all -j \$(( \$(nproc) / 6))"
+                sh "./gcc-release/hyriseTest gcc-release"
+                sh "./gcc-release/hyriseSystemTest gcc-release"
+                sh "./scripts/test/hyriseConsole_test.py gcc-release"
+                sh "./scripts/test/hyriseServer_test.py gcc-release"
+                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+              }
+            } else {
+                Utils.markStageSkippedForConditional("gccRelease")
+            }
+          }, clangReleaseAddrUBSanitizers: {
+            stage("clang-release:addr-ub-sanitizers") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
+                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+                sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+              } else {
+                Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
+              }
+            }
+          }, clangRelWithDebInfoThreadSanitizer: {
+            stage("clang-relwithdebinfo:thread-sanitizer") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(nproc) / 6))"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+              } else {
+                Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+              }
+            }
+          }, clangDebugCoverage: {
+            stage("clang-debug-coverage") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "./scripts/coverage.sh --generate_badge=true"
+                sh "find coverage -type d -exec chmod +rx {} \\;"
+                archive 'coverage_badge.svg'
+                archive 'coverage_percent.txt'
+                publishHTML (target: [
+                  allowMissing: false,
+                  alwaysLinkToLastBuild: false,
+                  keepAll: true,
+                  reportDir: 'coverage',
+                  reportFiles: 'index.html',
+                  reportName: "Llvm-cov_Report"
+                ])
+                script {
+                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+                }
+              } else {
+                Utils.markStageSkippedForConditional("clangDebugCoverage")
+              }
+            }
+          }
 
           parallel memcheckReleaseTest: {
             stage("memcheckReleaseTest") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -290,7 +290,7 @@ try {
           }, tpchVerification: {
             stage("tpchVerification") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./clang-release/hyriseBenchmarkTPCH -r 1 -s 1 --verify"
+                sh "./clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 1 -s 1 --verify"
               } else {
                 Utils.markStageSkippedForConditional("tpchVerification")
               }
@@ -298,7 +298,7 @@ try {
           }, tpchQueryPlans: {
             stage("tpchQueryPlans") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                sh "mkdir -p query_plans/tpch; cd query_plans/tpch && ../../clang-release/hyriseBenchmarkTPCH --dont_cache_binary_tables -r 2 -s 10 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
                 archiveArtifacts artifacts: 'query_plans/tpch/*.svg'
                 archiveArtifacts artifacts: 'query_plans/tpch/operator_breakdown.pdf'
               } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,7 +308,7 @@ try {
           }, tpcdsQueryPlansAndVerification: {
             stage("tpcdsQueryPlansAndVerification") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS -r 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
                 archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
                 archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
               } else {
@@ -318,7 +318,8 @@ try {
           }, jobQueryPlans: {
             stage("jobQueryPlans") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *.svg query_plans/job"
+                // In contrast to TPC-H and TPC-DS above, we execute the JoinOrderBenchmark from the project's root directoy because its setup script requires us to do so.
+                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder --dont_cache_binary_tables -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *.svg query_plans/job"
                 archiveArtifacts artifacts: 'query_plans/job/*.svg'
                 archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
               } else {
@@ -334,7 +335,6 @@ try {
     }
   }
 
-  // I have not found a nice way to run this in parallel with the steps above, as those are in a `docker.inside` block and this is not.
   parallel clangDebugMacX64: {
     node('mac') {
       stage("clangDebugMacX64") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,6 +315,16 @@ try {
                 Utils.markStageSkippedForConditional("tpcdsQueryPlansAndVerification")
               }
             }
+          }, jobQueryPlans: {
+            stage("jobQueryPlans") {
+              if (env.BRANCH_NAME == 'master' || full_ci) {
+                sh "mkdir -p query_plans/job; cd query_plans/job && ln -s ../../resources; ../../clang-release/hyriseBenchmarkJoinOrder -r 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                archiveArtifacts artifacts: 'query_plans/job/*.svg'
+                archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
+              } else {
+                Utils.markStageSkippedForConditional("jobQueryPlans")
+              }
+            }
           }
         } finally {
           sh "ls -A1 | xargs rm -rf"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -140,139 +140,140 @@ try {
                 Utils.markStageSkippedForConditional("clangRelease")
               }
             }
-          }, debugSystemTests: {
-            stage("system-tests") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
-                sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
-                sh "./scripts/test/hyriseConsole_test.py clang-debug"
-                sh "./scripts/test/hyriseServer_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
-                sh "./scripts/test/hyriseConsole_test.py gcc-debug"
-                sh "./scripts/test/hyriseServer_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-                sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
-
-              } else {
-                Utils.markStageSkippedForConditional("debugSystemTests")
-              }
-            }
-          }, clangDebugRunShuffled: {
-            stage("clang-debug:test-shuffle") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir ./clang-debug/run-shuffled"
-                sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
-                sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugRunShuffled")
-              }
-            }
-          }, clangDebugUnityODR: {
-            stage("clang-debug-unity-odr") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
-                sh "cd clang-debug-unity-odr && make all -j \$(( \$(nproc) / 3))"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugUnityODR")
-              }
-            }
-          }, clangDebugTidy: {
-            stage("clang-debug:tidy") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugTidy")
-              }
-            }
-          }, clangDebugDisablePrecompileHeaders: {
-            stage("clang-debug:disable-precompile-headers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
-                sh "cd clang-debug-disable-precompile-headers && make hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
-              }
-            }
-          }, clangDebugAddrUBSanitizers: {
-            stage("clang-debug:addr-ub-sanitizers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugAddrUBSanitizers")
-              }
-            }
-          }, gccRelease: {
-            if (env.BRANCH_NAME == 'master' || full_ci) {
-              stage("gcc-release") {
-                sh "cd gcc-release && make all -j \$(( \$(nproc) / 6))"
-                sh "./gcc-release/hyriseTest gcc-release"
-                sh "./gcc-release/hyriseSystemTest gcc-release"
-                sh "./scripts/test/hyriseConsole_test.py gcc-release"
-                sh "./scripts/test/hyriseServer_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
-                sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
-                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-                sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
-              }
-            } else {
-                Utils.markStageSkippedForConditional("gccRelease")
-            }
-          }, clangReleaseAddrUBSanitizers: {
-            stage("clang-release:addr-ub-sanitizers") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
-                sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-                sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
-              } else {
-                Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
-              }
-            }
-          }, clangRelWithDebInfoThreadSanitizer: {
-            stage("clang-relwithdebinfo:thread-sanitizer") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(nproc) / 6))"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
-                sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
-              } else {
-                Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
-              }
-            }
-          }, clangDebugCoverage: {
-            stage("clang-debug-coverage") {
-              if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "./scripts/coverage.sh --generate_badge=true"
-                sh "find coverage -type d -exec chmod +rx {} \\;"
-                archive 'coverage_badge.svg'
-                archive 'coverage_percent.txt'
-                publishHTML (target: [
-                  allowMissing: false,
-                  alwaysLinkToLastBuild: false,
-                  keepAll: true,
-                  reportDir: 'coverage',
-                  reportFiles: 'index.html',
-                  reportName: "Llvm-cov_Report"
-                ])
-                script {
-                  coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
-                  githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
-                }
-              } else {
-                Utils.markStageSkippedForConditional("clangDebugCoverage")
-              }
-            }
           }
+          // , debugSystemTests: {
+          //   stage("system-tests") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir clang-debug-system &&  ./clang-debug/hyriseSystemTest clang-debug-system"
+          //       sh "mkdir gcc-debug-system &&  ./gcc-debug/hyriseSystemTest gcc-debug-system"
+          //       sh "./scripts/test/hyriseConsole_test.py clang-debug"
+          //       sh "./scripts/test/hyriseServer_test.py clang-debug"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py clang-debug"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py clang-debug"
+          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          //       sh "cd clang-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
+          //       sh "./scripts/test/hyriseConsole_test.py gcc-debug"
+          //       sh "./scripts/test/hyriseServer_test.py gcc-debug"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-debug"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-debug"
+          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          //       sh "cd gcc-debug && ../scripts/test/hyriseBenchmarkJCCH_test.py ." // Own folder to isolate visualization
+
+          //     } else {
+          //       Utils.markStageSkippedForConditional("debugSystemTests")
+          //     }
+          //   }
+          // }, clangDebugRunShuffled: {
+          //   stage("clang-debug:test-shuffle") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "mkdir ./clang-debug/run-shuffled"
+          //       sh "./clang-debug/hyriseTest clang-debug/run-shuffled --gtest_repeat=5 --gtest_shuffle"
+          //       sh "./clang-debug/hyriseSystemTest clang-debug/run-shuffled --gtest_repeat=2 --gtest_shuffle"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugRunShuffled")
+          //     }
+          //   }
+          // }, clangDebugUnityODR: {
+          //   stage("clang-debug-unity-odr") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // Check if unity builds work even if everything is batched into a single compilation unit. This helps prevent ODR (one definition rule) issues.
+          //       sh "cd clang-debug-unity-odr && make all -j \$(( \$(nproc) / 3))"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugUnityODR")
+          //     }
+          //   }
+          // }, clangDebugTidy: {
+          //   stage("clang-debug:tidy") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
+          //       sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugTidy")
+          //     }
+          //   }
+          // }, clangDebugDisablePrecompileHeaders: {
+          //   stage("clang-debug:disable-precompile-headers") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       // Check if builds work even when precompile headers is turned off. Executing the binaries is unnecessary as the observed errors are missing includes.
+          //       sh "cd clang-debug-disable-precompile-headers && make hyriseTest hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 6))"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugDisablePrecompileHeaders")
+          //     }
+          //   }
+          // }, clangDebugAddrUBSanitizers: {
+          //   stage("clang-debug:addr-ub-sanitizers") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-debug-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseTest clang-debug-addr-ub-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-debug-addr-ub-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-debug-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 1"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugAddrUBSanitizers")
+          //     }
+          //   }
+          // }, gccRelease: {
+          //   if (env.BRANCH_NAME == 'master' || full_ci) {
+          //     stage("gcc-release") {
+          //       sh "cd gcc-release && make all -j \$(( \$(nproc) / 6))"
+          //       sh "./gcc-release/hyriseTest gcc-release"
+          //       sh "./gcc-release/hyriseSystemTest gcc-release"
+          //       sh "./scripts/test/hyriseConsole_test.py gcc-release"
+          //       sh "./scripts/test/hyriseServer_test.py gcc-release"
+          //       sh "./scripts/test/hyriseBenchmarkJoinOrder_test.py gcc-release"
+          //       sh "./scripts/test/hyriseBenchmarkFileBased_test.py gcc-release"
+          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+          //       sh "cd gcc-release && ../scripts/test/hyriseBenchmarkTPCH_test.py ." // Own folder to isolate visualization
+          //     }
+          //   } else {
+          //       Utils.markStageSkippedForConditional("gccRelease")
+          //   }
+          // }, clangReleaseAddrUBSanitizers: {
+          //   stage("clang-release:addr-ub-sanitizers") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-release-addr-ub-sanitizers && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH hyriseBenchmarkTPCC -j \$(( \$(nproc) / 6))"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseTest clang-release-addr-ub-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-release-addr-ub-sanitizers"
+          //       sh "LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ./clang-release-addr-ub-sanitizers/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+          //       sh "cd clang-release-addr-ub-sanitizers && LSAN_OPTIONS=suppressions=resources/.lsan-ignore.txt ASAN_OPTIONS=suppressions=resources/.asan-ignore.txt ../scripts/test/hyriseBenchmarkTPCC_test.py ." // Own folder to isolate binary export tests
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangReleaseAddrUBSanitizers")
+          //     }
+          //   }
+          // }, clangRelWithDebInfoThreadSanitizer: {
+          //   stage("clang-relwithdebinfo:thread-sanitizer") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "cd clang-relwithdebinfo-thread-sanitizer && make hyriseTest hyriseSystemTest hyriseBenchmarkTPCH -j \$(( \$(nproc) / 6))"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseTest clang-relwithdebinfo-thread-sanitizer"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseSystemTest ${tests_excluded_in_sanitizer_builds} clang-relwithdebinfo-thread-sanitizer"
+          //       sh "TSAN_OPTIONS=\"history_size=7 suppressions=resources/.tsan-ignore.txt\" ./clang-relwithdebinfo-thread-sanitizer/hyriseBenchmarkTPCH -s .01 --verify -r 100 --scheduler --clients 10"
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangRelWithDebInfoThreadSanitizer")
+          //     }
+          //   }
+          // }, clangDebugCoverage: {
+          //   stage("clang-debug-coverage") {
+          //     if (env.BRANCH_NAME == 'master' || full_ci) {
+          //       sh "./scripts/coverage.sh --generate_badge=true"
+          //       sh "find coverage -type d -exec chmod +rx {} \\;"
+          //       archive 'coverage_badge.svg'
+          //       archive 'coverage_percent.txt'
+          //       publishHTML (target: [
+          //         allowMissing: false,
+          //         alwaysLinkToLastBuild: false,
+          //         keepAll: true,
+          //         reportDir: 'coverage',
+          //         reportFiles: 'index.html',
+          //         reportName: "Llvm-cov_Report"
+          //       ])
+          //       script {
+          //         coverageChange = sh script: "./scripts/compare_coverage.sh", returnStdout: true
+          //         githubNotify context: 'Coverage', description: "$coverageChange", status: 'SUCCESS', targetUrl: "${env.BUILD_URL}/RCov_20Report/index.html"
+          //       }
+          //     } else {
+          //       Utils.markStageSkippedForConditional("clangDebugCoverage")
+          //     }
+          //   }
+          // }
 
           parallel memcheckReleaseTest: {
             stage("memcheckReleaseTest") {
@@ -318,7 +319,7 @@ try {
           }, jobQueryPlans: {
             stage("jobQueryPlans") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/job; cd query_plans/job && ln -s ../../resources; ../../clang-release/hyriseBenchmarkJoinOrder -r 1 --visualize && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                sh "mkdir -p query_plans/job && ./clang-release/hyriseBenchmarkJoinOrder -r 1 --visualize && ./scripts/plot_operator_breakdown.py ./clang-release/ && mv operator_breakdown.pdf query_plans/job && mv *.svg query_plans/job"
                 archiveArtifacts artifacts: 'query_plans/job/*.svg'
                 archiveArtifacts artifacts: 'query_plans/job/operator_breakdown.pdf'
               } else {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -337,7 +337,7 @@ try {
   // I have not found a nice way to run this in parallel with the steps above, as those are in a `docker.inside` block and this is not.
   parallel clangDebugMacX64: {
     node('mac') {
-      stage("clang-debug-mac-x64") {
+      stage("clangDebugMacX64") {
         if (env.BRANCH_NAME == 'master' || full_ci) {
           try {
             checkout scm
@@ -356,14 +356,14 @@ try {
             sh "ls -A1 | xargs rm -rf"
           }
         } else {
-          Utils.markStageSkippedForConditional("clang-debug-mac-x64")
+          Utils.markStageSkippedForConditional("clangDebugMacX64")
         }
       }
     }
   }, clangReleaseMacArm: {
     // For this to work, we installed a native non-standard JDK (zulu) via brew. See #2339 for more details.
     node('mac-arm') {
-      stage("clang-release-mac-arm") {
+      stage("clangReleaseMacArm") {
         if (env.BRANCH_NAME == 'master' || full_ci) {
           try {
             checkout scm          
@@ -388,7 +388,7 @@ try {
             sh "ls -A1 | xargs rm -rf"
           }
         } else {
-          Utils.markStageSkippedForConditional("clang-release-mac-arm")
+          Utils.markStageSkippedForConditional("clangReleaseMacArm")
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ We support a number of benchmarks out of the box. This makes it easy to generate
 | ---------- | ------------------------------------------------------------------------------------------------------------------------ |
 | TPC-DS     | [Query Plans](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/query_plans/tpcds) |
 | TPC-H      | [Query Plans](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/query_plans/tpch)  |
+| Join Order | [Query Plans](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/query_plans/job)   |
 | JCC-H      | Call the hyriseBenchmarkTPCH binary with the -j flag.                                                                    | 
 | TPC-C      | In development, no proper optimization done yet                                                                          |
-| Join Order |                                                                                                                          |
 
 # Getting started
 


### PR DESCRIPTION
Now that we quite frequently work with, and optimize for the JOB, fast access to its query plans would be useful. Also, the setup procedure is much faster now (smaller data set and faster download due to different hosting). 

The other changes in the Jenkinsfile optimize the visualization of the CI process in the CI's UI: previously, both of the Mac building steps have been displayed in green even though they have been skipped, now they are shown in grey. (@Bouncner made me aware of that.)