### PR TITLE
Rename column `p_retailsize` in TPC-H's `part` table to `p_retailprice`

### DIFF
--- a/resources/benchmark/jcch/part.csv.json
+++ b/resources/benchmark/jcch/part.csv.json
@@ -36,7 +36,7 @@
             "type": "string"
         },
         {
-            "name": "p_retailsize",
+            "name": "p_retailprice",
             "nullable": false,
             "type": "float"
         },

--- a/resources/test_data/tbl/tpch/minimal/part.tbl
+++ b/resources/test_data/tbl/tpch/minimal/part.tbl
@@ -1,3 +1,3 @@
-p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailsize|p_comment
+p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment
 int|string|string|string|string|int|string|float|string
 1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|

--- a/resources/test_data/tbl/tpch/sf-0.001/part.tbl
+++ b/resources/test_data/tbl/tpch/sf-0.001/part.tbl
@@ -1,4 +1,4 @@
-p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailsize|p_comment
+p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment
 int|string|string|string|string|int|string|float|string
 1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|
 2|blush thistle blue yellow saddle|Manufacturer#1|Brand#13|LARGE BRUSHED BRASS|1|LG CASE|902.00|lar accounts amo|

--- a/resources/test_data/tbl/tpch/sf-0.002/part.tbl
+++ b/resources/test_data/tbl/tpch/sf-0.002/part.tbl
@@ -1,4 +1,4 @@
-p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailsize|p_comment
+p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment
 int|string|string|string|string|int|string|float|string
 1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|
 2|blush thistle blue yellow saddle|Manufacturer#1|Brand#13|LARGE BRUSHED BRASS|1|LG CASE|902.00|lar accounts amo|

--- a/resources/test_data/tbl/tpch/sf-0.01/part.tbl
+++ b/resources/test_data/tbl/tpch/sf-0.01/part.tbl
@@ -1,4 +1,4 @@
-p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailsize|p_comment
+p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment
 int|string|string|string|string|int|string|float|string
 1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|
 2|blush thistle blue yellow saddle|Manufacturer#1|Brand#13|LARGE BRUSHED BRASS|1|LG CASE|902.00|lar accounts amo|

--- a/resources/test_data/tbl/tpch/sf-0.02/part.tbl
+++ b/resources/test_data/tbl/tpch/sf-0.02/part.tbl
@@ -1,4 +1,4 @@
-p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailsize|p_comment
+p_partkey|p_name|p_mfgr|p_brand|p_type|p_size|p_container|p_retailprice|p_comment
 int|string|string|string|string|int|string|float|string
 1|goldenrod lavender spring chocolate lace|Manufacturer#1|Brand#13|PROMO BURNISHED COPPER|7|JUMBO PKG|901.00|ly. slyly ironi|
 2|blush thistle blue yellow saddle|Manufacturer#1|Brand#13|LARGE BRUSHED BRASS|1|LG CASE|902.00|lar accounts amo|

--- a/src/benchmarklib/tpch/tpch_table_generator.cpp
+++ b/src/benchmarklib/tpch/tpch_table_generator.cpp
@@ -36,7 +36,7 @@ const auto lineitem_column_types = boost::hana::tuple      <int32_t,     int32_t
 const auto lineitem_column_names = boost::hana::make_tuple("l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment");  // NOLINT
 
 const auto part_column_types = boost::hana::tuple      <int32_t,    pmr_string,  pmr_string,  pmr_string,  pmr_string,  int32_t,  pmr_string,    float,        pmr_string>();  // NOLINT
-const auto part_column_names = boost::hana::make_tuple("p_partkey", "p_name",    "p_mfgr",    "p_brand",   "p_type",    "p_size", "p_container", "p_retailsize", "p_comment");  // NOLINT
+const auto part_column_names = boost::hana::make_tuple("p_partkey", "p_name",    "p_mfgr",    "p_brand",   "p_type",    "p_size", "p_container", "p_retailprice", "p_comment");  // NOLINT
 
 const auto partsupp_column_types = boost::hana::tuple<     int32_t,      int32_t,      int32_t,       float,           pmr_string>();  // NOLINT
 const auto partsupp_column_names = boost::hana::make_tuple("ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment");  // NOLINT


### PR DESCRIPTION
According to the TPC-H schema [1, p. 15], the column's name is `p_retailprice` (which also makes more sense). The mistake did not show since the column is not queried. This PR replaces the incorrect column name with the correct one.

[1] https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v3.0.1.pdf