### PR TITLE
Enable pushdown of predicate barriers

### DIFF
--- a/src/benchmark/operators/join_aggregate_benchmark.cpp
+++ b/src/benchmark/operators/join_aggregate_benchmark.cpp
@@ -28,7 +28,7 @@ constexpr auto SELECTIVITY = 0.2;
 
 namespace opossum {
 
-using namespace opossum::expression_functional;  //NOLINT
+using namespace opossum::expression_functional;  // NOLINT
 
 pmr_vector<int32_t> generate_ids(const size_t table_size) {
   auto values = pmr_vector<int32_t>(table_size);

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -9,7 +9,7 @@ namespace opossum {
 /**
  * This node is used in the Optimizer to have an explicit root node that holds an LQP. Optimizer rules are not allowed
  * to remove this node or add nodes above it. By that, optimizer rules don't have to worry whether they change the
- * tree-identifying root node, e.g. by removing the Projection at the top of the tree.
+ * tree-identifying root node, e.g., by removing the Projection at the top of the tree.
  *
  * Moreover, optimizer rules can utilize this node during their runtime for, e.g., recursion purposes.
  * (See PredicatePlacementRule, for example)

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -7,12 +7,12 @@
 namespace opossum {
 
 /**
- * This node is used in the Optimizer to have an explicit root node it can hold onto the LQP with.
+ * This node is used in the Optimizer to have an explicit root node that holds an LQP. Optimizer rules are not allowed
+ * to remove this node or add nodes above it. By that, optimizer rules don't have to worry whether they change the
+ * tree-identifying root node, e.g. by removing the Projection at the top of the tree.
  *
- * Optimizer rules are not allowed to remove this node or add nodes above it.
- *
- * By that Optimizer Rules don't have to worry whether they change the tree-identifying root node,
- * e.g. by removing the Projection at the top of the tree.
+ * Moreover, optimizer rules can utilize this node during their runtime for, e.g., recursion purposes.
+ * (See PredicatePlacementRule, for example)
  */
 class LogicalPlanRootNode : public EnableMakeForLQPNode<LogicalPlanRootNode>, public AbstractLQPNode {
  public:

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -26,7 +26,7 @@ namespace {
  */
 class TemporaryRootNode : public LogicalPlanRootNode {
  public:
-  TemporaryRootNode() : LogicalPlanRootNode() {}
+  TemporaryRootNode() = default;
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override {
     return "[TemporaryRootNode]";

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -66,8 +66,8 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     auto next_push_down_traversal_root = barrier_node;
     if (barrier_node_is_pushdown_predicate) {
       // The barrier node is a predicate eligible for pushdown. Therefore, we would like it to be covered by the next
-      // recursion of _push_down_traversal. However, since _push_down_traversal looks at the inputs of a given
-      // root node only, barrier_node would not be pushed down.
+      // recursion of _push_down_traversal. However, since _push_down_traversal looks at the inputs of a given root node
+      // only, barrier_node would not be pushed down.
       // To allow for a pushdown of barrier_node, a temporary root node is inserted above it. Afterwards, the temporary
       // root node is used as a root for the next _push_down_traversal recursion. As a result, barrier_node will be seen
       // as an input of the temporary root node, and thus be pushed down by the rule, if possible.
@@ -79,6 +79,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       auto left_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
       _push_down_traversal(next_push_down_traversal_root, LQPInputSide::Left, left_push_down_nodes, estimator);
 
+      // Check for the left input node first because there cannot be a right input node otherwise.
       if (next_push_down_traversal_root->right_input()) {
         auto right_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
         _push_down_traversal(next_push_down_traversal_root, LQPInputSide::Right, right_push_down_nodes, estimator);
@@ -86,7 +87,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     }
 
     // The recursion calls to _push_down_traversal have returned. Therefore, we must remove the temporary root node, we
-    // might have inserted previously. (see comment above)
+    // might have inserted previously (see comment above).
     if (next_push_down_traversal_root->type == LQPNodeType::Root && next_push_down_traversal_root->output_count() > 0) {
       lqp_remove_node(next_push_down_traversal_root);
     }

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -389,7 +389,6 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       lqp_insert_node_above(diamond_origin_node, temporary_root_node);
       _push_down_traversal(temporary_root_node, LQPInputSide::Left, updated_push_down_nodes, estimator);
       lqp_remove_node(temporary_root_node);
-
     } break;
 
     default: {

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -84,13 +84,12 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
 
     auto next_push_down_traversal_root = barrier_node;
     if (barrier_node_is_pushdown_predicate) {
-      // The barrier node is a predicate eligible for a pushdown. Therefore, we would like it to be covered by the
-      // next recursion of _push_down_traversal. However, since _push_down_traversal only looks at the inputs of
-      // a given root node, the barrier node would not become pushed down.
-      // To allow for a pushdown of barrier_node, a temporary root node is inserted above it. In the following,
-      // the temporary root node is used as the root node for the next recursion of _push_down_traversal. As a result,
-      // barrier_node will be seen as an input of the temporary root node, and thus become pushed down by the rule,
-      // if possible.
+      // The barrier node is a predicate eligible for pushdown. Therefore, we would like it to be covered by the next
+      // recursion of _push_down_traversal. However, since _push_down_traversal looks at the inputs of a given
+      // root node only, barrier_node would not become pushed down.
+      // To allow for a pushdown of barrier_node, a temporary root node is inserted above it. Afterwards, the temporary
+      // root node is used as a root for the next _push_down_traversal recursion. As a result, barrier_node will be seen
+      // as an input of the temporary root node, and thus become pushed down by the rule, if possible.
       next_push_down_traversal_root = std::make_shared<TemporaryRootNode>();
       lqp_insert_node_above(barrier_node, next_push_down_traversal_root);
     }

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -30,7 +30,7 @@ class TemporaryRootNode : public LogicalPlanRootNode {
   }
 };
 
-}
+}  // namespace
 
 namespace opossum {
 
@@ -62,7 +62,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     return;  // Allow calling without checks
   }
 
-  // A helper method for cases where the input_node does not allow us to proceed
+  // A helper method for cases where the input_node does not allow us to proceed.
   const auto handle_barrier = [&]() {
     _insert_nodes(current_node, input_side, push_down_nodes);
 
@@ -94,7 +94,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
       _push_down_traversal(next_traversal_root, LQPInputSide::Right, right_push_down_nodes, estimator);
     }
 
-    if (next_traversal_root->type == LQPNodeType::Root) {
+    if (std::dynamic_pointer_cast<TemporaryRootNode>(next_traversal_root)) {
       lqp_remove_node(next_traversal_root);
     }
   };
@@ -105,8 +105,7 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
     return;
   }
 
-  // Removes input_node from the current LQP and continues to run _push_down_traversal. It is the caller's
-  // responsibility to put it back into the LQP at some new position.
+  // Removes input_node from the current LQP and continues to run _push_down_traversal.
   const auto untie_input_node_and_recurse = [&]() {
     push_down_nodes.emplace_back(input_node);
     lqp_remove_node(input_node, AllowRightInput::Yes);

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -368,17 +368,17 @@ void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<Abstract
         return;
       }
 
-      // Apply predicate pushdown to the diamond's nodes
+      // Apply predicate pushdown to the diamond's nodes.
       auto left_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
       auto right_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
       _push_down_traversal(union_node, LQPInputSide::Left, left_push_down_nodes, estimator);
       _push_down_traversal(union_node, LQPInputSide::Right, right_push_down_nodes, estimator);
 
-      // Continue predicate pushdown below the diamond
+      // Continue predicate pushdown below the diamond.
       auto updated_push_down_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};
       for (const auto& push_down_node : push_down_nodes) {
         if (_is_evaluable_on_lqp(push_down_node, diamond_origin_node)) {
-          // Save for next _push_down_traversal recursion
+          // Save for next _push_down_traversal recursion.
           updated_push_down_nodes.emplace_back(push_down_node);
         } else {
           // The diamond is a barrier for push_down_node.

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -414,8 +414,8 @@ TEST_F(PredicatePlacementRuleTest, StopPushdownAtDiamondOriginNode) {
   // We must stop pushing down predicates when reaching a node with multiple outputs.
   // clang-format off
   const auto input_common_node =
-  PredicateNode::make(greater_than_(_a_a, 1),
     ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
+      PredicateNode::make(greater_than_(_a_a, 1),
       _stored_table_a));
 
   const auto input_lqp =
@@ -432,8 +432,8 @@ TEST_F(PredicatePlacementRuleTest, StopPushdownAtDiamondOriginNode) {
   // We expect the diamond predicates to get pushed below the Projections. However, since the diamond's origin node
   // has multiple outputs, predicates are not expected to get pushed down any further.
   const auto expected_common_node =
-  PredicateNode::make(greater_than_(_a_a, 1),
-    ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
+  ProjectionNode::make(expression_vector(_a_a, _a_b, cast_(11, DataType::Float)),
+    PredicateNode::make(greater_than_(_a_a, 1),
       _stored_table_a));
 
   const auto expected_lqp =

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -592,7 +592,7 @@ TEST_F(PredicatePlacementRuleTest, HandleBarrierPredicatePushdown) {
 
   // clang-format off
   const auto barrier_predicate_node =
-  PredicateNode::make(greater_than_(_b_b, 123),                 // <-- 1st Predicate before pushdown (pushdown barrier due to output_count() == 2)
+  PredicateNode::make(greater_than_(_b_b, 123),                 // <-- 1st Predicate before pushdown (pushdown barrier due to output_count() == 2) //NOLINT
     JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),         // <-- 2nd Predicate before pushdown
       JoinNode::make(JoinMode::Inner, equals_(_b_a, _c_a),
         _stored_table_b,

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -590,6 +590,7 @@ TEST_F(PredicatePlacementRuleTest, HandleBarrierPredicatePushdown) {
   // multiple outputs (the barrier node). The purpose of this test is to check whether a barrier node becomes
   // pushed down by the rule, if it is a predicate eligible for pushdown.
 
+  // clang-format off
   const auto barrier_predicate_node =
   PredicateNode::make(greater_than_(_b_b, 123),                 // <-- 1st Predicate before pushdown (pushdown barrier due to output_count() == 2)
     JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),         // <-- 2nd Predicate before pushdown
@@ -598,7 +599,6 @@ TEST_F(PredicatePlacementRuleTest, HandleBarrierPredicatePushdown) {
         _stored_table_c),
       _stored_table_a));
 
-  // clang-format off
   auto input_lqp =
   PredicateNode::make(greater_than_(_c_a, 150),
     PredicateNode::make(greater_than_(_c_a, 100),

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -274,17 +274,17 @@ TEST_F(PredicatePlacementRuleTest, ConsecutiveDiamondPushdownTest) {
   // below the first diamond, only one predicate can also be pushed below the second diamond.
   // clang-format off
   const auto input_common_node =
-  UnionNode::make(SetOperationMode::Positions,
+  UnionNode::make(SetOperationMode::All,
     PredicateNode::make(like_(_c_a, "%woman%"),
-      ProjectionNode::make(expression_vector(_c_a, _c_b, cast_(11, DataType::Float)),
+      AggregateNode::make(expression_vector(_c_a), expression_vector(sum_(_c_b)),
         _stored_table_c)),
     PredicateNode::make(like_(_c_a, "%Woman%"),
-      ProjectionNode::make(expression_vector(_c_a, _c_b, cast_(11, DataType::Float)),
+      AggregateNode::make(expression_vector(_c_a), expression_vector(sum_(_c_b)),
         _stored_table_c)));
 
   const auto input_lqp =
-  PredicateNode::make(greater_than_(_c_a, 1000),  // <-- 1st Predicate before pushdown
-    PredicateNode::make(equals_(_c_b, 10),        // <-- 2nd Predicate before pushdown
+  PredicateNode::make(equals_(_c_a, 10),                                  // <-- 1st Predicate before pushdown
+    PredicateNode::make(greater_than_(sum_(_c_b), 1000),                  // <-- 2nd Predicate before pushdown
       UnionNode::make(SetOperationMode::Positions,
         PredicateNode::make(like_(_c_a, "%man%"),
           input_common_node),
@@ -296,16 +296,16 @@ TEST_F(PredicatePlacementRuleTest, ConsecutiveDiamondPushdownTest) {
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
 
   const auto expected_common_node2 =
-  PredicateNode::make(equals_(_c_b, 10),          // <-- 2nd Predicate after pushdown
+  PredicateNode::make(equals_(_c_a, 10),                                // <-- 1st Predicate after pushdown
     _stored_table_c);
 
   const auto expected_common_node1 =
-  PredicateNode::make(greater_than_(_c_a, 1000),  // <-- 1st Predicate after pushdown
-    UnionNode::make(SetOperationMode::Positions,
-      ProjectionNode::make(expression_vector(_c_a, _c_b, cast_(11, DataType::Float)),
+  PredicateNode::make(greater_than_(sum_(_c_b), 1000),                  // <-- 2nd Predicate after pushdown
+    UnionNode::make(SetOperationMode::All,
+      AggregateNode::make(expression_vector(_c_a), expression_vector(sum_(_c_b)),
         PredicateNode::make(like_(_c_a, "%woman%"),
           expected_common_node2)),
-      ProjectionNode::make(expression_vector(_c_a, _c_b, cast_(11, DataType::Float)),
+      AggregateNode::make(expression_vector(_c_a), expression_vector(sum_(_c_b)),
         PredicateNode::make(like_(_c_a, "%Woman%"),
           expected_common_node2))));
 

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -592,7 +592,7 @@ TEST_F(PredicatePlacementRuleTest, HandleBarrierPredicatePushdown) {
 
   // clang-format off
   const auto barrier_predicate_node =
-  PredicateNode::make(greater_than_(_b_b, 123),                 // <-- 1st Predicate before pushdown (pushdown barrier due to output_count() == 2) //NOLINT
+  PredicateNode::make(greater_than_(_b_b, 123),                 // <-- 1st Predicate before pushdown (pushdown barrier due to output_count() == 2) // NOLINT
     JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),         // <-- 2nd Predicate before pushdown
       JoinNode::make(JoinMode::Inner, equals_(_b_a, _c_a),
         _stored_table_b,

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -2991,7 +2991,7 @@ TEST_F(SQLTranslatorTest, CopyStatementExport) {
   // clang-format off
   {
     const auto [actual_lqp, translation_info] = sql_to_lqp_helper("COPY int_float TO 'a_file.tbl';");
-    const auto expected_lqp = ExportNode::make("int_float", "a_file.tbl", FileType::Auto, stored_table_node_int_float); //NOLINT
+    const auto expected_lqp = ExportNode::make("int_float", "a_file.tbl", FileType::Auto, stored_table_node_int_float); // NOLINT
     EXPECT_LQP_EQ(actual_lqp, expected_lqp);
   }
   {


### PR DESCRIPTION
The `PredicatePlacementRule` pushes down predicates until it reaches a barrier node that prevents further pushdown. In this case, pushdown predicates are inserted above the barrier node, and the pushdown traversal restarts at the barrier node.

Our `_push_down_traversal` subroutine takes a given node and processes the inputs. However, in some cases, the given node (a barrier from a previous pushdown) is also a predicate eligible for pushdown. Currently, these barrier predicates (having multiple outputs) cannot be pushed down.

This PR fixes the implementation so that predicate barriers are pushed down as well. As a result, the TPC-DS and Join Order benchmarks profit. In addition, this PR streamlines the code for pushdowns through Union-diamonds.

---

**System**
<details>
<summary>pella - click to expand</summary>

| property | value |
| -- | -- |
| Hostname | pella |
| CPU | Intel(R) Xeon(R) CPU E7- 8870  @ 2.40GHz |
| Memory | 1.5TB |
| numactl | nodebind: 2  |
| numactl | membind: 2  |
</details>

**Commit Info and Build Time**
| commit | date | message | build time |
| -- | -- | -- | -- |
| 29167e43c | 07.05.2022 20:12 | Refactor EnableMakeForLQPNode (#2456) | real 740.39 user 4811.95 sys 219.02|
| f31af39c1 | 11.05.2022 17:58 | Fix format | real 713.22 user 4302.77 sys 178.66|


**hyriseBenchmarkTPCH - single-threaded, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: -0%
 || 
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_29167e43c01ece6e762f371cf0f35dc6fb662051_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_f31af39c181c4d9cdc54f1d04b0290398afd16a1_st.json |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                             | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                             |
 |  benchmark_mode          | Ordered                                                                                                                                    | Ordered                                                                                                                                    |
 |  build_type              | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size              | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  clustering              | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                   | 0                                                                                                                                          | 0                                                                                                                                          |
 |  data_preparation_cores  | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                    | 2022-05-10 21:18:48                                                                                                                        | 2022-05-11 18:11:51                                                                                                                        |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                 | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration            | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs                | 100                                                                                                                                        | 100                                                                                                                                        |
 |  scale_factor            | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit               | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler         | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                  | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration         | 1000000000                                                                                                                                 | 1000000000                                                                                                                                 |
 +--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||  11039.6 | 10853.4 |   -2%  ||     0.09 |     0.09 |   +2%  |       ˅ |
 | TPC-H 02 ||     87.5 |    87.0 |   -1%˄ ||    11.43 |    11.50 |   +1%˄ |  0.6352 |
 | TPC-H 03 ||   4204.6 |  4203.0 |   -0%  ||     0.24 |     0.24 |   +0%  |  0.9510 |
 | TPC-H 04 ||   3113.5 |  3085.7 |   -1%  ||     0.32 |     0.32 |   +1%  |  0.2904 |
 | TPC-H 05 ||   6653.4 |  6620.2 |   -0%  ||     0.15 |     0.15 |   +1%  |  0.2872 |
 | TPC-H 06 ||    380.2 |   376.7 |   -1%˄ ||     2.63 |     2.65 |   +1%˄ |  0.2462 |
 | TPC-H 07 ||   1859.5 |  1865.7 |   +0%  ||     0.54 |     0.54 |   -0%  |  0.2308 |
 | TPC-H 08 ||   1517.6 |  1524.3 |   +0%  ||     0.66 |     0.66 |   -0%  |  0.0250 |
 | TPC-H 09 ||  11465.4 | 11477.2 |   +0%  ||     0.09 |     0.09 |   -0%  |       ˅ |
 | TPC-H 10 ||   4658.5 |  4649.3 |   -0%  ||     0.21 |     0.22 |   +0%  |  0.8232 |
 | TPC-H 11 ||    198.0 |   199.5 |   +1%˄ ||     5.05 |     5.01 |   -1%˄ |  0.1082 |
 | TPC-H 12 ||   2033.4 |  2027.3 |   -0%  ||     0.49 |     0.49 |   +0%  |  0.2238 |
 | TPC-H 13 ||  10894.9 | 10741.5 |   -1%  ||     0.09 |     0.09 |   +1%  |       ˅ |
 | TPC-H 14 ||    961.9 |   946.0 |   -2%  ||     1.04 |     1.06 |   +2%  |  0.0005 |
 | TPC-H 15 ||    495.1 |   492.9 |   -0%˄ ||     2.02 |     2.03 |   +0%˄ |  0.0000 |
+| TPC-H 16 ||   1353.5 |  1285.3 |   -5%  ||     0.74 |     0.78 |   +5%  |  0.0000 |
 | TPC-H 17 ||    563.5 |   564.0 |   +0%˄ ||     1.77 |     1.77 |   -0%˄ |  0.4031 |
 | TPC-H 18 ||   5073.9 |  5130.7 |   +1%  ||     0.20 |     0.19 |   -1%  |  0.3034 |
 | TPC-H 19 ||    662.6 |   665.2 |   +0%  ||     1.51 |     1.50 |   -0%  |  0.0001 |
 | TPC-H 20 ||    883.2 |   892.7 |   +1%  ||     1.13 |     1.12 |   -1%  |  0.4453 |
 | TPC-H 21 ||  10089.9 | 10113.3 |   +0%  ||     0.10 |     0.10 |   -0%  |       ˅ |
 | TPC-H 22 ||    943.6 |   940.1 |   -0%  ||     1.06 |     1.06 |   +0%  |  0.0222 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||  79133.4 | 78741.0 |   -0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   +0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |    Notes || ˄ Execution stopped due to max runs reached                           |
 |          || ˅ Insufficient number of runs for p-value calculation                 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - single-threaded, SF 0.01**
<details>
<summary>
Sum of avg. item runtimes: -0%
 || 
Geometric mean of throughput changes: -0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview----+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_29167e43c01ece6e762f371cf0f35dc6fb662051_st_s01.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_f31af39c181c4d9cdc54f1d04b0290398afd16a1_st_s01.json |
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                                 | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                                 |
 |  benchmark_mode          | Ordered                                                                                                                                        | Ordered                                                                                                                                        |
 |  build_type              | release                                                                                                                                        | release                                                                                                                                        |
 |  chunk_size              | 65535                                                                                                                                          | 65535                                                                                                                                          |
 |  clients                 | 1                                                                                                                                              | 1                                                                                                                                              |
 |  clustering              | None                                                                                                                                           | None                                                                                                                                           |
 |  compiler                | gcc 9.2                                                                                                                                        | gcc 9.2                                                                                                                                        |
 |  cores                   | 0                                                                                                                                              | 0                                                                                                                                              |
 |  data_preparation_cores  | 0                                                                                                                                              | 0                                                                                                                                              |
 |  date                    | 2022-05-10 21:44:01                                                                                                                            | 2022-05-11 18:36:56                                                                                                                            |
 |  encoding                | {'default': {'encoding': 'Dictionary'}}                                                                                                        | {'default': {'encoding': 'Dictionary'}}                                                                                                        |
 |  indexes                 | False                                                                                                                                          | False                                                                                                                                          |
 |  max_duration            | 60000000000                                                                                                                                    | 60000000000                                                                                                                                    |
 |  max_runs                | 100                                                                                                                                            | 100                                                                                                                                            |
 |  scale_factor            | 0.009999999776482582                                                                                                                           | 0.009999999776482582                                                                                                                           |
 |  time_unit               | ns                                                                                                                                             | ns                                                                                                                                             |
 |  use_prepared_statements | False                                                                                                                                          | False                                                                                                                                          |
 |  using_scheduler         | False                                                                                                                                          | False                                                                                                                                          |
 |  verify                  | False                                                                                                                                          | False                                                                                                                                          |
 |  warmup_duration         | 1000000000                                                                                                                                     | 1000000000                                                                                                                                     |
 +--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |          ||      old |     new |        ||      old |      new |        |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | TPC-H 01 ||     10.7 |    10.7 |   +0%˄ ||    93.47 |    93.23 |   -0%˄ |  0.5691 |
 | TPC-H 02 ||      9.6 |     9.5 |   -0%˄ ||   104.63 |   104.84 |   +0%˄ |  0.9578 |
 | TPC-H 03 ||      1.5 |     1.6 |   +2%˄ ||   646.50 |   634.73 |   -2%˄ |  0.7374 |
 | TPC-H 04 ||      1.0 |     1.0 |   -0%˄ ||  1045.27 |  1047.53 |   +0%˄ |  0.4946 |
 | TPC-H 05 ||      2.2 |     2.2 |   +0%˄ ||   449.36 |   448.89 |   -0%˄ |  0.9066 |
 | TPC-H 06 ||      0.5 |     0.5 |   +1%˄ ||  2204.55 |  2173.57 |   -1%˄ |  0.0731 |
 | TPC-H 07 ||     22.8 |    22.7 |   -0%˄ ||    43.87 |    44.05 |   +0%˄ |  0.9318 |
 | TPC-H 08 ||     26.8 |    26.7 |   -1%˄ ||    37.26 |    37.52 |   +1%˄ |  0.6219 |
 | TPC-H 09 ||      9.9 |     9.9 |   +1%˄ ||   101.43 |   100.49 |   -1%˄ |  0.9399 |
 | TPC-H 10 ||      1.5 |     1.5 |   +0%˄ ||   677.51 |   676.61 |   -0%˄ |  0.8540 |
 | TPC-H 11 ||      0.5 |     0.5 |   -0%˄ ||  2167.67 |  2173.40 |   +0%˄ |  0.7713 |
 | TPC-H 12 ||      1.4 |     1.4 |   -2%˄ ||   723.52 |   735.17 |   +2%˄ |  0.7817 |
 | TPC-H 13 ||      3.3 |     3.3 |   +0%˄ ||   305.66 |   304.17 |   -0%˄ |  0.1035 |
 | TPC-H 14 ||      0.6 |     0.6 |   -1%˄ ||  1576.79 |  1585.25 |   +1%˄ |  0.6287 |
 | TPC-H 15 ||      2.1 |     2.1 |   +1%˄ ||   475.92 |   471.53 |   -1%˄ |  0.0003 |
 | TPC-H 16 ||      3.5 |     3.6 |   +3%˄ ||   284.20 |   277.08 |   -3%˄ |  0.0000 |
 | TPC-H 17 ||      1.7 |     1.8 |   +1%˄ ||   571.06 |   566.56 |   -1%˄ |  0.9220 |
 | TPC-H 18 ||      2.8 |     2.8 |   +1%˄ ||   354.94 |   353.00 |   -1%˄ |  0.1498 |
 | TPC-H 19 ||     11.0 |    10.7 |   -2%˄ ||    90.73 |    93.00 |   +2%˄ |  0.0000 |
 | TPC-H 20 ||      4.0 |     4.2 |   +4%˄ ||   247.32 |   237.31 |   -4%˄ |  0.0814 |
 | TPC-H 21 ||      7.2 |     7.1 |   -2%˄ ||   139.33 |   141.49 |   +2%˄ |  0.2962 |
 | TPC-H 22 ||      2.0 |     2.0 |   -2%˄ ||   490.90 |   500.38 |   +2%˄ |  0.0000 |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 | Sum      ||    126.6 |   126.3 |   -0%  ||          |          |        |         |
 | Geomean  ||          |         |        ||          |          |   -0%  |         |
 +----------++----------+---------+--------++----------+----------+--------+---------+
 |    Notes || ˄ Execution stopped due to max runs reached                           |
 +----------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, ordered, 1 client, 10 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: +1%
 || 
Geometric mean of throughput changes: -1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_29167e43c01ece6e762f371cf0f35dc6fb662051_mt_ordered.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_f31af39c181c4d9cdc54f1d04b0290398afd16a1_mt_ordered.json |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                                     | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                                     |
 |  benchmark_mode               | Ordered                                                                                                                                            | Ordered                                                                                                                                            |
 |  build_type                   | release                                                                                                                                            | release                                                                                                                                            |
 |  chunk_size                   | 65535                                                                                                                                              | 65535                                                                                                                                              |
 |  clients                      | 1                                                                                                                                                  | 1                                                                                                                                                  |
 |  clustering                   | None                                                                                                                                               | None                                                                                                                                               |
 |  compiler                     | gcc 9.2                                                                                                                                            | gcc 9.2                                                                                                                                            |
 |  cores                        | 10                                                                                                                                                 | 10                                                                                                                                                 |
 |  data_preparation_cores       | 0                                                                                                                                                  | 0                                                                                                                                                  |
 |  date                         | 2022-05-10 21:44:36                                                                                                                                | 2022-05-11 18:37:31                                                                                                                                |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                            | {'default': {'encoding': 'Dictionary'}}                                                                                                            |
 |  indexes                      | False                                                                                                                                              | False                                                                                                                                              |
 |  max_duration                 | 60000000000                                                                                                                                        | 60000000000                                                                                                                                        |
 |  max_runs                     | -1                                                                                                                                                 | -1                                                                                                                                                 |
 |  scale_factor                 | 10.0                                                                                                                                               | 10.0                                                                                                                                               |
 |  time_unit                    | ns                                                                                                                                                 | ns                                                                                                                                                 |
 |  use_prepared_statements      | False                                                                                                                                              | False                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                               | True                                                                                                                                               |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                         | [0, 0, 10]                                                                                                                                         |
 |  verify                       | False                                                                                                                                              | False                                                                                                                                              |
 |  warmup_duration              | 0                                                                                                                                                  | 0                                                                                                                                                  |
 +-------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |     new |        ||      old |      new |        |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
-| TPC-H 01 ||   9410.2 |  9942.7 |   +6%  ||     0.10 |     0.08 |  -17%  | (run time too short) |
 | TPC-H 02 ||     60.7 |    60.5 |   -0%  ||    15.13 |    15.20 |   +0%  |               0.7215 |
 | TPC-H 03 ||   1477.7 |  1466.7 |   -1%  ||     0.67 |     0.67 |   -0%  | (run time too short) |
 | TPC-H 04 ||   1040.9 |  1027.4 |   -1%  ||     0.95 |     0.97 |   +2%  |               0.2293 |
 | TPC-H 05 ||   1929.7 |  1950.8 |   +1%  ||     0.52 |     0.50 |   -3%  | (run time too short) |
 | TPC-H 06 ||     86.0 |    85.1 |   -1%  ||    10.85 |    10.90 |   +0%  |               0.0089 |
 | TPC-H 07 ||    668.6 |   669.3 |   +0%  ||     1.48 |     1.48 |   -0%  |               0.8329 |
 | TPC-H 08 ||    519.9 |   516.2 |   -1%  ||     1.90 |     1.92 |   +1%  |               0.1283 |
 | TPC-H 09 ||   5410.0 |  5370.8 |   -1%  ||     0.18 |     0.18 |   -0%  |               0.5910 |
 | TPC-H 10 ||   2410.7 |  2390.1 |   -1%  ||     0.40 |     0.42 |   +4%  | (run time too short) |
 | TPC-H 11 ||    140.9 |   141.5 |   +0%  ||     6.85 |     6.82 |   -0%  |               0.2044 |
 | TPC-H 12 ||    832.5 |   831.9 |   -0%  ||     1.18 |     1.18 |   -0%  |               0.8824 |
 | TPC-H 13 ||   8042.5 |  8038.9 |   -0%  ||     0.12 |     0.12 |   +0%  | (run time too short) |
 | TPC-H 14 ||    290.5 |   289.6 |   -0%  ||     3.37 |     3.38 |   +0%  |               0.3323 |
 | TPC-H 15 ||    312.6 |   311.7 |   -0%  ||     3.13 |     3.15 |   +1%  |               0.2770 |
 | TPC-H 16 ||   1117.7 |  1116.6 |   -0%  ||     0.88 |     0.88 |   -0%  |               0.8982 |
 | TPC-H 17 ||    159.7 |   160.3 |   +0%  ||     6.08 |     6.07 |   -0%  |               0.2371 |
 | TPC-H 18 ||   5339.9 |  5365.8 |   +0%  ||     0.18 |     0.18 |   -0%  | (run time too short) |
 | TPC-H 19 ||    227.1 |   226.4 |   -0%  ||     4.28 |     4.28 |   -0%  |               0.4364 |
 | TPC-H 20 ||    344.9 |   347.5 |   +1%  ||     2.85 |     2.82 |   -1%  |               0.2880 |
 | TPC-H 21 ||   2028.2 |  2017.5 |   -1%  ||     0.48 |     0.48 |   -0%  | (run time too short) |
 | TPC-H 22 ||    257.3 |   257.1 |   -0%  ||     3.80 |     3.80 |   -0%  |               0.8772 |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
 | Sum      ||  42108.3 | 42584.3 |   +1%  ||          |          |        |                      |
 | Geomean  ||          |         |        ||          |          |   -1%  |                      |
 +----------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCH - multi-threaded, shuffled, 10 clients, 10 cores, SF 10.0**
<details>
<summary>
Sum of avg. item runtimes: -1%
 || 
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_29167e43c01ece6e762f371cf0f35dc6fb662051_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCH_f31af39c181c4d9cdc54f1d04b0290398afd16a1_mt.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                             | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                             |
 |  benchmark_mode               | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type                   | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                      | 10                                                                                                                                         | 10                                                                                                                                         |
 |  clustering                   | None                                                                                                                                       | None                                                                                                                                       |
 |  compiler                     | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                        | 10                                                                                                                                         | 10                                                                                                                                         |
 |  data_preparation_cores       | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                         | 2022-05-10 22:10:17                                                                                                                        | 2022-05-11 19:03:01                                                                                                                        |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                      | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration                 | 1200000000000                                                                                                                              | 1200000000000                                                                                                                              |
 |  max_runs                     | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor                 | 10.0                                                                                                                                       | 10.0                                                                                                                                       |
 |  time_unit                    | ns                                                                                                                                         | ns                                                                                                                                         |
 |  use_prepared_statements      | False                                                                                                                                      | False                                                                                                                                      |
 |  using_scheduler              | True                                                                                                                                       | True                                                                                                                                       |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                 | [0, 0, 10]                                                                                                                                 |
 |  verify                       | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration              | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item     || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |          ||      old |      new |        ||      old |      new |        |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | TPC-H 01 ||  13542.4 |  13320.6 |   -2%  ||     0.07 |     0.07 |   +3%  |               0.6752 |
+| TPC-H 02 ||    622.6 |    435.6 |  -30%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
+| TPC-H 03 ||   7791.0 |   7242.6 |   -7%  ||     0.07 |     0.07 |   +0%  |               0.5831 |
+| TPC-H 04 ||   4870.2 |   4563.0 |   -6%  ||     0.07 |     0.07 |   +2%  |               0.6895 |
 | TPC-H 05 ||  11445.9 |  11001.3 |   -4%  ||     0.07 |     0.07 |   +0%  |               0.7595 |
+| TPC-H 06 ||   1311.0 |   1098.8 |  -16%  ||     0.07 |     0.07 |   +0%  |               0.5710 |
+| TPC-H 07 ||   5707.2 |   4597.2 |  -19%  ||     0.07 |     0.07 |   +2%  |               0.2094 |
 | TPC-H 08 ||   4028.5 |   3858.1 |   -4%  ||     0.07 |     0.07 |   +1%  |               0.8029 |
-| TPC-H 09 ||  16243.0 |  17270.1 |   +6%  ||     0.07 |     0.07 |   +0%  |               0.4812 |
-| TPC-H 10 ||   8815.8 |  10390.0 |  +18%  ||     0.07 |     0.07 |   +1%  |               0.2126 |
 | TPC-H 11 ||    705.5 |    712.3 |   +1%  ||     0.07 |     0.07 |   +1%  |               0.9741 |
+| TPC-H 12 ||   4286.9 |   3914.2 |   -9%  ||     0.07 |     0.07 |   +1%  |               0.5957 |
 | TPC-H 13 ||  14405.0 |  14746.1 |   +2%  ||     0.07 |     0.07 |   +0%  |               0.6043 |
+| TPC-H 14 ||   2886.3 |   2140.4 |  -26%  ||     0.07 |     0.07 |   +1%  |               0.2768 |
-| TPC-H 15 ||    974.1 |   1550.8 |  +59%  ||     0.07 |     0.07 |   +1%  |               0.0643 |
+| TPC-H 16 ||   4947.7 |   3545.3 |  -28%  ||     0.07 |     0.07 |   -1%  |               0.0449 |
-| TPC-H 17 ||   1023.2 |   1571.9 |  +54%  ||     0.07 |     0.07 |   +1%  |               0.2769 |
-| TPC-H 18 ||   8006.6 |   8690.7 |   +9%  ||     0.07 |     0.07 |   +0%  |               0.1225 |
+| TPC-H 19 ||   1504.9 |   1378.4 |   -8%  ||     0.07 |     0.07 |   +1%  |               0.7177 |
-| TPC-H 20 ||   2244.2 |   2514.4 |  +12%  ||     0.07 |     0.07 |   +1%  |               0.4787 |
+| TPC-H 21 ||  13304.2 |  12239.2 |   -8%  ||     0.07 |     0.07 |   +1%  |               0.4651 |
-| TPC-H 22 ||   2124.6 |   2336.1 |  +10%  ||     0.07 |     0.07 |   +1%  |               0.7440 |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum      || 130790.7 | 129117.1 |   -1%  ||          |          |        |                      |
 | Geomean  ||          |          |        ||          |          |   +1%  |                      |
 +----------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCDS - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -0%
 || 
Geometric mean of throughput changes: +1%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_29167e43c01ece6e762f371cf0f35dc6fb662051_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_f31af39c181c4d9cdc54f1d04b0290398afd16a1_st.json |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                              | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                              |
 |  benchmark_mode         | Ordered                                                                                                                                     | Ordered                                                                                                                                     |
 |  build_type             | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size             | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                | 1                                                                                                                                           | 1                                                                                                                                           |
 |  compiler               | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                  | 0                                                                                                                                           | 0                                                                                                                                           |
 |  data_preparation_cores | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                   | 2022-05-10 22:33:37                                                                                                                         | 2022-05-11 19:26:19                                                                                                                         |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration           | 60000000000                                                                                                                                 | 60000000000                                                                                                                                 |
 |  max_runs               | 100                                                                                                                                         | 100                                                                                                                                         |
 |  time_unit              | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler        | False                                                                                                                                       | False                                                                                                                                       |
 |  verify                 | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration        | 1000000000                                                                                                                                  | 1000000000                                                                                                                                  |
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |         ||      old |     new |        ||      old |      new |        |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
-| 01      ||    456.4 |   553.7 |  +21%˄ ||     2.19 |     1.81 |  -18%˄ |  0.0000 |
 | 03      ||    172.4 |   172.2 |   -0%˄ ||     5.80 |     5.81 |   +0%˄ |  0.3837 |
 | 06      ||    335.1 |   337.5 |   +1%˄ ||     2.98 |     2.96 |   -1%˄ |  0.0003 |
 | 07      ||    586.5 |   595.9 |   +2%˄ ||     1.70 |     1.68 |   -2%˄ |  0.0000 |
 | 09      ||   2068.9 |  2070.3 |   +0%  ||     0.48 |     0.48 |   -0%  |  0.6630 |
 | 10      ||    286.6 |   287.3 |   +0%˄ ||     3.49 |     3.48 |   -0%˄ |  0.3066 |
 | 13      ||    878.8 |   854.7 |   -3%  ||     1.14 |     1.17 |   +3%  |  0.0000 |
 | 15      ||    222.7 |   228.0 |   +2%˄ ||     4.49 |     4.39 |   -2%˄ |  0.0000 |
 | 16      ||    336.8 |   342.2 |   +2%˄ ||     2.97 |     2.92 |   -2%˄ |  0.0000 |
+| 17      ||    796.0 |   627.9 |  -21%  ||     1.26 |     1.59 |  +27%  |  0.0000 |
 | 19      ||    208.0 |   206.9 |   -1%˄ ||     4.81 |     4.83 |   +1%˄ |  0.0001 |
 | 25      ||    345.6 |   347.2 |   +0%˄ ||     2.89 |     2.88 |   -0%˄ |  0.0581 |
 | 26      ||    257.9 |   260.8 |   +1%˄ ||     3.88 |     3.83 |   -1%˄ |  0.0003 |
 | 28      ||   1385.6 |  1389.6 |   +0%  ||     0.72 |     0.72 |   -0%  |  0.0011 |
 | 29      ||   1077.7 |  1084.8 |   +1%  ||     0.93 |     0.92 |   -1%  |  0.0013 |
 | 31      ||   2953.2 |  2926.2 |   -1%  ||     0.34 |     0.34 |   +1%  |  0.0001 |
 | 32      ||     97.3 |    98.2 |   +1%˄ ||    10.28 |    10.18 |   -1%˄ |  0.0261 |
 | 34      ||    329.2 |   329.3 |   +0%˄ ||     3.04 |     3.04 |   -0%˄ |  0.9282 |
 | 35      ||   1330.9 |  1331.4 |   +0%  ||     0.75 |     0.75 |   -0%  |  0.8351 |
 | 37      ||    613.3 |   626.5 |   +2%  ||     1.63 |     1.60 |   -2%  |  0.0003 |
 | 39a     ||   4248.6 |  4252.2 |   +0%  ||     0.24 |     0.24 |   -0%  |  0.8518 |
 | 39b     ||   4215.6 |  4258.2 |   +1%  ||     0.24 |     0.23 |   -1%  |  0.0077 |
 | 41      ||    634.2 |   625.9 |   -1%  ||     1.58 |     1.60 |   +1%  |  0.0000 |
 | 42      ||    171.0 |   170.5 |   -0%˄ ||     5.85 |     5.86 |   +0%˄ |  0.2662 |
 | 43      ||   1901.1 |  1893.7 |   -0%  ||     0.53 |     0.53 |   +0%  |  0.1228 |
 | 45      ||    224.3 |   227.0 |   +1%˄ ||     4.46 |     4.40 |   -1%˄ |  0.0000 |
 | 48      ||   2093.8 |  2092.6 |   -0%  ||     0.48 |     0.48 |   +0%  |  0.8453 |
 | 50      ||    237.8 |   237.3 |   -0%˄ ||     4.20 |     4.21 |   +0%˄ |  0.0486 |
 | 52      ||    171.0 |   170.3 |   -0%˄ ||     5.85 |     5.87 |   +0%˄ |  0.0088 |
 | 55      ||    165.3 |   164.8 |   -0%˄ ||     6.05 |     6.07 |   +0%˄ |  0.0038 |
 | 62      ||   1161.5 |  1161.3 |   -0%  ||     0.86 |     0.86 |   +0%  |  0.9136 |
 | 65      ||   3897.6 |  3934.2 |   +1%  ||     0.26 |     0.25 |   -1%  |  0.0033 |
 | 69      ||    267.9 |   265.9 |   -1%˄ ||     3.73 |     3.76 |   +1%˄ |  0.0000 |
 | 73      ||    175.2 |   172.9 |   -1%˄ ||     5.71 |     5.78 |   +1%˄ |  0.0000 |
 | 79      ||   1104.3 |  1086.6 |   -2%  ||     0.91 |     0.92 |   +2%  |  0.0000 |
 | 81      ||    420.6 |   426.4 |   +1%˄ ||     2.38 |     2.35 |   -1%˄ |  0.0000 |
 | 82      ||    806.1 |   811.6 |   +1%  ||     1.24 |     1.23 |   -1%  |  0.0306 |
 | 83      ||     85.5 |    85.6 |   +0%˄ ||    11.69 |    11.68 |   -0%˄ |  0.9149 |
+| 85      ||    551.0 |   272.7 |  -51%˄ ||     1.81 |     3.67 | +102%˄ |  0.0000 |
 | 88      ||   1395.7 |  1373.9 |   -2%  ||     0.72 |     0.73 |   +2%  |  0.0000 |
 | 91      ||     42.3 |    42.2 |   -0%˄ ||    23.66 |    23.68 |   +0%˄ |  0.9211 |
 | 92      ||     94.2 |    94.0 |   -0%˄ ||    10.62 |    10.63 |   +0%˄ |  0.6638 |
 | 93      ||   7798.5 |  7776.2 |   -0%  ||     0.13 |     0.13 |   +0%  |       ˅ |
 | 94      ||    216.9 |   219.6 |   +1%˄ ||     4.61 |     4.55 |   -1%˄ |  0.0008 |
 | 95      ||  21269.3 | 21282.5 |   +0%  ||     0.05 |     0.05 |   -0%  |       ˅ |
 | 96      ||    136.3 |   135.1 |   -1%˄ ||     7.34 |     7.40 |   +1%˄ |  0.0653 |
 | 97      ||   7820.2 |  7773.0 |   -1%  ||     0.13 |     0.13 |   +1%  |       ˅ |
 | 99      ||   2190.3 |  2188.2 |   -0%  ||     0.46 |     0.46 |   +0%  |  0.5643 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 | Sum     ||  78235.2 | 77865.1 |   -0%  ||          |          |        |         |
 | Geomean ||          |         |        ||          |          |   +1%  |         |
 +---------++----------+---------+--------++----------+----------+--------+---------+
 |   Notes || ˄ Execution stopped due to max runs reached                           |
 |         || ˅ Insufficient number of runs for p-value calculation                 |
 +---------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCDS - multi-threaded, shuffled, 10 clients, 10 cores**
<details>
<summary>
Sum of avg. item runtimes: -0%
 || 
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_29167e43c01ece6e762f371cf0f35dc6fb662051_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCDS_f31af39c181c4d9cdc54f1d04b0290398afd16a1_mt.json |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                              | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                              |
 |  benchmark_mode               | Shuffled                                                                                                                                    | Shuffled                                                                                                                                    |
 |  build_type                   | release                                                                                                                                     | release                                                                                                                                     |
 |  chunk_size                   | 65535                                                                                                                                       | 65535                                                                                                                                       |
 |  clients                      | 10                                                                                                                                          | 10                                                                                                                                          |
 |  compiler                     | gcc 9.2                                                                                                                                     | gcc 9.2                                                                                                                                     |
 |  cores                        | 10                                                                                                                                          | 10                                                                                                                                          |
 |  data_preparation_cores       | 0                                                                                                                                           | 0                                                                                                                                           |
 |  date                         | 2022-05-10 23:09:46                                                                                                                         | 2022-05-11 20:02:49                                                                                                                         |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     | {'default': {'encoding': 'Dictionary'}}                                                                                                     |
 |  indexes                      | False                                                                                                                                       | False                                                                                                                                       |
 |  max_duration                 | 1200000000000                                                                                                                               | 1200000000000                                                                                                                               |
 |  max_runs                     | -1                                                                                                                                          | -1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                          | ns                                                                                                                                          |
 |  using_scheduler              | True                                                                                                                                        | True                                                                                                                                        |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                  | [0, 0, 10]                                                                                                                                  |
 |  verify                       | False                                                                                                                                       | False                                                                                                                                       |
 |  warmup_duration              | 0                                                                                                                                           | 0                                                                                                                                           |
 +-------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| 01      ||   1820.4 |   1575.3 |  -13%  ||     0.07 |     0.07 |   +0%  |               0.5353 |
+| 03      ||    860.6 |    706.4 |  -18%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
-| 06      ||   1125.8 |   2068.5 |  +84%  ||     0.07 |     0.07 |   +0%  |               0.0504 |
+| 07      ||   2139.6 |   1208.1 |  -44%  ||     0.07 |     0.07 |   +1%  |               0.0625 |
+| 09      ||   3832.9 |   3623.3 |   -5%  ||     0.07 |     0.07 |   +1%  |               0.2009 |
+| 10      ||   1020.4 |    910.9 |  -11%  ||     0.07 |     0.07 |   +1%  |               0.8000 |
+| 13      ||   3833.3 |   2853.8 |  -26%  ||     0.07 |     0.07 |   +0%  |               0.0303 |
+| 15      ||    788.8 |    717.2 |   -9%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
-| 16      ||   1475.5 |   1603.7 |   +9%  ||     0.07 |     0.07 |   +0%  |               0.7757 |
+| 17      ||   2770.7 |   2230.3 |  -20%  ||     0.07 |     0.07 |   +1%  |               0.2606 |
-| 19      ||    934.8 |   1203.4 |  +29%  ||     0.07 |     0.07 |   +0%  |               0.5735 |
+| 25      ||   1495.1 |   1364.0 |   -9%  ||     0.07 |     0.07 |   -1%  |               0.7122 |
+| 26      ||   1166.0 |    877.4 |  -25%  ||     0.07 |     0.07 |   -1%  |               0.4952 |
+| 28      ||   1820.6 |   1435.4 |  -21%  ||     0.07 |     0.07 |   +0%  |               0.3071 |
+| 29      ||   3173.1 |   2781.4 |  -12%  ||     0.07 |     0.07 |   +0%  |               0.5053 |
-| 31      ||   3741.4 |   4373.6 |  +17%  ||     0.07 |     0.07 |   -1%  |               0.3837 |
-| 32      ||    419.5 |    603.6 |  +44%  ||     0.07 |     0.07 |   -1%  | (run time too short) |
+| 34      ||    885.5 |    804.2 |   -9%  ||     0.07 |     0.07 |   +1%  |               0.5679 |
+| 35      ||   5213.9 |   4043.6 |  -22%  ||     0.07 |     0.07 |   +0%  |               0.1447 |
-| 37      ||   1249.7 |   1315.1 |   +5%  ||     0.07 |     0.07 |   +0%  |               0.8295 |
+| 39a     ||   6426.7 |   5411.7 |  -16%  ||     0.07 |     0.07 |   -1%  |               0.1816 |
-| 39b     ||   5291.5 |   5571.7 |   +5%  ||     0.07 |     0.07 |   +0%  |               0.5653 |
+| 41      ||   4557.5 |   4278.2 |   -6%  ||     0.07 |     0.07 |   +0%  |               0.6564 |
-| 42      ||    459.4 |    946.2 | +106%  ||     0.07 |     0.07 |   +1%  | (run time too short) |
-| 43      ||   3413.8 |   4147.2 |  +21%  ||     0.07 |     0.07 |   -2%  |               0.2186 |
+| 45      ||   1241.9 |    914.7 |  -26%  ||     0.07 |     0.07 |   +0%  |               0.3958 |
+| 48      ||   6307.3 |   4597.6 |  -27%  ||     0.07 |     0.07 |   +0%  |               0.0375 |
-| 50      ||   1384.6 |   1453.0 |   +5%  ||     0.07 |     0.07 |   +0%  |               0.8785 |
+| 52      ||    744.5 |    697.8 |   -6%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
-| 55      ||    418.0 |    833.7 |  +99%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
 | 62      ||   2598.2 |   2597.7 |   -0%  ||     0.07 |     0.07 |   +0%  |               0.9992 |
 | 65      ||   8081.9 |   8003.7 |   -1%  ||     0.07 |     0.07 |   +0%  |               0.8711 |
+| 69      ||   1586.0 |   1326.6 |  -16%  ||     0.07 |     0.07 |   +0%  |               0.6306 |
-| 73      ||    522.7 |    557.9 |   +7%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
-| 79      ||   2779.5 |   3321.9 |  +20%  ||     0.07 |     0.07 |   +1%  |               0.3183 |
+| 81      ||   2232.6 |   1875.9 |  -16%  ||     0.07 |     0.07 |   +0%  |               0.5058 |
-| 82      ||   1737.9 |   1875.1 |   +8%  ||     0.07 |     0.07 |   +0%  |               0.6597 |
+| 83      ||    566.6 |    418.5 |  -26%  ||     0.07 |     0.07 |   +0%  | (run time too short) |
-| 85      ||   2566.2 |   3971.7 |  +55%  ||     0.07 |     0.07 |   +0%  |               0.3179 |
-| 88      ||   1726.3 |   2149.7 |  +25%  ||     0.07 |     0.07 |   -1%  |               0.4935 |
-| 91      ||    170.6 |    398.6 | +134%  ||     0.07 |     0.07 |   +1%  | (run time too short) |
-| 92      ||    400.3 |    430.2 |   +7%  ||     0.07 |     0.07 |   -1%  | (run time too short) |
-| 93      ||   6164.9 |   7012.2 |  +14%  ||     0.07 |     0.07 |   -1%  |               0.2365 |
-| 94      ||   1682.7 |   1905.4 |  +13%  ||     0.07 |     0.07 |   +0%  |               0.7160 |
 | 95      ||  19812.6 |  20640.9 |   +4%  ||     0.07 |     0.07 |   -2%  |               0.4403 |
-| 96      ||    369.1 |    440.9 |  +19%  ||     0.07 |     0.07 |   +1%  | (run time too short) |
 | 97      ||  10595.6 |  10832.8 |   +2%  ||     0.07 |     0.07 |   +0%  |               0.7590 |
 | 99      ||   4343.2 |   4350.2 |   +0%  ||     0.07 |     0.07 |   +1%  |               0.9928 |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Sum     || 137949.9 | 137260.8 |   -0%  ||          |          |        |                      |
 | Geomean ||          |          |        ||          |          |   +0%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkTPCC - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: +1%
 || 
Geometric mean of throughput changes: -2%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_29167e43c01ece6e762f371cf0f35dc6fb662051_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_f31af39c181c4d9cdc54f1d04b0290398afd16a1_st.json |
 +-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                             | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                             |
 |  benchmark_mode         | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type             | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size             | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                | 1                                                                                                                                          | 1                                                                                                                                          |
 |  compiler               | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                  | 0                                                                                                                                          | 0                                                                                                                                          |
 |  data_preparation_cores | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                   | 2022-05-10 23:30:43                                                                                                                        | 2022-05-11 20:23:45                                                                                                                        |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration           | 60000000000                                                                                                                                | 60000000000                                                                                                                                |
 |  max_runs               | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor           | 1                                                                                                                                          | 1                                                                                                                                          |
 |  time_unit              | ns                                                                                                                                         | ns                                                                                                                                         |
 |  using_scheduler        | False                                                                                                                                      | False                                                                                                                                      |
 |  verify                 | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration        | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||     47.2 |    47.1 |   -0%  ||     2.13 |     2.12 |   -1%  |  0.5558 |
 | New-Order    ||     32.8 |    33.5 |   +2%  ||    24.03 |    23.57 |   -2%  |  0.0521 |
 | Order-Status ||      2.1 |     2.1 |   +0%  ||     2.13 |     2.10 |   -2%  |  0.8276 |
 | Payment      ||      4.1 |     4.1 |   +1%  ||    22.94 |    22.44 |   -2%  |  0.0031 |
 | Stock-Level  ||      6.2 |     6.3 |   +2%  ||     2.13 |     2.07 |   -3%  |  0.0480 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||     92.3 |    93.1 |   +1%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   -2%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkTPCC - multi-threaded, shuffled, 10 clients, 10 cores**
<details>
<summary>
Sum of avg. item runtimes: -1%
 || 
Geometric mean of throughput changes: +0%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_29167e43c01ece6e762f371cf0f35dc6fb662051_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkTPCC_f31af39c181c4d9cdc54f1d04b0290398afd16a1_mt.json |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                             | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                             |
 |  benchmark_mode               | Shuffled                                                                                                                                   | Shuffled                                                                                                                                   |
 |  build_type                   | release                                                                                                                                    | release                                                                                                                                    |
 |  chunk_size                   | 65535                                                                                                                                      | 65535                                                                                                                                      |
 |  clients                      | 10                                                                                                                                         | 10                                                                                                                                         |
 |  compiler                     | gcc 9.2                                                                                                                                    | gcc 9.2                                                                                                                                    |
 |  cores                        | 10                                                                                                                                         | 10                                                                                                                                         |
 |  data_preparation_cores       | 0                                                                                                                                          | 0                                                                                                                                          |
 |  date                         | 2022-05-10 23:31:44                                                                                                                        | 2022-05-11 20:24:46                                                                                                                        |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                    | {'default': {'encoding': 'Dictionary'}}                                                                                                    |
 |  indexes                      | False                                                                                                                                      | False                                                                                                                                      |
 |  max_duration                 | 1200000000000                                                                                                                              | 1200000000000                                                                                                                              |
 |  max_runs                     | -1                                                                                                                                         | -1                                                                                                                                         |
 |  scale_factor                 | 1                                                                                                                                          | 1                                                                                                                                          |
 |  time_unit                    | ns                                                                                                                                         | ns                                                                                                                                         |
 |  using_scheduler              | True                                                                                                                                       | True                                                                                                                                       |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                 | [0, 0, 10]                                                                                                                                 |
 |  verify                       | False                                                                                                                                      | False                                                                                                                                      |
 |  warmup_duration              | 0                                                                                                                                          | 0                                                                                                                                          |
 +-------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Item         || Latency (ms/iter)  | Change || Throughput (iter/s) | Change | p-value |
 |              ||      old |     new |        ||      old |      new |        |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Delivery     ||    272.9 |   269.3 |   -1%  ||     3.02 |     3.05 |   +1%  |  0.2937 |
 |    unsucc.:  ||      4.7 |     4.9 |   +4%  ||     9.17 |     9.11 |   -1%  |         |
 | New-Order    ||     92.2 |    92.7 |   +1%  ||    60.53 |    60.08 |   -1%  |  0.1012 |
 |    unsucc.:  ||      5.3 |     5.4 |   +3%  ||    76.58 |    76.75 |   +0%  |         |
 | Order-Status ||     10.7 |    11.2 |   +4%  ||    12.19 |    12.16 |   -0%  |  0.0373 |
 | Payment      ||     12.1 |    12.2 |   +1%  ||    26.22 |    26.34 |   +0%  |  0.4633 |
 |    unsucc.:  ||      4.2 |     4.2 |   +0%  ||   104.81 |   104.41 |   -0%  |         |
 | Stock-Level  ||     22.6 |    22.6 |   -0%  ||    12.19 |    12.16 |   -0%  |  0.9372 |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
 | Sum          ||    410.5 |   407.9 |   -1%  ||          |          |        |         |
 | Geomean      ||          |         |        ||          |          |   +0%  |         |
 +--------------++----------+---------+--------++----------+----------+--------+---------+
```
</details>


**hyriseBenchmarkJoinOrder - single-threaded**
<details>
<summary>
Sum of avg. item runtimes: -7%
 || 
Geometric mean of throughput changes: +5%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter               | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_29167e43c01ece6e762f371cf0f35dc6fb662051_st.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_f31af39c181c4d9cdc54f1d04b0290398afd16a1_st.json |
 +-------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH               | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                                  | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                                  |
 |  benchmark_mode         | Ordered                                                                                                                                         | Ordered                                                                                                                                         |
 |  build_type             | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_size             | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                | 1                                                                                                                                               | 1                                                                                                                                               |
 |  compiler               | gcc 9.2                                                                                                                                         | gcc 9.2                                                                                                                                         |
 |  cores                  | 0                                                                                                                                               | 0                                                                                                                                               |
 |  data_preparation_cores | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                   | 2022-05-10 23:51:48                                                                                                                             | 2022-05-11 20:44:50                                                                                                                             |
 |  encoding               | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  indexes                | False                                                                                                                                           | False                                                                                                                                           |
 |  max_duration           | 60000000000                                                                                                                                     | 60000000000                                                                                                                                     |
 |  max_runs               | 100                                                                                                                                             | 100                                                                                                                                             |
 |  time_unit              | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler        | False                                                                                                                                           | False                                                                                                                                           |
 |  verify                 | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration        | 1000000000                                                                                                                                      | 1000000000                                                                                                                                      |
 +-------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)  | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |     new |        ||      old |      new |        |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 | 10a     ||    406.5 |   406.5 |   +0%˄ ||     2.46 |     2.46 |   -0%˄ |               0.9822 |
 | 10b     ||    319.0 |   319.3 |   +0%˄ ||     3.13 |     3.13 |   -0%˄ |               0.3020 |
 | 10c     ||    639.2 |   638.4 |   -0%  ||     1.56 |     1.57 |   +0%  |               0.4925 |
 | 11a     ||     44.3 |    44.1 |   -0%˄ ||    22.58 |    22.65 |   +0%˄ |               0.2318 |
 | 11b     ||     43.8 |    43.6 |   -1%˄ ||    22.84 |    22.96 |   +1%˄ |               0.0798 |
 | 11c     ||     55.3 |    54.0 |   -2%˄ ||    18.07 |    18.53 |   +3%˄ |               0.0000 |
 | 11d     ||     60.6 |    60.2 |   -1%˄ ||    16.50 |    16.61 |   +1%˄ |               0.0001 |
 | 12a     ||    107.9 |   107.8 |   -0%˄ ||     9.27 |     9.28 |   +0%˄ |               0.7968 |
 | 12b     ||     78.9 |    79.1 |   +0%˄ ||    12.67 |    12.63 |   -0%˄ |               0.0538 |
 | 12c     ||    169.3 |   169.3 |   -0%˄ ||     5.90 |     5.91 |   +0%˄ |               0.8858 |
+| 13a     ||    714.6 |   571.7 |  -20%˄ ||     1.40 |     1.75 |  +25%˄ | (run time too short) |
+| 13b     ||    448.6 |   292.3 |  -35%˄ ||     2.23 |     3.42 |  +53%˄ |               0.0000 |
+| 13c     ||    358.5 |   233.9 |  -35%˄ ||     2.79 |     4.28 |  +53%˄ |               0.0000 |
+| 13d     ||   1403.8 |  1242.6 |  -11%  ||     0.71 |     0.80 |  +13%  |               0.0000 |
+| 14a     ||   1056.0 |   968.2 |   -8%  ||     0.95 |     1.03 |   +9%  |               0.0000 |
 | 14b     ||    503.6 |   490.4 |   -3%˄ ||     1.99 |     2.04 |   +3%˄ |               0.0000 |
+| 14c     ||   1221.5 |  1122.8 |   -8%  ||     0.82 |     0.89 |   +9%  |               0.0000 |
 | 15a     ||    180.9 |   181.2 |   +0%˄ ||     5.53 |     5.52 |   -0%˄ |               0.5560 |
 | 15b     ||    178.4 |   178.9 |   +0%˄ ||     5.60 |     5.59 |   -0%˄ |               0.2004 |
-| 15c     ||    100.0 |   191.8 |  +92%˄ ||    10.00 |     5.21 |  -48%˄ |               0.0000 |
 | 15d     ||    184.4 |   183.2 |   -1%˄ ||     5.42 |     5.46 |   +1%˄ |               0.0026 |
 | 16a     ||   5233.3 |  5263.1 |   +1%  ||     0.19 |     0.19 |   -1%  |               0.1535 |
 | 16b     ||   7350.1 |  7281.8 |   -1%  ||     0.14 |     0.14 |   +1%  |                    ˅ |
 | 16c     ||   5449.3 |  5422.6 |   -0%  ||     0.18 |     0.18 |   +0%  |               0.0495 |
 | 16d     ||   5383.9 |  5392.6 |   +0%  ||     0.19 |     0.19 |   -0%  |               0.5151 |
 | 17a     ||   1225.3 |  1232.5 |   +1%  ||     0.82 |     0.81 |   -1%  |               0.0004 |
 | 17b     ||    999.9 |  1001.0 |   +0%  ||     1.00 |     1.00 |   -0%  |               0.3036 |
 | 17c     ||    973.4 |   955.3 |   -2%  ||     1.03 |     1.05 |   +2%  |               0.0000 |
 | 17d     ||   1099.8 |  1103.3 |   +0%  ||     0.91 |     0.91 |   -0%  |               0.0273 |
 | 17e     ||   3474.8 |  3459.5 |   -0%  ||     0.29 |     0.29 |   +0%  |               0.0525 |
 | 17f     ||   1939.7 |  1938.2 |   -0%  ||     0.52 |     0.52 |   +0%  |               0.7016 |
+| 18a     ||   3753.7 |  1308.5 |  -65%  ||     0.27 |     0.76 | +187%  |               0.0000 |
 | 18b     ||    309.3 |   312.1 |   +1%˄ ||     3.23 |     3.20 |   -1%˄ |               0.0000 |
 | 18c     ||   1089.0 |  1062.7 |   -2%  ||     0.92 |     0.94 |   +2%  |               0.0000 |
 | 19a     ||    418.9 |   420.4 |   +0%˄ ||     2.39 |     2.38 |   -0%˄ |               0.0021 |
 | 19b     ||    287.0 |   287.3 |   +0%˄ ||     3.48 |     3.48 |   -0%˄ |               0.2787 |
 | 19c     ||    440.5 |   440.5 |   +0%˄ ||     2.27 |     2.27 |   -0%˄ |               0.8966 |
 | 19d     ||   1545.4 |  1526.1 |   -1%  ||     0.65 |     0.66 |   +1%  |               0.0000 |
+| 1a      ||     28.6 |    24.7 |  -13%˄ ||    35.02 |    40.40 |  +15%˄ |               0.0000 |
 | 1b      ||     23.2 |    23.2 |   +0%˄ ||    43.11 |    43.06 |   -0%˄ |               0.7588 |
 | 1c      ||     26.1 |    26.1 |   -0%˄ ||    38.30 |    38.30 |   +0%˄ |               0.9701 |
 | 1d      ||     23.2 |    23.0 |   -1%˄ ||    43.08 |    43.47 |   +1%˄ |               0.0187 |
 | 20a     ||    838.9 |   836.8 |   -0%  ||     1.19 |     1.19 |   +0%  |               0.0012 |
 | 20b     ||    534.7 |   530.0 |   -1%˄ ||     1.87 |     1.89 |   +1%˄ |               0.0000 |
 | 20c     ||    523.8 |   520.8 |   -1%˄ ||     1.91 |     1.92 |   +1%˄ |               0.0000 |
 | 21a     ||     95.6 |    95.2 |   -0%˄ ||    10.46 |    10.51 |   +0%˄ |               0.0007 |
 | 21b     ||     51.2 |    50.8 |   -1%˄ ||    19.54 |    19.70 |   +1%˄ |               0.0000 |
 | 21c     ||     96.0 |    95.9 |   -0%˄ ||    10.41 |    10.42 |   +0%˄ |               0.5950 |
+| 22a     ||    495.7 |   371.3 |  -25%˄ ||     2.02 |     2.69 |  +34%˄ |               0.0000 |
+| 22b     ||    287.8 |   273.4 |   -5%˄ ||     3.47 |     3.66 |   +5%˄ |               0.0000 |
+| 22c     ||   1722.2 |   981.1 |  -43%  ||     0.58 |     1.02 |  +76%  |               0.0000 |
 | 22d     ||   1857.3 |  1809.0 |   -3%  ||     0.54 |     0.55 |   +3%  |               0.0000 |
 | 23a     ||    110.1 |   110.1 |   -0%˄ ||     9.08 |     9.08 |   +0%˄ |               0.9669 |
 | 23b     ||    122.7 |   121.2 |   -1%˄ ||     8.15 |     8.25 |   +1%˄ |               0.0000 |
-| 23c     ||    134.7 |   191.6 |  +42%˄ ||     7.43 |     5.22 |  -30%˄ |               0.0000 |
 | 24a     ||    414.9 |   398.9 |   -4%˄ ||     2.41 |     2.51 |   +4%˄ |               0.0000 |
 | 24b     ||    347.8 |   348.7 |   +0%˄ ||     2.88 |     2.87 |   -0%˄ |               0.0001 |
 | 25a     ||    616.1 |   615.2 |   -0%  ||     1.62 |     1.63 |   +0%  |               0.0989 |
 | 25b     ||    325.1 |   325.9 |   +0%˄ ||     3.08 |     3.07 |   -0%˄ |               0.3156 |
 | 25c     ||   1964.8 |  1917.8 |   -2%  ||     0.51 |     0.52 |   +2%  |               0.0000 |
 | 26a     ||    434.7 |   433.1 |   -0%˄ ||     2.30 |     2.31 |   +0%˄ |               0.0000 |
 | 26b     ||    363.3 |   364.9 |   +0%˄ ||     2.75 |     2.74 |   -0%˄ |               0.0000 |
 | 26c     ||    547.3 |   545.5 |   -0%˄ ||     1.83 |     1.83 |   +0%˄ |               0.0032 |
 | 27a     ||     58.6 |    58.3 |   -1%˄ ||    17.05 |    17.15 |   +1%˄ |               0.0067 |
 | 27b     ||     57.4 |    57.2 |   -0%˄ ||    17.43 |    17.47 |   +0%˄ |               0.1956 |
 | 27c     ||     95.7 |    96.0 |   +0%˄ ||    10.45 |    10.42 |   -0%˄ |               0.0375 |
+| 28a     ||    834.2 |   558.9 |  -33%˄ ||     1.20 |     1.79 |  +49%˄ | (run time too short) |
+| 28b     ||     95.5 |    90.5 |   -5%˄ ||    10.47 |    11.05 |   +6%˄ |               0.0000 |
+| 28c     ||    996.5 |   638.6 |  -36%  ||     1.00 |     1.57 |  +56%  |               0.0000 |
 | 29a     ||    241.2 |   240.1 |   -0%˄ ||     4.15 |     4.17 |   +0%˄ |               0.0060 |
 | 29b     ||    192.1 |   190.3 |   -1%˄ ||     5.20 |     5.25 |   +1%˄ |               0.0000 |
 | 29c     ||    415.5 |   409.1 |   -2%˄ ||     2.41 |     2.44 |   +2%˄ |               0.0000 |
 | 2a      ||    104.7 |   104.0 |   -1%˄ ||     9.55 |     9.62 |   +1%˄ |               0.0095 |
 | 2b      ||     87.3 |    87.3 |   +0%˄ ||    11.45 |    11.45 |   -0%˄ |               0.9733 |
+| 2c      ||     69.6 |    55.3 |  -21%˄ ||    14.38 |    18.09 |  +26%˄ |               0.0000 |
 | 2d      ||    138.1 |   137.4 |   -0%˄ ||     7.24 |     7.28 |   +0%˄ |               0.0287 |
 | 30a     ||    387.8 |   387.3 |   -0%˄ ||     2.58 |     2.58 |   +0%˄ |               0.1198 |
 | 30b     ||    343.9 |   345.3 |   +0%˄ ||     2.91 |     2.90 |   -0%˄ |               0.0000 |
 | 30c     ||    805.9 |   808.3 |   +0%  ||     1.24 |     1.24 |   -0%  |               0.0466 |
 | 31a     ||    399.8 |   401.2 |   +0%˄ ||     2.50 |     2.49 |   -0%˄ |               0.0332 |
 | 31b     ||    353.0 |   351.7 |   -0%˄ ||     2.83 |     2.84 |   +0%˄ |               0.0000 |
 | 31c     ||    447.0 |   449.5 |   +1%˄ ||     2.24 |     2.22 |   -1%˄ |               0.0000 |
 | 32a     ||     32.8 |    32.5 |   -1%˄ ||    30.44 |    30.73 |   +1%˄ |               0.1153 |
 | 32b     ||     74.4 |    74.0 |   -1%˄ ||    13.45 |    13.52 |   +1%˄ |               0.1466 |
 | 33a     ||     47.6 |    47.3 |   -1%˄ ||    20.98 |    21.12 |   +1%˄ |               0.1534 |
 | 33b     ||     46.0 |    45.7 |   -1%˄ ||    21.75 |    21.86 |   +1%˄ |               0.2571 |
+| 33c     ||     57.6 |    54.9 |   -5%˄ ||    17.37 |    18.22 |   +5%˄ |               0.0000 |
 | 3a      ||    262.9 |   264.5 |   +1%˄ ||     3.80 |     3.78 |   -1%˄ |               0.0076 |
 | 3b      ||     34.7 |    34.7 |   -0%˄ ||    28.80 |    28.83 |   +0%˄ |               0.7942 |
 | 3c      ||   1105.0 |  1107.1 |   +0%  ||     0.90 |     0.90 |   -0%  |               0.2729 |
+| 4a      ||    586.9 |   265.8 |  -55%˄ ||     1.70 |     3.76 | +121%˄ |               0.0000 |
 | 4b      ||     30.1 |    29.5 |   -2%˄ ||    33.25 |    33.92 |   +2%˄ |               0.0167 |
+| 4c      ||    662.8 |   294.3 |  -56%˄ ||     1.51 |     3.40 | +125%˄ | (run time too short) |
 | 5a      ||    111.2 |   109.9 |   -1%˄ ||     8.99 |     9.10 |   +1%˄ |               0.0000 |
 | 5b      ||    249.3 |   247.9 |   -1%˄ ||     4.01 |     4.03 |   +1%˄ |               0.0018 |
+| 5c      ||    417.8 |   315.9 |  -24%˄ ||     2.39 |     3.17 |  +32%˄ |               0.0000 |
 | 6a      ||    296.7 |   296.0 |   -0%˄ ||     3.37 |     3.38 |   +0%˄ |               0.0057 |
 | 6b      ||    329.5 |   330.6 |   +0%˄ ||     3.03 |     3.02 |   -0%˄ |               0.0000 |
 | 6c      ||    283.1 |   283.2 |   +0%˄ ||     3.53 |     3.53 |   -0%˄ |               0.6521 |
 | 6d      ||   1127.5 |  1129.7 |   +0%  ||     0.89 |     0.89 |   -0%  |               0.0778 |
 | 6e      ||    296.2 |   295.7 |   -0%˄ ||     3.38 |     3.38 |   +0%˄ |               0.0185 |
 | 6f      ||   1483.7 |  1478.1 |   -0%  ||     0.67 |     0.68 |   +0%  |               0.0063 |
 | 7a      ||    143.1 |   148.6 |   +4%˄ ||     6.99 |     6.73 |   -4%˄ |               0.0000 |
 | 7b      ||    136.9 |   136.6 |   -0%˄ ||     7.30 |     7.32 |   +0%˄ |               0.4128 |
 | 7c      ||   1195.8 |  1218.9 |   +2%  ||     0.84 |     0.82 |   -2%  |               0.0000 |
 | 8a      ||    105.6 |   105.3 |   -0%˄ ||     9.47 |     9.49 |   +0%˄ |               0.1684 |
 | 8b      ||     98.6 |    97.9 |   -1%˄ ||    10.14 |    10.21 |   +1%˄ |               0.0004 |
 | 8c      ||   3884.2 |  3845.0 |   -1%  ||     0.26 |     0.26 |   +1%  |               0.0001 |
 | 8d      ||    629.9 |   622.5 |   -1%  ||     1.59 |     1.61 |   +1%  |               0.0000 |
 | 9a      ||    403.5 |   403.4 |   -0%˄ ||     2.48 |     2.48 |   +0%˄ |               0.8756 |
 | 9b      ||    234.2 |   235.2 |   +0%˄ ||     4.27 |     4.25 |   -0%˄ |               0.0048 |
 | 9c      ||    583.0 |   579.0 |   -1%˄ ||     1.72 |     1.73 |   +1%˄ |               0.0000 |
 | 9d      ||    998.6 |   981.9 |   -2%  ||     1.00 |     1.02 |   +2%  |               0.0000 |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
+| Sum     ||  83307.3 | 77599.2 |   -7%  ||          |          |        |                      |
+| Geomean ||          |         |        ||          |          |   +5%  |                      |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
 |   Notes || ˄ Execution stopped due to max runs reached                                        |
 |         || ˅ Insufficient number of runs for p-value calculation                              |
 +---------++----------+---------+--------++----------+----------+--------+----------------------+
```
</details>


**hyriseBenchmarkJoinOrder - multi-threaded, shuffled, 10 clients, 10 cores**
<details>
<summary>
Sum of avg. item runtimes: -8%
 || 
Geometric mean of throughput changes: +8%
</summary>

<details>
<summary>Configuration Overview - click to expand</summary>

```diff
 +Configuration Overview---------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 | Parameter                     | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_29167e43c01ece6e762f371cf0f35dc6fb662051_mt.json | /home/Julian.Menzler/repo_hyrise2/cmake_release/benchmark_all_results/hyriseBenchmarkJoinOrder_f31af39c181c4d9cdc54f1d04b0290398afd16a1_mt.json |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
 |  GIT-HASH                     | 29167e43c01ece6e762f371cf0f35dc6fb662051-dirty                                                                                                  | f31af39c181c4d9cdc54f1d04b0290398afd16a1-dirty                                                                                                  |
 |  benchmark_mode               | Shuffled                                                                                                                                        | Shuffled                                                                                                                                        |
 |  build_type                   | release                                                                                                                                         | release                                                                                                                                         |
 |  chunk_size                   | 65535                                                                                                                                           | 65535                                                                                                                                           |
 |  clients                      | 10                                                                                                                                              | 10                                                                                                                                              |
 |  compiler                     | gcc 9.2                                                                                                                                         | gcc 9.2                                                                                                                                         |
 |  cores                        | 10                                                                                                                                              | 10                                                                                                                                              |
 |  data_preparation_cores       | 0                                                                                                                                               | 0                                                                                                                                               |
 |  date                         | 2022-05-11 01:00:06                                                                                                                             | 2022-05-11 21:51:12                                                                                                                             |
 |  encoding                     | {'default': {'encoding': 'Dictionary'}}                                                                                                         | {'default': {'encoding': 'Dictionary'}}                                                                                                         |
 |  indexes                      | False                                                                                                                                           | False                                                                                                                                           |
 |  max_duration                 | 1200000000000                                                                                                                                   | 1200000000000                                                                                                                                   |
 |  max_runs                     | -1                                                                                                                                              | -1                                                                                                                                              |
 |  time_unit                    | ns                                                                                                                                              | ns                                                                                                                                              |
 |  using_scheduler              | True                                                                                                                                            | True                                                                                                                                            |
 |  utilized_cores_per_numa_node | [0, 0, 10]                                                                                                                                      | [0, 0, 10]                                                                                                                                      |
 |  verify                       | False                                                                                                                                           | False                                                                                                                                           |
 |  warmup_duration              | 0                                                                                                                                               | 0                                                                                                                                               |
 +-------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>

```diff
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
 | Item    || Latency (ms/iter)   | Change || Throughput (iter/s) | Change |              p-value |
 |         ||      old |      new |        ||      old |      new |        |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| 10a     ||    640.8 |    674.3 |   +5%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 10b     ||    427.0 |    491.1 |  +15%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 10c     ||   1031.5 |   1195.8 |  +16%  ||     0.06 |     0.07 |   +8%  |               0.3711 |
+| 11a     ||     96.5 |    112.4 |  +17%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 11b     ||    324.2 |     98.7 |  -70%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 11c     ||    431.7 |    169.2 |  -61%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 11d     ||    228.4 |    202.0 |  -12%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 12a     ||    714.7 |    362.7 |  -49%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 12b     ||    126.3 |    206.2 |  +63%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 12c     ||    548.9 |    792.3 |  +44%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 13a     ||   1776.4 |   1547.8 |  -13%  ||     0.06 |     0.07 |   +8%  |               0.5350 |
+| 13b     ||   1140.6 |    883.7 |  -23%  ||     0.06 |     0.07 |   +7%  |               0.3964 |
+| 13c     ||    964.5 |    576.8 |  -40%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 13d     ||   2753.5 |   2945.7 |   +7%  ||     0.06 |     0.07 |   +8%  |               0.5993 |
+| 14a     ||   2142.0 |   1880.9 |  -12%  ||     0.06 |     0.07 |   +9%  |               0.2694 |
+| 14b     ||   1471.7 |   1100.0 |  -25%  ||     0.06 |     0.07 |   +7%  |               0.2092 |
+| 14c     ||   2488.7 |   2678.7 |   +8%  ||     0.06 |     0.07 |   +7%  |               0.5862 |
+| 15a     ||    310.8 |    400.9 |  +29%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 15b     ||    394.1 |    321.5 |  -18%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 15c     ||    310.1 |    451.9 |  +46%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 15d     ||    574.3 |    410.7 |  -28%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 16a     ||   7326.2 |   7425.7 |   +1%  ||     0.06 |     0.07 |   +8%  |               0.8178 |
+| 16b     ||  10473.7 |  10116.5 |   -3%  ||     0.06 |     0.07 |   +7%  |               0.4149 |
+| 16c     ||   7143.9 |   7600.9 |   +6%  ||     0.06 |     0.07 |   +7%  |               0.2367 |
+| 16d     ||   7047.9 |   7309.7 |   +4%  ||     0.06 |     0.07 |   +8%  |               0.4879 |
+| 17a     ||   2055.9 |   1665.4 |  -19%  ||     0.06 |     0.07 |   +8%  |               0.1168 |
+| 17b     ||   1626.9 |   1154.1 |  -29%  ||     0.06 |     0.07 |   +8%  |               0.0497 |
+| 17c     ||   1360.3 |   1334.1 |   -2%  ||     0.06 |     0.07 |   +8%  |               0.9053 |
+| 17d     ||   1430.9 |   1548.0 |   +8%  ||     0.06 |     0.07 |   +8%  |               0.6073 |
+| 17e     ||   4349.4 |   4296.6 |   -1%  ||     0.06 |     0.07 |   +8%  |               0.8796 |
+| 17f     ||   3024.3 |   2899.8 |   -4%  ||     0.06 |     0.07 |   +9%  |               0.6963 |
+| 18a     ||   4508.5 |   2030.6 |  -55%  ||     0.06 |     0.07 |   +7%  |               0.0000 |
+| 18b     ||    337.3 |    431.9 |  +28%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 18c     ||   1435.2 |   1301.6 |   -9%  ||     0.06 |     0.07 |   +7%  |               0.5454 |
+| 19a     ||   1225.9 |   1106.5 |  -10%  ||     0.06 |     0.07 |   +8%  |               0.6576 |
+| 19b     ||    920.8 |    883.2 |   -4%  ||     0.06 |     0.07 |   +9%  |               0.8772 |
+| 19c     ||   1433.6 |   1051.9 |  -27%  ||     0.06 |     0.07 |   +9%  |               0.1166 |
+| 19d     ||   3365.3 |   3050.1 |   -9%  ||     0.06 |     0.07 |   +9%  |               0.3157 |
+| 1a      ||    232.9 |     73.3 |  -69%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 1b      ||    142.1 |    131.4 |   -8%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 1c      ||     70.1 |    125.9 |  +80%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 1d      ||     63.6 |     67.8 |   +7%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 20a     ||   1152.3 |   1810.1 |  +57%  ||     0.06 |     0.07 |   +9%  |               0.0237 |
+| 20b     ||   1109.1 |    974.7 |  -12%  ||     0.06 |     0.07 |   +8%  |               0.4828 |
+| 20c     ||    966.1 |    866.6 |  -10%  ||     0.06 |     0.07 |   +9%  |               0.4470 |
+| 21a     ||    234.9 |    198.5 |  -16%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 21b     ||    164.0 |    247.5 |  +51%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 21c     ||    151.3 |    146.0 |   -3%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 22a     ||   1379.4 |   1038.9 |  -25%  ||     0.06 |     0.07 |   +7%  |               0.0505 |
+| 22b     ||    838.2 |   1070.6 |  +28%  ||     0.06 |     0.07 |   +7%  |               0.3764 |
+| 22c     ||   3594.1 |   2739.1 |  -24%  ||     0.06 |     0.07 |   +8%  |               0.0425 |
+| 22d     ||   3958.3 |   3220.4 |  -19%  ||     0.06 |     0.07 |   +7%  |               0.1467 |
+| 23a     ||    318.2 |    295.0 |   -7%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 23b     ||    317.1 |    255.5 |  -19%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 23c     ||    498.6 |    496.0 |   -1%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 24a     ||    917.9 |    863.9 |   -6%  ||     0.06 |     0.07 |   +8%  |               0.8003 |
+| 24b     ||    454.3 |    484.5 |   +7%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 25a     ||   1417.1 |   1472.0 |   +4%  ||     0.06 |     0.07 |   +7%  |               0.8824 |
+| 25b     ||    519.3 |    532.6 |   +3%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 25c     ||   2604.0 |   2872.8 |  +10%  ||     0.06 |     0.07 |   +8%  |               0.4455 |
+| 26a     ||    885.2 |    880.4 |   -1%  ||     0.06 |     0.07 |   +8%  |               0.9832 |
+| 26b     ||    616.1 |    633.0 |   +3%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 26c     ||   1628.2 |    923.4 |  -43%  ||     0.06 |     0.07 |   +7%  |               0.0531 |
+| 27a     ||    239.1 |    182.6 |  -24%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 27b     ||    405.9 |    176.6 |  -57%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 27c     ||    191.2 |    234.8 |  +23%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 28a     ||   2474.3 |   1548.4 |  -37%  ||     0.06 |     0.07 |   +9%  |               0.0253 |
+| 28b     ||    279.0 |    320.0 |  +15%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 28c     ||   2622.0 |   1928.3 |  -26%  ||     0.06 |     0.07 |   +8%  |               0.0902 |
+| 29a     ||    620.7 |    585.2 |   -6%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 29b     ||    375.0 |    593.0 |  +58%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 29c     ||    943.7 |    757.7 |  -20%  ||     0.06 |     0.07 |   +7%  |               0.3865 |
+| 2a      ||    408.3 |    259.0 |  -37%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 2b      ||    214.9 |    579.0 | +169%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 2c      ||    290.2 |    192.2 |  -34%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 2d      ||    575.3 |    492.3 |  -14%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 30a     ||    721.7 |   1109.1 |  +54%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 30b     ||   1013.8 |    476.1 |  -53%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 30c     ||   2053.2 |   1813.4 |  -12%  ||     0.06 |     0.07 |   +9%  |               0.5407 |
+| 31a     ||   1065.5 |    962.0 |  -10%  ||     0.06 |     0.07 |   +8%  |               0.7372 |
+| 31b     ||    479.7 |    587.7 |  +23%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 31c     ||   1000.6 |    678.5 |  -32%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 32a     ||    234.7 |    171.5 |  -27%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 32b     ||    362.0 |    568.8 |  +57%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 33a     ||    143.2 |    211.6 |  +48%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 33b     ||    160.5 |    149.3 |   -7%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 33c     ||    165.9 |    230.3 |  +39%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 3a      ||    809.6 |    927.4 |  +15%  ||     0.06 |     0.07 |   +8%  |               0.7429 |
+| 3b      ||    203.4 |    123.3 |  -39%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 3c      ||   1573.9 |   1866.6 |  +19%  ||     0.06 |     0.07 |   +8%  |               0.2878 |
+| 4a      ||   1413.5 |    600.8 |  -57%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 4b      ||    121.6 |    177.9 |  +46%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 4c      ||   1340.3 |    735.8 |  -45%  ||     0.06 |     0.07 |   +8%  |               0.0151 |
+| 5a      ||    280.3 |    408.1 |  +46%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 5b      ||    531.0 |    494.6 |   -7%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 5c      ||   1051.1 |    542.2 |  -48%  ||     0.06 |     0.07 |   +9%  | (run time too short) |
+| 6a      ||    549.1 |    414.3 |  -25%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 6b      ||    411.4 |    373.9 |   -9%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 6c      ||    272.1 |    348.4 |  +28%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 6d      ||   1636.6 |   1775.2 |   +8%  ||     0.06 |     0.07 |   +7%  |               0.6057 |
+| 6e      ||    371.2 |    543.4 |  +46%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 6f      ||   2279.7 |   2384.3 |   +5%  ||     0.06 |     0.07 |   +8%  |               0.7001 |
+| 7a      ||    316.5 |    406.4 |  +28%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 7b      ||    377.0 |    410.7 |   +9%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 7c      ||   2180.4 |   2303.1 |   +6%  ||     0.06 |     0.07 |   +8%  |               0.6388 |
+| 8a      ||    504.3 |    295.2 |  -41%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 8b      ||    401.3 |    326.9 |  -19%  ||     0.06 |     0.07 |   +7%  | (run time too short) |
+| 8c      ||   5940.9 |   6229.7 |   +5%  ||     0.06 |     0.07 |   +7%  |               0.5056 |
+| 8d      ||   1443.5 |   1319.7 |   -9%  ||     0.06 |     0.07 |   +8%  |               0.5971 |
+| 9a      ||   1352.4 |   1021.9 |  -24%  ||     0.06 |     0.07 |   +8%  |               0.2643 |
+| 9b      ||   1131.2 |    648.2 |  -43%  ||     0.06 |     0.07 |   +8%  | (run time too short) |
+| 9c      ||   1682.9 |   1782.5 |   +6%  ||     0.06 |     0.07 |   +9%  |               0.7247 |
+| 9d      ||   2665.7 |   2269.3 |  -15%  ||     0.06 |     0.07 |   +8%  |               0.2495 |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
+| Sum     || 150076.5 | 138667.0 |   -8%  ||          |          |        |                      |
+| Geomean ||          |          |        ||          |          |   +8%  |                      |
 +---------++----------+----------+--------++----------+----------+--------+----------------------+
```
</details>
