### PR TITLE
Use the scheduler for controlled data preparation parallelism

### DIFF
--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -45,7 +45,7 @@ class CompareBenchmarkScriptTest:
 
     # Checks the contents of context table which is printed above the results.
     def check_context_table(self):
-        assert self.script_output.startswith("+Configuration Overview----")
+        assert self.script_output.startswith("+Configuration Overview---+")
 
         horizontal_table_separators = [
             i for i, line in enumerate(self.script_output_lines) if line.startswith("+-------")

--- a/scripts/test/compareBenchmarkScriptTest.py
+++ b/scripts/test/compareBenchmarkScriptTest.py
@@ -45,7 +45,7 @@ class CompareBenchmarkScriptTest:
 
     # Checks the contents of context table which is printed above the results.
     def check_context_table(self):
-        assert self.script_output.startswith("+Configuration Overview---+")
+        assert self.script_output.startswith("+Configuration Overview---")
 
         horizontal_table_separators = [
             i for i, line in enumerate(self.script_output_lines) if line.startswith("+-------")

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -37,10 +37,9 @@ void AbstractTableGenerator::generate_and_store() {
 
   // Encoding table data and generating table statistics are time consuming processes. To reduce
   // the required execution time, we execute these data preparation steps in a multithreaded way.
-  const auto& initial_scheduler = Hyrise::get().scheduler();
+  const auto initial_scheduler = Hyrise::get().scheduler();
   Hyrise::get().topology.use_default_topology(_benchmark_config->data_preparation_cores);
-  const auto data_generation_scheduler = std::make_shared<NodeQueueScheduler>();
-  Hyrise::get().set_scheduler(data_generation_scheduler);
+  Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());
 
   std::cout << "- Loading/Generating tables " << std::endl;
   auto table_info_by_name = generate();

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -35,8 +35,9 @@ AbstractTableGenerator::AbstractTableGenerator(const std::shared_ptr<BenchmarkCo
 void AbstractTableGenerator::generate_and_store() {
   Timer timer;
 
-  // Encoding table data and generating table statistics are time consuming processes. To reduce
-  // the required execution time, we execute these data preparation steps in a multithreaded way.
+  // Encoding table data and generating table statistics are time consuming processes. To reduce the required execution
+  // time, we execute these data preparation steps in a multithreaded way. We store the current scheduler here in case
+  // a single-threaded scheduler is used.
   const auto initial_scheduler = Hyrise::get().scheduler();
   Hyrise::get().topology.use_default_topology(_benchmark_config->data_preparation_cores);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -36,8 +36,8 @@ void AbstractTableGenerator::generate_and_store() {
   Timer timer;
 
   // Encoding table data and generating table statistics are time consuming processes. To reduce the required execution
-  // time, we execute these data preparation steps in a multithreaded way. We store the current scheduler here in case
-  // a single-threaded scheduler is used.
+  // time, we execute these data preparation steps in a multi-threaded way. We store the current scheduler here in case
+  // a single-threaded scheduler is used. After data preparation, we switch back to the initially used scheduler.
   const auto initial_scheduler = Hyrise::get().scheduler();
   Hyrise::get().topology.use_default_topology(_benchmark_config->data_preparation_cores);
   Hyrise::get().set_scheduler(std::make_shared<NodeQueueScheduler>());

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -276,7 +276,7 @@ void AbstractTableGenerator::generate_and_store() {
       const auto& table_name = table_info_by_name_pair.first;
       auto& table_info = table_info_by_name_pair.second;
 
-      const auto add_table_with_statistics = [&]() {
+      const auto add_table = [&]() {
         Timer per_table_timer;
         if (storage_manager.has_table(table_name)) storage_manager.drop_table(table_name);
         storage_manager.add_table(table_name, table_info.table);
@@ -284,7 +284,7 @@ void AbstractTableGenerator::generate_and_store() {
             std::string{"-  Added '"} + table_name + "' " + "(" + per_table_timer.lap_formatted() + ")\n";
         std::cout << output << std::flush;
       };
-      jobs.emplace_back(std::make_shared<JobTask>(add_table_with_statistics));
+      jobs.emplace_back(std::make_shared<JobTask>(add_table));
     }
     Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -7,6 +7,8 @@
 #include "import_export/binary/binary_writer.hpp"
 #include "operators/sort.hpp"
 #include "operators/table_wrapper.hpp"
+#include "scheduler/job_task.hpp"
+#include "scheduler/node_queue_scheduler.hpp"
 #include "storage/index/group_key/composite_group_key_index.hpp"
 #include "storage/index/group_key/group_key_index.hpp"
 #include "storage/segment_iterate.hpp"
@@ -32,6 +34,13 @@ AbstractTableGenerator::AbstractTableGenerator(const std::shared_ptr<BenchmarkCo
 
 void AbstractTableGenerator::generate_and_store() {
   Timer timer;
+
+  // Encoding table data and generating table statistics are time consuming processes. To reduce
+  // the required execution time, we execute these data preparation steps in a multithreaded way.
+  const auto& initial_scheduler = Hyrise::get().scheduler();
+  Hyrise::get().topology.use_default_topology(_benchmark_config->data_preparation_cores);
+  const auto data_generation_scheduler = std::make_shared<NodeQueueScheduler>();
+  Hyrise::get().set_scheduler(data_generation_scheduler);
 
   std::cout << "- Loading/Generating tables " << std::endl;
   auto table_info_by_name = generate();
@@ -72,16 +81,15 @@ void AbstractTableGenerator::generate_and_store() {
     } else {
       std::cout << "- Sorting tables" << std::endl;
 
-      // We do not use JobTasks here (and in the rest of this file) because we want this part to be multi-threaded even
-      // if Hyrise uses no scheduler.
-      auto threads = std::vector<std::thread>{};
+      auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+      jobs.reserve(sort_order_by_table.size());
       for (const auto& sort_order_pair : sort_order_by_table) {
         // Cannot use structured binding here as it cannot be captured in the lambda:
         // http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#2313
         const auto& table_name = sort_order_pair.first;
         const auto& column_name = sort_order_pair.second;
 
-        threads.emplace_back([&] {
+        const auto sort_table = [&]() {
           auto& table = table_info_by_name[table_name].table;
           const auto sort_mode = SortMode::Ascending;  // currently fixed to ascending
           const auto sort_column_id = table->column_id_by_name(column_name);
@@ -173,9 +181,10 @@ void AbstractTableGenerator::generate_and_store() {
           output << "-  Sorted '" << table_name << "' by '" << column_name << "' (" << per_table_timer.lap_formatted()
                  << ")\n";
           std::cout << output.str() << std::flush;
-        });
+        };
+        jobs.emplace_back(std::make_shared<JobTask>(sort_table));
       }
-      for (auto& thread : threads) thread.join();
+      Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
       metrics.sort_duration = timer.lap();
       std::cout << "- Sorting tables done (" << format_duration(metrics.sort_duration) << ")" << std::endl;
@@ -193,12 +202,13 @@ void AbstractTableGenerator::generate_and_store() {
   {
     std::cout << "- Encoding tables (if necessary) and generating pruning statistics" << std::endl;
 
-    auto threads = std::vector<std::thread>{};
+    auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+    jobs.reserve(table_info_by_name.size());
     for (auto& table_info_by_name_pair : table_info_by_name) {
       const auto& table_name = table_info_by_name_pair.first;
       auto& table_info = table_info_by_name_pair.second;
 
-      threads.emplace_back([&] {
+      const auto encode_table = [&]() {
         Timer per_table_timer;
         table_info.re_encoded =
             BenchmarkTableEncoder::encode(table_name, table_info.table, _benchmark_config->encoding_config);
@@ -207,10 +217,10 @@ void AbstractTableGenerator::generate_and_store() {
                << (table_info.re_encoded ? "encoding applied" : "no encoding necessary") << " ("
                << per_table_timer.lap_formatted() << ")\n";
         std::cout << output.str() << std::flush;
-      });
+      };
+      jobs.emplace_back(std::make_shared<JobTask>(encode_table));
     }
-
-    for (auto& thread : threads) thread.join();
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
     metrics.encoding_duration = timer.lap();
     std::cout << "- Encoding tables and generating pruning statistic done ("
@@ -261,21 +271,23 @@ void AbstractTableGenerator::generate_and_store() {
   {
     std::cout << "- Adding tables to StorageManager and generating table statistics" << std::endl;
     auto& storage_manager = Hyrise::get().storage_manager;
-    auto threads = std::vector<std::thread>{};
+    auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+    jobs.reserve(table_info_by_name.size());
     for (auto& table_info_by_name_pair : table_info_by_name) {
       const auto& table_name = table_info_by_name_pair.first;
       auto& table_info = table_info_by_name_pair.second;
 
-      threads.emplace_back([&] {
+      const auto add_table_with_statistics = [&]() {
         Timer per_table_timer;
         if (storage_manager.has_table(table_name)) storage_manager.drop_table(table_name);
         storage_manager.add_table(table_name, table_info.table);
         const auto output =
             std::string{"-  Added '"} + table_name + "' " + "(" + per_table_timer.lap_formatted() + ")\n";
         std::cout << output << std::flush;
-      });
+      };
+      jobs.emplace_back(std::make_shared<JobTask>(add_table_with_statistics));
     }
-    for (auto& thread : threads) thread.join();
+    Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
     metrics.store_duration = timer.lap();
 
@@ -323,6 +335,10 @@ void AbstractTableGenerator::generate_and_store() {
   } else {
     std::cout << "- No indexes created as --indexes was not specified or set to false" << std::endl;
   }
+
+  // Set scheduler back to previously used scheduler.
+  Hyrise::get().topology.use_default_topology(_benchmark_config->cores);
+  Hyrise::get().set_scheduler(initial_scheduler);
 }
 
 std::shared_ptr<BenchmarkConfig> AbstractTableGenerator::create_benchmark_config_with_chunk_size(

--- a/src/benchmarklib/benchmark_config.cpp
+++ b/src/benchmarklib/benchmark_config.cpp
@@ -8,8 +8,9 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const 
                                  const Duration& init_warmup_duration,
                                  const std::optional<std::string>& init_output_file_path,
                                  const bool init_enable_scheduler, const uint32_t init_cores,
-                                 const uint32_t init_clients, const bool init_enable_visualization,
-                                 const bool init_verify, const bool init_cache_binary_tables, const bool init_metrics)
+                                 const uint32_t init_data_preparation_cores, const uint32_t init_clients,
+                                 const bool init_enable_visualization, const bool init_verify,
+                                 const bool init_cache_binary_tables, const bool init_metrics)
     : benchmark_mode(init_benchmark_mode),
       chunk_size(init_chunk_size),
       encoding_config(init_encoding_config),
@@ -20,6 +21,7 @@ BenchmarkConfig::BenchmarkConfig(const BenchmarkMode init_benchmark_mode, const 
       output_file_path(init_output_file_path),
       enable_scheduler(init_enable_scheduler),
       cores(init_cores),
+      data_preparation_cores(init_data_preparation_cores),
       clients(init_clients),
       enable_visualization(init_enable_visualization),
       verify(init_verify),

--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -22,8 +22,9 @@ class BenchmarkConfig {
                   const EncodingConfig& init_encoding_config, const bool init_indexes, const int64_t init_max_runs,
                   const Duration& init_max_duration, const Duration& init_warmup_duration,
                   const std::optional<std::string>& init_output_file_path, const bool init_enable_scheduler,
-                  const uint32_t init_cores, const uint32_t init_clients, const bool init_enable_visualization,
-                  const bool init_verify, const bool init_cache_binary_tables, const bool init_metrics);
+                  const uint32_t init_cores, const uint32_t init_data_preparation_cores, const uint32_t init_clients,
+                  const bool init_enable_visualization, const bool init_verify, const bool init_cache_binary_tables,
+                  const bool init_metrics);
 
   static BenchmarkConfig get_default_config();
 
@@ -37,6 +38,7 @@ class BenchmarkConfig {
   std::optional<std::string> output_file_path = std::nullopt;
   bool enable_scheduler = false;
   uint32_t cores = 0;
+  uint32_t data_preparation_cores = 0;
   uint32_t clients = 1;
   bool enable_visualization = false;
   bool verify = false;

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -500,7 +500,8 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("visualize", "Create a visualization image of one LQP and PQP for each query, do not properly run the benchmark", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("metrics", "Track more metrics (steps in SQL pipeline, system utilization, etc.) and add them to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")); // NOLINT
+    ("metrics", "Track more metrics (steps in SQL pipeline, system utilization, etc.) and add them to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")) // NOLINT
+    ("data_preparation_cores", "Specify the number of cores used by the scheduler for the data preparation steps, i.e., sorting and encoding tables and generating table statistics. 0 means all available cores. This option is only advised when the underlying system's memory capacity is overleaded by the preparation phase.", cxxopts::value<uint32_t>()->default_value("0")); // NOLINT
   // clang-format on
 
   return cli_options;
@@ -538,6 +539,7 @@ nlohmann::json BenchmarkRunner::create_context(const BenchmarkConfig& config) {
       {"using_scheduler", config.enable_scheduler},
       {"cores", config.cores},
       {"clients", config.clients},
+      {"data_preparation_cores", config.data_preparation_cores},
       {"verify", config.verify},
       {"time_unit", "ns"},
       {"GIT-HASH", GIT_HEAD_SHA1 + std::string(GIT_IS_DIRTY ? "-dirty" : "")}};

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -501,7 +501,8 @@ cxxopts::Options BenchmarkRunner::get_basic_cli_options(const std::string& bench
     ("verify", "Verify each query by comparing it with the SQLite result", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("dont_cache_binary_tables", "Do not cache tables as binary files for faster loading on subsequent runs", cxxopts::value<bool>()->default_value("false")) // NOLINT
     ("metrics", "Track more metrics (steps in SQL pipeline, system utilization, etc.) and add them to the output JSON (see -o)", cxxopts::value<bool>()->default_value("false")) // NOLINT
-    ("data_preparation_cores", "Specify the number of cores used by the scheduler for the data preparation steps, i.e., sorting and encoding tables and generating table statistics. 0 means all available cores. This option is only advised when the underlying system's memory capacity is overleaded by the preparation phase.", cxxopts::value<uint32_t>()->default_value("0")); // NOLINT
+    // This option is only advised when the underlying system's memory capacity is overleaded by the preparation phase.
+    ("data_preparation_cores", "Specify the number of cores used by the scheduler for data preparation, i.e., sorting and encoding tables and generating table statistics. 0 means all available cores.", cxxopts::value<uint32_t>()->default_value("0")); // NOLINT
   // clang-format on
 
   return cli_options;

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -1,7 +1,6 @@
 #include "benchmark_table_encoder.hpp"
 
 #include <atomic>
-#include <thread>
 
 #include "constant_mappings.hpp"
 #include "encoding_config.hpp"

--- a/src/benchmarklib/benchmark_table_encoder.cpp
+++ b/src/benchmarklib/benchmark_table_encoder.cpp
@@ -5,7 +5,9 @@
 
 #include "constant_mappings.hpp"
 #include "encoding_config.hpp"
+#include "hyrise.hpp"
 #include "resolve_type.hpp"
+#include "scheduler/job_task.hpp"
 #include "statistics/generate_pruning_statistics.hpp"
 #include "storage/abstract_encoded_segment.hpp"
 #include "storage/base_value_segment.hpp"
@@ -109,30 +111,21 @@ bool BenchmarkTableEncoder::encode(const std::string& table_name, const std::sha
   auto encoding_performed = std::atomic_bool{false};
   const auto column_data_types = table->column_data_types();
 
-  // Encode chunks in parallel, using `hardware_concurrency + 1` workers
-  // Not using JobTasks here because we want parallelism even if the scheduler is disabled.
-  auto next_chunk = std::atomic_uint{0};
-  const auto thread_count = std::min(static_cast<uint>(table->chunk_count()), std::thread::hardware_concurrency() + 1);
-  auto threads = std::vector<std::thread>{};
-  threads.reserve(thread_count);
+  auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+  jobs.reserve(table->chunk_count());
 
-  for (auto thread_id = 0u; thread_id < thread_count; ++thread_id) {
-    threads.emplace_back([&] {
-      while (true) {
-        auto my_chunk = next_chunk++;
-        if (my_chunk >= table->chunk_count()) return;
-
-        const auto chunk = table->get_chunk(ChunkID{my_chunk});
-        Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
-        if (!is_chunk_encoding_spec_satisfied(chunk_encoding_spec, get_chunk_encoding_spec(*chunk))) {
-          ChunkEncoder::encode_chunk(chunk, column_data_types, chunk_encoding_spec);
-          encoding_performed = true;
-        }
+  for (auto chunk_id = ChunkID{0}; chunk_id < table->chunk_count(); ++chunk_id) {
+    const auto encode = [&, chunk_id]() {
+      const auto chunk = table->get_chunk(ChunkID{chunk_id});
+      Assert(chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
+      if (!is_chunk_encoding_spec_satisfied(chunk_encoding_spec, get_chunk_encoding_spec(*chunk))) {
+        ChunkEncoder::encode_chunk(chunk, column_data_types, chunk_encoding_spec);
+        encoding_performed = true;
       }
-    });
+    };
+    jobs.emplace_back(std::make_shared<JobTask>(encode));
   }
-
-  for (auto& thread : threads) thread.join();
+  Hyrise::get().scheduler()->schedule_and_wait_for_tasks(jobs);
 
   generate_chunk_pruning_statistics(table);
 

--- a/src/benchmarklib/cli_config_parser.cpp
+++ b/src/benchmarklib/cli_config_parser.cpp
@@ -29,6 +29,11 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
   const auto core_info = enable_scheduler ? " using " + number_of_cores_str + " cores" : "";
   std::cout << "- Running in " + std::string(enable_scheduler ? "multi" : "single") + "-threaded mode" << core_info
             << std::endl;
+  const auto data_preparation_cores = parse_result["data_preparation_cores"].as<uint32_t>();
+  const auto number_of_data_preparation_cores_str =
+      (data_preparation_cores == 0) ? "all available" : std::to_string(data_preparation_cores);
+  std::cout << "- Data preparation will use " << number_of_data_preparation_cores_str
+            << (data_preparation_cores == 1 ? " core" : " cores") << std::endl;
 
   const auto clients = parse_result["clients"].as<uint32_t>();
   std::cout << "- " + std::to_string(clients) + " simulated ";
@@ -132,10 +137,22 @@ BenchmarkConfig CLIConfigParser::parse_cli_options(const cxxopts::ParseResult& p
     std::cout << "- Not tracking SQL metrics" << std::endl;
   }
 
-  return BenchmarkConfig{
-      benchmark_mode,  chunk_size,          *encoding_config, indexes, max_runs, timeout_duration,
-      warmup_duration, output_file_path,    enable_scheduler, cores,   clients,  enable_visualization,
-      verify,          cache_binary_tables, metrics};
+  return BenchmarkConfig{benchmark_mode,
+                         chunk_size,
+                         *encoding_config,
+                         indexes,
+                         max_runs,
+                         timeout_duration,
+                         warmup_duration,
+                         output_file_path,
+                         enable_scheduler,
+                         cores,
+                         data_preparation_cores,
+                         clients,
+                         enable_visualization,
+                         verify,
+                         cache_binary_tables,
+                         metrics};
 }
 
 EncodingConfig CLIConfigParser::parse_encoding_config(const std::string& encoding_file_str) {


### PR DESCRIPTION
With this PR, data preparation steps such as encoding and sorting table data, as well as generating table statistics, are executed using a `NodeQueueScheduler` instance. By default, the number of workers for the parallelized data preparation is equal to `std::thread::hardware_concurrency()`. A user can use the optional new benchmark flag `data_preparation_cores` to set the number of workers used for the data preparation.

Example configuration output of `compare_benchmarks.py` with this PR:
```
+Configuration Overview---+------------------------------------------------+------------------------------------------------+
| Parameter               | ./brel/file_based_output_1.json                | ./brel/file_based_output_1.json                |
+-------------------------+------------------------------------------------+------------------------------------------------+
|  GIT-HASH               | fb33ca74eec61b49aa1299387e257553bf909f37-dirty | fb33ca74eec61b49aa1299387e257553bf909f37-dirty |
|  benchmark_mode         | Shuffled                                       | Shuffled                                       |
|  build_type             | release                                        | release                                        |
|  chunk_size             | 65535                                          | 65535                                          |
|  clients                | 1                                              | 1                                              |
|  compiler               | clang 12.0.1                                   | clang 12.0.1                                   |
|  cores                  | 0                                              | 0                                              |
|  data_preparation_cores | 0                                              | 0                                              |
|  date                   | 2021-09-06 15:55:32                            | 2021-09-06 15:55:32                            |
|  encoding               | {'default': {'encoding': 'Unencoded'}}         | {'default': {'encoding': 'Unencoded'}}         |
|  indexes                | False                                          | False                                          |
|  max_duration           | 10000000000                                    | 10000000000                                    |
|  max_runs               | 100                                            | 100                                            |
|  time_unit              | ns                                             | ns                                             |
|  using_scheduler        | False                                          | False                                          |
|  verify                 | False                                          | False                                          |
|  warmup_duration        | 0                                              | 0                                              |
+-------------------------+------------------------------------------------+------------------------------------------------+
```
The new benchmark flag `data_preparation_cores` increases the width of the first column. Consequently, the output of the `compare_benchmarks.py` script does not start with `+Configuration Overview----` anymore. Instead, as shown above, it starts with `+Configuration Overview---+`. This is relevant for the changes in `compareBenchmarkScriptTest.py`.