### PR TITLE
Fix SegmentEncoder issue wrongly initializing the _null_values optional of ValueSegments

### DIFF
--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -54,6 +54,7 @@ std::shared_ptr<AbstractSegment> ChunkEncoder::encode_segment(const std::shared_
     if (encoding_spec.encoding_type == EncodingType::Unencoded) {
       pmr_vector<ColumnDataType> values;
       pmr_vector<bool> null_values;
+      auto nullable = bool{false};
 
       auto iterable = create_any_segment_iterable<ColumnDataType>(*segment);
       iterable.with_iterators([&](auto it, const auto end) {
@@ -68,11 +69,16 @@ std::shared_ptr<AbstractSegment> ChunkEncoder::encode_segment(const std::shared_
           if (!is_null) {
             values[current_position] = segment_item.value();
           } else {
+            nullable = true;
             values[current_position] = {};
           }
         }
       });
-      result = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
+      if (nullable) {
+        result = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
+      } else {
+        result = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values));
+      }
     } else {
       auto encoder = create_encoder(encoding_spec.encoding_type);
       if (encoding_spec.vector_compression_type) {

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<AbstractSegment> ChunkEncoder::encode_segment(const std::shared_
     if (encoding_spec.encoding_type == EncodingType::Unencoded) {
       pmr_vector<ColumnDataType> values;
       pmr_vector<bool> null_values;
-      auto nullable = bool{false};
+      auto contains_nulls = bool{false};
 
       auto iterable = create_any_segment_iterable<ColumnDataType>(*segment);
       iterable.with_iterators([&](auto it, const auto end) {
@@ -69,12 +69,12 @@ std::shared_ptr<AbstractSegment> ChunkEncoder::encode_segment(const std::shared_
           if (!is_null) {
             values[current_position] = segment_item.value();
           } else {
-            nullable = true;
+            contains_nulls = true;
             values[current_position] = {};
           }
         }
       });
-      if (nullable) {
+      if (contains_nulls) {
         result = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values), std::move(null_values));
       } else {
         result = std::make_shared<ValueSegment<ColumnDataType>>(std::move(values));

--- a/src/lib/storage/chunk_encoder.cpp
+++ b/src/lib/storage/chunk_encoder.cpp
@@ -54,7 +54,7 @@ std::shared_ptr<AbstractSegment> ChunkEncoder::encode_segment(const std::shared_
     if (encoding_spec.encoding_type == EncodingType::Unencoded) {
       pmr_vector<ColumnDataType> values;
       pmr_vector<bool> null_values;
-      auto contains_nulls = bool{false};
+      auto contains_nulls = false;
 
       auto iterable = create_any_segment_iterable<ColumnDataType>(*segment);
       iterable.with_iterators([&](auto it, const auto end) {

--- a/src/test/lib/storage/chunk_encoder_test.cpp
+++ b/src/test/lib/storage/chunk_encoder_test.cpp
@@ -242,8 +242,10 @@ TEST_F(ChunkEncoderTest, ReencodeNotNullableSegment) {
   value_segment->append(3);
   value_segment->append(4);
 
-  auto dict_segment = ChunkEncoder::encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
-  auto reencoded_segment = ChunkEncoder::encode_segment(dict_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Unencoded});
+  auto dict_segment = ChunkEncoder::encode_segment(
+    value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+  auto reencoded_segment = ChunkEncoder::encode_segment(
+    dict_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Unencoded});
   const auto casted_reencoded_segment = std::dynamic_pointer_cast<const ValueSegment<int>>(reencoded_segment);
 
   EXPECT_FALSE(casted_reencoded_segment->is_nullable());

--- a/src/test/lib/storage/chunk_encoder_test.cpp
+++ b/src/test/lib/storage/chunk_encoder_test.cpp
@@ -235,4 +235,19 @@ TEST_F(ChunkEncoderTest, ReencodingTable) {
   }
 }
 
+TEST_F(ChunkEncoderTest, ReencodeNotNullableSegment) {
+  auto value_segment = std::make_shared<ValueSegment<int>>();
+  value_segment->append(4);
+  value_segment->append(6);
+  value_segment->append(3);
+  value_segment->append(4);
+
+  auto dict_segment = ChunkEncoder::encode_segment(value_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Dictionary});
+  auto reencoded_segment = ChunkEncoder::encode_segment(dict_segment, DataType::Int, SegmentEncodingSpec{EncodingType::Unencoded});
+  const auto casted_reencoded_segment = std::dynamic_pointer_cast<const ValueSegment<int>>(reencoded_segment);
+
+  EXPECT_FALSE(casted_reencoded_segment->is_nullable());
+}
+
+
 }  // namespace hyrise


### PR DESCRIPTION
This PR fixes bug in the ´SegmentEncoder´.
I'm not sure if there is a corresponding issue.

The error was that when a not nullable encoded segment was passed to the segment encoder and `Unencoded` was selected as the target encoding, the new `ValueSegment` is created with an empty, but initialized `null_values` vector.
Because of that, the `_null_values` optional is set and `is_nullable` returned true, which resulted in errors.

A way to recreate this error on the master branch is to lead encoded tables in an unencoded benchmark:
First run `./hyriseBenchmarkTPCH -s 0.01 -r 1`, after that run `./hyriseBenchmarkTPCH -s 0.01 -r 1 -e Unencoded`.