### PR TITLE
Fix Casting of string `NULL` Values 

### DIFF
--- a/resources/test_data/tbl/string_numbers_null.tbl
+++ b/resources/test_data/tbl/string_numbers_null.tbl
@@ -1,0 +1,6 @@
+a
+string_null
+12
+null
+1234
+null

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -690,9 +690,8 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_cast_ex
     argument_result.as_view([&](const auto& argument_result_view) {
       const auto result_size = _result_size(argument_result_view.size());
       values.resize(result_size);
-      nulls = argument_result.nulls;
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(result_size); ++chunk_offset) {
-        if (argument_result.is_nullable() && nulls[chunk_offset]) {
+        if (argument_result_view.is_null(chunk_offset)) {
           continue;
         }
         const auto& argument_value = argument_result_view.value(chunk_offset);
@@ -705,6 +704,7 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_cast_ex
           Fail(error_message.str());
         }
       }
+      nulls = argument_result.nulls;
     });
   });
 

--- a/src/test/lib/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/lib/expression/expression_evaluator_to_values_test.cpp
@@ -811,6 +811,8 @@ TEST_F(ExpressionEvaluatorToValuesTest, CastSeries) {
   EXPECT_TRUE(test_expression<int32_t>(table_a, *cast_(f, DataType::Int), {99, 2, 13, 15}));
   EXPECT_TRUE(
       test_expression<pmr_string>(table_a, *cast_(c, DataType::String), {"33", std::nullopt, "34", std::nullopt}));
+  EXPECT_TRUE(test_expression<int32_t>(table_a, *cast_(extract_(DatetimeComponent::Year, dates2), DataType::Int),
+                                       {2017, 2014, std::nullopt, std::nullopt}));
 }
 
 }  // namespace opossum

--- a/src/test/lib/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/lib/expression/expression_evaluator_to_values_test.cpp
@@ -811,8 +811,14 @@ TEST_F(ExpressionEvaluatorToValuesTest, CastSeries) {
   EXPECT_TRUE(test_expression<int32_t>(table_a, *cast_(f, DataType::Int), {99, 2, 13, 15}));
   EXPECT_TRUE(
       test_expression<pmr_string>(table_a, *cast_(c, DataType::String), {"33", std::nullopt, "34", std::nullopt}));
-  EXPECT_TRUE(test_expression<int32_t>(table_a, *cast_(extract_(DatetimeComponent::Year, dates2), DataType::Int),
-                                       {2017, 2014, std::nullopt, std::nullopt}));
+}
+
+TEST_F(ExpressionEvaluatorToValuesTest, CastNullableStrings) {
+  auto table_string_nullable = load_table("resources/test_data/tbl/string_numbers_null.tbl");
+  auto string_column = PQPColumnExpression::from_table(*table_string_nullable, "a");
+
+  EXPECT_TRUE(test_expression<int32_t>(table_string_nullable, *cast_(string_column, DataType::Int),
+                                       {12, std::nullopt, 1234, std::nullopt}));
 }
 
 }  // namespace opossum


### PR DESCRIPTION
This PR fixes an error when casting nullable string columns to numeric types and adds a test for this case.

Steps to reproduce bug:
1. Consider the following file `a_table.tbl`:
  ```
a
string_null
1
null
  ```
2. Start `hyriseConsole` and import table (`COPY a_table FROM 'path_to_table'`)
3. Run the following query:

```SQL
SELECT CAST(a AS LONG) FROM a_table
```
4. Get the following error:
```
std::logic_error: src/lib/expression/evaluation/expression_evaluator.cpp:706 Cannot cast '' as Long
```

After applying this PR, we get the correct output:
```
=== Columns
|CAST(a AS long)|
|           long|
|           null|
=== Chunk 0 ===
|<ValueS>       |
|              1|
|           NULL|
===
2 rows total
```

We did not capture this bug in the tests yet as we only casted `NULL` values of numeric columns, which are 0-initialized and hence do not throw an error when being `NULL`.