### PR TITLE
Rename `BetweenExpression` and `InExpression`s' `value()` to `operand()`

### DIFF
--- a/src/benchmarklib/encoding_config.cpp
+++ b/src/benchmarklib/encoding_config.cpp
@@ -50,7 +50,7 @@ nlohmann::json EncodingConfig::to_json() const {
     nlohmann::json mapping{};
     mapping["encoding"] = std::string{magic_enum::enum_name(spec.encoding_type)};
     if (spec.vector_compression_type) {
-      mapping["compression"] = vector_compression_type_to_string.left.at(spec.vector_compression_type.value());
+      mapping["compression"] = vector_compression_type_to_string.left.at(*spec.vector_compression_type);
     }
     return mapping;
   };

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -76,7 +76,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
   // add column definitions and initialize each value vector
   TableColumnDefinitions column_definitions;
   for (auto column_id = size_t{0}; column_id < num_columns; ++column_id) {
-    const auto column_name = column_specifications[column_id].name ? column_specifications[column_id].name.value()
+    const auto column_name = column_specifications[column_id].name ? *column_specifications[column_id].name
                                                                    : "column_" + std::to_string(column_id + 1);
     column_definitions.emplace_back(column_name, column_specifications[column_id].data_type, false);
   }
@@ -183,7 +183,7 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
           } else {
             segments[column_index] =
                 ChunkEncoder::encode_segment(value_segment, column_specifications[column_index].data_type,
-                                             column_specifications[column_index].segment_encoding_spec.value());
+                                             *column_specifications[column_index].segment_encoding_spec);
           }
         });
       }));

--- a/src/benchmarklib/table_builder.hpp
+++ b/src/benchmarklib/table_builder.hpp
@@ -79,7 +79,7 @@ using get_value_type = typename GetValueType<T>::value_type;
 template <typename T>
 constexpr bool is_null(const T& optional_or_value) {
   if constexpr (is_optional_v<T>) {
-    return !optional_or_value.has_value();
+    return !optional_or_value;
   } else {
     return false;
   }
@@ -89,7 +89,7 @@ constexpr bool is_null(const T& optional_or_value) {
 template <typename T>
 get_value_type<T>& get_value(T& optional_or_value) {
   if constexpr (is_optional_v<T>) {
-    return optional_or_value.value();
+    return *optional_or_value;
   } else {
     return optional_or_value;
   }

--- a/src/lib/expression/between_expression.cpp
+++ b/src/lib/expression/between_expression.cpp
@@ -7,15 +7,15 @@
 namespace hyrise {
 
 BetweenExpression::BetweenExpression(const PredicateCondition init_predicate_condition,
-                                     const std::shared_ptr<AbstractExpression>& value,
+                                     const std::shared_ptr<AbstractExpression>& operand,
                                      const std::shared_ptr<AbstractExpression>& lower_bound,
                                      const std::shared_ptr<AbstractExpression>& upper_bound)
-    : AbstractPredicateExpression(init_predicate_condition, {value, lower_bound, upper_bound}) {
+    : AbstractPredicateExpression(init_predicate_condition, {operand, lower_bound, upper_bound}) {
   Assert(is_between_predicate_condition(predicate_condition),
          "Predicate Condition not supported by Between Expression");
 }
 
-const std::shared_ptr<AbstractExpression>& BetweenExpression::value() const {
+const std::shared_ptr<AbstractExpression>& BetweenExpression::operand() const {
   return arguments[0];
 }
 
@@ -29,14 +29,14 @@ const std::shared_ptr<AbstractExpression>& BetweenExpression::upper_bound() cons
 
 std::shared_ptr<AbstractExpression> BetweenExpression::_on_deep_copy(
     std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
-  return std::make_shared<BetweenExpression>(predicate_condition, value()->deep_copy(copied_ops),
+  return std::make_shared<BetweenExpression>(predicate_condition, operand()->deep_copy(copied_ops),
                                              lower_bound()->deep_copy(copied_ops),
                                              upper_bound()->deep_copy(copied_ops));
 }
 
 std::string BetweenExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << _enclose_argument(*value(), mode) << " " << predicate_condition << " "
+  stream << _enclose_argument(*operand(), mode) << " " << predicate_condition << " "
          << _enclose_argument(*lower_bound(), mode) << " AND " << _enclose_argument(*upper_bound(), mode);
   return stream.str();
 }

--- a/src/lib/expression/between_expression.hpp
+++ b/src/lib/expression/between_expression.hpp
@@ -8,11 +8,12 @@ namespace hyrise {
 
 class BetweenExpression : public AbstractPredicateExpression {
  public:
-  BetweenExpression(const PredicateCondition init_predicate_condition, const std::shared_ptr<AbstractExpression>& value,
+  BetweenExpression(const PredicateCondition init_predicate_condition,
+                    const std::shared_ptr<AbstractExpression>& operand,
                     const std::shared_ptr<AbstractExpression>& lower_bound,
                     const std::shared_ptr<AbstractExpression>& upper_bound);
 
-  const std::shared_ptr<AbstractExpression>& value() const;
+  const std::shared_ptr<AbstractExpression>& operand() const;
   const std::shared_ptr<AbstractExpression>& lower_bound() const;
   const std::shared_ptr<AbstractExpression>& upper_bound() const;
 

--- a/src/lib/expression/in_expression.cpp
+++ b/src/lib/expression/in_expression.cpp
@@ -7,9 +7,9 @@
 namespace hyrise {
 
 InExpression::InExpression(const PredicateCondition init_predicate_condition,
-                           const std::shared_ptr<AbstractExpression>& value,
+                           const std::shared_ptr<AbstractExpression>& operand,
                            const std::shared_ptr<AbstractExpression>& set)
-    : AbstractPredicateExpression(init_predicate_condition, {value, set}) {
+    : AbstractPredicateExpression(init_predicate_condition, {operand, set}) {
   DebugAssert(predicate_condition == PredicateCondition::In || predicate_condition == PredicateCondition::NotIn,
               "Expected either IN or NOT IN as PredicateCondition");
 }
@@ -18,7 +18,7 @@ bool InExpression::is_negated() const {
   return predicate_condition == PredicateCondition::NotIn;
 }
 
-const std::shared_ptr<AbstractExpression>& InExpression::value() const {
+const std::shared_ptr<AbstractExpression>& InExpression::operand() const {
   return arguments[0];
 }
 
@@ -28,13 +28,13 @@ const std::shared_ptr<AbstractExpression>& InExpression::set() const {
 
 std::shared_ptr<AbstractExpression> InExpression::_on_deep_copy(
     std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
-  return std::make_shared<InExpression>(predicate_condition, value()->deep_copy(copied_ops),
+  return std::make_shared<InExpression>(predicate_condition, operand()->deep_copy(copied_ops),
                                         set()->deep_copy(copied_ops));
 }
 
 std::string InExpression::description(const DescriptionMode mode) const {
   std::stringstream stream;
-  stream << _enclose_argument(*value(), mode) << " ";
+  stream << _enclose_argument(*operand(), mode) << " ";
   stream << predicate_condition << " ";
   stream << set()->description(mode);
   return stream.str();

--- a/src/lib/expression/in_expression.hpp
+++ b/src/lib/expression/in_expression.hpp
@@ -9,7 +9,7 @@ namespace hyrise {
  */
 class InExpression : public AbstractPredicateExpression {
  public:
-  InExpression(const PredicateCondition init_predicate_condition, const std::shared_ptr<AbstractExpression>& value,
+  InExpression(const PredicateCondition init_predicate_condition, const std::shared_ptr<AbstractExpression>& operand,
                const std::shared_ptr<AbstractExpression>& set);
 
   /**
@@ -18,7 +18,7 @@ class InExpression : public AbstractPredicateExpression {
    */
   bool is_negated() const;
 
-  const std::shared_ptr<AbstractExpression>& value() const;
+  const std::shared_ptr<AbstractExpression>& operand() const;
   const std::shared_ptr<AbstractExpression>& set() const;
 
   std::shared_ptr<AbstractExpression> _on_deep_copy(

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -49,7 +49,7 @@ AbstractOperator::~AbstractOperator() {
    *  the description() function.
    */
   if constexpr (HYRISE_DEBUG) {
-    auto transaction_context = _transaction_context.has_value() ? _transaction_context->lock() : nullptr;
+    auto transaction_context = _transaction_context ? _transaction_context->lock() : nullptr;
     auto aborted = transaction_context ? transaction_context->aborted() : false;
     auto left_has_executed = _left_input ? _left_input->executed() : false;
     auto right_has_executed = _right_input ? _right_input->executed() : false;

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -414,14 +414,14 @@ std::unique_ptr<AbstractTableScanImpl> TableScan::create_impl() {
     // lossless_predicate_variant_cast into the column's data type and reassemble the between condition.
 
     auto predicate_condition = between_expression->predicate_condition;
-    const auto left_column = std::dynamic_pointer_cast<PQPColumnExpression>(between_expression->value());
+    const auto left_column = std::dynamic_pointer_cast<PQPColumnExpression>(between_expression->operand());
 
     auto [lower_condition, upper_condition] = between_to_conditions(predicate_condition);
 
     auto lower_bound_value = expression_get_value_or_parameter(*between_expression->lower_bound());
     if (lower_bound_value) {
       const auto adjusted_predicate_and_value = lossless_predicate_variant_cast(
-          lower_condition, *lower_bound_value, between_expression->value()->data_type());
+          lower_condition, *lower_bound_value, between_expression->operand()->data_type());
       if (adjusted_predicate_and_value) {
         lower_condition = adjusted_predicate_and_value->first;
         lower_bound_value = adjusted_predicate_and_value->second;
@@ -433,7 +433,7 @@ std::unique_ptr<AbstractTableScanImpl> TableScan::create_impl() {
     auto upper_bound_value = expression_get_value_or_parameter(*between_expression->upper_bound());
     if (upper_bound_value) {
       const auto adjusted_predicate_and_value = lossless_predicate_variant_cast(
-          upper_condition, *upper_bound_value, between_expression->value()->data_type());
+          upper_condition, *upper_bound_value, between_expression->operand()->data_type());
       if (adjusted_predicate_and_value) {
         upper_condition = adjusted_predicate_and_value->first;
         upper_bound_value = adjusted_predicate_and_value->second;

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
@@ -138,7 +138,7 @@ void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
       return LQPVisitation::VisitInputs;
     }
 
-    const auto& left_expression = in_expression->value();
+    const auto& left_expression = in_expression->operand();
     const auto& right_side_expressions = static_cast<ListExpression&>(*in_expression->set()).elements();
 
     // Check whether all elements are literal values of the same data type (that is not NULL).
@@ -182,7 +182,7 @@ void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
                   _cardinality_estimator()->estimate_cardinality(sub_node->left_input()) >=
                       MIN_INPUT_ROWS_FOR_DISJUNCTION) &&
                  !in_expression->is_negated() &&
-                 !std::dynamic_pointer_cast<FunctionExpression>(in_expression->value())) {
+                 !std::dynamic_pointer_cast<FunctionExpression>(in_expression->operand())) {
         rewrite_to_disjunction(sub_node, left_expression, right_side_expressions, *common_data_type);
       } else {
         // Stick with the ExpressionEvaluator

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -249,7 +249,7 @@ std::optional<SubqueryToJoinRule::PredicateNodeInfo> SubqueryToJoinRule::is_pred
     result.join_mode = in_expression->is_negated() ? JoinMode::AntiNullAsTrue : JoinMode::Semi;
     // We need to deep_copy the subquery before modifying it as it might be in use somewhere else, too.
     result.subquery = std::static_pointer_cast<LQPSubqueryExpression>(in_expression->set()->deep_copy());
-    result.join_predicate = equals_(in_expression->value(), result.subquery->lqp->output_expressions()[0]);
+    result.join_predicate = equals_(in_expression->operand(), result.subquery->lqp->output_expressions()[0]);
 
     // Correlated NOT IN is very weird w.r.t. handling of null values and cannot be turned into a
     // multi-predicate join that treats all its predicates equivalently

--- a/src/lib/server/postgres_protocol_handler.cpp
+++ b/src/lib/server/postgres_protocol_handler.cpp
@@ -119,12 +119,12 @@ void PostgresProtocolHandler<SocketType>::send_data_row(
   _write_buffer.template put_value<uint16_t>(static_cast<uint16_t>(values_as_strings.size()));
 
   for (const auto& value_string : values_as_strings) {
-    if (value_string.has_value()) {
+    if (value_string) {
       // Size of string representation of value, NOT of value type's size
-      _write_buffer.template put_value<uint32_t>(static_cast<uint32_t>(value_string.value().size()));
+      _write_buffer.template put_value<uint32_t>(static_cast<uint32_t>(value_string->size()));
 
       // Text mode means all values are sent as non-terminated strings
-      _write_buffer.put_string(value_string.value(), HasNullTerminator::No);
+      _write_buffer.put_string(*value_string, HasNullTerminator::No);
     } else {
       // NULL values are represented by setting the value's length to -1
       _write_buffer.template put_value<int32_t>(-1);

--- a/src/lib/server/result_serializer.cpp
+++ b/src/lib/server/result_serializer.cpp
@@ -80,9 +80,9 @@ void ResultSerializer::send_query_response(
         const auto attribute_value = (*segments[segment_id])[chunk_offset];
         // The PostgreSQL protocol requires the conversion of values to strings
         const auto string_value = lossy_variant_cast<pmr_string>(attribute_value);
-        if (string_value.has_value()) {
+        if (string_value) {
           // Sum up string lengths for a row to save an extra loop during serialization
-          string_length_sum += static_cast<uint32_t>(string_value.value().size());
+          string_length_sum += static_cast<uint32_t>(string_value->size());
         }
         values_as_strings[segment_id] = string_value;
       }
@@ -94,7 +94,7 @@ void ResultSerializer::send_query_response(
 std::string ResultSerializer::build_command_complete_message(const ExecutionInformation& execution_information,
                                                              const uint64_t row_count) {
   if (execution_information.custom_command_complete_message) {
-    return execution_information.custom_command_complete_message.value();
+    return *execution_information.custom_command_complete_message;
   }
 
   return build_command_complete_message(execution_information.root_operator_type, row_count);

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -2071,14 +2071,14 @@ std::shared_ptr<AbstractExpression> SQLTranslator::_inverse_predicate(const Abst
       if (const auto* const between_expression = dynamic_cast<const BetweenExpression*>(&expression);
           between_expression) {
         // a BETWEEN b AND c -> a < b OR a > c
-        return or_(less_than_(between_expression->value(), between_expression->lower_bound()),
-                   greater_than_(between_expression->value(), between_expression->upper_bound()));
+        return or_(less_than_(between_expression->operand(), between_expression->lower_bound()),
+                   greater_than_(between_expression->operand(), between_expression->upper_bound()));
       }
 
       const auto* in_expression = dynamic_cast<const InExpression*>(&expression);
       Assert(in_expression, "Expected InExpression");
       return std::make_shared<InExpression>(inverse_predicate_condition(in_expression->predicate_condition),
-                                            in_expression->value(), in_expression->set());
+                                            in_expression->operand(), in_expression->set());
     } break;
 
     case ExpressionType::Logical: {

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -406,7 +406,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_predicate_node(
     auto expressions = std::vector<std::shared_ptr<AbstractExpression>>{};
     expressions.reserve(list_expression.elements().size());
     for (const auto& list_element : list_expression.elements()) {
-      expressions.emplace_back(equals_(in_expression->value(), list_element));
+      expressions.emplace_back(equals_(in_expression->operand(), list_element));
     }
 
     const auto disjunction = inflate_logical_expressions(expressions, LogicalOperator::Or);

--- a/src/lib/statistics/join_graph_statistics_cache.cpp
+++ b/src/lib/statistics/join_graph_statistics_cache.cpp
@@ -34,7 +34,7 @@ std::optional<JoinGraphStatisticsCache::Bitmask> JoinGraphStatisticsCache::bitma
 
   visit_lqp(lqp, [&](const auto& node) {
     // Early out if `bitmask.reset()` was called during the search below
-    if (!bitmask.has_value()) {
+    if (!bitmask) {
       return LQPVisitation::DoNotVisitInputs;
     }
 

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -224,7 +224,7 @@ bool RangeFilter<T>::does_not_contain(const PredicateCondition predicate_conditi
   // are not prunable. Malformed predicates such as can_prune(PredicateCondition::LessThan, {5}, NULL_VALUE) are not
   // pruned either. While this call might be considered nonsensical (everything compared to NULL is null), we do not
   // require callers to identify these circumstances.
-  if (variant_is_null(variant_value) || (variant_value2.has_value() && variant_is_null(variant_value2.value())) ||
+  if (variant_is_null(variant_value) || (variant_value2 && variant_is_null(*variant_value2)) ||
       predicate_condition == PredicateCondition::IsNull || predicate_condition == PredicateCondition::IsNotNull) {
     return false;
   }
@@ -276,7 +276,7 @@ bool RangeFilter<T>::does_not_contain(const PredicateCondition predicate_conditi
        *    - both bounds are within the same gap
        */
 
-      Assert(variant_value2.has_value(), "Between operator needs two values.");
+      Assert(variant_value2, "Between operator needs two values.");
       const auto value2 = boost::get<T>(*variant_value2);
 
       // a BETWEEN 5 AND 4 will always be empty

--- a/src/plugins/mvcc_delete_plugin.cpp
+++ b/src/plugins/mvcc_delete_plugin.cpp
@@ -119,7 +119,7 @@ void MvccDeletePlugin::_physical_delete_loop() {
       auto lowest_snapshot_commit_id = Hyrise::get().transaction_manager.get_lowest_active_snapshot_commit_id();
 
       if (lowest_snapshot_commit_id) {
-        conflicting_transactions = chunk->get_cleanup_commit_id().value() > lowest_snapshot_commit_id.value();
+        conflicting_transactions = *chunk->get_cleanup_commit_id() > lowest_snapshot_commit_id.value();
       }
 
       if (!conflicting_transactions) {

--- a/src/test/lib/expression/evaluation/like_matcher_test.cpp
+++ b/src/test/lib/expression/evaluation/like_matcher_test.cpp
@@ -57,8 +57,7 @@ TEST_F(LikeMatcherTest, NotMatching) {
 
 TEST_F(LikeMatcherTest, LowerUpperBound) {
   const auto pattern = pmr_string("Japan%");
-  const auto bounds = LikeMatcher::bounds(pattern);
-  const auto [lower_bound, upper_bound] = bounds.value();
+  const auto [lower_bound, upper_bound] = *LikeMatcher::bounds(pattern);
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, "Japao");
 }
@@ -81,8 +80,7 @@ TEST_F(LikeMatcherTest, LeadingWildcard) {
 TEST_F(LikeMatcherTest, NoWildcard) {
   const auto pattern = pmr_string("Japan");
   const auto expected_upper_bound = pmr_string("Japan") + '\0';
-  const auto bounds = LikeMatcher::bounds(pattern);
-  const auto [lower_bound, upper_bound] = bounds.value();
+  const auto [lower_bound, upper_bound] = *LikeMatcher::bounds(pattern);
   ASSERT_EQ(lower_bound, "Japan");
   ASSERT_EQ(upper_bound, expected_upper_bound);
 }
@@ -91,8 +89,7 @@ TEST_F(LikeMatcherTest, EmptyString) {
   // Check that if the pattern has no wildcard, std::nullopt is returned.
   const auto pattern = pmr_string("");
   const auto expected_upper_bound = pmr_string("") + '\0';
-  const auto bounds = LikeMatcher::bounds(pattern);
-  const auto [lower_bound, upper_bound] = bounds.value();
+  const auto [lower_bound, upper_bound] = *LikeMatcher::bounds(pattern);
   ASSERT_EQ(lower_bound, "");
   ASSERT_EQ(upper_bound, expected_upper_bound);
 }

--- a/src/test/lib/operators/import_test.cpp
+++ b/src/test/lib/operators/import_test.cpp
@@ -68,8 +68,8 @@ TEST_P(OperatorsImportMultiFileTypeTest, HasCorrectMvccData) {
 
   EXPECT_EQ(table->uses_mvcc(), UseMvcc::Yes);
   EXPECT_TRUE(table->get_chunk(ChunkID{0})->has_mvcc_data());
-  EXPECT_TRUE(table->get_chunk(ChunkID{0})->mvcc_data()->max_begin_cid.has_value());
-  EXPECT_EQ(table->get_chunk(ChunkID{0})->mvcc_data()->max_begin_cid.value(), CommitID{0});
+  EXPECT_TRUE(table->get_chunk(ChunkID{0})->mvcc_data()->max_begin_cid);
+  EXPECT_EQ(*table->get_chunk(ChunkID{0})->mvcc_data()->max_begin_cid, CommitID{0});
 }
 
 TEST_F(OperatorsImportTest, FileDoesNotExist) {

--- a/src/test/lib/operators/join_hash/join_hash_types_test.cpp
+++ b/src/test/lib/operators/join_hash/join_hash_types_test.cpp
@@ -31,7 +31,7 @@ void test_hash_map(const std::vector<T>& values) {
   // With only one offset value passed, one hash map will be created
   EXPECT_EQ(hash_maps.size(), 1);
 
-  const auto& first_hash_map = hash_maps.at(0).value();
+  const auto& first_hash_map = *hash_maps.at(0);
 
   ChunkOffset offset = ChunkOffset{0};
   for (const auto& element : partition.elements) {

--- a/src/test/lib/operators/table_scan_test.cpp
+++ b/src/test/lib/operators/table_scan_test.cpp
@@ -77,7 +77,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
           continue;
         }
 
-        chunk->set_individually_sorted_by(sorted_by.value());
+        chunk->set_individually_sorted_by(*sorted_by);
       }
     }
 

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -440,8 +440,9 @@ TEST_F(ColumnPruningRuleTest, AnnotatePrunableJoinInput) {
 
       apply_rule(rule, lqp);
 
-      EXPECT_TRUE(join_node->prunable_input_side().has_value()) << "With JoinMode::" << join_mode;
-      EXPECT_EQ(*join_node->prunable_input_side(), prunable_input_side) << "With JoinMode::" << join_mode;
+      SCOPED_TRACE("With JoinMode::" + std::string{magic_enum::enum_name(join_mode)});
+      EXPECT_TRUE(join_node->prunable_input_side());
+      EXPECT_EQ(*join_node->prunable_input_side(), prunable_input_side);
     }
   }
 }

--- a/src/test/lib/server/transaction_handling_test.cpp
+++ b/src/test/lib/server/transaction_handling_test.cpp
@@ -15,7 +15,7 @@ TEST_F(TransactionHandlingTest, CreateTableWithinTransaction) {
   // begin and commit transaction statements are executed successfully
   EXPECT_TRUE(execution_information.error_messages.empty());
   EXPECT_EQ(execution_information.result_table, nullptr);
-  EXPECT_EQ(execution_information.custom_command_complete_message.value(), "COMMIT");
+  EXPECT_EQ(*execution_information.custom_command_complete_message, "COMMIT");
   EXPECT_EQ(Hyrise::get().storage_manager.get_table("users")->row_count(), 1);
 }
 

--- a/src/test/lib/storage/storage_manager_test.cpp
+++ b/src/test/lib/storage/storage_manager_test.cpp
@@ -58,7 +58,7 @@ TEST_F(StorageManagerTest, StatisticCreationOnAddTable) {
   const auto table = sm.get_table("int_float");
   EXPECT_EQ(table->table_statistics()->row_count, 3.0f);
   const auto chunk = table->get_chunk(ChunkID{0});
-  EXPECT_TRUE(chunk->pruning_statistics().has_value());
+  EXPECT_TRUE(chunk->pruning_statistics());
   EXPECT_EQ(chunk->pruning_statistics()->at(0)->data_type, DataType::Int);
   EXPECT_EQ(chunk->pruning_statistics()->at(1)->data_type, DataType::Float);
 }


### PR DESCRIPTION
The arguments reference expressions to which the predicate should be applied. Thus, these are operands, not values (triggered my inner Monk, also see the other predicate expressions: BinaryPredicateExpression and IsNullExpression). Furthermore, as I grepped the codebase for `value()`, I removed some superfluous calls to `value()` and `has_value()` when dealing with `std::optional`s.