### PR TITLE
GitHub's "Cite this repository"

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,17 @@
+@inproceedings{HyriseEDBT2019,
+  author    = {Markus Dreseler and
+               Jan Kossmann and
+               Martin Boissier and
+               Stefan Klauck and
+               Matthias Uflacker and
+               Hasso Plattner},
+  title     = {Hyrise Re-engineered: An Extensible Database System for Research in
+               Relational In-Memory Data Management},
+  booktitle = {Advances in Database Technology - 22nd International Conference on
+               Extending Database Technology, {EDBT} 2019, Lisbon, Portugal, March
+               26-29, 2019},
+  pages     = {313--324},
+  year      = {2019},
+  url       = {https://doi.org/10.5441/002/edbt.2019.28},
+  doi       = {10.5441/002/edbt.2019.28}
+}


### PR DESCRIPTION
PR to add a bib file (`CITATION.bib`) that refers to the 2019 EDBT paper.

I hope I read this correctly here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#other-citation-files

The default syntax is quite strange and annying. Directly using a bibtex file means that GitHub does only provide this file and no other "styles" (e.g., APA style). But I doubt anybody from CS is going to use something else that Bibtex anyways.