### PR TITLE
Avoid coverage badge caching and change info text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://hyrise-ci.epic-hpi.de/buildStatus/icon?job=Hyrise/hyrise/master)](https://hyrise-ci.epic-hpi.de/blue/organizations/jenkins/hyrise%2Fhyrise/activity/)
-[![Coverage Status](https://hyrisecoverage.boissier.de/)](https://hyrise-ci.epic-hpi.de/job/Hyrise/job/hyrise/job/master/lastStableBuild/Llvm-cov_5fReport/)
+[![Coverage Status](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/coverage_badge.svg)](https://hyrise-ci.epic-hpi.de/job/Hyrise/job/hyrise/job/master/lastStableBuild/Llvm-cov_5fReport/)
 [![CodeFactor](https://www.codefactor.io/repository/github/hyrise/hyrise/badge)](https://www.codefactor.io/repository/github/hyrise/hyrise)
 
 # Welcome to Hyrise

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://hyrise-ci.epic-hpi.de/buildStatus/icon?job=Hyrise/hyrise/master)](https://hyrise-ci.epic-hpi.de/blue/organizations/jenkins/hyrise%2Fhyrise/activity/)
-[![Coverage Status](https://hyrise-ci.epic-hpi.de/job/hyrise/job/hyrise/job/master/lastStableBuild/artifact/coverage_badge.svg)](https://hyrise-ci.epic-hpi.de/job/Hyrise/job/hyrise/job/master/lastStableBuild/Llvm-cov_5fReport/)
+[![Coverage Status](https://hyrisecoverage.boissier.de/)](https://hyrise-ci.epic-hpi.de/job/Hyrise/job/hyrise/job/master/lastStableBuild/Llvm-cov_5fReport/)
 [![CodeFactor](https://www.codefactor.io/repository/github/hyrise/hyrise/badge)](https://www.codefactor.io/repository/github/hyrise/hyrise)
 
 # Welcome to Hyrise

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Contact: firstname.lastname@hpi.de
 -   Pascal    Führlich
 -   Carl      Gödecken
 -   Adrian    Holfter
+-   Theresa   Hradilak
 -   Ben       Hurdelhey
 -   Sven      Ihde
 -   Ivan      Illic
@@ -199,10 +200,12 @@ Contact: firstname.lastname@hpi.de
 -   Leander   Neiß
 -   Hendrik   Rätz
 -   Alexander Riese
+-   Marc      Rosenau
 -   Johannes  Schneider
 -   David     Schumann
 -   Simon     Siegert
 -   Arthur    Silber
+-   Furkan    Simsek
 -   Toni      Stachewicz
 -   Daniel    Stolpe
 -   Jonathan  Striebel
@@ -210,6 +213,7 @@ Contact: firstname.lastname@hpi.de
 -   Hendrik   Tjabben
 -   Justin    Trautmann
 -   Carsten   Walther
+-   Leo       Wendt
 -   Lukas     Wenzel
 -   Fabian    Wiebe
 -   Tim       Zimmermann

--- a/scripts/test/hyriseServer_test.py
+++ b/scripts/test/hyriseServer_test.py
@@ -21,7 +21,7 @@ def main():
     server = pexpect.spawn(f"{build_dir}/hyriseServer --benchmark_data=tpc-h:0.01 -p 0", timeout=10)
 
     server.expect_exact("Loading/Generating tables", timeout=120)
-    server.expect_exact("Encoding 'lineitem'", timeout=120)
+    server.expect_exact("Processing 'lineitem'", timeout=120)
     search_regex = r"Server started at 0.0.0.0 and port (\d+)"
     server.expect(search_regex, timeout=120)
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -217,7 +217,7 @@ void AbstractTableGenerator::generate_and_store() {
         table_info.re_encoded =
             BenchmarkTableEncoder::encode(table_name, table_info.table, _benchmark_config->encoding_config);
         auto output = std::stringstream{};
-        output << "-  Encoding '" + table_name << "' - "
+        output << "-  Processing '" + table_name << "' - "
                << (table_info.re_encoded ? "encoding applied" : "no encoding necessary") << " ("
                << per_table_timer.lap_formatted() << ")\n";
         std::cout << output.str() << std::flush;

--- a/src/lib/storage/reference_segment/reference_segment_iterable.hpp
+++ b/src/lib/storage/reference_segment/reference_segment_iterable.hpp
@@ -182,7 +182,6 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
       return other._pos_list_it - _pos_list_it;
     }
 
-    // TODO(anyone): benchmark if using two maps instead doing the dynamic cast every time really is faster.
     SegmentPosition<T> dereference() const {
       const auto pos_list_offset = static_cast<ChunkOffset>(_pos_list_it - _begin_pos_list_it);
 
@@ -219,7 +218,7 @@ class ReferenceSegmentIterable : public SegmentIterable<ReferenceSegmentIterable
     PosListIteratorType _begin_pos_list_it;
     PosListIteratorType _pos_list_it;
 
-    // PointAccessIterators share vector with one Accessor per Chunk
+    // PointAccessIterators share vector with one accessor per chunk
     std::shared_ptr<std::vector<std::shared_ptr<AbstractSegmentAccessor<T>>>> _accessors;
   };
 };


### PR DESCRIPTION
This tiny PR does two things:
 - change a text during benchmark loading
 - adds contributors

**Badge**:
The coverage badge URL remains the same (Jenkin's badget) but we internally rewrite the header caching information with the HPI to ensure that badges are not cached. This has been the reason for the previous solution on heroku.

**Benchmark information**:
Change the text for table encoding and stats generation from `Encoding 'lineitem' - no encoding necessary (12 s 248 ms)` to `Processing 'lineitem' - no encoding necessary (12 s 248 ms)`. Since there are stats generated, I am always curious what a lot cores can do for 12 seconds, when no re-encoding is necessary.
