### PR TITLE
Deep-Copy LQP node comments

### DIFF
--- a/src/lib/cost_estimation/abstract_cost_estimator.cpp
+++ b/src/lib/cost_estimation/abstract_cost_estimator.cpp
@@ -79,7 +79,7 @@ std::optional<Cost> AbstractCostEstimator::_get_subplan_cost_from_cache(
   }
 
   // Check whether the cache entry can be used: This is only the case if the entire subplan has not yet been
-  // visited. If any node in it has already has been visited, and we'd use the cache entry anyway, costs would get
+  // visited. If any node in it has already been visited, and we'd use the cache entry anyway, costs would get
   // counted twice
   auto subplan_already_visited = false;
   auto subplan_nodes = std::vector<std::shared_ptr<AbstractLQPNode>>{};

--- a/src/lib/cost_estimation/abstract_cost_estimator.hpp
+++ b/src/lib/cost_estimation/abstract_cost_estimator.hpp
@@ -57,7 +57,7 @@ class AbstractCostEstimator {
    *    - No node in the subplan has already been costed and is marked as @param visited. This avoids incorporating
    *      the cost of nodes multiple times in the presence of diamond shapes in the plan.
    *
-   * If the Cost for a subplan can be retrieved, all its nodes are marked as @param visisted.
+   * If the Cost for a subplan can be retrieved, all its nodes are marked as @param visited.
    */
   std::optional<Cost> _get_subplan_cost_from_cache(const std::shared_ptr<AbstractLQPNode>& lqp,
                                                    std::unordered_set<std::shared_ptr<AbstractLQPNode>>& visited) const;

--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -351,6 +351,7 @@ std::shared_ptr<AbstractLQPNode> AbstractLQPNode::_shallow_copy(LQPNodeMapping& 
   if (node_mapping_iter != node_mapping.end()) return node_mapping_iter->second;
 
   auto shallow_copy = _on_shallow_copy(node_mapping);
+  shallow_copy->comment = comment;
   node_mapping.emplace(shared_from_this(), shallow_copy);
 
   return shallow_copy;

--- a/src/lib/statistics/statistics_objects/generic_histogram.hpp
+++ b/src/lib/statistics/statistics_objects/generic_histogram.hpp
@@ -26,7 +26,7 @@ class GenericHistogram : public AbstractHistogram<T> {
                    std::vector<HistogramCountType>&& bin_heights, std::vector<HistogramCountType>&& bin_distinct_counts,
                    const HistogramDomain<T>& domain = {});
 
-  // Convenience builder for a GenericHistogram wiht a single bin
+  // Convenience builder for a GenericHistogram with a single bin
   static std::shared_ptr<GenericHistogram<T>> with_single_bin(const T& min, const T& max,
                                                               const HistogramCountType& height,
                                                               const HistogramCountType& distinct_count,

--- a/src/test/lib/logical_query_plan/mock_node_test.cpp
+++ b/src/test/lib/logical_query_plan/mock_node_test.cpp
@@ -69,8 +69,12 @@ TEST_F(MockNodeTest, HashingAndEqualityCheck) {
 }
 
 TEST_F(MockNodeTest, Copy) {
+  std::string comment = "Special MockNode.";
+  _mock_node_b->comment = comment;
+
   const auto copy = _mock_node_b->deep_copy();
   EXPECT_EQ(*_mock_node_b, *copy);
+  EXPECT_EQ(copy->comment, comment);
 
   _mock_node_b->set_pruned_column_ids({ColumnID{1}});
   EXPECT_NE(*_mock_node_b, *copy);


### PR DESCRIPTION
`AbstractLQPNode::_shallow_copy` does not cover the `comment` field. As a result, previously set comments get lost in deep-copied LQPs. With this PR, comments also get copied.