### PR TITLE
Use `system_clock` for Measurements

### DIFF
--- a/src/benchmarklib/benchmark_config.hpp
+++ b/src/benchmarklib/benchmark_config.hpp
@@ -13,8 +13,8 @@ namespace opossum {
  */
 enum class BenchmarkMode { Ordered, Shuffled };
 
-using Duration = std::chrono::high_resolution_clock::duration;
-using TimePoint = std::chrono::high_resolution_clock::time_point;
+using Duration = std::chrono::steady_clock::duration;
+using TimePoint = std::chrono::steady_clock::time_point;
 
 class BenchmarkConfig {
  public:

--- a/src/benchmarklib/benchmark_state.cpp
+++ b/src/benchmarklib/benchmark_state.cpp
@@ -20,7 +20,7 @@ BenchmarkState& BenchmarkState::operator=(const BenchmarkState& other) {
 bool BenchmarkState::keep_running() {
   switch (state) {
     case State::NotStarted:
-      benchmark_begin = std::chrono::high_resolution_clock::now();
+      benchmark_begin = std::chrono::steady_clock::now();
       state = State::Running;
       break;
     case State::Over:
@@ -29,7 +29,7 @@ bool BenchmarkState::keep_running() {
     }
   }
 
-  benchmark_duration = std::chrono::high_resolution_clock::now() - benchmark_begin;
+  benchmark_duration = std::chrono::steady_clock::now() - benchmark_begin;
 
   // Stop execution if we reached the time limit
   if (benchmark_duration >= max_duration) {

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -33,10 +33,10 @@ SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Transacti
 
   hsql::SQLParserResult parse_result;
 
-  const auto start = std::chrono::high_resolution_clock::now();
+  const auto start = std::chrono::steady_clock::now();
   hsql::SQLParser::parse(sql, &parse_result);
 
-  const auto done = std::chrono::high_resolution_clock::now();
+  const auto done = std::chrono::steady_clock::now();
   _metrics.parse_time_nanos = std::chrono::duration_cast<std::chrono::nanoseconds>(done - start);
   DTRACE_PROBE2(HYRISE, SQL_PARSING, sql.c_str(), _metrics.parse_time_nanos.count());
 

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -83,7 +83,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
 
   auto parsed_sql = get_parsed_sql_statement();
 
-  const auto started = std::chrono::high_resolution_clock::now();
+  const auto started = std::chrono::steady_clock::now();
 
   SQLTranslator sql_translator{_use_mvcc};
 
@@ -95,7 +95,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_unoptimized_lo
 
   _unoptimized_logical_plan = lqp_roots.front();
 
-  const auto done = std::chrono::high_resolution_clock::now();
+  const auto done = std::chrono::steady_clock::now();
   _metrics->sql_translation_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
 
   return _unoptimized_logical_plan;
@@ -130,7 +130,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
 
   auto unoptimized_lqp = get_unoptimized_logical_plan();
 
-  const auto started = std::chrono::high_resolution_clock::now();
+  const auto started = std::chrono::steady_clock::now();
 
   // The optimizer works on the original unoptimized LQP nodes. After optimizing, the unoptimized version is also
   // optimized, which could lead to subtle bugs. optimized_logical_plan holds the original values now.
@@ -141,7 +141,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
 
   _optimized_logical_plan = _optimizer->optimize(std::move(unoptimized_lqp), optimizer_rule_durations);
 
-  const auto done = std::chrono::high_resolution_clock::now();
+  const auto done = std::chrono::steady_clock::now();
   _metrics->optimization_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
   _metrics->optimizer_rule_durations = *optimizer_rule_durations;
 
@@ -164,7 +164,7 @@ const std::shared_ptr<AbstractOperator>& SQLPipelineStatement::get_physical_plan
   }
 
   // Stores when the actual compilation started/ended
-  auto started = std::chrono::high_resolution_clock::now();
+  auto started = std::chrono::steady_clock::now();
   auto done = started;  // dummy value needed for initialization
 
   // Try to retrieve the PQP from cache
@@ -186,11 +186,11 @@ const std::shared_ptr<AbstractOperator>& SQLPipelineStatement::get_physical_plan
     const auto& lqp = get_optimized_logical_plan();
 
     // Reset time to exclude previous pipeline steps
-    started = std::chrono::high_resolution_clock::now();
+    started = std::chrono::steady_clock::now();
     _physical_plan = LQPTranslator{}.translate_node(lqp);
   }
 
-  done = std::chrono::high_resolution_clock::now();
+  done = std::chrono::steady_clock::now();
 
   if (_use_mvcc == UseMvcc::Yes) _physical_plan->set_transaction_context_recursively(_transaction_context);
 
@@ -267,7 +267,7 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipelineSta
 
   const auto& tasks = get_tasks();
 
-  const auto started = std::chrono::high_resolution_clock::now();
+  const auto started = std::chrono::steady_clock::now();
 
   DTRACE_PROBE3(HYRISE, TASKS_PER_STATEMENT, reinterpret_cast<uintptr_t>(&tasks), _sql_string.c_str(),
                 reinterpret_cast<uintptr_t>(this));
@@ -289,7 +289,7 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipelineSta
            "Transaction should either be still active or have been auto-committed by now");
   }
 
-  const auto done = std::chrono::high_resolution_clock::now();
+  const auto done = std::chrono::steady_clock::now();
   _metrics->plan_execution_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(done - started);
 
   // Get result table, if it was not a transaction statement

--- a/src/lib/utils/timer.cpp
+++ b/src/lib/utils/timer.cpp
@@ -4,10 +4,10 @@
 
 namespace opossum {
 
-Timer::Timer() { _begin = std::chrono::high_resolution_clock::now(); }
+Timer::Timer() { _begin = std::chrono::steady_clock::now(); }
 
 std::chrono::nanoseconds Timer::lap() {
-  const auto now = std::chrono::high_resolution_clock::now();
+  const auto now = std::chrono::steady_clock::now();
   const auto lap_duration = std::chrono::duration_cast<std::chrono::nanoseconds>(now - _begin);
   _begin = now;
   return lap_duration;

--- a/src/lib/utils/timer.hpp
+++ b/src/lib/utils/timer.hpp
@@ -6,7 +6,7 @@
 namespace opossum {
 
 /**
- * Starts a std::chrono::high_resolution_clock base timer on construction and returns and resets measurement when
+ * Starts a std::chrono::steady_clock base timer on construction and returns and resets measurement when
  * lap() is called.
  */
 class Timer final {
@@ -24,7 +24,7 @@ class Timer final {
   std::string lap_formatted();
 
  private:
-  std::chrono::high_resolution_clock::time_point _begin;
+  std::chrono::steady_clock::time_point _begin;
 };
 
 }  // namespace opossum


### PR DESCRIPTION
While scrambling through different clocks on cppreference after hearing a talk related to increasing benchmark measurement accuracy, I came along [this little gem](https://en.cppreference.com/w/cpp/chrono/high_resolution_clock).

> The `high_resolution_clock` is not implemented consistently across different standard library implementations, and its use should be avoided. It is often just an alias for `std::chrono::steady_clock` or `std::chrono::system_clock`, but which one it is depends on the library or configuration. When it is a `system_clock`, it is not monotonic (e.g., the time can go backwards). For example, for gcc's libstdc++ it is `system_clock`, for MSVC it is `steady_clock`, and for clang's libc++ it depends on configuration.
Generally one should just use `std::chrono::steady_clock` or `std::chrono::system_clock` directly instead of `std::chrono::high_resolution_clock`: use `steady_clock` for duration measurements, and `system_clock` for wall-clock time. 

In the end, we could get wrong results now if the system clock is adjusted while running. Thus, I replaced every occurrence of `std::chrono::high_resolution_clock` with `std::chrono::steady_clock`. If there is no need to map the (start) time of benchmarks to wall clock time, this should be okay.