### PR TITLE
Jenkinsfile: Add root repository and submodule repositories as safe directories

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,12 +66,9 @@ try {
           stage("Setup") {
             checkout scm
 
-            sh "echo $WORKSPACE"
-            sh "echo \$(pwd)"
-            // pwd = sh "pwd"
-            // sh "git config --global --add safe.directory $pwd"
-            // // Get the paths of the submodules; for each path, add it as a git safe.directory
-            // sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $pwd/'{}'"
+            sh "git config --global --add safe.directory $WORKSPACE"
+            // Get the paths of the submodules; for each path, add it as a git safe.directory
+            sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'"
 
             sh "./install_dependencies.sh"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,10 +66,12 @@ try {
           stage("Setup") {
             checkout scm
 
-            pwd = sh "pwd"
-            sh "git config --global --add safe.directory $pwd"
-            // Get the paths of the submodules; for each path, add it as a git safe.directory
-            sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $pwd/'{}'"
+            sh "echo $WORKSPACE"
+            sh "echo \$(pwd)"
+            // pwd = sh "pwd"
+            // sh "git config --global --add safe.directory $pwd"
+            // // Get the paths of the submodules; for each path, add it as a git safe.directory
+            // sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $pwd/'{}'"
 
             sh "./install_dependencies.sh"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,9 @@ try {
           stage("Setup") {
             checkout scm
 
+            // During CI runs, the user is different from the owner of the directories, which blocks the execution of git
+            // commands since the fix of the git vulnerability CVE-2022-24765. git commands can then only be executed if
+            // the corresponding directories are added as safe directories.
             sh '''
             git config --global --add safe.directory $WORKSPACE
             # Get the paths of the submodules; for each path, add it as a git safe.directory

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ try {
             sh '''
             git config --global --add safe.directory $WORKSPACE
             # Get the paths of the submodules; for each path, add it as a git safe.directory
-            # grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
             '''
 
             sh "./install_dependencies.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,7 @@ try {
             checkout scm
 
             sh '''
+            whoami
             git config --global --add safe.directory $WORKSPACE
             # Get the paths of the submodules; for each path, add it as a git safe.directory
             grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,9 +66,11 @@ try {
           stage("Setup") {
             checkout scm
 
-            sh "git config --global --add safe.directory $WORKSPACE"
-            // Get the paths of the submodules; for each path, add it as a git safe.directory
-            sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'"
+            sh '''
+            git config --global --add safe.directory $WORKSPACE
+            # Get the paths of the submodules; for each path, add it as a git safe.directory
+            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+            '''
 
             sh "./install_dependencies.sh"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,9 +66,10 @@ try {
           stage("Setup") {
             checkout scm
 
-            sh "git config --global --add safe.directory $(pwd)"
+            pwd = sh "pwd"
+            sh "git config --global --add safe.directory $pwd"
             // Get the paths of the submodules; for each path, add it as a git safe.directory
-            sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'"
+            sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $pwd/'{}'"
 
             sh "./install_dependencies.sh"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,9 +64,10 @@ try {
       oppossumCI.inside("--cap-add SYS_PTRACE -u 0:0") {
         try {
           stage("Setup") {
-            checkout scm
+            // checkout scm
 
             sh '''
+            git clone https://github.com/hyrise/hyrise.git
             whoami
             git config --global --add safe.directory $WORKSPACE
             # Get the paths of the submodules; for each path, add it as a git safe.directory

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ try {
             sh '''
             git config --global --add safe.directory $WORKSPACE
             # Get the paths of the submodules; for each path, add it as a git safe.directory
-            grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
+            # grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'
             '''
 
             sh "./install_dependencies.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,11 +64,9 @@ try {
       oppossumCI.inside("--cap-add SYS_PTRACE -u 0:0") {
         try {
           stage("Setup") {
-            // checkout scm
+            checkout scm
 
             sh '''
-            git clone https://github.com/hyrise/hyrise.git
-            whoami
             git config --global --add safe.directory $WORKSPACE
             # Get the paths of the submodules; for each path, add it as a git safe.directory
             grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $WORKSPACE/'{}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,6 +65,11 @@ try {
         try {
           stage("Setup") {
             checkout scm
+
+            sh "git config --global --add safe.directory $(pwd)"
+            // Get the paths of the submodules; for each path, add it as a git safe.directory
+            sh "grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'"
+
             sh "./install_dependencies.sh"
 
             cmake = 'cmake -DCI_BUILD=ON'

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,13 +70,6 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 
-                ls ../ -al
-                ls ./third_party -al
-                whoami
-                git config --global --add safe.directory $(pwd)
-                # Get the paths of the submodules; for each path, add it as a git safe.directory
-                grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'
-
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."
                     exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,6 +70,10 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 
+                git config --global --add safe.directory $(pwd)
+                # Get the paths of the submodules; for each path, add it as a git safe.directory
+                grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'
+
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."
                     exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -67,6 +67,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                     sudo apt-get install --no-install-recommends -y libboost1.71-all-dev
                 fi
 
+                whoami
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -67,9 +67,6 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                     sudo apt-get install --no-install-recommends -y libboost1.71-all-dev
                 fi
 
-                whoami
-                ls ../ -al
-                ls ./third_party -al
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -68,6 +68,8 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 fi
 
                 whoami
+                ls ../ -al
+                ls ./third_party -al
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -70,6 +70,9 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
                 # Packages added here should also be added to the Dockerfile
                 sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-9 clang-format-9 clang-tidy-9 cmake curl dos2unix g++-9 gcc-9 gcovr git graphviz libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip systemtap systemtap-sdt-dev valgrind &
 
+                ls ../ -al
+                ls ./third_party -al
+                whoami
                 git config --global --add safe.directory $(pwd)
                 # Get the paths of the submodules; for each path, add it as a git safe.directory
                 grep path .gitmodules | sed 's/.*=//' | xargs -n 1 -I '{}' git config --global --add safe.directory $(pwd)/'{}'


### PR DESCRIPTION
After the security vulnerability [CVE-2022-24765](https://github.blog/2022-04-12-git-security-vulnerability-announced/), the latest git version available in ubuntu 20.04 was [patched](https://launchpad.net/ubuntu/+source/git/1:2.25.1-1ubuntu3.3).

With this patch, git checks the owner of the top-level directory and does not perform a git command if the owner is not the current user. This check can be disabled for a repository by adding it as a safe directory, i.e., `git config --global --add safe.directory <dir>`.

In a current CI run, the user is `root`, but the files and directories in the cloned Hyrise project directory have the owner `113`.

This PR adds the directory of the root repository and the directories of the submodule repositories as safe directories to avoid CI errors of the following kind:

```
fatal: unsafe repository ('/var/lib/jenkins/workspace/hyrise_hyrise_PR-2448' is owned by someone else)
```

References
- https://github.com/actions/checkout/issues/760
- https://github.com/gaurav-nelson/github-action-markdown-link-check/issues/132
- https://stackoverflow.com/questions/71849415/cannot-add-parent-directory-to-safe-directory-on-git
- https://github.blog/2022-04-12-git-security-vulnerability-announced/
- git repo, commit adding the safe.directory check: https://github.com/git/git/commit/0f85c4a30b072a26d74af8bbf63cc8f6a5dfc1b8
- git repo, commit enabling the safe.directory check: https://github.com/git/git/commit/bb50ec3cc300eeff3aba7a2bea145aabdb477d31