### PR TITLE
TPC-DS benchmark: Use SF 10 as default scale factor

### DIFF
--- a/src/benchmark/tpcds_benchmark.cpp
+++ b/src/benchmark/tpcds_benchmark.cpp
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
 
   // clang-format off
   cli_options.add_options()
-    ("s,scale", "Database scale factor (1 ~ 1GB)", cxxopts::value<int32_t>()->default_value("1"));
+    ("s,scale", "Database scale factor (10 ~ 10 GB)", cxxopts::value<int32_t>()->default_value("10"));
   // clang-format on
 
   auto config = std::shared_ptr<opossum::BenchmarkConfig>{};


### PR DESCRIPTION
This PR changes the default scale factor of the TPC-DS benchmark to 10.