### PR TITLE
JoinNode: Add semi reduction flag & reduced join reference as properties

### DIFF
--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mutex>
 #include <shared_mutex>
 
 #include <boost/heap/fibonacci_heap.hpp>
@@ -27,7 +28,9 @@ class GDFSCache : public AbstractCache<Key, Value> {
 
     // The underlying heap is a max-heap.
     // To have the item with lowest priority at the top, we invert the comparison.
-    bool operator<(const GDFSCacheEntry& other) const { return priority > other.priority; }
+    bool operator<(const GDFSCacheEntry& other) const {
+      return priority > other.priority;
+    }
   };
 
   using Handle = typename boost::heap::fibonacci_heap<GDFSCacheEntry>::handle_type;
@@ -38,7 +41,10 @@ class GDFSCache : public AbstractCache<Key, Value> {
 
   void set(const Key& key, const Value& value, double cost = 1.0, double size = 1.0) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
-    if (this->_capacity == 0) return;
+    if (this->_capacity == 0) {
+      return;
+    }
+
     auto it = _map.find(key);
     if (it != _map.end()) {
       // Update priority.
@@ -70,7 +76,9 @@ class GDFSCache : public AbstractCache<Key, Value> {
   std::optional<Value> try_get(const Key& query) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     auto it = _map.find(query);
-    if (it == _map.end()) return std::nullopt;
+    if (it == _map.end()) {
+      return std::nullopt;
+    }
 
     Handle handle = it->second;
     GDFSCacheEntry& entry = (*handle);
@@ -144,3 +152,4 @@ class GDFSCache : public AbstractCache<Key, Value> {
 };
 
 }  // namespace opossum
+

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <mutex>
 #include <shared_mutex>
 
 #include <boost/heap/fibonacci_heap.hpp>
@@ -39,10 +38,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
 
   void set(const Key& key, const Value& value, double cost = 1.0, double size = 1.0) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
-    if (this->_capacity == 0) {
-      return;
-    }
-
+    if (this->_capacity == 0) return;
     auto it = _map.find(key);
     if (it != _map.end()) {
       // Update priority.
@@ -74,9 +70,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
   std::optional<Value> try_get(const Key& query) final {
     std::unique_lock<std::shared_mutex> lock(_mutex);
     auto it = _map.find(query);
-    if (it == _map.end()) {
-      return std::nullopt;
-    }
+    if (it == _map.end()) return std::nullopt;
 
     Handle handle = it->second;
     GDFSCacheEntry& entry = (*handle);

--- a/src/lib/cache/gdfs_cache.hpp
+++ b/src/lib/cache/gdfs_cache.hpp
@@ -28,9 +28,7 @@ class GDFSCache : public AbstractCache<Key, Value> {
 
     // The underlying heap is a max-heap.
     // To have the item with lowest priority at the top, we invert the comparison.
-    bool operator<(const GDFSCacheEntry& other) const {
-      return priority > other.priority;
-    }
+    bool operator<(const GDFSCacheEntry& other) const { return priority > other.priority; }
   };
 
   using Handle = typename boost::heap::fibonacci_heap<GDFSCacheEntry>::handle_type;
@@ -152,4 +150,3 @@ class GDFSCache : public AbstractCache<Key, Value> {
 };
 
 }  // namespace opossum
-

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -228,14 +228,55 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
 
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicates() const { return node_expressions; }
 
+void JoinNode::mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_node) {
+  Assert(corresponding_join_node, "Corresponding JoinNode must be provided.");
+  Assert(!_is_reducer, "Function is meant to be called once only.");
+  DebugAssert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");
+  DebugAssert(join_predicates().size() == 1, "Semi join reductions are expected to have one join predicate only.");
+  DebugAssert(
+      std::any_of(corresponding_join_node->join_predicates().begin(), corresponding_join_node->join_predicates().end(),
+                  [&](const auto predicate) { return *predicate == *join_predicates()[0]; }),
+      "Did not find matching join predicate in given corresponding JoinNode.");
+  _is_reducer = true;
+  comment = "Semi Reduction";
+  _corresponding_join_node = std::weak_ptr<JoinNode>(corresponding_join_node);
+}
+
+bool JoinNode::is_reducer() const { return _is_reducer; }
+
+std::shared_ptr<JoinNode> JoinNode::get_or_find_corresponding_join_node() const {
+  if (!_is_reducer) return nullptr;
+
+  if (_corresponding_join_node.expired()) {
+    visit_lqp_upwards(const_cast<JoinNode*>(this)->shared_from_this(), [&](const auto& current_node) {
+      if (current_node.get() == this) return LQPUpwardVisitation::VisitOutputs;
+      if (current_node->type != LQPNodeType::Join) return LQPUpwardVisitation::VisitOutputs;
+      const auto join_node = std::static_pointer_cast<JoinNode>(current_node);
+      // Currently, semi reductions are supported for single predicate joins only.
+      if (join_node->join_predicates().size() != 1) return LQPUpwardVisitation::VisitOutputs;
+      if (*join_predicates()[0] != *join_node->join_predicates()[0]) return LQPUpwardVisitation::VisitOutputs;
+
+      _corresponding_join_node = std::weak_ptr<JoinNode>(join_node);
+      return LQPUpwardVisitation::DoNotVisitOutputs;
+    });
+    // TODO make if?
+    Assert(!_corresponding_join_node.expired(), "Could not find corresponding join node.");
+  }
+
+  return _corresponding_join_node.lock();
+}
+
 size_t JoinNode::_on_shallow_hash() const { return boost::hash_value(join_mode); }
 
 std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
-  if (!join_predicates().empty()) {
-    return JoinNode::make(join_mode, expressions_copy_and_adapt_to_different_lqp(join_predicates(), node_mapping));
-  } else {
+  if (join_predicates().empty()) {
+    Assert(join_mode == JoinMode::Cross, "Expected cross join.");
     return JoinNode::make(join_mode);
   }
+  const auto copied_join_node =
+      JoinNode::make(join_mode, expressions_copy_and_adapt_to_different_lqp(join_predicates(), node_mapping));
+  copied_join_node->_is_reducer = _is_reducer;
+  return copied_join_node;
 }
 
 bool JoinNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -252,7 +252,8 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_semi_reduction_corresponding_joi
   }
 
   if (_semi_reduction_corresponding_join_node.expired()) {
-    // Find corresponding join by traversing upwards
+    // The weak pointer is expired in deep copies of the LQP, for example. In such cases, find the corresponding join by
+    // traversing the LQP upwards.
     visit_lqp_upwards(std::const_pointer_cast<AbstractLQPNode>(shared_from_this()), [&](const auto& current_node) {
       if (current_node.get() == this) {
         return LQPUpwardVisitation::VisitOutputs;

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -231,12 +231,12 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicates() const { return node_expressions; }
 
 void JoinNode::mark_as_semi_reduction(const std::shared_ptr<JoinNode>& reduced_join_node) {
-  Assert(!_is_semi_reduction, "The semi reducer status should be set once only.");
+  Assert(!_is_semi_reduction, "The semi reduction status should be set once only.");
   Assert(reduced_join_node, "Reduced JoinNode must be provided.");
   Assert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");
   DebugAssert(join_predicates().size() == 1,
               "Currently, semi join reductions are expected to have a single join predicate.");
-  DebugAssert(std::any_of(reduced_join_node->join_predicates().begin(), reduced_join_node->join_predicates().end(),
+  DebugAssert(std::any_of(reduced_join_node->join_predicates().cbegin(), reduced_join_node->join_predicates().cend(),
                           [&](const auto predicate) { return *predicate == *join_predicates()[0]; }),
               "Both semi join reduction node and the reduced join should have a common join predicate.");
   _is_semi_reduction = true;

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -232,7 +232,8 @@ void JoinNode::mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_n
   Assert(corresponding_join_node, "Corresponding JoinNode must be provided.");
   Assert(!_is_reducer, "The semi reducer status should be set once only.");
   Assert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");
-  DebugAssert(join_predicates().size() == 1, "Currently, semi join reductions are expected to have a single join predicate.");
+  DebugAssert(join_predicates().size() == 1,
+              "Currently, semi join reductions are expected to have a single join predicate.");
   DebugAssert(
       std::any_of(corresponding_join_node->join_predicates().begin(), corresponding_join_node->join_predicates().end(),
                   [&](const auto predicate) { return *predicate == *join_predicates()[0]; }),

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -243,7 +243,10 @@ void JoinNode::mark_as_semi_reduction(const std::shared_ptr<JoinNode>& reduced_j
   _reduced_join_node = std::weak_ptr<JoinNode>(reduced_join_node);
 }
 
-bool JoinNode::is_semi_reduction() const { return _is_semi_reduction; }
+bool JoinNode::is_semi_reduction() const {
+  DebugAssert(!_is_semi_reduction || join_mode == JoinMode::Semi, "Non-semi join is marked as a semi reduction.");
+  return _is_semi_reduction;
+}
 
 std::shared_ptr<JoinNode> JoinNode::get_or_find_reduced_join_node() const {
   if (!_is_semi_reduction) {

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -230,15 +230,14 @@ const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicate
 
 void JoinNode::mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_node) {
   Assert(corresponding_join_node, "Corresponding JoinNode must be provided.");
-  Assert(!_is_reducer, "Function is meant to be called once only.");
-  DebugAssert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");
-  DebugAssert(join_predicates().size() == 1, "Semi join reductions are expected to have one join predicate only.");
+  Assert(!_is_reducer, "The semi reducer status should be set once only.");
+  Assert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");
+  DebugAssert(join_predicates().size() == 1, "Currently, semi join reductions are expected to have a single join predicate.");
   DebugAssert(
       std::any_of(corresponding_join_node->join_predicates().begin(), corresponding_join_node->join_predicates().end(),
                   [&](const auto predicate) { return *predicate == *join_predicates()[0]; }),
       "Did not find matching join predicate in given corresponding JoinNode.");
   _is_reducer = true;
-  comment = "Semi Reduction";
   _corresponding_join_node = std::weak_ptr<JoinNode>(corresponding_join_node);
 }
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -248,6 +248,7 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_corresponding_join_node() const 
   if (!_is_reducer) return nullptr;
 
   if (_corresponding_join_node.expired()) {
+    // Find corresponding join by traversing upwards
     visit_lqp_upwards(const_cast<JoinNode*>(this)->shared_from_this(), [&](const auto& current_node) {
       if (current_node.get() == this) return LQPUpwardVisitation::VisitOutputs;
       if (current_node->type != LQPNodeType::Join) return LQPUpwardVisitation::VisitOutputs;
@@ -259,7 +260,7 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_corresponding_join_node() const 
       _corresponding_join_node = std::weak_ptr<JoinNode>(join_node);
       return LQPUpwardVisitation::DoNotVisitOutputs;
     });
-    // TODO make if?
+
     Assert(!_corresponding_join_node.expired(), "Could not find corresponding join node.");
   }
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -228,7 +228,7 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
 
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicates() const { return node_expressions; }
 
-void JoinNode::mark_as_reducer_of(std::shared_ptr<JoinNode>& corresponding_join_node) {
+void JoinNode::mark_as_reducer_of(const std::shared_ptr<JoinNode>& corresponding_join_node) {
   Assert(corresponding_join_node, "Corresponding JoinNode must be provided.");
   Assert(!_is_reducer, "The semi reducer status should be set once only.");
   Assert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -281,6 +281,8 @@ std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node
 
 bool JoinNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& join_node = static_cast<const JoinNode&>(rhs);
+  // We do not consider the _is_reducer attribute in this comparison, because we want the LQPTranslator to translate
+  // identical semi joins into a single operator, regardless of the `is_reducer` property.
   if (join_mode != join_node.join_mode) return false;
   return expressions_equal_to_expressions_in_different_lqp(join_predicates(), join_node.join_predicates(),
                                                            node_mapping);

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -67,7 +67,9 @@ std::vector<std::shared_ptr<AbstractExpression>> JoinNode::output_expressions() 
 
   auto right_begin = std::copy(left_expressions.begin(), left_expressions.end(), output_expressions.begin());
 
-  if (output_both_inputs) std::copy(right_expressions.begin(), right_expressions.end(), right_begin);
+  if (output_both_inputs) {
+    std::copy(right_expressions.begin(), right_expressions.end(), right_begin);
+  }
 
   return output_expressions;
 }
@@ -228,9 +230,9 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
 
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicates() const { return node_expressions; }
 
-void JoinNode::mark_as_reducer_of(const std::shared_ptr<JoinNode>& corresponding_join_node) {
+void JoinNode::mark_as_semi_reduction_for(const std::shared_ptr<JoinNode>& corresponding_join_node) {
   Assert(corresponding_join_node, "Corresponding JoinNode must be provided.");
-  Assert(!_is_reducer, "The semi reducer status should be set once only.");
+  Assert(!_is_semi_reduction, "The semi reducer status should be set once only.");
   Assert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");
   DebugAssert(join_predicates().size() == 1,
               "Currently, semi join reductions are expected to have a single join predicate.");
@@ -238,33 +240,44 @@ void JoinNode::mark_as_reducer_of(const std::shared_ptr<JoinNode>& corresponding
       std::any_of(corresponding_join_node->join_predicates().begin(), corresponding_join_node->join_predicates().end(),
                   [&](const auto predicate) { return *predicate == *join_predicates()[0]; }),
       "Did not find matching join predicate in given corresponding JoinNode.");
-  _is_reducer = true;
-  _corresponding_join_node = std::weak_ptr<JoinNode>(corresponding_join_node);
+  _is_semi_reduction = true;
+  _semi_reduction_corresponding_join_node = std::weak_ptr<JoinNode>(corresponding_join_node);
 }
 
-bool JoinNode::is_reducer() const { return _is_reducer; }
+bool JoinNode::is_semi_reduction() const { return _is_semi_reduction; }
 
-std::shared_ptr<JoinNode> JoinNode::get_or_find_corresponding_join_node() const {
-  if (!_is_reducer) return nullptr;
+std::shared_ptr<JoinNode> JoinNode::get_or_find_semi_reduction_corresponding_join_node() const {
+  if (!_is_semi_reduction) {
+    return nullptr;
+  }
 
-  if (_corresponding_join_node.expired()) {
+  if (_semi_reduction_corresponding_join_node.expired()) {
     // Find corresponding join by traversing upwards
     visit_lqp_upwards(std::const_pointer_cast<AbstractLQPNode>(shared_from_this()), [&](const auto& current_node) {
-      if (current_node.get() == this) return LQPUpwardVisitation::VisitOutputs;
-      if (current_node->type != LQPNodeType::Join) return LQPUpwardVisitation::VisitOutputs;
+      if (current_node.get() == this) {
+        return LQPUpwardVisitation::VisitOutputs;
+      }
+      if (current_node->type != LQPNodeType::Join) {
+        return LQPUpwardVisitation::VisitOutputs;
+      }
       const auto join_node = std::static_pointer_cast<JoinNode>(current_node);
       // Currently, semi reductions are supported for single predicate joins only.
-      if (join_node->join_predicates().size() != 1) return LQPUpwardVisitation::VisitOutputs;
-      if (*join_predicates()[0] != *join_node->join_predicates()[0]) return LQPUpwardVisitation::VisitOutputs;
+      if (join_node->join_predicates().size() != 1) {
+        return LQPUpwardVisitation::VisitOutputs;
+      }
+      if (*join_predicates()[0] != *join_node->join_predicates()[0]) {
+        return LQPUpwardVisitation::VisitOutputs;
+      }
 
-      _corresponding_join_node = std::weak_ptr<JoinNode>(join_node);
+      _semi_reduction_corresponding_join_node = std::weak_ptr<JoinNode>(join_node);
       return LQPUpwardVisitation::DoNotVisitOutputs;
     });
 
-    Assert(!_corresponding_join_node.expired(), "Could not find corresponding join node.");
+    Assert(!_semi_reduction_corresponding_join_node.expired(),
+           "Could not find corresponding join node for this semi join reduction.");
   }
 
-  return _corresponding_join_node.lock();
+  return _semi_reduction_corresponding_join_node.lock();
 }
 
 size_t JoinNode::_on_shallow_hash() const { return boost::hash_value(join_mode); }
@@ -276,15 +289,17 @@ std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node
   }
   const auto copied_join_node =
       JoinNode::make(join_mode, expressions_copy_and_adapt_to_different_lqp(join_predicates(), node_mapping));
-  copied_join_node->_is_reducer = _is_reducer;
+  copied_join_node->_is_semi_reduction = _is_semi_reduction;
   return copied_join_node;
 }
 
 bool JoinNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& join_node = static_cast<const JoinNode&>(rhs);
-  // We do not consider the _is_reducer attribute in this comparison, because we want the LQPTranslator to translate
-  // identical semi joins into a single operator, regardless of the `is_reducer` property.
-  if (join_mode != join_node.join_mode) return false;
+  // We do not consider the _is_semi_reduction attribute in this comparison, because we want the LQPTranslator to translate
+  // identical semi joins into a single operator, regardless of the `is_semi_reduction` property.
+  if (join_mode != join_node.join_mode) {
+    return false;
+  }
   return expressions_equal_to_expressions_in_different_lqp(join_predicates(), join_node.join_predicates(),
                                                            node_mapping);
 }

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -275,7 +275,11 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_reduced_join_node() const {
   return _reduced_join_node.lock();
 }
 
-size_t JoinNode::_on_shallow_hash() const { return boost::hash_value(join_mode); }
+size_t JoinNode::_on_shallow_hash() const {
+  size_t hash = boost::hash_value(join_mode);
+  boost::hash_combine(&hash, _is_semi_reduction);
+  return hash;
+}
 
 std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
   if (join_predicates().empty()) {
@@ -293,6 +297,9 @@ bool JoinNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMappi
   // We do not consider the _is_semi_reduction attribute in this comparison, because we want the LQPTranslator to
   // translate identical semi joins into a single operator, regardless of the `is_semi_reduction` property.
   if (join_mode != join_node.join_mode) {
+    return false;
+  }
+  if (_is_semi_reduction != join_node._is_semi_reduction) {
     return false;
   }
   return expressions_equal_to_expressions_in_different_lqp(join_predicates(), join_node.join_predicates(),

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -277,7 +277,7 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_reduced_join_node() const {
 
 size_t JoinNode::_on_shallow_hash() const {
   size_t hash = boost::hash_value(join_mode);
-  boost::hash_combine(&hash, _is_semi_reduction);
+  boost::hash_combine(hash, _is_semi_reduction);
   return hash;
 }
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -294,8 +294,6 @@ std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node
 
 bool JoinNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& join_node = static_cast<const JoinNode&>(rhs);
-  // We do not consider the _is_semi_reduction attribute in this comparison, because we want the LQPTranslator to
-  // translate identical semi joins into a single operator, regardless of the `is_semi_reduction` property.
   if (join_mode != join_node.join_mode) {
     return false;
   }

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -293,10 +293,7 @@ std::shared_ptr<AbstractLQPNode> JoinNode::_on_shallow_copy(LQPNodeMapping& node
 
 bool JoinNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
   const auto& join_node = static_cast<const JoinNode&>(rhs);
-  if (join_mode != join_node.join_mode) {
-    return false;
-  }
-  if (_is_semi_reduction != join_node._is_semi_reduction) {
+  if (join_mode != join_node.join_mode || _is_semi_reduction != join_node._is_semi_reduction) {
     return false;
   }
   return expressions_equal_to_expressions_in_different_lqp(join_predicates(), join_node.join_predicates(),

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -228,7 +228,7 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
 
 const std::vector<std::shared_ptr<AbstractExpression>>& JoinNode::join_predicates() const { return node_expressions; }
 
-void JoinNode::mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_node) {
+void JoinNode::mark_as_reducer_of(std::shared_ptr<JoinNode>& corresponding_join_node) {
   Assert(corresponding_join_node, "Corresponding JoinNode must be provided.");
   Assert(!_is_reducer, "The semi reducer status should be set once only.");
   Assert(join_mode == JoinMode::Semi, "Semi join reductions require JoinMode::Semi.");

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -262,11 +262,8 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_semi_reduction_corresponding_joi
         return LQPUpwardVisitation::VisitOutputs;
       }
       const auto join_node = std::static_pointer_cast<JoinNode>(current_node);
-      // Currently, semi reductions are supported for single predicate joins only.
-      if (join_node->join_predicates().size() != 1) {
-        return LQPUpwardVisitation::VisitOutputs;
-      }
-      if (*join_predicates()[0] != *join_node->join_predicates()[0]) {
+      if (std::none_of(join_node->join_predicates().begin(), join_node->join_predicates().end(),
+                       [&](const auto& predicate) { return *predicate == *join_predicates()[0]; })) {
         return LQPUpwardVisitation::VisitOutputs;
       }
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -249,7 +249,7 @@ std::shared_ptr<JoinNode> JoinNode::get_or_find_corresponding_join_node() const 
 
   if (_corresponding_join_node.expired()) {
     // Find corresponding join by traversing upwards
-    visit_lqp_upwards(const_cast<JoinNode*>(this)->shared_from_this(), [&](const auto& current_node) {
+    visit_lqp_upwards(std::const_pointer_cast<AbstractLQPNode>(shared_from_this()), [&](const auto& current_node) {
       if (current_node.get() == this) return LQPUpwardVisitation::VisitOutputs;
       if (current_node->type != LQPNodeType::Join) return LQPUpwardVisitation::VisitOutputs;
       const auto join_node = std::static_pointer_cast<JoinNode>(current_node);

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -71,7 +71,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
    * @param corresponding_join_node having the same join predicate.
    * Note: This function is meant to be called by the SemiJoinReductionRule, which adds semi join reductions to LQPs.
    */
-  void mark_as_reducer_of(std::shared_ptr<JoinNode>& corresponding_join_node);
+  void mark_as_reducer_of(const std::shared_ptr<JoinNode>& corresponding_join_node);
 
   JoinMode join_mode;
 

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -64,27 +64,27 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
    * @pre     The SemiJoinReductionRule must have added this JoinNode to the LQP, so that ::is_semi_reduction returns
    *          true.
    * @returns a shared pointer to the JoinNode for which the semi join reduction was added as a pre-filter.
-   *          If the internal weak pointer to the corresponding join has expired, the LQP will be traversed upwards
-   *          until the corresponding join has been found, otherwise the function fails.
+   *          If the internal weak pointer to the reduced join is not set or expired, the LQP will be traversed upwards
+   *          until the reduced join has been found, otherwise the function fails.
    */
-  std::shared_ptr<JoinNode> get_or_find_semi_reduction_corresponding_join_node() const;
+  std::shared_ptr<JoinNode> get_or_find_reduced_join_node() const;
 
   /**
    * Sets the `is_semi_reduction` property of this JoinNode to true, and stores a weak pointer to the
-   * @param corresponding_join_node having the same join predicate.
+   * @param reduced_join which gets pre-filtered by this semi join reduction.
    * Note: This function is meant to be called by the SemiJoinReductionRule, which adds semi join reductions to LQPs.
    */
-  void mark_as_semi_reduction_for(const std::shared_ptr<JoinNode>& corresponding_join_node);
+  void mark_as_semi_reduction(const std::shared_ptr<JoinNode>& reduced_join);
 
   JoinMode join_mode;
 
  protected:
   /**
-   * The following members are relevant for semi join reductions added by the SemiJoinReductionRule only. For details,
-   * read the documentation of ::is_semi_reduction and ::get_or_find_semi_reduction_corresponding_join_node.
+   * The following data members are only relevant for semi joins added by the SemiJoinReductionRule. For details,
+   * read the documentation of ::is_semi_reduction and ::get_or_find_reduced_join_node.
    */
   bool _is_semi_reduction = false;
-  mutable std::weak_ptr<JoinNode> _semi_reduction_corresponding_join_node;
+  mutable std::weak_ptr<JoinNode> _reduced_join_node;
 
   /**
    * @return A subset of the given LQPUniqueConstraints @param left_unique_constraints and @param

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -53,31 +53,33 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;
 
   /**
-   * @returns true if the JoinNode has as a semi reduction role in the LQP. If so, it was most likely created by the
-   *          SemiJoinReductionRule.
+   * @returns true if the JoinNode has a semi reduction role in the LQP, and was added by the SemiJoinReductionRule.
    */
-  bool is_reducer() const;
+  bool is_semi_reduction() const;
 
   /**
    * @returns a shared pointer to the semi join reduction's corresponding JoinNode. If the pointer is not stored in a
    *          member variable, the LQP is traversed upwards until the corresponding JoinNode has been found, otherwise
    *          the function fails.
-   * @pre JoinNode is set to JoinMode::Semi, and ::mark_as_reducer_of has been called.
+   * @pre JoinNode is set to JoinMode::Semi, and ::mark_as_semi_reduction_for has been called.
    */
-  std::shared_ptr<JoinNode> get_or_find_corresponding_join_node() const;
+  std::shared_ptr<JoinNode> get_or_find_semi_reduction_corresponding_join_node() const;
 
   /**
-   * Sets the `is_reducer` property of this JoinNode to true, and stores a weak pointer to the
+   * Sets the `is_semi_reduction` property of this JoinNode to true, and stores a weak pointer to the
    * @param corresponding_join_node having the same join predicate.
    * Note: This function is meant to be called by the SemiJoinReductionRule, which adds semi join reductions to LQPs.
    */
-  void mark_as_reducer_of(const std::shared_ptr<JoinNode>& corresponding_join_node);
+  void mark_as_semi_reduction_for(const std::shared_ptr<JoinNode>& corresponding_join_node);
 
   JoinMode join_mode;
 
  protected:
-  bool _is_reducer = false;
-  mutable std::weak_ptr<JoinNode> _corresponding_join_node;
+  /**
+   * The following two attributes are relevant for semi join reductions
+   */
+  bool _is_semi_reduction = false;
+  mutable std::weak_ptr<JoinNode> _semi_reduction_corresponding_join_node;
 
   /**
    * @return A subset of the given LQPUniqueConstraints @param left_unique_constraints and @param

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -71,7 +71,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
    * @param corresponding_join_node having the same join predicate.
    * Note: This function is meant to be called by the SemiJoinReductionRule, which adds semi join reductions to LQPs.
    */
-  void mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_node);
+  void mark_as_reducer_of(std::shared_ptr<JoinNode>& corresponding_join_node);
 
   JoinMode join_mode;
 

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -52,9 +52,27 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
 
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;
 
+  /**
+   * @returns true if the SemiJoinReductionRule added this node to the LQP.
+   */
+  bool is_reducer() const;
+
+  /**
+   * TODO..
+   */
+  std::shared_ptr<JoinNode> get_or_find_corresponding_join_node() const;
+
+  /**
+   * This function should be called by the SemiJoinReductionRule only.
+   */
+  void mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_node);
+
   JoinMode join_mode;
 
  protected:
+  bool _is_reducer = false;
+  mutable std::weak_ptr<JoinNode> _corresponding_join_node;
+
   /**
    * @return A subset of the given LQPUniqueConstraints @param left_unique_constraints and @param
    *         right_unique_constraints that remains valid despite the join operation.

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -78,7 +78,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
  protected:
   /**
    * The following data members are only relevant for semi joins added by the SemiJoinReductionRule. For details,
-   * read the documentation of ::is_semi_reduction and ::get_or_find_reduced_join_node.
+   * read the documentation of ::mark_as_semi_reduction and ::get_or_find_reduced_join_node.
    */
   bool _is_semi_reduction = false;
   mutable std::weak_ptr<JoinNode> _reduced_join_node;

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -53,10 +53,7 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;
 
   /**
-   * There are two types of joins in LQPs: First, joins resulting from the SQL query translation, and second,
-   * artificial semi joins added by the SemiJoinReductionRule to pre-filter join tables.
-   *
-   * @returns true if this JoinNode was added artificially by the SemiJoinReductionRule for pre-filtering purposes.
+   * @returns true if this JoinNode was added added by the SemiJoinReductionRule for increased performance.
    */
   bool is_semi_reduction() const;
 

--- a/src/lib/logical_query_plan/join_node.hpp
+++ b/src/lib/logical_query_plan/join_node.hpp
@@ -53,17 +53,23 @@ class JoinNode : public EnableMakeForLQPNode<JoinNode>, public AbstractLQPNode {
   const std::vector<std::shared_ptr<AbstractExpression>>& join_predicates() const;
 
   /**
-   * @returns true if the SemiJoinReductionRule added this node to the LQP.
+   * @returns true if the JoinNode has as a semi reduction role in the LQP. If so, it was most likely created by the
+   *          SemiJoinReductionRule.
    */
   bool is_reducer() const;
 
   /**
-   * TODO..
+   * @returns a shared pointer to the semi join reduction's corresponding JoinNode. If the pointer is not stored in a
+   *          member variable, the LQP is traversed upwards until the corresponding JoinNode has been found, otherwise
+   *          the function fails.
+   * @pre JoinNode is set to JoinMode::Semi, and ::mark_as_reducer_of has been called.
    */
   std::shared_ptr<JoinNode> get_or_find_corresponding_join_node() const;
 
   /**
-   * This function should be called by the SemiJoinReductionRule only.
+   * Sets the `is_reducer` property of this JoinNode to true, and stores a weak pointer to the
+   * @param corresponding_join_node having the same join predicate.
+   * Note: This function is meant to be called by the SemiJoinReductionRule, which adds semi join reductions to LQPs.
    */
   void mark_as_reducer_of(std::shared_ptr<JoinNode> corresponding_join_node);
 

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -6,6 +6,7 @@
 
 #include "constant_mappings.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
+#include "logical_query_plan/join_node.hpp"
 
 using namespace std::string_literals;  // NOLINT
 
@@ -70,6 +71,14 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     stream << column_name(true, secondary_predicate.column_ids.first) << " ";
     stream << secondary_predicate.predicate_condition << " ";
     stream << column_name(false, secondary_predicate.column_ids.second);
+  }
+
+  // Add comment about semi join reduction if known.
+  if (_mode == JoinMode::Semi && lqp_node) {
+    const auto semi_join_node = std::dynamic_pointer_cast<const JoinNode>(lqp_node);
+    if (semi_join_node->is_reducer()) {
+      stream << separator << "Semi Reduction";
+    }
   }
 
   return stream.str();

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -60,7 +60,12 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
 
   const auto separator = (description_mode == DescriptionMode::SingleLine ? ' ' : '\n');
   std::stringstream stream;
-  stream << AbstractOperator::description(description_mode) << " (" << _mode << ")" << separator;
+  stream << AbstractOperator::description(description_mode);
+  if (_mode == JoinMode::Semi && lqp_node && std::static_pointer_cast<const JoinNode>(lqp_node)->is_semi_reduction()) {
+    stream << " (Semi Reduction)" << separator;
+  } else {
+    stream << " (" << _mode << ")" << separator;
+  }
   stream << column_name(true, _primary_predicate.column_ids.first) << " ";
   stream << _primary_predicate.predicate_condition << " ";
   stream << column_name(false, _primary_predicate.column_ids.second);
@@ -71,14 +76,6 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
     stream << column_name(true, secondary_predicate.column_ids.first) << " ";
     stream << secondary_predicate.predicate_condition << " ";
     stream << column_name(false, secondary_predicate.column_ids.second);
-  }
-
-  // Add comment about semi join reduction if known.
-  if (_mode == JoinMode::Semi && lqp_node) {
-    const auto semi_join_node = std::dynamic_pointer_cast<const JoinNode>(lqp_node);
-    if (semi_join_node->is_semi_reduction()) {
-      stream << separator << "(Semi Reduction)";
-    }
   }
 
   return stream.str();

--- a/src/lib/operators/abstract_join_operator.cpp
+++ b/src/lib/operators/abstract_join_operator.cpp
@@ -76,8 +76,8 @@ std::string AbstractJoinOperator::description(DescriptionMode description_mode) 
   // Add comment about semi join reduction if known.
   if (_mode == JoinMode::Semi && lqp_node) {
     const auto semi_join_node = std::dynamic_pointer_cast<const JoinNode>(lqp_node);
-    if (semi_join_node->is_reducer()) {
-      stream << separator << "Semi Reduction";
+    if (semi_join_node->is_semi_reduction()) {
+      stream << separator << "(Semi Reduction)";
     }
   }
 

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -54,7 +54,7 @@ void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_
         auto reducer_node_cardinality = estimator->estimate_cardinality(reducer_node);
 
         const auto semi_join_reduction_node = JoinNode::make(JoinMode::Semi, predicate_expression);
-        semi_join_reduction_node->mark_as_reducer_of(join_node);
+        semi_join_reduction_node->mark_as_semi_reduction_for(join_node);
         lqp_insert_node(join_node, side_of_join, semi_join_reduction_node);
         semi_join_reduction_node->set_right_input(reducer_node);
 

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -55,6 +55,7 @@ void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_
 
         const auto semi_join_reduction_node = JoinNode::make(JoinMode::Semi, predicate_expression);
         semi_join_reduction_node->mark_as_semi_reduction(join_node);
+        semi_join_reduction_node->comment = name();
         lqp_insert_node(join_node, side_of_join, semi_join_reduction_node);
         semi_join_reduction_node->set_right_input(reducer_node);
 

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -54,7 +54,7 @@ void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_
         auto reducer_node_cardinality = estimator->estimate_cardinality(reducer_node);
 
         const auto semi_join_reduction_node = JoinNode::make(JoinMode::Semi, predicate_expression);
-        semi_join_reduction_node->comment = "Semi Reduction";
+        semi_join_reduction_node->mark_as_reducer_of(join_node);
         lqp_insert_node(join_node, side_of_join, semi_join_reduction_node);
         semi_join_reduction_node->set_right_input(reducer_node);
 

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -54,7 +54,7 @@ void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_
         auto reducer_node_cardinality = estimator->estimate_cardinality(reducer_node);
 
         const auto semi_join_reduction_node = JoinNode::make(JoinMode::Semi, predicate_expression);
-        semi_join_reduction_node->mark_as_semi_reduction_for(join_node);
+        semi_join_reduction_node->mark_as_semi_reduction(join_node);
         lqp_insert_node(join_node, side_of_join, semi_join_reduction_node);
         semi_join_reduction_node->set_right_input(reducer_node);
 

--- a/src/lib/visualization/abstract_visualizer.hpp
+++ b/src/lib/visualization/abstract_visualizer.hpp
@@ -208,7 +208,9 @@ class AbstractVisualizer {
     }
 
     vertex_info.id = vertex_id;
-    if (wrap_label == WrapLabel::On) vertex_info.label = _wrap_label(vertex_info.label);
+    if (wrap_label == WrapLabel::On) {
+      vertex_info.label = _wrap_label(vertex_info.label);
+    }
     boost::add_vertex(vertex_info, _graph);
   }
 
@@ -243,7 +245,9 @@ class AbstractVisualizer {
   }
 
   std::string _wrap_label(const std::string& label) {
-    if (label.length() <= MAX_LABEL_WIDTH) return label;
+    if (label.length() <= MAX_LABEL_WIDTH) {
+      return label;
+    }
     std::stringstream label_stream;
 
     // 1. Split label into lines
@@ -251,7 +255,9 @@ class AbstractVisualizer {
     boost::split(lines, label, boost::is_any_of("\n"));
     const auto line_count = lines.size();
     for (auto line_idx = size_t{0}; line_idx < line_count; ++line_idx) {
-      if (line_idx > 0) label_stream << '\n';
+      if (line_idx > 0) {
+        label_stream << '\n';
+      }
       const auto& line = lines[line_idx];
       if (line.length() <= MAX_LABEL_WIDTH) {
         label_stream << line;
@@ -267,7 +273,9 @@ class AbstractVisualizer {
         line_length += line_words.at(word_idx).length();
 
         // Exit on last word
-        if (word_idx == line_words.size() - 1) break;
+        if (word_idx == line_words.size() - 1) {
+          break;
+        }
 
         line_length++;  // include whitespace
         word_idx++;

--- a/src/lib/visualization/lqp_visualizer.cpp
+++ b/src/lib/visualization/lqp_visualizer.cpp
@@ -46,7 +46,7 @@ void LQPVisualizer::_build_subtree(const std::shared_ptr<AbstractLQPNode>& node,
 
   auto node_label = node->description();
   if (!node->comment.empty()) {
-    node_label += "\\n(" + node->comment + ")";
+    node_label += "\n(" + node->comment + ")";
   }
   _add_vertex(node, node_label);
 

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -618,11 +618,13 @@ TEST_F(JoinNodeTest, GetOrFindReducedJoinNode) {
   // In a deep-copied LQP, the semi reduction node's weak pointer to the reduced join is unset (lazy approach).
   // Therefore, get_or_find_reduced_join_node must utilize an LQP upwards traversal for discovering the reduced join.
   const auto copied_lqp = lqp->deep_copy();
-  const auto copied_join_node = std::dynamic_pointer_cast<JoinNode>(copied_lqp);
-  const auto copied_semi_reduction_node = std::dynamic_pointer_cast<JoinNode>(copied_lqp->left_input()->left_input());
+  const auto copied_join_node = std::static_pointer_cast<JoinNode>(copied_lqp);
+  const auto copied_semi_reduction_node = std::static_pointer_cast<JoinNode>(copied_lqp->left_input()->left_input());
   EXPECT_EQ(copied_semi_reduction_node->get_or_find_reduced_join_node(), copied_join_node);
-  // Expect Fail if we do not find the reduced join.
-  EXPECT_THROW(semi_reduction_node->deep_copy()->get_or_find_reduced_join_node(), std::logic_error);
+
+  // If there is no reduced join, we expect to fail.
+  EXPECT_THROW(std::static_pointer_cast<JoinNode>(semi_reduction_node->deep_copy())->get_or_find_reduced_join_node(),
+               std::logic_error);
 }
 
 TEST_F(JoinNodeTest, GetOrFindReducedJoinNodeWithMultiplePredicates) {

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -31,8 +31,8 @@ class JoinNodeTest : public BaseTest {
     _cross_join_node = JoinNode::make(JoinMode::Cross, _mock_node_a, _mock_node_b);
     _inner_join_node = JoinNode::make(JoinMode::Inner, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
     _semi_join_node = JoinNode::make(JoinMode::Semi, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
-    _semi_join_reducer_node = JoinNode::make(JoinMode::Semi, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
-    _semi_join_reducer_node->mark_as_semi_reduction(_inner_join_node);
+    _semi_join_reduction_node = JoinNode::make(JoinMode::Semi, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
+    _semi_join_reduction_node->mark_as_semi_reduction(_inner_join_node);
     _anti_join_node = JoinNode::make(JoinMode::AntiNullAsTrue, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
 
     // Prepare constraint definitions
@@ -46,7 +46,7 @@ class JoinNodeTest : public BaseTest {
   std::shared_ptr<MockNode> _mock_node_a;
   std::shared_ptr<MockNode> _mock_node_b;
   std::shared_ptr<JoinNode> _inner_join_node;
-  std::shared_ptr<JoinNode> _semi_join_node, _semi_join_reducer_node;
+  std::shared_ptr<JoinNode> _semi_join_node, _semi_join_reduction_node;
   std::shared_ptr<JoinNode> _anti_join_node;
   std::shared_ptr<JoinNode> _cross_join_node;
   std::shared_ptr<LQPColumnExpression> _t_a_a;
@@ -84,10 +84,10 @@ TEST_F(JoinNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_cross_join_node, *_cross_join_node);
   EXPECT_EQ(*_inner_join_node, *_inner_join_node);
   EXPECT_EQ(*_semi_join_node, *_semi_join_node);
-  EXPECT_EQ(*_semi_join_reducer_node, *_semi_join_reducer_node);
+  EXPECT_EQ(*_semi_join_reduction_node, *_semi_join_reduction_node);
   // The `is_semi_reduction` property does not play a role in the equality check. See JoinNode::_on_shallow_equals for
-  // more details on this. As a result, we expect _semi_join_node and _semi_join_reducer_node to be considered as equal.
-  EXPECT_EQ(*_semi_join_reducer_node, *_semi_join_node);
+  // more details on this. As a result, we expect _semi_join_node and _semi_join_reduction_node to be considered as equal.
+  EXPECT_EQ(*_semi_join_reduction_node, *_semi_join_node);
 
   const auto other_join_node_a = JoinNode::make(JoinMode::Inner, equals_(_t_a_a, _t_b_x), _mock_node_a, _mock_node_b);
   const auto other_join_node_b = JoinNode::make(JoinMode::Inner, not_like_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
@@ -109,8 +109,8 @@ TEST_F(JoinNodeTest, Copy) {
   EXPECT_EQ(*_cross_join_node, *_cross_join_node->deep_copy());
   EXPECT_EQ(*_inner_join_node, *_inner_join_node->deep_copy());
   EXPECT_EQ(*_semi_join_node, *_semi_join_node->deep_copy());
-  EXPECT_EQ(*_semi_join_reducer_node, *_semi_join_reducer_node->deep_copy());
-  EXPECT_TRUE(std::static_pointer_cast<JoinNode>(_semi_join_reducer_node->deep_copy())->is_semi_reduction());
+  EXPECT_EQ(*_semi_join_reduction_node, *_semi_join_reduction_node->deep_copy());
+  EXPECT_TRUE(std::static_pointer_cast<JoinNode>(_semi_join_reduction_node->deep_copy())->is_semi_reduction());
   EXPECT_EQ(*_anti_join_node, *_anti_join_node->deep_copy());
 }
 

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -6,6 +6,7 @@
 #include "expression/expression_utils.hpp"
 #include "logical_query_plan/join_node.hpp"
 #include "logical_query_plan/mock_node.hpp"
+#include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/stored_table_node.hpp"
 #include "utils/constraint_test_utils.hpp"
@@ -30,6 +31,8 @@ class JoinNodeTest : public BaseTest {
     _cross_join_node = JoinNode::make(JoinMode::Cross, _mock_node_a, _mock_node_b);
     _inner_join_node = JoinNode::make(JoinMode::Inner, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
     _semi_join_node = JoinNode::make(JoinMode::Semi, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
+    _semi_join_reducer_node = JoinNode::make(JoinMode::Semi, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
+    _semi_join_reducer_node->mark_as_reducer_of(_inner_join_node);
     _anti_join_node = JoinNode::make(JoinMode::AntiNullAsTrue, equals_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
 
     // Prepare constraint definitions
@@ -43,7 +46,7 @@ class JoinNodeTest : public BaseTest {
   std::shared_ptr<MockNode> _mock_node_a;
   std::shared_ptr<MockNode> _mock_node_b;
   std::shared_ptr<JoinNode> _inner_join_node;
-  std::shared_ptr<JoinNode> _semi_join_node;
+  std::shared_ptr<JoinNode> _semi_join_node, _semi_join_reducer_node;
   std::shared_ptr<JoinNode> _anti_join_node;
   std::shared_ptr<JoinNode> _cross_join_node;
   std::shared_ptr<LQPColumnExpression> _t_a_a;
@@ -80,6 +83,9 @@ TEST_F(JoinNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_cross_join_node, *_cross_join_node);
   EXPECT_EQ(*_inner_join_node, *_inner_join_node);
   EXPECT_EQ(*_semi_join_node, *_semi_join_node);
+  EXPECT_EQ(*_semi_join_reducer_node, *_semi_join_reducer_node);
+  // The ::is_reducer property is just a flag and does not change the semi join. In the LQPTranslator... TODO
+  EXPECT_EQ(*_semi_join_reducer_node, *_semi_join_node);
   EXPECT_EQ(*_anti_join_node, *_anti_join_node);
 
   const auto other_join_node_a = JoinNode::make(JoinMode::Inner, equals_(_t_a_a, _t_b_x), _mock_node_a, _mock_node_b);
@@ -102,6 +108,8 @@ TEST_F(JoinNodeTest, Copy) {
   EXPECT_EQ(*_cross_join_node, *_cross_join_node->deep_copy());
   EXPECT_EQ(*_inner_join_node, *_inner_join_node->deep_copy());
   EXPECT_EQ(*_semi_join_node, *_semi_join_node->deep_copy());
+  EXPECT_EQ(*_semi_join_reducer_node, *_semi_join_reducer_node->deep_copy());
+  EXPECT_TRUE(std::static_pointer_cast<JoinNode>(_semi_join_reducer_node->deep_copy())->is_reducer());
   EXPECT_EQ(*_anti_join_node, *_anti_join_node->deep_copy());
 }
 
@@ -219,9 +227,9 @@ TEST_F(JoinNodeTest, FunctionalDependenciesSemiAndAntiJoins) {
   for (const auto join_mode : {JoinMode::Semi, JoinMode::AntiNullAsTrue, JoinMode::AntiNullAsFalse}) {
     // clang-format off
     const auto join_node =
-        JoinNode::make(join_mode, equals_(_t_a_a, _t_b_y),
-                       _mock_node_a,
-                       _mock_node_b);
+    JoinNode::make(join_mode, equals_(_t_a_a, _t_b_y),
+      _mock_node_a,
+      _mock_node_b);
     // clang-format on
 
     // We do not want JoinNode to return the FDs of the right input node
@@ -583,6 +591,33 @@ TEST_F(JoinNodeTest, UniqueConstraintsCrossJoin) {
   _mock_node_b->set_key_constraints({*_key_constraint_x, *_key_constraint_y});
 
   EXPECT_TRUE(_cross_join_node->unique_constraints()->empty());
+}
+
+TEST_F(JoinNodeTest, GetOrFindCorrespondingJoinNode) {
+  auto join_predicate = equals_(_t_a_a, _t_b_x);
+  auto semi_join_reduction_node = JoinNode::make(JoinMode::Semi, join_predicate, _mock_node_a, _mock_node_b);
+  // clang-format off
+  const auto lqp =
+  JoinNode::make(JoinMode::Inner, join_predicate,
+    PredicateNode::make(greater_than_(_t_a_a, _t_a_b),
+      semi_join_reduction_node),
+    _mock_node_b);
+  // clang-format on
+  const auto join_node = std::static_pointer_cast<JoinNode>(lqp);
+  semi_join_reduction_node->mark_as_reducer_of(join_node);
+  // The semi reduction join node should have a weak pointer to the corresponding join node.
+  EXPECT_EQ(semi_join_reduction_node->get_or_find_corresponding_join_node(), join_node);
+
+  const auto copied_lqp = lqp->deep_copy();
+
+  // A deep copied semi join reduction node does not have a weak pointer to a corresponding join node. Therefore,
+  // it must be discovered when get_or_find_corresponding_join_node is called.
+  const auto copied_join_node = std::dynamic_pointer_cast<JoinNode>(copied_lqp);
+  const auto copied_semi_join_reduction_node =
+      std::dynamic_pointer_cast<JoinNode>(copied_lqp->left_input()->left_input());
+  EXPECT_NE(copied_semi_join_reduction_node->get_or_find_corresponding_join_node(), join_node);
+  EXPECT_NE(copied_semi_join_reduction_node->get_or_find_corresponding_join_node(), copied_semi_join_reduction_node);
+  EXPECT_EQ(copied_semi_join_reduction_node->get_or_find_corresponding_join_node(), copied_join_node);
 }
 
 }  // namespace opossum

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -85,9 +85,6 @@ TEST_F(JoinNodeTest, HashingAndEqualityCheck) {
   EXPECT_EQ(*_inner_join_node, *_inner_join_node);
   EXPECT_EQ(*_semi_join_node, *_semi_join_node);
   EXPECT_EQ(*_semi_join_reduction_node, *_semi_join_reduction_node);
-  // The `is_semi_reduction` property does not play a role in the equality check. See JoinNode::_on_shallow_equals for
-  // more details on this. As a result, we expect _semi_join_node and _semi_join_reduction_node to be considered as equal.
-  EXPECT_EQ(*_semi_join_reduction_node, *_semi_join_node);
 
   const auto other_join_node_a = JoinNode::make(JoinMode::Inner, equals_(_t_a_a, _t_b_x), _mock_node_a, _mock_node_b);
   const auto other_join_node_b = JoinNode::make(JoinMode::Inner, not_like_(_t_a_a, _t_b_y), _mock_node_a, _mock_node_b);
@@ -103,6 +100,9 @@ TEST_F(JoinNodeTest, HashingAndEqualityCheck) {
   EXPECT_NE(other_join_node_b->hash(), _inner_join_node->hash());
   EXPECT_NE(other_join_node_c->hash(), _inner_join_node->hash());
   EXPECT_EQ(other_join_node_d->hash(), _inner_join_node->hash());
+
+  EXPECT_NE(_semi_join_node->hash(), _semi_join_reduction_node->hash());
+  EXPECT_NE(*_semi_join_reduction_node, *_semi_join_node);
 }
 
 TEST_F(JoinNodeTest, Copy) {
@@ -110,7 +110,6 @@ TEST_F(JoinNodeTest, Copy) {
   EXPECT_EQ(*_inner_join_node, *_inner_join_node->deep_copy());
   EXPECT_EQ(*_semi_join_node, *_semi_join_node->deep_copy());
   EXPECT_EQ(*_semi_join_reduction_node, *_semi_join_reduction_node->deep_copy());
-  EXPECT_TRUE(std::static_pointer_cast<JoinNode>(_semi_join_reduction_node->deep_copy())->is_semi_reduction());
   EXPECT_EQ(*_anti_join_node, *_anti_join_node->deep_copy());
 }
 

--- a/src/test/lib/logical_query_plan/join_node_test.cpp
+++ b/src/test/lib/logical_query_plan/join_node_test.cpp
@@ -621,6 +621,8 @@ TEST_F(JoinNodeTest, GetOrFindReducedJoinNode) {
   const auto copied_join_node = std::dynamic_pointer_cast<JoinNode>(copied_lqp);
   const auto copied_semi_reduction_node = std::dynamic_pointer_cast<JoinNode>(copied_lqp->left_input()->left_input());
   EXPECT_EQ(copied_semi_reduction_node->get_or_find_reduced_join_node(), copied_join_node);
+  // Expect Fail if we do not find the reduced join.
+  EXPECT_THROW(semi_reduction_node->deep_copy()->get_or_find_reduced_join_node(), std::logic_error);
 }
 
 TEST_F(JoinNodeTest, GetOrFindReducedJoinNodeWithMultiplePredicates) {

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -49,12 +49,15 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
     _node_a,
     _node_b);
 
-  const auto expected_lqp = JoinNode::make(JoinMode::Inner, equals_(_a_a, _b_a),
+  auto expected_lqp = JoinNode::make(JoinMode::Inner, equals_(_a_a, _b_a),
     JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
       _node_a,
       _node_b),
     _node_b);
   // clang-format on
+  const auto join_node = std::static_pointer_cast<JoinNode>(expected_lqp);
+  auto semi_reduction_node = std::static_pointer_cast<JoinNode>(expected_lqp->left_input());
+  semi_reduction_node->mark_as_reducer_of(join_node);
 
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -64,7 +64,7 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
   // Check whether the added semi join is marked as a reducer
   auto join_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
   ASSERT_TRUE(join_node->is_semi_reduction());
-  EXPECT_EQ(join_node->get_or_find_semi_reduction_corresponding_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
+  EXPECT_EQ(join_node->get_or_find_reduced_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
 }
 
 TEST_F(SemiJoinReductionRuleTest, CreateSimpleReductionRightSide) {

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -67,8 +67,8 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
 
   // Check whether the added semi join was also marked as a semi reduction.
   auto join_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
-  ASSERT_TRUE(join_node->is_semi_reduction());
-  ASSERT_EQ(join_node->comment, _rule->name());
+  EXPECT_TRUE(join_node->is_semi_reduction());
+  EXPECT_EQ(join_node->comment, _rule->name());
   EXPECT_EQ(join_node->get_or_find_reduced_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
 }
 

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -63,8 +63,8 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
 
   // Check whether the added semi join is marked as a reducer
   auto semi_reduction_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
-  ASSERT_TRUE(semi_reduction_node->is_reducer());
-  EXPECT_EQ(semi_reduction_node->get_or_find_corresponding_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
+  ASSERT_TRUE(semi_reduction_node->is_semi_reduction());
+  EXPECT_EQ(semi_reduction_node->get_or_find_semi_reduction_corresponding_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
 }
 
 TEST_F(SemiJoinReductionRuleTest, CreateSimpleReductionRightSide) {

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -61,8 +61,8 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 
-  // Check whether the added semi join has been marked as a reducer
-  auto semi_reduction_node = std::static_pointer_cast<JoinNode>(expected_lqp->left_input());
+  // Check whether the added semi join is marked as a reducer
+  auto semi_reduction_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
   ASSERT_TRUE(semi_reduction_node->is_reducer());
   EXPECT_EQ(semi_reduction_node->get_or_find_corresponding_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
 }

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -64,6 +64,7 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
   // Check whether the added semi join was also marked as a semi reduction.
   auto join_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
   ASSERT_TRUE(join_node->is_semi_reduction());
+  ASSERT_EQ(join_node->comment, _rule->name());
   EXPECT_EQ(join_node->get_or_find_reduced_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
 }
 

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -61,7 +61,7 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 
-  // Check whether the added semi join is marked as a reducer
+  // Check whether the added semi join was also marked as a semi reduction.
   auto join_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
   ASSERT_TRUE(join_node->is_semi_reduction());
   EXPECT_EQ(join_node->get_or_find_reduced_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -62,9 +62,9 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 
   // Check whether the added semi join is marked as a reducer
-  auto semi_reduction_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
-  ASSERT_TRUE(semi_reduction_node->is_semi_reduction());
-  EXPECT_EQ(semi_reduction_node->get_or_find_semi_reduction_corresponding_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
+  auto join_node = std::static_pointer_cast<JoinNode>(actual_lqp->left_input());
+  ASSERT_TRUE(join_node->is_semi_reduction());
+  EXPECT_EQ(join_node->get_or_find_semi_reduction_corresponding_join_node(), std::static_pointer_cast<JoinNode>(actual_lqp));
 }
 
 TEST_F(SemiJoinReductionRuleTest, CreateSimpleReductionRightSide) {

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -50,13 +50,17 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReduction) {
     _node_a,
     _node_b);
 
+  const auto expected_reduction =
+  JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
+    _node_a,
+    _node_b);
+
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, equals_(_a_a, _b_a),
-    JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
-      _node_a,
-      _node_b),
+    expected_reduction,
     _node_b);
   // clang-format on
+  expected_reduction->mark_as_semi_reduction(expected_lqp);
 
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -77,13 +81,17 @@ TEST_F(SemiJoinReductionRuleTest, CreateSimpleReductionRightSide) {
     _node_b,
     _node_a);
 
+  const auto expected_reduction =
+  JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
+    _node_a,
+    _node_b);
+
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, equals_(_a_a, _b_a),
     _node_b,
-    JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
-      _node_a,
-      _node_b));
+    expected_reduction);
   // clang-format on
+  expected_reduction->mark_as_semi_reduction(expected_lqp);
 
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -137,13 +145,17 @@ TEST_F(SemiJoinReductionRuleTest, ReductionOnlyForEquals) {
     _node_a,
     _node_b);
 
+  const auto expected_reduction =
+  JoinNode::make(JoinMode::Semi, equals_(_b_a, _a_a),
+    _node_a,
+    _node_b);
+
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, predicates,
-    JoinNode::make(JoinMode::Semi, equals_(_b_a, _a_a),
-      _node_a,
-      _node_b),
+    expected_reduction,
     _node_b);
   // clang-format on
+  expected_reduction->mark_as_semi_reduction(expected_lqp);
 
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
@@ -177,15 +189,19 @@ TEST_F(SemiJoinReductionRuleTest, TraverseRightInput) {
       _node_b,
       _node_c));
 
+  const auto expected_reduction =
+  JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
+    _node_a,
+    _node_b);
+
   const auto expected_lqp =
   JoinNode::make(JoinMode::Inner, equals_(_a_a, _b_a),
-    JoinNode::make(JoinMode::Semi, equals_(_a_a, _b_a),
-      _node_a,
-      _node_b),
+    expected_reduction,
     JoinNode::make(JoinMode::Inner, equals_(_a_b, _c_a),
       _node_b,
       _node_c));
   // clang-format on
+  expected_reduction->mark_as_semi_reduction(expected_lqp);
 
   auto actual_lqp = StrategyBaseTest::apply_rule(_rule, input_lqp);
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);

--- a/src/test/lib/sql/sql_translator_test.cpp
+++ b/src/test/lib/sql/sql_translator_test.cpp
@@ -2555,9 +2555,11 @@ TEST_F(SQLTranslatorTest, Execute) {
 }
 
 TEST_F(SQLTranslatorTest, ExecuteWithoutParams) {
+  // clang-format off
   const auto prepared_lqp =
   AggregateNode::make(expression_vector(), expression_vector(min_(int_float_a)),
     stored_table_node_int_float);
+  // clang-format on
 
   const auto prepared_plan = std::make_shared<PreparedPlan>(prepared_lqp, std::vector<ParameterID>{});
 


### PR DESCRIPTION
This PR prepares for

* #2312
* #2467 

It adds the following functions/properties to `JoinNode`, which become relevant in case of `JoinMode::Semi`:

* `::is_semi_reduction`
* `::mark_as_semi_reduction`
* `::get_or_find_reduced_join_node`