### PR TITLE
Clang Tidy: all parameters should be named in a function

### DIFF
--- a/src/benchmark/micro_benchmark_basic_fixture.cpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.cpp
@@ -25,7 +25,7 @@ void MicroBenchmarkBasicFixture::SetUp(::benchmark::State& state) {
   _table_dict_wrapper->execute();
 }
 
-void MicroBenchmarkBasicFixture::TearDown(::benchmark::State&) { opossum::Hyrise::reset(); }
+void MicroBenchmarkBasicFixture::TearDown(::benchmark::State& /*state*/) { opossum::Hyrise::reset(); }
 
 void MicroBenchmarkBasicFixture::_clear_cache() { micro_benchmark_clear_cache(); }
 

--- a/src/benchmark/micro_benchmark_basic_fixture.cpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.cpp
@@ -10,7 +10,7 @@
 
 namespace opossum {
 
-void MicroBenchmarkBasicFixture::SetUp(::benchmark::State& state) {
+void MicroBenchmarkBasicFixture::SetUp(::benchmark::State& /*state*/) {
   const auto chunk_size = ChunkOffset{2'000};
   const auto row_count = size_t{40'000};
 

--- a/src/benchmark/micro_benchmark_basic_fixture.hpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.hpp
@@ -13,7 +13,7 @@ class TableWrapper;
 // Defining the base fixture class
 class MicroBenchmarkBasicFixture : public benchmark::Fixture {
  public:
-  void SetUp(::benchmark::State& state) override;
+  void SetUp(::benchmark::State& /*state*/) override;
   void TearDown(::benchmark::State& /*state*/) override;
 
  protected:

--- a/src/benchmark/micro_benchmark_basic_fixture.hpp
+++ b/src/benchmark/micro_benchmark_basic_fixture.hpp
@@ -14,7 +14,7 @@ class TableWrapper;
 class MicroBenchmarkBasicFixture : public benchmark::Fixture {
  public:
   void SetUp(::benchmark::State& state) override;
-  void TearDown(::benchmark::State&) override;
+  void TearDown(::benchmark::State& /*state*/) override;
 
  protected:
   void _clear_cache();

--- a/src/benchmark/tpch_data_micro_benchmark.cpp
+++ b/src/benchmark/tpch_data_micro_benchmark.cpp
@@ -90,7 +90,7 @@ class TPCHDataMicroBenchmarkFixture : public MicroBenchmarkBasicFixture {
   }
 
   // Required to avoid resetting of StorageManager in MicroBenchmarkBasicFixture::TearDown()
-  void TearDown(::benchmark::State&) override {}
+  void TearDown(::benchmark::State& /*state*/) override {}
 
   std::map<std::string, std::shared_ptr<TableWrapper>> create_table_wrappers(StorageManager& sm) {
     std::map<std::string, std::shared_ptr<TableWrapper>> wrapper_map;

--- a/src/benchmarklib/table_builder.hpp
+++ b/src/benchmarklib/table_builder.hpp
@@ -38,7 +38,7 @@ template <typename T, bool _has_value>
 class OptionalConstexpr<T, _has_value, std::enable_if_t<!_has_value>> {
  public:
   template <typename... Args>
-  explicit OptionalConstexpr(Args&&...) {}
+  explicit OptionalConstexpr(Args&&... /*unused*/) {}
 
   static_assert(!_has_value);
   static constexpr bool has_value = false;

--- a/src/benchmarklib/table_builder.hpp
+++ b/src/benchmarklib/table_builder.hpp
@@ -38,7 +38,7 @@ template <typename T, bool _has_value>
 class OptionalConstexpr<T, _has_value, std::enable_if_t<!_has_value>> {
  public:
   template <typename... Args>
-  explicit OptionalConstexpr(Args&&... /*unused*/) {}
+  explicit OptionalConstexpr(Args&&... /*args*/) {}
 
   static_assert(!_has_value);
   static constexpr bool has_value = false;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -405,9 +405,9 @@ void Console::out(const std::shared_ptr<const Table>& table, const PrintFlags fl
 // Command functions
 
 // NOLINTNEXTLINE - while this particular method could be made static, others cannot.
-int Console::_exit(const std::string&) { return Console::ReturnCode::Quit; }
+int Console::_exit(const std::string& /*args*/) { return Console::ReturnCode::Quit; }
 
-int Console::_help(const std::string&) {
+int Console::_help(const std::string& /*args*/) {
   auto encoding_options = std::string{"                                                 Encoding options: "};
   encoding_options += boost::algorithm::join(
       encoding_type_to_string.right | boost::adaptors::transformed([](auto it) { return it.first; }), ", ");
@@ -892,7 +892,7 @@ int Console::_print_transaction_info(const std::string& input) {
   return ReturnCode::Ok;
 }
 
-int Console::_print_current_working_directory(const std::string&) {
+int Console::_print_current_working_directory(const std::string& /*args*/) {
   out(std::filesystem::current_path().string() + "\n");
   return ReturnCode::Ok;
 }

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -120,7 +120,7 @@ class Console : public Singleton<Console> {
   int _change_runtime_setting(const std::string& input);
 
   int _print_transaction_info(const std::string& input);
-  int _print_current_working_directory(const std::string& /*args/*);
+  int _print_current_working_directory(const std::string& /*args*/);
 
   int _load_plugin(const std::string& args);
   int _unload_plugin(const std::string& input);

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -107,8 +107,8 @@ class Console : public Singleton<Console> {
   int _eval_sql(const std::string& sql);
 
   // Command functions, registered to be called from the Console
-  int _exit(const std::string& args);
-  int _help(const std::string& args);
+  int _exit(const std::string& /*args*/);
+  int _help(const std::string& /*args*/);
   int _generate_tpcc(const std::string& args);
   int _generate_tpch(const std::string& args);
   int _generate_tpcds(const std::string& args);
@@ -120,7 +120,7 @@ class Console : public Singleton<Console> {
   int _change_runtime_setting(const std::string& input);
 
   int _print_transaction_info(const std::string& input);
-  int _print_current_working_directory(const std::string& args);
+  int _print_current_working_directory(const std::string& /*args/*);
 
   int _load_plugin(const std::string& args);
   int _unload_plugin(const std::string& input);

--- a/src/lib/expression/evaluation/expression_result_views.hpp
+++ b/src/lib/expression/evaluation/expression_result_views.hpp
@@ -92,8 +92,8 @@ class ExpressionResultLiteral {
 
   size_t size() const { return 1u; }
 
-  const T& value(const size_t /*value*/ = 0) const { return _value; }
-  bool is_null(const size_t /*value*/ = 0) const { return _null; }
+  const T& value(const size_t /*value*/) const { return _value; }
+  bool is_null(const size_t /*value*/) const { return _null; }
 
  private:
   T _value;

--- a/src/lib/expression/evaluation/expression_result_views.hpp
+++ b/src/lib/expression/evaluation/expression_result_views.hpp
@@ -92,8 +92,8 @@ class ExpressionResultLiteral {
 
   size_t size() const { return 1u; }
 
-  const T& value(const size_t = 0) const { return _value; }
-  bool is_null(const size_t = 0) const { return _null; }
+  const T& value(const size_t /*value*/ = 0) const { return _value; }
+  bool is_null(const size_t /*value*/ = 0) const { return _null; }
 
  private:
   T _value;

--- a/src/lib/expression/lqp_subquery_expression.cpp
+++ b/src/lib/expression/lqp_subquery_expression.cpp
@@ -59,7 +59,7 @@ DataType LQPSubqueryExpression::data_type() const {
   return lqp->output_expressions()[0]->data_type();
 }
 
-bool LQPSubqueryExpression::_on_is_nullable_on_lqp(const AbstractLQPNode&) const {
+bool LQPSubqueryExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*node*/) const {
   Assert(lqp->output_expressions().size() == 1,
          "Can only determine the nullability of SelectExpressions that return exactly one column");
   return lqp->is_column_nullable(ColumnID{0});

--- a/src/lib/expression/lqp_subquery_expression.hpp
+++ b/src/lib/expression/lqp_subquery_expression.hpp
@@ -44,7 +44,7 @@ class LQPSubqueryExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode&) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*node*/) const override;
 };
 
 }  // namespace opossum

--- a/src/lib/null_value.hpp
+++ b/src/lib/null_value.hpp
@@ -22,15 +22,15 @@ namespace opossum {
 struct NullValue {};
 
 // Relational operators
-inline bool operator==(const NullValue&, const NullValue&) { return false; }
-inline bool operator!=(const NullValue&, const NullValue&) { return false; }
-inline bool operator<(const NullValue&, const NullValue&) { return false; }
-inline bool operator<=(const NullValue&, const NullValue&) { return false; }
-inline bool operator>(const NullValue&, const NullValue&) { return false; }
-inline bool operator>=(const NullValue&, const NullValue&) { return false; }
-inline NullValue operator-(const NullValue&) { return NullValue{}; }
+inline bool operator==(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
+inline bool operator!=(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
+inline bool operator<(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
+inline bool operator<=(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
+inline bool operator>(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
+inline bool operator>=(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
+inline NullValue operator-(const NullValue&  /*value*/) { return NullValue{}; }
 
-inline size_t hash_value(const NullValue&) {
+inline size_t hash_value(const NullValue& /*value*/) {
   // Aggregate wants all NULLs in one bucket
   return 0;
 }

--- a/src/lib/null_value.hpp
+++ b/src/lib/null_value.hpp
@@ -28,7 +28,7 @@ inline bool operator<(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { retu
 inline bool operator<=(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
 inline bool operator>(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
 inline bool operator>=(const NullValue& /*lhs*/, const NullValue& /*rhs*/) { return false; }
-inline NullValue operator-(const NullValue&  /*value*/) { return NullValue{}; }
+inline NullValue operator-(const NullValue& /*value*/) { return NullValue{}; }
 
 inline size_t hash_value(const NullValue& /*value*/) {
   // Aggregate wants all NULLs in one bucket

--- a/src/lib/operators/abstract_read_only_operator.cpp
+++ b/src/lib/operators/abstract_read_only_operator.cpp
@@ -6,7 +6,7 @@
 
 namespace opossum {
 
-std::shared_ptr<const Table> AbstractReadOnlyOperator::_on_execute(std::shared_ptr<TransactionContext>) {
+std::shared_ptr<const Table> AbstractReadOnlyOperator::_on_execute(std::shared_ptr<TransactionContext> /*context*/) {
   return _on_execute();
 }
 

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -34,7 +34,7 @@ using namespace opossum;  // NOLINT
 constexpr auto CACHE_MASK = AggregateKeyEntry{1} << 63u;  // See explanation below
 
 template <typename CacheResultIds, typename ResultIds, typename Results, typename AggregateKey>
-typename Results::reference get_or_add_result(CacheResultIds /*unused*/, ResultIds& result_ids, Results& results,
+typename Results::reference get_or_add_result(CacheResultIds /*cache_result_ids*/, ResultIds& result_ids, Results& results,
                                               AggregateKey& key, const RowID& row_id) {
   if constexpr (std::is_same_v<AggregateKey, EmptyAggregateKey>) {
     // No GROUP BY columns are defined for this aggregate operator. We still want to keep most code paths similar and

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -34,7 +34,7 @@ using namespace opossum;  // NOLINT
 constexpr auto CACHE_MASK = AggregateKeyEntry{1} << 63u;  // See explanation below
 
 template <typename CacheResultIds, typename ResultIds, typename Results, typename AggregateKey>
-typename Results::reference get_or_add_result(CacheResultIds, ResultIds& result_ids, Results& results,
+typename Results::reference get_or_add_result(CacheResultIds /*unused*/, ResultIds& result_ids, Results& results,
                                               AggregateKey& key, const RowID& row_id) {
   if constexpr (std::is_same_v<AggregateKey, EmptyAggregateKey>) {
     // No GROUP BY columns are defined for this aggregate operator. We still want to keep most code paths similar and

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -34,8 +34,8 @@ using namespace opossum;  // NOLINT
 constexpr auto CACHE_MASK = AggregateKeyEntry{1} << 63u;  // See explanation below
 
 template <typename CacheResultIds, typename ResultIds, typename Results, typename AggregateKey>
-typename Results::reference get_or_add_result(CacheResultIds /*cache_result_ids*/, ResultIds& result_ids, Results& results,
-                                              AggregateKey& key, const RowID& row_id) {
+typename Results::reference get_or_add_result(CacheResultIds /*cache_result_ids*/, ResultIds& result_ids,
+                                              Results& results, AggregateKey& key, const RowID& row_id) {
   if constexpr (std::is_same_v<AggregateKey, EmptyAggregateKey>) {
     // No GROUP BY columns are defined for this aggregate operator. We still want to keep most code paths similar and
     // avoid special handling. Thus, get_or_add_result is still called, however, we always return the same result

--- a/src/lib/storage/fixed_string_dictionary_segment.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<AbstractSegment> FixedStringDictionarySegment<T>::copy_using_all
 }
 
 template <typename T>
-size_t FixedStringDictionarySegment<T>::memory_usage(const MemoryUsageCalculationMode) const {
+size_t FixedStringDictionarySegment<T>::memory_usage(const MemoryUsageCalculationMode /*mode*/) const {
   // MemoryUsageCalculationMode ignored as full calculation is efficient.
   return sizeof(*this) + _dictionary->data_size() + _attribute_vector->data_size();
 }

--- a/src/lib/storage/fixed_string_dictionary_segment.hpp
+++ b/src/lib/storage/fixed_string_dictionary_segment.hpp
@@ -40,7 +40,7 @@ class FixedStringDictionarySegment : public BaseDictionarySegment {
 
   std::shared_ptr<AbstractSegment> copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const final;
 
-  size_t memory_usage(const MemoryUsageCalculationMode = MemoryUsageCalculationMode::Full) const final;
+  size_t memory_usage(const MemoryUsageCalculationMode /*mode*/ = MemoryUsageCalculationMode::Full) const final;
   /**@}*/
 
   /**

--- a/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
+++ b/src/lib/storage/fixed_string_dictionary_segment/fixed_string_vector.cpp
@@ -58,7 +58,7 @@ ReverseIterator FixedStringVector::rend() noexcept { return ReverseIterator(begi
 
 FixedString FixedStringVector::operator[](const size_t pos) {
   PerformanceWarning("operator[] used");
-  return FixedString(&_chars[pos * _string_length], _string_length);
+  return {&_chars[pos * _string_length], _string_length};
 }
 
 FixedString FixedStringVector::at(const size_t pos) {
@@ -95,9 +95,9 @@ void FixedStringVector::erase(const FixedStringIterator<false> start, const Fixe
     return;
   }
 
-  auto it = _chars.begin();
-  std::advance(it, _chars.size() - count * _string_length);
-  _chars.erase(it, _chars.end());
+  auto iter = _chars.begin();
+  std::advance(iter, _chars.size() - count * _string_length);
+  _chars.erase(iter, _chars.end());
   _size -= count;
 }
 

--- a/src/lib/storage/frame_of_reference_segment.cpp
+++ b/src/lib/storage/frame_of_reference_segment.cpp
@@ -67,7 +67,7 @@ std::shared_ptr<AbstractSegment> FrameOfReferenceSegment<T, U>::copy_using_alloc
 }
 
 template <typename T, typename U>
-size_t FrameOfReferenceSegment<T, U>::memory_usage(const MemoryUsageCalculationMode) const {
+size_t FrameOfReferenceSegment<T, U>::memory_usage(const MemoryUsageCalculationMode /*mode*/) const {
   // MemoryUsageCalculationMode ignored since full calculation is efficient.
   size_t segment_size =
       sizeof(*this) + sizeof(T) * _block_minima.capacity() + _offset_values->data_size() + sizeof(_null_values);

--- a/src/lib/storage/frame_of_reference_segment.hpp
+++ b/src/lib/storage/frame_of_reference_segment.hpp
@@ -82,7 +82,7 @@ class FrameOfReferenceSegment : public AbstractEncodedSegment {
 
   std::shared_ptr<AbstractSegment> copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const final;
 
-  size_t memory_usage(const MemoryUsageCalculationMode) const final;
+  size_t memory_usage(const MemoryUsageCalculationMode /*mode*/) const final;
 
   /**@}*/
 

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.cpp
@@ -378,11 +378,11 @@ AbstractIndex::Iterator ARTNode256::end() const {
 
 Leaf::Leaf(AbstractIndex::Iterator& lower, AbstractIndex::Iterator& upper) : _begin(lower), _end(upper) {}
 
-AbstractIndex::Iterator Leaf::lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable&, size_t) const {
+AbstractIndex::Iterator Leaf::lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable& /*key*/, size_t) const {
   return _begin;
 }
 
-AbstractIndex::Iterator Leaf::upper_bound(const AdaptiveRadixTreeIndex::BinaryComparable&, size_t) const {
+AbstractIndex::Iterator Leaf::upper_bound(const AdaptiveRadixTreeIndex::BinaryComparable& /*key*/, size_t) const {
   return _end;
 }
 

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_nodes.hpp
@@ -182,8 +182,8 @@ class Leaf final : public ARTNode {
  public:
   explicit Leaf(Iterator& lower, Iterator& upper);
 
-  Iterator lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable&, size_t) const override;
-  Iterator upper_bound(const AdaptiveRadixTreeIndex::BinaryComparable&, size_t) const override;
+  Iterator lower_bound(const AdaptiveRadixTreeIndex::BinaryComparable& /*key*/, size_t) const override;
+  Iterator upper_bound(const AdaptiveRadixTreeIndex::BinaryComparable& /*key*/, size_t) const override;
   Iterator begin() const override;
   Iterator end() const override;
 

--- a/src/lib/storage/index/b_tree/b_tree_index.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.hpp
@@ -28,8 +28,8 @@ class BTreeIndex : public AbstractIndex {
   explicit BTreeIndex(const std::vector<std::shared_ptr<const AbstractSegment>>& segments_to_index);
 
  protected:
-  Iterator _lower_bound(const std::vector<AllTypeVariant>&) const override;
-  Iterator _upper_bound(const std::vector<AllTypeVariant>&) const override;
+  Iterator _lower_bound(const std::vector<AllTypeVariant>& values) const override;
+  Iterator _upper_bound(const std::vector<AllTypeVariant>& values) const override;
   Iterator _cbegin() const override;
   Iterator _cend() const override;
   std::vector<std::shared_ptr<const AbstractSegment>> _get_indexed_segments() const override;

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.cpp
@@ -103,7 +103,7 @@ void BTreeIndexImpl<DataType>::_bulk_insert(const std::shared_ptr<const Abstract
 }
 
 template <typename DataType>
-void BTreeIndexImpl<DataType>::_add_to_heap_memory_usage(const DataType&) {
+void BTreeIndexImpl<DataType>::_add_to_heap_memory_usage(const DataType& /*value*/) {
   // Except for pmr_string (see below), no supported data type uses heap allocations
 }
 

--- a/src/lib/storage/index/b_tree/b_tree_index_impl.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index_impl.hpp
@@ -44,21 +44,21 @@ class BTreeIndexImpl : public BaseBTreeIndexImpl {
   Iterator lower_bound(DataType value) const;
   Iterator upper_bound(DataType value) const;
 
-  Iterator lower_bound(const std::vector<AllTypeVariant>&) const override;
-  Iterator upper_bound(const std::vector<AllTypeVariant>&) const override;
+  Iterator lower_bound(const std::vector<AllTypeVariant>& values) const override;
+  Iterator upper_bound(const std::vector<AllTypeVariant>& values) const override;
   Iterator cbegin() const override;
   Iterator cend() const override;
 
  protected:
   void _bulk_insert(const std::shared_ptr<const AbstractSegment>&, std::vector<ChunkOffset>& _null_positions);
-  void _add_to_heap_memory_usage(const DataType&);
+  void _add_to_heap_memory_usage(const DataType& /*value*/);
 
   btree::btree_map<DataType, size_t> _btree;
   size_t _heap_bytes_used;
 };
 
 template <>
-void BTreeIndexImpl<pmr_string>::_add_to_heap_memory_usage(const pmr_string&);
+void BTreeIndexImpl<pmr_string>::_add_to_heap_memory_usage(const pmr_string& value);
 
 EXPLICITLY_DECLARE_DATA_TYPES(BTreeIndexImpl);
 

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -448,7 +448,7 @@ std::shared_ptr<AbstractSegment> LZ4Segment<T>::copy_using_allocator(const Polym
 }
 
 template <typename T>
-size_t LZ4Segment<T>::memory_usage(const MemoryUsageCalculationMode) const {
+size_t LZ4Segment<T>::memory_usage(const MemoryUsageCalculationMode /*mode*/) const {
   // MemoryUsageCalculationMode can be ignored since all relevant information can be either obtained directly (e.g.,
   // size of NULL values vector) or the actual size is already stored (e.g., data_size()).
 

--- a/src/lib/storage/lz4_segment.hpp
+++ b/src/lib/storage/lz4_segment.hpp
@@ -155,7 +155,7 @@ class LZ4Segment : public AbstractEncodedSegment {
 
   std::shared_ptr<AbstractSegment> copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const final;
 
-  size_t memory_usage(const MemoryUsageCalculationMode mode) const final;
+  size_t memory_usage(const MemoryUsageCalculationMode /*mode*/) const final;
 
   /**@}*/
 

--- a/src/lib/storage/pos_lists/entire_chunk_pos_list.cpp
+++ b/src/lib/storage/pos_lists/entire_chunk_pos_list.cpp
@@ -10,7 +10,7 @@ bool EntireChunkPosList::empty() const { return size() == 0; }
 
 size_t EntireChunkPosList::size() const { return _common_chunk_size; }
 
-size_t EntireChunkPosList::memory_usage(const MemoryUsageCalculationMode) const { return sizeof *this; }
+size_t EntireChunkPosList::memory_usage(const MemoryUsageCalculationMode /*mode*/) const { return sizeof *this; }
 
 AbstractPosList::PosListIterator<EntireChunkPosList, RowID> EntireChunkPosList::begin() const {
   return PosListIterator<EntireChunkPosList, RowID>(this, ChunkOffset{0});

--- a/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
+++ b/src/lib/storage/pos_lists/entire_chunk_pos_list.hpp
@@ -24,7 +24,7 @@ class EntireChunkPosList : public AbstractPosList {
 
   bool empty() const final;
   size_t size() const final;
-  size_t memory_usage(const MemoryUsageCalculationMode) const final;
+  size_t memory_usage(const MemoryUsageCalculationMode /*mode*/) const final;
 
   PosListIterator<EntireChunkPosList, RowID> begin() const;
   PosListIterator<EntireChunkPosList, RowID> end() const;

--- a/src/lib/utils/enum_constant.hpp
+++ b/src/lib/utils/enum_constant.hpp
@@ -78,7 +78,7 @@ struct value_impl<E, when<opossum::is_enum_constant_v<E>>> {
 template <typename E>
 struct hash_impl<E, when<opossum::is_enum_constant_v<E>>> {
   template <typename X>
-  static constexpr auto apply(const X&) {
+  static constexpr auto apply(const X& /*unused*/) {
     return type_c<opossum::enum_constant<decltype(X::value), X::value>>;
   }
 };

--- a/src/lib/utils/enum_constant.hpp
+++ b/src/lib/utils/enum_constant.hpp
@@ -78,7 +78,7 @@ struct value_impl<E, when<opossum::is_enum_constant_v<E>>> {
 template <typename E>
 struct hash_impl<E, when<opossum::is_enum_constant_v<E>>> {
   template <typename X>
-  static constexpr auto apply(const X& /*unused*/) {
+  static constexpr auto apply(const X& /*x*/) {
     return type_c<opossum::enum_constant<decltype(X::value), X::value>>;
   }
 };

--- a/src/test/lib/storage/segment_iterators_test.cpp
+++ b/src/test/lib/storage/segment_iterators_test.cpp
@@ -194,7 +194,7 @@ TEST_P(SegmentIteratorsTest, LegacyRandomIteratorCompatible) {
 }
 
 template <typename T>
-bool operator<(const AbstractSegmentPosition<T>&, const AbstractSegmentPosition<T>&) {
+bool operator<(const AbstractSegmentPosition<T>& /*lhs*/, const AbstractSegmentPosition<T>& /*rhs*/) {
   // Fake comparator needed by is_heap
   return false;
 }


### PR DESCRIPTION
This PR applies tidy's recommendation that unused parameters should have names. To avoid using getting an error for a unused parameter, tidy (more accurate: Google Style Guide and the "High Integrity C++ Coding Standard") recommends, e.g., `void print(std::string /*unused*/)`.

Note, the CI's clang-tidy will not catch these as they are part of more recent versions. With PR on using clang13/14, tidy starts to complain.