### PR TITLE
Disable encrypted connections in server tests

### DIFF
--- a/scripts/test/hyriseServer_test.py
+++ b/scripts/test/hyriseServer_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import pexpect
 import re
 
@@ -9,27 +10,29 @@ from hyriseBenchmarkCore import initialize
 def main():
     build_dir = initialize()
 
-    arguments = {}
-    arguments["--benchmark_data"] = "tpc-h:0.01"
+    server = pexpect.spawn(f"{build_dir}/hyriseServer --benchmark_data=tpc-h:0.01 -p 0", timeout=10)
 
-    benchmark = pexpect.spawn(f"{build_dir}/hyriseServer --benchmark_data=tpc-h:0.01 -p 0", timeout=10)
-
-    benchmark.expect_exact("Loading/Generating tables", timeout=120)
-    benchmark.expect_exact("Encoding 'lineitem'", timeout=120)
+    server.expect_exact("Loading/Generating tables", timeout=120)
+    server.expect_exact("Encoding 'lineitem'", timeout=120)
     search_regex = r"Server started at 0.0.0.0 and port (\d+)"
-    benchmark.expect(search_regex, timeout=120)
+    server.expect(search_regex, timeout=120)
 
-    server_port = int(re.search(search_regex, str(benchmark.after)).group(1))
-    client = pexpect.spawn(f"psql -h localhost -p {server_port}", timeout=20)
+    server_port = int(re.search(search_regex, str(server.after)).group(1))
+    # Recent Postgres/psql versions changed the authentication behavior. Disabling an environment variable solves the
+    # issue. Since hyriseServer does not implement authentication at all, this is no problem.
+    # See https://github.com/psycopg/psycopg2/issues/1084#issuecomment-656778107
+    environment_variables = os.environ.copy()
+    environment_variables.update({"PGGSSENCMODE": "disable"})
+    client = pexpect.spawn(f"psql -h localhost -p {server_port}", timeout=20, env=environment_variables)
 
     client.sendline("select count(*) from region;")
     client.expect_exact("COUNT(*)")
     client.expect_exact("5")
     client.expect_exact("(1 row)")
 
-    # Not using close_benchmark() here, as a server is started and a timeout of None would wait forever
+    # Not using close_benchmark() here, as a server is started and a timeout of None would wait forever.
     client.close()
-    benchmark.close()
+    server.close()
 
 
 if __name__ == "__main__":

--- a/scripts/test/hyriseServer_test.py
+++ b/scripts/test/hyriseServer_test.py
@@ -18,9 +18,11 @@ def main():
     server.expect(search_regex, timeout=120)
 
     server_port = int(re.search(search_regex, str(server.after)).group(1))
-    # Recent Postgres/psql versions changed the authentication behavior. Disabling an environment variable solves the
-    # issue. Since hyriseServer does not implement authentication at all, this is no problem.
-    # See https://github.com/psycopg/psycopg2/issues/1084#issuecomment-656778107
+    # Recent Postgres/psql versions changed the authentication behavior, resulting in connection errors on some setups.
+    # Disabling encrypted connections solves the issue. Since hyriseServer does not implement authentication at all,
+    # this is no problem.
+    # See https://github.com/psycopg/psycopg2/issues/1084#issuecomment-656778107 and
+    # https://www.postgresql.org/docs/13/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE
     environment_variables = os.environ.copy()
     environment_variables.update({"PGGSSENCMODE": "disable"})
     client = pexpect.spawn(f"psql -h localhost -p {server_port}", timeout=20, env=environment_variables)


### PR DESCRIPTION
On sidon (Ubuntu 20.04, psql 12.7) I got the following error when running the `hyriseServerTest.py` script/connecting to a `hyriseServer` with psql:
```
psql: error: could not connect to server: Connection refused
	Is the server running on host "localhost" (::1) and accepting
	TCP/IP connections on port 41963?
received invalid response to GSSAPI negotiation: R
```

When applying this suggestion [1], everything worked fine. Basically, we disable encrypted connections to the server for the test [2]. Since we do not perform user authentication/encryption by any means, this should be okay. Though I could not reproduce the error on macOS/psql 14.05, I adapted the test file. 

[1] https://github.com/psycopg/psycopg2/issues/1084#issuecomment-656778107
[2] https://www.postgresql.org/docs/13/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE