### PR TITLE
Adjust benchmark_all.sh to allow faster benchmark cycles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -308,7 +308,7 @@ try {
           }, tpcdsQueryPlansAndVerification: {
             stage("tpcdsQueryPlansAndVerification") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
-                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
+                sh "mkdir -p query_plans/tpcds; cd query_plans/tpcds && ln -s ../../resources; ../../clang-release/hyriseBenchmarkTPCDS --dont_cache_binary_tables -r 1 -s 1 --visualize --verify && ../../scripts/plot_operator_breakdown.py ../../clang-release/"
                 archiveArtifacts artifacts: 'query_plans/tpcds/*.svg'
                 archiveArtifacts artifacts: 'query_plans/tpcds/operator_breakdown.pdf'
               } else {

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -15,12 +15,12 @@ benchmarks='hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkTPCC hyriseB
 warmup_seconds=2
 runs=100
 
-# Setting the number of clients used for the multi-threaded scenario to the machine's core count.
-# This only works for macOS and Linux.
+# Setting the number of clients used for the multi-threaded scenario to the machine's physical core count.
+# This only works for macOS and Linux. For macOS, we simply divide the CPU count by 2.
 output="$(uname -s)"
 case "${output}" in
-    Linux*)     num_phy_cores="$(lscpu -p | egrep -v '^#' | grep '^[0-9]*,[0-9]*,0,0' | wc -l)";;
-    Darwin*)    num_phy_cores="$(sysctl -n hw.ncpu)";;
+    Linux*)     num_phy_cores="$(lscpu -p | egrep -v '^#' | grep '^[0-9]*,[0-9]*,0,0' | sort -u -t, -k 2,4 | wc -l)";;
+    Darwin*)    num_mt_clients="$(($(sysctl -n hw.ncpu) / 2))";;
     *)          echo 'Unsupported operating system. Aborting.' && exit 1;;
 esac
 

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -84,8 +84,14 @@ do
   cd ..  # hyriseBenchmarkJoinOrder needs to run from project root
   for benchmark in $benchmarks
   do
-    echo "Running $benchmark for $commit... (single-threaded)"
-    ( "${build_folder}"/"$benchmark" -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
+    if [ "$benchmark" = "hyriseBenchmarkTPCC" ]; then
+      echo "Running $benchmark for $commit... (single-threaded)"
+      # Warming up does not work properly for TPCC.
+      ( "${build_folder}"/"$benchmark" -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
+    else
+      echo "Running $benchmark for $commit... (single-threaded)"
+      ( "${build_folder}"/"$benchmark" -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
+    fi
 
     if [ "$benchmark" = "hyriseBenchmarkTPCH" ]; then
       echo "Running $benchmark for $commit... (single-threaded, SF 0.01)"

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -165,8 +165,8 @@ do
       case "${config}" in
         "st") echo -n "single-threaded, SF 10.0" ;;
         "st_s01") echo -n "single-threaded, SF 0.01" ;;
-        "mt") echo -n "multi-threaded, ordered, 1 client, ${num_phy_cores} cores, SF 10.0" ;;
-        "mt_ordered") echo -n "multi-threaded, shuffled, ${num_phy_cores} clients, ${num_phy_cores} cores, SF 10.0" ;;
+        "mt_ordered") echo -n "multi-threaded, ordered, 1 client, ${num_phy_cores} cores, SF 10.0" ;;
+        "mt") echo -n "multi-threaded, shuffled, ${num_phy_cores} clients, ${num_phy_cores} cores, SF 10.0" ;;
       esac
     else
       case "${config}" in

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -14,6 +14,7 @@ fi
 benchmarks='hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkTPCC hyriseBenchmarkJoinOrder'
 # Set to 1 because even a single warmup run of a query makes the observed runtimes much more stable. See discussion in #2405 for some preliminary reasoning.
 warmup_seconds=1
+mt_shuffled_runtime=1200
 runs=100
 
 # Setting the number of clients used for the multi-threaded scenario to the machine's physical core count.
@@ -86,7 +87,7 @@ do
   do
     if [ "$benchmark" = "hyriseBenchmarkTPCC" ]; then
       echo "Running $benchmark for $commit... (single-threaded)"
-      # Warming up does not work properly for TPCC.
+      # Warming up does not make sense/much of a difference for TPCC.
       ( "${build_folder}"/"$benchmark" -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st.log"
     else
       echo "Running $benchmark for $commit... (single-threaded)"
@@ -102,7 +103,7 @@ do
     fi
 
     echo "Running $benchmark for $commit... (multi-threaded, shuffled, $num_phy_cores clients)"
-    ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --cores ${num_phy_cores} -m Shuffled -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
+    ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --cores ${num_phy_cores} -m Shuffled -t ${mt_shuffled_runtime} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
   done
   cd "${build_folder}"
 

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -92,11 +92,11 @@ do
       ( "${build_folder}"/"$benchmark" -s .01 -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
 
       echo "Running $benchmark for $commit... (multi-threaded, ordered, single client)"
-      ( "${build_folder}"/"$benchmark" --scheduler --clients 1 --core ${num_phy_cores} -m Ordered -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
+      ( "${build_folder}"/"$benchmark" --scheduler --clients 1 --cores ${num_phy_cores} -m Ordered -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
     fi
 
     echo "Running $benchmark for $commit... (multi-threaded, shuffled, multiple clients)"
-    ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --core ${num_phy_cores} -m Shuffled -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
+    ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --cores ${num_phy_cores} -m Shuffled -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
   done
   cd "${build_folder}"
 

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -17,12 +17,11 @@ warmup_seconds=1
 mt_shuffled_runtime=1200
 runs=100
 
-# Setting the number of clients used for the multi-threaded scenario to the machine's physical core count.
-# This only works for macOS and Linux. For macOS, we simply divide the CPU count by 2.
+# Setting the number of clients used for the multi-threaded scenario to the machine's physical core count. This only works for macOS and Linux.
 output="$(uname -s)"
 case "${output}" in
     Linux*)     num_phy_cores="$(lscpu -p | egrep -v '^#' | grep '^[0-9]*,[0-9]*,0,0' | sort -u -t, -k 2,4 | wc -l)";;
-    Darwin*)    num_phy_cores="$(($(sysctl -n hw.ncpu) / 2))";;
+    Darwin*)    num_phy_cores="$(sysctl -n hw.physicalcpu)";;
     *)          echo 'Unsupported operating system. Aborting.' && exit 1;;
 esac
 

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -91,11 +91,11 @@ do
       echo "Running $benchmark for $commit... (single-threaded, SF 0.01)"
       ( "${build_folder}"/"$benchmark" -s .01 -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
 
-      echo "Running $benchmark for $commit... (multi-threaded, ordered, single client)"
+      echo "Running $benchmark for $commit... (multi-threaded, ordered, 1 client)"
       ( "${build_folder}"/"$benchmark" --scheduler --clients 1 --cores ${num_phy_cores} -m Ordered -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
     fi
 
-    echo "Running $benchmark for $commit... (multi-threaded, shuffled, multiple clients)"
+    echo "Running $benchmark for $commit... (multi-threaded, shuffled, $num_phy_cores clients)"
     ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --cores ${num_phy_cores} -m Shuffled -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt.log"
   done
   cd "${build_folder}"

--- a/scripts/benchmark_all.sh
+++ b/scripts/benchmark_all.sh
@@ -91,7 +91,7 @@ do
       ( "${build_folder}"/"$benchmark" -s .01 -r ${runs} -w ${warmup_seconds} -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_st_s01.log"
 
       echo "Running $benchmark for $commit... (multi-threaded, ordered)"
-    ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --core ${num_phy_cores} -m Ordered -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
+      ( "${build_folder}"/"$benchmark" --scheduler --clients ${num_phy_cores} --core ${num_phy_cores} -m Ordered -o "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.json" 2>&1 ) | tee "${build_folder}/benchmark_all_results/${benchmark}_${commit}_mt_ordered.log"
     fi
 
     echo "Running $benchmark for $commit... (multi-threaded, shuffled)"

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -347,9 +347,9 @@ if github_format:
         + "```diff\n"
     )
     for line in table_string.splitlines():
-        if (green_control_sequence + "+" in line) or ("| Sum " in line and green_control_sequence in line):
+        if (green_control_sequence in line) or ("| Sum " in line and green_control_sequence in line):
             table_string_reformatted += "+"
-        elif (red_control_sequence + "-" in line) or ("| Sum " in line and red_control_sequence in line):
+        elif (red_control_sequence in line) or ("| Sum " in line and red_control_sequence in line):
             table_string_reformatted += "-"
         else:
             table_string_reformatted += " "

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -12,6 +12,7 @@ from scipy.stats import ttest_ind
 p_value_significance_threshold = 0.001
 min_iterations = 10
 min_runtime_ns = 59 * 1000 * 1000 * 1000
+min_iterations_disabling_min_runtime = 100
 
 
 def format_diff(diff):
@@ -46,7 +47,7 @@ def calculate_and_format_p_value(old_durations, new_durations):
 
     old_runtime = sum(runtime for runtime in old_durations)
     new_runtime = sum(runtime for runtime in new_durations)
-    if old_runtime < min_runtime_ns or new_runtime < min_runtime_ns:
+    if (old_runtime < min_runtime_ns or new_runtime < min_runtime_ns) and (len(old_durations) < min_iterations_disabling_min_runtime or len(new_durations) < min_iterations_disabling_min_runtime):
         is_significant = False
         return "(run time too short)"
     elif len(old_durations) < min_iterations or len(new_durations) < min_iterations:

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -47,7 +47,13 @@ def calculate_and_format_p_value(old_durations, new_durations):
 
     old_runtime = sum(runtime for runtime in old_durations)
     new_runtime = sum(runtime for runtime in new_durations)
-    if (old_runtime < min_runtime_ns or new_runtime < min_runtime_ns) and (len(old_durations) < min_iterations_disabling_min_runtime or len(new_durations) < min_iterations_disabling_min_runtime):
+
+    # The results for a query are considered to be statistically not significant if the runtime is too short. However,
+    # if the item has been executed > `min_iterations_disabling_min_runtime` times, it is considered significant.
+    if (old_runtime < min_runtime_ns or new_runtime < min_runtime_ns) and (
+        len(old_durations) < min_iterations_disabling_min_runtime
+        or len(new_durations) < min_iterations_disabling_min_runtime
+    ):
         is_significant = False
         return "(run time too short)"
     elif len(old_durations) < min_iterations or len(new_durations) < min_iterations:
@@ -348,9 +354,9 @@ if github_format:
         + "```diff\n"
     )
     for line in table_string.splitlines():
-        if (green_control_sequence in line) or ("| Sum " in line and green_control_sequence in line):
+        if green_control_sequence in line:
             table_string_reformatted += "+"
-        elif (red_control_sequence in line) or ("| Sum " in line and red_control_sequence in line):
+        elif red_control_sequence in line:
             table_string_reformatted += "-"
         else:
             table_string_reformatted += " "

--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
 
   // clang-format off
   cli_options.add_options()
-    ("s,scale", "Database scale factor (1 ~ 1GB)", cxxopts::value<int32_t>()->default_value("1"));
+    ("s,scale", "Database scale factor (10 ~ 10GB)", cxxopts::value<int32_t>()->default_value("10"));
   // clang-format on
 
   auto config = std::shared_ptr<opossum::BenchmarkConfig>{};

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -748,7 +748,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
         if (input_table_statistics->row_count == 0 || sliced_histogram->total_count() == 0.0f) {
           selectivity = 0.0f;
         } else {
-          selectivity = sliced_histogram->total_count() / scan_statistics_object->total_count();
+          selectivity = sliced_histogram->total_count() / input_table_statistics->row_count;
         }
 
         const auto column_statistics = std::make_shared<AttributeStatistics<ColumnDataType>>();

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -748,7 +748,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
         if (input_table_statistics->row_count == 0 || sliced_histogram->total_count() == 0.0f) {
           selectivity = 0.0f;
         } else {
-          selectivity = sliced_histogram->total_count() / input_table_statistics->row_count;
+          selectivity = sliced_histogram->total_count() / scan_statistics_object->total_count();
         }
 
         const auto column_statistics = std::make_shared<AttributeStatistics<ColumnDataType>>();


### PR DESCRIPTION
Fixes #2381.

I updated the `benchmark_all.sh` according to #2381 and I want to get some feedback on the changes and whether they reflect what all of you had in mind when we decided to change the script. Currently, this PR is only meant to be used for discussions. Once we agree on the script, I will run some benchmarks and we can validate whether we still trust the script.

- [ ] Tackle the _green for increased throughput issue_