### PR TITLE
Prettier Visualizer plans with consistent label wrapping & updated operator descriptions

### DIFF
--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -40,14 +40,12 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
       desc << "," << separator;
     }
     if (lqp_node) {
-      desc << lqp_node->left_input()->output_expressions()[groupby_column_idx]->as_column_name();
+      desc << " " << lqp_node->left_input()->output_expressions()[groupby_column_idx]->as_column_name();
     } else {
       desc << "Column #" + std::to_string(_groupby_column_ids[groupby_column_idx]);
     }
   }
-  desc << "}" << separator;
-  // Add additional newline for clear separation of group-by and aggregate expressions in query plans
-  if (group_by_count > 1 && description_mode == DescriptionMode::MultiLine) desc << separator;
+  desc << " }" << separator;
   auto aggregate_count = _aggregates.size();
   for (auto aggregate_idx = size_t{0}; aggregate_idx < aggregate_count; ++aggregate_idx) {
     if (aggregate_idx > 0) {

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -32,7 +32,8 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
 
   std::stringstream desc;
-  desc << AbstractOperator::description(description_mode) << separator << "GroupBy ColumnIDs: ";
+  desc << AbstractOperator::description(description_mode) << separator;
+  desc << "GroupBy ColumnIDs: ";
   for (size_t groupby_column_idx = 0; groupby_column_idx < _groupby_column_ids.size(); ++groupby_column_idx) {
     desc << _groupby_column_ids[groupby_column_idx];
 
@@ -40,8 +41,8 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
       desc << ", ";
     }
   }
-
-  desc << " Aggregates: ";
+  desc << separator;
+  desc << "Aggregates: ";
   for (size_t expression_idx = 0; expression_idx < _aggregates.size(); ++expression_idx) {
     const auto& aggregate = _aggregates[expression_idx];
     desc << aggregate->as_column_name();

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -35,6 +35,7 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
   desc << AbstractOperator::description(description_mode) << separator;
   desc << "GroupBy {";
   auto group_by_count = _groupby_column_ids.size();
+  if (group_by_count > 1 && description_mode == DescriptionMode::MultiLine) desc << separator;
   for (auto groupby_column_idx = size_t{0}; groupby_column_idx < group_by_count; ++groupby_column_idx) {
     if (groupby_column_idx > 0) {
       desc << "," << separator;
@@ -45,6 +46,7 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
       desc << "Column #" + std::to_string(_groupby_column_ids[groupby_column_idx]);
     }
   }
+  if (group_by_count > 1 && description_mode == DescriptionMode::MultiLine) desc << separator;
   desc << "}" << separator;
   auto aggregate_count = _aggregates.size();
   for (auto aggregate_idx = size_t{0}; aggregate_idx < aggregate_count; ++aggregate_idx) {

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -41,7 +41,7 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
     }
     const size_t group_by_column_id = _groupby_column_ids[groupby_column_idx];
     if (lqp_node) {
-      desc << lqp_node->left_input()->output_expressions()[group_by_column_id];
+      desc << lqp_node->left_input()->output_expressions()[group_by_column_id]->as_column_name();
     } else {
       desc << "Column #" + std::to_string(group_by_column_id);
     }

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -39,10 +39,11 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
     if (groupby_column_idx > 0) {
       desc << "," << separator;
     }
+    const size_t group_by_column_id = _groupby_column_ids[groupby_column_idx];
     if (lqp_node) {
-      desc << lqp_node->left_input()->output_expressions()[groupby_column_idx]->as_column_name();
-    } else {
-      desc << "Column #" + std::to_string(_groupby_column_ids[groupby_column_idx]);
+      desc << lqp_node->left_input()->output_expressions()[group_by_column_id];
+    } else { 
+      desc << "Column #" + std::to_string(group_by_column_id);
     }
   }
   desc << "}" << separator;

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -29,7 +29,7 @@ const std::vector<std::shared_ptr<AggregateExpression>>& AbstractAggregateOperat
 const std::vector<ColumnID>& AbstractAggregateOperator::groupby_column_ids() const { return _groupby_column_ids; }
 
 std::string AbstractAggregateOperator::description(DescriptionMode description_mode) const {
-  const auto* const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
 
   std::stringstream desc;
   desc << AbstractOperator::description(description_mode) << separator << "GroupBy ColumnIDs: ";

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -42,7 +42,6 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
     }
   }
   desc << "}" << separator;
-  desc << "Aggregates:" << separator;
   for (size_t expression_idx = 0; expression_idx < _aggregates.size(); ++expression_idx) {
     const auto& aggregate = _aggregates[expression_idx];
     desc << aggregate->as_column_name();

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -42,7 +42,7 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
     const size_t group_by_column_id = _groupby_column_ids[groupby_column_idx];
     if (lqp_node) {
       desc << lqp_node->left_input()->output_expressions()[group_by_column_id];
-    } else { 
+    } else {
       desc << "Column #" + std::to_string(group_by_column_id);
     }
   }

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -33,13 +33,17 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
 
   std::stringstream desc;
   desc << AbstractOperator::description(description_mode) << separator;
-  desc << "GroupBy ColumnIDs: {";
+  desc << "GroupBy {";
   auto group_by_count = _groupby_column_ids.size();
   for (auto groupby_column_idx = size_t{0}; groupby_column_idx < group_by_count; ++groupby_column_idx) {
     if (groupby_column_idx > 0) {
-      desc << ", ";
+      desc << "," << separator;
     }
-    desc << _groupby_column_ids[groupby_column_idx];
+    if (lqp_node) {
+      desc << lqp_node->left_input()->output_expressions()[groupby_column_idx]->as_column_name();
+    } else {
+      desc << "Column #" + std::to_string(_groupby_column_ids[groupby_column_idx]);
+    }
   }
   desc << "}" << separator;
   auto aggregate_count = _aggregates.size();

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -33,7 +33,7 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
 
   std::stringstream desc;
   desc << AbstractOperator::description(description_mode) << separator;
-  desc << "GroupBy ColumnIDs: ";
+  desc << "GroupBy ColumnIDs: {";
   for (size_t groupby_column_idx = 0; groupby_column_idx < _groupby_column_ids.size(); ++groupby_column_idx) {
     desc << _groupby_column_ids[groupby_column_idx];
 
@@ -41,13 +41,13 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
       desc << ", ";
     }
   }
-  desc << separator;
-  desc << "Aggregates: ";
+  desc << "}" << separator;
+  desc << "Aggregates:" << separator;
   for (size_t expression_idx = 0; expression_idx < _aggregates.size(); ++expression_idx) {
     const auto& aggregate = _aggregates[expression_idx];
     desc << aggregate->as_column_name();
 
-    if (expression_idx + 1 < _aggregates.size()) desc << ", ";
+    if (expression_idx + 1 < _aggregates.size()) desc << ", " << separator;
   }
   return desc.str();
 }

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -35,7 +35,6 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
   desc << AbstractOperator::description(description_mode) << separator;
   desc << "GroupBy {";
   auto group_by_count = _groupby_column_ids.size();
-  if (group_by_count > 1 && description_mode == DescriptionMode::MultiLine) desc << separator;
   for (auto groupby_column_idx = size_t{0}; groupby_column_idx < group_by_count; ++groupby_column_idx) {
     if (groupby_column_idx > 0) {
       desc << "," << separator;
@@ -46,8 +45,9 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
       desc << "Column #" + std::to_string(_groupby_column_ids[groupby_column_idx]);
     }
   }
-  if (group_by_count > 1 && description_mode == DescriptionMode::MultiLine) desc << separator;
   desc << "}" << separator;
+  // Add additional newline for clear separation of group-by and aggregate expressions in query plans
+  if (group_by_count > 1 && description_mode == DescriptionMode::MultiLine) desc << separator;
   auto aggregate_count = _aggregates.size();
   for (auto aggregate_idx = size_t{0}; aggregate_idx < aggregate_count; ++aggregate_idx) {
     if (aggregate_idx > 0) {

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -34,19 +34,21 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
   std::stringstream desc;
   desc << AbstractOperator::description(description_mode) << separator;
   desc << "GroupBy ColumnIDs: {";
-  for (size_t groupby_column_idx = 0; groupby_column_idx < _groupby_column_ids.size(); ++groupby_column_idx) {
-    desc << _groupby_column_ids[groupby_column_idx];
-
-    if (groupby_column_idx + 1 < _groupby_column_ids.size()) {
+  auto group_by_count = _groupby_column_ids.size();
+  for (auto groupby_column_idx = size_t{0}; groupby_column_idx < group_by_count; ++groupby_column_idx) {
+    if (groupby_column_idx > 0) {
       desc << ", ";
     }
+    desc << _groupby_column_ids[groupby_column_idx];
   }
   desc << "}" << separator;
-  for (size_t expression_idx = 0; expression_idx < _aggregates.size(); ++expression_idx) {
-    const auto& aggregate = _aggregates[expression_idx];
+  auto aggregate_count = _aggregates.size();
+  for (auto aggregate_idx = size_t{0}; aggregate_idx < aggregate_count; ++aggregate_idx) {
+    if (aggregate_idx > 0) {
+      desc << ", " << separator;
+    }
+    const auto& aggregate = _aggregates[aggregate_idx];
     desc << aggregate->as_column_name();
-
-    if (expression_idx + 1 < _aggregates.size()) desc << ", " << separator;
   }
   return desc.str();
 }

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -40,12 +40,12 @@ std::string AbstractAggregateOperator::description(DescriptionMode description_m
       desc << "," << separator;
     }
     if (lqp_node) {
-      desc << " " << lqp_node->left_input()->output_expressions()[groupby_column_idx]->as_column_name();
+      desc << lqp_node->left_input()->output_expressions()[groupby_column_idx]->as_column_name();
     } else {
       desc << "Column #" + std::to_string(_groupby_column_ids[groupby_column_idx]);
     }
   }
-  desc << " }" << separator;
+  desc << "}" << separator;
   auto aggregate_count = _aggregates.size();
   for (auto aggregate_idx = size_t{0}; aggregate_idx < aggregate_count; ++aggregate_idx) {
     if (aggregate_idx > 0) {

--- a/src/lib/operators/abstract_aggregate_operator.cpp
+++ b/src/lib/operators/abstract_aggregate_operator.cpp
@@ -29,7 +29,7 @@ const std::vector<std::shared_ptr<AggregateExpression>>& AbstractAggregateOperat
 const std::vector<ColumnID>& AbstractAggregateOperator::groupby_column_ids() const { return _groupby_column_ids; }
 
 std::string AbstractAggregateOperator::description(DescriptionMode description_mode) const {
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
 
   std::stringstream desc;
   desc << AbstractOperator::description(description_mode) << separator;

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -60,7 +60,7 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
   stream << AbstractOperator::description(description_mode);
-  stream << " (" <<_mode << ")" << separator;
+  stream << " (" << _mode << ")" << separator;
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -57,18 +57,20 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     return "Column #"s + std::to_string(column_id);
   };
 
-  const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
-
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
-  stream << AbstractOperator::description(description_mode) << separator << "(" << _mode << " Join where "
-         << column_name(true, _primary_predicate.column_ids.first) << " " << _primary_predicate.predicate_condition
-         << " " << column_name(false, _primary_predicate.column_ids.second);
+  stream << AbstractOperator::description(description_mode) << separator;
+  stream << "(" << _mode << " Join where ";
+  stream << column_name(true, _primary_predicate.column_ids.first) << " ";
+  stream << _primary_predicate.predicate_condition << " ";
+  stream << column_name(false, _primary_predicate.column_ids.second);
 
-  // add information about secondary join predicates
+  // Add information about secondary join predicates
   for (const auto& secondary_predicate : _secondary_predicates) {
-    stream << " AND " << column_name(true, secondary_predicate.column_ids.first) << " "
-           << secondary_predicate.predicate_condition << " "
-           << column_name(false, secondary_predicate.column_ids.second);
+    stream << separator << "AND ";
+    stream << column_name(true, secondary_predicate.column_ids.first) << " ";
+    stream << secondary_predicate.predicate_condition << " ";
+    stream << column_name(false, secondary_predicate.column_ids.second);
   }
 
   stream << ")";

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -59,8 +59,9 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
 
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
-  stream << AbstractOperator::description(description_mode) << separator;
-  stream <<  _mode << " Join WHERE ";
+  stream << AbstractOperator::description(description_mode);
+  stream << " (" <<_mode << ")" << separator;
+  stream << "WHERE ";
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -60,8 +60,7 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
   stream << AbstractOperator::description(description_mode) << separator;
-  stream << "(" << _mode << " Join)" << separator;
-  stream << "WHERE ";
+  stream <<  _mode << " Join WHERE ";
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -61,7 +61,6 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
   std::stringstream stream;
   stream << AbstractOperator::description(description_mode);
   stream << " (" <<_mode << ")" << separator;
-  stream << "WHERE ";
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -59,8 +59,7 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
 
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
-  stream << AbstractOperator::description(description_mode);
-  stream << " (" << _mode << ")" << separator;
+  stream << AbstractOperator::description(description_mode) << " (" << _mode << ")" << separator;
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -57,7 +57,7 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     return "Column #"s + std::to_string(column_id);
   };
 
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
   stream << AbstractOperator::description(description_mode) << " (" << _mode << ")" << separator;
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -60,7 +60,8 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
   stream << AbstractOperator::description(description_mode) << separator;
-  stream << "(" << _mode << " Join where ";
+  stream << "(" << _mode << " Join)" << separator;
+  stream << "WHERE ";
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);
@@ -72,8 +73,6 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     stream << secondary_predicate.predicate_condition << " ";
     stream << column_name(false, secondary_predicate.column_ids.second);
   }
-
-  stream << ")";
 
   return stream.str();
 }

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -26,9 +26,7 @@ std::string AliasOperator::description(DescriptionMode description_mode) const {
   std::stringstream stream;
 
   stream << AbstractOperator::description(description_mode) << separator;
-  stream << "[";
-  stream << boost::algorithm::join(_aliases, ", ");
-  stream << "]";
+  stream << "[" << boost::algorithm::join(_aliases, ", ") << "]";
   return stream.str();
 }
 

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -25,7 +25,8 @@ std::string AliasOperator::description(DescriptionMode description_mode) const {
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
 
-  stream << AbstractOperator::description(description_mode) << separator << "[";
+  stream << AbstractOperator::description(description_mode) << separator;
+  stream << "[";
   stream << boost::algorithm::join(_aliases, ", ");
   stream << "]";
   return stream.str();

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -22,7 +22,7 @@ const std::string& AliasOperator::name() const {
 }
 
 std::string AliasOperator::description(DescriptionMode description_mode) const {
-  const auto* const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
 
   stream << AbstractOperator::description(description_mode) << separator << "[";

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -22,7 +22,7 @@ const std::string& AliasOperator::name() const {
 }
 
 std::string AliasOperator::description(DescriptionMode description_mode) const {
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
 
   stream << AbstractOperator::description(description_mode) << separator;

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -39,17 +39,16 @@ const std::string& GetTable::name() const {
 
 std::string GetTable::description(DescriptionMode description_mode) const {
   const auto stored_table = Hyrise::get().storage_manager.get_table(_name);
-
   const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
-
   std::stringstream stream;
 
-  stream << AbstractOperator::description(description_mode) << separator << "(" << table_name() << ")";
-
-  stream << separator << "pruned:" << separator;
+  stream << AbstractOperator::description(description_mode) << separator;
+  stream << "(" << table_name() << ")" << separator;
+  stream << "pruned:" << separator;
   stream << _pruned_chunk_ids.size() << "/" << stored_table->chunk_count() << " chunk(s)";
   if (description_mode == DescriptionMode::SingleLine) stream << ",";
-  stream << separator << _pruned_column_ids.size() << "/" << stored_table->column_count() << " column(s)";
+  stream << separator;
+  stream << _pruned_column_ids.size() << "/" << stored_table->column_count() << " column(s)";
 
   return stream.str();
 }

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -39,7 +39,7 @@ const std::string& GetTable::name() const {
 
 std::string GetTable::description(DescriptionMode description_mode) const {
   const auto stored_table = Hyrise::get().storage_manager.get_table(_name);
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
 
   stream << AbstractOperator::description(description_mode) << separator;

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -40,7 +40,7 @@ const std::string& GetTable::name() const {
 std::string GetTable::description(DescriptionMode description_mode) const {
   const auto stored_table = Hyrise::get().storage_manager.get_table(_name);
 
-  const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
 
   std::stringstream stream;
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -577,7 +577,7 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
 void JoinHash::PerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
   OperatorPerformanceData<OperatorSteps>::output_to_stream(stream, description_mode);
 
-  const auto* const separator = description_mode == DescriptionMode::SingleLine ? " " : "\n";
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   stream << separator << "Radix bits: " << radix_bits << ".";
   stream << separator << "Build side is " << (left_input_is_build_side ? "left." : "right.");
 }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -46,9 +46,10 @@ const std::string& JoinHash::name() const {
 }
 
 std::string JoinHash::description(DescriptionMode description_mode) const {
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::ostringstream stream;
-  stream << AbstractJoinOperator::description(description_mode);
-  stream << " Radix bits: " << (_radix_bits ? std::to_string(*_radix_bits) : "Unspecified");
+  stream << AbstractJoinOperator::description(description_mode) << separator;
+  stream << "Radix bits: " << (_radix_bits ? std::to_string(*_radix_bits) : "Unspecified");
 
   return stream.str();
 }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -46,7 +46,7 @@ const std::string& JoinHash::name() const {
 }
 
 std::string JoinHash::description(DescriptionMode description_mode) const {
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::ostringstream stream;
   stream << AbstractJoinOperator::description(description_mode) << separator;
   stream << "Radix bits: " << (_radix_bits ? std::to_string(*_radix_bits) : "Unspecified");
@@ -578,7 +578,7 @@ class JoinHash::JoinHashImpl : public AbstractReadOnlyOperatorImpl {
 void JoinHash::PerformanceData::output_to_stream(std::ostream& stream, DescriptionMode description_mode) const {
   OperatorPerformanceData<OperatorSteps>::output_to_stream(stream, description_mode);
 
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   stream << separator << "Radix bits: " << radix_bits << ".";
   stream << separator << "Build side is " << (left_input_is_build_side ? "left." : "right.");
 }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -45,15 +45,6 @@ const std::string& JoinHash::name() const {
   return name;
 }
 
-std::string JoinHash::description(DescriptionMode description_mode) const {
-  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
-  std::ostringstream stream;
-  stream << AbstractJoinOperator::description(description_mode) << separator;
-  stream << "Radix bits: " << (_radix_bits ? std::to_string(*_radix_bits) : "Unspecified");
-
-  return stream.str();
-}
-
 std::shared_ptr<AbstractOperator> JoinHash::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -32,7 +32,6 @@ class JoinHash : public AbstractJoinOperator {
            const std::optional<size_t>& radix_bits = std::nullopt);
 
   const std::string& name() const override;
-  std::string description(DescriptionMode description_mode) const override;
 
   static size_t calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode);
 

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -65,7 +65,7 @@ const std::string& JoinIndex::name() const {
 }
 
 std::string JoinIndex::description(DescriptionMode description_mode) const {
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   const auto* const index_side_str = _index_side == IndexSide::Left ? "Left" : "Right";
 
   std::ostringstream stream(AbstractJoinOperator::description(description_mode), std::ios_base::ate);

--- a/src/lib/operators/join_index.cpp
+++ b/src/lib/operators/join_index.cpp
@@ -65,7 +65,7 @@ const std::string& JoinIndex::name() const {
 }
 
 std::string JoinIndex::description(DescriptionMode description_mode) const {
-  const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   const auto* const index_side_str = _index_side == IndexSide::Left ? "Left" : "Right";
 
   std::ostringstream stream(AbstractJoinOperator::description(description_mode), std::ios_base::ate);

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -70,7 +70,7 @@ const std::string& TableScan::name() const {
 }
 
 std::string TableScan::description(DescriptionMode description_mode) const {
-  const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
+  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
 
   std::stringstream stream;
 

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -70,7 +70,7 @@ const std::string& TableScan::name() const {
 }
 
 std::string TableScan::description(DescriptionMode description_mode) const {
-  const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+  const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
 
   std::stringstream stream;
 

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -59,7 +59,7 @@ class TableScan : public AbstractReadOnlyOperator {
     void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
       OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps>::output_to_stream(stream, description_mode);
 
-      const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
+      const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
       stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped with no results, ";
       stream << separator << num_chunks_with_all_rows_matching.load() << " skipped with all matching, ";
       stream << num_chunks_with_binary_search.load() << " scanned using binary search.";

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -59,7 +59,7 @@ class TableScan : public AbstractReadOnlyOperator {
     void output_to_stream(std::ostream& stream, DescriptionMode description_mode) const override {
       OperatorPerformanceData<AbstractOperatorPerformanceData::NoSteps>::output_to_stream(stream, description_mode);
 
-      const auto* const separator = description_mode == DescriptionMode::MultiLine ? "\n" : " ";
+      const char separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
       stream << separator << "Chunks: " << num_chunks_with_early_out.load() << " skipped with no results, ";
       stream << separator << num_chunks_with_all_rows_matching.load() << " skipped with all matching, ";
       stream << num_chunks_with_binary_search.load() << " scanned using binary search.";

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -245,7 +245,8 @@ class AbstractVisualizer {
   std::string _wrap_label(const std::string& label) {
     if (label.length() <= MAX_LABEL_WIDTH) return label;
     std::stringstream label_stream;
-
+    std::cout << "_wrap_label Input" << std::endl;
+    std::cout << label << std::endl;
     // 1. Split label into lines
     std::vector<std::string> lines;
     boost::split(lines, label, boost::is_any_of("\n"));

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -261,10 +261,11 @@ class AbstractVisualizer {
       size_t line_length = 0;
       std::vector<std::string> line_words;
       boost::split(line_words, line, boost::is_any_of(" "));
-      for (const auto& word : line_words) {
+      for (size_t word_idx = 0; word_idx < line_words.size(); ++word_idx) {
+        auto word = line_words.at(word_idx);
         label_stream << word << ' ';
         line_length += word.length() + 1;  // include whitespace
-        if (line_length > MAX_LABEL_WIDTH) {
+        if (line_length > MAX_LABEL_WIDTH && word_idx < line_words.size() - 1) {
           label_stream << '\n';
           line_length = 0;
         }

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -244,27 +244,32 @@ class AbstractVisualizer {
 
   std::string _wrap_label(const std::string& label) {
     if (label.length() <= MAX_LABEL_WIDTH) return label;
+    std::stringstream label_stream;
 
-    // Split by word so we don't break a line in the middle of a word
-    std::vector<std::string> label_words;
-    boost::split(label_words, label, boost::is_any_of(" "));
+    // 1. Split label into lines
+    std::vector<std::string> lines;
+    boost::split(lines, label, boost::is_any_of("\n"));
 
-    std::stringstream wrapped_label;
-    auto current_line_length = 0;
-
-    for (const auto& word : label_words) {
-      auto word_length = word.length() + 1;  // include whitespace
-
-      if (current_line_length + word_length > MAX_LABEL_WIDTH) {
-        wrapped_label << "\\n";
-        current_line_length = 0u;
+    for (const auto& line : lines) {
+      if (line.length() <= MAX_LABEL_WIDTH) {
+        label_stream << line << '\n';
+        continue;
       }
-
-      wrapped_label << word << ' ';
-      current_line_length += word_length;
+      // 2. Split line into words, so we don't break a line in the middle of a word
+      size_t line_length = 0;
+      std::vector<std::string> line_words;
+      boost::split(line_words, line, boost::is_any_of(" "));
+      for (const auto& word : line_words) {
+        label_stream << word << ' ';
+        line_length += word.length() + 1;  // include whitespace
+        if (line_length > MAX_LABEL_WIDTH) {
+          label_stream << '\n';
+          line_length = 0;
+        }
+      }
     }
 
-    return wrapped_label.str();
+    return label_stream.str();
   }
 
   std::string _random_color() {

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -262,14 +262,14 @@ class AbstractVisualizer {
       boost::split(line_words, line, boost::is_any_of(" "));
       size_t line_length = 0;
       size_t word_idx = 0;
-      while (word_idx < line_words.size()) {
+      while (true) {
         label_stream << line_words.at(word_idx);
         line_length += line_words.at(word_idx).length();
 
-        // Exit on last word in line
+        // Exit while on last word
         if (word_idx++ == line_words.size()) break;
 
-        if (line_length++ < MAX_LABEL_WIDTH) {  // includes whitespace
+        if (line_length++ < MAX_LABEL_WIDTH) {  // include whitespace with ++
           label_stream << ' ';
         } else {
           label_stream << '\n';
@@ -278,6 +278,8 @@ class AbstractVisualizer {
       }
     }
 
+    std::cout << "_wrap_label Output:" << std::endl;
+    std::cout << label_stream.str();
     return label_stream.str();
   }
 

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -268,9 +268,11 @@ class AbstractVisualizer {
         line_length += line_words.at(word_idx).length();
 
         // Exit while on last word
-        if (++word_idx == line_words.size()) break;
+        if (word_idx == line_words.size() - 1) break;
 
-        if (++line_length < MAX_LABEL_WIDTH) {  // include whitespace with ++
+        line_length++; // include whitespace
+        size_t next_line_length = line_length + line_words.at(++word_idx).length();
+        if (next_line_length < MAX_LABEL_WIDTH) {
           label_stream << ' ';
         } else {
           label_stream << '\n';

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -258,16 +258,23 @@ class AbstractVisualizer {
         continue;
       }
       // 2. Split line into words, so we don't break a line in the middle of a word
-      size_t line_length = 0;
       std::vector<std::string> line_words;
       boost::split(line_words, line, boost::is_any_of(" "));
-      for (size_t word_idx = 0; word_idx < line_words.size(); ++word_idx) {
-        auto word = line_words.at(word_idx);
-        label_stream << word << ' ';
-        line_length += word.length() + 1;  // include whitespace
-        if (line_length > MAX_LABEL_WIDTH && word_idx < line_words.size() - 1) {
+      size_t line_length = 0;
+      size_t word_idx = 0;
+      while (word_idx < line_words.size()) {
+        label_stream << line_words.at(word_idx);
+        line_length += line_words.at(word_idx).length();
+
+        // Exit on last word in line
+        if (word_idx++ == line_words.size()) break;
+
+        if (line_length++ < MAX_LABEL_WIDTH) {  // includes whitespace
+          label_stream << ' ';
+        } else {
           label_stream << '\n';
           line_length = 0;
+          break;
         }
       }
     }

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -247,7 +247,7 @@ class AbstractVisualizer {
     std::stringstream label_stream;
 
     // 1. Split label into lines
-    std::vector<std::string> lines;
+    auto lines = std::vector<std::string>();
     boost::split(lines, label, boost::is_any_of("\n"));
     const auto line_count = lines.size();
     for (auto line_idx = size_t{0}; line_idx < line_count; ++line_idx) {
@@ -258,10 +258,10 @@ class AbstractVisualizer {
         continue;
       }
       // 2. Split line into words, so we don't break a line in the middle of a word
-      std::vector<std::string> line_words;
+      auto line_words = std::vector<std::string>();
       boost::split(line_words, line, boost::is_any_of(" "));
-      size_t line_length = 0;
-      size_t word_idx = 0;
+      auto line_length = size_t{0};
+      auto word_idx = size_t{0};
       while (true) {
         label_stream << line_words.at(word_idx);
         line_length += line_words.at(word_idx).length();
@@ -270,7 +270,8 @@ class AbstractVisualizer {
         if (word_idx == line_words.size() - 1) break;
 
         line_length++;  // include whitespace
-        size_t next_line_length = line_length + line_words.at(++word_idx).length();
+        word_idx++;
+        auto next_line_length = line_length + line_words.at(word_idx).length();
         if (next_line_length < MAX_LABEL_WIDTH) {
           label_stream << ' ';
         } else {

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -250,7 +250,7 @@ class AbstractVisualizer {
     std::vector<std::string> lines;
     boost::split(lines, label, boost::is_any_of("\n"));
     const auto line_count = lines.size();
-    for (size_t line_idx = 0; line_idx < line_count; ++line_idx) {
+    for (auto line_idx = size_t{0}; line_idx < line_count; ++line_idx) {
       if (line_idx > 0) label_stream << '\n';
       const auto& line = lines[line_idx];
       if (line.length() <= MAX_LABEL_WIDTH) {

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -245,8 +245,7 @@ class AbstractVisualizer {
   std::string _wrap_label(const std::string& label) {
     if (label.length() <= MAX_LABEL_WIDTH) return label;
     std::stringstream label_stream;
-    std::cout << "_wrap_label Input" << std::endl;
-    std::cout << label << std::endl;
+
     // 1. Split label into lines
     std::vector<std::string> lines;
     boost::split(lines, label, boost::is_any_of("\n"));
@@ -267,10 +266,10 @@ class AbstractVisualizer {
         label_stream << line_words.at(word_idx);
         line_length += line_words.at(word_idx).length();
 
-        // Exit while on last word
+        // Exit on last word
         if (word_idx == line_words.size() - 1) break;
 
-        line_length++; // include whitespace
+        line_length++;  // include whitespace
         size_t next_line_length = line_length + line_words.at(++word_idx).length();
         if (next_line_length < MAX_LABEL_WIDTH) {
           label_stream << ' ';
@@ -281,8 +280,6 @@ class AbstractVisualizer {
       }
     }
 
-    std::cout << "_wrap_label Output:" << std::endl;
-    std::cout << label_stream.str();
     return label_stream.str();
   }
 

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -249,10 +249,10 @@ class AbstractVisualizer {
     // 1. Split label into lines
     std::vector<std::string> lines;
     boost::split(lines, label, boost::is_any_of("\n"));
-
-    for (size_t line_idx = 0; line_idx < lines.size(); ++line_idx) {
+    const auto line_count = lines.size();
+    for (size_t line_idx = 0; line_idx < line_count; ++line_idx) {
       if (line_idx > 0) label_stream << '\n';
-      const auto& line = lines.at(line_idx);
+      const auto& line = lines[line_idx];
       if (line.length() <= MAX_LABEL_WIDTH) {
         label_stream << line;
         continue;

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -274,7 +274,6 @@ class AbstractVisualizer {
         } else {
           label_stream << '\n';
           line_length = 0;
-          break;
         }
       }
     }

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -250,9 +250,11 @@ class AbstractVisualizer {
     std::vector<std::string> lines;
     boost::split(lines, label, boost::is_any_of("\n"));
 
-    for (const auto& line : lines) {
+    for (size_t line_idx = 0; line_idx < lines.size(); ++line_idx) {
+      if (line_idx > 0) label_stream << '\n';
+      const auto& line = lines.at(line_idx);
       if (line.length() <= MAX_LABEL_WIDTH) {
-        label_stream << line << '\n';
+        label_stream << line;
         continue;
       }
       // 2. Split line into words, so we don't break a line in the middle of a word

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -272,7 +272,7 @@ class AbstractVisualizer {
         line_length++;  // include whitespace
         word_idx++;
         auto next_line_length = line_length + line_words.at(word_idx).length();
-        if (next_line_length < MAX_LABEL_WIDTH) {
+        if (next_line_length <= MAX_LABEL_WIDTH) {
           label_stream << ' ';
         } else {
           label_stream << '\n';

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -267,9 +267,9 @@ class AbstractVisualizer {
         line_length += line_words.at(word_idx).length();
 
         // Exit while on last word
-        if (word_idx++ == line_words.size()) break;
+        if (++word_idx == line_words.size()) break;
 
-        if (line_length++ < MAX_LABEL_WIDTH) {  // include whitespace with ++
+        if (++line_length < MAX_LABEL_WIDTH) {  // include whitespace with ++
           label_stream << ' ';
         } else {
           label_stream << '\n';

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -86,10 +86,8 @@ TEST_F(OperatorsJoinHashTest, DescriptionAndName) {
             "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinHash (Inner) a = a AND a != a");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\na = a\nAND a != a");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinHash (Inner) a = a AND a != a");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinHash (Inner)\na = a\nAND a != a");
 
   EXPECT_EQ(join_operator->name(), "JoinHash");
 }

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -81,15 +81,15 @@ TEST_F(OperatorsJoinHashTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinHash (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: Unspecified");
+            "JoinHash\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nRadix bits: Unspecified");
   EXPECT_EQ(join_operator_with_radix->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: 4");
+            "JoinHash\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nRadix bits: 4");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinHash (Inner Join where a = a AND a != a) Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where a = a AND a != a) Radix bits: Unspecified");
+            "JoinHash\n(Inner Join where a = a \nAND a != a)\nRadix bits: Unspecified");
 
   EXPECT_EQ(join_operator->name(), "JoinHash");
 }

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -81,15 +81,15 @@ TEST_F(OperatorsJoinHashTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinHash (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nRadix bits: Unspecified");
+            "JoinHash\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: Unspecified");
   EXPECT_EQ(join_operator_with_radix->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nRadix bits: 4");
+            "JoinHash\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: 4");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinHash (Inner Join where a = a AND a != a) Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where a = a \nAND a != a)\nRadix bits: Unspecified");
+            "JoinHash\n(Inner Join where a = a\nAND a != a)\nRadix bits: Unspecified");
 
   EXPECT_EQ(join_operator->name(), "JoinHash");
 }

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -79,17 +79,17 @@ TEST_F(OperatorsJoinHashTest, DescriptionAndName) {
                                  std::vector<OperatorJoinPredicate>{secondary_predicate}, 4);
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinHash (Inner) Column #0 = Column #0 AND Column #0 != Column #0 Radix bits: Unspecified");
+            "JoinHash (Inner) Column #0 = Column #0 AND Column #0 != Column #0");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0\nRadix bits: Unspecified");
+            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0");
   EXPECT_EQ(join_operator_with_radix->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0\nRadix bits: 4");
+            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinHash (Inner) a = a AND a != a Radix bits: Unspecified");
+            "JoinHash (Inner) a = a AND a != a");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\na = a\nAND a != a\nRadix bits: Unspecified");
+            "JoinHash (Inner)\na = a\nAND a != a");
 
   EXPECT_EQ(join_operator->name(), "JoinHash");
 }

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -79,17 +79,17 @@ TEST_F(OperatorsJoinHashTest, DescriptionAndName) {
                                  std::vector<OperatorJoinPredicate>{secondary_predicate}, 4);
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinHash (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: Unspecified");
+            "JoinHash (Inner) Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: Unspecified");
+            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: Unspecified");
   EXPECT_EQ(join_operator_with_radix->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: 4");
+            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: 4");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinHash (Inner Join where a = a AND a != a) Radix bits: Unspecified");
+            "JoinHash (Inner) a = a AND a != a Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash\n(Inner Join where a = a\nAND a != a)\nRadix bits: Unspecified");
+            "JoinHash (Inner)\na = a\nAND a != a)\nRadix bits: Unspecified");
 
   EXPECT_EQ(join_operator->name(), "JoinHash");
 }

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -79,17 +79,17 @@ TEST_F(OperatorsJoinHashTest, DescriptionAndName) {
                                  std::vector<OperatorJoinPredicate>{secondary_predicate}, 4);
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinHash (Inner) Column #0 = Column #0 AND Column #0 != Column #0) Radix bits: Unspecified");
+            "JoinHash (Inner) Column #0 = Column #0 AND Column #0 != Column #0 Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: Unspecified");
+            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0\nRadix bits: Unspecified");
   EXPECT_EQ(join_operator_with_radix->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nRadix bits: 4");
+            "JoinHash (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0\nRadix bits: 4");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinHash (Inner) a = a AND a != a Radix bits: Unspecified");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinHash (Inner)\na = a\nAND a != a)\nRadix bits: Unspecified");
+            "JoinHash (Inner)\na = a\nAND a != a\nRadix bits: Unspecified");
 
   EXPECT_EQ(join_operator->name(), "JoinHash");
 }

--- a/src/test/lib/operators/join_index_test.cpp
+++ b/src/test/lib/operators/join_index_test.cpp
@@ -176,14 +176,14 @@ TEST_F(OperatorsJoinIndexTest, DescriptionAndName) {
   dummy_input->execute();
 
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner) a = a AND a != a) Index side: Left");
+            "JoinIndex (Inner) a = a AND a != a Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex (Inner)\na = a\nAND a != a)\nIndex side: Left");
+            "JoinIndex (Inner)\na = a\nAND a != a\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner) a = a AND a != a) Index side: Right");
+            "JoinIndex (Inner) a = a AND a != a Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex (Inner)\na = a\nAND a != a)\nIndex side: Right");
+            "JoinIndex (Inner)\na = a\nAND a != a\nIndex side: Right");
 
   EXPECT_EQ(join_operator_index_left->name(), "JoinIndex");
 }

--- a/src/test/lib/operators/join_index_test.cpp
+++ b/src/test/lib/operators/join_index_test.cpp
@@ -166,24 +166,24 @@ TEST_F(OperatorsJoinIndexTest, DescriptionAndName) {
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nIndex side: Left");
+            "JoinIndex\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nIndex side: Right");
+            "JoinIndex\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Right");
 
   dummy_input->execute();
 
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where a = a AND a != a) Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where a = a \nAND a != a)\nIndex side: Left");
+            "JoinIndex\n(Inner Join where a = a\nAND a != a)\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where a = a AND a != a) Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where a = a \nAND a != a)\nIndex side: Right");
+            "JoinIndex\n(Inner Join where a = a\nAND a != a)\nIndex side: Right");
 
   EXPECT_EQ(join_operator_index_left->name(), "JoinIndex");
 }

--- a/src/test/lib/operators/join_index_test.cpp
+++ b/src/test/lib/operators/join_index_test.cpp
@@ -166,24 +166,24 @@ TEST_F(OperatorsJoinIndexTest, DescriptionAndName) {
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)\nIndex side: Left");
+            "JoinIndex\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)\nIndex side: Right");
+            "JoinIndex\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)\nIndex side: Right");
 
   dummy_input->execute();
 
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where a = a AND a != a) Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where a = a AND a != a)\nIndex side: Left");
+            "JoinIndex\n(Inner Join where a = a \nAND a != a)\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
             "JoinIndex (Inner Join where a = a AND a != a) Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where a = a AND a != a)\nIndex side: Right");
+            "JoinIndex\n(Inner Join where a = a \nAND a != a)\nIndex side: Right");
 
   EXPECT_EQ(join_operator_index_left->name(), "JoinIndex");
 }

--- a/src/test/lib/operators/join_index_test.cpp
+++ b/src/test/lib/operators/join_index_test.cpp
@@ -164,14 +164,14 @@ TEST_F(OperatorsJoinIndexTest, DescriptionAndName) {
                                   std::vector<OperatorJoinPredicate>{secondary_predicate}, IndexSide::Right);
 
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner) Column #0 = Column #0 AND Column #0 != Column #0) Index side: Left");
+            "JoinIndex (Inner) Column #0 = Column #0 AND Column #0 != Column #0 Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Left");
+            "JoinIndex (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner) Column #0 = Column #0 AND Column #0 != Column #0) Index side: Right");
+            "JoinIndex (Inner) Column #0 = Column #0 AND Column #0 != Column #0 Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Right");
+            "JoinIndex (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0\nIndex side: Right");
 
   dummy_input->execute();
 

--- a/src/test/lib/operators/join_index_test.cpp
+++ b/src/test/lib/operators/join_index_test.cpp
@@ -164,26 +164,26 @@ TEST_F(OperatorsJoinIndexTest, DescriptionAndName) {
                                   std::vector<OperatorJoinPredicate>{secondary_predicate}, IndexSide::Right);
 
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Index side: Left");
+            "JoinIndex (Inner) Column #0 = Column #0 AND Column #0 != Column #0) Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Left");
+            "JoinIndex (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0) Index side: Right");
+            "JoinIndex (Inner) Column #0 = Column #0 AND Column #0 != Column #0) Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Right");
+            "JoinIndex (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)\nIndex side: Right");
 
   dummy_input->execute();
 
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner Join where a = a AND a != a) Index side: Left");
+            "JoinIndex (Inner) a = a AND a != a) Index side: Left");
   EXPECT_EQ(join_operator_index_left->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where a = a\nAND a != a)\nIndex side: Left");
+            "JoinIndex (Inner)\na = a\nAND a != a)\nIndex side: Left");
 
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::SingleLine),
-            "JoinIndex (Inner Join where a = a AND a != a) Index side: Right");
+            "JoinIndex (Inner) a = a AND a != a) Index side: Right");
   EXPECT_EQ(join_operator_index_right->description(DescriptionMode::MultiLine),
-            "JoinIndex\n(Inner Join where a = a\nAND a != a)\nIndex side: Right");
+            "JoinIndex (Inner)\na = a\nAND a != a)\nIndex side: Right");
 
   EXPECT_EQ(join_operator_index_left->name(), "JoinIndex");
 }

--- a/src/test/lib/operators/join_nested_loop_test.cpp
+++ b/src/test/lib/operators/join_nested_loop_test.cpp
@@ -27,15 +27,13 @@ TEST_F(OperatorsJoinNestedLoopTest, DescriptionAndName) {
                                        std::vector<OperatorJoinPredicate>{secondary_predicate});
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinNestedLoop (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinNestedLoop (Inner) Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)");
+            "JoinNestedLoop (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinNestedLoop (Inner Join where a = a AND a != a)");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop\n(Inner Join where a = a\nAND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinNestedLoop (Inner) a = a AND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinNestedLoop (Inner)\na = a\nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinNestedLoop");
 }

--- a/src/test/lib/operators/join_nested_loop_test.cpp
+++ b/src/test/lib/operators/join_nested_loop_test.cpp
@@ -27,13 +27,13 @@ TEST_F(OperatorsJoinNestedLoopTest, DescriptionAndName) {
                                        std::vector<OperatorJoinPredicate>{secondary_predicate});
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinNestedLoop (Inner) Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinNestedLoop (Inner) Column #0 = Column #0 AND Column #0 != Column #0");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)");
+            "JoinNestedLoop (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinNestedLoop (Inner) a = a AND a != a)");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinNestedLoop (Inner)\na = a\nAND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinNestedLoop (Inner) a = a AND a != a");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinNestedLoop (Inner)\na = a\nAND a != a");
 
   EXPECT_EQ(join_operator->name(), "JoinNestedLoop");
 }

--- a/src/test/lib/operators/join_nested_loop_test.cpp
+++ b/src/test/lib/operators/join_nested_loop_test.cpp
@@ -29,13 +29,13 @@ TEST_F(OperatorsJoinNestedLoopTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinNestedLoop (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinNestedLoop\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinNestedLoop (Inner Join where a = a AND a != a)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop\n(Inner Join where a = a AND a != a)");
+            "JoinNestedLoop\n(Inner Join where a = a \nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinNestedLoop");
 }

--- a/src/test/lib/operators/join_nested_loop_test.cpp
+++ b/src/test/lib/operators/join_nested_loop_test.cpp
@@ -29,13 +29,13 @@ TEST_F(OperatorsJoinNestedLoopTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinNestedLoop (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)");
+            "JoinNestedLoop\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinNestedLoop (Inner Join where a = a AND a != a)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinNestedLoop\n(Inner Join where a = a \nAND a != a)");
+            "JoinNestedLoop\n(Inner Join where a = a\nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinNestedLoop");
 }

--- a/src/test/lib/operators/join_sort_merge_test.cpp
+++ b/src/test/lib/operators/join_sort_merge_test.cpp
@@ -29,13 +29,13 @@ TEST_F(OperatorsJoinSortMergeTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinSortMerge (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinSortMerge\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinSortMerge (Inner Join where a = a AND a != a)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge\n(Inner Join where a = a AND a != a)");
+            "JoinSortMerge\n(Inner Join where a = a \nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinSortMerge");
 }

--- a/src/test/lib/operators/join_sort_merge_test.cpp
+++ b/src/test/lib/operators/join_sort_merge_test.cpp
@@ -29,13 +29,13 @@ TEST_F(OperatorsJoinSortMergeTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinSortMerge (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)");
+            "JoinSortMerge\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinSortMerge (Inner Join where a = a AND a != a)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge\n(Inner Join where a = a \nAND a != a)");
+            "JoinSortMerge\n(Inner Join where a = a\nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinSortMerge");
 }

--- a/src/test/lib/operators/join_sort_merge_test.cpp
+++ b/src/test/lib/operators/join_sort_merge_test.cpp
@@ -27,13 +27,13 @@ TEST_F(OperatorsJoinSortMergeTest, DescriptionAndName) {
                                       std::vector<OperatorJoinPredicate>{secondary_predicate});
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinSortMerge (Inner) Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinSortMerge (Inner) Column #0 = Column #0 AND Column #0 != Column #0");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)");
+            "JoinSortMerge (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinSortMerge (Inner) a = a AND a != a)");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinSortMerge (Inner)\na = a\nAND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinSortMerge (Inner) a = a AND a != a");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinSortMerge (Inner)\na = a\nAND a != a");
 
   EXPECT_EQ(join_operator->name(), "JoinSortMerge");
 }

--- a/src/test/lib/operators/join_sort_merge_test.cpp
+++ b/src/test/lib/operators/join_sort_merge_test.cpp
@@ -27,15 +27,13 @@ TEST_F(OperatorsJoinSortMergeTest, DescriptionAndName) {
                                       std::vector<OperatorJoinPredicate>{secondary_predicate});
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinSortMerge (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinSortMerge (Inner) Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)");
+            "JoinSortMerge (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinSortMerge (Inner Join where a = a AND a != a)");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinSortMerge\n(Inner Join where a = a\nAND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinSortMerge (Inner) a = a AND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinSortMerge (Inner)\na = a\nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinSortMerge");
 }

--- a/src/test/lib/operators/join_verification_test.cpp
+++ b/src/test/lib/operators/join_verification_test.cpp
@@ -27,15 +27,13 @@ TEST_F(OperatorsJoinVerificationTest, DescriptionAndName) {
                                          std::vector<OperatorJoinPredicate>{secondary_predicate});
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinVerification (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinVerification (Inner) Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)");
+            "JoinVerification (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinVerification (Inner Join where a = a AND a != a)");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification\n(Inner Join where a = a\nAND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinVerification (Inner) a = a AND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinVerification (Inner)\na = a\nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinVerification");
 }

--- a/src/test/lib/operators/join_verification_test.cpp
+++ b/src/test/lib/operators/join_verification_test.cpp
@@ -27,13 +27,13 @@ TEST_F(OperatorsJoinVerificationTest, DescriptionAndName) {
                                          std::vector<OperatorJoinPredicate>{secondary_predicate});
 
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
-            "JoinVerification (Inner) Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinVerification (Inner) Column #0 = Column #0 AND Column #0 != Column #0");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0)");
+            "JoinVerification (Inner)\nColumn #0 = Column #0\nAND Column #0 != Column #0");
 
   dummy_input->execute();
-  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinVerification (Inner) a = a AND a != a)");
-  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinVerification (Inner)\na = a\nAND a != a)");
+  EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine), "JoinVerification (Inner) a = a AND a != a");
+  EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine), "JoinVerification (Inner)\na = a\nAND a != a");
 
   EXPECT_EQ(join_operator->name(), "JoinVerification");
 }

--- a/src/test/lib/operators/join_verification_test.cpp
+++ b/src/test/lib/operators/join_verification_test.cpp
@@ -29,13 +29,13 @@ TEST_F(OperatorsJoinVerificationTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinVerification (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)");
+            "JoinVerification\n(Inner Join where Column #0 = Column #0\nAND Column #0 != Column #0)");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinVerification (Inner Join where a = a AND a != a)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification\n(Inner Join where a = a \nAND a != a)");
+            "JoinVerification\n(Inner Join where a = a\nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinVerification");
 }

--- a/src/test/lib/operators/join_verification_test.cpp
+++ b/src/test/lib/operators/join_verification_test.cpp
@@ -29,13 +29,13 @@ TEST_F(OperatorsJoinVerificationTest, DescriptionAndName) {
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinVerification (Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification\n(Inner Join where Column #0 = Column #0 AND Column #0 != Column #0)");
+            "JoinVerification\n(Inner Join where Column #0 = Column #0 \nAND Column #0 != Column #0)");
 
   dummy_input->execute();
   EXPECT_EQ(join_operator->description(DescriptionMode::SingleLine),
             "JoinVerification (Inner Join where a = a AND a != a)");
   EXPECT_EQ(join_operator->description(DescriptionMode::MultiLine),
-            "JoinVerification\n(Inner Join where a = a AND a != a)");
+            "JoinVerification\n(Inner Join where a = a \nAND a != a)");
 
   EXPECT_EQ(join_operator->name(), "JoinVerification");
 }


### PR DESCRIPTION
The visualizer uses a `_wrap_label` function for shortening vertex labels. However, the implementation is messy and does not respect newline characters in string arguments, leading to line-width-inconsistencies and sometimes ugly plans.

This PR refactors `_wrap_label` and some operator descriptions to make plans look more nicely. For example: 

> <img width="790" alt="image" src="https://user-images.githubusercontent.com/9380917/130358401-5db70365-b461-40f9-b5f2-e78959d853cd.png">
> <img width="1412" alt="image" src="https://user-images.githubusercontent.com/9380917/130441470-70688875-ead1-4de5-abaf-3eb3c58c0c98.png">
> (new plans on the right)


