### PR TITLE
Enable binary table loading for TPC-C in server

### DIFF
--- a/scripts/test/hyriseBenchmarkTPCH_test.py
+++ b/scripts/test/hyriseBenchmarkTPCH_test.py
@@ -46,6 +46,7 @@ def main():
     benchmark.expect_exact("Benchmarking Queries: [ 1, 13, 19 ]")
     benchmark.expect_exact("TPC-H scale factor is 0.01")
     benchmark.expect_exact("Using prepared statements: yes")
+    benchmark.expect_exact("Loading/Generating tables done")
     benchmark.expect_exact("Sorting tables")
     benchmark.expect_exact("Creating index on customer [ c_custkey ]")
     benchmark.expect_exact("Preparing queries")
@@ -128,7 +129,6 @@ def main():
     arguments["--scheduler"] = "true"
     arguments["--clients"] = "4"
     arguments["--verify"] = "true"
-    arguments["--dont_cache_binary_tables"] = "true"
 
     benchmark = run_benchmark(build_dir, arguments, "hyriseBenchmarkTPCH", True)
 
@@ -144,6 +144,8 @@ def main():
     benchmark.expect_exact("TPC-H scale factor is 0.01")
     benchmark.expect_exact("Using prepared statements: no")
     benchmark.expect_exact("Multi-threaded Topology:")
+    benchmark.expect_exact("Loading/Generating tables done")
+    benchmark.expect_exact("Writing 'lineitem' into binary file \"tpch_cached_tables/sf-0.010000/lineitem.bin\"")
 
     close_benchmark(benchmark)
     check_exit_status(benchmark)
@@ -162,6 +164,9 @@ def main():
     benchmark.expect_exact("Visualizing the plans into SVG files. This will make the performance numbers invalid.")
     benchmark.expect_exact("Chunk size is 10000")
     benchmark.expect_exact("Benchmarking Queries: [ 6 ]")
+    benchmark.expect_exact("Loading table 'orders' from cached binary \"tpch_cached_tables/sf-0.010000/orders.bin\"")
+    # Different encoding then previously loaded, writes binary tables again.
+    benchmark.expect_exact("Writing 'lineitem' into binary file \"tpch_cached_tables/sf-0.010000/lineitem.bin\"")
 
     close_benchmark(benchmark)
     check_exit_status(benchmark)

--- a/src/bin/server.cpp
+++ b/src/bin/server.cpp
@@ -36,7 +36,6 @@ void generate_benchmark_data(std::string argument_string) {
   auto config = std::make_shared<opossum::BenchmarkConfig>(opossum::BenchmarkConfig::get_default_config());
   config->cache_binary_tables = true;
   if (benchmark_name == "tpcc") {
-    config->cache_binary_tables = false;  // Not yet supported for TPC-C
     opossum::TPCCTableGenerator{static_cast<uint32_t>(sizing_factor), config}.generate_and_store();
   } else if (benchmark_name == "tpcds") {
     opossum::TPCDSTableGenerator{static_cast<uint32_t>(sizing_factor), config}.generate_and_store();


### PR DESCRIPTION
This PR enables binary table loading for TPC-C in the `hyriseServer` binary. #2337 enabled it.