### PR TITLE
Mini fixes

### DIFF
--- a/src/lib/expression/evaluation/expression_functors.hpp
+++ b/src/lib/expression/evaluation/expression_functors.hpp
@@ -143,8 +143,8 @@ using AdditionEvaluator = STLArithmeticFunctorWrapper<std::plus>;
 using SubtractionEvaluator = STLArithmeticFunctorWrapper<std::minus>;
 using MultiplicationEvaluator = STLArithmeticFunctorWrapper<std::multiplies>;
 
-// Modulo selects between the operator `%` for integrals and fmod() for floats. Custom NULL logic returns NULL if the
-// divisor is NULL
+// Modulo selects between the operator `%` for integrals and std::fmod() for floats. Custom NULL logic returns NULL if
+// the divisor is NULL.
 struct ModuloEvaluator {
   template <typename Result, typename ArgA, typename ArgB>
   struct supports {
@@ -170,7 +170,7 @@ struct ModuloEvaluator {
         if constexpr (std::is_integral_v<ArgA> && std::is_integral_v<ArgB>) {
           result_value = static_cast<Result>(a_value % b_value);
         } else {
-          result_value = static_cast<Result>(fmod(a_value, b_value));
+          result_value = static_cast<Result>(std::fmod(a_value, b_value));
         }
       }
     }

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -95,7 +95,7 @@ size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t
       static_cast<double>(sizeof(uint32_t)) / 0.8;
 
   const auto cluster_count = std::max(1.0, complete_hash_map_size / L2_CACHE_MAX_USABLE);
-  
+
   // We limit the max fan out for radix partitioning to 8 bits (i.e., 256 partitions). "An Experimental Comparison of
   // Thirteen Relational Equi-Joins in Main Memory" by Schuh et al. analyzed the number of radix bits and how much
   // large fan outs hurt performance due to TLB misses. As we do not use software-managed buffers, a smaller number of

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -279,7 +279,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
 
   // Currently, we just do one pass
   const auto pass = size_t{0};
-  const auto radix_mask = static_cast<size_t>(pow(2, radix_bits * (pass + 1)) - 1);
+  const auto radix_mask = static_cast<size_t>(std::pow(2, radix_bits * (pass + 1)) - 1);
 
   Assert(output_bloom_filter.empty(), "output_bloom_filter should be empty");
   output_bloom_filter.resize(BLOOM_FILTER_SIZE);
@@ -531,7 +531,7 @@ RadixContainer<T> partition_by_radix(const RadixContainer<T>& radix_container,
 
   // currently, we just do one pass
   const size_t pass = 0;
-  const size_t radix_mask = static_cast<uint32_t>(pow(2, radix_bits * (pass + 1)) - 1);
+  const size_t radix_mask = static_cast<uint32_t>(std::pow(2, radix_bits * (pass + 1)) - 1);
 
   // allocate new (shared) output
   auto output = RadixContainer<T>(output_partition_count);


### PR DESCRIPTION
Two issues I found when using clang9. I have no idea why they appear right now, but `pow` and `fmod` (both C lib functions) require both `double` values. Using their C++ pendants works fine.

The `fmod` issue could be caused by clang instantiating the function for differnet types of `a_value` and `b_value`.

Further, this PR sets a maximum to the number of radix bits which was beneficial for large scale factors (> SF 100).