### PR TITLE
CMake: include libnuma's include path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,9 +70,12 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/src/benchmarklib/
     ${PROJECT_SOURCE_DIR}/src/lib/
     ${PROJECT_SOURCE_DIR}/src/plugins/
-
-    ${NUMA_INCLUDE_DIR}
 )
+
+if (NUMA_FOUND)
+    # Add libnuma sources for NUMA systems only
+    include_directories(${NUMA_INCLUDE_DIR})
+endif()
 
 # Include these libraries as system libraries to silence some warnings caused by -Weverything
 include_directories(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,8 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/src/benchmarklib/
     ${PROJECT_SOURCE_DIR}/src/lib/
     ${PROJECT_SOURCE_DIR}/src/plugins/
+
+    ${NUMA_INCLUDE_DIR}
 )
 
 # Include these libraries as system libraries to silence some warnings caused by -Weverything


### PR DESCRIPTION
This PR ensures that the include path of `libnuma` is used by the compiler when it's explicitly given to CMake (e.g., on non-root systems). Follow up to #2420.