### PR TITLE
Fix redundant predicate reordering

### DIFF
--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -55,8 +55,9 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
   DebugAssert(cost_estimator, "PredicateReorderingRule requires cost estimator to be set");
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateReorderingRule needs root to hold onto");
 
+  std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
   visit_lqp(lqp_root, [&](const auto& node) {
-    if (is_predicate_style_node(node)) {
+    if (is_predicate_style_node(node) && !visited_nodes.contains(node)) {
       std::vector<std::shared_ptr<AbstractLQPNode>> predicate_nodes;
 
       // Gather adjacent PredicateNodes
@@ -77,6 +78,7 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
        * Sort PredicateNodes in descending order with regards to the expected row_count
        * Continue rule in deepest input
        */
+      visited_nodes.insert(predicate_nodes.cbegin(), predicate_nodes.cend());
       if (predicate_nodes.size() > 1) {
         _reorder_predicates(predicate_nodes);
       }

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -29,8 +29,8 @@ bool is_predicate_style_node(const std::shared_ptr<AbstractLQPNode>& node) {
   if (node->type == LQPNodeType::Validate) return true;
 
   // Semi-/Anti-Joins also reduce the number of tuples and can be freely reordered within a chain of predicates. This
-  // might place the join below a validate node, but since it is not a "proper" join (i.e., one that returns columns
-  // from multiple tables), the validate will still be able to operate on the semi join's output.
+  // might place the join below a ValidateNode, but since it is not a "proper" join (i.e., one that returns columns
+  // from multiple tables), the ValidateNode will still be able to operate on the semi join's output.
   if (node->type == LQPNodeType::Join) {
     const auto& join_node = static_cast<JoinNode&>(*node);
     if (join_node.join_mode == JoinMode::Semi || join_node.join_mode == JoinMode::AntiNullAsTrue ||

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -55,10 +55,10 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
   DebugAssert(cost_estimator, "PredicateReorderingRule requires cost estimator to be set");
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateReorderingRule needs root to hold onto");
 
-  // We keep track of the visited predicate chains' nodes, so that this rule touches involved nodes only once.
-  std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_predicate_chain_nodes;
+  // We keep track of reordered predicate nodes, so that this rule touches predicate nodes once only.
+  std::unordered_set<std::shared_ptr<AbstractLQPNode>> reordered_predicate_nodes;
   visit_lqp(lqp_root, [&](const auto& node) {
-    if (is_predicate_style_node(node) && !visited_predicate_chain_nodes.contains(node)) {
+    if (is_predicate_style_node(node) && !reordered_predicate_nodes.contains(node)) {
       std::vector<std::shared_ptr<AbstractLQPNode>> predicate_nodes;
 
       // Gather adjacent PredicateNodes
@@ -80,8 +80,8 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
        * Continue rule in deepest input
        */
       if (predicate_nodes.size() > 1) {
-        visited_predicate_chain_nodes.insert(predicate_nodes.cbegin(), predicate_nodes.cend());
         _reorder_predicates(predicate_nodes);
+        reordered_predicate_nodes.insert(predicate_nodes.cbegin(), predicate_nodes.cend());
       }
     }
 


### PR DESCRIPTION
The `PredicateReorderingRule` re-orders already-touched predicates. By tracking the visited nodes, this can be prohibited.

Here are some debug prints for TPC-DS Q41:
* Before
```
Before reordering:
0x6000025b5568: [Predicate] SUBQUERY (LQP, 0x600002780018, Parameters: [i_manufact, id=0]) > 0 card: 18000
0x6000025b5098: [Predicate] i_manufact_id BETWEEN INCLUSIVE 738 AND 778 card: 236.222
0x6000023e2bd8: [Validate] card: 18000
After reordering:
0x6000025b5568: [Predicate] SUBQUERY (LQP, 0x600002780018, Parameters: [i_manufact, id=0]) > 0 card: 18000
0x6000023e2bd8: [Validate] card: 18000
0x6000025b5098: [Predicate] i_manufact_id BETWEEN INCLUSIVE 738 AND 778 card: 236.222

Before reordering:
0x6000023e2bd8: [Validate] card: 18000
0x6000025b5098: [Predicate] i_manufact_id BETWEEN INCLUSIVE 738 AND 778 card: 236.222
After reordering:
0x6000023e2bd8: [Validate] card: 18000
0x6000025b5098: [Predicate] i_manufact_id BETWEEN INCLUSIVE 738 AND 778 card: 236.222
```

* After
```
Before reordering:
0x6000027902d8: [Predicate] SUBQUERY (LQP, 0x600002580018, Parameters: [i_manufact, id=0]) > 0 card: 18000
0x600002790388: [Predicate] i_manufact_id BETWEEN INCLUSIVE 738 AND 778 card: 236.222
0x6000021ea638: [Validate] card: 18000
After reordering:
0x6000027902d8: [Predicate] SUBQUERY (LQP, 0x600002580018, Parameters: [i_manufact, id=0]) > 0 card: 18000
0x6000021ea638: [Validate] card: 18000
0x600002790388: [Predicate] i_manufact_id BETWEEN INCLUSIVE 738 AND 778 card: 236.222
```

--- 

### Results for TPC-H SF 0.01

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+------------------------------------------------+------------------------------------------------+
 | Parameter                | tpch_master_optimizer.json                     | tpch_improve_predicate_reordering_rule.json    |
 +--------------------------+------------------------------------------------+------------------------------------------------+
 |  GIT-HASH                | 02e587e5cc28cfd259325df3b94d0092d0e06133-dirty | 5253be4ddaac5a200640752ae41c4916f65e2687-dirty |
 |  benchmark_mode          | Ordered                                        | Ordered                                        |
 |  build_type              | release                                        | release                                        |
 |  chunk_size              | 65535                                          | 65535                                          |
 |  clients                 | 1                                              | 1                                              |
 |  clustering              | None                                           | None                                           |
 |  compiler                | gcc 9.2                                        | gcc 9.2                                        |
 |  cores                   | 0                                              | 0                                              |
 |  data_preparation_cores  | 0                                              | 0                                              |
 |  date                    | 2022-04-22 14:06:07                            | 2022-04-22 14:32:01                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}        | {'default': {'encoding': 'Dictionary'}}        |
 |  indexes                 | False                                          | False                                          |
 |  max_duration            | 60000000000                                    | 60000000000                                    |
 |  max_runs                | -1                                             | -1                                             |
 |  scale_factor            | 0.009999999776482582                           | 0.009999999776482582                           |
 |  time_unit               | ns                                             | ns                                             |
 |  use_prepared_statements | False                                          | False                                          |
 |  using_scheduler         | False                                          | False                                          |
 |  verify                  | False                                          | False                                          |
 |  warmup_duration         | 0                                              | 0                                              |
 +--------------------------+------------------------------------------------+------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||      9.4 |     9.5 |   +1%  ||   106.20 |   105.33 |   -1%  |  0.0000 |
 | TPC-H 02 ||      1.5 |     1.4 |   -1%  ||   687.21 |   695.71 |   +1%  |  0.0867 |
 | TPC-H 03 ||      1.3 |     1.3 |   -2%  ||   771.23 |   785.42 |   +2%  |  0.0000 |
 | TPC-H 04 ||      0.9 |     0.9 |   +1%  ||  1172.56 |  1165.31 |   -1%  |  0.0000 |
 | TPC-H 05 ||      2.0 |     2.0 |   +0%  ||   503.34 |   502.97 |   -0%  |  0.7495 |
 | TPC-H 06 ||      0.4 |     0.4 |   +1%  ||  2436.94 |  2413.70 |   -1%  |  0.0000 |
 | TPC-H 07 ||      3.0 |     2.9 |   -4%  ||   335.33 |   347.60 |   +4%  |  0.0411 |
 | TPC-H 08 ||     25.3 |    25.3 |   -0%  ||    39.51 |    39.54 |   +0%  |  0.9256 |
 | TPC-H 09 ||      3.9 |     3.9 |   -0%  ||   254.47 |   254.70 |   +0%  |  0.6648 |
 | TPC-H 10 ||      1.5 |     1.5 |   -0%  ||   673.48 |   675.24 |   +0%  |  0.0000 |
 | TPC-H 11 ||      0.5 |     0.5 |   -0%  ||  2065.83 |  2068.60 |   +0%  |  0.0024 |
 | TPC-H 12 ||      1.2 |     1.2 |   -0%  ||   807.67 |   810.66 |   +0%  |  0.0000 |
 | TPC-H 13 ||      3.4 |     3.4 |   -0%  ||   291.75 |   292.20 |   +0%  |  0.0000 |
 | TPC-H 14 ||      0.7 |     0.6 |   -2%  ||  1512.02 |  1552.70 |   +3%  |  0.0000 |
 | TPC-H 15 ||      2.1 |     2.2 |   +0%  ||   464.31 |   463.53 |   -0%  |  0.0000 |
 | TPC-H 16 ||      3.7 |     3.6 |   -1%  ||   272.08 |   274.27 |   +1%  |  0.0000 |
 | TPC-H 17 ||      0.6 |     0.6 |   +0%  ||  1632.20 |  1627.26 |   -0%  |  0.0928 |
 | TPC-H 18 ||      2.9 |     2.9 |   +0%  ||   347.11 |   346.52 |   -0%  |  0.0000 |
+| TPC-H 19 ||     13.0 |    11.3 |  -13%  ||    76.93 |    88.35 |  +15%  |  0.0000 |
+| TPC-H 20 ||      4.5 |     4.2 |   -7%  ||   220.18 |   236.88 |   +8%  |  0.0000 |
 | TPC-H 21 ||      7.4 |     7.4 |   +0%  ||   135.59 |   135.44 |   -0%  |  0.5691 |
 | TPC-H 22 ||      2.1 |     2.0 |   -3%  ||   474.50 |   487.32 |   +3%  |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||     91.2 |    89.0 |   -2%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +1%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
