### PR TITLE
Removed superfluous file removal during `SetUp `

### DIFF
--- a/src/test/lib/import_export/binary/binary_writer_test.cpp
+++ b/src/test/lib/import_export/binary/binary_writer_test.cpp
@@ -19,7 +19,9 @@ namespace opossum {
 
 class BinaryWriterTest : public BaseTest {
  protected:
-  void TearDown() override { std::remove(filename.c_str()); }
+  void TearDown() override {
+    std::remove(filename.c_str());
+  }
 
   std::shared_ptr<Table> table;
   const std::string filename = test_data_path + "export_test.bin";

--- a/src/test/lib/import_export/binary/binary_writer_test.cpp
+++ b/src/test/lib/import_export/binary/binary_writer_test.cpp
@@ -19,8 +19,6 @@ namespace opossum {
 
 class BinaryWriterTest : public BaseTest {
  protected:
-  void SetUp() override { std::remove(filename.c_str()); }
-
   void TearDown() override { std::remove(filename.c_str()); }
 
   std::shared_ptr<Table> table;


### PR DESCRIPTION
Minor change to the BinaryWriterTest with regard to Issue #2472:
- Removed unnecessary file removal in test setup

The tests still run successful and no files exist after finishing the tests.