### PR TITLE
Reduce Output Expression Complexity

### DIFF
--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -57,11 +57,11 @@ std::vector<std::shared_ptr<AbstractExpression>> JoinNode::output_expressions() 
    */
 
   const auto& left_expressions = left_input()->output_expressions();
-  const auto& right_expressions = right_input()->output_expressions();
-
   const auto output_both_inputs =
       join_mode != JoinMode::Semi && join_mode != JoinMode::AntiNullAsTrue && join_mode != JoinMode::AntiNullAsFalse;
+  if (!output_both_inputs) return left_expressions;
 
+  const auto& right_expressions = right_input()->output_expressions();
   auto output_expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
   output_expressions.resize(left_expressions.size() + (output_both_inputs ? right_expressions.size() : 0));
 

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -19,8 +19,10 @@ std::string UnionNode::description(const DescriptionMode mode) const {
 }
 
 std::vector<std::shared_ptr<AbstractExpression>> UnionNode::output_expressions() const {
-  Assert(expressions_equal(left_input()->output_expressions(), right_input()->output_expressions()),
-         "Input Expressions must match");
+  if (set_operation_mode != SetOperationMode::Positions) {
+    Assert(expressions_equal(left_input()->output_expressions(), right_input()->output_expressions()),
+           "Input Expressions must match");
+  }
   return left_input()->output_expressions();
 }
 

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -74,6 +74,11 @@ TEST_F(JoinNodeTest, OutputColumnExpressions) {
   EXPECT_EQ(*_cross_join_node->output_expressions().at(2), *_t_a_c);
   EXPECT_EQ(*_cross_join_node->output_expressions().at(3), *_t_b_x);
   EXPECT_EQ(*_cross_join_node->output_expressions().at(4), *_t_b_y);
+
+  ASSERT_EQ(_semi_join_node->output_expressions().size(), 3u);
+  EXPECT_EQ(*_semi_join_node->output_expressions().at(0), *_t_a_a);
+  EXPECT_EQ(*_semi_join_node->output_expressions().at(1), *_t_a_b);
+  EXPECT_EQ(*_semi_join_node->output_expressions().at(2), *_t_a_c);
 }
 
 TEST_F(JoinNodeTest, HashingAndEqualityCheck) {


### PR DESCRIPTION
An LQP Node's output expressions are computed on demand and not persisted, resulting in recursive calculation of output expressions for LQPs. For nodes with two inputs (`JoinNode` and `UnionNode`), this results in added complexity for diamonds, e.g., for semi joins or unions that stem from queries with `SELECT ... FROM table_a WHERE ... OR ...`. This PR only fetches the output expressions of both inputs whenever they are required, i.e., a `JoinNode` is not a semi/anti join and a `UnionNode` does not union PosLists (and hence, should do a sanity check that the expressions are equal).
