### PR TITLE
Update setup_imdb script

### DIFF
--- a/scripts/setup_imdb.py
+++ b/scripts/setup_imdb.py
@@ -75,7 +75,7 @@ hash_md5 = hashlib.md5()
 url = urllib.request.urlopen(LOCATION)
 
 meta = url.info()
-file_size = int(meta["Content-Length"])
+file_size = int(meta["X-Dropbox-Content-Length"])
 
 file = open(FILE_NAME, "wb")
 


### PR DESCRIPTION
Currently, out script to download the IMDB data [fails](https://hyrise-ci.epic-hpi.de/blue/organizations/jenkins/hyrise%2Fhyrise/detail/PR-2432/2/pipeline). The script downloads the IMDB data from dropbox. During the download, we display the download's progress on the command line. For displaying the progress, we need the total file size. Apparently, dropbox has changed the meta attribute for the file size from `Content-Length` to `X-Dropbox-Content-Length`.