### PR TITLE
Readme: Add hint to link alternate brew package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The install script was tested under macOS Big Sur (10.16) and Ubuntu 20.10 (apt-
 See [dependencies](DEPENDENCIES.md) for a detailed list of dependencies to use with `brew install` or `apt-get install`, depending on your platform. As compilers, we generally use the most recent version of clang and gcc (Linux only). Please make sure that the system compiler points to the most recent version or use cmake (see below) accordingly.
 Older versions may work, but are neither tested nor supported.
 
-**Note about LLVM 13 and TBB 2021:** Hyrise can currently not be built with LLVM 13. We hope to get LLVM 13 running soon. For TBB, please use a `2020*` version until https://github.com/oneapi-src/oneTBB/issues/378 is resolved. On MacOS with brew, LLVM 12 and TBB 2020 can be installed as follows: `brew install tbb@2020 && brew install llvm@12`
+**Note about LLVM 13 and TBB 2021:** Hyrise can currently not be built with LLVM 13. We hope to get LLVM 13 running soon. For TBB, please use a `2020*` version until https://github.com/oneapi-src/oneTBB/issues/378 is resolved. On MacOS with brew, LLVM 12 and TBB 2020 can be installed as follows: `brew install tbb@2020 && brew install llvm@12`. Keep in mind that these package versions are alternate versions and thus not symlinked into `/usr/local`. `brew link tbb@2020` and `brew link llvm@12` symlinks these packages.
 
 ## Setup using Docker
 If you want to create a Docker-based development environment using CLion, head over to our [dedicated tutorial](https://github.com/hyrise/hyrise/wiki/Use-Docker-with-CLion). 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The install script was tested under macOS Big Sur (10.16) and Ubuntu 20.10 (apt-
 See [dependencies](DEPENDENCIES.md) for a detailed list of dependencies to use with `brew install` or `apt-get install`, depending on your platform. As compilers, we generally use the most recent version of clang and gcc (Linux only). Please make sure that the system compiler points to the most recent version or use cmake (see below) accordingly.
 Older versions may work, but are neither tested nor supported.
 
-**Note about LLVM 13 and TBB 2021:** Hyrise can currently not be built with LLVM 13. We hope to get LLVM 13 running soon. For TBB, please use a `2020*` version until https://github.com/oneapi-src/oneTBB/issues/378 is resolved. On MacOS with brew, LLVM 12 and TBB 2020 can be installed as follows: `brew install tbb@2020 && brew install llvm@12`. Keep in mind that these package versions are alternate versions and thus not symlinked into `/usr/local`. `brew link tbb@2020` and `brew link llvm@12` symlinks these packages.
+**Note about LLVM 13 and TBB 2021:** Hyrise can currently not be built with LLVM 13. We hope to get LLVM 13 running soon. For TBB, please use a `2020*` version until https://github.com/oneapi-src/oneTBB/issues/378 is resolved. On MacOS with brew, LLVM 12 and TBB 2020 can be installed as follows: `brew install tbb@2020 && brew install llvm@12`. Keep in mind that these package versions are alternate versions and, thus, not symlinked into `/usr/local`. `brew link tbb@2020` and `brew link llvm@12` symlinks these packages.
 
 ## Setup using Docker
 If you want to create a Docker-based development environment using CLion, head over to our [dedicated tutorial](https://github.com/hyrise/hyrise/wiki/Use-Docker-with-CLion). 


### PR DESCRIPTION
Since missing to link the alternate versions has already happened multiple times for different people, let's add additional information about linking the alternate version.