### PR TITLE
Remove LTO builds warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ endif()
 
 # Link Time Optimization (LTO)
 cmake_policy(SET CMP0069 NEW)
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 option(ENABLE_LTO "Set to ON to build Hyrise with enabled Link Time Optimization (LTO). Default: OFF" OFF)
 if (${ENABLE_LTO})
     if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")


### PR DESCRIPTION
This PR fixes a spammy Cmake output when using link time optimization.

```
CMake Warning (dev) at third_party/benchmark/src/CMakeLists.txt:20 (add_library):
  Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
  enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
  'benchmark'.
This warning is for project developers.  Use -Wno-dev to suppress it.
```