### PR TITLE
Fix imdb_script content length (again)

### DIFF
--- a/scripts/setup_imdb.py
+++ b/scripts/setup_imdb.py
@@ -75,7 +75,15 @@ hash_md5 = hashlib.md5()
 url = urllib.request.urlopen(LOCATION)
 
 meta = url.info()
-file_size = int(meta["X-Dropbox-Content-Length"])
+
+if "X-Dropbox-Content-Length" in meta:
+    file_size = int(meta["X-Dropbox-Content-Length"])
+elif "Content-Length" in meta:
+    file_size = int(meta["Content-Length"])
+else:
+    print("- Aborting. Could not retrieve the imdb dataset's file size.")
+    clean_up()
+    sys.exit(1)
 
 file = open(FILE_NAME, "wb")
 


### PR DESCRIPTION
I don't know why the attribute changes from time to time. Maybe it depends on the dropbox server from which we download which might change based on utilization or whatever.