### PR TITLE
[WIP] Test LLVM 15 for CI runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,7 +206,6 @@ try {
             stage("clang-debug:tidy") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                // As clang-tidy is the slowest step, we allow it to use more parallel jobs.
                 sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 10))"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugTidy")
@@ -301,6 +300,7 @@ try {
               // Runs after the other sanitizers as it depends on gcc-release to be built. With #2402, valgrind now
               // uses the GCC build instead of the clang build as there are issues with valgrind and the debug symbols
               // of clang 14 (https://bugs.kde.org/show_bug.cgi?id=452758).
+              // TODO(anybody): Valgrind 3.20 should fix the clang-14 issues (not shipped with Ubuntu 22.04).
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 sh "mkdir ./clang-release-memcheck-test"
                 // If this shows a leak, try --leak-check=full, which is slower but more precise

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -50,7 +50,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
             echo "Installing dependencies (this may take a while)..."
             if sudo apt-get update >/dev/null; then
                 # Packages added here should also be added to the Dockerfile
-                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-11 clang-14 clang-format-14 clang-tidy-14 cmake curl dos2unix g++-9 gcc-9 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip valgrind &
+                sudo apt-get install --no-install-recommends -y autoconf bash-completion bc clang-11 clang-15 clang-format-15 clang-tidy-15 cmake curl dos2unix g++-9 gcc-9 g++-11 gcc-11 gcovr git graphviz libboost-all-dev libhwloc-dev libncurses5-dev libnuma-dev libnuma1 libpq-dev libreadline-dev libsqlite3-dev libtbb-dev lld man parallel postgresql-server-dev-all python3 python3-pip valgrind &
 
                 if ! git submodule update --jobs 5 --init --recursive; then
                     echo "Error during git fetching submodules."
@@ -71,7 +71,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
 
                 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 90 --slave /usr/bin/g++ g++ /usr/bin/g++-11
                 # we use llvm-profdata-11 and llvm-cov-11 due to an unresolved issue with coverage under clang14 (https://github.com/llvm/llvm-project/issues/54907)
-                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-14 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-14 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-11 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-11 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-14
+                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-15 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-15 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-15
             else
                 echo "Error during installation."
                 exit 1

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -71,7 +71,7 @@ if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
 
                 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 90 --slave /usr/bin/g++ g++ /usr/bin/g++-11
                 # we use llvm-profdata-11 and llvm-cov-11 due to an unresolved issue with coverage under clang14 (https://github.com/llvm/llvm-project/issues/54907)
-                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-15 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-15 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-15
+                sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 90 --slave /usr/bin/clang++ clang++ /usr/bin/clang++-15 --slave /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 --slave /usr/bin/llvm-profdata llvm-profdata /usr/bin/llvm-profdata-11 --slave /usr/bin/llvm-cov llvm-cov /usr/bin/llvm-cov-11 --slave /usr/bin/clang-format clang-format /usr/bin/clang-format-15
             else
                 echo "Error during installation."
                 exit 1

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -36,8 +36,8 @@ cd build-coverage
 # We use clang 11 for the coverage check as clang 14 (the default clang version for Ubuntu 22.04) has an unresolved
 # issue (see https://github.com/llvm/llvm-project/issues/54907).
 path_to_compiler=''
-c_compiler='clang-11'
-cxx_compiler='clang++-11'
+c_compiler='clang-15'
+cxx_compiler='clang++-15'
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -33,11 +33,11 @@ fi
 mkdir -p build-coverage
 cd build-coverage
 
-# We use clang 11 for the coverage check as clang 14 (the default clang version for Ubuntu 22.04) has an unresolved
-# issue (see https://github.com/llvm/llvm-project/issues/54907).
+# We use clang 11 for the coverage check as clang 14 and 15 have an unresolved issue
+# (see https://github.com/llvm/llvm-project/issues/54907).
 path_to_compiler=''
-c_compiler='clang-15'
-cxx_compiler='clang++-15'
+c_compiler='clang-11'
+cxx_compiler='clang++-11'
 
 unamestr=$(uname)
 if [[ "$unamestr" == 'Darwin' ]]; then


### PR DESCRIPTION
Upped the CI pipeline to use clang 15.

Closing, as clang-tidy crashes (see https://github.com/llvm/llvm-project/issues/60895) and the coverage issue that made us e use llvm 11 for overage is not fixed.