### PR TITLE
Allow predicate pushdown through Union diamonds

### DIFF
--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -214,6 +214,23 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
   node->set_left_input(old_input);
 }
 
+void lqp_insert_node_above(const std::shared_ptr<AbstractLQPNode>& node,
+                           const std::shared_ptr<AbstractLQPNode>& node_to_insert,
+                           const AllowRightInput allow_right_input) {
+  Assert(!node_to_insert->left_input() && (!node_to_insert->right_input() || allow_right_input == AllowRightInput::Yes),
+         "Expected node without inputs.");
+
+  // Re-link @param node's outputs to @param node_to_insert
+  const auto node_outputs = node->outputs();
+  for (const auto& output_node : node_outputs) {
+    const LQPInputSide input_side = node->get_input_side(output_node);
+    output_node->set_input(input_side, node_to_insert);
+  }
+
+  // Place @param node_to_insert above @param node
+  node_to_insert->set_left_input(node);
+}
+
 bool lqp_is_validated(const std::shared_ptr<AbstractLQPNode>& lqp) {
   if (!lqp) return true;
   if (lqp->type == LQPNodeType::Validate) return true;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -550,8 +550,8 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
     return LQPVisitation::VisitInputs;
   });
 
-  if (!is_diamond || !diamond_origin_node.has_value()) return nullptr;
-  return diamond_origin_node.value();
+  if (is_diamond && diamond_origin_node) *diamond_origin_node;
+  return nullptr;
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -540,6 +540,7 @@ std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<
           }
           return LQPVisitation::DoNotVisitInputs;
         } else if (!diamond_node->left_input()) {
+          // We should have found a bottom diamond node with multiple outputs at this point.
           is_diamond = false;
         }
         return LQPVisitation::VisitInputs;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -527,21 +527,21 @@ std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_bottom_node;
   visit_lqp(union_node, [&](const auto& diamond_node) {
-        if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
-        if (diamond_node->output_count() > 1) {
-          if (!diamond_bottom_node.has_value()) {
-            diamond_bottom_node = diamond_node;
-          } else if (diamond_bottom_node != diamond_node) {
-            // The LQP traversal should always end in the same bottom node having multiple outputs. Since we found two
-            // differing diamond bottom nodes, we must abort the traversal.
-            is_diamond = false;
-          }
-          return LQPVisitation::DoNotVisitInputs;
-        } else if (!diamond_node->left_input()) {
-          // We should have found a bottom diamond node with multiple outputs at this point.
-          is_diamond = false;
-        }
-        return LQPVisitation::VisitInputs;
+    if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
+    if (diamond_node->output_count() > 1) {
+      if (!diamond_bottom_node.has_value()) {
+        diamond_bottom_node = diamond_node;
+      } else if (diamond_bottom_node != diamond_node) {
+        // The LQP traversal should always end in the same bottom node having multiple outputs. Since we found two
+        // differing diamond bottom nodes, we must abort the traversal.
+        is_diamond = false;
+      }
+      return LQPVisitation::DoNotVisitInputs;
+    } else if (!diamond_node->left_input()) {
+      // We should have found a bottom diamond node with multiple outputs at this point.
+      is_diamond = false;
+    }
+    return LQPVisitation::VisitInputs;
   });
 
   if (!is_diamond || !diamond_bottom_node.has_value()) return nullptr;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -521,12 +521,12 @@ void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::
    */
 }
 
-std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<AbstractLQPNode>& union_node) {
-  Assert(union_node->type == LQPNodeType::Union, "Expecting UnionNode as the diamond's root node.");
-  Assert(union_node->input_count() > 1, "Diamond root node does not have two inputs.");
+std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<AbstractLQPNode>& union_root_node) {
+  Assert(union_root_node->type == LQPNodeType::Union, "Expecting UnionNode as the diamond's root node.");
+  Assert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_bottom_node;
-  visit_lqp(union_node, [&](const auto& diamond_node) {
+  visit_lqp(union_root_node, [&](const auto& diamond_node) {
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
     if (diamond_node->output_count() > 1) {
       if (!diamond_bottom_node.has_value()) {

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -205,9 +205,9 @@ void lqp_remove_node(const std::shared_ptr<AbstractLQPNode>& node, const AllowRi
 
 void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side,
                      const std::shared_ptr<AbstractLQPNode>& node_to_insert, const AllowRightInput allow_right_input) {
-  DebugAssert(!node_to_insert->left_input(), "Expected node without a left input set.");
+  DebugAssert(!node_to_insert->left_input(), "Expected node without a left input.");
   DebugAssert(!node_to_insert->right_input() || allow_right_input == AllowRightInput::Yes,
-              "Expected node without a right input set.");
+              "Expected node without a right input.");
   DebugAssert(node_to_insert->output_count() == 0, "Expected node without outputs.");
 
   const auto old_input = parent_node->input(input_side);
@@ -218,9 +218,9 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
 void lqp_insert_node_above(const std::shared_ptr<AbstractLQPNode>& node,
                            const std::shared_ptr<AbstractLQPNode>& node_to_insert,
                            const AllowRightInput allow_right_input) {
-  DebugAssert(!node_to_insert->left_input(), "Expected node without a left input set.");
+  DebugAssert(!node_to_insert->left_input(), "Expected node without a left input.");
   DebugAssert(!node_to_insert->right_input() || allow_right_input == AllowRightInput::Yes,
-              "Expected node without a right input set.");
+              "Expected node without a right input.");
   DebugAssert(node_to_insert->output_count() == 0, "Expected node without outputs.");
 
   // Re-link @param node's outputs to @param node_to_insert
@@ -526,32 +526,32 @@ void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::
    */
 }
 
-std::shared_ptr<AbstractLQPNode> find_diamond_bottom_root_node(
+std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
     const std::shared_ptr<AbstractLQPNode>& union_root_node) {
   Assert(union_root_node->type == LQPNodeType::Union, "Expecting UnionNode as the diamond's root node.");
   DebugAssert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;
-  std::optional<std::shared_ptr<AbstractLQPNode>> diamond_bottom_root_node;
+  std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
     if (diamond_node->output_count() > 1) {
-      if (!diamond_bottom_root_node.has_value()) {
-        diamond_bottom_root_node = diamond_node;
-      } else if (diamond_bottom_root_node != diamond_node) {
-        // The LQP traversal should always end in the same bottom root node having multiple outputs. Since we found two
-        // different bottom root nodes, we abort the traversal.
+      if (!diamond_origin_node.has_value()) {
+        diamond_origin_node = diamond_node;
+      } else if (diamond_origin_node != diamond_node) {
+        // The LQP traversal should always end in the same origin node having multiple outputs. Since we found two
+        // different origin nodes, we abort the traversal.
         is_diamond = false;
       }
       return LQPVisitation::DoNotVisitInputs;
     } else if (!diamond_node->left_input()) {
-      // We should have found a common bottom root node with multiple outputs at this point.
+      // We should have found a common origin node with multiple outputs at this point.
       is_diamond = false;
     }
     return LQPVisitation::VisitInputs;
   });
 
-  if (!is_diamond || !diamond_bottom_root_node.has_value()) return nullptr;
-  return diamond_bottom_root_node.value();
+  if (!is_diamond || !diamond_origin_node.has_value()) return nullptr;
+  return diamond_origin_node.value();
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -526,8 +526,7 @@ void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::
    */
 }
 
-std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
-    const std::shared_ptr<AbstractLQPNode>& union_root_node) {
+std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<AbstractLQPNode>& union_root_node) {
   Assert(union_root_node->type == LQPNodeType::Union, "Expecting UnionNode as the diamond's root node.");
   DebugAssert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -215,10 +215,8 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
 }
 
 void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
-                           const std::shared_ptr<AbstractLQPNode>& node_to_insert,
-                           const AllowRightInput allow_right_input) {
-  Assert(!node_to_insert->left_input() && (!node_to_insert->right_input() || allow_right_input == AllowRightInput::Yes),
-         "Expected node without inputs.");
+                           const std::shared_ptr<AbstractLQPNode>& node_to_insert) {
+  Assert(!node_to_insert->left_input(), "Expected node without a left input set.");
 
   // Re-link @param node's outputs to @param node_to_insert
   const auto node_outputs = node->outputs();

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -532,6 +532,7 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
+    if (diamond_node == union_root_node) LQPVisitation::VisitInputs;
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
     if (diamond_node->output_count() > 1) {
       if (!diamond_origin_node) {

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -214,7 +214,7 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
   node->set_left_input(old_input);
 }
 
-void lqp_insert_node_above(const std::shared_ptr<AbstractLQPNode>& node,
+void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
                            const std::shared_ptr<AbstractLQPNode>& node_to_insert,
                            const AllowRightInput allow_right_input) {
   Assert(!node_to_insert->left_input() && (!node_to_insert->right_input() || allow_right_input == AllowRightInput::Yes),

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -544,9 +544,11 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
       }
       return LQPVisitation::DoNotVisitInputs;
     } else if (!diamond_node->left_input()) {
-      // We should have found a common origin node with multiple outputs at this point.
+      // The traversal ends because we reached a MockNode, StoredTableNode or StaticTableNode. Since we did not find a
+      // node with multiple outputs yet, union_root_node cannot be considered the root of a diamond.
       is_diamond = false;
     }
+
     return LQPVisitation::VisitInputs;
   });
 

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -532,8 +532,9 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
-    if (diamond_node == union_root_node) LQPVisitation::VisitInputs;
+    if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
+
     if (diamond_node->output_count() > 1) {
       if (!diamond_origin_node) {
         diamond_origin_node = diamond_node;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -550,7 +550,7 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
     return LQPVisitation::VisitInputs;
   });
 
-  if (is_diamond && diamond_origin_node) *diamond_origin_node;
+  if (is_diamond && diamond_origin_node.has_value()) *diamond_origin_node;
   return nullptr;
 }
 

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -521,17 +521,18 @@ void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::
    */
 }
 
-std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<AbstractLQPNode>& union_root_node) {
+std::shared_ptr<AbstractLQPNode> find_diamond_bottom_root_node(
+    const std::shared_ptr<AbstractLQPNode>& union_root_node) {
   Assert(union_root_node->type == LQPNodeType::Union, "Expecting UnionNode as the diamond's root node.");
   Assert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;
-  std::optional<std::shared_ptr<AbstractLQPNode>> diamond_bottom_node;
+  std::optional<std::shared_ptr<AbstractLQPNode>> diamond_bottom_root_node;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
     if (diamond_node->output_count() > 1) {
-      if (!diamond_bottom_node.has_value()) {
-        diamond_bottom_node = diamond_node;
-      } else if (diamond_bottom_node != diamond_node) {
+      if (!diamond_bottom_root_node.has_value()) {
+        diamond_bottom_root_node = diamond_node;
+      } else if (diamond_bottom_root_node != diamond_node) {
         // The LQP traversal should always end in the same bottom node having multiple outputs. Since we found two
         // differing diamond bottom nodes, we must abort the traversal.
         is_diamond = false;
@@ -544,8 +545,8 @@ std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<
     return LQPVisitation::VisitInputs;
   });
 
-  if (!is_diamond || !diamond_bottom_node.has_value()) return nullptr;
-  return diamond_bottom_node.value();
+  if (!is_diamond || !diamond_bottom_root_node.has_value()) return nullptr;
+  return diamond_bottom_root_node.value();
 }
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -531,7 +531,7 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<
   DebugAssert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
-  std::cout << "union root ptr: " << union_root_ptr << std::endl;
+  std::cout << "union root ptr: " << union_root_node << std::endl;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
     std::cout << "traversal: " << diamond_node << std::endl;
     if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -532,7 +532,7 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
-    //if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;
+    if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
 
     if (diamond_node->output_count() > 1) {

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -535,9 +535,9 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
     if (diamond_node->output_count() > 1) {
-      if (!diamond_origin_node.has_value()) {
+      if (!diamond_origin_node) {
         diamond_origin_node = diamond_node;
-      } else if (diamond_origin_node != diamond_node) {
+      } else {
         // The LQP traversal should always end in the same origin node having multiple outputs. Since we found two
         // different origin nodes, we abort the traversal.
         is_diamond = false;

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -539,6 +539,8 @@ std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<
             is_diamond = false;
           }
           return LQPVisitation::DoNotVisitInputs;
+        } else if (!diamond_node->left_input()) {
+          is_diamond = false;
         }
         return LQPVisitation::VisitInputs;
   });

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -550,7 +550,7 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(
     return LQPVisitation::VisitInputs;
   });
 
-  if (is_diamond && diamond_origin_node.has_value()) *diamond_origin_node;
+  if (is_diamond && diamond_origin_node) return *diamond_origin_node;
   return nullptr;
 }
 

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -531,7 +531,9 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<
   DebugAssert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
+  std::cout << "union root ptr: " << union_root_ptr << std::endl;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
+    std::cout << "traversal: " << diamond_node << std::endl;
     if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
 

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -531,10 +531,8 @@ std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<
   DebugAssert(union_root_node->input_count() > 1, "Diamond root node does not have two inputs.");
   bool is_diamond = true;
   std::optional<std::shared_ptr<AbstractLQPNode>> diamond_origin_node;
-  std::cout << "union root ptr: " << union_root_node << std::endl;
   visit_lqp(union_root_node, [&](const auto& diamond_node) {
-    std::cout << "traversal: " << diamond_node << std::endl;
-    if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;
+    //if (diamond_node == union_root_node) return LQPVisitation::VisitInputs;
     if (!is_diamond) return LQPVisitation::DoNotVisitInputs;
 
     if (diamond_node->output_count() > 1) {

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -96,6 +96,9 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
                      const std::shared_ptr<AbstractLQPNode>& node,
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
+void lqp_insert_node_above(const std::shared_ptr<AbstractLQPNode>& node,
+                         const std::shared_ptr<AbstractLQPNode>& node_to_insert,
+                         const AllowRightInput allow_right_input = AllowRightInput::No);
 /**
  * @return whether all paths to all leaves contain a Validate node - i.e. the LQP can be used in an MVCC aware context
  */

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -96,6 +96,7 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
                      const std::shared_ptr<AbstractLQPNode>& node,
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
+// TODO(julianmenzler) Rename to: lqp_insert_above_node
 void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
                            const std::shared_ptr<AbstractLQPNode>& node_to_insert);
 /**
@@ -248,6 +249,6 @@ std::vector<FunctionalDependency> fds_from_unique_constraints(
  */
 void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::vector<FunctionalDependency>& fds);
 
-std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
+std::shared_ptr<AbstractLQPNode> find_diamond_bottom_root_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -93,12 +93,15 @@ void lqp_remove_node(const std::shared_ptr<AbstractLQPNode>& node,
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
 void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const LQPInputSide input_side,
-                     const std::shared_ptr<AbstractLQPNode>& node,
+                     const std::shared_ptr<AbstractLQPNode>& node_to_insert,
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
-// TODO(julianmenzler) Rename to: lqp_insert_above_node, Maybe add allow_right_input == AllowRightInput::kYes
-void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
-                           const std::shared_ptr<AbstractLQPNode>& node_to_insert);
+/**
+ * Sets @param node as the left input of @param node_to_insert, and re-connects all outputs to @param node_to_insert.
+ */
+void lqp_insert_node_above(const std::shared_ptr<AbstractLQPNode>& node,
+                           const std::shared_ptr<AbstractLQPNode>& node_to_insert,
+                           const AllowRightInput allow_right_input = AllowRightInput::No);
 /**
  * @return whether all paths to all leaves contain a Validate node - i.e. the LQP can be used in an MVCC aware context
  */
@@ -249,6 +252,10 @@ std::vector<FunctionalDependency> fds_from_unique_constraints(
  */
 void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::vector<FunctionalDependency>& fds);
 
+/**
+ * Takes the given UnionNode @param union_root_node, and traverses the LQP until a common bottom root node was found.
+ * @returns a shared pointer to the diamond's bottom root node, if one was found. Otherwise, a null pointer is returned.
+ */
 std::shared_ptr<AbstractLQPNode> find_diamond_bottom_root_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -96,9 +96,9 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
                      const std::shared_ptr<AbstractLQPNode>& node,
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
-void lqp_insert_node_above(const std::shared_ptr<AbstractLQPNode>& node,
-                         const std::shared_ptr<AbstractLQPNode>& node_to_insert,
-                         const AllowRightInput allow_right_input = AllowRightInput::No);
+void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
+                           const std::shared_ptr<AbstractLQPNode>& node_to_insert,
+                           const AllowRightInput allow_right_input = AllowRightInput::No);
 /**
  * @return whether all paths to all leaves contain a Validate node - i.e. the LQP can be used in an MVCC aware context
  */

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -253,8 +253,8 @@ std::vector<FunctionalDependency> fds_from_unique_constraints(
 void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::vector<FunctionalDependency>& fds);
 
 /**
- * Takes the given UnionNode @param union_root_node, and traverses the LQP until a common bottom root node was found.
- * @returns a shared pointer to the diamond's bottom root node, if one was found. Otherwise, a null pointer is returned.
+ * Takes the given UnionNode @param union_root_node and traverses the LQP until a common bottom root node was found.
+ * @returns a shared pointer to the diamond's bottom root node. If it was not found, a null pointer is returned.
  */
 std::shared_ptr<AbstractLQPNode> find_diamond_bottom_root_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
 

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -97,8 +97,7 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
 void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
-                           const std::shared_ptr<AbstractLQPNode>& node_to_insert,
-                           const AllowRightInput allow_right_input = AllowRightInput::No);
+                           const std::shared_ptr<AbstractLQPNode>& node_to_insert);
 /**
  * @return whether all paths to all leaves contain a Validate node - i.e. the LQP can be used in an MVCC aware context
  */

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -248,6 +248,6 @@ std::vector<FunctionalDependency> fds_from_unique_constraints(
  */
 void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::vector<FunctionalDependency>& fds);
 
-std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<AbstractLQPNode>& diamond_root_node);
+std::shared_ptr<AbstractLQPNode> find_diamond_bottom_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -253,9 +253,9 @@ std::vector<FunctionalDependency> fds_from_unique_constraints(
 void remove_invalid_fds(const std::shared_ptr<const AbstractLQPNode>& lqp, std::vector<FunctionalDependency>& fds);
 
 /**
- * Takes the given UnionNode @param union_root_node and traverses the LQP until a common bottom root node was found.
- * @returns a shared pointer to the diamond's bottom root node. If it was not found, a null pointer is returned.
+ * Takes the given UnionNode @param union_root_node and traverses the LQP until a common origin node was found.
+ * @returns a shared pointer to the diamond's origin node. If it was not found, a null pointer is returned.
  */
-std::shared_ptr<AbstractLQPNode> find_diamond_bottom_root_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
+std::shared_ptr<AbstractLQPNode> find_diamond_origin_node(const std::shared_ptr<AbstractLQPNode>& union_root_node);
 
 }  // namespace opossum

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -96,7 +96,7 @@ void lqp_insert_node(const std::shared_ptr<AbstractLQPNode>& parent_node, const 
                      const std::shared_ptr<AbstractLQPNode>& node,
                      const AllowRightInput allow_right_input = AllowRightInput::No);
 
-// TODO(julianmenzler) Rename to: lqp_insert_above_node
+// TODO(julianmenzler) Rename to: lqp_insert_above_node, Maybe add allow_right_input == AllowRightInput::kYes
 void lqp_insert_above_node(const std::shared_ptr<AbstractLQPNode>& node,
                            const std::shared_ptr<AbstractLQPNode>& node_to_insert);
 /**

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -303,8 +303,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         return;
       }
 
-      // Do not move predicates below a JoinNode or another UnionNode
       if (diamond_bottom_node->right_input()) {
+        // Do not move predicates below a JoinNode or another UnionNode
         for (const auto& push_down_node : push_down_nodes) {
           if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node)) {
             lqp_insert_above_node(diamond_bottom_node, push_down_node);
@@ -314,6 +314,11 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
           }
         }
 
+        // TODO Idea for improvement:
+        //  1. If nodes were inserted below the diamond, store the topmost node's reference.
+        //     Call _push_down_traversal(inserted_node, LQPInputSide::Left, push_down_nodes, estimator);
+        //  2. If nothing was inserted below the diamond, call _push_down_traversal for each input side, as already done
+        //     so below
         // Continue pushdown traversal for both inputs
         auto left_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
         _push_down_traversal(diamond_bottom_node, LQPInputSide::Left, left_push_down_nodes, estimator);

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -113,9 +113,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       auto right_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
 
       // It is safe to move predicates down past the named joins as doing so does not affect the presence of NULLs
-      if (join_node->join_mode == JoinMode::Inner || join_node->join_mode == JoinMode::Cross ||
-          join_node->join_mode == JoinMode::Semi || join_node->join_mode == JoinMode::AntiNullAsTrue ||
-          join_node->join_mode == JoinMode::AntiNullAsFalse) {
+      if (join_node->join_mode == JoinMode::Inner || join_node->join_mode == JoinMode::Cross) {
         for (const auto& push_down_node : push_down_nodes) {
           const auto move_to_left = _is_evaluable_on_lqp(push_down_node, join_node->left_input());
           const auto move_to_right = _is_evaluable_on_lqp(push_down_node, join_node->right_input());

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -281,10 +281,22 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
 
     case LQPNodeType::Union: {
       const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
-      // If we have a predicate-diamond, where all UnionNode inputs result from the same bottom node,
-      // the pushdown-traversal should continue below the diamond's bottom node.
-      std::shared_ptr<AbstractLQPNode> diamond_bottom_node = find_diamond_bottom_node(union_node);
-      if (!diamond_bottom_node) {
+      // If we have a diamond of predicates, where all UnionNode inputs result from the same bottom node,
+      // the pushdown-traversal should continue below the diamond's bottom node, if possible.
+      //
+      //                                        |
+      //                                  ____Union_____
+      //                                 /              \
+      //                      Predicate(a LIKE %man)    |
+      //                                |               |
+      //                                |     Predicate(a LIKE %woman)
+      //                                |               |
+      //                                |               |
+      //  Diamond's bottom node ----->  \_____Node______/    ________ Try to continue pushdown traversal here
+      //                                        |  <--------´
+      //                                        |
+      std::shared_ptr<AbstractLQPNode> diamond_bottom_root_node = find_diamond_bottom_root_node(union_node);
+      if (!diamond_bottom_root_node) {
         handle_barrier();
         return;
       }
@@ -292,6 +304,31 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       // We must determine whether the diamond's bottom node is used as an input by nodes which are not part of the
       // diamond. For this, we check the diamond's bottom node output count, and compare it with the number of
       // UnionNodes in the diamond structure.
+      //                                           |
+      //                                     ____Union_____
+      //                                    /              \
+      //                             ______/               |
+      //                            /                      |
+      //                     ____Union_____                |
+      //                    /              \               |
+      //                   /               |     Predicate(a LIKE %woman)
+      //        Predicate(a LIKE %man)     |               |
+      //                  |                |               |
+      //                  |       Predicate(a LIKE %child) |                      ...
+      //                  |                |               |                       |
+      //                  |                \______   ______/                 Join(a = x)
+      //                   \                      \ /                           /    |
+      //                    \____________________  |  _________________________/     |
+      //                                         \ | /                               |
+      //     Diamond's bottom root node ------->  Node                             Table
+      //     has four output nodes, but only       |
+      //     three of them are part of the        ...
+      //     predicate diamond. Consequently,
+      //     we cannot continue the pushdown
+      //     traversal below this node, because
+      //     we would filter the predicates of
+      //     the Join node otherwise.
+      //
       size_t union_node_count = 1;
       visit_lqp(union_node, [&](const auto& diamond_node) {
         if (diamond_node == diamond_bottom_node) return LQPVisitation::DoNotVisitInputs;

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -323,8 +323,9 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       } else {
         // Push predicates below the diamond, if possible
         auto diamond_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+        const auto diamond_input_node = diamond_bottom_node->left_input();
         for (const auto& push_down_node : push_down_nodes) {
-          if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node->left_input())) {
+          if (diamond_input_node && _is_evaluable_on_lqp(push_down_node, diamond_input_node)) {
             diamond_push_down_nodes.emplace_back(push_down_node);
           } else if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node)) {
             lqp_insert_above_node(diamond_bottom_node, push_down_node);

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -282,9 +282,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     case LQPNodeType::Union: {
       const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
       /**
-       *
-       * If we have a diamond of predicates, where all UnionNode inputs result from the same bottom node,
-       * the pushdown-traversal should continue below the diamond's bottom node, if possible.
+       * If we have a diamond of predicates, where all UnionNode inputs result from the same bottom root node,
+       * the pushdown-traversal should continue below the diamond's bottom root node, if possible.
        *
        *                                        |
        *                                  ____Union_____

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -282,8 +282,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     case LQPNodeType::Union: {
       const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
       /**
-       * If we have a diamond of predicates, where all UnionNode inputs result from the same bottom root node,
-       * the pushdown-traversal should continue below the diamond's bottom root node, if possible.
+       * If we have a diamond of predicates where all UnionNode inputs result from the same bottom root node, the
+       * pushdown traversal should continue below the diamond's bottom root node, if possible.
        *
        *                                        |
        *                                  ____Union_____
@@ -322,11 +322,11 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *                   \                      \ /                            |    |
        *                    \___________________  | |  __________________________/    |
        *                                        \ | | /                               |
-       *                  ------------------->    Node                              Table
-       *                /                          |
-       *               /                          ...
-       *   ___________/______________
-       *   Diamond's bottom root node has four outputs, but only three outputs are part of the diamond structure.
+       *                     ---------------->    Node                              Table
+       *                    /                      |
+       *                   /                      ...
+       *       ___________/______________
+       *   The diamond's bottom root node has four outputs, but only three outputs are part of the diamond structure.
        *   Therefore, we do not want to continue the pushdown traversal below the diamond. Because otherwise, we would
        *   incorrectly filter the Join's left input.
        *

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -320,19 +320,18 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *                  |                |               |                     |    |
        *                  |                \______   ______/                     |    |
        *                   \                      \ /                            |    |
-       *                    \____________________  |  __________________________/     |
-       *                                         \ | /                                |
-       *     Diamond's bottom root node ------->  Node                              Table
-       *     has four output nodes, but only       |
-       *     three of them are part of the        ...
-       *     predicate diamond. Consequently,
-       *     we cannot continue the pushdown
-       *     traversal below this node. Otherwise,
-       *     we would filter the Join's input
-       *     predicates, which is incorrect.
+       *                    \___________________  | |  __________________________/    |
+       *                                        \ | | /                               |
+       *                  ------------------->    Node                              Table
+       *                /                          |
+       *               /                          ...
+       *   ___________/______________
+       *   Diamond's bottom root node has four outputs, but only three outputs are part of the diamond structure.
+       *   Therefore, we do not want to continue the pushdown traversal below the diamond. Because otherwise, we would
+       *   incorrectly filter the Join's left input.
        *
-       * To identify cases as above, we check the diamond's bottom root node output count and compare it with the number
-       * of Unions in the diamond structure.
+       * To identify cases as above, we check the outputs count of the diamond's bottom root node and compare it with
+       * the number of UnionNodes in the diamond structure.
        */
       size_t union_node_count = 1;
       visit_lqp(union_node, [&](const auto& diamond_node) {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -284,7 +284,10 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       // If we have a predicate-diamond, where all UnionNode inputs result from the same bottom node,
       // the pushdown traversal should continue below the diamond's bottom node.
       std::shared_ptr<AbstractLQPNode> diamond_bottom_node = find_diamond_bottom_node(union_node);
-      if (!diamond_bottom_node) handle_barrier();
+      if (!diamond_bottom_node) {
+        handle_barrier();
+        return;
+      }
 
       // We must determine whether the diamond's bottom node is used as an input by nodes which are not part of the
       // diamond. For this, we check the diamond's bottom node output count, and compare it the number of UnionNodes in
@@ -295,7 +298,10 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         if (diamond_node->type == LQPNodeType::Union) union_node_count++;
         return LQPVisitation::VisitInputs;
       });
-      if (union_node_count + 1 < diamond_bottom_node->output_count()) handle_barrier();
+      if (union_node_count + 1 < diamond_bottom_node->output_count()) {
+        handle_barrier();
+        return;
+      }
 
       // We should push predicates below the diamond, if possible
       auto diamond_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -282,7 +282,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     case LQPNodeType::Union: {
       const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
       // If we have a predicate-diamond, where all UnionNode inputs result from the same bottom node,
-      // the pushdown traversal should continue below the diamond's bottom node.
+      // the pushdown-traversal should continue below the diamond's bottom node.
       std::shared_ptr<AbstractLQPNode> diamond_bottom_node = find_diamond_bottom_node(union_node);
       if (!diamond_bottom_node) {
         handle_barrier();
@@ -290,8 +290,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       }
 
       // We must determine whether the diamond's bottom node is used as an input by nodes which are not part of the
-      // diamond. For this, we check the diamond's bottom node output count, and compare it the number of UnionNodes in
-      // the diamond structure.
+      // diamond. For this, we check the diamond's bottom node output count, and compare it with the number of
+      // UnionNodes in the diamond structure.
       size_t union_node_count = 1;
       visit_lqp(union_node, [&](const auto& diamond_node) {
         if (diamond_node == diamond_bottom_node) return LQPVisitation::DoNotVisitInputs;
@@ -303,7 +303,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         return;
       }
 
-      // Do not move predicates below a Join or another UnionNode
+      // Do not move predicates below a JoinNode or another UnionNode
       if (diamond_bottom_node->right_input()) {
         for (const auto& push_down_node : push_down_nodes) {
           if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node)) {
@@ -332,9 +332,9 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
             // Insert above the diamond structure
             lqp_insert_above_node(input_node, push_down_node);
           }
+        }
         // Continue pushdown below the diamond
         _push_down_traversal(diamond_bottom_node, LQPInputSide::Left, diamond_push_down_nodes, estimator);
-        }
       }
 
       // Optimize the diamond itself
@@ -345,7 +345,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     } break;
 
     default: {
-      // All not explicitly handled node types are barriers and we do not push predicates past them.
+      // All not explicitly handled node types are barriers, and we do not push predicates past them.
       handle_barrier();
     }
   }

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -12,6 +12,7 @@
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/union_node.hpp"
 #include "operators/operator_scan_predicate.hpp"
 #include "statistics/cardinality_estimator.hpp"
 
@@ -272,10 +273,43 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         if (_is_evaluable_on_lqp(push_down_node, input_node->left_input())) {
           aggregate_push_down_nodes.emplace_back(push_down_node);
         } else {
-          _insert_nodes(current_node, input_side, {push_down_node});
+          lqp_insert_node_above(input_node, push_down_node);
         }
       }
       _push_down_traversal(input_node, LQPInputSide::Left, aggregate_push_down_nodes, estimator);
+    } break;
+
+    case LQPNodeType::Union: {
+      const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
+      // If we have a predicate-diamond, where all UnionNode inputs result from the same bottom node,
+      // the pushdown traversal should continue below the diamond's bottom node.
+      std::shared_ptr<AbstractLQPNode> diamond_bottom_node = find_diamond_bottom_node(union_node);
+      if (!diamond_bottom_node) handle_barrier();
+
+      // We must determine whether the diamond's bottom node is used as an input by nodes which are not part of the
+      // diamond. For this, we check the diamond's bottom node output count, and compare it the number of UnionNodes in
+      // the diamond structure.
+      size_t union_node_count = 1;
+      visit_lqp(union_node, [&](const auto& diamond_node) {
+        if (diamond_node == diamond_bottom_node) return LQPVisitation::DoNotVisitInputs;
+        if (diamond_node->type == LQPNodeType::Union) union_node_count++;
+        return LQPVisitation::VisitInputs;
+      });
+      if (union_node_count + 1 < diamond_bottom_node->output_count()) handle_barrier();
+
+      // We can push predicates below the diamond.
+      auto diamond_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+      for (const auto& push_down_node : push_down_nodes) {
+        if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node->left_input())) {
+          diamond_push_down_nodes.emplace_back(push_down_node);
+        } else if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node)) {
+          lqp_insert_node_above(push_down_node, diamond_bottom_node);
+        } else {
+          // Insert above the diamond structure
+          lqp_insert_node_above(push_down_node, input_node);
+        }
+      }
+      _push_down_traversal(diamond_bottom_node, LQPInputSide::Left, diamond_push_down_nodes, estimator);
     } break;
 
     default: {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -280,8 +280,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     case LQPNodeType::Union: {
       const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
       /**
-       * If we have a diamond of predicates where all UnionNode inputs result from the same bottom root node, the
-       * pushdown traversal should continue below the diamond's bottom root node, if possible.
+       * If we have a diamond of predicates where all UnionNode inputs result from the same origin node, the
+       * pushdown traversal should continue below the diamond's origin node, if possible.
        *
        *                                        |
        *                                  ____Union_____
@@ -291,18 +291,18 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *                                |     Predicate(a LIKE %woman)
        *                                |               |
        *                                |               |
-       *                                \_____Node______/  <---- Diamond's bottom root node
+       *                                \_____Node______/  <---- Diamond's origin node
        *                                        |  <------------ Continue pushdown traversal here, if possible
        *                                        |
        */
-      std::shared_ptr<AbstractLQPNode> diamond_bottom_root_node = find_diamond_bottom_root_node(union_node);
-      if (!diamond_bottom_root_node) {
+      std::shared_ptr<AbstractLQPNode> diamond_origin_node = find_diamond_origin_node(union_node);
+      if (!diamond_origin_node) {
         handle_barrier();
         return;
       }
 
       /**
-       * In the following, we determine whether the diamond's bottom root node is used as an input by nodes which are
+       * In the following, we determine whether the diamond's origin node is used as an input by nodes which are
        * not part of the diamond because we should only filter the predicates of the diamond nodes, not other nodes'
        * predicates. For example:
        *                                           |                                |
@@ -324,54 +324,54 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *                     ---------------->    Node                              Table
        *                    /                      |
        *                   /                      ...
-       *       ___________/______________
-       *   The diamond's bottom root node has four outputs, but only three outputs are part of the diamond structure.
+       *       ___________/_________
+       *   The diamond's origin node has four outputs, but only three outputs are part of the diamond structure.
        *   Therefore, we do not want to continue the pushdown traversal below the diamond. Because otherwise, we would
        *   incorrectly filter the Join's left input.
        *
-       * To identify cases such as above, we check the outputs count of the diamond's bottom root node and compare it
+       * To identify cases such as above, we check the outputs count of the diamond's origin node and compare it
        * with the number of UnionNodes in the diamond structure.
        */
       size_t union_node_count = 0;
       visit_lqp(union_node, [&](const auto& diamond_node) {
-        if (diamond_node == diamond_bottom_root_node) return LQPVisitation::DoNotVisitInputs;
+        if (diamond_node == diamond_origin_node) return LQPVisitation::DoNotVisitInputs;
         if (diamond_node->type == LQPNodeType::Union) union_node_count++;
         return LQPVisitation::VisitInputs;
       });
-      if (diamond_bottom_root_node->output_count() != union_node_count + 1) {
+      if (diamond_origin_node->output_count() != union_node_count + 1) {
         handle_barrier();
         return;
       }
 
-      if (diamond_bottom_root_node->input_count() == 1) {
+      if (diamond_origin_node->input_count() == 1) {
         auto diamond_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
-        const auto node_below_diamond = diamond_bottom_root_node->left_input();
+        const auto node_below_diamond = diamond_origin_node->left_input();
         for (const auto& push_down_node : push_down_nodes) {
           if (node_below_diamond && _is_evaluable_on_lqp(push_down_node, node_below_diamond)) {
-            // Push predicate below the diamond's bottom root node
+            // Push predicate below the diamond's origin node
             diamond_push_down_nodes.emplace_back(push_down_node);
-          } else if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_root_node)) {
-            // Push predicate above the diamond's bottom root node
-            lqp_insert_node_above(diamond_bottom_root_node, push_down_node, AllowRightInput::Yes);
+          } else if (_is_evaluable_on_lqp(push_down_node, diamond_origin_node)) {
+            // Push predicate above the diamond's origin node
+            lqp_insert_node_above(diamond_origin_node, push_down_node, AllowRightInput::Yes);
           } else {
             // Insert predicate above the diamond, so that it stays evaluable.
             lqp_insert_node_above(union_node, push_down_node, AllowRightInput::Yes);
           }
         }
         // Continue predicate pushdown below the diamond structure
-        _push_down_traversal(diamond_bottom_root_node, LQPInputSide::Left, diamond_push_down_nodes, estimator);
+        _push_down_traversal(diamond_origin_node, LQPInputSide::Left, diamond_push_down_nodes, estimator);
 
       } else {
-        // Do not move pushdown predicates below the diamond's bottom root node if it is a Join, a Union or another node
+        // Do not move pushdown predicates below the diamond's origin node if it is a Join, a Union or another node
         // with multiple inputs. Instead, insert the pushdown predicates above it and call the _push_down_traversal
         // subroutine again, so that the predicate pushdown for the node with multiple inputs is handled appropriately.
-        auto updated_diamond_bottom_root_node = diamond_bottom_root_node;
+        auto updated_diamond_origin_node = diamond_origin_node;
         for (const auto& push_down_node : push_down_nodes) {
-          if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_root_node)) {
-            // Push predicate above the diamond's bottom root node
-            lqp_insert_node_above(diamond_bottom_root_node, push_down_node, AllowRightInput::Yes);
-            if (updated_diamond_bottom_root_node == diamond_bottom_root_node) {
-              updated_diamond_bottom_root_node = push_down_node;
+          if (_is_evaluable_on_lqp(push_down_node, diamond_origin_node)) {
+            // Push predicate above the diamond's origin node
+            lqp_insert_node_above(diamond_origin_node, push_down_node, AllowRightInput::Yes);
+            if (updated_diamond_origin_node == diamond_origin_node) {
+              updated_diamond_origin_node = push_down_node;
             }
           } else {
             // Insert predicate above the diamond, so that it stays evaluable.
@@ -381,8 +381,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
 
         auto left_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
         auto right_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
-        _push_down_traversal(updated_diamond_bottom_root_node, LQPInputSide::Left, left_push_down_nodes, estimator);
-        _push_down_traversal(updated_diamond_bottom_root_node, LQPInputSide::Right, right_push_down_nodes, estimator);
+        _push_down_traversal(updated_diamond_origin_node, LQPInputSide::Left, left_push_down_nodes, estimator);
+        _push_down_traversal(updated_diamond_origin_node, LQPInputSide::Right, right_push_down_nodes, estimator);
       }
 
       // Optimize the diamond itself

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -365,7 +365,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         // Do not move pushdown predicates below the diamond's origin node if it is a Join, a Union or another node
         // with multiple inputs. Instead, insert the pushdown predicates above it and call the _push_down_traversal
         // subroutine again, so that the predicate pushdown for the node with multiple inputs is handled appropriately.
-        auto updated_diamond_origin_node = diamond_origin_node;
+        auto& updated_diamond_origin_node = diamond_origin_node;
         for (const auto& push_down_node : push_down_nodes) {
           if (_is_evaluable_on_lqp(push_down_node, diamond_origin_node)) {
             // Push predicate above the diamond's origin node

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -360,13 +360,13 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
             lqp_insert_node_above(union_node, push_down_node, AllowRightInput::Yes);
           }
         }
-        // Continue pushdown below the diamond
+        // Continue predicate pushdown below the diamond structure
         _push_down_traversal(diamond_bottom_root_node, LQPInputSide::Left, diamond_push_down_nodes, estimator);
 
       } else {
-        // Do not move predicates below Joins or Unions. If evaluable, insert the pushdown predicates above the
-        // UnionNode/JoinNode. Afterwards, we call the _push_down_traversal subroutine again, so that it handles the
-        // predicate pushdown for the JoinNode, respective UnionNode.
+        // Do not move pushdown predicates below the diamond's bottom root node if it is a Join, a Union or another node
+        // with multiple inputs. Instead, insert the pushdown predicates above it and call the _push_down_traversal
+        // subroutine again, so that the predicate pushdown for the node with multiple inputs is handled appropriately.
         auto updated_diamond_bottom_root_node = diamond_bottom_root_node;
         for (const auto& push_down_node : push_down_nodes) {
           if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_root_node)) {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -302,6 +302,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         handle_barrier();
         return;
       }
+
       /**
        * In the following, we determine whether the diamond's bottom root node is used as an input by nodes which are
        * not part of the diamond because we should only filter the predicates of the diamond nodes, not other nodes'

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -278,7 +278,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     } break;
 
     case LQPNodeType::Union: {
-      const auto union_node = std::dynamic_pointer_cast<UnionNode>(input_node);
+      const auto union_node = std::static_pointer_cast<UnionNode>(input_node);
       /**
        * If we have a diamond of predicates where all UnionNode inputs result from the same origin node, the
        * pushdown traversal should continue below the diamond's origin node, if possible.
@@ -295,7 +295,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *                                        |  <------------ Continue pushdown traversal here, if possible
        *                                        |
        */
-      std::shared_ptr<AbstractLQPNode> diamond_origin_node = find_diamond_origin_node(union_node);
+      const auto diamond_origin_node = find_diamond_origin_node(union_node);
       if (!diamond_origin_node) {
         handle_barrier();
         return;
@@ -329,7 +329,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *   Therefore, we do not want to continue the pushdown traversal below the diamond. Because otherwise, we would
        *   incorrectly filter the Join's left input.
        *
-       * To identify cases such as above, we check the outputs count of the diamond's origin node and compare it
+       * To identify cases such as above, we check the output count of the diamond's origin node and compare it
        * with the number of UnionNodes in the diamond structure.
        */
       size_t union_node_count = 0;
@@ -345,9 +345,9 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
 
       if (diamond_origin_node->input_count() == 1) {
         auto diamond_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
-        const auto node_below_diamond = diamond_origin_node->left_input();
+        const auto& node_below_diamond_origin = diamond_origin_node->left_input();
         for (const auto& push_down_node : push_down_nodes) {
-          if (node_below_diamond && _is_evaluable_on_lqp(push_down_node, node_below_diamond)) {
+          if (node_below_diamond_origin && _is_evaluable_on_lqp(push_down_node, node_below_diamond_origin)) {
             // Push predicate below the diamond's origin node
             diamond_push_down_nodes.emplace_back(push_down_node);
           } else if (_is_evaluable_on_lqp(push_down_node, diamond_origin_node)) {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -495,7 +495,7 @@ bool PredicatePlacementRule::_is_expensive_predicate(const std::shared_ptr<Abstr
   auto predicate_contains_correlated_subquery = false;
   visit_expression(predicate, [&](const auto& sub_expression) {
     if (const auto subquery_expression = std::dynamic_pointer_cast<LQPSubqueryExpression>(sub_expression);
-        subquery_expression && !subquery_expression->arguments.empty()) {
+        subquery_expression && subquery_expression->is_correlated()) {
       predicate_contains_correlated_subquery = true;
       return ExpressionVisitation::DoNotVisitArguments;
     } else {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -365,7 +365,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         // Do not move pushdown predicates below the diamond's origin node if it is a Join, a Union or another node
         // with multiple inputs. Instead, insert the pushdown predicates above it and call the _push_down_traversal
         // subroutine again, so that the predicate pushdown for the node with multiple inputs is handled appropriately.
-        auto& updated_diamond_origin_node = diamond_origin_node;
+        auto updated_diamond_origin_node = diamond_origin_node;
         for (const auto& push_down_node : push_down_nodes) {
           if (_is_evaluable_on_lqp(push_down_node, diamond_origin_node)) {
             // Push predicate above the diamond's origin node

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -297,7 +297,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       });
       if (union_node_count + 1 < diamond_bottom_node->output_count()) handle_barrier();
 
-      // We can push predicates below the diamond.
+      // We should push predicates below the diamond, if possible
       auto diamond_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
       for (const auto& push_down_node : push_down_nodes) {
         if (_is_evaluable_on_lqp(push_down_node, diamond_bottom_node->left_input())) {
@@ -309,7 +309,14 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
           lqp_insert_node_above(push_down_node, input_node);
         }
       }
+      // Continue pushdown below the diamond
       _push_down_traversal(diamond_bottom_node, LQPInputSide::Left, diamond_push_down_nodes, estimator);
+
+      // Optimize the diamond itself
+      auto left_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+      _push_down_traversal(input_node, LQPInputSide::Left, left_push_down_nodes, estimator);
+      auto right_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
+      _push_down_traversal(input_node, LQPInputSide::Right, right_push_down_nodes, estimator);
     } break;
 
     default: {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -314,7 +314,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
           }
         }
 
-        // TODO Idea for improvement:
+        // TODO(julianmenzler) Idea for improvement:
         //  1. If nodes were inserted below the diamond, store the topmost node's reference.
         //     Call _push_down_traversal(inserted_node, LQPInputSide::Left, push_down_nodes, estimator);
         //  2. If nothing was inserted below the diamond, call _push_down_traversal for each input side, as already done

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -330,8 +330,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        *   Therefore, we do not want to continue the pushdown traversal below the diamond. Because otherwise, we would
        *   incorrectly filter the Join's left input.
        *
-       * To identify cases as above, we check the outputs count of the diamond's bottom root node and compare it with
-       * the number of UnionNodes in the diamond structure.
+       * To identify cases such as above, we check the outputs count of the diamond's bottom root node and compare it
+       * with the number of UnionNodes in the diamond structure.
        */
       size_t union_node_count = 0;
       visit_lqp(union_node, [&](const auto& diamond_node) {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -333,13 +333,13 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
        * To identify cases as above, we check the outputs count of the diamond's bottom root node and compare it with
        * the number of UnionNodes in the diamond structure.
        */
-      size_t union_node_count = 1;
+      size_t union_node_count = 0;
       visit_lqp(union_node, [&](const auto& diamond_node) {
         if (diamond_node == diamond_bottom_root_node) return LQPVisitation::DoNotVisitInputs;
         if (diamond_node->type == LQPNodeType::Union) union_node_count++;
         return LQPVisitation::VisitInputs;
       });
-      if (union_node_count + 1 < diamond_bottom_root_node->output_count()) {
+      if (diamond_bottom_root_node->output_count() != union_node_count + 1) {
         handle_barrier();
         return;
       }

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -362,4 +362,31 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
   }
 }
 
+TEST_F(LQPUtilsTest, InsertAboveNode) {
+  // clang-format off
+  const auto lqp =
+  UnionNode::make(SetOperationMode::Positions,
+    PredicateNode::make(less_than_(a_a, value_(3)),
+      node_a),
+    PredicateNode::make(greater_than_(a_a, value_(5)),
+      node_a));
+
+  const auto node_to_insert = ProjectionNode::make(expression_vector(a_a, a_b, add_(a_a, a_b)));
+  lqp_insert_node_above(node_a, node_to_insert);
+
+  const auto expected_common_node =
+  ProjectionNode::make(expression_vector(a_a, a_b, add_(a_a, a_b)),
+    node_a);
+
+  const auto expected_lqp =
+  UnionNode::make(SetOperationMode::Positions,
+    PredicateNode::make(less_than_(a_a, value_(3)),
+      expected_common_node),
+    PredicateNode::make(greater_than_(a_a, value_(5)),
+      expected_common_node));
+  // clang-format on
+
+  EXPECT_LQP_EQ(lqp, expected_lqp);
+}
+
 }  // namespace opossum

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -315,8 +315,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(greater_than_(a_a, value_(5)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_node, node_a);
+    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
+    EXPECT_EQ(diamond_bottom_root_node, node_a);
   }
   {
     // clang-format off
@@ -327,8 +327,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(greater_than_(a_a, value_(5)),
         node_b));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_node, nullptr);
+    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
+    EXPECT_EQ(diamond_bottom_root_node, nullptr);
   }
   {
     // clang-format off
@@ -342,8 +342,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(equals_(a_a, value_(7)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_node, node_a);
+    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
+    EXPECT_EQ(diamond_bottom_root_node, node_a);
   }
   {
     // clang-format off
@@ -357,8 +357,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(equals_(a_a, value_(7)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_node, nullptr);
+    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
+    EXPECT_EQ(diamond_bottom_root_node, nullptr);
   }
 }
 

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -353,9 +353,9 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
         PredicateNode::make(equals_(a_a, value_(3)),
           node_a),
         PredicateNode::make(equals_(a_a, value_(5)),
-          node_b),
+          node_b)),
       PredicateNode::make(equals_(a_a, value_(7)),
-        node_a)));
+        node_a));
     // clang-format on
     const auto diamond_bottom_node = find_diamond_bottom_node(lqp);
     EXPECT_EQ(diamond_bottom_node, nullptr);

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -332,7 +332,8 @@ TEST_F(LQPUtilsTest, CollectSubqueryExpressionsByLQPNestedSubqueries) {
   EXPECT_EQ(subquery_expressions_by_lqp.find(max_a_subquery->lqp)->second.at(0).lock(), max_a_subquery);
 }
 
-TEST_F(LQPUtilsTest, FindDiamondOriginNode) {
+TEST_F(LQPUtilsTest, FindDiamondOriginNodeSingleUnion) {
+  // Test if the origin node of a simple diamond is returned.
   {
     // clang-format off
     const auto lqp =
@@ -345,6 +346,8 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNode) {
     const auto diamond_origin_node = find_diamond_origin_node(lqp);
     EXPECT_EQ(diamond_origin_node, node_a);
   }
+
+  // Test for null pointer, because the diamond from above no longer has a common origin node.
   {
     // clang-format off
     const auto lqp =
@@ -357,6 +360,10 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNode) {
     const auto diamond_origin_node = find_diamond_origin_node(lqp);
     EXPECT_EQ(diamond_origin_node, nullptr);
   }
+}
+
+TEST_F(LQPUtilsTest, FindDiamondOriginNodeMultipleUnions) {
+  // Test if the diamond's origin node is returned in case of multiple UnionNodes.
   {
     // clang-format off
     const auto lqp =
@@ -372,6 +379,8 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNode) {
     const auto diamond_origin_node = find_diamond_origin_node(lqp);
     EXPECT_EQ(diamond_origin_node, node_a);
   }
+
+  // Test for null pointer, because the diamond from above no longer has a common origin node.
   {
     // clang-format off
     const auto lqp =

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -315,7 +315,7 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(greater_than_(a_a, value_(5)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_node(lqp);
+    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
     EXPECT_EQ(diamond_bottom_node, node_a);
   }
   {
@@ -327,7 +327,7 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(greater_than_(a_a, value_(5)),
         node_b));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_node(lqp);
+    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
     EXPECT_EQ(diamond_bottom_node, nullptr);
   }
   {
@@ -342,7 +342,7 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(equals_(a_a, value_(7)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_node(lqp);
+    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
     EXPECT_EQ(diamond_bottom_node, node_a);
   }
   {
@@ -357,7 +357,7 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
       PredicateNode::make(equals_(a_a, value_(7)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_node = find_diamond_bottom_node(lqp);
+    const auto diamond_bottom_node = find_diamond_bottom_root_node(lqp);
     EXPECT_EQ(diamond_bottom_node, nullptr);
   }
 }

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -400,24 +400,27 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNodeNestedUnions) {
 
 TEST_F(LQPUtilsTest, FindDiamondOriginNodeConsecutiveDiamonds) {
   // clang-format off
-  const auto bottom_diamond =
+  const auto bottom_diamond_root_node =
   UnionNode::make(SetOperationMode::Positions,
     PredicateNode::make(less_than_(a_a, value_(3)),
       node_a),
     PredicateNode::make(greater_than_(a_a, value_(5)),
       node_a));
 
-  const auto top_diamond =
+  const auto top_diamond_root_node =
   UnionNode::make(SetOperationMode::Positions,
     PredicateNode::make(less_than_(a_a, value_(3)),
-      bottom_diamond),
+      bottom_diamond_root_node),
     PredicateNode::make(greater_than_(a_a, value_(5)),
-      bottom_diamond));
+      bottom_diamond_root_node));
   // clang-format on
 
-  ASSERT_EQ(bottom_diamond->output_count(), 2);
-  const auto bottom_diamond_origin_node = find_diamond_origin_node(bottom_diamond);
+  ASSERT_EQ(bottom_diamond_root_node->output_count(), 2);
+  const auto bottom_diamond_origin_node = find_diamond_origin_node(bottom_diamond_root_node);
   EXPECT_EQ(bottom_diamond_origin_node, node_a);
+
+  const auto top_diamond_origin_node = find_diamond_origin_node(top_diamond_root_node);
+  EXPECT_EQ(bottom_diamond_origin_node, bottom_diamond_root_node);
 }
 
 }  // namespace opossum

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -342,8 +342,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomRootNode) {
       PredicateNode::make(greater_than_(a_a, value_(5)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_root_node, node_a);
+    const auto diamond_origin_node = find_diamond_origin_node(lqp);
+    EXPECT_EQ(diamond_origin_node, node_a);
   }
   {
     // clang-format off
@@ -354,8 +354,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomRootNode) {
       PredicateNode::make(greater_than_(a_a, value_(5)),
         node_b));
     // clang-format on
-    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_root_node, nullptr);
+    const auto diamond_origin_node = find_diamond_origin_node(lqp);
+    EXPECT_EQ(diamond_origin_node, nullptr);
   }
   {
     // clang-format off
@@ -369,8 +369,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomRootNode) {
       PredicateNode::make(equals_(a_a, value_(7)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_root_node, node_a);
+    const auto diamond_origin_node = find_diamond_origin_node(lqp);
+    EXPECT_EQ(diamond_origin_node, node_a);
   }
   {
     // clang-format off
@@ -384,8 +384,8 @@ TEST_F(LQPUtilsTest, FindDiamondBottomRootNode) {
       PredicateNode::make(equals_(a_a, value_(7)),
         node_a));
     // clang-format on
-    const auto diamond_bottom_root_node = find_diamond_bottom_root_node(lqp);
-    EXPECT_EQ(diamond_bottom_root_node, nullptr);
+    const auto diamond_origin_node = find_diamond_origin_node(lqp);
+    EXPECT_EQ(diamond_origin_node, nullptr);
   }
 }
 

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -332,7 +332,7 @@ TEST_F(LQPUtilsTest, CollectSubqueryExpressionsByLQPNestedSubqueries) {
   EXPECT_EQ(subquery_expressions_by_lqp.find(max_a_subquery->lqp)->second.at(0).lock(), max_a_subquery);
 }
 
-TEST_F(LQPUtilsTest, FindDiamondBottomRootNode) {
+TEST_F(LQPUtilsTest, FindDiamondOriginNode) {
   {
     // clang-format off
     const auto lqp =

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -399,6 +399,7 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNodeNestedUnions) {
 }
 
 TEST_F(LQPUtilsTest, FindDiamondOriginNodeConsecutiveDiamonds) {
+  // Edge case: In this test, the diamond's root node has the same number of outputs as the diamond's origin node.
   // clang-format off
   const auto bottom_diamond_root_node =
   UnionNode::make(SetOperationMode::Positions,
@@ -414,8 +415,8 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNodeConsecutiveDiamonds) {
     PredicateNode::make(greater_than_(a_a, value_(5)),
       bottom_diamond_root_node));
   // clang-format on
+  ASSERT_EQ(bottom_diamond_root_node->output_count(), node_a->output_count());
 
-  ASSERT_EQ(bottom_diamond_root_node->output_count(), 2);
   const auto bottom_diamond_origin_node = find_diamond_origin_node(bottom_diamond_root_node);
   EXPECT_EQ(bottom_diamond_origin_node, node_a);
 

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -338,9 +338,9 @@ TEST_F(LQPUtilsTest, FindDiamondBottomNode) {
         PredicateNode::make(equals_(a_a, value_(3)),
           node_a),
         PredicateNode::make(equals_(a_a, value_(5)),
-          node_a),
+          node_a)),
       PredicateNode::make(equals_(a_a, value_(7)),
-        node_a)));
+        node_a));
     // clang-format on
     const auto diamond_bottom_node = find_diamond_bottom_node(lqp);
     EXPECT_EQ(diamond_bottom_node, node_a);

--- a/src/test/lib/logical_query_plan/lqp_utils_test.cpp
+++ b/src/test/lib/logical_query_plan/lqp_utils_test.cpp
@@ -420,7 +420,7 @@ TEST_F(LQPUtilsTest, FindDiamondOriginNodeConsecutiveDiamonds) {
   EXPECT_EQ(bottom_diamond_origin_node, node_a);
 
   const auto top_diamond_origin_node = find_diamond_origin_node(top_diamond_root_node);
-  EXPECT_EQ(bottom_diamond_origin_node, bottom_diamond_root_node);
+  EXPECT_EQ(top_diamond_origin_node, bottom_diamond_root_node);
 }
 
 }  // namespace opossum

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -161,7 +161,7 @@ TEST_F(PredicatePlacementRuleTest, SimpleDiamondPushdownTest) {
     _stored_table_a);
 
   const auto input_lqp =
-  PredicateNode::make(equals_(_a_b, 10),  // <-- This PredicateNode should get pushed below the diamond.
+  PredicateNode::make(equals_(_a_b, 10),    // <-- Predicate before pushdown
     UnionNode::make(SetOperationMode::Positions,
       PredicateNode::make(like_(_a_a, "%man%"),
         input_common_node),
@@ -170,7 +170,7 @@ TEST_F(PredicatePlacementRuleTest, SimpleDiamondPushdownTest) {
 
   const auto expected_common_node =
   ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
-    PredicateNode::make(equals_(_a_b, 10),
+    PredicateNode::make(equals_(_a_b, 10),  // <-- Predicate after pushdown
       _stored_table_a));
 
   const auto expected_lqp =
@@ -225,8 +225,8 @@ TEST_F(PredicatePlacementRuleTest, PartialDiamondPushdownTest) {
     _stored_table_a);
 
   const auto input_lqp =
-  PredicateNode::make(equals_(_a_a, 10),
-    PredicateNode::make(greater_than_(min_(_a_b), 100),
+  PredicateNode::make(equals_(_a_a, 10),                 // <-- 1st Predicate before pushdown
+    PredicateNode::make(greater_than_(min_(_a_b), 100),  // <-- 2nd Predicate before pushdown
       UnionNode::make(SetOperationMode::Positions,
         PredicateNode::make(like_(_a_a, "%man%"),
           input_common_node),
@@ -234,9 +234,9 @@ TEST_F(PredicatePlacementRuleTest, PartialDiamondPushdownTest) {
           input_common_node))));
 
   const auto expected_common_node =
-  PredicateNode::make(greater_than_(min_(_a_b), 100),
+  PredicateNode::make(greater_than_(min_(_a_b), 100),   // <-- 2nd Predicate after pushdown
     AggregateNode::make(expression_vector(_a_a), expression_vector(min_(_a_b)),
-      PredicateNode::make(equals_(_a_a, 10),
+      PredicateNode::make(equals_(_a_a, 10),            // <-- 1st Predicate after pushdown
         _stored_table_a)));
 
   const auto expected_lqp =
@@ -311,7 +311,7 @@ TEST_F(PredicatePlacementRuleTest, BigDiamondPushdown) {
     _stored_table_a);
 
   const auto input_lqp =
-  PredicateNode::make(equals_(_a_b, 10),  // <-- This PredicateNode should get pushed below the diamond.
+  PredicateNode::make(equals_(_a_b, 10),  // <-- Predicate before pushdown
     UnionNode::make(SetOperationMode::Positions,
       UnionNode::make(SetOperationMode::Positions,
         PredicateNode::make(like_(_a_a, "%man"),
@@ -323,7 +323,7 @@ TEST_F(PredicatePlacementRuleTest, BigDiamondPushdown) {
 
   const auto expected_common_node =
   ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
-    PredicateNode::make(equals_(_a_b, 10),  // <-- PredicateNode should end up here after the pushdown.
+    PredicateNode::make(equals_(_a_b, 10),  // <-- Predicate after pushdown
       _stored_table_a));
 
   const auto expected_lqp =

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -205,7 +205,7 @@ TEST_F(PredicatePlacementRuleTest, BlockSimpleDiamondPushdownTest) {
         ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
           input_common_node))));
 
-  // Increase the outputs count of input_common_node
+  // Increase the output count of input_common_node
   ASSERT_EQ(input_common_node->outputs().size(), 2);
   const auto non_diamond_lqp_node = ProjectionNode::make(expression_vector(_a_a), input_common_node);
   ASSERT_EQ(input_common_node->outputs().size(), 3);

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -168,7 +168,10 @@ TEST_F(PredicatePlacementRuleTest, DiamondPushdownInputRecoveryTest) {
     ProjectionNode::make(expression_vector(_a_a, cast_(3.2, DataType::Float)),
       input_sub_lqp));
 
-  const auto expected_sub_lqp = input_sub_lqp->deep_copy();
+  const auto expected_sub_lqp =
+  PredicateNode::make(greater_than_(_a_a, 1),
+    ValidateNode::make(
+      _stored_table_a));
 
   const auto expected_lqp =
   UpdateNode::make("int_float",
@@ -203,7 +206,10 @@ TEST_F(PredicatePlacementRuleTest, StopPushdownAtDiamondBottomRootNode) {
 
   // We expect the diamond predicates to get pushed below the Projections. However, since the diamond's bottom root node
   // has multiple outputs, predicates are not expected to get pushed down any further.
-  const auto expected_common_node = input_common_node->deep_copy();
+  const auto expected_common_node =
+  PredicateNode::make(greater_than_(_a_a, 1),
+    ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
+      _stored_table_a));
 
   const auto expected_lqp =
   UnionNode::make(SetOperationMode::All,

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -204,7 +204,6 @@ TEST_F(PredicatePlacementRuleTest, BlockSimpleDiamondPushdownTest) {
       PredicateNode::make(like_(_a_a, "%Man%"),  // <-- Predicate before pushdown
         ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
           input_common_node))));
-  // clang-format on
 
   // Increase the outputs count of input_common_node
   ASSERT_EQ(input_common_node->outputs().size(), 2);
@@ -226,6 +225,7 @@ TEST_F(PredicatePlacementRuleTest, BlockSimpleDiamondPushdownTest) {
       ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
         PredicateNode::make(like_(_a_a, "%Man%"),  // <-- Predicate after pushdown
           expected_common_node))));
+  // clang-format on
 
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
 

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -211,7 +211,7 @@ TEST_F(PredicatePlacementRuleTest, BlockSimpleDiamondPushdownTest) {
   ASSERT_EQ(input_common_node->outputs().size(), 3);
 
   // Predicates are not pushed through the diamond. However, predicates inside the diamond are pushed towards the
-  // diamond's bottom.
+  // diamond's origin.
   const auto expected_common_node =
   ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
     _stored_table_a);
@@ -409,7 +409,7 @@ TEST_F(PredicatePlacementRuleTest, StopPushdownAtUnion) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
-TEST_F(PredicatePlacementRuleTest, StopPushdownAtDiamondBottomRootNode) {
+TEST_F(PredicatePlacementRuleTest, StopPushdownAtDiamondOriginNode) {
   // We must stop pushing down predicates when reaching a node with multiple outputs.
   // clang-format off
   const auto input_common_node =

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -187,7 +187,7 @@ TEST_F(PredicatePlacementRuleTest, SimpleDiamondPushdownTest) {
 }
 
 TEST_F(PredicatePlacementRuleTest, BlockSimpleDiamondPushdownTest) {
-  // Derived from SimpleDiamondPushdownTest. In this test, the diamond's bottom root node is used by another LQP node,
+  // Derived from SimpleDiamondPushdownTest. In this test, the diamond's origin node is used by another LQP node,
   // which is not part of the diamond. As a result, the predicate pushdown must be blocked because it would incorrectly
   // filter the other LQP node not part of the diamond.
   // clang-format off
@@ -233,7 +233,7 @@ TEST_F(PredicatePlacementRuleTest, BlockSimpleDiamondPushdownTest) {
 }
 
 TEST_F(PredicatePlacementRuleTest, PartialDiamondPushdownTest) {
-  // Derived from SimpleDiamondPushdownTest. In this test, the diamond's bottom root node is an AggregateNode which
+  // Derived from SimpleDiamondPushdownTest. In this test, the diamond's origin node is an AggregateNode which
   // blocks one predicate from getting pushed below the diamond.
   // clang-format off
   const auto input_common_node =
@@ -428,7 +428,7 @@ TEST_F(PredicatePlacementRuleTest, StopPushdownAtDiamondBottomRootNode) {
        ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(5.2, DataType::Float)),
         input_common_node))));
 
-  // We expect the diamond predicates to get pushed below the Projections. However, since the diamond's bottom root node
+  // We expect the diamond predicates to get pushed below the Projections. However, since the diamond's origin node
   // has multiple outputs, predicates are not expected to get pushed down any further.
   const auto expected_common_node =
   PredicateNode::make(greater_than_(_a_a, 1),

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -279,11 +279,11 @@ TEST_F(PredicatePlacementRuleTest, ConsecutiveDiamondPushdownTest) {
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
 
   const auto expected_common_node2 =
-  PredicateNode::make(equals_(_c_b, 10),         // <-- 2nd Predicate after pushdown
+  PredicateNode::make(equals_(_c_b, 10),          // <-- 2nd Predicate after pushdown
     _stored_table_c);
 
   const auto expected_common_node1 =
-  PredicateNode::make(greater_than_(_c_a, 1000), // <-- 1st Predicate after pushdown
+  PredicateNode::make(greater_than_(_c_a, 1000),  // <-- 1st Predicate after pushdown
     UnionNode::make(SetOperationMode::Positions,
       ProjectionNode::make(expression_vector(_c_a, _c_b, cast_(11, DataType::Float)),
         PredicateNode::make(like_(_c_a, "%woman%"),


### PR DESCRIPTION
I have juggled around with JOB query plans and noticed that semi-join pushdowns are often blocked by diamond structures, involving `UnionNode`. Therefore, I changed the `PredicatePlacementRule` to allow for predicate pushdown through Union-based diamonds.

## Results

* TPC-H results stay unchanged

* JOB benchmark benefits heavily (~25%), mainly due to semi-joins getting pushed below Union-Like-Like diamonds.

* TPC-DS Q28 gains a boost of ~400%. 

**System**
<details>
<summary>pella - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | pella |
| CPU | Intel(R) Xeon(R) CPU E7- 8870  @ 2.40GHz |
| Memory | 1.5TB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 02e587e5c | 18.04.2022 12:37 | Jenkinsfile: Add root repository and submodule repositories as safe directories (#2449) | real 753.51 user 4989.21 sys 229.50|
| e27e1262f | 21.04.2022 22:42 | Improve code... | real 711.15 user 4273.85 sys 175.94|


**hyriseBenchmarkTPCH - single-threaded, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: -1%
 || 
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_02e587e5cc28cfd259325df3b94d0092d0e06133_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_e27e1262f9bb48af51d898c9801ab1149e7446f2_st.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                             | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  clustering              | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  data_preparation_cores  | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2022-04-21 23:06:28                                                                                                                        | 2022-04-22 03:25:18                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | 100                                                                                                                                        | 100                                                                                                                                        |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 1000000000                                                                                                                                 | 1000000000                                                                                                                                 |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||  10945.5 | 10820.0 |   -1%  ||     0.09 |     0.09 |   +1%  |       ˅ |
 | TPC-H 02 ||     87.8 |    87.0 |   -1%˄ ||    11.39 |    11.49 |   +1%˄ |  0.4231 |
 | TPC-H 03 ||   4145.6 |  4156.4 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8030 |
 | TPC-H 04 ||   3073.4 |  3025.6 |   -2%  ||     0.33 |     0.33 |   +2%  |  0.0237 |
 | TPC-H 05 ||   6566.0 |  6483.1 |   -1%  ||     0.15 |     0.15 |   +1%  |  0.0145 |
 | TPC-H 06 ||    373.9 |   372.6 |   -0%˄ ||     2.67 |     2.68 |   +0%˄ |  0.6467 |
 | TPC-H 07 ||   1843.5 |  1817.9 |   -1%  ||     0.54 |     0.55 |   +1%  |  0.0000 |
 | TPC-H 08 ||   1515.2 |  1492.5 |   -1%  ||     0.66 |     0.67 |   +2%  |  0.0000 |
 | TPC-H 09 ||  11301.0 | 11297.1 |   -0%  ||     0.09 |     0.09 |   +0%  |       ˅ |
 | TPC-H 10 ||   4634.9 |  4562.3 |   -2%  ||     0.22 |     0.22 |   +2%  |  0.1165 |
 | TPC-H 11 ||    193.8 |   191.6 |   -1%˄ ||     5.16 |     5.22 |   +1%˄ |  0.0354 |
 | TPC-H 12 ||   2044.4 |  2011.9 |   -2%  ||     0.49 |     0.50 |   +2%  |  0.0000 |
 | TPC-H 13 ||  10639.0 | 10646.2 |   +0%  ||     0.09 |     0.09 |   -0%  |       ˅ |
 | TPC-H 14 ||    936.8 |   935.4 |   -0%  ||     1.07 |     1.07 |   +0%  |  0.5560 |
 | TPC-H 15 ||    484.1 |   479.7 |   -1%˄ ||     2.07 |     2.08 |   +1%˄ |  0.0000 |
 | TPC-H 16 ||   1336.9 |  1347.1 |   +1%  ||     0.75 |     0.74 |   -1%  |  0.0199 |
 | TPC-H 17 ||    557.2 |   555.9 |   -0%˄ ||     1.79 |     1.80 |   +0%˄ |  0.0109 |
 | TPC-H 18 ||   5128.4 |  5009.0 |   -2%  ||     0.19 |     0.20 |   +2%  |  0.0470 |
 | TPC-H 19 ||    673.6 |   672.3 |   -0%  ||     1.48 |     1.49 |   +0%  |  0.6678 |
 | TPC-H 20 ||    887.9 |   878.6 |   -1%  ||     1.13 |     1.14 |   +1%  |  0.3944 |
 | TPC-H 21 ||  10037.8 |  9980.0 |   -1%  ||     0.10 |     0.10 |   +1%  |       ˅ |
 | TPC-H 22 ||    969.6 |   958.8 |   -1%  ||     1.03 |     1.04 |   +1%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  78376.4 | 77781.3 |   -1%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |    Notes || ˄ Execution stopped due to max runs reached                           |
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: +4%
 || 
Geometric mean of throughput changes: -5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_02e587e5cc28cfd259325df3b94d0092d0e06133_st_s01.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_e27e1262f9bb48af51d898c9801ab1149e7446f2_st_s01.json |
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                                 | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                                 |
 |  benchmark_mode          | Ordered                                                                                                                                        | Ordered                                                                                                                                        |
 |  build_type              | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_size              | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                 | 1                                                                                                                                              | 1                                                                                                                                              |
 |  clustering              | None                                                                                                                                           | None                                                                                                                                           |
 |  compiler                | gcc 9.2                                                                                                                                        | gcc 9.2                                                                                                                                        |
 |  cores                   | 0                                                                                                                                              | 0                                                                                                                                              |
 |  data_preparation_cores  | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                    | 2022-04-21 23:31:25                                                                                                                            | 2022-04-22 03:50:30                                                                                                                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                        | {'default': {'encoding': 'Dictionary'}}                                                                                                        |
 |  indexes                 | False                                                                                                                                          | False                                                                                                                                          |
 |  max_duration            | 60000000000                                                                                                                                    | 60000000000                                                                                                                                    |
 |  max_runs                | 100                                                                                                                                            | 100                                                                                                                                            |
 |  scale_factor            | 0.009999999776482582                                                                                                                           | 0.009999999776482582                                                                                                                           |
 |  time_unit               | ns                                                                                                                                             | ns                                                                                                                                             |
 |  use_prepared_statements | False                                                                                                                                          | False                                                                                                                                          |
 |  using_scheduler         | False                                                                                                                                          | False                                                                                                                                          |
 |  verify                  | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration         | 1000000000                                                                                                                                     | 1000000000                                                                                                                                     |
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||     10.7 |    10.8 |   +1%˄ ||    93.18 |    92.40 |   -1%˄ |  0.0744 |
 | TPC-H 02 ||      9.6 |     9.6 |   +0%˄ ||   104.58 |   104.08 |   -0%˄ |  0.8983 |
 | TPC-H 03 ||      1.5 |     1.5 |   +1%˄ ||   651.08 |   644.31 |   -1%˄ |  0.8365 |
 | TPC-H 04 ||      1.0 |     1.0 |   -1%˄ ||  1020.63 |  1030.81 |   +1%˄ |  0.0495 |
 | TPC-H 05 ||      2.2 |     2.2 |   -1%˄ ||   445.76 |   448.64 |   +1%˄ |  0.4386 |
 | TPC-H 06 ||      0.5 |     0.5 |   -1%˄ ||  2149.98 |  2166.78 |   +1%˄ |  0.1868 |
 | TPC-H 07 ||     22.3 |    23.2 |   +4%˄ ||    44.85 |    43.11 |   -4%˄ |  0.4242 |
 | TPC-H 08 ||     26.2 |    26.2 |   -0%˄ ||    38.10 |    38.20 |   +0%˄ |  0.9127 |
 | TPC-H 09 ||      9.4 |     9.0 |   -4%˄ ||   106.73 |   111.52 |   +4%˄ |  0.7334 |
 | TPC-H 10 ||      1.4 |     1.5 |   +0%˄ ||   689.18 |   687.31 |   -0%˄ |  0.4998 |
 | TPC-H 11 ||      0.5 |     0.5 |   +1%˄ ||  2166.67 |  2144.76 |   -1%˄ |  0.3422 |
-| TPC-H 12 ||      1.7 |     1.8 |   +6%˄ ||   604.27 |   570.03 |   -6%˄ |  0.4802 |
-| TPC-H 13 ||      3.3 |     3.8 |  +16%˄ ||   302.91 |   261.06 |  -14%˄ |  0.0000 |
-| TPC-H 14 ||      0.6 |     0.7 |  +12%˄ ||  1559.45 |  1396.05 |  -10%˄ |  0.0000 |
-| TPC-H 15 ||      2.2 |     2.4 |  +12%˄ ||   463.19 |   413.57 |  -11%˄ |  0.0000 |
-| TPC-H 16 ||      3.5 |     4.0 |  +14%˄ ||   285.15 |   249.16 |  -13%˄ |  0.0000 |
-| TPC-H 17 ||      1.7 |     2.3 |  +29%˄ ||   571.62 |   441.86 |  -23%˄ |  0.0014 |
-| TPC-H 18 ||      2.8 |     3.2 |  +14%˄ ||   352.61 |   310.32 |  -12%˄ |  0.0000 |
-| TPC-H 19 ||     12.6 |    14.4 |  +14%˄ ||    79.24 |    69.47 |  -12%˄ |  0.0000 |
 | TPC-H 20 ||      4.4 |     4.6 |   +4%˄ ||   226.25 |   217.06 |   -4%˄ |  0.0215 |
 | TPC-H 21 ||      7.5 |     7.3 |   -3%˄ ||   133.24 |   137.34 |   +3%˄ |  0.0453 |
 | TPC-H 22 ||      2.1 |     2.1 |   -0%˄ ||   478.76 |   478.82 |   +0%˄ |  0.9512 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||    127.8 |   132.4 |   +4%  ||          |          |        |         |
-| Geomean  ||          |         |        ||          |          |   -5%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |    Notes || ˄ Execution stopped due to max runs reached                           |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, ordered, 1 client, 10 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +2%
 || 
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_02e587e5cc28cfd259325df3b94d0092d0e06133_mt_ordered.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_e27e1262f9bb48af51d898c9801ab1149e7446f2_mt_ordered.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                                     | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                                     |
 |  benchmark_mode               | Ordered                                                                                                                                            | Ordered                                                                                                                                            |
 |  build_type                   | release                                                                                                                                            | release                                                                                                                                            |
 |  chunk_size                   | 65535                                                                                                                                              | 65535                                                                                                                                              |
 |  clients                      | 1                                                                                                                                                  | 1                                                                                                                                                  |
 |  clustering                   | None                                                                                                                                               | None                                                                                                                                               |
 |  compiler                     | gcc 9.2                                                                                                                                            | gcc 9.2                                                                                                                                            |
 |  cores                        | 10                                                                                                                                                 | 10                                                                                                                                                 |
 |  data_preparation_cores       | 0                                                                                                                                                  | 0                                                                                                                                                  |
 |  date                         | 2022-04-21 23:32:00                                                                                                                                | 2022-04-22 03:51:05                                                                                                                                |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                            | {'default': {'encoding': 'Dictionary'}}                                                                                                            |
 |  indexes                      | False                                                                                                                                              | False                                                                                                                                              |
 |  max_duration                 | 60000000000                                                                                                                                        | 60000000000                                                                                                                                        |
 |  max_runs                     | -1                                                                                                                                                 | -1                                                                                                                                                 |
 |  scale_factor                 | 10.0                                                                                                                                               | 10.0                                                                                                                                               |
 |  time_unit                    | ns                                                                                                                                                 | ns                                                                                                                                                 |
 |  use_prepared_statements      | False                                                                                                                                              | False                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                               | True                                                                                                                                               |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                         | [0, 0, 10]                                                                                                                                         |
 |  verify                       | False                                                                                                                                              | False                                                                                                                                              |
 |  warmup_duration              | 0                                                                                                                                                  | 0                                                                                                                                                  |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
-| TPC-H 01 ||   9541.8 | 10317.3 |   +8%  ||     0.10 |     0.08 |  -17%  | (run time too short) |
 | TPC-H 02 ||     61.4 |    61.8 |   +1%  ||    15.08 |    14.97 |   -1%  |               0.4551 |
 | TPC-H 03 ||   1485.7 |  1464.0 |   -1%  ||     0.67 |     0.67 |   -0%  | (run time too short) |
 | TPC-H 04 ||   1030.0 |  1019.4 |   -1%  ||     0.95 |     0.97 |   +2%  | (run time too short) |
 | TPC-H 05 ||   1908.6 |  1927.3 |   +1%  ||     0.52 |     0.52 |   -0%  |               0.5093 |
 | TPC-H 06 ||     86.2 |    86.6 |   +0%  ||    10.68 |    10.62 |   -1%  |               0.3292 |
 | TPC-H 07 ||    673.3 |   667.7 |   -1%  ||     1.47 |     1.48 |   +1%  |               0.1160 |
 | TPC-H 08 ||    520.6 |   516.4 |   -1%  ||     1.90 |     1.92 |   +1%  |               0.0911 |
 | TPC-H 09 ||   5292.7 |  5312.5 |   +0%  ||     0.18 |     0.18 |   +0%  | (run time too short) |
 | TPC-H 10 ||   2425.3 |  2385.2 |   -2%  ||     0.40 |     0.42 |   +4%  | (run time too short) |
 | TPC-H 11 ||    140.2 |   139.6 |   -0%  ||     6.88 |     6.90 |   +0%  |               0.1952 |
 | TPC-H 12 ||    838.7 |   831.8 |   -1%  ||     1.18 |     1.18 |   -0%  |               0.0656 |
 | TPC-H 13 ||   7946.9 |  7981.4 |   +0%  ||     0.12 |     0.12 |   -0%  | (run time too short) |
 | TPC-H 14 ||    288.4 |   289.1 |   +0%  ||     3.40 |     3.40 |   +0%  |               0.3345 |
 | TPC-H 15 ||    309.9 |   308.9 |   -0%  ||     3.17 |     3.18 |   +1%  |               0.0219 |
 | TPC-H 16 ||   1119.1 |  1122.9 |   +0%  ||     0.88 |     0.88 |   +0%  |               0.7444 |
 | TPC-H 17 ||    159.4 |   159.2 |   -0%  ||     6.10 |     6.12 |   +0%  |               0.7165 |
 | TPC-H 18 ||   5259.3 |  5189.2 |   -1%  ||     0.18 |     0.18 |   +0%  | (run time too short) |
 | TPC-H 19 ||    240.3 |   237.4 |   -1%  ||     4.05 |     4.08 |   +1%  |               0.0041 |
 | TPC-H 20 ||    346.2 |   349.5 |   +1%  ||     2.83 |     2.82 |   -1%  |               0.1976 |
 | TPC-H 21 ||   2018.1 |  2011.6 |   -0%  ||     0.48 |     0.48 |   +0%  | (run time too short) |
 | TPC-H 22 ||    262.3 |   260.7 |   -1%  ||     3.73 |     3.75 |   +0%  |               0.0515 |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum      ||  41954.2 | 42639.6 |   +2%  ||          |          |        |                      |
 | Geomean  ||          |         |        ||          |          |   -0%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, shuffled, 10 clients, 10 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: -2%
 || 
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_02e587e5cc28cfd259325df3b94d0092d0e06133_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_e27e1262f9bb48af51d898c9801ab1149e7446f2_mt.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                             | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                             |
 |  benchmark_mode               | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type                   | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                      | 10                                                                                                                                         | 10                                                                                                                                         |
 |  clustering                   | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                     | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                        | 10                                                                                                                                         | 10                                                                                                                                         |
 |  data_preparation_cores       | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                         | 2022-04-21 23:57:33                                                                                                                        | 2022-04-22 04:16:31                                                                                                                        |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                      | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration                 | 1200000000000                                                                                                                              | 1200000000000                                                                                                                              |
 |  max_runs                     | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor                 | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit                    | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements      | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                       | True                                                                                                                                       |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                 | [0, 0, 10]                                                                                                                                 |
 |  verify                       | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration              | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||  13169.7 |  13581.0 |   +3%  ||     0.07 |     0.07 |   -0%  |               0.4617 |
+| TPC-H 02 ||    689.4 |    311.2 |  -55%  ||     0.07 |     0.07 |   +1%  | (run time too short) |
 | TPC-H 03 ||   6249.2 |   6346.8 |   +2%  ||     0.07 |     0.07 |   +1%  |               0.9039 |
-| TPC-H 04 ||   5300.6 |   5991.5 |  +13%  ||     0.07 |     0.07 |   +1%  |               0.4446 |
 | TPC-H 05 ||  11093.6 |  11023.1 |   -1%  ||     0.07 |     0.07 |   +1%  |               0.9603 |
-| TPC-H 06 ||    726.4 |   1179.7 |  +62%  ||     0.07 |     0.07 |   +2%  |               0.1156 |
+| TPC-H 07 ||   5543.4 |   4264.8 |  -23%  ||     0.07 |     0.07 |   +1%  |               0.1022 |
+| TPC-H 08 ||   4930.0 |   3660.8 |  -26%  ||     0.07 |     0.07 |   +1%  |               0.1014 |
-| TPC-H 09 ||  14856.8 |  16515.3 |  +11%  ||     0.07 |     0.07 |   -0%  |               0.1517 |
+| TPC-H 10 ||   9278.6 |   8810.7 |   -5%  ||     0.07 |     0.07 |   +2%  |               0.6425 |
+| TPC-H 11 ||   1086.2 |    816.0 |  -25%  ||     0.07 |     0.07 |   +2%  |               0.3906 |
-| TPC-H 12 ||   4683.3 |   5494.6 |  +17%  ||     0.07 |     0.07 |   +1%  |               0.3482 |
+| TPC-H 13 ||  14683.7 |  14006.1 |   -5%  ||     0.07 |     0.07 |   +2%  |               0.2512 |
+| TPC-H 14 ||   2091.2 |   1901.3 |   -9%  ||     0.07 |     0.07 |   +1%  |               0.6636 |
-| TPC-H 15 ||    883.8 |   1002.8 |  +13%  ||     0.07 |     0.07 |   +1%  |               0.1592 |
+| TPC-H 16 ||   4451.0 |   3882.6 |  -13%  ||     0.07 |     0.07 |   +1%  |               0.4224 |
-| TPC-H 17 ||   1086.4 |   1434.6 |  +32%  ||     0.07 |     0.07 |   -0%  |               0.3490 |
 | TPC-H 18 ||   7924.1 |   7839.2 |   -1%  ||     0.07 |     0.07 |   +1%  |               0.8269 |
+| TPC-H 19 ||   2138.5 |   1558.0 |  -27%  ||     0.07 |     0.07 |   +1%  |               0.2614 |
 | TPC-H 20 ||   2450.3 |   2397.0 |   -2%  ||     0.07 |     0.07 |   +1%  |               0.9012 |
+| TPC-H 21 ||  13181.4 |  12410.9 |   -6%  ||     0.07 |     0.07 |   -0%  |               0.4909 |
+| TPC-H 22 ||   2655.7 |   2290.9 |  -14%  ||     0.07 |     0.07 |   -0%  |               0.6120 |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum      || 129153.4 | 126718.9 |   -2%  ||          |          |        |                      |
 | Geomean  ||          |          |        ||          |          |   +1%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -6%
 || 
Geometric mean of throughput changes: +3%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_02e587e5cc28cfd259325df3b94d0092d0e06133_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_e27e1262f9bb48af51d898c9801ab1149e7446f2_st.json |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                              | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                              |
 |  benchmark_mode         | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type             | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size             | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler               | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                  | 0                                                                                                                                           | 0                                                                                                                                           |
 |  data_preparation_cores | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                   | 2022-04-22 00:20:48                                                                                                                         | 2022-04-22 04:39:49                                                                                                                         |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration           | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs               | 100                                                                                                                                         | 100                                                                                                                                         |
 |  time_unit              | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler        | False                                                                                                                                       | False                                                                                                                                       |
 |  verify                 | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration        | 1000000000                                                                                                                                  | 1000000000                                                                                                                                  |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | 01      ||    454.3 |   456.0 |   +0%˄ ||     2.20 |     2.19 |   -0%˄ |  0.4698 |
 | 03      ||    170.4 |   170.3 |   -0%˄ ||     5.87 |     5.87 |   +0%˄ |  0.7729 |
 | 06      ||    338.9 |   335.3 |   -1%˄ ||     2.95 |     2.98 |   +1%˄ |  0.0108 |
 | 07      ||    586.9 |   593.7 |   +1%˄ ||     1.70 |     1.68 |   -1%˄ |  0.0104 |
-| 09      ||   2018.0 |  2114.7 |   +5%  ||     0.50 |     0.47 |   -5%  |  0.0000 |
 | 10      ||    287.9 |   288.5 |   +0%˄ ||     3.47 |     3.47 |   -0%˄ |  0.4856 |
 | 13      ||    884.2 |   875.1 |   -1%  ||     1.13 |     1.14 |   +1%  |  0.0000 |
 | 15      ||    233.7 |   226.6 |   -3%˄ ||     4.28 |     4.41 |   +3%˄ |  0.0000 |
 | 16      ||    331.3 |   335.1 |   +1%˄ ||     3.02 |     2.98 |   -1%˄ |  0.0002 |
 | 17      ||    786.9 |   788.2 |   +0%  ||     1.27 |     1.27 |   -0%  |  0.1607 |
 | 19      ||    205.0 |   207.2 |   +1%˄ ||     4.88 |     4.83 |   -1%˄ |  0.0000 |
 | 25      ||    338.9 |   345.2 |   +2%˄ ||     2.95 |     2.90 |   -2%˄ |  0.0000 |
 | 26      ||    251.7 |   256.2 |   +2%˄ ||     3.97 |     3.90 |   -2%˄ |  0.0000 |
+| 28      ||   6655.9 |  1347.2 |  -80%  ||     0.15 |     0.74 | +394%  |  0.0000 |
 | 29      ||   1060.9 |  1062.9 |   +0%  ||     0.94 |     0.94 |   -0%  |  0.3449 |
 | 31      ||   2828.8 |  2854.2 |   +1%  ||     0.35 |     0.35 |   -1%  |  0.0000 |
 | 32      ||     95.1 |    96.3 |   +1%˄ ||    10.52 |    10.38 |   -1%˄ |  0.0003 |
 | 34      ||    314.3 |   327.2 |   +4%˄ ||     3.18 |     3.06 |   -4%˄ |  0.0000 |
 | 35      ||   1309.4 |  1323.6 |   +1%  ||     0.76 |     0.76 |   -1%  |  0.0000 |
 | 37      ||    607.2 |   607.9 |   +0%  ||     1.65 |     1.65 |   -0%  |  0.7423 |
 | 39a     ||   4149.6 |  4165.6 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.3400 |
 | 39b     ||   4158.1 |  4155.2 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.8550 |
 | 41      ||    649.6 |   631.8 |   -3%  ||     1.54 |     1.58 |   +3%  |  0.0000 |
 | 42      ||    167.6 |   169.3 |   +1%˄ ||     5.97 |     5.91 |   -1%˄ |  0.0000 |
 | 43      ||   1896.9 |  1882.6 |   -1%  ||     0.53 |     0.53 |   +1%  |  0.0006 |
 | 45      ||    230.2 |   226.8 |   -1%˄ ||     4.34 |     4.41 |   +1%˄ |  0.0000 |
 | 48      ||   2009.1 |  2045.3 |   +2%  ||     0.50 |     0.49 |   -2%  |  0.0000 |
 | 50      ||    235.2 |   236.2 |   +0%˄ ||     4.25 |     4.23 |   -0%˄ |  0.0010 |
 | 52      ||    167.8 |   168.4 |   +0%˄ ||     5.96 |     5.94 |   -0%˄ |  0.0028 |
 | 55      ||    162.4 |   162.9 |   +0%˄ ||     6.16 |     6.14 |   -0%˄ |  0.0263 |
 | 62      ||   1154.1 |  1158.8 |   +0%  ||     0.87 |     0.86 |   -0%  |  0.0083 |
 | 65      ||   3867.7 |  3871.0 |   +0%  ||     0.26 |     0.26 |   -0%  |  0.7989 |
 | 69      ||    265.2 |   266.1 |   +0%˄ ||     3.77 |     3.76 |   -0%˄ |  0.1175 |
 | 73      ||    172.5 |   173.3 |   +0%˄ ||     5.80 |     5.77 |   -0%˄ |  0.0196 |
 | 79      ||   1084.1 |  1093.4 |   +1%  ||     0.92 |     0.91 |   -1%  |  0.0000 |
 | 81      ||    422.1 |   428.5 |   +2%˄ ||     2.37 |     2.33 |   -1%˄ |  0.0000 |
 | 82      ||    802.3 |   803.1 |   +0%  ||     1.25 |     1.25 |   -0%  |  0.7832 |
 | 83      ||     84.8 |    85.0 |   +0%˄ ||    11.80 |    11.76 |   -0%˄ |  0.6857 |
+| 85      ||    570.8 |   544.9 |   -5%˄ ||     1.75 |     1.84 |   +5%˄ |  0.0000 |
 | 88      ||   1362.0 |  1389.4 |   +2%  ||     0.73 |     0.72 |   -2%  |  0.0000 |
 | 91      ||     43.0 |    41.5 |   -3%˄ ||    23.25 |    24.06 |   +3%˄ |  0.0000 |
 | 92      ||     92.2 |    91.8 |   -0%˄ ||    10.84 |    10.89 |   +0%˄ |  0.3070 |
 | 93      ||   7731.4 |  7724.4 |   -0%  ||     0.13 |     0.13 |   +0%  |       ˅ |
 | 94      ||    215.6 |   217.6 |   +1%˄ ||     4.64 |     4.60 |   -1%˄ |  0.0044 |
 | 95      ||  20804.0 | 20811.5 |   +0%  ||     0.05 |     0.05 |   -0%  |       ˅ |
 | 96      ||    136.0 |   136.1 |   +0%˄ ||     7.35 |     7.35 |   -0%˄ |  0.9431 |
 | 97      ||   7632.7 |  7653.7 |   +0%  ||     0.13 |     0.13 |   -0%  |       ˅ |
 | 99      ||   2189.0 |  2193.6 |   +0%  ||     0.46 |     0.46 |   -0%  |  0.3031 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
+| Sum     ||  82215.4 | 77139.6 |   -6%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +3%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 |   Notes || ˄ Execution stopped due to max runs reached                           |
 |         || ˅ Insufficient number of runs for p-value calculation                 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, shuffled, 10 clients, 10 cores**
<details>
<summary>
Sum of avg. item runtimes: -11%
 || 
Geometric mean of throughput changes: +14%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_02e587e5cc28cfd259325df3b94d0092d0e06133_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_e27e1262f9bb48af51d898c9801ab1149e7446f2_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                              | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                              |
 |  benchmark_mode               | Shuffled                                                                                                                                    | Shuffled                                                                                                                                    |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 10                                                                                                                                          | 10                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 10                                                                                                                                          | 10                                                                                                                                          |
 |  data_preparation_cores       | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2022-04-22 00:56:54                                                                                                                         | 2022-04-22 05:15:49                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 1200000000000                                                                                                                               | 1200000000000                                                                                                                               |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                  | [0, 0, 10]                                                                                                                                  |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| 01      ||   1399.9 |   1449.4 |   +4%  ||     0.06 |     0.07 |  +12%  |               0.8633 |
+| 03      ||    881.0 |    521.3 |  -41%  ||     0.06 |     0.07 |  +12%  | (run time too short) |
+| 06      ||    982.9 |   1643.5 |  +67%  ||     0.06 |     0.07 |  +13%  |               0.0449 |
+| 07      ||   1714.7 |   1555.8 |   -9%  ||     0.06 |     0.07 |  +15%  |               0.7113 |
+| 09      ||   4181.5 |   3829.9 |   -8%  ||     0.06 |     0.07 |  +14%  |               0.2737 |
+| 10      ||    914.0 |    886.2 |   -3%  ||     0.06 |     0.07 |  +15%  |               0.9191 |
+| 13      ||   3840.8 |   4470.5 |  +16%  ||     0.06 |     0.07 |  +15%  |               0.3482 |
+| 15      ||    795.6 |   1234.1 |  +55%  ||     0.06 |     0.07 |  +15%  | (run time too short) |
+| 16      ||   1866.4 |   1240.9 |  -34%  ||     0.06 |     0.07 |  +13%  |               0.2059 |
+| 17      ||   3475.7 |   2710.6 |  -22%  ||     0.06 |     0.07 |  +14%  |               0.2823 |
+| 19      ||    624.6 |    740.3 |  +19%  ||     0.06 |     0.07 |  +13%  | (run time too short) |
+| 25      ||   1623.0 |   1966.2 |  +21%  ||     0.06 |     0.07 |  +12%  |               0.5459 |
+| 26      ||    863.8 |    662.0 |  -23%  ||     0.06 |     0.07 |  +13%  | (run time too short) |
+| 28      ||   6578.8 |   1224.6 |  -81%  ||     0.06 |     0.07 |  +15%  |               0.0000 |
+| 29      ||   3578.9 |   3245.6 |   -9%  ||     0.06 |     0.07 |  +14%  |               0.6769 |
+| 31      ||   4210.0 |   3142.2 |  -25%  ||     0.06 |     0.07 |  +15%  |               0.0516 |
+| 32      ||    294.7 |   1124.8 | +282%  ||     0.06 |     0.07 |  +14%  | (run time too short) |
+| 34      ||   1572.4 |   1693.1 |   +8%  ||     0.06 |     0.07 |  +15%  |               0.8379 |
+| 35      ||   5267.8 |   4254.2 |  -19%  ||     0.06 |     0.07 |  +14%  |               0.2805 |
+| 37      ||   1246.2 |    896.3 |  -28%  ||     0.06 |     0.07 |  +13%  |               0.1510 |
+| 39a     ||   5257.0 |   5680.7 |   +8%  ||     0.06 |     0.07 |  +15%  |               0.5101 |
+| 39b     ||   6055.9 |   5307.0 |  -12%  ||     0.06 |     0.07 |  +14%  |               0.3001 |
+| 41      ||   4642.1 |   4256.1 |   -8%  ||     0.06 |     0.07 |  +13%  |               0.5193 |
+| 42      ||   1158.3 |    607.7 |  -48%  ||     0.06 |     0.07 |  +13%  | (run time too short) |
+| 43      ||   3874.2 |   3200.0 |  -17%  ||     0.06 |     0.07 |  +13%  |               0.2108 |
+| 45      ||   1338.1 |   1145.6 |  -14%  ||     0.06 |     0.07 |  +14%  |               0.6420 |
+| 48      ||   5380.5 |   4891.7 |   -9%  ||     0.06 |     0.07 |  +14%  |               0.4993 |
+| 50      ||    844.2 |    810.4 |   -4%  ||     0.06 |     0.07 |  +15%  |               0.8182 |
+| 52      ||   1112.9 |    564.0 |  -49%  ||     0.06 |     0.07 |  +15%  | (run time too short) |
+| 55      ||    714.7 |    456.6 |  -36%  ||     0.06 |     0.07 |  +15%  | (run time too short) |
+| 62      ||   2279.8 |   2669.2 |  +17%  ||     0.06 |     0.07 |  +13%  |               0.3833 |
+| 65      ||   8655.6 |   7858.9 |   -9%  ||     0.06 |     0.07 |  +14%  |               0.1694 |
+| 69      ||    914.3 |    843.7 |   -8%  ||     0.06 |     0.07 |  +13%  |               0.7871 |
+| 73      ||    581.7 |   1056.8 |  +82%  ||     0.06 |     0.07 |  +15%  | (run time too short) |
+| 79      ||   3733.8 |   2790.6 |  -25%  ||     0.06 |     0.07 |  +15%  |               0.2181 |
+| 81      ||   1269.1 |   1460.3 |  +15%  ||     0.06 |     0.07 |  +15%  |               0.3673 |
+| 82      ||   1782.3 |   2279.0 |  +28%  ||     0.06 |     0.07 |  +12%  |               0.2960 |
+| 83      ||    895.3 |   1195.8 |  +34%  ||     0.06 |     0.07 |  +15%  |               0.6298 |
+| 85      ||   3302.5 |   2900.9 |  -12%  ||     0.06 |     0.07 |  +15%  |               0.6614 |
+| 88      ||   2241.0 |   2023.8 |  -10%  ||     0.06 |     0.07 |  +12%  |               0.6707 |
+| 91      ||    902.4 |    437.7 |  -51%  ||     0.06 |     0.07 |  +13%  | (run time too short) |
+| 92      ||    635.7 |    623.0 |   -2%  ||     0.06 |     0.07 |  +14%  | (run time too short) |
+| 93      ||   7236.1 |   6508.1 |  -10%  ||     0.06 |     0.07 |  +14%  |               0.3739 |
+| 94      ||   1737.6 |    673.1 |  -61%  ||     0.06 |     0.07 |  +13%  | (run time too short) |
+| 95      ||  22927.6 |  20788.2 |   -9%  ||     0.06 |     0.07 |  +14%  |               0.0453 |
+| 96      ||    699.2 |    353.5 |  -49%  ||     0.06 |     0.07 |  +13%  | (run time too short) |
+| 97      ||  10633.2 |  10810.1 |   +2%  ||     0.06 |     0.07 |  +15%  |               0.8447 |
+| 99      ||   3610.1 |   3312.2 |   -8%  ||     0.06 |     0.07 |  +15%  |               0.3745 |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| Sum     || 150328.1 | 133996.1 |  -11%  ||          |          |        |                      |
+| Geomean ||          |          |        ||          |          |  +14%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -1%
 || 
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_02e587e5cc28cfd259325df3b94d0092d0e06133_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_e27e1262f9bb48af51d898c9801ab1149e7446f2_st.json |
 +-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                             | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                             |
 |  benchmark_mode         | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type             | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size             | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler               | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                  | 0                                                                                                                                          | 0                                                                                                                                          |
 |  data_preparation_cores | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                   | 2022-04-22 01:17:51                                                                                                                        | 2022-04-22 05:36:47                                                                                                                        |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration           | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs               | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor           | 1                                                                                                                                          | 1                                                                                                                                          |
 |  time_unit              | ns                                                                                                                                         | ns                                                                                                                                         |
 |  using_scheduler        | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                 | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration        | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||     54.4 |    54.2 |   -0%  ||     1.73 |     1.73 |   -0%  |  0.4889 |
 | New-Order    ||     40.8 |    40.3 |   -1%  ||    19.61 |    19.83 |   +1%  |  0.3334 |
 | Order-Status ||      2.4 |     2.4 |   +1%  ||     1.73 |     1.78 |   +3%  |  0.3987 |
 | Payment      ||      4.7 |     4.7 |   +0%  ||    18.71 |    18.93 |   +1%  |  0.9786 |
 | Stock-Level  ||      6.3 |     6.2 |   -0%  ||     1.73 |     1.77 |   +2%  |  0.7480 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    108.6 |   107.9 |   -1%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +1%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 10 clients, 10 cores**
<details>
<summary>
Sum of avg. item runtimes: +3%
 || 
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_02e587e5cc28cfd259325df3b94d0092d0e06133_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_e27e1262f9bb48af51d898c9801ab1149e7446f2_mt.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                             | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                             |
 |  benchmark_mode               | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type                   | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                      | 10                                                                                                                                         | 10                                                                                                                                         |
 |  compiler                     | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                        | 10                                                                                                                                         | 10                                                                                                                                         |
 |  data_preparation_cores       | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                         | 2022-04-22 01:18:52                                                                                                                        | 2022-04-22 05:37:49                                                                                                                        |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                      | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration                 | 1200000000000                                                                                                                              | 1200000000000                                                                                                                              |
 |  max_runs                     | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                         | ns                                                                                                                                         |
 |  using_scheduler              | True                                                                                                                                       | True                                                                                                                                       |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                 | [0, 0, 10]                                                                                                                                 |
 |  verify                       | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration              | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    282.1 |   293.2 |   +4%  ||     2.91 |     2.83 |   -3%  |  0.0027 |
 |    unsucc.:  ||      4.6 |     4.8 |   +6%  ||     8.65 |     8.70 |   +1%  |         |
 | New-Order    ||    102.9 |   102.7 |   -0%  ||    55.35 |    54.86 |   -1%  |  0.6679 |
 |    unsucc.:  ||      5.6 |     6.2 |  +12%  ||    74.72 |    74.82 |   +0%  |         |
 | Order-Status ||     11.5 |    12.0 |   +4%  ||    11.56 |    11.53 |   -0%  |  0.0490 |
 | Payment      ||     13.7 |    13.6 |   -1%  ||    24.23 |    24.09 |   -1%  |  0.4879 |
 |    unsucc.:  ||      4.0 |     4.2 |   +5%  ||   100.06 |    99.83 |   -0%  |         |
 | Stock-Level  ||     21.8 |    22.8 |   +4%  ||    11.56 |    11.53 |   -0%  |  0.0046 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    431.9 |   444.3 |   +3%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   -1%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -19%
 || 
Geometric mean of throughput changes: +26%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_02e587e5cc28cfd259325df3b94d0092d0e06133_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_e27e1262f9bb48af51d898c9801ab1149e7446f2_st.json |
 +-------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                                  | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                                  |
 |  benchmark_mode         | Ordered                                                                                                                                         | Ordered                                                                                                                                         |
 |  build_type             | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_size             | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                | 1                                                                                                                                               | 1                                                                                                                                               |
 |  compiler               | gcc 9.2                                                                                                                                         | gcc 9.2                                                                                                                                         |
 |  cores                  | 0                                                                                                                                               | 0                                                                                                                                               |
 |  data_preparation_cores | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                   | 2022-04-22 01:38:56                                                                                                                             | 2022-04-22 05:57:53                                                                                                                             |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  indexes                | False                                                                                                                                           | False                                                                                                                                           |
 |  max_duration           | 60000000000                                                                                                                                     | 60000000000                                                                                                                                     |
 |  max_runs               | 100                                                                                                                                             | 100                                                                                                                                             |
 |  time_unit              | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler        | False                                                                                                                                           | False                                                                                                                                           |
 |  verify                 | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration        | 1000000000                                                                                                                                      | 1000000000                                                                                                                                      |
 +-------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | 10a     ||    401.1 |   401.2 |   +0%˄ ||     2.49 |     2.49 |   -0%˄ |               0.9607 |
 | 10b     ||    313.7 |   313.9 |   +0%˄ ||     3.19 |     3.19 |   -0%˄ |               0.4885 |
 | 10c     ||    631.4 |   631.9 |   +0%  ||     1.58 |     1.58 |   -0%  |               0.6907 |
+| 11a     ||    119.1 |    43.6 |  -63%˄ ||     8.39 |    22.91 | +173%˄ |               0.0000 |
+| 11b     ||    117.0 |    43.2 |  -63%˄ ||     8.55 |    23.17 | +171%˄ |               0.0000 |
+| 11c     ||    112.2 |    54.7 |  -51%˄ ||     8.91 |    18.27 | +105%˄ |               0.0000 |
 | 11d     ||     60.3 |    59.9 |   -1%˄ ||    16.59 |    16.68 |   +1%˄ |               0.0003 |
+| 12a     ||    115.5 |   106.9 |   -7%˄ ||     8.66 |     9.35 |   +8%˄ |               0.0000 |
+| 12b     ||    179.5 |    78.9 |  -56%˄ ||     5.57 |    12.67 | +127%˄ |               0.0000 |
 | 12c     ||    167.7 |   168.4 |   +0%˄ ||     5.96 |     5.94 |   -0%˄ |               0.0820 |
 | 13a     ||    710.4 |   706.5 |   -1%  ||     1.41 |     1.42 |   +1%  |               0.0001 |
-| 13b     ||    219.5 |   445.8 | +103%˄ ||     4.56 |     2.24 |  -51%˄ |               0.0000 |
-| 13c     ||    155.7 |   356.2 | +129%˄ ||     6.42 |     2.81 |  -56%˄ |               0.0000 |
 | 13d     ||   1404.9 |  1403.6 |   -0%  ||     0.71 |     0.71 |   +0%  |               0.6696 |
 | 14a     ||   1038.6 |  1041.8 |   +0%  ||     0.96 |     0.96 |   -0%  |               0.2231 |
+| 14b     ||    692.4 |   499.6 |  -28%˄ ||     1.44 |     2.00 |  +39%˄ | (run time too short) |
 | 14c     ||   1197.7 |  1199.3 |   +0%  ||     0.83 |     0.83 |   -0%  |               0.5771 |
 | 15a     ||    178.0 |   177.8 |   -0%˄ ||     5.62 |     5.62 |   +0%˄ |               0.7071 |
 | 15b     ||    175.1 |   176.4 |   +1%˄ ||     5.71 |     5.67 |   -1%˄ |               0.0107 |
 | 15c     ||     98.4 |    99.0 |   +1%˄ ||    10.16 |    10.10 |   -1%˄ |               0.0000 |
 | 15d     ||    187.3 |   182.7 |   -2%˄ ||     5.34 |     5.47 |   +3%˄ |               0.0000 |
 | 16a     ||   5165.7 |  5189.8 |   +0%  ||     0.19 |     0.19 |   -0%  |               0.1783 |
 | 16b     ||   7307.2 |  7206.4 |   -1%  ||     0.14 |     0.14 |   +1%  |                    ˅ |
 | 16c     ||   5380.4 |  5371.5 |   -0%  ||     0.19 |     0.19 |   +0%  |               0.5798 |
 | 16d     ||   5347.7 |  5328.8 |   -0%  ||     0.19 |     0.19 |   +0%  |               0.6847 |
 | 17a     ||   1211.2 |  1211.8 |   +0%  ||     0.83 |     0.83 |   -0%  |               0.7306 |
 | 17b     ||    984.8 |   989.6 |   +0%  ||     1.02 |     1.01 |   -0%  |               0.0000 |
 | 17c     ||    941.4 |   942.6 |   +0%  ||     1.06 |     1.06 |   -0%  |               0.2112 |
 | 17d     ||   1080.7 |  1084.0 |   +0%  ||     0.93 |     0.92 |   -0%  |               0.0030 |
 | 17e     ||   3428.0 |  3414.9 |   -0%  ||     0.29 |     0.29 |   +0%  |               0.0617 |
 | 17f     ||   1924.4 |  1917.5 |   -0%  ||     0.52 |     0.52 |   +0%  |               0.0184 |
 | 18a     ||   3693.0 |  3636.0 |   -2%  ||     0.27 |     0.28 |   +2%  |               0.0239 |
 | 18b     ||    304.3 |   308.4 |   +1%˄ ||     3.29 |     3.24 |   -1%˄ |               0.0000 |
 | 18c     ||   1100.9 |  1087.8 |   -1%  ||     0.91 |     0.92 |   +1%  |               0.0000 |
+| 19a     ||   2896.4 |   414.9 |  -86%˄ ||     0.35 |     2.41 | +598%˄ | (run time too short) |
+| 19b     ||   2601.6 |   283.6 |  -89%˄ ||     0.38 |     3.53 | +817%˄ | (run time too short) |
+| 19c     ||   2724.5 |   435.0 |  -84%˄ ||     0.37 |     2.30 | +526%˄ | (run time too short) |
 | 19d     ||   1559.8 |  1524.2 |   -2%  ||     0.64 |     0.66 |   +2%  |               0.0000 |
+| 1a      ||     55.6 |    28.5 |  -49%˄ ||    18.00 |    35.07 |  +95%˄ |               0.0000 |
 | 1b      ||     23.1 |    23.1 |   +0%˄ ||    43.34 |    43.31 |   -0%˄ |               0.8868 |
 | 1c      ||     25.7 |    25.9 |   +1%˄ ||    38.84 |    38.61 |   -1%˄ |               0.1369 |
 | 1d      ||     22.9 |    23.1 |   +1%˄ ||    43.59 |    43.25 |   -1%˄ |               0.0359 |
+| 20a     ||   1336.8 |   829.6 |  -38%  ||     0.75 |     1.21 |  +61%  |               0.0000 |
+| 20b     ||   1099.0 |   528.5 |  -52%˄ ||     0.91 |     1.89 | +108%˄ | (run time too short) |
+| 20c     ||    774.9 |   519.7 |  -33%˄ ||     1.29 |     1.92 |  +49%˄ | (run time too short) |
+| 21a     ||    166.0 |    94.0 |  -43%˄ ||     6.02 |    10.64 |  +77%˄ |               0.0000 |
+| 21b     ||    134.1 |    50.6 |  -62%˄ ||     7.46 |    19.76 | +165%˄ |               0.0000 |
+| 21c     ||    171.1 |    94.9 |  -45%˄ ||     5.84 |    10.54 |  +80%˄ |               0.0000 |
 | 22a     ||    490.0 |   491.3 |   +0%˄ ||     2.04 |     2.04 |   -0%˄ |               0.0761 |
 | 22b     ||    285.3 |   286.0 |   +0%˄ ||     3.50 |     3.50 |   -0%˄ |               0.2143 |
 | 22c     ||   1684.0 |  1694.1 |   +1%  ||     0.59 |     0.59 |   -1%  |               0.0003 |
 | 22d     ||   1832.6 |  1833.1 |   +0%  ||     0.55 |     0.55 |   -0%  |               0.9134 |
 | 23a     ||    108.5 |   108.8 |   +0%˄ ||     9.22 |     9.19 |   -0%˄ |               0.0595 |
 | 23b     ||    122.3 |   122.1 |   -0%˄ ||     8.17 |     8.19 |   +0%˄ |               0.0583 |
-| 23c     ||    119.6 |   133.9 |  +12%˄ ||     8.36 |     7.47 |  -11%˄ |               0.0000 |
+| 24a     ||   2668.7 |   409.3 |  -85%˄ ||     0.37 |     2.44 | +552%˄ | (run time too short) |
+| 24b     ||   2622.8 |   343.7 |  -87%˄ ||     0.38 |     2.91 | +663%˄ | (run time too short) |
 | 25a     ||    608.2 |   607.5 |   -0%  ||     1.64 |     1.65 |   +0%  |               0.1535 |
 | 25b     ||    317.9 |   320.5 |   +1%˄ ||     3.15 |     3.12 |   -1%˄ |               0.0000 |
 | 25c     ||   1956.2 |  1939.3 |   -1%  ||     0.51 |     0.52 |   +1%  |               0.0000 |
+| 26a     ||    707.1 |   431.7 |  -39%˄ ||     1.41 |     2.32 |  +64%˄ | (run time too short) |
+| 26b     ||    643.1 |   360.5 |  -44%˄ ||     1.55 |     2.77 |  +78%˄ | (run time too short) |
+| 26c     ||    803.7 |   542.8 |  -32%˄ ||     1.24 |     1.84 |  +48%˄ | (run time too short) |
+| 27a     ||    130.8 |    57.8 |  -56%˄ ||     7.65 |    17.29 | +126%˄ |               0.0000 |
+| 27b     ||    128.8 |    56.7 |  -56%˄ ||     7.76 |    17.62 | +127%˄ |               0.0000 |
+| 27c     ||    166.2 |    94.7 |  -43%˄ ||     6.02 |    10.56 |  +76%˄ |               0.0000 |
 | 28a     ||    810.3 |   811.4 |   +0%  ||     1.23 |     1.23 |   -0%  |               0.2895 |
 | 28b     ||     94.6 |    94.5 |   -0%˄ ||    10.57 |    10.58 |   +0%˄ |               0.5067 |
 | 28c     ||    977.2 |   976.8 |   -0%  ||     1.02 |     1.02 |   +0%  |               0.7928 |
+| 29a     ||   2523.5 |   237.9 |  -91%˄ ||     0.40 |     4.20 | +961%˄ | (run time too short) |
 | 29b     ||    188.2 |   188.8 |   +0%˄ ||     5.31 |     5.30 |   -0%˄ |               0.0192 |
+| 29c     ||   2685.3 |   409.0 |  -85%˄ ||     0.37 |     2.45 | +557%˄ | (run time too short) |
 | 2a      ||    102.8 |   103.5 |   +1%˄ ||     9.73 |     9.66 |   -1%˄ |               0.0088 |
 | 2b      ||     86.1 |    86.7 |   +1%˄ ||    11.62 |    11.53 |   -1%˄ |               0.0032 |
 | 2c      ||     68.4 |    68.8 |   +1%˄ ||    14.62 |    14.52 |   -1%˄ |               0.0043 |
 | 2d      ||    137.0 |   136.8 |   -0%˄ ||     7.30 |     7.31 |   +0%˄ |               0.5697 |
 | 30a     ||    381.9 |   383.2 |   +0%˄ ||     2.62 |     2.61 |   -0%˄ |               0.0000 |
+| 30b     ||    475.5 |   339.1 |  -29%˄ ||     2.10 |     2.95 |  +40%˄ |               0.0000 |
 | 30c     ||    799.5 |   800.7 |   +0%  ||     1.25 |     1.25 |   -0%  |               0.2033 |
 | 31a     ||    393.9 |   395.9 |   +1%˄ ||     2.54 |     2.53 |   -1%˄ |               0.0000 |
+| 31b     ||    512.8 |   347.6 |  -32%˄ ||     1.95 |     2.88 |  +48%˄ |               0.0000 |
 | 31c     ||    443.2 |   442.8 |   -0%˄ ||     2.26 |     2.26 |   +0%˄ |               0.1750 |
 | 32a     ||     32.2 |    32.5 |   +1%˄ ||    31.07 |    30.77 |   -1%˄ |               0.0374 |
 | 32b     ||     73.8 |    73.6 |   -0%˄ ||    13.55 |    13.59 |   +0%˄ |               0.4853 |
 | 33a     ||     47.4 |    47.5 |   +0%˄ ||    21.08 |    21.05 |   -0%˄ |               0.7388 |
 | 33b     ||     45.8 |    45.9 |   +0%˄ ||    21.85 |    21.79 |   -0%˄ |               0.5177 |
 | 33c     ||     57.0 |    57.3 |   +1%˄ ||    17.55 |    17.45 |   -1%˄ |               0.0808 |
 | 3a      ||    261.7 |   263.5 |   +1%˄ ||     3.82 |     3.79 |   -1%˄ |               0.0028 |
 | 3b      ||     34.3 |    34.3 |   +0%˄ ||    29.17 |    29.13 |   -0%˄ |               0.6983 |
 | 3c      ||   1096.3 |  1096.6 |   +0%  ||     0.91 |     0.91 |   -0%  |               0.8458 |
 | 4a      ||    574.4 |   574.2 |   -0%˄ ||     1.74 |     1.74 |   +0%˄ |               0.8889 |
 | 4b      ||     29.9 |    30.2 |   +1%˄ ||    33.46 |    33.12 |   -1%˄ |               0.1848 |
 | 4c      ||    648.8 |   652.0 |   +0%  ||     1.54 |     1.53 |   -0%  |               0.0412 |
 | 5a      ||    110.7 |   110.1 |   -1%˄ ||     9.03 |     9.08 |   +1%˄ |               0.0484 |
 | 5b      ||    246.8 |   246.9 |   +0%˄ ||     4.05 |     4.05 |   -0%˄ |               0.9323 |
 | 5c      ||    415.7 |   414.5 |   -0%˄ ||     2.41 |     2.41 |   +0%˄ |               0.1117 |
 | 6a      ||    290.3 |   290.3 |   +0%˄ ||     3.45 |     3.44 |   -0%˄ |               0.8887 |
 | 6b      ||    326.6 |   326.9 |   +0%˄ ||     3.06 |     3.06 |   -0%˄ |               0.2285 |
 | 6c      ||    278.3 |   278.8 |   +0%˄ ||     3.59 |     3.59 |   -0%˄ |               0.0013 |
 | 6d      ||   1109.6 |  1116.0 |   +1%  ||     0.90 |     0.90 |   -1%  |               0.0000 |
 | 6e      ||    290.2 |   294.0 |   +1%˄ ||     3.45 |     3.40 |   -1%˄ |               0.0000 |
 | 6f      ||   1482.5 |  1457.7 |   -2%  ||     0.67 |     0.69 |   +2%  |               0.0000 |
+| 7a      ||    184.7 |   141.9 |  -23%˄ ||     5.41 |     7.05 |  +30%˄ |               0.0000 |
 | 7b      ||    135.0 |   135.8 |   +1%˄ ||     7.40 |     7.36 |   -1%˄ |               0.0155 |
+| 7c      ||   1280.0 |  1185.8 |   -7%  ||     0.78 |     0.84 |   +8%  |               0.0000 |
 | 8a      ||    104.1 |   104.4 |   +0%˄ ||     9.60 |     9.58 |   -0%˄ |               0.2402 |
+| 8b      ||    158.6 |    96.7 |  -39%˄ ||     6.30 |    10.34 |  +64%˄ |               0.0000 |
 | 8c      ||   3881.5 |  3824.4 |   -1%  ||     0.26 |     0.26 |   +1%  |               0.0000 |
 | 8d      ||    629.3 |   621.3 |   -1%  ||     1.59 |     1.61 |   +1%  |               0.0000 |
+| 9a      ||    547.5 |   398.7 |  -27%˄ ||     1.83 |     2.51 |  +37%˄ |               0.0000 |
 | 9b      ||    239.9 |   231.5 |   -3%˄ ||     4.17 |     4.32 |   +4%˄ |               0.0000 |
 | 9c      ||    572.2 |   576.2 |   +1%˄ ||     1.75 |     1.74 |   -1%˄ |               0.0000 |
 | 9d      ||   1004.3 |   983.2 |   -2%  ||     1.00 |     1.02 |   +2%  |               0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
+| Sum     || 102002.3 | 82156.2 |  -19%  ||          |          |        |                      |
+| Geomean ||          |         |        ||          |          |  +26%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 |         || ˅ Insufficient number of runs for p-value calculation                              |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, shuffled, 10 clients, 10 cores**
<details>
<summary>
Sum of avg. item runtimes: -16%
 || 
Geometric mean of throughput changes: +22%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_02e587e5cc28cfd259325df3b94d0092d0e06133_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_e27e1262f9bb48af51d898c9801ab1149e7446f2_mt.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty                                                                                                  | e27e1262f9bb48af51d898c9801ab1149e7446f2-dirty                                                                                                  |
 |  benchmark_mode               | Shuffled                                                                                                                                        | Shuffled                                                                                                                                        |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 10                                                                                                                                              | 10                                                                                                                                              |
 |  compiler                     | gcc 9.2                                                                                                                                         | gcc 9.2                                                                                                                                         |
 |  cores                        | 10                                                                                                                                              | 10                                                                                                                                              |
 |  data_preparation_cores       | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2022-04-22 02:52:48                                                                                                                             | 2022-04-22 07:05:58                                                                                                                             |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  indexes                      | False                                                                                                                                           | False                                                                                                                                           |
 |  max_duration                 | 1200000000000                                                                                                                                   | 1200000000000                                                                                                                                   |
 |  max_runs                     | -1                                                                                                                                              | -1                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                      | [0, 0, 10]                                                                                                                                      |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 0                                                                                                                                               | 0                                                                                                                                               |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| 10a     ||    720.1 |    568.0 |  -21%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 10b     ||    372.7 |    626.7 |  +68%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 10c     ||   1706.7 |    967.1 |  -43%  ||     0.05 |     0.06 |  +20%  |               0.0444 |
+| 11a     ||    310.3 |    138.6 |  -55%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 11b     ||    219.8 |    122.9 |  -44%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 11c     ||    344.3 |    163.8 |  -52%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 11d     ||    381.4 |    212.1 |  -44%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 12a     ||    727.8 |    335.3 |  -54%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 12b     ||    281.9 |    139.5 |  -51%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 12c     ||    722.0 |    758.8 |   +5%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 13a     ||   2035.9 |   1941.7 |   -5%  ||     0.05 |     0.06 |  +24%  |               0.7863 |
+| 13b     ||    361.9 |    909.4 | +151%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 13c     ||    252.6 |    648.4 | +157%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 13d     ||   3270.5 |   2713.6 |  -17%  ||     0.05 |     0.06 |  +20%  |               0.1884 |
+| 14a     ||   2777.8 |   2047.5 |  -26%  ||     0.05 |     0.06 |  +19%  |               0.0476 |
+| 14b     ||   1987.4 |   1189.1 |  -40%  ||     0.05 |     0.06 |  +20%  |               0.0265 |
+| 14c     ||   2879.7 |   2904.9 |   +1%  ||     0.05 |     0.06 |  +20%  |               0.9627 |
+| 15a     ||    382.0 |    280.7 |  -27%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 15b     ||    471.7 |    654.2 |  +39%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 15c     ||    238.4 |    270.0 |  +13%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 15d     ||    785.6 |    444.5 |  -43%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 16a     ||   8279.4 |   6816.8 |  -18%  ||     0.05 |     0.06 |  +22%  |               0.0200 |
+| 16b     ||  11105.3 |   9790.3 |  -12%  ||     0.05 |     0.06 |  +24%  |               0.0008 |
+| 16c     ||   8007.7 |   7512.8 |   -6%  ||     0.05 |     0.06 |  +20%  |               0.2471 |
+| 16d     ||   8342.7 |   7043.0 |  -16%  ||     0.05 |     0.06 |  +22%  |               0.0264 |
+| 17a     ||   1817.3 |   2517.9 |  +39%  ||     0.05 |     0.06 |  +20%  |               0.0490 |
+| 17b     ||   1769.7 |   1787.0 |   +1%  ||     0.05 |     0.06 |  +20%  |               0.9632 |
+| 17c     ||   1630.9 |   1160.3 |  -29%  ||     0.05 |     0.06 |  +20%  |               0.0520 |
+| 17d     ||   2401.8 |   1147.9 |  -52%  ||     0.05 |     0.06 |  +22%  |               0.0051 |
+| 17e     ||   5320.7 |   4689.7 |  -12%  ||     0.05 |     0.06 |  +20%  |               0.2689 |
+| 17f     ||   3113.3 |   2865.0 |   -8%  ||     0.05 |     0.06 |  +24%  |               0.4430 |
+| 18a     ||   5542.3 |   4953.0 |  -11%  ||     0.05 |     0.06 |  +24%  |               0.2639 |
+| 18b     ||    511.7 |    475.8 |   -7%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 18c     ||   2093.8 |   1523.7 |  -27%  ||     0.05 |     0.06 |  +22%  |               0.1917 |
+| 19a     ||   1660.9 |   1044.3 |  -37%  ||     0.05 |     0.06 |  +22%  |               0.0195 |
+| 19b     ||   1744.9 |   1099.9 |  -37%  ||     0.05 |     0.06 |  +20%  |               0.0933 |
+| 19c     ||   2610.3 |   1157.3 |  -56%  ||     0.05 |     0.06 |  +22%  |               0.0001 |
+| 19d     ||   4217.4 |   3539.9 |  -16%  ||     0.05 |     0.06 |  +24%  |               0.1881 |
+| 1a      ||    165.3 |    251.7 |  +52%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 1b      ||     63.5 |     55.7 |  -12%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 1c      ||    481.2 |     95.1 |  -80%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 1d      ||     60.7 |     40.3 |  -34%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 20a     ||   1611.6 |   1632.5 |   +1%  ||     0.05 |     0.06 |  +22%  |               0.9498 |
+| 20b     ||   1532.6 |    949.9 |  -38%  ||     0.05 |     0.06 |  +22%  |               0.0388 |
+| 20c     ||   1554.6 |    995.8 |  -36%  ||     0.05 |     0.06 |  +22%  |               0.0880 |
+| 21a     ||    460.3 |    166.8 |  -64%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 21b     ||    608.7 |    116.7 |  -81%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 21c     ||    384.2 |    152.3 |  -60%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 22a     ||   1778.0 |   1242.4 |  -30%  ||     0.05 |     0.06 |  +22%  |               0.0366 |
+| 22b     ||   1336.6 |    958.0 |  -28%  ||     0.05 |     0.06 |  +22%  |               0.1819 |
+| 22c     ||   4207.6 |   3128.7 |  -26%  ||     0.05 |     0.06 |  +24%  |               0.0029 |
+| 22d     ||   3692.2 |   3530.0 |   -4%  ||     0.05 |     0.06 |  +22%  |               0.7429 |
+| 23a     ||    469.8 |    339.0 |  -28%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 23b     ||    767.4 |    345.1 |  -55%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 23c     ||    615.2 |    321.3 |  -48%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 24a     ||   1601.3 |    786.9 |  -51%  ||     0.05 |     0.06 |  +20%  |               0.0070 |
+| 24b     ||   1856.4 |    787.1 |  -58%  ||     0.05 |     0.06 |  +22%  |               0.0010 |
+| 25a     ||   1474.4 |    973.8 |  -34%  ||     0.05 |     0.06 |  +22%  |               0.0274 |
+| 25b     ||    366.7 |    415.9 |  +13%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 25c     ||   3422.8 |   2874.1 |  -16%  ||     0.05 |     0.06 |  +22%  |               0.2616 |
+| 26a     ||    942.5 |   1137.0 |  +21%  ||     0.05 |     0.06 |  +20%  |               0.4473 |
+| 26b     ||    582.2 |    461.0 |  -21%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 26c     ||   1054.8 |   1173.5 |  +11%  ||     0.05 |     0.06 |  +20%  |               0.5120 |
+| 27a     ||    234.7 |    179.1 |  -24%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 27b     ||    670.6 |    324.8 |  -52%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 27c     ||    323.7 |    255.7 |  -21%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 28a     ||   2075.4 |   2297.9 |  +11%  ||     0.05 |     0.06 |  +22%  |               0.5412 |
+| 28b     ||    755.8 |    611.1 |  -19%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 28c     ||   2753.0 |   2304.0 |  -16%  ||     0.05 |     0.06 |  +20%  |               0.1488 |
+| 29a     ||   2059.7 |    627.7 |  -70%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 29b     ||    595.8 |    654.4 |  +10%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 29c     ||   1874.0 |   1094.5 |  -42%  ||     0.05 |     0.06 |  +24%  |               0.0452 |
+| 2a      ||    293.4 |    286.5 |   -2%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 2b      ||    252.9 |    379.9 |  +50%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 2c      ||    495.4 |    251.8 |  -49%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 2d      ||    426.5 |    427.4 |   +0%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 30a     ||   1059.0 |    928.3 |  -12%  ||     0.05 |     0.06 |  +22%  |               0.6757 |
+| 30b     ||    476.1 |    678.5 |  +43%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 30c     ||   1962.0 |   2407.7 |  +23%  ||     0.05 |     0.06 |  +20%  |               0.3730 |
+| 31a     ||    580.0 |    784.4 |  +35%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 31b     ||    866.3 |    500.6 |  -42%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 31c     ||    836.8 |   1036.7 |  +24%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 32a     ||    329.4 |    131.8 |  -60%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 32b     ||    825.9 |    337.1 |  -59%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 33a     ||    198.1 |    191.6 |   -3%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 33b     ||    250.7 |    111.5 |  -56%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 33c     ||    216.3 |    201.4 |   -7%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 3a      ||   1092.2 |    868.2 |  -21%  ||     0.05 |     0.06 |  +22%  |               0.4693 |
+| 3b      ||     95.8 |    210.8 | +120%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 3c      ||   2130.5 |   1962.2 |   -8%  ||     0.05 |     0.06 |  +22%  |               0.6336 |
+| 4a      ||   1030.5 |   1056.6 |   +3%  ||     0.05 |     0.06 |  +22%  |               0.8934 |
+| 4b      ||    258.6 |    182.8 |  -29%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 4c      ||   1628.8 |   1349.2 |  -17%  ||     0.05 |     0.06 |  +22%  |               0.3868 |
+| 5a      ||    301.0 |    552.1 |  +83%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 5b      ||    710.0 |    795.8 |  +12%  ||     0.05 |     0.06 |  +24%  | (run time too short) |
+| 5c      ||   1200.7 |    882.6 |  -26%  ||     0.05 |     0.06 |  +24%  |               0.2290 |
+| 6a      ||    654.1 |    376.9 |  -42%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 6b      ||    433.5 |    320.3 |  -26%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 6c      ||    389.7 |    411.0 |   +5%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 6d      ||   1768.7 |   1371.8 |  -22%  ||     0.05 |     0.06 |  +22%  |               0.0869 |
+| 6e      ||    280.3 |    639.3 | +128%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 6f      ||   2862.4 |   2555.5 |  -11%  ||     0.05 |     0.06 |  +24%  |               0.3712 |
+| 7a      ||    518.5 |    607.1 |  +17%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 7b      ||    302.4 |    545.7 |  +80%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 7c      ||   2677.0 |   2304.1 |  -14%  ||     0.05 |     0.06 |  +20%  |               0.2230 |
+| 8a      ||    265.7 |    380.2 |  +43%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 8b      ||    227.3 |    283.6 |  +25%  ||     0.05 |     0.06 |  +22%  | (run time too short) |
+| 8c      ||   7365.1 |   6389.2 |  -13%  ||     0.05 |     0.06 |  +22%  |               0.1197 |
+| 8d      ||   1821.5 |   1543.9 |  -15%  ||     0.05 |     0.06 |  +20%  |               0.3558 |
+| 9a      ||   1026.0 |   1098.2 |   +7%  ||     0.05 |     0.06 |  +22%  |               0.7563 |
+| 9b      ||    953.9 |    647.5 |  -32%  ||     0.05 |     0.06 |  +20%  | (run time too short) |
+| 9c      ||   2331.5 |   1437.0 |  -38%  ||     0.05 |     0.06 |  +20%  |               0.0171 |
+| 9d      ||   2138.7 |   2352.8 |  +10%  ||     0.05 |     0.06 |  +20%  |               0.4911 |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| Sum     || 177367.3 | 148220.4 |  -16%  ||          |          |        |                      |
+| Geomean ||          |          |        ||          |          |  +22%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>
