### PR TITLE
Add user-callable functions to plugins

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,6 +70,10 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 
+                git config --global --add safe.directory $(pwd)
+                # Get the paths of the submodules; for each path, add it as a git safe.directory
+                grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'
+
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."
                     exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,10 +70,6 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 
-                git config --global --add safe.directory $(pwd)
-                # Get the paths of the submodules; for each path, add it as a git safe.directory
-                grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'
-
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."
                     exit 1

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -593,6 +593,8 @@ set(
     utils/meta_tables/meta_chunks_table.hpp
     utils/meta_tables/meta_columns_table.cpp
     utils/meta_tables/meta_columns_table.hpp
+    utils/meta_tables/meta_exec_table.cpp
+    utils/meta_tables/meta_exec_table.hpp
     utils/meta_tables/meta_log_table.cpp
     utils/meta_tables/meta_log_table.hpp
     utils/meta_tables/meta_plugins_table.cpp

--- a/src/lib/utils/abstract_plugin.hpp
+++ b/src/lib/utils/abstract_plugin.hpp
@@ -12,6 +12,9 @@ namespace opossum {
 #define EXPORT_PLUGIN(PluginName) \
   extern "C" AbstractPlugin* factory() { return new PluginName(); }
 
+using PluginFunctionName = std::string;
+using PluginFunctionPointer = std::function<void(void)>;
+
 // AbstractPlugin is the abstract super class for all plugins. An example implementation can be found
 // under test/utils/test_plugin.cpp. Usually plugins are implemented as singletons because there
 // shouldn't be multiple instances of them as they would compete against each other.
@@ -25,7 +28,7 @@ class AbstractPlugin {
 
   virtual void stop() = 0;
 
-  virtual std::vector<std::pair<std::string, std::function<void(void)>>> keywords_functions() const {
+  virtual std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const {
     return {};
   }
 };

--- a/src/lib/utils/abstract_plugin.hpp
+++ b/src/lib/utils/abstract_plugin.hpp
@@ -28,7 +28,7 @@ class AbstractPlugin {
 
   virtual void stop() = 0;
 
-  virtual std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const {
+  virtual std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> provided_user_executable_functions() const {
     return {};
   }
 };

--- a/src/lib/utils/abstract_plugin.hpp
+++ b/src/lib/utils/abstract_plugin.hpp
@@ -24,6 +24,10 @@ class AbstractPlugin {
   virtual void start() = 0;
 
   virtual void stop() = 0;
+
+  virtual std::vector<std::pair<std::string, std::function<void(void)>>> keywords_functions() const {
+    return {};
+  }
 };
 
 }  // namespace opossum

--- a/src/lib/utils/abstract_plugin.hpp
+++ b/src/lib/utils/abstract_plugin.hpp
@@ -28,6 +28,12 @@ class AbstractPlugin {
 
   virtual void stop() = 0;
 
+  // This method provides an interface for making plugin functions executable by plugin users.
+  // Please see the test_plugin.cpp and the meta_exec_table_test.cpp for examples on how to use it.
+  // IMPORTANT: The execution of such user-executable functions is blocking, see the PluginManager's
+  // exec_user_function method. If you are writing a plugin and provide user-exectuable functions it
+  // is YOUR responsibility to keep these function calls as short and efficient as possible, e.g.,
+  // by spinning up a thread inside the plugin to execute the actual functionality.
   virtual std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> provided_user_executable_functions() const {
     return {};
   }

--- a/src/lib/utils/meta_table_manager.cpp
+++ b/src/lib/utils/meta_table_manager.cpp
@@ -3,6 +3,7 @@
 #include "utils/meta_tables/meta_chunk_sort_orders_table.hpp"
 #include "utils/meta_tables/meta_chunks_table.hpp"
 #include "utils/meta_tables/meta_columns_table.hpp"
+#include "utils/meta_tables/meta_exec_table.hpp"
 #include "utils/meta_tables/meta_log_table.hpp"
 #include "utils/meta_tables/meta_plugins_table.hpp"
 #include "utils/meta_tables/meta_segments_accurate_table.hpp"
@@ -19,6 +20,7 @@ MetaTableManager::MetaTableManager() {
                                                                        std::make_shared<MetaColumnsTable>(),
                                                                        std::make_shared<MetaChunksTable>(),
                                                                        std::make_shared<MetaChunkSortOrdersTable>(),
+                                                                       std::make_shared<MetaExecTable>(),
                                                                        std::make_shared<MetaLogTable>(),
                                                                        std::make_shared<MetaSegmentsTable>(),
                                                                        std::make_shared<MetaSegmentsAccurateTable>(),

--- a/src/lib/utils/meta_tables/meta_exec_table.cpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.cpp
@@ -20,6 +20,11 @@ bool MetaExecTable::can_insert() const { return true; }
 std::shared_ptr<Table> MetaExecTable::_on_generate() const {
   auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
 
+  for (const auto& [key, _] : Hyrise::get().plugin_manager.user_executable_functions()) {
+    const auto& [plugin_name, function_name] = key;
+    output_table->append({pmr_string{plugin_name}, pmr_string{function_name}});
+  }
+
   return output_table;
 }
 

--- a/src/lib/utils/meta_tables/meta_exec_table.cpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.cpp
@@ -23,8 +23,8 @@ std::shared_ptr<Table> MetaExecTable::_on_generate() const {
 
 void MetaExecTable::_on_insert(const std::vector<AllTypeVariant>& values) {
   const auto plugin_name = PluginName{boost::get<pmr_string>(values.at(0))};
-  const auto function_name = std::string{boost::get<pmr_string>(values.at(1))};
-  Hyrise::get().plugin_manager.exec_function(plugin_name, function_name);
+  const auto function_name = PluginFunctionName{boost::get<pmr_string>(values.at(1))};
+  Hyrise::get().plugin_manager.exec_user_function(plugin_name, function_name);
 
   // Todo(all): Decide if we want to add something to the table or just execute.
 }

--- a/src/lib/utils/meta_tables/meta_exec_table.cpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.cpp
@@ -6,7 +6,9 @@
 
 namespace opossum {
 
-MetaExecTable::MetaExecTable() : AbstractMetaTable(TableColumnDefinitions{{"plugin_name", DataType::String, false}, {"function_name", DataType::String, false}}) {}
+MetaExecTable::MetaExecTable()
+    : AbstractMetaTable(TableColumnDefinitions{{"plugin_name", DataType::String, false},
+                                               {"function_name", DataType::String, false}}) {}
 
 const std::string& MetaExecTable::name() const {
   static const auto name = std::string{"exec"};

--- a/src/lib/utils/meta_tables/meta_exec_table.cpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.cpp
@@ -27,8 +27,6 @@ void MetaExecTable::_on_insert(const std::vector<AllTypeVariant>& values) {
   const auto plugin_name = PluginName{boost::get<pmr_string>(values.at(0))};
   const auto function_name = PluginFunctionName{boost::get<pmr_string>(values.at(1))};
   Hyrise::get().plugin_manager.exec_user_function(plugin_name, function_name);
-
-  // Todo(all): Decide if we want to add something to the table or just execute.
 }
 
 }  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_exec_table.cpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.cpp
@@ -1,0 +1,32 @@
+#include "meta_exec_table.hpp"
+
+#include <boost/algorithm/string.hpp>
+
+#include "hyrise.hpp"
+
+namespace opossum {
+
+MetaExecTable::MetaExecTable() : AbstractMetaTable(TableColumnDefinitions{{"plugin_name", DataType::String, false}, {"function_name", DataType::String, false}}) {}
+
+const std::string& MetaExecTable::name() const {
+  static const auto name = std::string{"exec"};
+  return name;
+}
+
+bool MetaExecTable::can_insert() const { return true; }
+
+std::shared_ptr<Table> MetaExecTable::_on_generate() const {
+  auto output_table = std::make_shared<Table>(_column_definitions, TableType::Data, std::nullopt, UseMvcc::Yes);
+
+  return output_table;
+}
+
+void MetaExecTable::_on_insert(const std::vector<AllTypeVariant>& values) {
+  const auto plugin_name = PluginName{boost::get<pmr_string>(values.at(0))};
+  const auto function_name = std::string{boost::get<pmr_string>(values.at(1))};
+  Hyrise::get().plugin_manager.exec_function(plugin_name, function_name);
+
+  // Todo(all): Decide if we want to add something to the table or just execute.
+}
+
+}  // namespace opossum

--- a/src/lib/utils/meta_tables/meta_exec_table.hpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.hpp
@@ -5,8 +5,8 @@
 namespace opossum {
 
 /**
- * This is a class for plugin control via a meta table.
- * Inserting loads a plugin, deleting unloads it.
+ * This is a class for calling user executable functions provided by plugins.
+ * Inserting plugin and function name calls a function, selecting from the table returns all executable functions.
  */
 class MetaExecTable : public AbstractMetaTable {
  public:

--- a/src/lib/utils/meta_tables/meta_exec_table.hpp
+++ b/src/lib/utils/meta_tables/meta_exec_table.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "utils/meta_tables/abstract_meta_table.hpp"
+
+namespace opossum {
+
+/**
+ * This is a class for plugin control via a meta table.
+ * Inserting loads a plugin, deleting unloads it.
+ */
+class MetaExecTable : public AbstractMetaTable {
+ public:
+  MetaExecTable();
+
+  const std::string& name() const final;
+
+  bool can_insert() const final;
+
+ protected:
+  std::shared_ptr<Table> _on_generate() const final;
+
+  void _on_insert(const std::vector<AllTypeVariant>& values) final;
+};
+
+}  // namespace opossum

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -35,6 +35,11 @@ std::vector<PluginName> PluginManager::loaded_plugins() const {
   return plugin_names;
 }
 
+std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash>
+PluginManager::user_executable_functions() const {
+  return _user_executable_functions;
+}
+
 void PluginManager::load_plugin(const std::filesystem::path& path) {
   const auto plugin_name = plugin_name_from_path(path);
 

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -70,7 +70,8 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
 }
 
 void PluginManager::exec_user_function(const PluginName& plugin_name, const PluginFunctionName& function_name) {
-  Assert(_user_executable_functions.count({plugin_name, function_name}) > 0, "There is no " + function_name + " defined for plugin " + plugin_name + ".");
+  Assert(_user_executable_functions.count({plugin_name, function_name}) > 0,
+         "There is no " + function_name + " defined for plugin " + plugin_name + ".");
 
   const auto user_executable_function = _user_executable_functions[{plugin_name, function_name}];
   user_executable_function();
@@ -80,7 +81,8 @@ void PluginManager::exec_user_function(const PluginName& plugin_name, const Plug
 
 void PluginManager::unload_plugin(const PluginName& plugin_name) {
   auto plugin_iter = _plugins.find(plugin_name);
-  Assert(plugin_iter != _plugins.cend(), "Unloading plugin failed: A plugin with name " + plugin_name + " does not exist.");
+  Assert(plugin_iter != _plugins.cend(),
+         "Unloading plugin failed: A plugin with name " + plugin_name + " does not exist.");
 
   _unload_and_erase_plugin(plugin_iter);
 }

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -76,7 +76,7 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
 }
 
 void PluginManager::exec_user_function(const PluginName& plugin_name, const PluginFunctionName& function_name) {
-  Assert(_user_executable_functions.count({plugin_name, function_name}) > 0,
+  Assert(_user_executable_functions.count({plugin_name, function_name}) == 1,
          "There is no " + function_name + " defined for plugin " + plugin_name + ".");
 
   const auto user_executable_function = _user_executable_functions[{plugin_name, function_name}];

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -62,6 +62,7 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
   plugin_handle_wrapper.plugin->start();
   _plugins[plugin_name] = std::move(plugin_handle_wrapper);
 
+  // Add the newly loaded plugin's user executable functions to our map of functions.
   const auto user_executable_functions = _plugins[plugin_name].plugin->get_user_executable_functions();
   for (const auto& [function_name, function_pointer] : user_executable_functions) {
     _user_executable_functions[{plugin_name, function_name}] = function_pointer;
@@ -89,7 +90,7 @@ std::unordered_map<PluginName, PluginHandleWrapper>::iterator PluginManager::_un
   const PluginName plugin_name = plugin_iter->first;
   const auto& plugin_handle_wrapper = plugin_iter->second;
 
-  // Delete keywords and functions for plugin to be unloaded.
+  // Delete user exectuable functions of the plugin to be unloaded from the map of functions.
   std::erase_if(_user_executable_functions, [&](const auto& item) {
     const auto& [item_plugin_name, _] = item.first;
     return item_plugin_name == plugin_name;

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -43,7 +43,8 @@ PluginManager::user_executable_functions() const {
 void PluginManager::load_plugin(const std::filesystem::path& path) {
   const auto plugin_name = plugin_name_from_path(path);
 
-  Assert(!_plugins.count(plugin_name), "Loading plugin failed: A plugin with name " + plugin_name + " already exists.");
+  Assert(!_plugins.contains(plugin_name),
+         "Loading plugin failed: A plugin with name " + plugin_name + " already exists.");
 
   PluginHandle plugin_handle = dlopen(path.c_str(), static_cast<uint8_t>(RTLD_NOW) | static_cast<uint8_t>(RTLD_LOCAL));
   Assert(plugin_handle, std::string{"Loading plugin failed: "} + dlerror());

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -69,7 +69,7 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
   _plugins[plugin_name] = std::move(plugin_handle_wrapper);
 
   // Add the newly loaded plugin's user executable functions to our map of functions.
-  const auto user_executable_functions = _plugins[plugin_name].plugin->get_user_executable_functions();
+  const auto user_executable_functions = _plugins[plugin_name].plugin->provided_user_executable_functions();
   for (const auto& [function_name, function_pointer] : user_executable_functions) {
     _user_executable_functions[{plugin_name, function_name}] = function_pointer;
   }

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -35,9 +35,9 @@ std::vector<PluginName> PluginManager::loaded_plugins() const {
 }
 
 void PluginManager::load_plugin(const std::filesystem::path& path) {
-  const auto name = plugin_name_from_path(path);
+  const auto plugin_name = plugin_name_from_path(path);
 
-  Assert(!_plugins.count(name), "Loading plugin failed: A plugin with name " + name + " already exists.");
+  Assert(!_plugins.count(plugin_name), "Loading plugin failed: A plugin with name " + plugin_name + " already exists.");
 
   PluginHandle plugin_handle = dlopen(path.c_str(), static_cast<uint8_t>(RTLD_NOW) | static_cast<uint8_t>(RTLD_LOCAL));
   Assert(plugin_handle, std::string{"Loading plugin failed: "} + dlerror());
@@ -60,40 +60,41 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
          "Loading plugin failed: There can only be one instance of every plugin.");
 
   plugin_handle_wrapper.plugin->start();
-  _plugins[name] = std::move(plugin_handle_wrapper);
+  _plugins[plugin_name] = std::move(plugin_handle_wrapper);
 
-  const auto keywords_functions = _plugins[name].plugin->keywords_functions();
-  for (const auto& [keyword, function] : keywords_functions) {
-    _keyword_function_map[{name, keyword}] = function;
+  const auto user_executable_functions = _plugins[plugin_name].plugin->get_user_executable_functions();
+  for (const auto& [function_name, function_pointer] : user_executable_functions) {
+    _user_executable_functions[{plugin_name, function_name}] = function_pointer;
   }
 }
 
-void PluginManager::exec_function(const PluginName& plugin_name, const std::string& keyword) {
-  Assert(_keyword_function_map.count({plugin_name, keyword}) > 0, "There is no " + keyword + " defined for plugin " + plugin_name + ".");
-  const auto function = _keyword_function_map[{plugin_name, keyword}];
-  function();
+void PluginManager::exec_user_function(const PluginName& plugin_name, const PluginFunctionName& function_name) {
+  Assert(_user_executable_functions.count({plugin_name, function_name}) > 0, "There is no " + function_name + " defined for plugin " + plugin_name + ".");
+
+  const auto user_executable_function = _user_executable_functions[{plugin_name, function_name}];
+  user_executable_function();
 
   // Todo(all): Decide whether we want logging here
 }
 
-void PluginManager::unload_plugin(const PluginName& name) {
-  auto plugin_iter = _plugins.find(name);
-  Assert(plugin_iter != _plugins.cend(), "Unloading plugin failed: A plugin with name " + name + " does not exist.");
+void PluginManager::unload_plugin(const PluginName& plugin_name) {
+  auto plugin_iter = _plugins.find(plugin_name);
+  Assert(plugin_iter != _plugins.cend(), "Unloading plugin failed: A plugin with name " + plugin_name + " does not exist.");
 
   _unload_and_erase_plugin(plugin_iter);
 }
 
 std::unordered_map<PluginName, PluginHandleWrapper>::iterator PluginManager::_unload_and_erase_plugin(
     const std::unordered_map<PluginName, PluginHandleWrapper>::iterator plugin_iter) {
-  const PluginName name = plugin_iter->first;
+  const PluginName plugin_name = plugin_iter->first;
   const auto& plugin_handle_wrapper = plugin_iter->second;
 
   // Delete keywords and functions for plugin to be unloaded.
-  auto it = _keyword_function_map.cbegin();
-  while (it != _keyword_function_map.cend()) {
+  auto it = _user_executable_functions.cbegin();
+  while (it != _user_executable_functions.cend()) {
     // Accessing first element of a pair that forms map's key.
-    if (it->first.first == name) {
-      it = _keyword_function_map.erase(it);
+    if (it->first.first == plugin_name) {
+      it = _user_executable_functions.erase(it);
     } else {
       it++;
     }

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -76,7 +76,7 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
 }
 
 void PluginManager::exec_user_function(const PluginName& plugin_name, const PluginFunctionName& function_name) {
-  Assert(_user_executable_functions.count({plugin_name, function_name}) == 1,
+  Assert(_user_executable_functions.contains({plugin_name, function_name}),
          "There is no " + function_name + " defined for plugin " + plugin_name + ".");
 
   const auto user_executable_function = _user_executable_functions[{plugin_name, function_name}];

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -69,7 +69,7 @@ void PluginManager::load_plugin(const std::filesystem::path& path) {
   _plugins[plugin_name] = std::move(plugin_handle_wrapper);
 
   // Add the newly loaded plugin's user executable functions to our map of functions.
-  const auto user_executable_functions = _plugins[plugin_name].plugin->provided_user_executable_functions();
+  const auto& user_executable_functions = _plugins[plugin_name].plugin->provided_user_executable_functions();
   for (const auto& [function_name, function_pointer] : user_executable_functions) {
     _user_executable_functions[{plugin_name, function_name}] = function_pointer;
   }

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 
+#include "hyrise.hpp"
 #include "utils/abstract_plugin.hpp"
 #include "utils/assert.hpp"
 
@@ -76,7 +77,11 @@ void PluginManager::exec_user_function(const PluginName& plugin_name, const Plug
   const auto user_executable_function = _user_executable_functions[{plugin_name, function_name}];
   user_executable_function();
 
-  // Todo(all): Decide whether we want logging here
+  auto& log_manager = Hyrise::get().log_manager;
+  log_manager.add_message(
+      "PluginManager",
+      "Called user executable function `" + function_name + "` provided by plugin `" + plugin_name + "`.",
+      LogLevel::Info);
 }
 
 void PluginManager::unload_plugin(const PluginName& plugin_name) {

--- a/src/lib/utils/plugin_manager.cpp
+++ b/src/lib/utils/plugin_manager.cpp
@@ -90,15 +90,10 @@ std::unordered_map<PluginName, PluginHandleWrapper>::iterator PluginManager::_un
   const auto& plugin_handle_wrapper = plugin_iter->second;
 
   // Delete keywords and functions for plugin to be unloaded.
-  auto it = _user_executable_functions.cbegin();
-  while (it != _user_executable_functions.cend()) {
-    // Accessing first element of a pair that forms map's key.
-    if (it->first.first == plugin_name) {
-      it = _user_executable_functions.erase(it);
-    } else {
-      it++;
-    }
-  }
+  std::erase_if(_user_executable_functions, [&](const auto& item) {
+    const auto& [item_plugin_name, _] = item.first;
+    return item_plugin_name == plugin_name;
+  });
 
   plugin_handle_wrapper.plugin->stop();
   auto* const handle = plugin_handle_wrapper.handle;

--- a/src/lib/utils/plugin_manager.hpp
+++ b/src/lib/utils/plugin_manager.hpp
@@ -18,7 +18,7 @@ struct PluginHandleWrapper {
 };
 
 struct plugin_name_function_name_hash {
-  size_t operator() (const std::pair<PluginName, PluginFunctionName> &p) const {
+  size_t operator()(const std::pair<PluginName, PluginFunctionName>& p) const {
     size_t hash{0};
     boost::hash_combine(hash, p.first);
     boost::hash_combine(hash, p.second);
@@ -49,7 +49,8 @@ class PluginManager : public Noncopyable {
   PluginManager& operator=(PluginManager&&) = default;
 
   std::unordered_map<PluginName, PluginHandleWrapper> _plugins;
-  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash> _user_executable_functions;
+  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash>
+      _user_executable_functions;
 
   // This method is called during destruction and stops and unloads all currently loaded plugions.
   void _clean_up();

--- a/src/lib/utils/plugin_manager.hpp
+++ b/src/lib/utils/plugin_manager.hpp
@@ -9,8 +9,12 @@
 
 namespace opossum {
 
+struct plugin_name_function_name_hash;
+
 using PluginHandle = void*;
 using PluginName = std::string;
+using UserExecutableFunctionMap = std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer,
+                                                     plugin_name_function_name_hash>;
 
 struct PluginHandleWrapper {
   PluginHandle handle;
@@ -19,7 +23,7 @@ struct PluginHandleWrapper {
 
 struct plugin_name_function_name_hash {
   size_t operator()(const std::pair<PluginName, PluginFunctionName>& p) const {
-    size_t hash{0};
+    auto hash = size_t{0};
     boost::hash_combine(hash, p.first);
     boost::hash_combine(hash, p.second);
 
@@ -39,8 +43,7 @@ class PluginManager : public Noncopyable {
 
   std::vector<PluginName> loaded_plugins() const;
 
-  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash>
-  user_executable_functions() const;
+  UserExecutableFunctionMap user_executable_functions() const;
 
   ~PluginManager();
 
@@ -52,8 +55,7 @@ class PluginManager : public Noncopyable {
   PluginManager& operator=(PluginManager&&) = default;
 
   std::unordered_map<PluginName, PluginHandleWrapper> _plugins;
-  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash>
-      _user_executable_functions;
+  UserExecutableFunctionMap _user_executable_functions;
 
   // This method is called during destruction and stops and unloads all currently loaded plugions.
   void _clean_up();

--- a/src/lib/utils/plugin_manager.hpp
+++ b/src/lib/utils/plugin_manager.hpp
@@ -11,15 +11,14 @@ namespace opossum {
 
 using PluginHandle = void*;
 using PluginName = std::string;
-using Keyword = std::string;
 
 struct PluginHandleWrapper {
   PluginHandle handle;
   std::unique_ptr<AbstractPlugin> plugin;
 };
 
-struct string_pair_hash {
-  size_t operator () (const std::pair<PluginName, Keyword> &p) const {
+struct plugin_name_function_name_hash {
+  size_t operator() (const std::pair<PluginName, PluginFunctionName> &p) const {
     size_t hash{0};
     boost::hash_combine(hash, p.first);
     boost::hash_combine(hash, p.second);
@@ -36,7 +35,7 @@ class PluginManager : public Noncopyable {
  public:
   void load_plugin(const std::filesystem::path& path);
   void unload_plugin(const PluginName& name);
-  void exec_function(const PluginName& plugin_name, const std::string& keyword);
+  void exec_user_function(const PluginName& plugin_name, const PluginFunctionName& function_name);
 
   std::vector<PluginName> loaded_plugins() const;
 
@@ -50,7 +49,7 @@ class PluginManager : public Noncopyable {
   PluginManager& operator=(PluginManager&&) = default;
 
   std::unordered_map<PluginName, PluginHandleWrapper> _plugins;
-  std::unordered_map<std::pair<PluginName, Keyword>, std::function<void(void)>, string_pair_hash> _keyword_function_map;
+  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash> _user_executable_functions;
 
   // This method is called during destruction and stops and unloads all currently loaded plugions.
   void _clean_up();

--- a/src/lib/utils/plugin_manager.hpp
+++ b/src/lib/utils/plugin_manager.hpp
@@ -39,6 +39,9 @@ class PluginManager : public Noncopyable {
 
   std::vector<PluginName> loaded_plugins() const;
 
+  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash>
+  user_executable_functions() const;
+
   ~PluginManager();
 
  protected:

--- a/src/lib/utils/plugin_manager.hpp
+++ b/src/lib/utils/plugin_manager.hpp
@@ -11,10 +11,21 @@ namespace opossum {
 
 using PluginHandle = void*;
 using PluginName = std::string;
+using Keyword = std::string;
 
 struct PluginHandleWrapper {
   PluginHandle handle;
   std::unique_ptr<AbstractPlugin> plugin;
+};
+
+struct string_pair_hash {
+  size_t operator () (const std::pair<PluginName, Keyword> &p) const {
+    size_t hash{0};
+    boost::hash_combine(hash, p.first);
+    boost::hash_combine(hash, p.second);
+
+    return hash;
+  }
 };
 
 class PluginManager : public Noncopyable {
@@ -25,6 +36,7 @@ class PluginManager : public Noncopyable {
  public:
   void load_plugin(const std::filesystem::path& path);
   void unload_plugin(const PluginName& name);
+  void exec_function(const PluginName& plugin_name, const std::string& keyword);
 
   std::vector<PluginName> loaded_plugins() const;
 
@@ -38,6 +50,7 @@ class PluginManager : public Noncopyable {
   PluginManager& operator=(PluginManager&&) = default;
 
   std::unordered_map<PluginName, PluginHandleWrapper> _plugins;
+  std::unordered_map<std::pair<PluginName, Keyword>, std::function<void(void)>, string_pair_hash> _keyword_function_map;
 
   // This method is called during destruction and stops and unloads all currently loaded plugions.
   void _clean_up();

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -34,6 +34,7 @@ function(add_plugin)
 endfunction(add_plugin)
 
 add_plugin(NAME hyriseMvccDeletePlugin SRCS mvcc_delete_plugin.cpp mvcc_delete_plugin.hpp DEPS sqlparser magic_enum gtest)
+add_plugin(NAME hyriseSecondTestPlugin SRCS second_test_plugin.cpp second_test_plugin.hpp DEPS sqlparser)
 add_plugin(NAME hyriseTestPlugin SRCS test_plugin.cpp test_plugin.hpp DEPS sqlparser)
 add_plugin(NAME hyriseTestNonInstantiablePlugin SRCS non_instantiable_plugin.cpp)
 

--- a/src/plugins/second_test_plugin.cpp
+++ b/src/plugins/second_test_plugin.cpp
@@ -1,0 +1,28 @@
+#include "second_test_plugin.hpp"
+
+#include "storage/table.hpp"
+
+namespace opossum {
+
+std::string SecondTestPlugin::description() const { return "This is the Hyrise SecondTestPlugin"; }
+
+void SecondTestPlugin::start() {}
+
+void SecondTestPlugin::stop() {}
+
+std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> SecondTestPlugin::get_user_executable_functions()
+    const {
+  return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}};
+}
+
+void SecondTestPlugin::a_user_executable_function() const {
+  TableColumnDefinitions column_definitions;
+  column_definitions.emplace_back("col_A", DataType::Int, false);
+  auto table = std::make_shared<Table>(column_definitions, TableType::Data);
+
+  storage_manager.add_table("TableOfSecondTestPlugin", table);
+}
+
+EXPORT_PLUGIN(SecondTestPlugin)
+
+}  // namespace opossum

--- a/src/plugins/second_test_plugin.cpp
+++ b/src/plugins/second_test_plugin.cpp
@@ -10,7 +10,7 @@ void SecondTestPlugin::start() {}
 
 void SecondTestPlugin::stop() {}
 
-std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> SecondTestPlugin::get_user_executable_functions()
+std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> SecondTestPlugin::provided_user_executable_functions()
     const {
   return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}};
 }

--- a/src/plugins/second_test_plugin.hpp
+++ b/src/plugins/second_test_plugin.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "hyrise.hpp"
+#include "utils/abstract_plugin.hpp"
+
+namespace opossum {
+
+class SecondTestPlugin : public AbstractPlugin {
+ public:
+  SecondTestPlugin() : storage_manager(Hyrise::get().storage_manager) {}
+
+  std::string description() const final;
+
+  void start() final;
+
+  void stop() final;
+
+  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const final;
+
+  void a_user_executable_function() const;
+
+  StorageManager& storage_manager;
+};
+
+}  // namespace opossum

--- a/src/plugins/second_test_plugin.hpp
+++ b/src/plugins/second_test_plugin.hpp
@@ -15,7 +15,7 @@ class SecondTestPlugin : public AbstractPlugin {
 
   void stop() final;
 
-  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const final;
+  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> provided_user_executable_functions() const final;
 
   void a_user_executable_function() const;
 

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -16,7 +16,7 @@ void TestPlugin::start() {
 
 void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
 
-std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::get_user_executable_functions() const {
+std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::provided_user_executable_functions() const {
   return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }},
           {"SpecialFunction17", [&]() { this->another_user_executable_function(); }}};
 }

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -17,9 +17,7 @@ void TestPlugin::start() {
 void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
 
 std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::get_user_executable_functions() const {
-  return {
-    {"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}
-  };
+  return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}};
 };
 
 void TestPlugin::a_user_executable_function() const {

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -17,12 +17,19 @@ void TestPlugin::start() {
 void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
 
 std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::get_user_executable_functions() const {
-  return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}};
+  return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }},
+          {"SpecialFunction17", [&]() { this->another_user_executable_function(); }}};
 }
 
 void TestPlugin::a_user_executable_function() const {
-  std::cout << "This output was triggered by user interaction." << std::endl;
+  TableColumnDefinitions column_definitions;
+  column_definitions.emplace_back("col_A", DataType::Int, false);
+  auto table = std::make_shared<Table>(column_definitions, TableType::Data);
+
+  storage_manager.add_table("TableOfTestPlugin", table);
 }
+
+void TestPlugin::another_user_executable_function() const { std::cout << "This is never being called!" << std::endl; }
 
 EXPORT_PLUGIN(TestPlugin)
 

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -18,7 +18,7 @@ void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable")
 
 std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::get_user_executable_functions() const {
   return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}};
-};
+}
 
 void TestPlugin::a_user_executable_function() const {
   std::cout << "This output was triggered by user interaction." << std::endl;

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -16,6 +16,18 @@ void TestPlugin::start() {
 
 void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
 
+std::vector<std::pair<std::string, std::function<void(void)>>> TestPlugin::keywords_functions() const {
+  std::vector<std::pair<std::string, std::function<void(void)>>> result;
+
+  result.push_back({"UserCallable", [&]() { this->test_user_callable_function(); }});
+
+  return result;
+};
+
+void TestPlugin::test_user_callable_function() const {
+  std::cout << "This output was triggered by user interaction." << std::endl;
+}
+
 EXPORT_PLUGIN(TestPlugin)
 
 }  // namespace opossum

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -16,7 +16,8 @@ void TestPlugin::start() {
 
 void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
 
-std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::provided_user_executable_functions() const {
+std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::provided_user_executable_functions()
+    const {
   return {{"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }},
           {"SpecialFunction17", [&]() { this->another_user_executable_function(); }}};
 }

--- a/src/plugins/test_plugin.cpp
+++ b/src/plugins/test_plugin.cpp
@@ -16,15 +16,13 @@ void TestPlugin::start() {
 
 void TestPlugin::stop() { Hyrise::get().storage_manager.drop_table("DummyTable"); }
 
-std::vector<std::pair<std::string, std::function<void(void)>>> TestPlugin::keywords_functions() const {
-  std::vector<std::pair<std::string, std::function<void(void)>>> result;
-
-  result.push_back({"UserCallable", [&]() { this->test_user_callable_function(); }});
-
-  return result;
+std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> TestPlugin::get_user_executable_functions() const {
+  return {
+    {"OurFreelyChoosableFunctionName", [&]() { this->a_user_executable_function(); }}
+  };
 };
 
-void TestPlugin::test_user_callable_function() const {
+void TestPlugin::a_user_executable_function() const {
   std::cout << "This output was triggered by user interaction." << std::endl;
 }
 

--- a/src/plugins/test_plugin.hpp
+++ b/src/plugins/test_plugin.hpp
@@ -2,7 +2,6 @@
 
 #include "hyrise.hpp"
 #include "utils/abstract_plugin.hpp"
-#include "utils/singleton.hpp"
 
 namespace opossum {
 
@@ -19,6 +18,8 @@ class TestPlugin : public AbstractPlugin {
   std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const final;
 
   void a_user_executable_function() const;
+
+  void another_user_executable_function() const;
 
   StorageManager& storage_manager;
 };

--- a/src/plugins/test_plugin.hpp
+++ b/src/plugins/test_plugin.hpp
@@ -16,9 +16,9 @@ class TestPlugin : public AbstractPlugin {
 
   void stop() final;
 
-  std::vector<std::pair<std::string, std::function<void(void)>>> keywords_functions() const final;
+  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const final;
 
-  void test_user_callable_function() const;
+  void a_user_executable_function() const;
 
   StorageManager& storage_manager;
 };

--- a/src/plugins/test_plugin.hpp
+++ b/src/plugins/test_plugin.hpp
@@ -15,7 +15,7 @@ class TestPlugin : public AbstractPlugin {
 
   void stop() final;
 
-  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> get_user_executable_functions() const final;
+  std::vector<std::pair<PluginFunctionName, PluginFunctionPointer>> provided_user_executable_functions() const final;
 
   void a_user_executable_function() const;
 

--- a/src/plugins/test_plugin.hpp
+++ b/src/plugins/test_plugin.hpp
@@ -16,6 +16,10 @@ class TestPlugin : public AbstractPlugin {
 
   void stop() final;
 
+  std::vector<std::pair<std::string, std::function<void(void)>>> keywords_functions() const final;
+
+  void test_user_callable_function() const;
+
   StorageManager& storage_manager;
 };
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -273,7 +273,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Configure hyriseTest
 add_executable(hyriseTest ${HYRISE_UNIT_TEST_SOURCES})
-add_dependencies(hyriseTest hyriseTestPlugin hyriseMvccDeletePlugin hyriseTestNonInstantiablePlugin)
+add_dependencies(hyriseTest hyriseSecondTestPlugin hyriseTestPlugin hyriseMvccDeletePlugin hyriseTestNonInstantiablePlugin)
 target_link_libraries(hyriseTest hyrise ${LIBRARIES})
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -212,6 +212,7 @@ set(
     lib/utils/log_manager_test.cpp
     lib/utils/lossless_predicate_cast_test.cpp
     lib/utils/meta_table_manager_test.cpp
+    lib/utils/meta_tables/meta_exec_table_test.cpp
     lib/utils/meta_tables/meta_log_table_test.cpp
     lib/utils/meta_tables/meta_mock_table.cpp
     lib/utils/meta_tables/meta_mock_table.hpp

--- a/src/test/lib/utils/lossless_predicate_cast_test.cpp
+++ b/src/test/lib/utils/lossless_predicate_cast_test.cpp
@@ -18,7 +18,7 @@ TEST_F(LosslessPredicateCastTest, NextFloatTowards) {
   // Edge cases:
   EXPECT_EQ(next_float_towards(3.1, 3.1), std::nullopt);
 
-  // // Maximum double that can losslessly represented as a float and the next higher double
+  // Maximum double that can losslessly represented as a float and the next higher double
   EXPECT_EQ(*next_float_towards(340282346638528859811704183484516925440.0, 0),
             340282326356119256160033759537265639424.0f);
   EXPECT_EQ(

--- a/src/test/lib/utils/meta_table_manager_test.cpp
+++ b/src/test/lib/utils/meta_table_manager_test.cpp
@@ -8,6 +8,7 @@
 #include "utils/meta_tables/meta_chunk_sort_orders_table.hpp"
 #include "utils/meta_tables/meta_chunks_table.hpp"
 #include "utils/meta_tables/meta_columns_table.hpp"
+#include "utils/meta_tables/meta_exec_table.hpp"
 #include "utils/meta_tables/meta_log_table.hpp"
 #include "utils/meta_tables/meta_plugins_table.hpp"
 #include "utils/meta_tables/meta_segments_accurate_table.hpp"
@@ -26,17 +27,18 @@ using MetaTableNames = std::vector<std::string>;
 class MetaTableManagerTest : public BaseTest {
  public:
   static MetaTables meta_tables() {
-    return {std::make_shared<MetaTablesTable>(),
-            std::make_shared<MetaColumnsTable>(),
-            std::make_shared<MetaChunksTable>(),
+    return {std::make_shared<MetaChunksTable>(),
             std::make_shared<MetaChunkSortOrdersTable>(),
+            std::make_shared<MetaColumnsTable>(),
+            std::make_shared<MetaExecTable>(),
+            std::make_shared<MetaLogTable>(),
+            std::make_shared<MetaPluginsTable>(),
             std::make_shared<MetaSegmentsTable>(),
             std::make_shared<MetaSegmentsAccurateTable>(),
-            std::make_shared<MetaPluginsTable>(),
             std::make_shared<MetaSettingsTable>(),
-            std::make_shared<MetaLogTable>(),
             std::make_shared<MetaSystemInformationTable>(),
-            std::make_shared<MetaSystemUtilizationTable>()};
+            std::make_shared<MetaSystemUtilizationTable>(),
+            std::make_shared<MetaTablesTable>()};
   }
 
   static MetaTableNames meta_table_names() {

--- a/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
@@ -1,0 +1,97 @@
+#include "base_test.hpp"
+
+#include "operators/table_wrapper.hpp"
+#include "utils/meta_tables/meta_exec_table.hpp"
+
+#include "../plugin_test_utils.hpp"
+
+namespace opossum {
+
+class MetaExecTest : public BaseTest {
+ protected:
+  // void TearDown() override { Hyrise::reset(); }
+};
+
+TEST_F(MetaExecTest, IsMutable) {
+  const auto meta_exec_table = std::make_shared<MetaExecTable>();
+
+  EXPECT_TRUE(meta_exec_table->can_insert());
+  EXPECT_FALSE(meta_exec_table->can_update());
+  EXPECT_FALSE(meta_exec_table->can_delete());
+}
+
+TEST_F(MetaExecTest, CallUserExecutableFunctions) {
+  auto& pm = Hyrise::get().plugin_manager;
+  auto& sm = Hyrise::get().storage_manager;
+
+  pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
+  pm.load_plugin(build_dylib_path("libhyriseSecondTestPlugin"));
+
+  SQLPipelineBuilder{
+      "INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseTestPlugin', "
+      "'OurFreelyChoosableFunctionName')"}
+      .create_pipeline()
+      .get_result_table();
+  // The test plugin creates the below table when the called function is executed
+  EXPECT_TRUE(sm.has_table("TableOfTestPlugin"));
+
+  SQLPipelineBuilder{
+      "INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseSecondTestPlugin', "
+      "'OurFreelyChoosableFunctionName')"}
+      .create_pipeline()
+      .get_result_table();
+  // The second test plugin creates the below table when the called function is executed
+  EXPECT_TRUE(sm.has_table("TableOfSecondTestPlugin"));
+}
+
+TEST_F(MetaExecTest, CallNotCallableUserExecutableFunctions) {
+  auto& pm = Hyrise::get().plugin_manager;
+
+  // We have to manually rollback the transaction contexts below because otherwise their destruction would cause an
+  // exeception to be thrown. This is due to an assert in the TransactionContext's destructor checking for failed
+  // operators. See ~TransactionContext for details.
+
+  // Call non-existing function
+  {
+    auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
+    auto sql_pipeline =
+        SQLPipelineBuilder{
+            "INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseUnknownPlugin', "
+            "'OurFreelyChoosableFunctionName')"}
+            .with_transaction_context(transaction_context)
+            .create_pipeline();
+    EXPECT_THROW(sql_pipeline.get_result_table(), std::logic_error);
+    sql_pipeline.transaction_context()->rollback(RollbackReason::Conflict);
+  }
+
+  // // Call existing, loaded plugin but non-existing function
+  pm.load_plugin(build_dylib_path("libhyriseSecondTestPlugin"));
+
+  {
+    auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
+    auto sql_pipeline =
+        SQLPipelineBuilder{
+            "INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseSecondTestPlugin', 'SpecialFunction17')"}
+            .with_transaction_context(transaction_context)
+            .create_pipeline();
+    EXPECT_THROW(sql_pipeline.get_result_table(), std::logic_error);
+    sql_pipeline.transaction_context()->rollback(RollbackReason::Conflict);
+  }
+
+  // Call function exposed by plugin but plugin has been unloaded before
+  pm.unload_plugin("hyriseSecondTestPlugin");
+
+  {
+    auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
+    auto sql_pipeline =
+        SQLPipelineBuilder{
+            "INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseSecondTestPlugin', "
+            "'OurFreelyChoosableFunctionName')"}
+            .with_transaction_context(transaction_context)
+            .create_pipeline();
+    EXPECT_THROW(sql_pipeline.get_result_table(), std::logic_error);
+    sql_pipeline.transaction_context()->rollback(RollbackReason::Conflict);
+  }
+}
+
+}  // namespace opossum

--- a/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
@@ -82,7 +82,7 @@ TEST_F(MetaExecTest, CallNotCallableUserExecutableFunctions) {
     sql_pipeline.transaction_context()->rollback(RollbackReason::Conflict);
   }
 
-  // // Call existing, loaded plugin but non-existing function
+  // Call existing, loaded plugin but non-existing function
   pm.load_plugin(build_dylib_path("libhyriseSecondTestPlugin"));
 
   {

--- a/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
@@ -69,7 +69,7 @@ TEST_F(MetaExecTest, CallNotCallableUserExecutableFunctions) {
   // exeception to be thrown. This is due to an assert in the TransactionContext's destructor checking for failed
   // operators. See ~TransactionContext for details.
 
-  // Call non-existing function
+  // Call non-existing plugin (with non-existing function)
   {
     auto transaction_context = Hyrise::get().transaction_manager.new_transaction_context(AutoCommit::No);
     auto sql_pipeline =

--- a/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
+++ b/src/test/lib/utils/meta_tables/meta_exec_table_test.cpp
@@ -25,7 +25,7 @@ TEST_F(MetaExecTest, SelectUserExecutableFunctions) {
 
   const auto expected_table = std::make_shared<Table>(
       TableColumnDefinitions{{"plugin_name", DataType::String, false}, {"function_name", DataType::String, false}},
-      TableType::Data, 5);
+      TableType::Data, ChunkOffset{5});
 
   expected_table->append({pmr_string{"hyriseSecondTestPlugin"}, pmr_string{"OurFreelyChoosableFunctionName"}});
   expected_table->append({pmr_string{"hyriseTestPlugin"}, pmr_string{"OurFreelyChoosableFunctionName"}});

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -28,7 +28,7 @@ TEST_F(PluginManagerTest, LoadUnloadPlugin) {
   EXPECT_EQ(plugins.size(), 0u);
   pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
 
-  EXPECT_EQ(plugins.count("hyriseTestPlugin"), 1u);
+  EXPECT_TRUE(plugins.contains("hyriseTestPlugin"));
   EXPECT_EQ(plugins["hyriseTestPlugin"].plugin->description(), "This is the Hyrise TestPlugin");
   EXPECT_NE(plugins["hyriseTestPlugin"].handle, nullptr);
   EXPECT_NE(plugins["hyriseTestPlugin"].plugin, nullptr);
@@ -40,7 +40,7 @@ TEST_F(PluginManagerTest, LoadUnloadPlugin) {
 
   // The test plugin removes the dummy table from the storage manager when it is unloaded
   EXPECT_FALSE(sm.has_table("DummyTable"));
-  EXPECT_EQ(plugins.count("hyriseTestPlugin"), 0u);
+  EXPECT_FALSE(plugins.contains("hyriseTestPlugin"));
 }
 
 // Plugins are unloaded when the PluginManager's destructor is called, this is simulated and tested here.
@@ -52,7 +52,7 @@ TEST_F(PluginManagerTest, LoadPluginAutomaticUnload) {
   EXPECT_EQ(plugins.size(), 0u);
   pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
 
-  EXPECT_EQ(plugins.count("hyriseTestPlugin"), 1u);
+  EXPECT_TRUE(plugins.contains("hyriseTestPlugin"));
   EXPECT_EQ(plugins["hyriseTestPlugin"].plugin->description(), "This is the Hyrise TestPlugin");
   EXPECT_NE(plugins["hyriseTestPlugin"].handle, nullptr);
   EXPECT_NE(plugins["hyriseTestPlugin"].plugin, nullptr);
@@ -82,9 +82,9 @@ TEST_F(PluginManagerTest, LoadingUnloadingUserExecutableFunctions) {
     auto user_executable_functions = pm.user_executable_functions();
 
     EXPECT_EQ(user_executable_functions.size(), 3);
-    EXPECT_EQ(user_executable_functions.count({"hyriseSecondTestPlugin", "OurFreelyChoosableFunctionName"}), 1);
-    EXPECT_EQ(user_executable_functions.count({"hyriseTestPlugin", "OurFreelyChoosableFunctionName"}), 1);
-    EXPECT_EQ(user_executable_functions.count({"hyriseTestPlugin", "SpecialFunction17"}), 1);
+    EXPECT_TRUE(user_executable_functions.contains({"hyriseSecondTestPlugin", "OurFreelyChoosableFunctionName"}));
+    EXPECT_TRUE(user_executable_functions.contains({"hyriseTestPlugin", "OurFreelyChoosableFunctionName"}));
+    EXPECT_TRUE(user_executable_functions.contains({"hyriseTestPlugin", "SpecialFunction17"}));
   }
 
   pm.unload_plugin("hyriseTestPlugin");

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -134,7 +134,7 @@ TEST_F(PluginManagerTest, CallUserExecutableFunctions) {
 TEST_F(PluginManagerTest, CallNotCallableUserExecutableFunctions) {
   auto& pm = Hyrise::get().plugin_manager;
 
-  // Call non-existing function
+  // Call non-existing plugin (with non-existing function)
   EXPECT_THROW(pm.exec_user_function("hyriseUnknownPlugin", "OurFreelyChoosableFunctionName"), std::exception);
 
   // Call existing, loaded plugin but non-existing function

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -36,7 +36,9 @@ TEST_F(PluginManagerTest, LoadUnloadPlugin) {
   // The test plugin creates a dummy table when it is started
   EXPECT_TRUE(sm.has_table("DummyTable"));
 
-  SQLPipelineBuilder{"INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseTestPlugin', 'UserCallable')"}.create_pipeline().get_result_table();
+  SQLPipelineBuilder{"INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseTestPlugin', 'UserCallable')"}
+      .create_pipeline()
+      .get_result_table();
 
   pm.unload_plugin("hyriseTestPlugin");
 

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -14,13 +14,6 @@ class PluginManagerTest : public BaseTest {
     return pm._plugins;
   }
 
-  std::unordered_map<std::pair<PluginName, PluginFunctionName>, PluginFunctionPointer, plugin_name_function_name_hash>&
-  get_user_executable_functions() {
-    auto& pm = Hyrise::get().plugin_manager;
-
-    return pm._user_executable_functions;
-  }
-
   void call_clean_up() {
     auto& pm = Hyrise::get().plugin_manager;
     pm._clean_up();
@@ -85,18 +78,20 @@ TEST_F(PluginManagerTest, LoadingUnloadingUserExecutableFunctions) {
   pm.load_plugin(build_dylib_path("libhyriseSecondTestPlugin"));
   EXPECT_EQ(plugins.size(), 2u);
 
-  auto& user_executable_functions = get_user_executable_functions();
+  {
+    auto user_executable_functions = pm.user_executable_functions();
 
-  EXPECT_EQ(user_executable_functions.size(), 3);
-  EXPECT_EQ(user_executable_functions.count({"hyriseSecondTestPlugin", "OurFreelyChoosableFunctionName"}), 1);
-  EXPECT_EQ(user_executable_functions.count({"hyriseTestPlugin", "OurFreelyChoosableFunctionName"}), 1);
-  EXPECT_EQ(user_executable_functions.count({"hyriseTestPlugin", "SpecialFunction17"}), 1);
+    EXPECT_EQ(user_executable_functions.size(), 3);
+    EXPECT_EQ(user_executable_functions.count({"hyriseSecondTestPlugin", "OurFreelyChoosableFunctionName"}), 1);
+    EXPECT_EQ(user_executable_functions.count({"hyriseTestPlugin", "OurFreelyChoosableFunctionName"}), 1);
+    EXPECT_EQ(user_executable_functions.count({"hyriseTestPlugin", "SpecialFunction17"}), 1);
+  }
 
   pm.unload_plugin("hyriseTestPlugin");
-  EXPECT_EQ(user_executable_functions.size(), 1);
+  EXPECT_EQ(pm.user_executable_functions().size(), 1);
 
   pm.unload_plugin("hyriseSecondTestPlugin");
-  EXPECT_EQ(user_executable_functions.size(), 0);
+  EXPECT_EQ(pm.user_executable_functions().size(), 0);
 }
 
 TEST_F(PluginManagerTest, CallUserExecutableFunctions) {

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -106,18 +106,10 @@ TEST_F(PluginManagerTest, CallUserExecutableFunctions) {
   pm.load_plugin(build_dylib_path("libhyriseTestPlugin"));
   pm.load_plugin(build_dylib_path("libhyriseSecondTestPlugin"));
 
-  // SQLPipelineBuilder{"INSERT INTO meta_exec (plugin_name, function_name)
-  // VALUES ('hyriseTestPlugin', 'OurFreelyChoosableFunctionName')"}
-  //     .create_pipeline()
-  //     .get_result_table();
   pm.exec_user_function("hyriseTestPlugin", "OurFreelyChoosableFunctionName");
   // The test plugin creates the below table when the called function is executed
   EXPECT_TRUE(sm.has_table("TableOfTestPlugin"));
 
-  // SQLPipelineBuilder{"INSERT INTO meta_exec (plugin_name, function_name)
-  // VALUES ('hyriseSecondTestPlugin', 'OurFreelyChoosableFunctionName')"}
-  //     .create_pipeline()
-  //     .get_result_table();
   pm.exec_user_function("hyriseSecondTestPlugin", "OurFreelyChoosableFunctionName");
   // The second test plugin creates the below table when the called function is executed
   EXPECT_TRUE(sm.has_table("TableOfSecondTestPlugin"));
@@ -128,32 +120,14 @@ TEST_F(PluginManagerTest, CallNotCallableUserExecutableFunctions) {
 
   // Call non-existing function
   EXPECT_THROW(pm.exec_user_function("hyriseUnknownPlugin", "OurFreelyChoosableFunctionName"), std::exception);
-  // EXPECT_THROW(SQLPipelineBuilder{"INSERT INTO meta_exec (plugin_name, function_name)
-  // VALUES ('hyriseUnknownPlugin', "
-  //                                 "'OurFreelyChoosableFunctionName')"}
-  //                  .create_pipeline()
-  //                  .get_result_table(),
-  //              std::logic_error);
 
   // Call existing, loaded plugin but non-existing function
   pm.load_plugin(build_dylib_path("libhyriseSecondTestPlugin"));
   EXPECT_THROW(pm.exec_user_function("hyriseSecondTestPlugin", "SpecialFunction17"), std::exception);
-  // auto sql_pipeline_2 =
-  //     SQLPipelineBuilder{
-  //         "INSERT INTO meta_exec (plugin_name, function_name)
-  // VALUES ('hyriseSecondTestPlugin', 'SpecialFunction17')"}
-  //         .create_pipeline();
-  // EXPECT_THROW(sql_pipeline_2.get_result_table(), std::exception);
 
   // Call function exposed by plugin but plugin has been unloaded before
   pm.unload_plugin("hyriseSecondTestPlugin");
   EXPECT_THROW(pm.exec_user_function("hyriseSecondTestPlugin", "OurFreelyChoosableFunctionName"), std::exception);
-  // auto sql_pipeline_3 =
-  //     SQLPipelineBuilder{
-  //         "INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseSecondTestPlugin', "
-  //         "'OurFreelyChoosableFunctionName')"}
-  //         .create_pipeline();
-  // EXPECT_THROW(sql_pipeline_3.get_result_table(), std::exception);
 }
 
 TEST_F(PluginManagerTest, LoadingSameName) {

--- a/src/test/lib/utils/plugin_manager_test.cpp
+++ b/src/test/lib/utils/plugin_manager_test.cpp
@@ -36,6 +36,8 @@ TEST_F(PluginManagerTest, LoadUnloadPlugin) {
   // The test plugin creates a dummy table when it is started
   EXPECT_TRUE(sm.has_table("DummyTable"));
 
+  SQLPipelineBuilder{"INSERT INTO meta_exec (plugin_name, function_name) VALUES ('hyriseTestPlugin', 'UserCallable')"}.create_pipeline().get_result_table();
+
   pm.unload_plugin("hyriseTestPlugin");
 
   // The test plugin removes the dummy table from the storage manager when it is unloaded


### PR DESCRIPTION
As highlighted by @Bouncner in #2437 there are many scenarios where the user (_Anwender_) wants to trigger a plugin function, e.g., to manually start reoptimization. 

There are two challenges to solve for this to work.

1. How should the user interaction look like? 
1. How can the PluginManager call plugin functions that are not known in advance without modifying the PluginManager. 

A possible solution for challenge 1 could be to use a new meta table. Inserting a row containing the name of the plugin and action to execute into this table could trigger the action.

This is the first proposal for a solution for challenge 2. The plugin's developer can just implement user-callable functions as a _normal_ plugin function. Afterward, the developer only has to use the macro `EXPORT_USER_CALLABLE_FUNCTION` that the AbstractPlugin provides. 

Alternatively, @Bouncner also had the idea that plugins can subscribe keywords and function calls to the PluginManager upon the instantiation of the plugins. The PluginManager maintains a list of such keywords. If a keyword is sent, the corresponding function is called. This might be a cleaner solution but also require more changes and I don't find the above's solution particularly unclean.
~~_Edit: I don't know whether this solution would work at all. The PluginManager would need to keep a map of keywords and function pointers. However, function pointers to member functions also contain the class type. For different plugins, the class type varies so we could not create such a map at compile time. Using AbstractPlugin as type would also not work because then we would need to define all user-callable functions for AbstractPlugin, too. Am I missing something or would this really not work?_~~ << It [does work,](https://gist.github.com/Bouncner/6d31c7ebe55aeb9d9fb8d0a5efb654fb) as @Bouncner pointed out.

The interface via MetaTables would be mostly identical for both solutions. Also, I believe both solutions can only offer non-parameterized and void-returning functions as the types must be known during the PluginManager's compile time.