### PR TITLE
Add missing space in benchmark runner output

### DIFF
--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -255,7 +255,7 @@ void AbstractTableGenerator::generate_and_store() {
         binary_file_path.replace_extension(".bin");
       }
 
-      std::cout << "- Writing '" << table_name << "' into binary file " << binary_file_path << " " << std::flush;
+      std::cout << "-  Writing '" << table_name << "' into binary file " << binary_file_path << " " << std::flush;
       Timer per_table_timer;
       BinaryWriter::write(*table_info.table, binary_file_path);
       std::cout << "(" << per_table_timer.lap_formatted() << ")" << std::endl;


### PR DESCRIPTION
We usually indent the single table items when data is loaded or encoded:
```
- Loading/Generating tables
-  Loading table 'partsupp' from cached binary "tpch_cached_tables/sf-10.000000/partsupp.bin" (1 s 710 ms)
-  Loading table 'nation' from cached binary "tpch_cached_tables/sf-10.000000/nation.bin" (78 µs 761 ns)
-  Loading table 'supplier' from cached binary "tpch_cached_tables/sf-10.000000/supplier.bin" (30 ms 700 µs)
-  Loading table 'part' from cached binary "tpch_cached_tables/sf-10.000000/part.bin" (361 ms 356 µs)
-  Loading table 'orders' from cached binary "tpch_cached_tables/sf-10.000000/orders.bin" (2 s 184 ms)
-  Loading table 'customer' from cached binary "tpch_cached_tables/sf-10.000000/customer.bin" (522 ms 798 µs)
-  Loading table 'region' from cached binary "tpch_cached_tables/sf-10.000000/region.bin" (40 µs 956 ns)
-  Loading table 'lineitem' from cached binary "tpch_cached_tables/sf-10.000000/lineitem.bin" (7 s 815 ms)
- Loading/Generating tables done (12 s 627 ms)
- Encoding tables (if necessary) and generating pruning statistics
-  Encoding 'region' - encoding applied (5 ms 983 µs)
-  Encoding 'nation' - encoding applied (5 s 899 ms)
-  Encoding 'supplier' - encoding applied (6 s 622 ms)
-  Encoding 'part' - encoding applied (21 s 320 ms)
-  Encoding 'customer' - encoding applied (22 s 384 ms)
-  Encoding 'partsupp' - encoding applied (1 min 2 s)
-  Encoding 'orders' - encoding applied (1 min 49 s)
-  Encoding 'lineitem' - encoding applied (5 min 58 s)
- Encoding tables and generating pruning statistic done (5 min 58 s)
```

However, it's not done for the binary file writing:
```
- Writing tables into binary files if necessary
- Writing 'lineitem' into binary file "tpch_cached_tables/sf-10.000000/lineitem.bin" (13 s 998 ms)
- Writing 'region' into binary file "tpch_cached_tables/sf-10.000000/region.bin" (172 µs 207 ns)
- Writing 'customer' into binary file "tpch_cached_tables/sf-10.000000/customer.bin" (320 ms 435 µs)
- Writing 'part' into binary file "tpch_cached_tables/sf-10.000000/part.bin" (265 ms 768 µs)
- Writing 'supplier' into binary file "tpch_cached_tables/sf-10.000000/supplier.bin" (8 ms 865 µs)
- Writing 'nation' into binary file "tpch_cached_tables/sf-10.000000/nation.bin" (72 µs 545 ns)
- Writing 'orders' into binary file "tpch_cached_tables/sf-10.000000/orders.bin" (2 s 420 ms)
- Writing 'partsupp' into binary file "tpch_cached_tables/sf-10.000000/partsupp.bin" (1 s 322 ms)
- Writing tables into binary files done (18 s 336 ms)
```

This is obviously an absolute show stopper and needs to be fixed asap.