### PR TITLE
Remove dummy table output from maintenance operators

### DIFF
--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -127,12 +127,9 @@ void AbstractOperator::execute() {
       const auto& lqp_expressions = lqp_node->output_expressions();
       if (!_output) {
         Assert(lqp_expressions.empty(), "Operator did not produce a result, but the LQP expects it to");
-      } else if (std::dynamic_pointer_cast<const AbstractNonQueryNode>(lqp_node) ||
-                 std::dynamic_pointer_cast<const DummyTableNode>(lqp_node)) {
-        // AbstractNonQueryNodes do not have any consumable output_expressions, but the corresponding operators return
-        // 'OK' for better compatibility with the console and the server. We do not assert anything here.
-        // Similarly, DummyTableNodes do not produce expressions that are used in the remainder of the LQP and do not
-        // need to be tested.
+      } else if (std::dynamic_pointer_cast<const DummyTableNode>(lqp_node)) {
+        // DummyTableNodes do not produce expressions that are used in the remainder of the LQP and do not need to be
+        // tested.
       } else {
         // Check that LQP expressions and PQP columns match. If they do not, this is a severe bug as the operators might
         // be operating on the wrong column. This should not only be caught here, but also by more detailed tests.
@@ -151,8 +148,8 @@ void AbstractOperator::execute() {
       }
     }
 
-    // Verify that nullability of columns and segments match for ValueSegments
-    // Only ValueSegments have an individual is_nullable attribute
+    // Verify that nullability of columns and segments match for ValueSegments. Only ValueSegments have an individual
+    // `is_nullable` attribute.
     if (_output && _output->type() == TableType::Data) {
       for (auto chunk_id = ChunkID{0}; chunk_id < _output->chunk_count(); ++chunk_id) {
         for (auto column_id = ColumnID{0}; column_id < _output->column_count(); ++column_id) {

--- a/src/lib/operators/maintenance/create_table.cpp
+++ b/src/lib/operators/maintenance/create_table.cpp
@@ -80,7 +80,7 @@ std::shared_ptr<const Table> CreateTable::_on_execute(std::shared_ptr<Transactio
     _insert->set_transaction_context(context);
     _insert->execute();
   }
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
+  return nullptr;
 }
 
 std::shared_ptr<AbstractOperator> CreateTable::_on_deep_copy(

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<const Table> CreateView::_on_execute() {
   if (!_if_not_exists || !Hyrise::get().storage_manager.has_view(_view_name)) {
     Hyrise::get().storage_manager.add_view(_view_name, _view);
   }
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
+  return nullptr;
 }
 
 }  // namespace hyrise

--- a/src/lib/operators/maintenance/drop_table.cpp
+++ b/src/lib/operators/maintenance/drop_table.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<const Table> DropTable::_on_execute() {
     Hyrise::get().storage_manager.drop_table(table_name);
   }
 
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
+  return nullptr;
 }
 
 std::shared_ptr<AbstractOperator> DropTable::_on_deep_copy(

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<const Table> DropView::_on_execute() {
     Hyrise::get().storage_manager.drop_view(view_name);
   }
 
-  return std::make_shared<Table>(TableColumnDefinitions{{"OK", DataType::Int, false}}, TableType::Data);  // Dummy table
+  return nullptr;
 }
 
 }  // namespace hyrise

--- a/src/test/lib/operators/maintenance/create_table_test.cpp
+++ b/src/test/lib/operators/maintenance/create_table_test.cpp
@@ -80,6 +80,8 @@ TEST_F(CreateTableTest, Execute) {
   create_table->execute();
   context->commit();
 
+  EXPECT_TRUE(create_table->executed());
+  EXPECT_FALSE(create_table->get_output());
   EXPECT_TRUE(Hyrise::get().storage_manager.has_table("t"));
 
   const auto table = Hyrise::get().storage_manager.get_table("t");
@@ -98,6 +100,8 @@ TEST_F(CreateTableTest, SoftKeyConstraints) {
   create_table->execute();
   context->commit();
 
+  EXPECT_TRUE(create_table->executed());
+  EXPECT_FALSE(create_table->get_output());
   EXPECT_TRUE(Hyrise::get().storage_manager.has_table("t"));
 
   const auto table = Hyrise::get().storage_manager.get_table("t");

--- a/src/test/lib/operators/maintenance/create_view_test.cpp
+++ b/src/test/lib/operators/maintenance/create_view_test.cpp
@@ -26,21 +26,22 @@ TEST_F(CreateViewTest, OperatorName) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view, false);
+  const auto create_view = std::make_shared<CreateView>("view_name", view, false);
 
-  EXPECT_EQ(cv->name(), "CreateView");
+  EXPECT_EQ(create_view->name(), "CreateView");
 }
 
 TEST_F(CreateViewTest, DeepCopy) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view, false);
+  const auto create_view = std::make_shared<CreateView>("view_name", view, false);
 
-  cv->execute();
-  EXPECT_NE(cv->get_output(), nullptr);
+  create_view->execute();
+  EXPECT_TRUE(create_view->executed());
+  EXPECT_FALSE(create_view->get_output());
 
-  const auto copy = cv->deep_copy();
+  const auto copy = create_view->deep_copy();
   EXPECT_FALSE(copy->executed());
 }
 
@@ -48,36 +49,39 @@ TEST_F(CreateViewTest, Execute) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view_in, false);
-  cv->execute();
+  const auto create_view = std::make_shared<CreateView>("view_name", view_in, false);
+  create_view->execute();
 
-  EXPECT_EQ(cv->get_output()->row_count(), 0u);
+  EXPECT_TRUE(create_view->executed());
+  EXPECT_FALSE(create_view->get_output());
 
   EXPECT_TRUE(Hyrise::get().storage_manager.has_view("view_name"));
 
-  auto view_out = Hyrise::get().storage_manager.get_view("view_name");
+  const auto view_out = Hyrise::get().storage_manager.get_view("view_name");
   EXPECT_EQ(view_out->lqp->type, LQPNodeType::Mock);
 
-  auto cv_2 = std::make_shared<CreateView>("view_name", view_in, false);
-  EXPECT_ANY_THROW(cv_2->execute());
+  const auto create_view_2 = std::make_shared<CreateView>("view_name", view_in, false);
+  EXPECT_ANY_THROW(create_view_2->execute());
 }
 
 TEST_F(CreateViewTest, ExecuteWithIfNotExists) {
   const auto view_lqp = MockNode::make(MockNode::ColumnDefinitions{{{DataType::Int, "x"}}});
   const auto view_in = std::make_shared<LQPView>(view_lqp, std::unordered_map<ColumnID, std::string>{});
 
-  auto cv = std::make_shared<CreateView>("view_name", view_in, true);
-  cv->execute();
+  const auto create_view = std::make_shared<CreateView>("view_name", view_in, true);
+  create_view->execute();
 
-  EXPECT_EQ(cv->get_output()->row_count(), 0u);
+  EXPECT_TRUE(create_view->executed());
+  EXPECT_FALSE(create_view->get_output());
 
   EXPECT_TRUE(Hyrise::get().storage_manager.has_view("view_name"));
 
-  auto view_out = Hyrise::get().storage_manager.get_view("view_name");
+  const auto view_out = Hyrise::get().storage_manager.get_view("view_name");
   EXPECT_EQ(view_out->lqp->type, LQPNodeType::Mock);
 
-  auto cv_2 = std::make_shared<CreateView>("view_name", view_in, true);
-  EXPECT_NO_THROW(cv_2->execute());
+  const auto create_view_2 = std::make_shared<CreateView>("view_name", view_in, true);
+  EXPECT_NO_THROW(create_view_2->execute());
+  EXPECT_TRUE(create_view_2->executed());
 }
 
 }  // namespace hyrise

--- a/src/test/lib/operators/maintenance/drop_table_test.cpp
+++ b/src/test/lib/operators/maintenance/drop_table_test.cpp
@@ -34,6 +34,8 @@ TEST_F(DropTableTest, NameAndDescription) {
 TEST_F(DropTableTest, Execute) {
   Hyrise::get().storage_manager.add_table("t", table);
   drop_table->execute();
+  EXPECT_TRUE(drop_table->executed());
+  EXPECT_FALSE(drop_table->get_output());
   EXPECT_FALSE(Hyrise::get().storage_manager.has_table("t"));
 }
 
@@ -45,10 +47,13 @@ TEST_F(DropTableTest, ExecuteWithIfExists) {
   Hyrise::get().storage_manager.add_table("t", table);
   auto drop_table_if_exists_1 = std::make_shared<DropTable>("t", true);
   drop_table_if_exists_1->execute();
+  EXPECT_TRUE(drop_table_if_exists_1->executed());
+  EXPECT_FALSE(drop_table_if_exists_1->get_output());
   EXPECT_FALSE(Hyrise::get().storage_manager.has_table("t"));
 
   auto drop_table_if_exists_2 = std::make_shared<DropTable>("t", true);
   EXPECT_NO_THROW(drop_table_if_exists_2->execute());
+  EXPECT_TRUE(drop_table_if_exists_2->executed());
   EXPECT_FALSE(Hyrise::get().storage_manager.has_table("t"));
 }
 

--- a/src/test/lib/operators/maintenance/drop_view_test.cpp
+++ b/src/test/lib/operators/maintenance/drop_view_test.cpp
@@ -27,41 +27,45 @@ class DropViewTest : public BaseTest {
 };
 
 TEST_F(DropViewTest, OperatorName) {
-  auto dv = std::make_shared<DropView>("view_name", false);
+  const auto drop_view = std::make_shared<DropView>("view_name", false);
 
-  EXPECT_EQ(dv->name(), "DropView");
+  EXPECT_EQ(drop_view->name(), "DropView");
 }
 
 TEST_F(DropViewTest, DeepCopy) {
-  auto dv = std::make_shared<DropView>("view_name", false);
+  const auto drop_view = std::make_shared<DropView>("view_name", false);
 
-  dv->execute();
-  EXPECT_NE(dv->get_output(), nullptr);
+  drop_view->execute();
+  EXPECT_TRUE(drop_view->executed());
+  EXPECT_FALSE(drop_view->get_output());
 
-  const auto copy = dv->deep_copy();
+  const auto copy = drop_view->deep_copy();
   EXPECT_FALSE(copy->executed());
 }
 
 TEST_F(DropViewTest, Execute) {
-  auto dv = std::make_shared<DropView>("view_name", false);
-  dv->execute();
+  const auto drop_view = std::make_shared<DropView>("view_name", false);
+  drop_view->execute();
 
-  EXPECT_EQ(dv->get_output()->row_count(), 0u);
+  EXPECT_TRUE(drop_view->executed());
+  EXPECT_FALSE(drop_view->get_output());
 
   EXPECT_FALSE(Hyrise::get().storage_manager.has_view("view_name"));
 }
 
 TEST_F(DropViewTest, ExecuteWithIfExists) {
-  auto dv_1 = std::make_shared<DropView>("view_name", true);
-  dv_1->execute();
+  const auto drop_view_1 = std::make_shared<DropView>("view_name", true);
+  drop_view_1->execute();
 
-  EXPECT_EQ(dv_1->get_output()->row_count(), 0u);
+  EXPECT_TRUE(drop_view_1->executed());
+  EXPECT_FALSE(drop_view_1->get_output());
 
   EXPECT_FALSE(Hyrise::get().storage_manager.has_view("view_name"));
 
-  auto dv_2 = std::make_shared<DropView>("view_name", true);
+  const auto drop_view_2 = std::make_shared<DropView>("view_name", true);
 
-  EXPECT_NO_THROW(dv_2->execute());
+  EXPECT_NO_THROW(drop_view_2->execute());
+  EXPECT_TRUE(drop_view_2->executed());
 
   EXPECT_FALSE(Hyrise::get().storage_manager.has_view("view_name"));
 }


### PR DESCRIPTION
Just stumbled across table creation and noticed that some maintenance operators return a dummy table. Since others don't (`Insert/Delete`, `Import/Export`, ...) and this is also nothing SQL standardish, this PR removes this behavior.