### PR TITLE
Update clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,7 +52,7 @@ WarningsAsErrors: '*'
 
 # Explanation of disabled checks:
 #   - *-default-arguments*                                      We do use default arguments (and like them)
-#   - google-build-using-namespace                              We use namespaces (cf. expression_functional)
+#   - google-build-using-namespace                              We use using namespace (see anonymous namespaces and expression_functional)
 #   - clang-analyzer-security.insecureAPI.rand                  We don't care about cryptographically unsafe rand() calls
 #   - readability-implicit-bool-conversion                      Doesn't like if(map.count(foo))
 #   - cppcoreguidelines-pro-type-reinterpret-cast               We use reinterpret_cast

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,8 +16,6 @@ Checks: '
          -cert-dcl58-cpp,
          -modernize-avoid-bind,
          -hicpp-no-assembler,
-         -cppcoreguidelines-pro-type-vararg,
-         -hicpp-vararg,
          -cert-env33-c,
          -misc-macro-parentheses,
          -fuchsia-overloaded-operator,
@@ -65,8 +63,6 @@ WarningsAsErrors: '*'
 #   - cert-dcl58-cpp                                            Adding a hash function to std is perfectly legal: https://en.cppreference.com/w/cpp/language/extending_std
 #   - modernize-avoid-bind                                      meh, bind isn't thaaaat bad
 #   - hicpp-no-assembler                                        Sometimes we need assembler...
-#   - cppcoreguidelines-pro-type-vararg                         We use old C functions for ncurses
-#   - hicpp-vararg                                               (same)
 #   - cert-env33-c                                              Yes, we do call system()
 #   - misc-macro-parentheses                                    Causes weird problems with BOOST_PP_TUPLE_ELEM
 #   - fuchsia-overloaded-operator                               We are not supposed to overload operator()?!
@@ -132,7 +128,7 @@ CheckOptions:
   - { key: readability-identifier-naming.UnionCase, value: CamelCase }
   - { key: readability-identifier-naming.UsingCase, value: lower_case }
   - { key: readability-identifier-naming.ValueTemplateParameterCase, value: lower_case }
-  - { key: readability-identifier-naming.VariableCase, value: lower_case
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
 
   # Iff(!) the context is clear, 'it' for iterator, 'op' for operator, or 'fd' for functional dependency are fine.
   - { key: readability-identifier-length.IgnoredParameterNames, value: "^(it|fd|op)$" }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -63,7 +63,6 @@ WarningsAsErrors: '*'
 #   - cppcoreguidelines-pro-bounds-array-to-pointer-decay       Weird stuff - it doesn't like `description_mode == DescriptionMode::MultiLine`
 #   - hicpp-no-array-decay                                       (same)
 #   - cert-dcl58-cpp                                            Adding a hash function to std is perfectly legal: https://en.cppreference.com/w/cpp/language/extending_std
-#   - clang-analyzer-optin.cplusplus.VirtualCall                false positive in boost::lexical_cast
 #   - modernize-avoid-bind                                      meh, bind isn't thaaaat bad
 #   - hicpp-no-assembler                                        Sometimes we need assembler...
 #   - cppcoreguidelines-pro-type-vararg                         We use old C functions for ncurses
@@ -86,7 +85,6 @@ WarningsAsErrors: '*'
 #   - modernize-use-trailing-return-type                        https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-trailing-return-type.html - no that is way too weird
 #   - clang-diagnostic-unknown-warning-option                   Don't complain about gcc warning options
 #   - modernize-use-nodiscard                                   Don't want to tag everything [[nodiscard]]
-#   - cppcoreguidelines-init-variables                          If a variable is only declared and initialized in two different branches, we do not want to initialize it first
 #   - llvmlibc-*                                                LLVM-internal development guidelines.
 #   - altera-*                                                  Checks related to OpenCL programming for FPGAs.
 #   - abseil-*                                                  Checks related to Google's abseil library (not used in Hyrise).
@@ -103,105 +101,40 @@ WarningsAsErrors: '*'
 
 
 CheckOptions:
-  - key: readability-identifier-naming.ClassCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.ConstexprVariableCase
-    value: UPPER_CASE
-
-  - key: readability-identifier-naming.EnumCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.EnumConstantCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.FunctionCase
-    value: lower_case
-
-  - key: readability-identifier-naming.GlobalFunctionCase
-    value: lower_case
-
-  - key: readability-identifier-naming.InlineNamespaceCase
-    value: lower_case
-
-  - key: readability-identifier-naming.LocalConstantCase
-    value: lower_case
-
-  - key: readability-identifier-naming.LocalVariableCase
-    value: lower_case
-
-  - key: readability-identifier-naming.MemberCase
-    value: lower_case
-
-  - key: readability-identifier-naming.PrivateMemberPrefix
-    value: '_'
-
-  - key: readability-identifier-naming.ProtectedMemberPrefix
-    value: '_'
-
-  - key: readability-identifier-naming.PublicMemberCase
-    value: lower_case
-
-  - key: readability-identifier-naming.MethodCase
-    value: lower_case
-
-  - key: readability-identifier-naming.PrivateMethodPrefix
-    value: '_'
-
-  - key: readability-identifier-naming.ProtectedMethodPrefix
-    value: '_'
-
-  - key: readability-identifier-naming.NamespaceCase
-    value: lower_case
-
-  - key: readability-identifier-naming.ParameterCase
-    value: lower_case
-
-  - key: readability-identifier-naming.ConstantParameterCase
-    value: lower_case
-
-  - key: readability-identifier-naming.ParameterPackCase
-    value: lower_case
-
-  - key: readability-identifier-naming.StaticConstantCase
-    value: lower_case
-
-  - key: readability-identifier-naming.StaticVariableCase
-    value: lower_case
-
-  - key: readability-identifier-naming.StructCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.TemplateParameterCase
-    value: UPPER_CASE
-
-  - key: readability-identifier-naming.TemplateTemplateParameterCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.TemplateUsingCase
-    value: lower_case
-
-  - key: readability-identifier-naming.TypeTemplateParameterCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.TypedefCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.UnionCase
-    value: CamelCase
-
-  - key: readability-identifier-naming.UsingCase
-    value: lower_case
-
-  - key: readability-identifier-naming.ValueTemplateParameterCase
-    value: lower_case
-
-  - key: readability-identifier-naming.VariableCase
-    value: lower_case
+  - { key: readability-identifier-naming.ClassCase, value: CamelCase }
+  - { key: readability-identifier-naming.ConstexprVariableCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumCase, value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantCase, value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.GlobalFunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.InlineNamespaceCase, value: lower_case }
+  - { key: readability-identifier-naming.LocalConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.LocalVariableCase, value: lower_case }
+  - { key: readability-identifier-naming.MemberCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: '_' }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix, value: '_' }
+  - { key: readability-identifier-naming.PublicMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.MethodCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMethodPrefix, value: '_' }
+  - { key: readability-identifier-naming.ProtectedMethodPrefix, value: '_' }
+  - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterPackCase, value: lower_case }
+  - { key: readability-identifier-naming.StaticConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.StaticVariableCase, value: lower_case }
+  - { key: readability-identifier-naming.StructCase, value: CamelCase }
+  - { key: readability-identifier-naming.TemplateParameterCase, value: UPPER_CASE }
+  - { key: readability-identifier-naming.TemplateTemplateParameterCase, value: CamelCase }
+  - { key: readability-identifier-naming.TemplateUsingCase, value: lower_case }
+  - { key: readability-identifier-naming.TypeTemplateParameterCase, value: CamelCase }
+  - { key: readability-identifier-naming.TypedefCase, value: CamelCase }
+  - { key: readability-identifier-naming.UnionCase, value: CamelCase }
+  - { key: readability-identifier-naming.UsingCase, value: lower_case }
+  - { key: readability-identifier-naming.ValueTemplateParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case
 
   # Iff(!) the context is clear, 'it' for iterator, 'op' for operator, or 'fd' for functional dependency are fine.
-  - key: readability-identifier-length.IgnoredParameterNames
-    value: "^(it|fd|op)$"
-  - key: readability-identifier-length.IgnoredVariableNames
-    value: "^(it|fd|op)$"
+  - { key: readability-identifier-length.IgnoredParameterNames, value: "^(it|fd|op)$" }
+  - { key: readability-identifier-length.IgnoredVariableNames, value: "^(it|fd|op)$" }
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,7 +13,6 @@ Checks: '
          -hicpp-no-array-decay,
          -cert-dcl58-cpp,
          -modernize-avoid-bind,
-         -hicpp-no-assembler,
          -cert-env33-c,
          -misc-macro-parentheses,
          -fuchsia-overloaded-operator,
@@ -55,7 +54,7 @@ WarningsAsErrors: '*'
 #   - cppcoreguidelines-pro-type-reinterpret-cast               We use reinterpret_cast
 #   - modernize-pass-by-value                                   We don't trust people to properly use std::move
 #   - cppcoreguidelines-pro-bounds-constant-array-index         "Do not use array subscript when the index is not an integer constant expression"?!
-#   - cppcoreguidelines-pro-type-static-cast-downcast           We do allow static downcasts for performance reasons
+#   - cppcoreguidelines-pro-type-static-cast-downcast           We use static downcasts when we can safely obtain the type (e.g., static casts of LQPNodes via node->type)
 #   - cppcoreguidelines-pro-bounds-array-to-pointer-decay       Weird stuff - it doesn't like `description_mode == DescriptionMode::MultiLine`
 #   - hicpp-no-array-decay                                       (same)
 #   - cert-dcl58-cpp                                            Adding a hash function to std is perfectly legal: https://en.cppreference.com/w/cpp/language/extending_std

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -52,7 +52,7 @@ WarningsAsErrors: '*'
 
 # Explanation of disabled checks:
 #   - *-default-arguments*                                      We do use default arguments (and like them)
-#   - google-build-using-namespace                              We use using namespace (see anonymous namespaces and expression_functional)
+#   - google-build-using-namespace                              We use `using namespace` a lot (see anonymous namespaces and expression_functional)
 #   - clang-analyzer-security.insecureAPI.rand                  We don't care about cryptographically unsafe rand() calls
 #   - readability-implicit-bool-conversion                      Doesn't like if(map.count(foo))
 #   - cppcoreguidelines-pro-type-reinterpret-cast               We use reinterpret_cast

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,7 +41,8 @@ Checks: '
          -misc-no-recursion,
          -bugprone-easily-swappable-parameters,
          -readability-function-cognitive-complexity,
-         -bugprone-suspicious-include
+         -bugprone-suspicious-include,
+         -bugprone-unchecked-optional-access
          '
 
 WarningsAsErrors: '*'
@@ -91,6 +92,7 @@ WarningsAsErrors: '*'
 #   - bugprone-suspicious-include                               Unity builds use `#include`s for cpp files. However, unity builds significantly improve the runtime of clang-tidy,
 #                                                                which is otherwise the slowest step of the CI pipeline by a factor of two. Furthermore, the linter checks for 
 #                                                                these includes as well.
+#   - bugprone-unchecked-optional-access                        Too many false positives (with clang-tidy 14/15). TODO(anyone): Re-evaluate for future clang versions.
 
 
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,10 +9,8 @@ Checks: '
          -modernize-pass-by-value,
          -cppcoreguidelines-pro-bounds-constant-array-index,
          -cppcoreguidelines-pro-type-static-cast-downcast,
-         -misc-unused-parameters,
          -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
          -hicpp-no-array-decay,
-         -readability-named-parameter,
          -cert-dcl58-cpp,
          -modernize-avoid-bind,
          -hicpp-no-assembler,
@@ -57,7 +55,6 @@ WarningsAsErrors: '*'
 #   - modernize-pass-by-value                                   We don't trust people to properly use std::move
 #   - cppcoreguidelines-pro-bounds-constant-array-index         "Do not use array subscript when the index is not an integer constant expression"?!
 #   - cppcoreguidelines-pro-type-static-cast-downcast           We do allow static downcasts for performance reasons
-#   - misc-unused-parameters                                    We don't care about unused parameters
 #   - cppcoreguidelines-pro-bounds-array-to-pointer-decay       Weird stuff - it doesn't like `description_mode == DescriptionMode::MultiLine`
 #   - hicpp-no-array-decay                                       (same)
 #   - cert-dcl58-cpp                                            Adding a hash function to std is perfectly legal: https://en.cppreference.com/w/cpp/language/extending_std

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,7 +14,6 @@ Checks: '
          -hicpp-no-array-decay,
          -readability-named-parameter,
          -cert-dcl58-cpp,
-         -clang-analyzer-optin.cplusplus.VirtualCall,
          -modernize-avoid-bind,
          -hicpp-no-assembler,
          -cppcoreguidelines-pro-type-vararg,
@@ -38,7 +37,6 @@ Checks: '
          -modernize-use-trailing-return-type,
          -clang-diagnostic-unknown-warning-option,
          -modernize-use-nodiscard,
-         -cppcoreguidelines-init-variables,
          -llvmlibc-*,
          -altera-*,
          -abseil-*,
@@ -54,18 +52,16 @@ WarningsAsErrors: '*'
 
 # Explanation of disabled checks:
 #   - *-default-arguments*                                      We do use default arguments (and like them)
-#   - google-build-using-namespace                              While we discourage its use, in some cases, using namespace makes sense
+#   - google-build-using-namespace                              We use namespaces (cf. expression_functional)
 #   - clang-analyzer-security.insecureAPI.rand                  We don't care about cryptographically unsafe rand() calls
 #   - readability-implicit-bool-conversion                      Doesn't like if(map.count(foo))
 #   - cppcoreguidelines-pro-type-reinterpret-cast               We use reinterpret_cast
-#   - readability-misleading-indentation                        Doesn't like if constexpr
 #   - modernize-pass-by-value                                   We don't trust people to properly use std::move
-#   - cppcoreguidelines-pro-bounds-constant-array-index         Weird stuff. "do not use array subscript when the index is not an integer constant expression"?!
+#   - cppcoreguidelines-pro-bounds-constant-array-index         "Do not use array subscript when the index is not an integer constant expression"?!
 #   - cppcoreguidelines-pro-type-static-cast-downcast           We do allow static downcasts for performance reasons
 #   - misc-unused-parameters                                    We don't care about unused parameters
 #   - cppcoreguidelines-pro-bounds-array-to-pointer-decay       Weird stuff - it doesn't like `description_mode == DescriptionMode::MultiLine`
 #   - hicpp-no-array-decay                                       (same)
-#   - readability-named-parameter                               Unused parameters don't need names
 #   - cert-dcl58-cpp                                            Adding a hash function to std is perfectly legal: https://en.cppreference.com/w/cpp/language/extending_std
 #   - clang-analyzer-optin.cplusplus.VirtualCall                false positive in boost::lexical_cast
 #   - modernize-avoid-bind                                      meh, bind isn't thaaaat bad
@@ -98,7 +94,7 @@ WarningsAsErrors: '*'
 #   - readability-identifier-naming                             Error spamming on non-Hyrise code. LLVM Bug. TODO(anyone): test renabling with newer LLVM versions which fixes
 #                                                                https://github.com/llvm/llvm-project/issues/46097
 #   - misc-no-recursion                                         Ignore general recommendation to avoid recursion, which we commonly use when working with query plans.
-#   - bugprone-easily-swappable-parameters                      Ignore issues with swapple parameters as we found them to be of no help.
+#   - bugprone-easily-swappable-parameters                      Ignore issues with swappable parameters as we found them to be of no help.
 #   - readability-function-cognitive-complexity                 When appropriate, long functions with a sequential data flow (which is sometimes easier to read) are fine. In many
 #                                                                places, the rule catches functions where the code could be improved, but will likely not be due to a lack of time.
 #   - bugprone-suspicious-include                               Unity builds use `#include`s for cpp files. However, unity builds significantly improve the runtime of clang-tidy,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -59,7 +59,6 @@ WarningsAsErrors: '*'
 #   - hicpp-no-array-decay                                       (same)
 #   - cert-dcl58-cpp                                            Adding a hash function to std is perfectly legal: https://en.cppreference.com/w/cpp/language/extending_std
 #   - modernize-avoid-bind                                      meh, bind isn't thaaaat bad
-#   - hicpp-no-assembler                                        Sometimes we need assembler...
 #   - cert-env33-c                                              Yes, we do call system()
 #   - misc-macro-parentheses                                    Causes weird problems with BOOST_PP_TUPLE_ELEM
 #   - fuchsia-overloaded-operator                               We are not supposed to overload operator()?!

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@ Checks: '
          -clang-analyzer-security.insecureAPI.rand,
          -readability-implicit-bool-conversion,
          -cppcoreguidelines-pro-type-reinterpret-cast,
-         -readability-misleading-indentation,
          -modernize-pass-by-value,
          -cppcoreguidelines-pro-bounds-constant-array-index,
          -cppcoreguidelines-pro-type-static-cast-downcast,
@@ -22,7 +21,6 @@ Checks: '
          -hicpp-vararg,
          -cert-env33-c,
          -misc-macro-parentheses,
-         -readability-else-after-return,
          -fuchsia-overloaded-operator,
          -cppcoreguidelines-pro-bounds-pointer-arithmetic,
          -google-runtime-references,
@@ -76,7 +74,6 @@ WarningsAsErrors: '*'
 #   - hicpp-vararg                                               (same)
 #   - cert-env33-c                                              Yes, we do call system()
 #   - misc-macro-parentheses                                    Causes weird problems with BOOST_PP_TUPLE_ELEM
-#   - readability-else-after-return                             "do not use 'else' after 'return'" - no idea who originally came up with that...
 #   - fuchsia-overloaded-operator                               We are not supposed to overload operator()?!
 #   - cppcoreguidelines-pro-bounds-pointer-arithmetic           Doesn't like DebugAssert
 #   - google-runtime-references                                 Doesn't like mutable references
@@ -94,7 +91,7 @@ WarningsAsErrors: '*'
 #   - clang-diagnostic-unknown-warning-option                   Don't complain about gcc warning options
 #   - modernize-use-nodiscard                                   Don't want to tag everything [[nodiscard]]
 #   - cppcoreguidelines-init-variables                          If a variable is only declared and initialized in two different branches, we do not want to initialize it first
-#   - -llvmlibc-*                                               LLVM-internal development guidelines.
+#   - llvmlibc-*                                                LLVM-internal development guidelines.
 #   - altera-*                                                  Checks related to OpenCL programming for FPGAs.
 #   - abseil-*                                                  Checks related to Google's abseil library (not used in Hyrise).
 #   - readability-use-anyofallof                                We prefer `for (auto item : items)` over `std::ranges::all_of()` with a lambda.
@@ -104,7 +101,7 @@ WarningsAsErrors: '*'
 #   - bugprone-easily-swappable-parameters                      Ignore issues with swapple parameters as we found them to be of no help.
 #   - readability-function-cognitive-complexity                 When appropriate, long functions with a sequential data flow (which is sometimes easier to read) are fine. In many
 #                                                                places, the rule catches functions where the code could be improved, but will likely not be due to a lack of time.
-#   -bugprone-suspicious-include                                Unity builds use `#include`s for cpp files. However, unity builds significantly improve the runtime of clang-tidy,
+#   - bugprone-suspicious-include                               Unity builds use `#include`s for cpp files. However, unity builds significantly improve the runtime of clang-tidy,
 #                                                                which is otherwise the slowest step of the CI pipeline by a factor of two. Furthermore, the linter checks for 
 #                                                                these includes as well.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,7 +207,7 @@ try {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
                 // As clang-tidy is the slowest step, we allow it to use more parallel jobs.
-                sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer -k -j \$(( \$(nproc) / 10))"
+                sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k -j \$(( \$(nproc) / 10))"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugTidy")
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,7 +206,6 @@ try {
             stage("clang-debug:tidy") {
               if (env.BRANCH_NAME == 'master' || full_ci) {
                 // We do not run tidy checks on the src/test folder, so there is no point in running the expensive clang-tidy for those files
-                // As clang-tidy is the slowest step, we allow it to use more parallel jobs.
                 sh "cd clang-debug-tidy && make hyrise_impl hyriseBenchmarkFileBased hyriseBenchmarkTPCH hyriseBenchmarkTPCDS hyriseBenchmarkJoinOrder hyriseConsole hyriseServer hyriseMvccDeletePlugin hyriseUccDiscoveryPlugin -k -j \$(( \$(nproc) / 10))"
               } else {
                 Utils.markStageSkippedForConditional("clangDebugTidy")

--- a/scripts/clang_tidy_wrapper.sh
+++ b/scripts/clang_tidy_wrapper.sh
@@ -10,7 +10,7 @@ shift  # Remove the file from $@
 file_relative_to_source=${file//$cmake_source_dir/}             # Remove the source dir from $file
 file_relative_to_source=${file_relative_to_source/..\/src/src}  # Remove `../src`, which gets added by Ninja
 
-if grep "$file_relative_to_source" $cmake_source_dir/.clang-tidy-ignore > /dev/null; then
+if grep -- "$file_relative_to_source" $cmake_source_dir/.clang-tidy-ignore > /dev/null; then
     echo "clang-tidy: Ignoring $file_relative_to_source"
     exit 0
 else

--- a/src/benchmark/operators/join_aggregate_benchmark.cpp
+++ b/src/benchmark/operators/join_aggregate_benchmark.cpp
@@ -105,7 +105,7 @@ std::shared_ptr<Table> create_table(const size_t table_size, const pmr_vector<in
         ids_vector.begin() + (chunk_index * chunk_size), ids_vector.begin() + ((chunk_index + 1) * chunk_size)));
     const auto value_segment = std::make_shared<ValueSegment<int32_t>>(pmr_vector<int32_t>(
         values.cbegin() + (chunk_index * chunk_size), values.cbegin() + ((chunk_index + 1) * chunk_size)));
-    Segments segments;
+    auto segments = Segments{};
     segments.push_back(ids_value_segment);
     segments.push_back(value_segment);
 

--- a/src/benchmark/operators/union_positions_benchmark.cpp
+++ b/src/benchmark/operators/union_positions_benchmark.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<Table> create_reference_table(std::shared_ptr<Table> referenced_
   for (size_t row_idx = 0; row_idx < num_rows;) {
     const auto num_rows_in_this_chunk = std::min(num_rows_per_chunk, num_rows - row_idx);
 
-    Segments segments;
+    auto segments = Segments{};
     for (auto column_idx = ColumnID{0}; column_idx < num_columns; ++column_idx) {
       /**
        * By specifying a chunk size of num_rows * 0.2f for the referenced table, we're emulating a referenced table

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -255,9 +255,9 @@ void AbstractTableGenerator::generate_and_store() {
 
       auto binary_file_path = std::filesystem::path{};
       if (table_info.binary_file_path) {
-        binary_file_path = *table_info.binary_file_path;
+        binary_file_path = *table_info.binary_file_path;  // NOLINT(bugprone-unchecked-optional-access)
       } else {
-        binary_file_path = *table_info.text_file_path;
+        binary_file_path = *table_info.text_file_path;  // NOLINT(bugprone-unchecked-optional-access)
         binary_file_path.replace_extension(".bin");
       }
 

--- a/src/benchmarklib/abstract_table_generator.cpp
+++ b/src/benchmarklib/abstract_table_generator.cpp
@@ -255,9 +255,9 @@ void AbstractTableGenerator::generate_and_store() {
 
       auto binary_file_path = std::filesystem::path{};
       if (table_info.binary_file_path) {
-        binary_file_path = *table_info.binary_file_path;  // NOLINT(bugprone-unchecked-optional-access)
+        binary_file_path = *table_info.binary_file_path;
       } else {
-        binary_file_path = *table_info.text_file_path;  // NOLINT(bugprone-unchecked-optional-access)
+        binary_file_path = *table_info.text_file_path;
         binary_file_path.replace_extension(".bin");
       }
 

--- a/src/benchmarklib/benchmark_runner.cpp
+++ b/src/benchmarklib/benchmark_runner.cpp
@@ -194,8 +194,9 @@ void BenchmarkRunner::run() {
       if (result.successful_runs.empty()) {
         continue;
       }
-      Assert(result.verification_passed.load(), "Verification result should have been set");
-      any_verification_failed |= !(*result.verification_passed.load());
+      const auto verification_status = result.verification_passed.load();
+      Assert(verification_status, "Verification result should have been set");
+      any_verification_failed |= !(*verification_status);
     }
 
     Assert(!any_verification_failed, "Verification failed");

--- a/src/benchmarklib/file_based_benchmark_item_runner.cpp
+++ b/src/benchmarklib/file_based_benchmark_item_runner.cpp
@@ -19,7 +19,7 @@ FileBasedBenchmarkItemRunner::FileBasedBenchmarkItemRunner(
     : AbstractBenchmarkItemRunner(config) {
   const auto is_sql_file = [](const std::string& filename) { return boost::algorithm::ends_with(filename, ".sql"); };
 
-  std::filesystem::path path{query_path};
+  const auto path = std::filesystem::path{query_path};
   Assert(std::filesystem::exists(path), "No such file or directory '" + query_path + "'");
 
   if (std::filesystem::is_regular_file(path)) {
@@ -69,7 +69,7 @@ void FileBasedBenchmarkItemRunner::_parse_query_file(
   // The names of queries from, e.g., "queries/TPCH-7.sql" will be prefixed with "TPCH-7."
   const auto item_name_prefix = query_file_path.stem().string();
 
-  std::string content{std::istreambuf_iterator<char>(file), {}};
+  const auto content = std::string{std::istreambuf_iterator<char>(file), {}};
 
   /**
    * A file can contain multiple SQL statements, and each statement may cover one or more lines.

--- a/src/benchmarklib/file_based_table_generator.cpp
+++ b/src/benchmarklib/file_based_table_generator.cpp
@@ -66,8 +66,6 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
    */
   for (auto& [table_name, table_info] : table_info_by_name) {
     if (table_info.binary_file_path && table_info.text_file_path) {
-      // NOLINTBEGIN(bugprone-unchecked-optional-access)
-      // False positive, we checked that the optionals hold a value one line earlier.
       const auto last_binary_write = std::filesystem::last_write_time(*table_info.binary_file_path);
       const auto last_text_write = std::filesystem::last_write_time(*table_info.text_file_path);
 
@@ -76,7 +74,6 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
                   << "' is out of date and needs to be re-exported" << std::endl;
         table_info.binary_file_out_of_date = true;
       }
-      // NOLINTEND(bugprone-unchecked-optional-access)
     }
   }
 
@@ -90,8 +87,6 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
 
     // Pick a source file to load a table from, prefer the binary version
     if (table_info.binary_file_path && !table_info.binary_file_out_of_date) {
-      // NOLINTBEGIN(bugprone-unchecked-optional-access)
-      // False positive, we checked that the optional holds a value one line earlier.
       std::cout << "from " << *table_info.binary_file_path << std::flush;
       table_info.table = BinaryParser::parse(*table_info.binary_file_path);
       table_info.loaded_from_binary = true;
@@ -105,7 +100,6 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
       } else {
         Fail("Unknown textual file format. This should have been caught earlier.");
       }
-      // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
     std::cout << " (" << table_info.table->row_count() << " rows; " << timer.lap_formatted() << ")" << std::endl;

--- a/src/benchmarklib/file_based_table_generator.cpp
+++ b/src/benchmarklib/file_based_table_generator.cpp
@@ -66,6 +66,8 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
    */
   for (auto& [table_name, table_info] : table_info_by_name) {
     if (table_info.binary_file_path && table_info.text_file_path) {
+      // NOLINTBEGIN(bugprone-unchecked-optional-access)
+      // False positive, we checked that the optionals hold a value one line earlier.
       const auto last_binary_write = std::filesystem::last_write_time(*table_info.binary_file_path);
       const auto last_text_write = std::filesystem::last_write_time(*table_info.text_file_path);
 
@@ -74,6 +76,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
                   << "' is out of date and needs to be re-exported" << std::endl;
         table_info.binary_file_out_of_date = true;
       }
+      // NOLINTEND(bugprone-unchecked-optional-access)
     }
   }
 
@@ -87,6 +90,8 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
 
     // Pick a source file to load a table from, prefer the binary version
     if (table_info.binary_file_path && !table_info.binary_file_out_of_date) {
+      // NOLINTBEGIN(bugprone-unchecked-optional-access)
+      // False positive, we checked that the optional holds a value one line earlier.
       std::cout << "from " << *table_info.binary_file_path << std::flush;
       table_info.table = BinaryParser::parse(*table_info.binary_file_path);
       table_info.loaded_from_binary = true;
@@ -100,6 +105,7 @@ std::unordered_map<std::string, BenchmarkTableInfo> FileBasedTableGenerator::gen
       } else {
         Fail("Unknown textual file format. This should have been caught earlier.");
       }
+      // NOLINTEND(bugprone-unchecked-optional-access)
     }
 
     std::cout << " (" << table_info.table->row_count() << " rows; " << timer.lap_formatted() << ")" << std::endl;

--- a/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
@@ -120,7 +120,9 @@ bool JCCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, Be
     // Writing `1-1` to make people aware that this is zero-indexed while TPC-H query names are not
     case 1 - 1: {
       // In some cases, we still need to do the date calculations that SQLite (used for verification) does not
-      // support yet. When parsing a date, we expect the generator to provide sound date strings and omit checks.
+      // support yet. When parsing a date, we expect the generator to provide sound date strings and omit checks when
+      // dereferencing the optionals.
+      // NOLINTBEGIN(bugprone-unchecked-optional-access)
       const auto date = date_interval(boost::gregorian::date{1998, 12, 01}, -std::stoi(raw_params_iter->at(0)),
                                       DatetimeComponent::Day);
       parameters.emplace_back("'"s + date_to_string(date) + "'");
@@ -342,6 +344,7 @@ bool JCCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, Be
     default:
       Fail("There are only 22 JCC-H queries");
   }
+  // NOLINTEND(bugprone-unchecked-optional-access)
 
   if (sql.empty()) {
     sql = _substitute_placeholders(item_id, parameters);

--- a/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
+++ b/src/benchmarklib/jcch/jcch_benchmark_item_runner.cpp
@@ -122,7 +122,6 @@ bool JCCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, Be
       // In some cases, we still need to do the date calculations that SQLite (used for verification) does not
       // support yet. When parsing a date, we expect the generator to provide sound date strings and omit checks when
       // dereferencing the optionals.
-      // NOLINTBEGIN(bugprone-unchecked-optional-access)
       const auto date = date_interval(boost::gregorian::date{1998, 12, 01}, -std::stoi(raw_params_iter->at(0)),
                                       DatetimeComponent::Day);
       parameters.emplace_back("'"s + date_to_string(date) + "'");
@@ -344,7 +343,6 @@ bool JCCHBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, Be
     default:
       Fail("There are only 22 JCC-H queries");
   }
-  // NOLINTEND(bugprone-unchecked-optional-access)
 
   if (sql.empty()) {
     sql = _substitute_placeholders(item_id, parameters);

--- a/src/benchmarklib/synthetic_table_generator.cpp
+++ b/src/benchmarklib/synthetic_table_generator.cpp
@@ -74,11 +74,8 @@ std::shared_ptr<Table> SyntheticTableGenerator::generate_table(
   // add column definitions and initialize each value vector
   auto column_definitions = TableColumnDefinitions{};
   for (auto column_id = size_t{0}; column_id < num_columns; ++column_id) {
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
-    // False positive, we literally check that the optional holds a value in the same line.
     const auto column_name = column_specifications[column_id].name ? *column_specifications[column_id].name
                                                                    : "column_" + std::to_string(column_id + 1);
-    // NOLINTEND(bugprone-unchecked-optional-access)
     column_definitions.emplace_back(column_name, column_specifications[column_id].data_type, false);
   }
   auto table = std::make_shared<Table>(column_definitions, TableType::Data, chunk_size, use_mvcc);

--- a/src/benchmarklib/tpcc/procedures/tpcc_delivery.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_delivery.cpp
@@ -43,7 +43,7 @@ bool TPCCDelivery::_on_execute() {
                               " AND O_D_ID = " + std::to_string(d_id) + " AND O_ID = " + std::to_string(no_o_id));
     const auto& order_table = order_select_pair.second;
     Assert(order_table && order_table->row_count() == 1, "Did not find order");
-    const auto o_c_id = *order_table->get_value<int32_t>(ColumnID{0}, 0);  // NOLINT(bugprone-unchecked-optional-access)
+    const auto o_c_id = *order_table->get_value<int32_t>(ColumnID{0}, 0);
 
     // Update ORDER
     const auto order_update_pair =
@@ -60,9 +60,7 @@ bool TPCCDelivery::_on_execute() {
         " AND OL_D_ID = " + std::to_string(d_id) + " AND OL_O_ID = " + std::to_string(no_o_id));
     const auto& order_line_table = order_line_select_pair.second;
     Assert(order_line_table && order_line_table->row_count() == 1, "Did not find order lines");
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     const auto amount = *order_line_table->get_value<double>(ColumnID{0}, 0);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // Set delivery date in ORDER_LINE
     const auto order_line_update_pair =

--- a/src/benchmarklib/tpcc/procedures/tpcc_delivery.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_delivery.cpp
@@ -18,18 +18,16 @@ bool TPCCDelivery::_on_execute() {
   for (auto d_id = 1; d_id <= 10; ++d_id) {
     // TODO(anyone): This could be optimized by querying only once and grouping by NO_D_ID
     const auto new_order_select_pair =
-        _sql_executor.execute(std::string{"SELECT MIN(NO_O_ID) IS NULL, MIN(NO_O_ID) FROM NEW_ORDER WHERE NO_W_ID = "} +
+        _sql_executor.execute(std::string{"SELECT MIN(NO_O_ID) FROM NEW_ORDER WHERE NO_W_ID = "} +
                               std::to_string(w_id) + " AND NO_D_ID = " + std::to_string(d_id));
     const auto& new_order_table = new_order_select_pair.second;
-
-    // TODO(anyone): Selecting MIN(NO_O_ID) IS NULL and using it here would not be necessary if get_value returned
-    // NULLs as nullopt
-    if (*new_order_table->get_value<int32_t>(ColumnID{0}, 0) == 1) {
+    const auto min_no_o_id = new_order_table->get_value<int32_t>(ColumnID{0}, 0);
+    if (!min_no_o_id) {
       continue;
     }
 
     // The oldest undelivered order in that district
-    const auto no_o_id = *new_order_table->get_value<int32_t>(ColumnID{1}, 0);
+    const auto no_o_id = *min_no_o_id;
 
     // Delete from NEW_ORDER
     const auto new_order_update_pair =
@@ -45,7 +43,7 @@ bool TPCCDelivery::_on_execute() {
                               " AND O_D_ID = " + std::to_string(d_id) + " AND O_ID = " + std::to_string(no_o_id));
     const auto& order_table = order_select_pair.second;
     Assert(order_table && order_table->row_count() == 1, "Did not find order");
-    auto o_c_id = *order_table->get_value<int32_t>(ColumnID{0}, 0);
+    const auto o_c_id = *order_table->get_value<int32_t>(ColumnID{0}, 0);  // NOLINT(bugprone-unchecked-optional-access)
 
     // Update ORDER
     const auto order_update_pair =
@@ -62,7 +60,9 @@ bool TPCCDelivery::_on_execute() {
         " AND OL_D_ID = " + std::to_string(d_id) + " AND OL_O_ID = " + std::to_string(no_o_id));
     const auto& order_line_table = order_line_select_pair.second;
     Assert(order_line_table && order_line_table->row_count() == 1, "Did not find order lines");
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     const auto amount = *order_line_table->get_value<double>(ColumnID{0}, 0);
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // Set delivery date in ORDER_LINE
     const auto order_line_update_pair =

--- a/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
@@ -53,9 +53,6 @@ bool TPCCNewOrder::_on_execute() {
   const auto& warehouse_table = warehouse_select_pair.second;
   Assert(warehouse_table && warehouse_table->row_count() == 1, "Did not find warehouse (or found more than one)");
 
-  // NOLINTBEGIN(bugprone-unchecked-optional-access)
-  // All values we access in this method via `get_value` are from non-nullable columns. Thus, we cannot get an
-  // std::nullopt and dereference the optionals without an additional check.
   const auto w_tax = *warehouse_table->get_value<float>(ColumnID{0}, 0);
   Assert(w_tax >= 0.f && w_tax <= .2f, "Invalid warehouse tax rate encountered");
 
@@ -149,7 +146,6 @@ bool TPCCNewOrder::_on_execute() {
     const auto s_ytd = *stock_table->get_value<int32_t>(ColumnID{3}, 0);
     const auto s_order_cnt = *stock_table->get_value<int32_t>(ColumnID{4}, 0);
     const auto s_remote_cnt = *stock_table->get_value<int32_t>(ColumnID{4}, 0);
-    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // Calculate the new values for S_QUANTITY, S_YTD, S_ORDER_CNT
     auto new_s_quantity = 0;

--- a/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_new_order.cpp
@@ -23,7 +23,7 @@ TPCCNewOrder::TPCCNewOrder(const int num_warehouses, BenchmarkSQLExecutor& sql_e
 
     std::uniform_int_distribution<> home_warehouse_dist{1, 100};
     // 1% chance of remote warehouses (if more than one).
-    auto is_home_warehouse = num_warehouses == 1 || home_warehouse_dist(_random_engine) > 1;
+    const auto is_home_warehouse = num_warehouses == 1 || home_warehouse_dist(_random_engine) > 1;
     if (is_home_warehouse) {
       order_line.ol_supply_w_id = w_id;
     } else {
@@ -52,6 +52,10 @@ bool TPCCNewOrder::_on_execute() {
       _sql_executor.execute(std::string{"SELECT W_TAX FROM WAREHOUSE WHERE W_ID = "} + std::to_string(w_id));
   const auto& warehouse_table = warehouse_select_pair.second;
   Assert(warehouse_table && warehouse_table->row_count() == 1, "Did not find warehouse (or found more than one)");
+
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
+  // All values we access in this method via `get_value` are from non-nullable columns. Thus, we cannot get an
+  // std::nullopt and dereference the optionals without an additional check.
   const auto w_tax = *warehouse_table->get_value<float>(ColumnID{0}, 0);
   Assert(w_tax >= 0.f && w_tax <= .2f, "Invalid warehouse tax rate encountered");
 
@@ -145,6 +149,7 @@ bool TPCCNewOrder::_on_execute() {
     const auto s_ytd = *stock_table->get_value<int32_t>(ColumnID{3}, 0);
     const auto s_order_cnt = *stock_table->get_value<int32_t>(ColumnID{4}, 0);
     const auto s_remote_cnt = *stock_table->get_value<int32_t>(ColumnID{4}, 0);
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     // Calculate the new values for S_QUANTITY, S_YTD, S_ORDER_CNT
     auto new_s_quantity = 0;

--- a/src/benchmarklib/tpcc/procedures/tpcc_order_status.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_order_status.cpp
@@ -46,9 +46,12 @@ bool TPCCOrderStatus::_on_execute() {
     Assert(customer_table->row_count() >= 1, "Did not find customer by name");
 
     // Calculate ceil(n/2)
-    auto customer_offset =
+    const auto customer_offset =
         static_cast<size_t>(std::min(std::ceil(static_cast<double>(customer_table->row_count()) / 2.0),
                                      static_cast<double>(customer_table->row_count() - 1)));
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    // All values we access in this method via `get_value` are from non-nullable columns. Thus, we cannot get an
+    // std::nullopt and dereference the optionals without an additional check.
     customer_id = *customer_table->get_value<int32_t>(ColumnID{0}, customer_offset);
   }
 
@@ -72,6 +75,7 @@ bool TPCCOrderStatus::_on_execute() {
          "Did not find order lines");
   for (auto row = size_t{0}; row < order_line_table->row_count(); ++row) {
     ol_quantity_sum += *order_line_table->get_value<int32_t>(ColumnID{2}, row);
+    // NOLINTEND(bugprone-unchecked-optional-access)
   }
 
   _sql_executor.commit();

--- a/src/benchmarklib/tpcc/procedures/tpcc_order_status.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_order_status.cpp
@@ -49,9 +49,6 @@ bool TPCCOrderStatus::_on_execute() {
     const auto customer_offset =
         static_cast<size_t>(std::min(std::ceil(static_cast<double>(customer_table->row_count()) / 2.0),
                                      static_cast<double>(customer_table->row_count() - 1)));
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
-    // All values we access in this method via `get_value` are from non-nullable columns. Thus, we cannot get an
-    // std::nullopt and dereference the optionals without an additional check.
     customer_id = *customer_table->get_value<int32_t>(ColumnID{0}, customer_offset);
   }
 
@@ -75,7 +72,6 @@ bool TPCCOrderStatus::_on_execute() {
          "Did not find order lines");
   for (auto row = size_t{0}; row < order_line_table->row_count(); ++row) {
     ol_quantity_sum += *order_line_table->get_value<int32_t>(ColumnID{2}, row);
-    // NOLINTEND(bugprone-unchecked-optional-access)
   }
 
   _sql_executor.commit();

--- a/src/benchmarklib/tpcc/procedures/tpcc_payment.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_payment.cpp
@@ -50,9 +50,6 @@ bool TPCCPayment::_on_execute() {
       std::to_string(w_id));
   const auto& warehouse_table = warehouse_select_pair.second;
   Assert(warehouse_table && warehouse_table->row_count() == 1, "Did not find warehouse (or found more than one)");
-  // NOLINTBEGIN(bugprone-unchecked-optional-access)
-  // All values we access in this method via `get_value` are from non-nullable columns. Thus, we cannot get an
-  // std::nullopt and dereference the optionals without an additional check.
   const auto w_name = *warehouse_table->get_value<pmr_string>(ColumnID{0}, 0);
   const auto w_ytd = *warehouse_table->get_value<float>(ColumnID{6}, 0);
 
@@ -71,10 +68,8 @@ bool TPCCPayment::_on_execute() {
       std::to_string(w_id) + " AND D_ID = " + std::to_string(d_id));
   const auto& district_table = district_select_pair.second;
   Assert(district_table && district_table->row_count() == 1, "Did not find district (or found more than one)");
-  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   const auto d_name = *district_table->get_value<pmr_string>(ColumnID{0}, 0);
   const auto d_ytd = *district_table->get_value<float>(ColumnID{6}, 0);
-  // NOLINTEND(bugprone-unchecked-optional-access)
 
   // Update district YTD
   const auto district_update_pair =
@@ -136,7 +131,6 @@ bool TPCCPayment::_on_execute() {
     new_c_data_stream << w_id;
     new_c_data_stream << h_amount;
     new_c_data_stream << *customer_table->get_value<pmr_string>(ColumnID{15}, customer_offset);  // C_DATA
-    // NOLINTEND(bugprone-unchecked-optional-access)
     auto new_c_data = new_c_data_stream.str();
     new_c_data.resize(std::min(new_c_data.size(), size_t{500}));
     const auto customer_update_data_pair = _sql_executor.execute(

--- a/src/benchmarklib/tpcc/procedures/tpcc_stock_level.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_stock_level.cpp
@@ -28,7 +28,11 @@ bool TPCCStockLevel::_on_execute() {
   Assert(district_table && district_table->row_count() == 1, "Did not find district (or found more than one)");
 
   // We check the stock levels for the 20 orders before that next order ID
-  auto first_o_id = *district_table->get_value<int32_t>(ColumnID{0}, 0) - 20;
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
+  // The column is not nullable. Thus, we cannot get an std::nullopt and dereference the optional without an additional
+  // check.
+  const auto first_o_id = *district_table->get_value<int32_t>(ColumnID{0}, 0) - 20;
+  // NOLINTEND(bugprone-unchecked-optional-access)
 
   // Retrieve the distict item ids of those orders
   const auto order_line_table_pair = _sql_executor.execute(
@@ -39,7 +43,9 @@ bool TPCCStockLevel::_on_execute() {
   // Build a string for the IN expression
   std::stringstream ol_i_ids_stream;
   for (auto order_line_idx = size_t{0}; order_line_idx < order_line_table->row_count(); ++order_line_idx) {
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     ol_i_ids_stream << *order_line_table->get_value<int32_t>(ColumnID{0}, order_line_idx) << ", ";
+    // NOLINTEND(bugprone-unchecked-optional-access)
   }
   auto ol_i_ids = ol_i_ids_stream.str();
   ol_i_ids.resize(ol_i_ids.size() - 2);  // Remove final ", "

--- a/src/benchmarklib/tpcc/procedures/tpcc_stock_level.cpp
+++ b/src/benchmarklib/tpcc/procedures/tpcc_stock_level.cpp
@@ -28,11 +28,7 @@ bool TPCCStockLevel::_on_execute() {
   Assert(district_table && district_table->row_count() == 1, "Did not find district (or found more than one)");
 
   // We check the stock levels for the 20 orders before that next order ID
-  // NOLINTBEGIN(bugprone-unchecked-optional-access)
-  // The column is not nullable. Thus, we cannot get an std::nullopt and dereference the optional without an additional
-  // check.
   const auto first_o_id = *district_table->get_value<int32_t>(ColumnID{0}, 0) - 20;
-  // NOLINTEND(bugprone-unchecked-optional-access)
 
   // Retrieve the distict item ids of those orders
   const auto order_line_table_pair = _sql_executor.execute(
@@ -43,9 +39,7 @@ bool TPCCStockLevel::_on_execute() {
   // Build a string for the IN expression
   std::stringstream ol_i_ids_stream;
   for (auto order_line_idx = size_t{0}; order_line_idx < order_line_table->row_count(); ++order_line_idx) {
-    // NOLINTBEGIN(bugprone-unchecked-optional-access)
     ol_i_ids_stream << *order_line_table->get_value<int32_t>(ColumnID{0}, order_line_idx) << ", ";
-    // NOLINTEND(bugprone-unchecked-optional-access)
   }
   auto ol_i_ids = ol_i_ids_stream.str();
   ol_i_ids.resize(ol_i_ids.size() - 2);  // Remove final ", "

--- a/src/benchmarklib/tpcc/tpcc_benchmark_item_runner.cpp
+++ b/src/benchmarklib/tpcc/tpcc_benchmark_item_runner.cpp
@@ -18,7 +18,7 @@ const std::vector<BenchmarkItemID>& TPCCBenchmarkItemRunner::items() const {
 }
 
 bool TPCCBenchmarkItemRunner::_on_execute_item(const BenchmarkItemID item_id, BenchmarkSQLExecutor& sql_executor) {
-  bool successful;
+  auto successful = false;
   switch (item_id) {
     case 0:
       successful = TPCCDelivery{_num_warehouses, sql_executor}.execute();

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -50,11 +50,11 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_item_table() {
                      });
   _add_column<pmr_string>(
       segments_by_chunk, column_definitions, "I_DATA", cardinalities, [&](const std::vector<size_t>& indices) {
-        std::string data = _random_gen.astring(26, 50);
-        bool is_original = original_ids.find(indices[0]) != original_ids.end();
+        auto data = _random_gen.astring(26, 50);
+        const auto is_original = original_ids.find(indices[0]) != original_ids.end();
         if (is_original) {
-          std::string original_string("ORIGINAL");
-          size_t start_pos = _random_gen.random_number(0, data.length() - 1 - original_string.length());
+          const auto original_string = std::string{"ORIGINAL"};
+          const auto start_pos = _random_gen.random_number(0, data.length() - 1 - original_string.length());
           data.replace(start_pos, original_string.length(), original_string);
         }
         return pmr_string{data};
@@ -153,10 +153,10 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_stock_table() {
   _add_column<pmr_string>(
       segments_by_chunk, column_definitions, "S_DATA", cardinalities, [&](const std::vector<size_t>& indices) {
         std::string data = _random_gen.astring(26, 50);
-        bool is_original = original_ids.find(indices[1]) != original_ids.end();
+        const auto is_original = original_ids.find(indices[1]) != original_ids.end();
         if (is_original) {
-          std::string original_string("ORIGINAL");
-          size_t start_pos = _random_gen.random_number(0, data.length() - 1 - original_string.length());
+          const auto original_string = std::string{"ORIGINAL"};
+          const auto start_pos = _random_gen.random_number(0, data.length() - 1 - original_string.length());
           data.replace(start_pos, original_string.length(), original_string);
         }
         return pmr_string{data};
@@ -273,7 +273,7 @@ std::shared_ptr<Table> TPCCTableGenerator::generate_customer_table() {
                        [&](const std::vector<size_t>& /*indices*/) { return _current_date; });
   _add_column<pmr_string>(segments_by_chunk, column_definitions, "C_CREDIT", cardinalities,
                           [&](const std::vector<size_t>& indices) {
-                            bool is_original = original_ids.find(indices[2]) != original_ids.end();
+                            const auto is_original = original_ids.find(indices[2]) != original_ids.end();
                             return pmr_string{is_original ? "BC" : "GC"};
                           });
   _add_column<float>(segments_by_chunk, column_definitions, "C_CREDIT_LIM", cardinalities,
@@ -539,18 +539,17 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCCTableGenerator::generate
     return _load_binary_tables_from_path(cache_directory);
   }
 
-  std::vector<std::thread> threads;
-  auto item_table = generate_item_table();
-  auto warehouse_table = generate_warehouse_table();
-  auto stock_table = generate_stock_table();
-  auto district_table = generate_district_table();
-  auto customer_table = generate_customer_table();
-  auto history_table = generate_history_table();
-  auto new_order_table = generate_new_order_table();
+  const auto item_table = generate_item_table();
+  const auto warehouse_table = generate_warehouse_table();
+  const auto stock_table = generate_stock_table();
+  const auto district_table = generate_district_table();
+  const auto customer_table = generate_customer_table();
+  const auto history_table = generate_history_table();
+  const auto new_order_table = generate_new_order_table();
 
-  auto order_line_counts = generate_order_line_counts();
-  auto order_table = generate_order_table(order_line_counts);
-  auto order_line_table = generate_order_line_table(order_line_counts);
+  const auto order_line_counts = generate_order_line_counts();
+  const auto order_table = generate_order_table(order_line_counts);
+  const auto order_line_table = generate_order_line_table(order_line_counts);
 
   auto table_info_by_name =
       std::unordered_map<std::string, BenchmarkTableInfo>({{"ITEM", BenchmarkTableInfo{item_table}},
@@ -566,7 +565,9 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCCTableGenerator::generate
   if (_benchmark_config->cache_binary_tables) {
     std::filesystem::create_directories(cache_directory);
     for (auto& [table_name, table_info] : table_info_by_name) {
-      table_info.binary_file_path = cache_directory + "/" + table_name + ".bin";  // NOLINT
+      // NOLINTBEGIN(performance-inefficient-string-concatenation)
+      table_info.binary_file_path = cache_directory + "/" + table_name + ".bin";
+      // NOLINTEND(performance-inefficient-string-concatenation)
     }
   }
 

--- a/src/benchmarklib/tpcc/tpcc_table_generator.cpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.cpp
@@ -565,9 +565,8 @@ std::unordered_map<std::string, BenchmarkTableInfo> TPCCTableGenerator::generate
   if (_benchmark_config->cache_binary_tables) {
     std::filesystem::create_directories(cache_directory);
     for (auto& [table_name, table_info] : table_info_by_name) {
-      // NOLINTBEGIN(performance-inefficient-string-concatenation)
+      // NOLINTNEXTLINE(performance-inefficient-string-concatenation)
       table_info.binary_file_path = cache_directory + "/" + table_name + ".bin";
-      // NOLINTEND(performance-inefficient-string-concatenation)
     }
   }
 

--- a/src/benchmarklib/tpcc/tpcc_table_generator.hpp
+++ b/src/benchmarklib/tpcc/tpcc_table_generator.hpp
@@ -237,7 +237,7 @@ class TPCCTableGenerator : public AbstractTableGenerator {
    * NULL values).
    *
    * Note that this is not a general purpose function. The implementation of _add_column checks whether NULL values
-   * were actually passed and sets the column's nullable flag accordingly. As such, if this method is used with an
+   * were actually passed and sets the column's nullable flag accordingly. As such, if this method is used with a
    * generator that returns optionals but no nullopts, the column will not be nullable. For TPC-C, this is fine.
    */
   template <typename T>

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -123,7 +123,9 @@ pmr_string boolean_to_string(bool boolean) {
 
 pmr_string zip_to_string(int32_t zip) {
   auto result = pmr_string(5, '?');
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   const auto snprintf_rc = std::snprintf(result.data(), result.size() + 1, "%05d", zip);
+  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   Assert(snprintf_rc > 0, "Unexpected string to parse.");
   return result;
 }
@@ -138,8 +140,10 @@ std::optional<pmr_string> resolve_date_id(int column_id, ds_key_t date_id) {
   jtodt(&date, static_cast<int>(date_id));
 
   auto result = pmr_string(10, '?');
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   const auto snprintf_rc =
       std::snprintf(result.data(), result.size() + 1, "%4d-%02d-%02d", date.year, date.month, date.day);
+  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   Assert(snprintf_rc > 0, "Unexpected string to parse.");
 
   return result;
@@ -433,8 +437,10 @@ std::shared_ptr<Table> TPCDSTableGenerator::generate_catalog_page(ds_key_t max_r
                                            catalog_page_column_names, static_cast<ChunkOffset>(catalog_page_count)};
 
   auto catalog_page = CATALOG_PAGE_TBL{};
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   const auto snprintf_rc =
       std::snprintf(catalog_page.cp_department, sizeof(catalog_page.cp_department), "%s", "DEPARTMENT");
+  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   Assert(snprintf_rc > 0, "Unexpected string to parse.");
   for (auto catalog_page_index = ds_key_t{0}; catalog_page_index < catalog_page_count; ++catalog_page_index) {
     // need a pointer to the previous result of mk_w_catalog_page, because cp_department is only set once
@@ -1148,7 +1154,9 @@ std::shared_ptr<Table> TPCDSTableGenerator::generate_web_site(ds_key_t max_rows)
 
   auto web_site = W_WEB_SITE_TBL{};
   static_assert(sizeof(web_site.web_class) == 51);
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   const auto snprintf_rc = std::snprintf(web_site.web_class, sizeof(web_site.web_class), "%s", "Unknown");
+  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   Assert(snprintf_rc > 0, "Unexpected string to parse.");
   for (auto web_site_index = ds_key_t{0}; web_site_index < web_site_count; ++web_site_index) {
     // mk_w_web_site needs a pointer to the previous result because it expects values set previously to still be there

--- a/src/benchmarklib/tpcds/tpcds_table_generator.cpp
+++ b/src/benchmarklib/tpcds/tpcds_table_generator.cpp
@@ -123,9 +123,8 @@ pmr_string boolean_to_string(bool boolean) {
 
 pmr_string zip_to_string(int32_t zip) {
   auto result = pmr_string(5, '?');
-  // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   const auto snprintf_rc = std::snprintf(result.data(), result.size() + 1, "%05d", zip);
-  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   Assert(snprintf_rc > 0, "Unexpected string to parse.");
   return result;
 }
@@ -1154,9 +1153,8 @@ std::shared_ptr<Table> TPCDSTableGenerator::generate_web_site(ds_key_t max_rows)
 
   auto web_site = W_WEB_SITE_TBL{};
   static_assert(sizeof(web_site.web_class) == 51);
-  // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   const auto snprintf_rc = std::snprintf(web_site.web_class, sizeof(web_site.web_class), "%s", "Unknown");
-  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
   Assert(snprintf_rc > 0, "Unexpected string to parse.");
   for (auto web_site_index = ds_key_t{0}; web_site_index < web_site_count; ++web_site_index) {
     // mk_w_web_site needs a pointer to the previous result because it expects values set previously to still be there

--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -1,6 +1,7 @@
 #include "pagination.hpp"
 
-#include <ncurses.h>
+#include "ncurses.h"
+
 #include <string>
 #include <vector>
 
@@ -9,7 +10,7 @@ constexpr auto CURSES_CTRL_C = static_cast<uint32_t>('c') & uint32_t{31};
 namespace hyrise {
 
 Pagination::Pagination(std::stringstream& input) {
-  std::string line;
+  auto line = std::string{};
   while (std::getline(input, line, '\n')) {
     _lines.push_back(line);
     _max_width = std::max(_max_width, line.length());
@@ -31,16 +32,16 @@ void Pagination::display() {
   // Last line on the screen should show instructions
   --_size_y;
 
-  size_t line_count = _lines.size();
-  size_t end_line = line_count > _size_y ? line_count - _size_y : 0;
-  size_t current_line = 0;
-  size_t current_column = 0;
+  auto line_count = _lines.size();
+  auto end_line = line_count > _size_y ? line_count - _size_y : 0;
+  auto current_line = size_t{0};
+  auto current_column = size_t{0};
 
   // Indicator if the display should be reprinted after a keyboard input
-  bool reprint = false;
+  auto reprint = false;
   _print_page(current_line, current_column);
 
-  int key_pressed;
+  auto key_pressed = int{};
   while ((key_pressed = getch()) != 'q' && key_pressed != CURSES_CTRL_C) {
     switch (key_pressed) {
       case 'j':
@@ -63,7 +64,7 @@ void Pagination::display() {
 
       case ' ':
       case KEY_NPAGE: {
-        size_t new_line = current_line + _size_y;
+        auto new_line = current_line + _size_y;
         while ((new_line + _size_y) > line_count && new_line > 0) {
           --new_line;
         }
@@ -161,7 +162,7 @@ void Pagination::display() {
 void Pagination::_print_page(size_t first_line, size_t first_column) {
   clear();
 
-  for (size_t i = first_line; i < first_line + _size_y; ++i) {
+  for (auto i = first_line; i < first_line + _size_y; ++i) {
     if (i >= _lines.size()) {
       break;
     }
@@ -179,7 +180,7 @@ void Pagination::_print_page(size_t first_line, size_t first_column) {
 }
 
 void Pagination::_print_help_screen() {
-  WINDOW* help_screen = newwin(0, 0, 0, 0);
+  auto help_screen = newwin(0, 0, 0, 0);
 
   wclear(help_screen);
 
@@ -199,7 +200,7 @@ void Pagination::_print_help_screen() {
 
   wrefresh(help_screen);
 
-  int key_pressed;
+  auto key_pressed = int{};
   while ((key_pressed = getch()) != 'q' && key_pressed != CURSES_CTRL_C) {}
 
   delwin(help_screen);

--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -1,9 +1,9 @@
 #include "pagination.hpp"
 
-#include "ncurses.h"
-
 #include <string>
 #include <vector>
+
+#include "ncurses.h"
 
 constexpr auto CURSES_CTRL_C = static_cast<uint32_t>('c') & uint32_t{31};
 

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -35,12 +35,12 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
 }
 
 void TransactionManager::_register_transaction(const CommitID snapshot_commit_id) {
-  const auto lock = std::lock_guard<std::mutex>(_active_snapshot_commit_ids_mutex);
+  const auto lock = std::lock_guard<std::mutex>{_active_snapshot_commit_ids_mutex};
   _active_snapshot_commit_ids.insert(snapshot_commit_id);
 }
 
 void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_id) {
-  const auto lock = std::lock_guard<std::mutex>(_active_snapshot_commit_ids_mutex);
+  const auto lock = std::lock_guard<std::mutex>{_active_snapshot_commit_ids_mutex};
 
   auto it = std::find(_active_snapshot_commit_ids.begin(), _active_snapshot_commit_ids.end(), snapshot_commit_id);
 
@@ -56,7 +56,7 @@ void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_
 }
 
 std::optional<CommitID> TransactionManager::get_lowest_active_snapshot_commit_id() const {
-  const auto lock = std::lock_guard<std::mutex>(_active_snapshot_commit_ids_mutex);
+  const auto lock = std::lock_guard<std::mutex>{_active_snapshot_commit_ids_mutex};
 
   if (_active_snapshot_commit_ids.empty()) {
     return std::nullopt;

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -35,12 +35,12 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
 }
 
 void TransactionManager::_register_transaction(const CommitID snapshot_commit_id) {
-  const std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
+  const auto lock = std::lock_guard<std::mutex>(_active_snapshot_commit_ids_mutex);
   _active_snapshot_commit_ids.insert(snapshot_commit_id);
 }
 
 void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_id) {
-  const std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
+  const auto lock = std::lock_guard<std::mutex>(_active_snapshot_commit_ids_mutex);
 
   auto it = std::find(_active_snapshot_commit_ids.begin(), _active_snapshot_commit_ids.end(), snapshot_commit_id);
 
@@ -56,7 +56,7 @@ void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_
 }
 
 std::optional<CommitID> TransactionManager::get_lowest_active_snapshot_commit_id() const {
-  const std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
+  const auto lock = std::lock_guard<std::mutex>(_active_snapshot_commit_ids_mutex);
 
   if (_active_snapshot_commit_ids.empty()) {
     return std::nullopt;

--- a/src/lib/concurrency/transaction_manager.cpp
+++ b/src/lib/concurrency/transaction_manager.cpp
@@ -35,12 +35,12 @@ std::shared_ptr<TransactionContext> TransactionManager::new_transaction_context(
 }
 
 void TransactionManager::_register_transaction(const CommitID snapshot_commit_id) {
-  std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
+  const std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
   _active_snapshot_commit_ids.insert(snapshot_commit_id);
 }
 
 void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_id) {
-  std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
+  const std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
 
   auto it = std::find(_active_snapshot_commit_ids.begin(), _active_snapshot_commit_ids.end(), snapshot_commit_id);
 
@@ -56,7 +56,7 @@ void TransactionManager::_deregister_transaction(const CommitID snapshot_commit_
 }
 
 std::optional<CommitID> TransactionManager::get_lowest_active_snapshot_commit_id() const {
-  std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
+  const std::lock_guard<std::mutex> lock(_active_snapshot_commit_ids_mutex);
 
   if (_active_snapshot_commit_ids.empty()) {
     return std::nullopt;

--- a/src/lib/expression/aggregate_expression.cpp
+++ b/src/lib/expression/aggregate_expression.cpp
@@ -121,7 +121,7 @@ size_t AggregateExpression::_shallow_hash() const {
   return boost::hash_value(static_cast<size_t>(aggregate_function));
 }
 
-bool AggregateExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool AggregateExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   // Aggregates (except COUNT and COUNT DISTINCT) will return NULL when executed on an
   // empty group - thus they are always nullable
   return aggregate_function != AggregateFunction::Count && aggregate_function != AggregateFunction::CountDistinct;

--- a/src/lib/expression/aggregate_expression.hpp
+++ b/src/lib/expression/aggregate_expression.hpp
@@ -45,7 +45,7 @@ class AggregateExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/expression/correlated_parameter_expression.cpp
+++ b/src/lib/expression/correlated_parameter_expression.cpp
@@ -23,13 +23,13 @@ CorrelatedParameterExpression::CorrelatedParameterExpression(const ParameterID i
       _referenced_expression_info(referenced_expression_info) {}
 
 std::shared_ptr<AbstractExpression> CorrelatedParameterExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   auto copy = std::make_shared<CorrelatedParameterExpression>(parameter_id, _referenced_expression_info);
   copy->_value = _value;
   return copy;
 }
 
-std::string CorrelatedParameterExpression::description(const DescriptionMode mode) const {
+std::string CorrelatedParameterExpression::description(const DescriptionMode /*mode*/) const {
   std::stringstream stream;
   stream << "Parameter[";
   stream << "name=" << _referenced_expression_info.column_name << "; ";
@@ -76,7 +76,7 @@ size_t CorrelatedParameterExpression::_shallow_hash() const {
   return hash;
 }
 
-bool CorrelatedParameterExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool CorrelatedParameterExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   // Assume all correlated expression to be nullable - it is very taxing, code-wise, to determine whether
   // it actually is
   return true;

--- a/src/lib/expression/correlated_parameter_expression.hpp
+++ b/src/lib/expression/correlated_parameter_expression.hpp
@@ -35,8 +35,8 @@ class CorrelatedParameterExpression : public AbstractExpression {
 
   bool requires_computation() const override;
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
-  std::string description(const DescriptionMode mode) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
   DataType data_type() const override;
 
   const ParameterID parameter_id;
@@ -44,7 +44,7 @@ class CorrelatedParameterExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 
  private:
   const ReferencedExpressionInfo _referenced_expression_info;

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -326,7 +326,7 @@ ExpressionEvaluator::_evaluate_like_expression<ExpressionEvaluator::Bool>(const 
     }
   } else if (!left_results->is_literal() && right_results->is_literal()) {
     // E.g., `a LIKE '%hello%'` -- A single matcher for all rows
-    LikeMatcher like_matcher{right_results->values.front()};
+    const auto like_matcher = LikeMatcher{right_results->values.front()};
 
     for (auto row_idx = ChunkOffset{0}; row_idx < result_size; ++row_idx) {
       like_matcher.resolve(invert_results, [&](const auto& matcher) {
@@ -1076,7 +1076,7 @@ RowIDPosList ExpressionEvaluator::evaluate_expression_to_pos_list(const Abstract
                   ExpressionFunctorType{}(matches, left_result.value(chunk_offset),  // NOLINT
                                           right_result.value(chunk_offset));
                   if (matches != 0) {
-                    result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
+                    result_pos_list.emplace_back(_chunk_id, chunk_offset);
                   }
                 }
               } else {
@@ -1101,14 +1101,14 @@ RowIDPosList ExpressionEvaluator::evaluate_expression_to_pos_list(const Abstract
               for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(_output_row_count);
                    ++chunk_offset) {
                 if (result.is_null(chunk_offset)) {
-                  result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
+                  result_pos_list.emplace_back(_chunk_id, chunk_offset);
                 }
               }
             } else {  // PredicateCondition::IsNotNull
               for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(_output_row_count);
                    ++chunk_offset) {
                 if (!result.is_null(chunk_offset)) {
-                  result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
+                  result_pos_list.emplace_back(_chunk_id, chunk_offset);
                 }
               }
             }
@@ -1130,7 +1130,7 @@ RowIDPosList ExpressionEvaluator::evaluate_expression_to_pos_list(const Abstract
             for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(_output_row_count);
                  ++chunk_offset) {
               if (result_view.value(chunk_offset) != 0 && !result_view.is_null(chunk_offset)) {
-                result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
+                result_pos_list.emplace_back(_chunk_id, chunk_offset);
               }
             }
           });
@@ -1169,14 +1169,14 @@ RowIDPosList ExpressionEvaluator::evaluate_expression_to_pos_list(const Abstract
         for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(_output_row_count);
              ++chunk_offset) {
           if ((subquery_result_tables[chunk_offset]->row_count() > 0) ^ invert) {
-            result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
+            result_pos_list.emplace_back(_chunk_id, chunk_offset);
           }
         }
       } else {
         if ((subquery_result_tables.front()->row_count() > 0) ^ invert) {
           for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(_output_row_count);
                ++chunk_offset) {
-            result_pos_list.emplace_back(RowID{_chunk_id, chunk_offset});
+            result_pos_list.emplace_back(_chunk_id, chunk_offset);
           }
         }
       }
@@ -1330,7 +1330,7 @@ void ExpressionEvaluator::_resolve_to_expression_result(const AbstractExpression
 
   if (expression.data_type() == DataType::Null) {
     // resolve_data_type() doesn't support Null, so we have handle it explicitly
-    ExpressionResult<NullValue> null_value_result{{NullValue{}}, {true}};
+    const auto null_value_result = ExpressionResult<NullValue>{{NullValue{}}, {true}};
 
     functor(null_value_result);
   } else {

--- a/src/lib/expression/evaluation/expression_evaluator.cpp
+++ b/src/lib/expression/evaluation/expression_evaluator.cpp
@@ -909,10 +909,10 @@ std::shared_ptr<ExpressionResult<Result>> ExpressionEvaluator::_evaluate_subquer
     if (row_count == 0) {
       Assert(!subquery_expression.is_correlated(), "Correlated subqueries must return one row for each tuple.");
       return std::make_shared<ExpressionResult<Result>>();
-    } else {
-      Assert(row_count == 1, "Expected precisely one row to be returned from SelectExpression.");
-      result_values[chunk_offset] = subquery_results[chunk_offset]->value(0);
     }
+
+    Assert(row_count == 1, "Expected precisely one row to be returned from SelectExpression.");
+    result_values[chunk_offset] = subquery_results[chunk_offset]->value(0);
   }
 
   // Optionally materialize nulls if any row returned a nullable result.

--- a/src/lib/expression/evaluation/expression_evaluator.hpp
+++ b/src/lib/expression/evaluation/expression_evaluator.hpp
@@ -70,24 +70,24 @@ class ExpressionEvaluator final {
   std::shared_ptr<ExpressionResult<Result>> _evaluate_arithmetic_expression(const ArithmeticExpression& expression);
 
   template <typename Result>
-  std::shared_ptr<ExpressionResult<Result>> _evaluate_logical_expression(const LogicalExpression& expression);
+  std::shared_ptr<ExpressionResult<Result>> _evaluate_logical_expression(const LogicalExpression& /*expression*/);
 
   template <typename Result>
   std::shared_ptr<ExpressionResult<Result>> _evaluate_predicate_expression(
-      const AbstractPredicateExpression& predicate_expression);
+      const AbstractPredicateExpression& /*predicate_expression*/);
 
   template <typename Result>
   std::shared_ptr<ExpressionResult<Result>> _evaluate_binary_predicate_expression(
-      const BinaryPredicateExpression& expression);
+      const BinaryPredicateExpression& /*expression*/);
 
   template <typename Result>
-  std::shared_ptr<ExpressionResult<Result>> _evaluate_like_expression(const BinaryPredicateExpression& expression);
+  std::shared_ptr<ExpressionResult<Result>> _evaluate_like_expression(const BinaryPredicateExpression& /*expression*/);
 
   template <typename Result>
-  std::shared_ptr<ExpressionResult<Result>> _evaluate_is_null_expression(const IsNullExpression& expression);
+  std::shared_ptr<ExpressionResult<Result>> _evaluate_is_null_expression(const IsNullExpression& /*expression*/);
 
   template <typename Result>
-  std::shared_ptr<ExpressionResult<Result>> _evaluate_in_expression(const InExpression& in_expression);
+  std::shared_ptr<ExpressionResult<Result>> _evaluate_in_expression(const InExpression& /*in_expression*/);
 
   template <typename Result>
   std::shared_ptr<ExpressionResult<Result>> _evaluate_subquery_expression(
@@ -127,7 +127,7 @@ class ExpressionEvaluator final {
                                                                         const Functor extract_component);
 
   template <typename Result>
-  std::shared_ptr<ExpressionResult<Result>> _evaluate_exists_expression(const ExistsExpression& exists_expression);
+  std::shared_ptr<ExpressionResult<Result>> _evaluate_exists_expression(const ExistsExpression& /*exists_expression*/);
 
   // See docs for `_evaluate_default_null_logic()`
   template <typename Result, typename Functor>

--- a/src/lib/expression/exists_expression.cpp
+++ b/src/lib/expression/exists_expression.cpp
@@ -47,7 +47,7 @@ size_t ExistsExpression::_shallow_hash() const {
   return exists_expression_type == ExistsExpressionType::Exists;
 }
 
-bool ExistsExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool ExistsExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   return false;
 }
 

--- a/src/lib/expression/exists_expression.hpp
+++ b/src/lib/expression/exists_expression.hpp
@@ -26,7 +26,7 @@ class ExistsExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/expression/interval_expression.cpp
+++ b/src/lib/expression/interval_expression.cpp
@@ -14,11 +14,11 @@ DataType IntervalExpression::data_type() const {
 }
 
 std::shared_ptr<AbstractExpression> IntervalExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<IntervalExpression>(duration, unit);
 }
 
-std::string IntervalExpression::description(const DescriptionMode mode) const {
+std::string IntervalExpression::description(const DescriptionMode /*mode*/) const {
   std::stringstream stream;
   stream << "INTERVAL '" << duration << "' " << magic_enum::enum_name(unit);
   return stream.str();

--- a/src/lib/expression/interval_expression.hpp
+++ b/src/lib/expression/interval_expression.hpp
@@ -14,8 +14,8 @@ class IntervalExpression : public AbstractExpression {
   IntervalExpression(const int64_t init_duration, const DatetimeComponent init_unit);
 
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
-  std::string description(const DescriptionMode mode) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
 
   DataType data_type() const override;
 

--- a/src/lib/expression/is_null_expression.cpp
+++ b/src/lib/expression/is_null_expression.cpp
@@ -38,7 +38,7 @@ ExpressionPrecedence IsNullExpression::_precedence() const {
   return ExpressionPrecedence::UnaryPredicate;
 }
 
-bool IsNullExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool IsNullExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   // IS NULL always returns a boolean value, never NULL
   return false;
 }

--- a/src/lib/expression/is_null_expression.hpp
+++ b/src/lib/expression/is_null_expression.hpp
@@ -19,7 +19,7 @@ class IsNullExpression : public AbstractPredicateExpression {
 
  protected:
   ExpressionPrecedence _precedence() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/expression/lqp_column_expression.cpp
+++ b/src/lib/expression/lqp_column_expression.cpp
@@ -18,7 +18,7 @@ LQPColumnExpression::LQPColumnExpression(const std::shared_ptr<const AbstractLQP
       original_column_id(init_original_column_id) {}
 
 std::shared_ptr<AbstractExpression> LQPColumnExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<LQPColumnExpression>(original_node.lock(), original_column_id);
 }
 
@@ -120,7 +120,7 @@ size_t LQPColumnExpression::_shallow_hash() const {
   return hash;
 }
 
-bool LQPColumnExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool LQPColumnExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   Fail(
       "Should not be called. This should have been forwarded to StoredTableNode/StaticTableNode/MockNode by "
       "AbstractExpression::is_nullable_on_lqp()");

--- a/src/lib/expression/lqp_column_expression.hpp
+++ b/src/lib/expression/lqp_column_expression.hpp
@@ -13,7 +13,7 @@ class LQPColumnExpression : public AbstractExpression {
                                const ColumnID original_column_id);
 
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
   bool requires_computation() const override;
@@ -28,7 +28,7 @@ class LQPColumnExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/expression/lqp_subquery_expression.cpp
+++ b/src/lib/expression/lqp_subquery_expression.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<AbstractExpression> LQPSubqueryExpression::parameter_expression(
 }
 
 std::shared_ptr<AbstractExpression> LQPSubqueryExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   const auto lqp_copy = lqp->deep_copy();
 
   return std::make_shared<LQPSubqueryExpression>(lqp_copy, parameter_ids, expressions_deep_copy(arguments));

--- a/src/lib/expression/lqp_subquery_expression.hpp
+++ b/src/lib/expression/lqp_subquery_expression.hpp
@@ -28,7 +28,7 @@ class LQPSubqueryExpression : public AbstractExpression {
                         const std::vector<std::shared_ptr<AbstractExpression>>& init_parameter_expressions);
 
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   std::string description(const DescriptionMode mode) const override;
   DataType data_type() const override;
 

--- a/src/lib/expression/placeholder_expression.cpp
+++ b/src/lib/expression/placeholder_expression.cpp
@@ -14,11 +14,11 @@ PlaceholderExpression::PlaceholderExpression(const ParameterID init_parameter_id
     : AbstractExpression(ExpressionType::Placeholder, {}), parameter_id(init_parameter_id) {}
 
 std::shared_ptr<AbstractExpression> PlaceholderExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<PlaceholderExpression>(parameter_id);
 }
 
-std::string PlaceholderExpression::description(const DescriptionMode mode) const {
+std::string PlaceholderExpression::description(const DescriptionMode /*mode*/) const {
   std::stringstream stream;
   stream << "Placeholder[ParameterID=" << std::to_string(parameter_id) << "]";
   return stream.str();
@@ -43,7 +43,7 @@ size_t PlaceholderExpression::_shallow_hash() const {
   return boost::hash_value(static_cast<ParameterID::base_type>(parameter_id));
 }
 
-bool PlaceholderExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool PlaceholderExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   // Placeholder COULD be replaced with NULL
   return true;
 }

--- a/src/lib/expression/placeholder_expression.hpp
+++ b/src/lib/expression/placeholder_expression.hpp
@@ -14,8 +14,8 @@ class PlaceholderExpression : public AbstractExpression {
 
   bool requires_computation() const override;
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
-  std::string description(const DescriptionMode mode) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
   DataType data_type() const override;
 
   const ParameterID parameter_id;
@@ -23,7 +23,7 @@ class PlaceholderExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/expression/pqp_column_expression.cpp
+++ b/src/lib/expression/pqp_column_expression.cpp
@@ -26,11 +26,11 @@ PQPColumnExpression::PQPColumnExpression(const ColumnID init_column_id, const Da
       _column_name(column_name) {}
 
 std::shared_ptr<AbstractExpression> PQPColumnExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<PQPColumnExpression>(column_id, _data_type, _nullable, _column_name);
 }
 
-std::string PQPColumnExpression::description(const DescriptionMode mode) const {
+std::string PQPColumnExpression::description(const DescriptionMode /*mode*/) const {
   return _column_name;
 }
 
@@ -54,7 +54,7 @@ size_t PQPColumnExpression::_shallow_hash() const {
   return boost::hash_value(static_cast<size_t>(column_id));
 }
 
-bool PQPColumnExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool PQPColumnExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   Fail("Nullability 'on lqp' should never be queried from a PQPColumn");
 }
 

--- a/src/lib/expression/pqp_column_expression.hpp
+++ b/src/lib/expression/pqp_column_expression.hpp
@@ -19,8 +19,8 @@ class PQPColumnExpression : public AbstractExpression {
                       const std::string& column_name);
 
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
-  std::string description(const DescriptionMode mode) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/ w) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
   DataType data_type() const override;
   bool requires_computation() const override;
 
@@ -29,7 +29,7 @@ class PQPColumnExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 
  private:
   const DataType _data_type;

--- a/src/lib/expression/pqp_subquery_expression.cpp
+++ b/src/lib/expression/pqp_subquery_expression.cpp
@@ -40,7 +40,7 @@ bool PQPSubqueryExpression::is_correlated() const {
   return !parameters.empty();
 }
 
-std::string PQPSubqueryExpression::description(const DescriptionMode mode) const {
+std::string PQPSubqueryExpression::description(const DescriptionMode /*mode*/) const {
   std::stringstream stream;
   stream << "SUBQUERY (PQP, " << pqp.get() << ")";
   return stream.str();
@@ -64,7 +64,7 @@ size_t PQPSubqueryExpression::_shallow_hash() const {
   return hash;
 }
 
-bool PQPSubqueryExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool PQPSubqueryExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   Fail("Nullability 'on lqp' should never be queried from a PQPSelect");
 }
 

--- a/src/lib/expression/pqp_subquery_expression.hpp
+++ b/src/lib/expression/pqp_subquery_expression.hpp
@@ -28,7 +28,7 @@ class PQPSubqueryExpression : public AbstractExpression {
   std::shared_ptr<AbstractExpression> _on_deep_copy(
       std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
 
-  std::string description(const DescriptionMode mode) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
   DataType data_type() const override;
 
   // Returns whether this query is correlated, i.e., uses external parameters
@@ -40,7 +40,7 @@ class PQPSubqueryExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 
  private:
   // If the PQPSubqueryExpression returns precisely one column, it "has" this column's data type and nullability.

--- a/src/lib/expression/value_expression.cpp
+++ b/src/lib/expression/value_expression.cpp
@@ -15,11 +15,11 @@ bool ValueExpression::requires_computation() const {
 }
 
 std::shared_ptr<AbstractExpression> ValueExpression::_on_deep_copy(
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<ValueExpression>(value);
 }
 
-std::string ValueExpression::description(const DescriptionMode mode) const {
+std::string ValueExpression::description(const DescriptionMode /*mode*/) const {
   std::stringstream stream;
 
   if (value.type() == typeid(pmr_string)) {
@@ -60,7 +60,7 @@ size_t ValueExpression::_shallow_hash() const {
   return std::hash<AllTypeVariant>{}(value);
 }
 
-bool ValueExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const {
+bool ValueExpression::_on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const {
   return value.type() == typeid(NullValue);
 }
 

--- a/src/lib/expression/value_expression.hpp
+++ b/src/lib/expression/value_expression.hpp
@@ -14,8 +14,8 @@ class ValueExpression : public AbstractExpression {
 
   bool requires_computation() const override;
   std::shared_ptr<AbstractExpression> _on_deep_copy(
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
-  std::string description(const DescriptionMode mode) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
   DataType data_type() const override;
 
   const AllTypeVariant value;
@@ -23,7 +23,7 @@ class ValueExpression : public AbstractExpression {
  protected:
   bool _shallow_equals(const AbstractExpression& expression) const override;
   size_t _shallow_hash() const override;
-  bool _on_is_nullable_on_lqp(const AbstractLQPNode& lqp) const override;
+  bool _on_is_nullable_on_lqp(const AbstractLQPNode& /*lqp*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/import_export/binary/binary_parser.cpp
+++ b/src/lib/import_export/binary/binary_parser.cpp
@@ -113,7 +113,7 @@ void BinaryParser::_import_chunk(std::ifstream& file, std::shared_ptr<Table>& ta
   for (ColumnID sorted_column_id{0}; sorted_column_id < num_sorted_columns; ++sorted_column_id) {
     const auto column_id = _read_value<ColumnID>(file);
     const auto sort_mode = _read_value<SortMode>(file);
-    sorted_columns.emplace_back(SortColumnDefinition{column_id, sort_mode});
+    sorted_columns.emplace_back(column_id, sort_mode);
   }
 
   Segments output_segments;

--- a/src/lib/import_export/binary/binary_parser.cpp
+++ b/src/lib/import_export/binary/binary_parser.cpp
@@ -214,7 +214,7 @@ std::shared_ptr<FixedStringDictionarySegment<pmr_string>> BinaryParser::_import_
 
 template <typename T>
 std::shared_ptr<RunLengthSegment<T>> BinaryParser::_import_run_length_segment(std::ifstream& file,
-                                                                              ChunkOffset row_count) {
+                                                                              ChunkOffset /*row_count*/) {
   const auto size = _read_value<uint32_t>(file);
   const auto values = std::make_shared<pmr_vector<T>>(_read_values<T>(file, size));
   const auto null_values = std::make_shared<pmr_vector<bool>>(_read_values<bool>(file, size));

--- a/src/lib/import_export/binary/binary_parser.hpp
+++ b/src/lib/import_export/binary/binary_parser.hpp
@@ -80,7 +80,7 @@ class BinaryParser {
       std::ifstream& file, ChunkOffset row_count);
 
   template <typename T>
-  static std::shared_ptr<RunLengthSegment<T>> _import_run_length_segment(std::ifstream& file, ChunkOffset row_count);
+  static std::shared_ptr<RunLengthSegment<T>> _import_run_length_segment(std::ifstream& file, ChunkOffset /*row_count*/);
 
   template <typename T>
   static std::shared_ptr<FrameOfReferenceSegment<T>> _import_frame_of_reference_segment(std::ifstream& file,

--- a/src/lib/import_export/binary/binary_parser.hpp
+++ b/src/lib/import_export/binary/binary_parser.hpp
@@ -80,7 +80,8 @@ class BinaryParser {
       std::ifstream& file, ChunkOffset row_count);
 
   template <typename T>
-  static std::shared_ptr<RunLengthSegment<T>> _import_run_length_segment(std::ifstream& file, ChunkOffset /*row_count*/);
+  static std::shared_ptr<RunLengthSegment<T>> _import_run_length_segment(std::ifstream& file,
+                                                                         ChunkOffset /*row_count*/);
 
   template <typename T>
   static std::shared_ptr<FrameOfReferenceSegment<T>> _import_frame_of_reference_segment(std::ifstream& file,

--- a/src/lib/import_export/binary/binary_writer.cpp
+++ b/src/lib/import_export/binary/binary_writer.cpp
@@ -31,11 +31,12 @@ void export_values(std::ofstream& ofstream, const std::vector<T, Alloc>& values)
  * This approach is indeed faster than a dynamic approach with a stringstream.
  */
 void export_string_values(std::ofstream& ofstream, const pmr_vector<pmr_string>& values) {
-  pmr_vector<size_t> string_lengths(values.size());
-  size_t total_length = 0;
+  const auto value_count = values.size();
+  auto string_lengths = pmr_vector<size_t>(value_count);
+  auto total_length = size_t{0};
 
   // Save the length of each string.
-  for (size_t i = 0; i < values.size(); ++i) {
+  for (auto i = size_t{0}; i < value_count; ++i) {
     string_lengths[i] = values[i].size();
     total_length += values[i].size();
   }
@@ -48,8 +49,8 @@ void export_string_values(std::ofstream& ofstream, const pmr_vector<pmr_string>&
   }
 
   // Write all string contents into to buffer.
-  pmr_vector<char> buffer(total_length);
-  size_t start = 0;
+  auto buffer = pmr_vector<char>(total_length);
+  auto start = size_t{0};
   for (const auto& str : values) {
     std::memcpy(buffer.data() + start, str.data(), str.size());
     start += str.size();
@@ -104,7 +105,7 @@ void BinaryWriter::write(const Table& table, const std::string& filename) {
   _write_header(table, ofstream);
 
   const auto chunk_count = table.chunk_count();
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     _write_chunk(table, ofstream, chunk_id);
   }
 }
@@ -115,9 +116,9 @@ void BinaryWriter::_write_header(const Table& table, std::ofstream& ofstream) {
   export_value(ofstream, static_cast<ChunkID::base_type>(table.chunk_count()));
   export_value(ofstream, static_cast<ColumnID::base_type>(table.column_count()));
 
-  pmr_vector<pmr_string> column_types(table.column_count());
-  pmr_vector<pmr_string> column_names(table.column_count());
-  pmr_vector<bool> columns_are_nullable(table.column_count());
+  auto column_types = pmr_vector<pmr_string>(table.column_count());
+  auto column_names = pmr_vector<pmr_string>(table.column_count());
+  auto columns_are_nullable = pmr_vector<bool>(table.column_count());
 
   // Transform column types and copy column names in order to write them to the file.
   const auto column_count = table.column_count();

--- a/src/lib/import_export/binary/binary_writer.cpp
+++ b/src/lib/import_export/binary/binary_writer.cpp
@@ -145,7 +145,7 @@ void BinaryWriter::_write_chunk(const Table& table, std::ofstream& ofstream, con
   // Iterating over all segments of this chunk and exporting them
   for (auto column_id = ColumnID{0}; column_id < chunk->column_count(); column_id++) {
     resolve_data_and_segment_type(*chunk->get_segment(column_id),
-                                  [&](const auto data_type_t, const auto& resolved_segment) {
+                                  [&](const auto /*data_type_t*/, const auto& resolved_segment) {
                                     _write_segment(resolved_segment, table.column_is_nullable(column_id), ofstream);
                                   });
   }
@@ -217,7 +217,7 @@ void BinaryWriter::_write_segment(const DictionarySegment<T>& dictionary_segment
 
 template <typename T>
 void BinaryWriter::_write_segment(const FixedStringDictionarySegment<T>& fixed_string_dictionary_segment,
-                                  bool column_is_nullable, std::ofstream& ofstream) {
+                                  bool /*column_is_nullable*/, std::ofstream& ofstream) {
   export_value(ofstream, EncodingType::FixedStringDictionary);
 
   // Write attribute vector compression id
@@ -278,7 +278,8 @@ void BinaryWriter::_write_segment(const FrameOfReferenceSegment<int32_t>& frame_
 }
 
 template <typename T>
-void BinaryWriter::_write_segment(const LZ4Segment<T>& lz4_segment, bool column_is_nullable, std::ofstream& ofstream) {
+void BinaryWriter::_write_segment(const LZ4Segment<T>& lz4_segment, bool /*column_is_nullable*/,
+                                  std::ofstream& ofstream) {
   export_value(ofstream, EncodingType::LZ4);
 
   // Write num elements (rows in segment)

--- a/src/lib/import_export/binary/binary_writer.cpp
+++ b/src/lib/import_export/binary/binary_writer.cpp
@@ -103,7 +103,8 @@ void BinaryWriter::write(const Table& table, const std::string& filename) {
 
   _write_header(table, ofstream);
 
-  for (ChunkID chunk_id{0}; chunk_id < table.chunk_count(); chunk_id++) {
+  const auto chunk_count = table.chunk_count();
+  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
     _write_chunk(table, ofstream, chunk_id);
   }
 }
@@ -119,7 +120,8 @@ void BinaryWriter::_write_header(const Table& table, std::ofstream& ofstream) {
   pmr_vector<bool> columns_are_nullable(table.column_count());
 
   // Transform column types and copy column names in order to write them to the file.
-  for (auto column_id = ColumnID{0}; column_id < table.column_count(); ++column_id) {
+  const auto column_count = table.column_count();
+  for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     column_types[column_id] = data_type_to_string.left.at(table.column_data_type(column_id));
     column_names[column_id] = table.column_name(column_id);
     columns_are_nullable[column_id] = table.column_is_nullable(column_id);
@@ -143,7 +145,8 @@ void BinaryWriter::_write_chunk(const Table& table, std::ofstream& ofstream, con
   }
 
   // Iterating over all segments of this chunk and exporting them
-  for (auto column_id = ColumnID{0}; column_id < chunk->column_count(); column_id++) {
+  const auto column_count = chunk->column_count();
+  for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     resolve_data_and_segment_type(*chunk->get_segment(column_id),
                                   [&](const auto /*data_type_t*/, const auto& resolved_segment) {
                                     _write_segment(resolved_segment, table.column_is_nullable(column_id), ofstream);

--- a/src/lib/import_export/binary/binary_writer.cpp
+++ b/src/lib/import_export/binary/binary_writer.cpp
@@ -198,7 +198,7 @@ void BinaryWriter::_write_segment(const ReferenceSegment& reference_segment, boo
 }
 
 template <typename T>
-void BinaryWriter::_write_segment(const DictionarySegment<T>& dictionary_segment, bool column_is_nullable,
+void BinaryWriter::_write_segment(const DictionarySegment<T>& dictionary_segment, bool /*column_is_nullable*/,
                                   std::ofstream& ofstream) {
   export_value(ofstream, EncodingType::Dictionary);
 
@@ -237,7 +237,7 @@ void BinaryWriter::_write_segment(const FixedStringDictionarySegment<T>& fixed_s
 }
 
 template <typename T>
-void BinaryWriter::_write_segment(const RunLengthSegment<T>& run_length_segment, bool column_is_nullable,
+void BinaryWriter::_write_segment(const RunLengthSegment<T>& run_length_segment, bool /*column_is_nullable*/,
                                   std::ofstream& ofstream) {
   export_value(ofstream, EncodingType::RunLength);
 
@@ -254,7 +254,7 @@ void BinaryWriter::_write_segment(const RunLengthSegment<T>& run_length_segment,
 
 template <>
 void BinaryWriter::_write_segment(const FrameOfReferenceSegment<int32_t>& frame_of_reference_segment,
-                                  bool column_is_nullable, std::ofstream& ofstream) {
+                                  bool /*column_is_nullable*/, std::ofstream& ofstream) {
   export_value(ofstream, EncodingType::FrameOfReference);
 
   // Write attribute vector compression id

--- a/src/lib/import_export/binary/binary_writer.hpp
+++ b/src/lib/import_export/binary/binary_writer.hpp
@@ -119,7 +119,7 @@ class BinaryWriter {
    * ²: This field is only written if the vector compression is FixedWidthInteger
    */
   template <typename T>
-  static void _write_segment(const DictionarySegment<T>& dictionary_segment, bool column_is_nullable,
+  static void _write_segment(const DictionarySegment<T>& dictionary_segment, bool /*column_is_nullable*/,
                              std::ofstream& ofstream);
 
   /**
@@ -220,7 +220,7 @@ class BinaryWriter {
    * ³: This field is only written if the vector compression is BitPacking
    */
   template <typename T>
-  static void _write_segment(const LZ4Segment<T>& lz4_segment, bool column_is_nullable, std::ofstream& ofstream);
+  static void _write_segment(const LZ4Segment<T>& lz4_segment, bool /*column_is_nullable*/, std::ofstream& ofstream);
 
   template <typename T>
   static CompressedVectorTypeID _compressed_vector_type_id(const AbstractEncodedSegment& abstract_encoded_segment);

--- a/src/lib/import_export/binary/binary_writer.hpp
+++ b/src/lib/import_export/binary/binary_writer.hpp
@@ -144,7 +144,7 @@ class BinaryWriter {
    */
   template <typename T>
   static void _write_segment(const FixedStringDictionarySegment<T>& fixed_string_dictionary_segment,
-                             bool column_is_nullable, std::ofstream& ofstream);
+                             bool /*column_is_nullable*/, std::ofstream& ofstream);
 
   /**
    * RunLengthSegments are dumped with the following layout:

--- a/src/lib/import_export/binary/binary_writer.hpp
+++ b/src/lib/import_export/binary/binary_writer.hpp
@@ -161,7 +161,7 @@ class BinaryWriter {
    * The type of the column can be found in the global header of the file.
    */
   template <typename T>
-  static void _write_segment(const RunLengthSegment<T>& run_length_segment, bool column_is_nullable,
+  static void _write_segment(const RunLengthSegment<T>& run_length_segment, bool /*column_is_nullable*/,
                              std::ofstream& ofstream);
 
   /**
@@ -188,7 +188,7 @@ class BinaryWriter {
    * ³: This field is only written if the vector compression is FixedWidthInteger
    */
   template <typename T>
-  static void _write_segment(const FrameOfReferenceSegment<T>& frame_of_reference_segment, bool column_is_nullable,
+  static void _write_segment(const FrameOfReferenceSegment<T>& frame_of_reference_segment, bool /*column_is_nullable*/,
                              std::ofstream& ofstream);
 
   /**

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -225,7 +225,7 @@ size_t CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vecto
 
   // Transform the field_offsets to segments and add segments to chunk.
   {
-    std::lock_guard<std::mutex> lock(append_chunk_mutex);
+    const auto lock = std::lock_guard<std::mutex>(append_chunk_mutex);
     for (auto& converter : converters) {
       segments.push_back(converter->finish());
     }

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -24,10 +24,10 @@ std::shared_ptr<Table> CsvParser::parse(const std::string& filename, const Chunk
                                         const std::optional<CsvMeta>& csv_meta) {
   // If no meta info is given as a parameter, look for a json file
   auto meta = CsvMeta{};
-  if (csv_meta == std::nullopt) {
-    meta = process_csv_meta_file(filename + CsvMeta::META_FILE_EXTENSION);
-  } else {
+  if (csv_meta) {
     meta = *csv_meta;
+  } else {
+    meta = process_csv_meta_file(filename + CsvMeta::META_FILE_EXTENSION);
   }
 
   auto escaped_linebreak = std::string(1, meta.config.delimiter_escape) + std::string(1, meta.config.delimiter);

--- a/src/lib/import_export/csv/csv_parser.cpp
+++ b/src/lib/import_export/csv/csv_parser.cpp
@@ -225,7 +225,7 @@ size_t CsvParser::_parse_into_chunk(std::string_view csv_chunk, const std::vecto
 
   // Transform the field_offsets to segments and add segments to chunk.
   {
-    const auto lock = std::lock_guard<std::mutex>(append_chunk_mutex);
+    const auto lock = std::lock_guard<std::mutex>{append_chunk_mutex};
     for (auto& converter : converters) {
       segments.push_back(converter->finish());
     }

--- a/src/lib/import_export/csv/csv_writer.cpp
+++ b/src/lib/import_export/csv/csv_writer.cpp
@@ -26,9 +26,8 @@ void CsvWriter::_generate_meta_info_file(const Table& table, const std::string& 
     meta.columns.push_back(column_meta);
   }
 
-  const auto meta_json = nlohmann::json{meta};
-
-  std::ofstream meta_file_stream(filename);
+  const auto meta_json = nlohmann::json(meta);
+  auto meta_file_stream = std::ofstream{filename};
   meta_file_stream << std::setw(4) << meta_json << std::endl;
 }
 

--- a/src/lib/import_export/csv/csv_writer.cpp
+++ b/src/lib/import_export/csv/csv_writer.cpp
@@ -26,7 +26,7 @@ void CsvWriter::_generate_meta_info_file(const Table& table, const std::string& 
     meta.columns.push_back(column_meta);
   }
 
-  nlohmann::json meta_json = meta;
+  const auto meta_json = nlohmann::json{meta};
 
   std::ofstream meta_file_stream(filename);
   meta_file_stream << std::setw(4) << meta_json << std::endl;

--- a/src/lib/logical_query_plan/abstract_non_query_node.cpp
+++ b/src/lib/logical_query_plan/abstract_non_query_node.cpp
@@ -17,8 +17,8 @@ FunctionalDependencies AbstractNonQueryNode::non_trivial_functional_dependencies
 }
 
 bool AbstractNonQueryNode::is_column_nullable(const ColumnID /*column_id*/) const {
-  // The majority of non-query nodes output no column (CreateTable, DropTable, ...)
-  // Non-query nodes that do return columns (ShowColumns, ...) need to override this function
+  // The majority of non-query nodes output no column (CreateTable, DropTable, ...). Non-query nodes that return
+  // columns (ShowColumns, ...) need to override this function.
   Fail("Node does not return any column");
 }
 

--- a/src/lib/logical_query_plan/abstract_non_query_node.cpp
+++ b/src/lib/logical_query_plan/abstract_non_query_node.cpp
@@ -8,18 +8,18 @@ std::vector<std::shared_ptr<AbstractExpression>> AbstractNonQueryNode::output_ex
   return {};
 }
 
-bool AbstractNonQueryNode::is_column_nullable(const ColumnID column_id) const {
-  // The majority of non-query nodes output no column (CreateTable, DropTable, ...)
-  // Non-query nodes that do return columns (ShowColumns, ...) need to override this function
-  Fail("Node does not return any column");
-}
-
 UniqueColumnCombinations AbstractNonQueryNode::unique_column_combinations() const {
   Fail("Node does not support unique column combinations.");
 }
 
 FunctionalDependencies AbstractNonQueryNode::non_trivial_functional_dependencies() const {
   Fail("Node does not support functional dependencies.");
+}
+
+bool AbstractNonQueryNode::is_column_nullable(const ColumnID /*column_id*/) const {
+  // The majority of non-query nodes output no column (CreateTable, DropTable, ...)
+  // Non-query nodes that do return columns (ShowColumns, ...) need to override this function
+  Fail("Node does not return any column");
 }
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/abstract_non_query_node.hpp
+++ b/src/lib/logical_query_plan/abstract_non_query_node.hpp
@@ -19,7 +19,7 @@ class AbstractNonQueryNode : public AbstractLQPNode {
 
   FunctionalDependencies non_trivial_functional_dependencies() const override;
 
-  bool is_column_nullable(const ColumnID column_id) const override;
+  bool is_column_nullable(const ColumnID /*column_id*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/change_meta_table_node.cpp
+++ b/src/lib/logical_query_plan/change_meta_table_node.cpp
@@ -6,7 +6,7 @@ ChangeMetaTableNode::ChangeMetaTableNode(const std::string& init_table_name,
                                          const MetaTableChangeType& init_change_type)
     : AbstractNonQueryNode(LQPNodeType::ChangeMetaTable), table_name(init_table_name), change_type(init_change_type) {}
 
-std::string ChangeMetaTableNode::description(const DescriptionMode mode) const {
+std::string ChangeMetaTableNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream desc;
 
   desc << "[Change] Meta Table: '" << table_name << "'";
@@ -14,7 +14,7 @@ std::string ChangeMetaTableNode::description(const DescriptionMode mode) const {
   return desc.str();
 }
 
-std::shared_ptr<AbstractLQPNode> ChangeMetaTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> ChangeMetaTableNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return ChangeMetaTableNode::make(table_name, change_type);
 }
 
@@ -24,7 +24,7 @@ size_t ChangeMetaTableNode::_on_shallow_hash() const {
   return hash;
 }
 
-bool ChangeMetaTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool ChangeMetaTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& change_meta_table_node = static_cast<const ChangeMetaTableNode&>(rhs);
   return table_name == change_meta_table_node.table_name && change_type == change_meta_table_node.change_type;
 }

--- a/src/lib/logical_query_plan/change_meta_table_node.hpp
+++ b/src/lib/logical_query_plan/change_meta_table_node.hpp
@@ -28,8 +28,8 @@ class ChangeMetaTableNode : public EnableMakeForLQPNode<ChangeMetaTableNode>, pu
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/create_prepared_plan_node.cpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.cpp
@@ -10,7 +10,7 @@ CreatePreparedPlanNode::CreatePreparedPlanNode(const std::string& init_name,
                                                const std::shared_ptr<PreparedPlan>& init_prepared_plan)
     : AbstractNonQueryNode(LQPNodeType::CreatePreparedPlan), name(init_name), prepared_plan(init_prepared_plan) {}
 
-std::string CreatePreparedPlanNode::description(const DescriptionMode mode) const {
+std::string CreatePreparedPlanNode::description(const DescriptionMode /*mode*/) const {
   std::stringstream stream;
   stream << "[CreatePreparedPlan] '" << name << "' {\n";
   stream << *prepared_plan;
@@ -25,11 +25,12 @@ size_t CreatePreparedPlanNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> CreatePreparedPlanNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> CreatePreparedPlanNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return CreatePreparedPlanNode::make(name, prepared_plan);
 }
 
-bool CreatePreparedPlanNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool CreatePreparedPlanNode::_on_shallow_equals(const AbstractLQPNode& rhs,
+                                                const LQPNodeMapping& /*node_mapping*/) const {
   const auto& create_prepared_plan_node = static_cast<const CreatePreparedPlanNode&>(rhs);
   return name == create_prepared_plan_node.name && *prepared_plan == *create_prepared_plan_node.prepared_plan;
 }

--- a/src/lib/logical_query_plan/create_prepared_plan_node.hpp
+++ b/src/lib/logical_query_plan/create_prepared_plan_node.hpp
@@ -20,8 +20,8 @@ class CreatePreparedPlanNode : public EnableMakeForLQPNode<CreatePreparedPlanNod
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/create_table_node.cpp
+++ b/src/lib/logical_query_plan/create_table_node.cpp
@@ -9,7 +9,7 @@ namespace hyrise {
 CreateTableNode::CreateTableNode(const std::string& init_table_name, const bool init_if_not_exists)
     : AbstractNonQueryNode(LQPNodeType::CreateTable), table_name(init_table_name), if_not_exists(init_if_not_exists) {}
 
-std::string CreateTableNode::description(const DescriptionMode mode) const {
+std::string CreateTableNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream stream;
 
   stream << "[CreateTable] " << (if_not_exists ? "IfNotExists " : "");
@@ -24,11 +24,11 @@ size_t CreateTableNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> CreateTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> CreateTableNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return CreateTableNode::make(table_name, if_not_exists, left_input());
 }
 
-bool CreateTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool CreateTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& create_table_node = static_cast<const CreateTableNode&>(rhs);
   return table_name == create_table_node.table_name && if_not_exists == create_table_node.if_not_exists;
 }

--- a/src/lib/logical_query_plan/create_table_node.hpp
+++ b/src/lib/logical_query_plan/create_table_node.hpp
@@ -22,8 +22,8 @@ class CreateTableNode : public EnableMakeForLQPNode<CreateTableNode>, public Abs
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/create_view_node.cpp
+++ b/src/lib/logical_query_plan/create_view_node.cpp
@@ -14,7 +14,7 @@ CreateViewNode::CreateViewNode(const std::string& init_view_name, const std::sha
       view(init_view),
       if_not_exists(init_if_not_exists) {}
 
-std::string CreateViewNode::description(const DescriptionMode mode) const {
+std::string CreateViewNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream stream;
   stream << "[CreateView] " << (if_not_exists ? "IfNotExists " : "");
   stream << "Name: " << view_name << ", Columns: ";
@@ -35,11 +35,11 @@ size_t CreateViewNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> CreateViewNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> CreateViewNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return CreateViewNode::make(view_name, view->deep_copy(), if_not_exists);
 }
 
-bool CreateViewNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool CreateViewNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& create_view_node_rhs = static_cast<const CreateViewNode&>(rhs);
 
   return view_name == create_view_node_rhs.view_name && view->deep_equals(*create_view_node_rhs.view) &&

--- a/src/lib/logical_query_plan/create_view_node.hpp
+++ b/src/lib/logical_query_plan/create_view_node.hpp
@@ -23,8 +23,8 @@ class CreateViewNode : public EnableMakeForLQPNode<CreateViewNode>, public Abstr
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -23,11 +23,11 @@ std::vector<std::shared_ptr<AbstractExpression>> DeleteNode::output_expressions(
   return {};
 }
 
-std::shared_ptr<AbstractLQPNode> DeleteNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> DeleteNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return DeleteNode::make();
 }
 
-bool DeleteNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool DeleteNode::_on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const {
   return true;
 }
 

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -11,7 +11,7 @@ namespace hyrise {
 
 DeleteNode::DeleteNode() : AbstractNonQueryNode(LQPNodeType::Delete) {}
 
-std::string DeleteNode::description(const DescriptionMode mode) const {
+std::string DeleteNode::description(const DescriptionMode /*mode*/) const {
   return "[Delete]";
 }
 

--- a/src/lib/logical_query_plan/delete_node.cpp
+++ b/src/lib/logical_query_plan/delete_node.cpp
@@ -15,7 +15,7 @@ std::string DeleteNode::description(const DescriptionMode /*mode*/) const {
   return "[Delete]";
 }
 
-bool DeleteNode::is_column_nullable(const ColumnID column_id) const {
+bool DeleteNode::is_column_nullable(const ColumnID /*column_id*/) const {
   Fail("Delete does not output any columns");
 }
 

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -15,7 +15,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractNonQu
   DeleteNode();
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  bool is_column_nullable(const ColumnID column_id) const override;
+  bool is_column_nullable(const ColumnID /*column_id*/) const override;
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
  protected:

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -19,7 +19,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractNonQu
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
   bool _on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 

--- a/src/lib/logical_query_plan/delete_node.hpp
+++ b/src/lib/logical_query_plan/delete_node.hpp
@@ -20,7 +20,7 @@ class DeleteNode : public EnableMakeForLQPNode<DeleteNode>, public AbstractNonQu
 
  protected:
   std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/drop_table_node.cpp
+++ b/src/lib/logical_query_plan/drop_table_node.cpp
@@ -5,7 +5,7 @@ namespace hyrise {
 DropTableNode::DropTableNode(const std::string& init_table_name, const bool init_if_exists)
     : AbstractNonQueryNode(LQPNodeType::DropTable), table_name(init_table_name), if_exists(init_if_exists) {}
 
-std::string DropTableNode::description(const DescriptionMode mode) const {
+std::string DropTableNode::description(const DescriptionMode /*mode*/) const {
   return std::string("[DropTable] Name: '") + table_name + "'";
 }
 
@@ -15,11 +15,11 @@ size_t DropTableNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> DropTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> DropTableNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return DropTableNode::make(table_name, if_exists);
 }
 
-bool DropTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool DropTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& drop_table_node = static_cast<const DropTableNode&>(rhs);
   return table_name == drop_table_node.table_name && if_exists == drop_table_node.if_exists;
 }

--- a/src/lib/logical_query_plan/drop_table_node.hpp
+++ b/src/lib/logical_query_plan/drop_table_node.hpp
@@ -16,8 +16,8 @@ class DropTableNode : public EnableMakeForLQPNode<DropTableNode>, public Abstrac
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/drop_view_node.cpp
+++ b/src/lib/logical_query_plan/drop_view_node.cpp
@@ -14,7 +14,7 @@ namespace hyrise {
 DropViewNode::DropViewNode(const std::string& init_view_name, const bool init_if_exists)
     : AbstractNonQueryNode(LQPNodeType::DropView), view_name(init_view_name), if_exists(init_if_exists) {}
 
-std::string DropViewNode::description(const DescriptionMode mode) const {
+std::string DropViewNode::description(const DescriptionMode /*mode*/) const {
   return "[Drop] View: '"s + view_name + "'";
 }
 
@@ -24,11 +24,11 @@ size_t DropViewNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> DropViewNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> DropViewNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return DropViewNode::make(view_name, if_exists);
 }
 
-bool DropViewNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool DropViewNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& drop_view_node = static_cast<const DropViewNode&>(rhs);
   return view_name == drop_view_node.view_name && if_exists == drop_view_node.if_exists;
 }

--- a/src/lib/logical_query_plan/drop_view_node.hpp
+++ b/src/lib/logical_query_plan/drop_view_node.hpp
@@ -21,8 +21,8 @@ class DropViewNode : public EnableMakeForLQPNode<DropViewNode>, public AbstractN
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/dummy_table_node.cpp
+++ b/src/lib/logical_query_plan/dummy_table_node.cpp
@@ -12,7 +12,7 @@ namespace hyrise {
 
 DummyTableNode::DummyTableNode() : AbstractLQPNode(LQPNodeType::DummyTable) {}
 
-std::string DummyTableNode::description(const DescriptionMode mode) const {
+std::string DummyTableNode::description(const DescriptionMode /*mode*/) const {
   return "[DummyTable]";
 }
 
@@ -20,7 +20,7 @@ std::vector<std::shared_ptr<AbstractExpression>> DummyTableNode::output_expressi
   return {};
 }
 
-bool DummyTableNode::is_column_nullable(const ColumnID column_id) const {
+bool DummyTableNode::is_column_nullable(const ColumnID /*column_id*/) const {
   Fail("DummyTable does not output any columns");
 }
 
@@ -28,11 +28,11 @@ UniqueColumnCombinations DummyTableNode::unique_column_combinations() const {
   return UniqueColumnCombinations{};
 }
 
-std::shared_ptr<AbstractLQPNode> DummyTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> DummyTableNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return std::make_shared<DummyTableNode>();
 }
 
-bool DummyTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool DummyTableNode::_on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const {
   return true;
 }
 

--- a/src/lib/logical_query_plan/dummy_table_node.hpp
+++ b/src/lib/logical_query_plan/dummy_table_node.hpp
@@ -20,14 +20,14 @@ class DummyTableNode : public EnableMakeForLQPNode<DummyTableNode>, public Abstr
 
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
-  bool is_column_nullable(const ColumnID column_id) const override;
+  bool is_column_nullable(const ColumnID /*column_id*/) const override;
 
   UniqueColumnCombinations unique_column_combinations() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
 
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/except_node.cpp
+++ b/src/lib/logical_query_plan/except_node.cpp
@@ -13,7 +13,7 @@ namespace hyrise {
 ExceptNode::ExceptNode(const SetOperationMode init_operation_mode)
     : AbstractLQPNode(LQPNodeType::Except), set_operation_mode(init_operation_mode) {}
 
-std::string ExceptNode::description(const DescriptionMode mode) const {
+std::string ExceptNode::description(const DescriptionMode /*mode*/) const {
   return "[ExceptNode] Mode: " + std::string{magic_enum::enum_name(set_operation_mode)};
 }
 
@@ -42,11 +42,11 @@ size_t ExceptNode::_on_shallow_hash() const {
   return boost::hash_value(set_operation_mode);
 }
 
-std::shared_ptr<AbstractLQPNode> ExceptNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> ExceptNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return ExceptNode::make(set_operation_mode);
 }
 
-bool ExceptNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool ExceptNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& except_node = static_cast<const ExceptNode&>(rhs);
   return set_operation_mode == except_node.set_operation_mode;
 }

--- a/src/lib/logical_query_plan/except_node.hpp
+++ b/src/lib/logical_query_plan/except_node.hpp
@@ -30,7 +30,7 @@ class ExceptNode : public EnableMakeForLQPNode<ExceptNode>, public AbstractLQPNo
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/export_node.cpp
+++ b/src/lib/logical_query_plan/export_node.cpp
@@ -10,7 +10,7 @@ namespace hyrise {
 ExportNode::ExportNode(const std::string& init_file_name, const FileType init_file_type)
     : AbstractNonQueryNode(LQPNodeType::Export), file_name(init_file_name), file_type(init_file_type) {}
 
-std::string ExportNode::description(const DescriptionMode mode) const {
+std::string ExportNode::description(const DescriptionMode /*mode*/) const {
   auto file_type_str = std::string{magic_enum::enum_name(file_type)};
   boost::algorithm::to_lower(file_type_str);
   return "[Export] to '" + file_name + "' (" + file_type_str + ")";
@@ -22,11 +22,11 @@ size_t ExportNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> ExportNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> ExportNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return ExportNode::make(file_name, file_type);
 }
 
-bool ExportNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool ExportNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& export_node = static_cast<const ExportNode&>(rhs);
   return file_name == export_node.file_name && file_type == export_node.file_type;
 }

--- a/src/lib/logical_query_plan/export_node.hpp
+++ b/src/lib/logical_query_plan/export_node.hpp
@@ -23,8 +23,8 @@ class ExportNode : public EnableMakeForLQPNode<ExportNode>, public AbstractNonQu
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/import_node.cpp
+++ b/src/lib/logical_query_plan/import_node.cpp
@@ -11,7 +11,7 @@ ImportNode::ImportNode(const std::string& init_table_name, const std::string& in
       file_name(init_file_name),
       file_type(init_file_type) {}
 
-std::string ImportNode::description(const DescriptionMode mode) const {
+std::string ImportNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream stream;
   stream << "[Import] Name: '" << table_name << "'";
   return stream.str();
@@ -24,11 +24,11 @@ size_t ImportNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> ImportNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> ImportNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return ImportNode::make(table_name, file_name, file_type);
 }
 
-bool ImportNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool ImportNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& import_node = static_cast<const ImportNode&>(rhs);
   return table_name == import_node.table_name && file_name == import_node.file_name &&
          file_type == import_node.file_type;

--- a/src/lib/logical_query_plan/import_node.hpp
+++ b/src/lib/logical_query_plan/import_node.hpp
@@ -24,8 +24,8 @@ class ImportNode : public EnableMakeForLQPNode<ImportNode>, public AbstractNonQu
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/insert_node.cpp
+++ b/src/lib/logical_query_plan/insert_node.cpp
@@ -13,7 +13,7 @@ namespace hyrise {
 InsertNode::InsertNode(const std::string& init_table_name)
     : AbstractNonQueryNode(LQPNodeType::Insert), table_name(init_table_name) {}
 
-std::string InsertNode::description(const DescriptionMode mode) const {
+std::string InsertNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream desc;
 
   desc << "[Insert] Into table '" << table_name << "'";
@@ -25,11 +25,11 @@ size_t InsertNode::_on_shallow_hash() const {
   return boost::hash_value(table_name);
 }
 
-std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> InsertNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return InsertNode::make(table_name);
 }
 
-bool InsertNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool InsertNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& insert_node_rhs = static_cast<const InsertNode&>(rhs);
   return table_name == insert_node_rhs.table_name;
 }

--- a/src/lib/logical_query_plan/insert_node.hpp
+++ b/src/lib/logical_query_plan/insert_node.hpp
@@ -21,8 +21,8 @@ class InsertNode : public EnableMakeForLQPNode<InsertNode>, public AbstractNonQu
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/intersect_node.cpp
+++ b/src/lib/logical_query_plan/intersect_node.cpp
@@ -13,7 +13,7 @@ namespace hyrise {
 IntersectNode::IntersectNode(const SetOperationMode init_operation_mode)
     : AbstractLQPNode(LQPNodeType::Intersect), set_operation_mode(init_operation_mode) {}
 
-std::string IntersectNode::description(const DescriptionMode mode) const {
+std::string IntersectNode::description(const DescriptionMode /*mode*/) const {
   return "[IntersectNode] Mode: " + std::string{magic_enum::enum_name(set_operation_mode)};
 }
 
@@ -46,11 +46,11 @@ size_t IntersectNode::_on_shallow_hash() const {
   return boost::hash_value(set_operation_mode);
 }
 
-std::shared_ptr<AbstractLQPNode> IntersectNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> IntersectNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return IntersectNode::make(set_operation_mode);
 }
 
-bool IntersectNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool IntersectNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& intersect_node = static_cast<const IntersectNode&>(rhs);
   return set_operation_mode == intersect_node.set_operation_mode;
 }

--- a/src/lib/logical_query_plan/intersect_node.hpp
+++ b/src/lib/logical_query_plan/intersect_node.hpp
@@ -25,7 +25,7 @@ class IntersectNode : public EnableMakeForLQPNode<IntersectNode>, public Abstrac
  public:
   explicit IntersectNode(const SetOperationMode init_operation_mode);
 
-  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
+  std::string description(const DescriptionMode /*mode*/) const override;
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 
@@ -38,7 +38,7 @@ class IntersectNode : public EnableMakeForLQPNode<IntersectNode>, public Abstrac
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/intersect_node.hpp
+++ b/src/lib/logical_query_plan/intersect_node.hpp
@@ -25,7 +25,7 @@ class IntersectNode : public EnableMakeForLQPNode<IntersectNode>, public Abstrac
  public:
   explicit IntersectNode(const SetOperationMode init_operation_mode);
 
-  std::string description(const DescriptionMode /*mode*/) const override;
+  std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
   bool is_column_nullable(const ColumnID column_id) const override;
 

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -117,10 +117,10 @@ UniqueColumnCombinations JoinNode::_output_unique_column_combinations(
   }
 
   // Check uniqueness of join columns.
-  bool left_operand_is_unique =
+  const auto left_operand_is_unique =
       !left_unique_column_combinations.empty() &&
       contains_matching_unique_column_combination(left_unique_column_combinations, {join_predicate->left_operand()});
-  bool right_operand_is_unique =
+  const auto right_operand_is_unique =
       !right_unique_column_combinations.empty() &&
       contains_matching_unique_column_combination(right_unique_column_combinations, {join_predicate->right_operand()});
 
@@ -234,7 +234,7 @@ bool JoinNode::is_column_nullable(const ColumnID column_id) const {
     return left_input()->is_column_nullable(column_id);
   }
 
-  ColumnID right_column_id =
+  const auto right_column_id =
       static_cast<ColumnID>(column_id - static_cast<ColumnID::base_type>(left_input_column_count));
   return right_input()->is_column_nullable(right_column_id);
 }

--- a/src/lib/logical_query_plan/logical_plan_root_node.cpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.cpp
@@ -8,11 +8,11 @@ namespace hyrise {
 
 LogicalPlanRootNode::LogicalPlanRootNode() : AbstractLQPNode(LQPNodeType::Root) {}
 
-std::string LogicalPlanRootNode::description(const DescriptionMode mode) const {
+std::string LogicalPlanRootNode::description(const DescriptionMode /*mode*/) const {
   return "[LogicalPlanRootNode]";
 }
 
-std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> LogicalPlanRootNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return make();
 }
 
@@ -24,7 +24,8 @@ FunctionalDependencies LogicalPlanRootNode::non_trivial_functional_dependencies(
   Fail("LogicalPlanRootNode is not expected to be queried for functional dependencies.");
 }
 
-bool LogicalPlanRootNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool LogicalPlanRootNode::_on_shallow_equals(const AbstractLQPNode& /*rhs*/,
+                                             const LQPNodeMapping& /*node_mapping*/) const {
   return true;
 }
 

--- a/src/lib/logical_query_plan/logical_plan_root_node.hpp
+++ b/src/lib/logical_query_plan/logical_plan_root_node.hpp
@@ -25,8 +25,8 @@ class LogicalPlanRootNode : public EnableMakeForLQPNode<LogicalPlanRootNode>, pu
   FunctionalDependencies non_trivial_functional_dependencies() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/lqp_translator.cpp
+++ b/src/lib/logical_query_plan/lqp_translator.cpp
@@ -320,7 +320,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_sort_node(
     Assert(pqp_column_expression,
            "Sort Expression '"s + pqp_expression->as_column_name() + "' must be available as column, LQP is invalid");
 
-    column_definitions.emplace_back(SortColumnDefinition{pqp_column_expression->column_id, *sort_mode_iter});
+    column_definitions.emplace_back(pqp_column_expression->column_id, *sort_mode_iter);
   }
   current_pqp = std::make_shared<Sort>(current_pqp, column_definitions);
 
@@ -478,13 +478,13 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_union_node(
 
 // NOLINTNEXTLINE - while this particular method could be made static, others cannot.
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_intersect_node(
-    const std::shared_ptr<AbstractLQPNode>& node) const {
+    const std::shared_ptr<AbstractLQPNode>& /*node*/) const {
   FailInput("Hyrise does not yet support set operations");
 }
 
 // NOLINTNEXTLINE - while this particular method could be made static, others cannot.
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_except_node(
-    const std::shared_ptr<AbstractLQPNode>& node) const {
+    const std::shared_ptr<AbstractLQPNode>& /*node*/) const {
   FailInput("Hyrise does not yet support set operations");
 }
 
@@ -567,7 +567,7 @@ std::shared_ptr<AbstractOperator> LQPTranslator::_translate_create_prepared_plan
 
 // NOLINTNEXTLINE - while this particular method could be made static, others cannot.
 std::shared_ptr<AbstractOperator> LQPTranslator::_translate_dummy_table_node(
-    const std::shared_ptr<AbstractLQPNode>& node) const {
+    const std::shared_ptr<AbstractLQPNode>& /*node*/) const {
   return std::make_shared<TableWrapper>(Projection::dummy_table());
 }
 

--- a/src/lib/logical_query_plan/lqp_translator.hpp
+++ b/src/lib/logical_query_plan/lqp_translator.hpp
@@ -45,12 +45,12 @@ class LQPTranslator {
   std::shared_ptr<AbstractOperator> _translate_limit_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_insert_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_delete_node(const std::shared_ptr<AbstractLQPNode>& node) const;
-  std::shared_ptr<AbstractOperator> _translate_dummy_table_node(const std::shared_ptr<AbstractLQPNode>& node) const;
+  std::shared_ptr<AbstractOperator> _translate_dummy_table_node(const std::shared_ptr<AbstractLQPNode>& /*node*/) const;
   std::shared_ptr<AbstractOperator> _translate_static_table_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_update_node(const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_union_node(const std::shared_ptr<AbstractLQPNode>& node) const;
-  std::shared_ptr<AbstractOperator> _translate_intersect_node(const std::shared_ptr<AbstractLQPNode>& node) const;
-  std::shared_ptr<AbstractOperator> _translate_except_node(const std::shared_ptr<AbstractLQPNode>& node) const;
+  std::shared_ptr<AbstractOperator> _translate_intersect_node(const std::shared_ptr<AbstractLQPNode>& /*node*/) const;
+  std::shared_ptr<AbstractOperator> _translate_except_node(const std::shared_ptr<AbstractLQPNode>& /*node*/) const;
   std::shared_ptr<AbstractOperator> _translate_change_meta_table_node(
       const std::shared_ptr<AbstractLQPNode>& node) const;
   std::shared_ptr<AbstractOperator> _translate_validate_node(const std::shared_ptr<AbstractLQPNode>& node) const;

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -78,7 +78,7 @@ const std::vector<ColumnID>& MockNode::pruned_column_ids() const {
   return _pruned_column_ids;
 }
 
-std::string MockNode::description(const DescriptionMode mode) const {
+std::string MockNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream stream;
   stream << "[MockNode '"s << name.value_or("Unnamed") << "'] Columns:";
 
@@ -159,7 +159,7 @@ size_t MockNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> MockNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> MockNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   const auto mock_node = MockNode::make(_column_definitions, name);
   mock_node->set_table_statistics(_table_statistics);
   mock_node->set_key_constraints(_table_key_constraints);
@@ -168,7 +168,7 @@ std::shared_ptr<AbstractLQPNode> MockNode::_on_shallow_copy(LQPNodeMapping& node
   return mock_node;
 }
 
-bool MockNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool MockNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& mock_node = static_cast<const MockNode&>(rhs);
 
   return _column_definitions == mock_node._column_definitions && _pruned_column_ids == mock_node._pruned_column_ids &&

--- a/src/lib/logical_query_plan/mock_node.hpp
+++ b/src/lib/logical_query_plan/mock_node.hpp
@@ -64,8 +64,8 @@ class MockNode : public EnableMakeForLQPNode<MockNode>, public AbstractLQPNode {
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 
  private:
   mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -11,7 +11,7 @@ namespace hyrise {
 StaticTableNode::StaticTableNode(const std::shared_ptr<Table>& init_table)
     : AbstractLQPNode(LQPNodeType::StaticTable), table(init_table) {}
 
-std::string StaticTableNode::description(const DescriptionMode mode) const {
+std::string StaticTableNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream stream;
 
   stream << "[StaticTable]:"
@@ -81,11 +81,11 @@ size_t StaticTableNode::_on_shallow_hash() const {
   return boost::hash_value(hash - soft_key_constraints.size());
 }
 
-std::shared_ptr<AbstractLQPNode> StaticTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> StaticTableNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return StaticTableNode::make(table);
 }
 
-bool StaticTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool StaticTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& static_table_node = static_cast<const StaticTableNode&>(rhs);
   return table->column_definitions() == static_table_node.table->column_definitions() &&
          table->soft_key_constraints() == static_table_node.table->soft_key_constraints();

--- a/src/lib/logical_query_plan/static_table_node.cpp
+++ b/src/lib/logical_query_plan/static_table_node.cpp
@@ -12,7 +12,7 @@ StaticTableNode::StaticTableNode(const std::shared_ptr<Table>& init_table)
     : AbstractLQPNode(LQPNodeType::StaticTable), table(init_table) {}
 
 std::string StaticTableNode::description(const DescriptionMode /*mode*/) const {
-  std::ostringstream stream;
+  auto stream = std::ostringstream{};
 
   stream << "[StaticTable]:"
          << " (";
@@ -38,9 +38,10 @@ std::vector<std::shared_ptr<AbstractExpression>> StaticTableNode::output_express
   // Need to initialize the expressions lazily because they will have a weak_ptr to this node and we can't obtain
   // that in the constructor
   if (!_output_expressions) {
-    _output_expressions.emplace(table->column_count());
+    const auto column_count = table->column_count();
+    _output_expressions.emplace(column_count);
 
-    for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {
+    for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
       (*_output_expressions)[column_id] = std::make_shared<LQPColumnExpression>(shared_from_this(), column_id);
     }
   }
@@ -68,7 +69,7 @@ bool StaticTableNode::is_column_nullable(const ColumnID column_id) const {
 }
 
 size_t StaticTableNode::_on_shallow_hash() const {
-  size_t hash{0};
+  auto hash = size_t{0};
   for (const auto& column_definition : table->column_definitions()) {
     boost::hash_combine(hash, column_definition.hash());
   }

--- a/src/lib/logical_query_plan/static_table_node.hpp
+++ b/src/lib/logical_query_plan/static_table_node.hpp
@@ -31,8 +31,8 @@ class StaticTableNode : public EnableMakeForLQPNode<StaticTableNode>, public Abs
   mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;
 
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -70,7 +70,7 @@ const std::vector<ColumnID>& StoredTableNode::pruned_column_ids() const {
   return _pruned_column_ids;
 }
 
-std::string StoredTableNode::description(const DescriptionMode mode) const {
+std::string StoredTableNode::description(const DescriptionMode /*mode*/) const {
   const auto stored_table = Hyrise::get().storage_manager.get_table(table_name);
 
   std::ostringstream stream;
@@ -187,14 +187,14 @@ size_t StoredTableNode::_on_shallow_hash() const {
   return hash;
 }
 
-std::shared_ptr<AbstractLQPNode> StoredTableNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> StoredTableNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   const auto copy = make(table_name);
   copy->set_pruned_chunk_ids(_pruned_chunk_ids);
   copy->set_pruned_column_ids(_pruned_column_ids);
   return copy;
 }
 
-bool StoredTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool StoredTableNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& stored_table_node = static_cast<const StoredTableNode&>(rhs);
   return table_name == stored_table_node.table_name && _pruned_chunk_ids == stored_table_node._pruned_chunk_ids &&
          _pruned_column_ids == stored_table_node._pruned_column_ids;

--- a/src/lib/logical_query_plan/stored_table_node.hpp
+++ b/src/lib/logical_query_plan/stored_table_node.hpp
@@ -54,8 +54,8 @@ class StoredTableNode : public EnableMakeForLQPNode<StoredTableNode>, public Abs
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 
  private:
   mutable std::optional<std::vector<std::shared_ptr<AbstractExpression>>> _output_expressions;

--- a/src/lib/logical_query_plan/union_node.cpp
+++ b/src/lib/logical_query_plan/union_node.cpp
@@ -13,7 +13,7 @@ namespace hyrise {
 UnionNode::UnionNode(const SetOperationMode init_set_operation_mode)
     : AbstractLQPNode(LQPNodeType::Union), set_operation_mode(init_set_operation_mode) {}
 
-std::string UnionNode::description(const DescriptionMode mode) const {
+std::string UnionNode::description(const DescriptionMode /*mode*/) const {
   return "[UnionNode] Mode: " + std::string{magic_enum::enum_name(set_operation_mode)};
 }
 
@@ -100,11 +100,11 @@ size_t UnionNode::_on_shallow_hash() const {
   return boost::hash_value(set_operation_mode);
 }
 
-std::shared_ptr<AbstractLQPNode> UnionNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> UnionNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return UnionNode::make(set_operation_mode);
 }
 
-bool UnionNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool UnionNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& union_node = static_cast<const UnionNode&>(rhs);
   return set_operation_mode == union_node.set_operation_mode;
 }

--- a/src/lib/logical_query_plan/union_node.hpp
+++ b/src/lib/logical_query_plan/union_node.hpp
@@ -40,7 +40,7 @@ class UnionNode : public EnableMakeForLQPNode<UnionNode>, public AbstractLQPNode
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/update_node.cpp
+++ b/src/lib/logical_query_plan/update_node.cpp
@@ -13,7 +13,7 @@ namespace hyrise {
 UpdateNode::UpdateNode(const std::string& init_table_name)
     : AbstractNonQueryNode(LQPNodeType::Update), table_name(init_table_name) {}
 
-std::string UpdateNode::description(const DescriptionMode mode) const {
+std::string UpdateNode::description(const DescriptionMode /*mode*/) const {
   std::ostringstream desc;
 
   desc << "[Update] Table: '" << table_name << "'";
@@ -21,11 +21,11 @@ std::string UpdateNode::description(const DescriptionMode mode) const {
   return desc.str();
 }
 
-std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> UpdateNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return UpdateNode::make(table_name);
 }
 
-bool UpdateNode::is_column_nullable(const ColumnID column_id) const {
+bool UpdateNode::is_column_nullable(const ColumnID /*column_id*/) const {
   Fail("Update does not output any colums");
 }
 
@@ -37,7 +37,7 @@ size_t UpdateNode::_on_shallow_hash() const {
   return boost::hash_value(table_name);
 }
 
-bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool UpdateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const {
   const auto& update_node_rhs = static_cast<const UpdateNode&>(rhs);
   return table_name == update_node_rhs.table_name;
 }

--- a/src/lib/logical_query_plan/update_node.hpp
+++ b/src/lib/logical_query_plan/update_node.hpp
@@ -18,15 +18,15 @@ class UpdateNode : public EnableMakeForLQPNode<UpdateNode>, public AbstractNonQu
   explicit UpdateNode(const std::string& init_table_name);
 
   std::string description(const DescriptionMode mode = DescriptionMode::Short) const override;
-  bool is_column_nullable(const ColumnID column_id) const override;
+  bool is_column_nullable(const ColumnID /*column_id*/) const override;
   std::vector<std::shared_ptr<AbstractExpression>> output_expressions() const override;
 
   const std::string table_name;
 
  protected:
   size_t _on_shallow_hash() const override;
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/logical_query_plan/validate_node.cpp
+++ b/src/lib/logical_query_plan/validate_node.cpp
@@ -6,7 +6,7 @@ namespace hyrise {
 
 ValidateNode::ValidateNode() : AbstractLQPNode(LQPNodeType::Validate) {}
 
-std::string ValidateNode::description(const DescriptionMode mode) const {
+std::string ValidateNode::description(const DescriptionMode /*mode*/) const {
   return "[Validate]";
 }
 
@@ -14,11 +14,11 @@ UniqueColumnCombinations ValidateNode::unique_column_combinations() const {
   return _forward_left_unique_column_combinations();
 }
 
-std::shared_ptr<AbstractLQPNode> ValidateNode::_on_shallow_copy(LQPNodeMapping& node_mapping) const {
+std::shared_ptr<AbstractLQPNode> ValidateNode::_on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const {
   return ValidateNode::make();
 }
 
-bool ValidateNode::_on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const {
+bool ValidateNode::_on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const {
   return true;
 }
 

--- a/src/lib/logical_query_plan/validate_node.hpp
+++ b/src/lib/logical_query_plan/validate_node.hpp
@@ -19,8 +19,8 @@ class ValidateNode : public EnableMakeForLQPNode<ValidateNode>, public AbstractL
   UniqueColumnCombinations unique_column_combinations() const override;
 
  protected:
-  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& node_mapping) const override;
-  bool _on_shallow_equals(const AbstractLQPNode& rhs, const LQPNodeMapping& node_mapping) const override;
+  std::shared_ptr<AbstractLQPNode> _on_shallow_copy(LQPNodeMapping& /*node_mapping*/) const override;
+  bool _on_shallow_equals(const AbstractLQPNode& /*rhs*/, const LQPNodeMapping& /*node_mapping*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/memory/boost_default_memory_resource.cpp
+++ b/src/lib/memory/boost_default_memory_resource.cpp
@@ -40,6 +40,7 @@ memory_resource* new_delete_resource() BOOST_NOEXCEPT {
   return get_default_resource();
 }
 
+// NOLINTNEXTLINE: lint.sh thinks thrre is a C-style cast in the next line.
 memory_resource* set_default_resource(memory_resource* /*resource*/) BOOST_NOEXCEPT {
   // Do nothing
   return get_default_resource();

--- a/src/lib/memory/boost_default_memory_resource.cpp
+++ b/src/lib/memory/boost_default_memory_resource.cpp
@@ -13,11 +13,11 @@ namespace boost::container::pmr {
 
 class default_resource_impl : public memory_resource {
  public:
-  void* do_allocate(std::size_t bytes, std::size_t alignment) override {
+  void* do_allocate(std::size_t bytes, std::size_t /*alignment*/) override {
     return std::malloc(bytes);
   }
 
-  void do_deallocate(void* pointer, std::size_t bytes, std::size_t alignment) override {
+  void do_deallocate(void* pointer, std::size_t /*bytes*/, std::size_t /*alignment*/) override {
     std::free(pointer);
   }
 
@@ -40,7 +40,7 @@ memory_resource* new_delete_resource() BOOST_NOEXCEPT {
   return get_default_resource();
 }
 
-memory_resource* set_default_resource(memory_resource* resource) BOOST_NOEXCEPT {
+memory_resource* set_default_resource(memory_resource* /*resource*/) BOOST_NOEXCEPT {
   // Do nothing
   return get_default_resource();
 }

--- a/src/lib/memory/boost_default_memory_resource.cpp
+++ b/src/lib/memory/boost_default_memory_resource.cpp
@@ -40,7 +40,7 @@ memory_resource* new_delete_resource() BOOST_NOEXCEPT {
   return get_default_resource();
 }
 
-// NOLINTNEXTLINE: lint.sh thinks thrre is a C-style cast in the next line.
+// NOLINTNEXTLINE: lint.sh thinks there is a C-style cast in the next line.
 memory_resource* set_default_resource(memory_resource* /*resource*/) BOOST_NOEXCEPT {
   // Do nothing
   return get_default_resource();

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -164,7 +164,7 @@ void AbstractOperator::execute() {
       const auto chunk_count = _output->chunk_count();
       const auto column_count = _output->column_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
-        for (auto column_id = ColumnID{0}; column_id < ; ++column_id) {
+        for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
           const auto& abstract_segment = _output->get_chunk(chunk_id)->get_segment(column_id);
           resolve_data_and_segment_type(*abstract_segment, [&](const auto data_type_t, const auto& segment) {
             using ColumnDataType = typename decltype(data_type_t)::type;

--- a/src/lib/operators/abstract_operator.cpp
+++ b/src/lib/operators/abstract_operator.cpp
@@ -85,7 +85,7 @@ void AbstractOperator::execute() {
     Assert(!_right_input || _right_input->get_output(), "Right input has no output data.");
   }
 
-  Timer performance_timer;
+  auto performance_timer = Timer{};
 
   auto transaction_context = this->transaction_context();
   if (transaction_context) {
@@ -161,8 +161,8 @@ void AbstractOperator::execute() {
     // Verify that nullability of columns and segments match for ValueSegments. Only ValueSegments have an individual
     // `is_nullable` attribute.
     if (_output && _output->type() == TableType::Data) {
-      const auto chunk_count = _output->chunk_count();
       const auto column_count = _output->column_count();
+      const auto chunk_count = _output->chunk_count();
       for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
         for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
           const auto& abstract_segment = _output->get_chunk(chunk_id)->get_segment(column_id);
@@ -408,7 +408,7 @@ void AbstractOperator::_search_and_register_uncorrelated_subqueries(
 
 std::ostream& operator<<(std::ostream& stream, const AbstractOperator& abstract_operator) {
   const auto get_children_fn = [](const auto& op) {
-    std::vector<std::shared_ptr<const AbstractOperator>> children;
+    auto children = std::vector<std::shared_ptr<const AbstractOperator>>{};
     if (op->left_input()) {
       children.emplace_back(op->left_input());
     }

--- a/src/lib/operators/abstract_operator.hpp
+++ b/src/lib/operators/abstract_operator.hpp
@@ -276,7 +276,7 @@ class AbstractOperator : public std::enable_shared_from_this<AbstractOperator>, 
 
   // State management
   std::atomic<OperatorState> _state{OperatorState::Created};
-  void _transition_to(OperatorState new_state);
+  void _transition_to(const OperatorState new_state);
 
   /**
    * OperatorTasks wrap operators for scheduling. Since operator results are shared between uncorrelated subqueries

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -8,17 +8,16 @@
 #include <utility>
 #include <vector>
 
+#include "tsl/robin_set.h"
+
 #include "aggregate/aggregate_traits.hpp"
 #include "expression/pqp_column_expression.hpp"
 #include "hyrise.hpp"
 #include "resolve_type.hpp"
 #include "scheduler/abstract_task.hpp"
 #include "scheduler/job_task.hpp"
-#include "storage/create_iterable_from_segment.hpp"
 #include "storage/segment_iterate.hpp"
-#include "utils/aligned_size.hpp"
 #include "utils/assert.hpp"
-#include "utils/performance_warning.hpp"
 #include "utils/timer.hpp"
 
 namespace {

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -217,7 +217,7 @@ __attribute__((hot)) void AggregateHash::_aggregate_segment(ChunkID chunk_id, Co
   auto& result_ids = *context.result_ids;
   auto& results = context.results;
 
-  ChunkOffset chunk_offset{0};
+  auto chunk_offset = ChunkOffset{0};
 
   // CacheResultIds is a boolean type parameter that is forwarded to get_or_add_result, see the documentation over there
   // for details.
@@ -614,7 +614,7 @@ void AggregateHash::_aggregate() {
 
   // Process Chunks and perform aggregations
   const auto chunk_count = input_table->chunk_count();
-  for (ChunkID chunk_id{0}; chunk_id < chunk_count; ++chunk_id) {
+  for (auto chunk_id = ChunkID{0}; chunk_id < chunk_count; ++chunk_id) {
     const auto chunk_in = input_table->get_chunk(chunk_id);
     if (!chunk_in) {
       continue;
@@ -646,7 +646,7 @@ void AggregateHash::_aggregate() {
       // Add value or combination of values is added to the list of distinct value(s). This is done by calling
       // get_or_add_result, which adds the corresponding entry in the list of GROUP BY values.
       if (_use_immediate_key_shortcut) {
-        for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
+        for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk_size; ++chunk_offset) {
           // We are able to use immediate keys, so pass true_type so that the combined caching/immediate key code path
           // is enabled in get_or_add_result.
           get_or_add_result(std::true_type{}, result_ids, results,
@@ -656,14 +656,14 @@ void AggregateHash::_aggregate() {
       } else {
         // Same as above, but we do not have immediate keys, so we disable that code path to reduce the complexity of
         // get_aggregate_key.
-        for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
+        for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk_size; ++chunk_offset) {
           get_or_add_result(std::false_type{}, result_ids, results,
                             get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
                             RowID{chunk_id, chunk_offset});
         }
       }
     } else {
-      ColumnID aggregate_idx{0};
+      auto aggregate_idx = ColumnID{0};
       for (const auto& aggregate : _aggregates) {
         /**
          * Special COUNT(*) implementation.
@@ -698,7 +698,7 @@ void AggregateHash::_aggregate() {
             // Count occurrences for each group key -  If we have more than one aggregate function (and thus more than
             // one context), it makes sense to cache the results indexes, see get_or_add_result for details.
             if (_contexts_per_column.size() > 1 || _use_immediate_key_shortcut) {
-              for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
+              for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk_size; ++chunk_offset) {
                 // Use CacheResultIds==true_type if we have more than one group by column or if the cached result ids
                 // have been written by the immediate key shortcut
                 auto& result =
@@ -708,7 +708,7 @@ void AggregateHash::_aggregate() {
                 ++result.aggregate_count;
               }
             } else {
-              for (ChunkOffset chunk_offset{0}; chunk_offset < input_chunk_size; chunk_offset++) {
+              for (auto chunk_offset = ChunkOffset{0}; chunk_offset < input_chunk_size; ++chunk_offset) {
                 auto& result =
                     get_or_add_result(std::false_type{}, result_ids, results,
                                       get_aggregate_key<AggregateKey>(keys_per_chunk, chunk_id, chunk_offset),
@@ -824,7 +824,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
   Write the aggregated columns to the output
   */
   const auto& input_table = left_input_table();
-  ColumnID aggregate_idx{0};
+  auto aggregate_idx = ColumnID{0};
   for (const auto& aggregate : _aggregates) {
     const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
     const auto input_column_id = pqp_column.column_id;
@@ -841,7 +841,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
   }
 
   // Write the output
-  Timer timer;
+  auto timer = Timer{};
   auto output = std::make_shared<Table>(_output_column_definitions, TableType::Data);
   if (_output_segments.at(0)->size() > 0) {
     output->append_chunk(_output_segments);
@@ -995,7 +995,7 @@ write_aggregate_values(pmr_vector<AggregateType>& values, pmr_vector<bool>& null
 }
 
 void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
-  Timer timer;
+  auto timer = Timer{};
   auto input_table = left_input_table();
 
   auto unaggregated_columns = std::vector<std::pair<ColumnID, ColumnID>>{};
@@ -1111,7 +1111,7 @@ void AggregateHash::write_aggregate_output(ColumnID aggregate_index) {
   // subtracted from the runtime of this method (thus, it's either non-zero for the first aggregate column or zero for
   // the remaining columns).
   auto excluded_time = std::chrono::nanoseconds{};
-  Timer timer;
+  auto timer = Timer{};
 
   // retrieve type information from the aggregation traits
   typename AggregateTraits<ColumnDataType, aggregate_function>::AggregateType aggregate_type;
@@ -1144,7 +1144,7 @@ void AggregateHash::write_aggregate_output(ColumnID aggregate_index) {
       }
       pos_list.emplace_back(result.row_id);
     }
-    Timer write_groupby_output_timer;
+    auto write_groupby_output_timer = Timer{};
     _write_groupby_output(pos_list);
     excluded_time = write_groupby_output_timer.lap();
   }

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include "tsl/robin_set.h"
+#include "tsl/robin_map.h"
 
 #include "aggregate/aggregate_traits.hpp"
 #include "expression/pqp_column_expression.hpp"
@@ -1029,10 +1029,11 @@ void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
 
       const auto column_is_nullable = input_table->column_is_nullable(input_column_id);
 
+      const auto pos_list_size = pos_list.size();
       auto values = pmr_vector<ColumnDataType>{};
-      values.reserve(pos_list.size());
+      values.reserve(pos_list_size);
       auto null_values = pmr_vector<bool>{};
-      null_values.reserve(column_is_nullable ? pos_list.size() : 0);
+      null_values.reserve(pos_list_size);
 
       auto accessors =
           std::vector<std::unique_ptr<AbstractSegmentAccessor<ColumnDataType>>>(input_table->chunk_count());

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -10,15 +10,15 @@
 #include <utility>
 #include <vector>
 
-#include <tsl/robin_map.h>  // NOLINT
-#include <tsl/robin_set.h>  // NOLINT
 #include <boost/container/pmr/monotonic_buffer_resource.hpp>
 #include <boost/container/pmr/polymorphic_allocator.hpp>
 #include <boost/container/scoped_allocator.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/container_hash/hash.hpp>
-#include <bytell_hash_map.hpp>
-#include <uninitialized_vector.hpp>
+
+#include "bytell_hash_map.hpp"
+#include "tsl/robin_set.h"
+#include "uninitialized_vector.hpp"
 
 #include "abstract_aggregate_operator.hpp"
 #include "abstract_read_only_operator.hpp"

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -400,7 +400,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
   }
 
   // Create aggregate column definitions
-  ColumnID aggregate_idx{0};
+  auto aggregate_idx = ColumnID{0};
   for (const auto& aggregate : _aggregates) {
     const auto& pqp_column = static_cast<const PQPColumnExpression&>(*aggregate->argument());
     const auto column_id = pqp_column.column_id;
@@ -452,7 +452,7 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
     return result_table;
   }
 
-  std::shared_ptr<const Table> sorted_table = input_table;
+  auto sorted_table = input_table;
   if (!_groupby_column_ids.empty()) {
     /**
     * If there is a value clustering for a column, it means that all tuples with the same value in that column are in
@@ -569,7 +569,8 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
       auto values = pmr_vector<ColumnDataType>(group_boundaries.size() + 1);
       auto null_values = pmr_vector<bool>(column_is_nullable ? group_boundaries.size() + 1 : 0);
 
-      for (size_t value_index = 0; value_index < values.size(); value_index++) {
+      const auto value_count = values.size();
+      for (size_t value_index = 0; value_index < value_count; ++value_index) {
         RowID group_start;
         if (value_index == 0) {
           // First group starts in the first row, but there is no corresponding entry in the set. See above for reasons.

--- a/src/lib/operators/aggregate_sort.cpp
+++ b/src/lib/operators/aggregate_sort.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<const Table> sort_table_by_column_ids(const std::shared_ptr<cons
   auto sort_definitions = std::vector<SortColumnDefinition>{};
   sort_definitions.reserve(column_ids.size());
   for (const auto& column_id : column_ids) {
-    sort_definitions.emplace_back(SortColumnDefinition{column_id, SortMode::Ascending});
+    sort_definitions.emplace_back(column_id, SortMode::Ascending);
   }
 
   const auto table_wrapper = std::make_shared<TableWrapper>(table_to_sort);
@@ -93,7 +93,7 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
 
   const auto chunk_count = sorted_table->chunk_count();
 
-  AggregateAccumulator<aggregate_function, AggregateType> accumulator{};
+  auto accumulator = AggregateAccumulator<aggregate_function, AggregateType>{};
   auto current_chunk_id = ChunkID{0};
   if (aggregate_function == AggregateFunction::Count && input_column_id == INVALID_COLUMN_ID) {
     /*
@@ -129,7 +129,7 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
     // Compute value count with null values for the last iteration
     value_count_with_null = sorted_table->get_chunk(current_group_begin_pointer.chunk_id)->size() -
                             current_group_begin_pointer.chunk_offset;
-    for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < chunk_count; chunk_id++) {
+    for (auto chunk_id = ChunkID{current_group_begin_pointer.chunk_id + 1}; chunk_id < chunk_count; ++chunk_id) {
       value_count_with_null += sorted_table->get_chunk(chunk_id)->size();
     }
 
@@ -165,18 +165,18 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
           // Reset helper variables
           accumulator = {};
           unique_values.clear();
-          value_count = 0u;
-          value_count_with_null = 0u;
+          value_count = 0;
+          value_count_with_null = 0;
 
           // Update indexing variables
-          aggregate_group_index++;
-          group_boundary_iter++;
+          ++aggregate_group_index;
+          ++group_boundary_iter;
         }
 
         // Update helper variables
         if (!position.is_null()) {
           aggregator(new_value, value_count, accumulator);
-          value_count++;
+          ++value_count;
           if constexpr (aggregate_function == AggregateFunction::CountDistinct) {
             unique_values.insert(new_value);
           } else if constexpr (aggregate_function == AggregateFunction::Any) {
@@ -184,9 +184,9 @@ void AggregateSort::_aggregate_values(const std::set<RowID>& group_boundaries, c
             return;
           }
         }
-        value_count_with_null++;
+        ++value_count_with_null;
       });
-      current_chunk_id++;
+      ++current_chunk_id;
     }
   }
   // Aggregate value for the last group was not written yet
@@ -291,7 +291,7 @@ void AggregateSort::_set_and_write_aggregate_value(
 
 Segments AggregateSort::_get_segments_of_chunk(const std::shared_ptr<const Table>& input_table,
                                                const ChunkID chunk_id) {
-  Segments segments{};
+  auto segments = Segments{};
   const auto column_count = input_table->column_count();
   segments.reserve(column_count);
   const auto chunk = input_table->get_chunk(chunk_id);
@@ -346,7 +346,7 @@ std::shared_ptr<Table> AggregateSort::_sort_table_chunk_wise(const std::shared_p
     } else {
       // Creating a new table holding only the current chunk and pass it to the sort operator.
       auto single_chunk_table = std::make_shared<Table>(input_table->column_definitions(), input_table->type());
-      Segments segments;
+      auto segments = Segments{};
       segments.reserve(column_count);
       for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
         segments.emplace_back(chunk->get_segment(column_id));
@@ -712,8 +712,8 @@ std::shared_ptr<const Table> AggregateSort::_on_execute() {
 
 std::shared_ptr<AbstractOperator> AggregateSort::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<AggregateSort>(copied_left_input, _aggregates, _groupby_column_ids);
 }
 
@@ -722,7 +722,7 @@ void AggregateSort::_on_set_parameters(const std::unordered_map<ParameterID, All
 void AggregateSort::_on_cleanup() {}
 
 template <typename ColumnType>
-void AggregateSort::_create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> type,
+void AggregateSort::_create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/,
                                                          ColumnID column_index, AggregateFunction aggregate_function) {
   /*
    * We are aware that the switch looks very repetitive, but we could not find a dynamic solution.

--- a/src/lib/operators/aggregate_sort.hpp
+++ b/src/lib/operators/aggregate_sort.hpp
@@ -88,8 +88,8 @@ class AggregateSort : public AbstractAggregateOperator {
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
@@ -103,7 +103,7 @@ class AggregateSort : public AbstractAggregateOperator {
                          const std::shared_ptr<const Table>& sorted_table);
 
   template <typename ColumnType>
-  void _create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> type, ColumnID column_index,
+  void _create_aggregate_column_definitions(boost::hana::basic_type<ColumnType> /*type*/, ColumnID column_index,
                                             AggregateFunction aggregate_function);
 
   /*

--- a/src/lib/operators/alias_operator.cpp
+++ b/src/lib/operators/alias_operator.cpp
@@ -32,8 +32,8 @@ std::string AliasOperator::description(DescriptionMode description_mode) const {
 
 std::shared_ptr<AbstractOperator> AliasOperator::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<AliasOperator>(copied_left_input, _column_ids, _aliases);
 }
 
@@ -92,7 +92,7 @@ std::shared_ptr<const Table> AliasOperator::_on_execute() {
             std::find_if(input_sorted_by.cbegin(), input_sorted_by.cend(),
                          [&](const auto& sorted_information) { return column_id == sorted_information.column; });
         if (it != input_sorted_by.cend()) {
-          sort_definitions.emplace_back(SortColumnDefinition(output_column_id, it->sort_mode));
+          sort_definitions.emplace_back(output_column_id, it->sort_mode);
         }
       }
       Assert(input_sorted_by.size() == sort_definitions.size(),

--- a/src/lib/operators/alias_operator.hpp
+++ b/src/lib/operators/alias_operator.hpp
@@ -19,8 +19,8 @@ class AliasOperator : public AbstractReadOnlyOperator {
  protected:
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/lib/operators/change_meta_table.cpp
+++ b/src/lib/operators/change_meta_table.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<const Table> ChangeMetaTable::_on_execute(std::shared_ptr<Transa
 std::shared_ptr<AbstractOperator> ChangeMetaTable::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<ChangeMetaTable>(_meta_table_name, _change_type, copied_left_input, copied_right_input);
 }
 

--- a/src/lib/operators/change_meta_table.hpp
+++ b/src/lib/operators/change_meta_table.hpp
@@ -38,7 +38,7 @@ class ChangeMetaTable : public AbstractReadWriteOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   void _on_commit_records(const CommitID cid) override {}

--- a/src/lib/operators/delete.cpp
+++ b/src/lib/operators/delete.cpp
@@ -136,8 +136,8 @@ void Delete::_on_rollback_records() {
 
 std::shared_ptr<AbstractOperator> Delete::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Delete>(copied_left_input);
 }
 

--- a/src/lib/operators/delete.hpp
+++ b/src/lib/operators/delete.hpp
@@ -24,8 +24,8 @@ class Delete : public AbstractReadWriteOperator {
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
   void _on_commit_records(const CommitID commit_id) override;
   void _on_rollback_records() override;

--- a/src/lib/operators/difference.cpp
+++ b/src/lib/operators/difference.cpp
@@ -28,7 +28,7 @@ const std::string& Difference::name() const {
 std::shared_ptr<AbstractOperator> Difference::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Difference>(copied_left_input, copied_right_input);
 }
 

--- a/src/lib/operators/difference.hpp
+++ b/src/lib/operators/difference.hpp
@@ -26,7 +26,7 @@ class Difference : public AbstractReadOnlyOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
  private:

--- a/src/lib/operators/export.cpp
+++ b/src/lib/operators/export.cpp
@@ -55,8 +55,8 @@ std::shared_ptr<const Table> Export::_on_execute() {
 
 std::shared_ptr<AbstractOperator> Export::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Export>(copied_left_input, _filename, _file_type);
 }
 

--- a/src/lib/operators/export.hpp
+++ b/src/lib/operators/export.hpp
@@ -42,8 +42,8 @@ class Export : public AbstractReadOnlyOperator {
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
  private:

--- a/src/lib/operators/get_table.cpp
+++ b/src/lib/operators/get_table.cpp
@@ -69,9 +69,9 @@ const std::vector<ColumnID>& GetTable::pruned_column_ids() const {
 }
 
 std::shared_ptr<AbstractOperator> GetTable::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<GetTable>(_name, _pruned_chunk_ids, _pruned_column_ids);
 }
 

--- a/src/lib/operators/get_table.hpp
+++ b/src/lib/operators/get_table.hpp
@@ -35,9 +35,9 @@ class GetTable : public AbstractReadOnlyOperator {
   const std::vector<ColumnID>& pruned_column_ids() const;
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
  protected:

--- a/src/lib/operators/import.cpp
+++ b/src/lib/operators/import.cpp
@@ -61,9 +61,9 @@ std::shared_ptr<const Table> Import::_on_execute() {
 }
 
 std::shared_ptr<AbstractOperator> Import::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Import>(filename, _tablename, _chunk_size, _file_type, _csv_meta);
 }
 

--- a/src/lib/operators/import.hpp
+++ b/src/lib/operators/import.hpp
@@ -37,9 +37,9 @@ class Import : public AbstractReadOnlyOperator {
  protected:
   std::shared_ptr<const Table> _on_execute() final;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -52,7 +52,7 @@ std::shared_ptr<const Table> IndexScan::_on_execute() {
     }
   } else {
     jobs.reserve(included_chunk_ids.size());
-    for (auto chunk_id : included_chunk_ids) {
+    for (const auto chunk_id : included_chunk_ids) {
       if (_in_table->get_chunk(chunk_id)) {
         jobs.push_back(_create_job(chunk_id, output_mutex));
       }
@@ -66,8 +66,8 @@ std::shared_ptr<const Table> IndexScan::_on_execute() {
 
 std::shared_ptr<AbstractOperator> IndexScan::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<IndexScan>(copied_left_input, _index_type, _left_column_ids, _predicate_condition,
                                      _right_values, _right_values2);
 }
@@ -88,13 +88,13 @@ std::shared_ptr<AbstractTask> IndexScan::_create_job(const ChunkID chunk_id, std
     }
 
     Segments segments;
-
-    for (ColumnID column_id{0u}; column_id < _in_table->column_count(); ++column_id) {
+    const auto column_count = _in_table->column_count();
+    for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
       auto ref_segment_out = std::make_shared<ReferenceSegment>(_in_table, column_id, matches_out);
       segments.push_back(ref_segment_out);
     }
 
-    std::lock_guard<std::mutex> lock(output_mutex);
+    const auto lock = std::lock_guard<std::mutex>{output_mutex};
     _out_table->append_chunk(segments, nullptr, chunk->get_allocator());
   });
 
@@ -199,7 +199,7 @@ RowIDPosList IndexScan::_scan_chunk(const ChunkID chunk_id) {
 
   for (auto matches_position = current_matches_size; matches_position < final_matches_size; ++matches_position) {
     matches_out[matches_position] = RowID{chunk_id, *range_begin};
-    range_begin++;
+    ++range_begin;
   }
 
   return matches_out;

--- a/src/lib/operators/index_scan.cpp
+++ b/src/lib/operators/index_scan.cpp
@@ -87,7 +87,7 @@ std::shared_ptr<AbstractTask> IndexScan::_create_job(const ChunkID chunk_id, std
       return;
     }
 
-    Segments segments;
+    auto segments = Segments{};
     const auto column_count = _in_table->column_count();
     for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
       auto ref_segment_out = std::make_shared<ReferenceSegment>(_in_table, column_id, matches_out);

--- a/src/lib/operators/index_scan.hpp
+++ b/src/lib/operators/index_scan.hpp
@@ -35,8 +35,8 @@ class IndexScan : public AbstractReadOnlyOperator {
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   void _validate_input();

--- a/src/lib/operators/insert.cpp
+++ b/src/lib/operators/insert.cpp
@@ -50,7 +50,7 @@ void copy_value_range(const std::shared_ptr<const AbstractSegment>& source_abstr
       }
     }
   } else {
-    segment_with_iterators<T>(*source_abstract_segment, [&](const auto source_begin, const auto source_end) {
+    segment_with_iterators<T>(*source_abstract_segment, [&](const auto source_begin, const auto /*source_end*/) {
       auto source_iter = source_begin + source_begin_offset;
       auto target_iter = target_values.begin() + target_begin_offset;
 
@@ -280,8 +280,8 @@ void Insert::_on_rollback_records() {
 
 std::shared_ptr<AbstractOperator> Insert::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Insert>(_target_table_name, copied_left_input);
 }
 

--- a/src/lib/operators/insert.hpp
+++ b/src/lib/operators/insert.hpp
@@ -30,8 +30,8 @@ class Insert : public AbstractReadWriteOperator {
   std::shared_ptr<const Table> _on_execute(std::shared_ptr<TransactionContext> context) override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
   void _on_commit_records(const CommitID cid) override;
   void _on_rollback_records() override;

--- a/src/lib/operators/join_hash/join_hash_steps.hpp
+++ b/src/lib/operators/join_hash/join_hash_steps.hpp
@@ -408,7 +408,7 @@ RadixContainer<T> materialize_input(const std::shared_ptr<const Table>& in_table
 
       if (Hyrise::get().is_multi_threaded()) {
         // Merge the local_output_bloom_filter into output_bloom_filter
-        std::lock_guard<std::mutex> lock{output_bloom_filter_mutex};
+        const auto lock = std::lock_guard<std::mutex>{output_bloom_filter_mutex};
         output_bloom_filter |= local_output_bloom_filter;
       }
     };

--- a/src/lib/operators/join_index.hpp
+++ b/src/lib/operators/join_index.hpp
@@ -59,7 +59,7 @@ class JoinIndex : public AbstractJoinOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
   void _fallback_nested_loop(const ChunkID index_chunk_id, const bool track_probe_matches,
                              const bool track_index_matches, const bool is_semi_or_anti_join,

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -72,7 +72,7 @@ join_two_typed_segments(const BinaryFunctor& func, LeftIterator left_it, LeftIte
 
 namespace hyrise {
 
-bool JoinNestedLoop::supports(const JoinConfiguration config) {
+bool JoinNestedLoop::supports(const JoinConfiguration /*config*/) {
   return true;
 }
 
@@ -92,7 +92,7 @@ const std::string& JoinNestedLoop::name() const {
 std::shared_ptr<AbstractOperator> JoinNestedLoop::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<JoinNestedLoop>(copied_left_input, copied_right_input, _mode, _primary_predicate,
                                           _secondary_predicates);
 }

--- a/src/lib/operators/join_nested_loop.cpp
+++ b/src/lib/operators/join_nested_loop.cpp
@@ -233,7 +233,7 @@ std::shared_ptr<const Table> JoinNestedLoop::_on_execute() {
   }
 
   // Write output Chunk based on the PosList(s) we created during the Join
-  Segments segments;
+  auto segments = Segments{};
 
   if (semi_or_anti_join) {
     _write_output_chunk(segments, left_table, pos_list_left);

--- a/src/lib/operators/join_nested_loop.hpp
+++ b/src/lib/operators/join_nested_loop.hpp
@@ -17,7 +17,7 @@ class JoinIndex;
 
 class JoinNestedLoop : public AbstractJoinOperator {
  public:
-  static bool supports(const JoinConfiguration config);
+  static bool supports(const JoinConfiguration /*config*/);
 
   JoinNestedLoop(const std::shared_ptr<const AbstractOperator>& left,
                  const std::shared_ptr<const AbstractOperator>& right, const JoinMode mode,
@@ -45,7 +45,7 @@ class JoinNestedLoop : public AbstractJoinOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   std::shared_ptr<const Table> _on_execute() override;

--- a/src/lib/operators/join_sort_merge.cpp
+++ b/src/lib/operators/join_sort_merge.cpp
@@ -50,7 +50,7 @@ JoinSortMerge::JoinSortMerge(const std::shared_ptr<const AbstractOperator>& left
 std::shared_ptr<AbstractOperator> JoinSortMerge::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<JoinSortMerge>(copied_left_input, copied_right_input, _mode, _primary_predicate,
                                          _secondary_predicates);
 }
@@ -546,8 +546,8 @@ class JoinSortMerge::JoinSortMergeImpl : public AbstractReadOnlyOperatorImpl {
 
       const auto compare_result = _compare(left_value, right_value);
 
-      TableRange left_run(cluster_id, left_run_start, left_run_end);
-      TableRange right_run(cluster_id, right_run_start, right_run_end);
+      const auto left_run = TableRange(cluster_id, left_run_start, left_run_end);
+      const auto right_run = TableRange(cluster_id, right_run_start, right_run_end);
       _join_runs(left_run, right_run, compare_result, multi_predicate_join_evaluator, cluster_id);
 
       // Advance to the next run on the smaller side or both if equal

--- a/src/lib/operators/join_sort_merge.hpp
+++ b/src/lib/operators/join_sort_merge.hpp
@@ -54,7 +54,7 @@ class JoinSortMerge : public AbstractJoinOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   template <typename T>

--- a/src/lib/operators/join_verification.cpp
+++ b/src/lib/operators/join_verification.cpp
@@ -110,7 +110,7 @@ std::shared_ptr<const Table> JoinVerification::_on_execute() {
         }
       }
 
-      // Add tuples without matches to output table      
+      // Add tuples without matches to output table.
       for (auto left_tuple_idx = size_t{0}; left_tuple_idx < left_row_count; ++left_tuple_idx) {
         if (!left_matches[left_tuple_idx]) {
           output_table->append(concatenate(left_tuples[left_tuple_idx], null_tuple_right));

--- a/src/lib/operators/join_verification.hpp
+++ b/src/lib/operators/join_verification.hpp
@@ -11,7 +11,7 @@ namespace hyrise {
  */
 class JoinVerification : public AbstractJoinOperator {
  public:
-  static bool supports(const JoinConfiguration config);
+  static bool supports(const JoinConfiguration /*config*/);
 
   using Tuple = std::vector<AllTypeVariant>;
 
@@ -28,7 +28,7 @@ class JoinVerification : public AbstractJoinOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 

--- a/src/lib/operators/limit.cpp
+++ b/src/lib/operators/limit.cpp
@@ -28,7 +28,7 @@ std::shared_ptr<AbstractExpression> Limit::row_count_expression() const {
 
 std::shared_ptr<AbstractOperator> Limit::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
     std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
   return std::make_shared<Limit>(copied_left_input, _row_count_expression->deep_copy(copied_ops));
 }

--- a/src/lib/operators/limit.cpp
+++ b/src/lib/operators/limit.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<const Table> Limit::_on_execute() {
 
   auto chunk_id = ChunkID{0};
   const auto chunk_count = input_table->chunk_count();
-  for (size_t index = 0; index < num_rows && chunk_id < chunk_count; ++chunk_id) {
+  for (auto index = size_t{0}; index < num_rows && chunk_id < chunk_count; ++chunk_id) {
     const auto input_chunk = input_table->get_chunk(chunk_id);
     Assert(input_chunk, "Physically deleted chunk should not reach this point, see get_chunk / #1686.");
 
@@ -91,7 +91,7 @@ std::shared_ptr<const Table> Limit::_on_execute() {
       } else {
         referenced_table = input_table;
         for (auto chunk_offset = ChunkOffset{0}; chunk_offset < static_cast<ChunkOffset>(output_chunk_row_count);
-             chunk_offset++) {
+             ++chunk_offset) {
           (*output_pos_list)[chunk_offset] = RowID{chunk_id, chunk_offset};
         }
       }

--- a/src/lib/operators/limit.hpp
+++ b/src/lib/operators/limit.hpp
@@ -22,7 +22,7 @@ class Limit : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
       std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 

--- a/src/lib/operators/maintenance/create_prepared_plan.cpp
+++ b/src/lib/operators/maintenance/create_prepared_plan.cpp
@@ -41,9 +41,9 @@ std::shared_ptr<const Table> CreatePreparedPlan::_on_execute() {
 void CreatePreparedPlan::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
 std::shared_ptr<AbstractOperator> CreatePreparedPlan::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<CreatePreparedPlan>(_prepared_plan_name, _prepared_plan->deep_copy());
 }
 

--- a/src/lib/operators/maintenance/create_prepared_plan.hpp
+++ b/src/lib/operators/maintenance/create_prepared_plan.hpp
@@ -21,9 +21,9 @@ class CreatePreparedPlan : public AbstractReadOnlyOperator {
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
  private:
   const std::string _prepared_plan_name;

--- a/src/lib/operators/maintenance/create_table.cpp
+++ b/src/lib/operators/maintenance/create_table.cpp
@@ -84,8 +84,8 @@ std::shared_ptr<const Table> CreateTable::_on_execute(std::shared_ptr<Transactio
 
 std::shared_ptr<AbstractOperator> CreateTable::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<CreateTable>(table_name, if_not_exists, copied_left_input);
 }
 

--- a/src/lib/operators/maintenance/create_table.hpp
+++ b/src/lib/operators/maintenance/create_table.hpp
@@ -24,8 +24,8 @@ class CreateTable : public AbstractReadWriteOperator {
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 

--- a/src/lib/operators/maintenance/create_view.cpp
+++ b/src/lib/operators/maintenance/create_view.cpp
@@ -30,9 +30,9 @@ bool CreateView::if_not_exists() const {
 }
 
 std::shared_ptr<AbstractOperator> CreateView::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<CreateView>(_view_name, _view->deep_copy(), _if_not_exists);
 }
 

--- a/src/lib/operators/maintenance/create_view.hpp
+++ b/src/lib/operators/maintenance/create_view.hpp
@@ -24,9 +24,9 @@ class CreateView : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
  private:

--- a/src/lib/operators/maintenance/drop_table.cpp
+++ b/src/lib/operators/maintenance/drop_table.cpp
@@ -26,9 +26,9 @@ std::shared_ptr<const Table> DropTable::_on_execute() {
 }
 
 std::shared_ptr<AbstractOperator> DropTable::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<DropTable>(table_name, if_exists);
 }
 

--- a/src/lib/operators/maintenance/drop_table.hpp
+++ b/src/lib/operators/maintenance/drop_table.hpp
@@ -19,9 +19,9 @@ class DropTable : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
 
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 };

--- a/src/lib/operators/maintenance/drop_view.cpp
+++ b/src/lib/operators/maintenance/drop_view.cpp
@@ -18,9 +18,9 @@ const std::string& DropView::name() const {
 }
 
 std::shared_ptr<AbstractOperator> DropView::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<DropView>(view_name, if_exists);
 }
 

--- a/src/lib/operators/maintenance/drop_view.hpp
+++ b/src/lib/operators/maintenance/drop_view.hpp
@@ -22,9 +22,9 @@ class DropView : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 };
 }  // namespace hyrise

--- a/src/lib/operators/print.cpp
+++ b/src/lib/operators/print.cpp
@@ -43,8 +43,8 @@ const std::string& Print::name() const {
 
 std::shared_ptr<AbstractOperator> Print::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Print>(copied_left_input, _flags, _out);
 }
 
@@ -187,7 +187,6 @@ std::vector<uint16_t> Print::_column_string_widths(uint16_t min, uint16_t max,
       continue;
     }
 
-    const auto column_count = chunk->column_count();
     for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
       const auto chunk_size = chunk->size();
       for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
@@ -211,8 +210,8 @@ std::string Print::_truncate_cell(const AllTypeVariant& cell, uint16_t max_width
 }
 
 std::string Print::_segment_type(const std::shared_ptr<AbstractSegment>& segment) {
-  std::string segment_type;
-  segment_type.reserve(8);
+  auto segment_type = std::string{};
+  segment_type.reserve(10);
   segment_type += "<";
 
   if (std::dynamic_pointer_cast<BaseValueSegment>(segment)) {

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -14,7 +14,9 @@ namespace hyrise {
  * PrintFlags::IgnoreChunkBoundaries:  If set, print a logical view of the Table, i.e., do not print info about Chunks or
  *                              Segment types.
  */
-enum class PrintFlags : uint32_t { None = 0u, Mvcc = 1u << 0u, IgnoreChunkBoundaries = 1u << 1u };
+enum class PrintFlags : uint32_t { None = uint32_t{0},
+                                   Mvcc = uint32_t{1} << 0,
+                                   IgnoreChunkBoundaries = uint32_t{1} << 1 };
 
 /**
  * operator to print the table with its data
@@ -42,8 +44,8 @@ class Print : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   PrintFlags _flags;

--- a/src/lib/operators/print.hpp
+++ b/src/lib/operators/print.hpp
@@ -14,9 +14,11 @@ namespace hyrise {
  * PrintFlags::IgnoreChunkBoundaries:  If set, print a logical view of the Table, i.e., do not print info about Chunks or
  *                              Segment types.
  */
-enum class PrintFlags : uint32_t { None = uint32_t{0},
-                                   Mvcc = uint32_t{1} << 0,
-                                   IgnoreChunkBoundaries = uint32_t{1} << 1 };
+enum class PrintFlags : uint32_t {
+  None = uint32_t{0},
+  Mvcc = uint32_t{1} << 0,
+  IgnoreChunkBoundaries = uint32_t{1} << 1
+};
 
 /**
  * operator to print the table with its data

--- a/src/lib/operators/product.cpp
+++ b/src/lib/operators/product.cpp
@@ -128,7 +128,7 @@ void Product::_add_product_of_two_chunks(const std::shared_ptr<Table>& output, C
 std::shared_ptr<AbstractOperator> Product::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Product>(copied_left_input, copied_right_input);
 }
 

--- a/src/lib/operators/product.hpp
+++ b/src/lib/operators/product.hpp
@@ -28,7 +28,7 @@ class Product : public AbstractReadOnlyOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 };
 }  // namespace hyrise

--- a/src/lib/operators/projection.hpp
+++ b/src/lib/operators/projection.hpp
@@ -56,7 +56,7 @@ class Projection : public AbstractReadOnlyOperator {
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
       std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
 
   ExpressionUnorderedSet _determine_forwarded_columns(const TableType table_type) const;

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -29,12 +29,13 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
   Assert(pos_list.size() == unsorted_table->row_count(), "Mismatching size of input table and PosList");
 
   // Vector of segments for each chunk
-  std::vector<Segments> output_segments_by_chunk(output_chunk_count);
+  auto output_segments_by_chunk = std::vector<Segments>(output_chunk_count);
 
   // Materialize column by column, starting a new ValueSegment whenever output_chunk_size is reached
   const auto input_chunk_count = unsorted_table->chunk_count();
+  const auto output_column_count = unsorted_table->column_count();
   const auto row_count = unsorted_table->row_count();
-  for (ColumnID column_id{0u}; column_id < output->column_count(); ++column_id) {
+  for (auto column_id = ColumnID{0}; column_id < output_column_count; ++column_id) {
     const auto column_data_type = output->column_data_type(column_id);
     const auto column_is_nullable = unsorted_table->column_is_nullable(column_id);
 
@@ -42,10 +43,10 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
       using ColumnDataType = typename decltype(type)::type;
 
       auto chunk_it = output_segments_by_chunk.begin();
-      auto current_segment_size = 0u;
+      auto current_segment_size = size_t{0};
 
-      auto value_segment_value_vector = pmr_vector<ColumnDataType>();
-      auto value_segment_null_vector = pmr_vector<bool>();
+      auto value_segment_value_vector = pmr_vector<ColumnDataType>{};
+      auto value_segment_null_vector = pmr_vector<bool>{};
 
       {
         const auto next_chunk_size = std::min(static_cast<size_t>(output_chunk_size), static_cast<size_t>(row_count));
@@ -77,7 +78,7 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
 
         // Check if value segment is full
         if (current_segment_size >= output_chunk_size) {
-          current_segment_size = 0u;
+          current_segment_size = 0;
 
           std::shared_ptr<ValueSegment<ColumnDataType>> value_segment;
           if (column_is_nullable) {
@@ -88,8 +89,8 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
           }
 
           chunk_it->push_back(value_segment);
-          value_segment_value_vector = pmr_vector<ColumnDataType>();
-          value_segment_null_vector = pmr_vector<bool>();
+          value_segment_value_vector = pmr_vector<ColumnDataType>{};
+          value_segment_null_vector = pmr_vector<bool>{};
 
           const auto next_chunk_size =
               std::min(static_cast<size_t>(output_chunk_size), static_cast<size_t>(row_count - row_index));
@@ -103,7 +104,7 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
       }
 
       // Last segment has not been added
-      if (current_segment_size > 0u) {
+      if (current_segment_size > 0) {
         std::shared_ptr<ValueSegment<ColumnDataType>> value_segment;
         if (column_is_nullable) {
           value_segment = std::make_shared<ValueSegment<ColumnDataType>>(std::move(value_segment_value_vector),
@@ -150,11 +151,11 @@ std::shared_ptr<Table> write_reference_output_table(const std::shared_ptr<const 
     // Shortcut: No need to copy RowIDs if input_pos_list is small enough and we do not need to resolve the indirection.
     const auto output_pos_list = std::make_shared<RowIDPosList>(std::move(input_pos_list));
     auto& output_segments = output_segments_by_chunk.at(0);
-    for (auto column_id = ColumnID{0u}; column_id < column_count; ++column_id) {
+    for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
       output_segments[column_id] = std::make_shared<ReferenceSegment>(unsorted_table, column_id, output_pos_list);
     }
   } else {
-    for (ColumnID column_id{0u}; column_id < column_count; ++column_id) {
+    for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
       // To keep the implementation simple, we write the output ReferenceSegments column by column. This means that even
       // if input ReferenceSegments share a PosList, the output will contain independent PosLists. While this is
       // slightly more expensive to generate and slightly less efficient for following operators, we assume that the
@@ -250,8 +251,8 @@ const std::string& Sort::name() const {
 
 std::shared_ptr<AbstractOperator> Sort::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Sort>(copied_left_input, _sort_definitions, _output_chunk_size, _force_materialization);
 }
 

--- a/src/lib/operators/sort.cpp
+++ b/src/lib/operators/sort.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<Table> write_materialized_output_table(const std::shared_ptr<con
   Assert(pos_list.size() == unsorted_table->row_count(), "Mismatching size of input table and PosList");
 
   // Vector of segments for each chunk
-  auto output_segments_by_chunk = std::vector<Segments>(output_chunk_count);
+  auto output_segments_by_chunk = std::vector<Segments>{output_chunk_count};
 
   // Materialize column by column, starting a new ValueSegment whenever output_chunk_size is reached
   const auto input_chunk_count = unsorted_table->chunk_count();

--- a/src/lib/operators/sort.hpp
+++ b/src/lib/operators/sort.hpp
@@ -38,8 +38,8 @@ class Sort : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   template <typename SortColumnType>

--- a/src/lib/operators/table_scan.cpp
+++ b/src/lib/operators/table_scan.cpp
@@ -81,7 +81,7 @@ void TableScan::_on_set_parameters(const std::unordered_map<ParameterID, AllType
 
 std::shared_ptr<AbstractOperator> TableScan::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
     std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
   return std::make_shared<TableScan>(copied_left_input, _predicate->deep_copy(copied_ops));
 }
@@ -278,7 +278,7 @@ std::shared_ptr<const AbstractExpression> TableScan::_resolve_uncorrelated_subqu
       });
     }
 
-    new_arguments.emplace_back(value_(std::move(subquery_result)));
+    new_arguments.emplace_back(value_(subquery_result));
     ++computed_subqueries_count;
   }
   DebugAssert(new_arguments.size() == predicate->arguments.size(), "Unexpected number of arguments.");

--- a/src/lib/operators/table_scan.hpp
+++ b/src/lib/operators/table_scan.hpp
@@ -72,7 +72,7 @@ class TableScan : public AbstractReadOnlyOperator {
 
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
       std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
 
   void _on_set_transaction_context(const std::weak_ptr<TransactionContext>& transaction_context) override;

--- a/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_between_table_scan_impl.cpp
@@ -42,12 +42,12 @@ void ColumnBetweenTableScanImpl::_scan_non_reference_segment(
   const auto& chunk_sorted_by = _in_table->get_chunk(chunk_id)->individually_sorted_by();
 
   // Check if a sorted scan is possible for the current predicate. Do not use the sorted search for predicates on
-  // pre-filtered dictionary segments with string data. In this case, the optimized _scan_dictionary_segment() path if
+  // pre-filtered dictionary segments with string data. In this case, the optimized _scan_dictionary_segment() path is
   // faster than the sorted search. Without this workaround, TPC-H Q6 would lose up to 30%. When the iterator issues of
   // #1531 are resolved, the current workaround should be revisited.
   const auto* dictionary_segment = dynamic_cast<const BaseDictionarySegment*>(&segment);
   if (!chunk_sorted_by.empty() &&
-      !(dictionary_segment && position_filter && _in_table->column_data_type(_column_id) == DataType::String)) {
+      (!dictionary_segment || !position_filter || _in_table->column_data_type(_column_id) != DataType::String)) {
     for (const auto& sorted_by : chunk_sorted_by) {
       if (sorted_by.column == _column_id) {
         _scan_sorted_segment(segment, chunk_id, matches, position_filter, sorted_by.sort_mode);

--- a/src/lib/operators/table_scan/column_is_null_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_is_null_table_scan_impl.cpp
@@ -147,7 +147,7 @@ bool ColumnIsNullTableScanImpl::_matches_none(const BaseValueSegment& segment) c
 void ColumnIsNullTableScanImpl::_add_all(const ChunkID chunk_id, RowIDPosList& matches, const size_t segment_size) {
   const auto num_rows = segment_size;
   for (auto chunk_offset = ChunkOffset{0}; chunk_offset < num_rows; ++chunk_offset) {
-    matches.emplace_back(RowID{chunk_id, chunk_offset});
+    matches.emplace_back(chunk_id, chunk_offset);
   }
 }
 

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<RowIDPosList> ColumnVsColumnTableScanImpl::scan_chunk(ChunkID ch
   const auto left_segment = chunk->get_segment(_left_column_id);
   const auto right_segment = chunk->get_segment(_right_column_id);
 
-  std::shared_ptr<RowIDPosList> result;
+  auto result = std::shared_ptr<RowIDPosList>{};
 
   /**
    * Reducing the compile time:
@@ -146,7 +146,7 @@ ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterators(ChunkID chunk_id, 
                                                               const RightIterator& right_end) const {
   auto matches_out = std::make_shared<RowIDPosList>();
 
-  bool condition_was_flipped = false;
+  auto condition_was_flipped = false;
   auto maybe_flipped_condition = _predicate_condition;
   if (maybe_flipped_condition == PredicateCondition::GreaterThan ||
       maybe_flipped_condition == PredicateCondition::GreaterThanEquals) {
@@ -154,7 +154,7 @@ ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterators(ChunkID chunk_id, 
     condition_was_flipped = true;
   }
 
-  auto conditionally_erase_comparator_type = [](auto comparator, const auto& it1, const auto& it2) {
+  auto conditionally_erase_comparator_type = [](auto comparator, const auto& /*it1*/, const auto& /*it2*/) {
     if constexpr (erase_comparator_type == EraseTypes::OnlyInDebugBuild) {
       return comparator;
     } else {

--- a/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
+++ b/src/lib/operators/table_scan/column_vs_column_table_scan_impl.cpp
@@ -154,7 +154,8 @@ ColumnVsColumnTableScanImpl::_typed_scan_chunk_with_iterators(ChunkID chunk_id, 
     condition_was_flipped = true;
   }
 
-  auto conditionally_erase_comparator_type = [](auto comparator, const auto& /*it1*/, const auto& /*it2*/) {
+  // NOLINTNEXTLINE(misc-unused-parameters): false positive for it1 and it2 being unused.
+  auto conditionally_erase_comparator_type = [](auto comparator, const auto& it1, const auto& it2) {
     if constexpr (erase_comparator_type == EraseTypes::OnlyInDebugBuild) {
       return comparator;
     } else {

--- a/src/lib/operators/table_wrapper.cpp
+++ b/src/lib/operators/table_wrapper.cpp
@@ -15,9 +15,9 @@ const std::string& TableWrapper::name() const {
 }
 
 std::shared_ptr<AbstractOperator> TableWrapper::_on_deep_copy(
-    const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<TableWrapper>(table);
 }
 

--- a/src/lib/operators/table_wrapper.hpp
+++ b/src/lib/operators/table_wrapper.hpp
@@ -24,9 +24,9 @@ class TableWrapper : public AbstractReadOnlyOperator {
  protected:
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
-      const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_left_input*/,
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 };
 }  // namespace hyrise

--- a/src/lib/operators/union_all.cpp
+++ b/src/lib/operators/union_all.cpp
@@ -57,7 +57,7 @@ std::shared_ptr<const Table> UnionAll::_on_execute() {
 std::shared_ptr<AbstractOperator> UnionAll::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<UnionAll>(copied_left_input, copied_right_input);
 }
 

--- a/src/lib/operators/union_all.hpp
+++ b/src/lib/operators/union_all.hpp
@@ -21,7 +21,7 @@ class UnionAll : public AbstractReadOnlyOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 };
 }  // namespace hyrise

--- a/src/lib/operators/union_positions.cpp
+++ b/src/lib/operators/union_positions.cpp
@@ -64,7 +64,7 @@ UnionPositions::UnionPositions(const std::shared_ptr<const AbstractOperator>& le
 std::shared_ptr<AbstractOperator> UnionPositions::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<UnionPositions>(copied_left_input, copied_right_input);
 }
 

--- a/src/lib/operators/union_positions.hpp
+++ b/src/lib/operators/union_positions.hpp
@@ -93,7 +93,7 @@ class UnionPositions : public AbstractReadOnlyOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   void _on_cleanup() override;

--- a/src/lib/operators/update.cpp
+++ b/src/lib/operators/update.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<const Table> Update::_on_execute(std::shared_ptr<TransactionCont
 std::shared_ptr<AbstractOperator> Update::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Update>(_table_to_update_name, copied_left_input, copied_right_input);
 }
 

--- a/src/lib/operators/update.hpp
+++ b/src/lib/operators/update.hpp
@@ -36,7 +36,7 @@ class Update : public AbstractReadWriteOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 
   // Commit happens in Insert and Delete operators

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -169,6 +169,8 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
     // If we are validating a reference segment, this is the table referenced by ref_segment_in.
     auto referenced_table = std::shared_ptr<const Table>{};
 
+    const auto column_count = chunk_in->column_count();
+
     // If the segments in this chunk reference a segment, build a poslist for a reference segment.
     if (ref_segment_in) {
       DebugAssert(chunk_in->references_exactly_one_table(),
@@ -242,7 +244,6 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
       }
 
       // Construct the actual ReferenceSegment objects and add them to the chunk.
-      const auto column_count = chunk_in->column_count();
       for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
         const auto reference_segment =
             std::static_pointer_cast<const ReferenceSegment>(chunk_in->get_segment(column_id));
@@ -276,7 +277,6 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
       }
 
       // Create actual ReferenceSegment objects.
-      const auto column_count = chunk_in->column_count();
       for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
         auto ref_segment_out = std::make_shared<ReferenceSegment>(referenced_table, column_id, pos_list_out);
         output_segments.push_back(ref_segment_out);
@@ -284,7 +284,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
     }
 
     if (!pos_list_out->empty()) {
-      const auto lock = std::lock_guard<std::mutex>(output_mutex);
+      const auto lock = std::lock_guard<std::mutex>{output_mutex};
       // The validate operator does not affect the sorted_by property. If a chunk has been sorted before, it still is
       // after the validate operator.
       const auto chunk = std::make_shared<Chunk>(output_segments);

--- a/src/lib/operators/validate.cpp
+++ b/src/lib/operators/validate.cpp
@@ -65,8 +65,8 @@ const std::string& Validate::name() const {
 
 std::shared_ptr<AbstractOperator> Validate::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
-    const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<Validate>(copied_left_input);
 }
 
@@ -85,10 +85,10 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
   const auto our_tid = transaction_context->transaction_id();
   const auto snapshot_commit_id = transaction_context->snapshot_commit_id();
 
-  std::vector<std::shared_ptr<AbstractTask>> jobs;
-  std::vector<std::shared_ptr<Chunk>> output_chunks;
+  auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
+  auto output_chunks = std::vector<std::shared_ptr<Chunk>>{};
   output_chunks.reserve(chunk_count);
-  std::mutex output_mutex;
+  auto output_mutex = std::mutex{};
 
   auto job_start_chunk_id = ChunkID{0};
   auto job_end_chunk_id = ChunkID{0};
@@ -119,7 +119,7 @@ std::shared_ptr<const Table> Validate::_on_execute(std::shared_ptr<TransactionCo
     job_row_count += chunk->size();
     if (job_row_count >= Chunk::DEFAULT_SIZE || job_end_chunk_id == (chunk_count - 1)) {
       // Single tasks are executed directly instead of scheduling a single job.
-      bool execute_directly = job_start_chunk_id == 0 && job_end_chunk_id == (chunk_count - 1);
+      const auto execute_directly = job_start_chunk_id == 0 && job_end_chunk_id == (chunk_count - 1);
 
       if (execute_directly) {
         _validate_chunks(input_table, job_start_chunk_id, job_end_chunk_id, our_tid, snapshot_commit_id, output_chunks,
@@ -160,7 +160,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
 
     const auto expected_number_of_valid_rows = chunk_in->size() - chunk_in->invalid_row_count();
 
-    Segments output_segments;
+    auto output_segments = Segments{};
     std::shared_ptr<const AbstractPosList> pos_list_out = std::make_shared<const RowIDPosList>();
 
     const auto ref_segment_in = std::dynamic_pointer_cast<const ReferenceSegment>(chunk_in->get_segment(ColumnID{0}));
@@ -195,7 +195,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
           // this shortcut to keep the code short.
           pos_list_out = pos_list_in;
         } else {
-          RowIDPosList temp_pos_list;
+          auto temp_pos_list = RowIDPosList{};
           temp_pos_list.guarantee_single_chunk();
           for (auto row_id : *pos_list_in) {
             if (hyrise::is_row_visible(our_tid, snapshot_commit_id, row_id.chunk_offset, *mvcc_data)) {
@@ -209,7 +209,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
         // build a list of entirely visible chunks. Rows with chunk ids from that list do not need to be tested
         // individually. For chunk ids that are NOT in the list of entirely visible chunks, we need to actually look at
         // their MVCC information.
-        RowIDPosList temp_pos_list;
+        auto temp_pos_list = RowIDPosList{};
         temp_pos_list.reserve(expected_number_of_valid_rows);
 
         if (entirely_visible_chunks.empty()) {
@@ -225,7 +225,7 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
           }
         }
 
-        for (auto row_id : *pos_list_in) {
+        for (const auto row_id : *pos_list_in) {
           if (entirely_visible_chunks[row_id.chunk_id]) {
             temp_pos_list.emplace_back(row_id);
             continue;
@@ -242,7 +242,8 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
       }
 
       // Construct the actual ReferenceSegment objects and add them to the chunk.
-      for (auto column_id = ColumnID{0}; column_id < chunk_in->column_count(); ++column_id) {
+      const auto column_count = chunk_in->column_count();
+      for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
         const auto reference_segment =
             std::static_pointer_cast<const ReferenceSegment>(chunk_in->get_segment(column_id));
         const auto referenced_column_id = reference_segment->referenced_column_id();
@@ -261,28 +262,29 @@ void Validate::_validate_chunks(const std::shared_ptr<const Table>& input_table,
         pos_list_out = std::make_shared<EntireChunkPosList>(chunk_id, chunk_in->size());
       } else {
         const auto mvcc_data = chunk_in->mvcc_data();
-        RowIDPosList temp_pos_list;
+        auto temp_pos_list = RowIDPosList{};
         temp_pos_list.reserve(expected_number_of_valid_rows);
         temp_pos_list.guarantee_single_chunk();
         // Generate pos_list_out.
         auto chunk_size = chunk_in->size();  // The compiler fails to optimize this in the for clause :(
         for (auto chunk_offset = ChunkOffset{0}; chunk_offset < chunk_size; ++chunk_offset) {
           if (hyrise::is_row_visible(our_tid, snapshot_commit_id, chunk_offset, *mvcc_data)) {
-            temp_pos_list.emplace_back(RowID{chunk_id, chunk_offset});
+            temp_pos_list.emplace_back(chunk_id, chunk_offset);
           }
         }
         pos_list_out = std::make_shared<const RowIDPosList>(std::move(temp_pos_list));
       }
 
       // Create actual ReferenceSegment objects.
-      for (auto column_id = ColumnID{0}; column_id < chunk_in->column_count(); ++column_id) {
+      const auto column_count = chunk_in->column_count();
+      for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
         auto ref_segment_out = std::make_shared<ReferenceSegment>(referenced_table, column_id, pos_list_out);
         output_segments.push_back(ref_segment_out);
       }
     }
 
     if (!pos_list_out->empty()) {
-      std::lock_guard<std::mutex> lock(output_mutex);
+      const auto lock = std::lock_guard<std::mutex>(output_mutex);
       // The validate operator does not affect the sorted_by property. If a chunk has been sorted before, it still is
       // after the validate operator.
       const auto chunk = std::make_shared<Chunk>(output_segments);

--- a/src/lib/operators/validate.hpp
+++ b/src/lib/operators/validate.hpp
@@ -44,8 +44,8 @@ class Validate : public AbstractReadOnlyOperator {
   std::shared_ptr<const Table> _on_execute() override;
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
-      const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      const std::shared_ptr<AbstractOperator>& /*copied_right_input*/,
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
 };
 

--- a/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
+++ b/src/lib/optimizer/join_ordering/enumerate_ccp.cpp
@@ -131,7 +131,7 @@ void EnumerateCcp::_enumerate_cmp(const JoinGraphVertexSet& primary_vertex_set) 
     auto cmp_vertex_set = JoinGraphVertexSet(_num_vertices);
     cmp_vertex_set.set(*iter);
 
-    _csg_cmp_pairs.emplace_back(std::make_pair(primary_vertex_set, cmp_vertex_set));
+    _csg_cmp_pairs.emplace_back(primary_vertex_set, cmp_vertex_set);
 
     const auto extended_exclusion_set = exclusion_set | (_exclusion_set(*iter) & neighborhood);
 
@@ -139,7 +139,7 @@ void EnumerateCcp::_enumerate_cmp(const JoinGraphVertexSet& primary_vertex_set) 
     _enumerate_csg_recursive(csgs, cmp_vertex_set, extended_exclusion_set);
 
     for (const auto& csg : csgs) {
-      _csg_cmp_pairs.emplace_back(std::make_pair(primary_vertex_set, csg));
+      _csg_cmp_pairs.emplace_back(primary_vertex_set, csg);
     }
   }
 }

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
@@ -143,7 +143,7 @@ void DependentGroupByReductionRule::_apply_to_plan_without_subqueries(
         continue;
       }
 
-      bool success = remove_dependent_group_by_columns(fd, aggregate_node, group_by_columns);
+      const auto success = remove_dependent_group_by_columns(fd, aggregate_node, group_by_columns);
       if (success) {
         // Refresh data structures correspondingly.
         group_by_list_changed = true;

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
@@ -68,8 +68,7 @@ void rewrite_to_join(const std::shared_ptr<AbstractLQPNode>& node,
 
 void rewrite_to_disjunction(const std::shared_ptr<AbstractLQPNode>& node,
                             const std::shared_ptr<AbstractExpression>& left_expression,
-                            const std::vector<std::shared_ptr<AbstractExpression>>& right_side_expressions,
-                            DataType data_type) {
+                            const std::vector<std::shared_ptr<AbstractExpression>>& right_side_expressions) {
   // It is easier not to use lqp_replace_node here, so we need to cache the original output relations
   const auto old_output_relations = node->output_relations();
 
@@ -173,7 +172,7 @@ void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
                       in_expression->is_negated());
     } else if (strategy == Strategy::Disjunction) {
       Assert(!in_expression->is_negated(), "Disjunctions cannot handle NOT IN");
-      rewrite_to_disjunction(sub_node, left_expression, right_side_expressions, *common_data_type);
+      rewrite_to_disjunction(sub_node, left_expression, right_side_expressions);
     } else if (strategy == Strategy::Auto) {
       if (right_side_expressions.size() >= MIN_ELEMENTS_FOR_JOIN) {
         rewrite_to_join(sub_node, left_expression, right_side_expressions, *common_data_type,
@@ -183,7 +182,7 @@ void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
                       MIN_INPUT_ROWS_FOR_DISJUNCTION) &&
                  !in_expression->is_negated() &&
                  !std::dynamic_pointer_cast<FunctionExpression>(in_expression->operand())) {
-        rewrite_to_disjunction(sub_node, left_expression, right_side_expressions, *common_data_type);
+        rewrite_to_disjunction(sub_node, left_expression, right_side_expressions);
       } else {
         // Stick with the ExpressionEvaluator
       }

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -94,7 +94,8 @@ void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<Abstra
   }
 }
 
-void NullScanRemovalRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
+void NullScanRemovalRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }
 

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -94,7 +94,7 @@ void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<Abstra
   }
 }
 
-void NullScanRemovalRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+void NullScanRemovalRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }
 

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -22,7 +22,7 @@ class NullScanRemovalRule : public AbstractRule {
   static void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -58,7 +58,7 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateReorderingRule needs root to hold onto");
 
   // We keep track of reordered predicate nodes, so that this rule touches predicate nodes once only.
-  std::unordered_set<std::shared_ptr<AbstractLQPNode>> reordered_predicate_nodes;
+  auto reordered_predicate_nodes = std::unordered_set<std::shared_ptr<AbstractLQPNode>>{};
   visit_lqp(lqp_root, [&](const auto& node) {
     if (is_predicate_style_node(node) && !reordered_predicate_nodes.contains(node)) {
       std::vector<std::shared_ptr<AbstractLQPNode>> predicate_nodes;
@@ -126,11 +126,13 @@ void PredicateReorderingRule::_reorder_predicates(
   // Ensure that nodes are chained correctly
   nodes_and_cardinalities.back().first->set_left_input(input);
 
-  for (size_t output_idx = 0; output_idx < outputs.size(); ++output_idx) {
+  const auto output_count = outputs.size();
+  for (auto output_idx = size_t{0}; output_idx < output_count; ++output_idx) {
     outputs[output_idx]->set_input(input_sides[output_idx], nodes_and_cardinalities.front().first);
   }
 
-  for (size_t predicate_index = 0; predicate_index + 1 < nodes_and_cardinalities.size(); predicate_index++) {
+  const auto nodes_and_cardinalities_count = nodes_and_cardinalities.size();
+  for (auto predicate_index = size_t{0}; predicate_index + 1 < nodes_and_cardinalities_count; ++predicate_index) {
     nodes_and_cardinalities[predicate_index].first->set_left_input(nodes_and_cardinalities[predicate_index + 1].first);
   }
 }

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -120,7 +120,7 @@ void StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<Logical
 }
 
 void StoredTableColumnAlignmentRule::_apply_to_plan_without_subqueries(
-    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+    const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }
 

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -66,7 +66,7 @@ class StoredTableColumnAlignmentRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -114,7 +114,7 @@ void AbstractTask::schedule(NodeID preferred_node_id) {
 }
 
 void AbstractTask::_join() {
-  auto lock = std::unique_lock<std::mutex>(_done_condition_variable_mutex);
+  auto lock = std::unique_lock<std::mutex>{_done_condition_variable_mutex};
   if (is_done()) {
     return;
   }
@@ -153,7 +153,7 @@ void AbstractTask::execute() {
   }
 
   {
-    const auto lock = std::lock_guard<std::mutex>(_done_condition_variable_mutex);
+    const auto lock = std::lock_guard<std::mutex>{_done_condition_variable_mutex};
     _done_condition_variable.notify_all();
   }
 }
@@ -206,7 +206,7 @@ bool AbstractTask::_try_transition_to(TaskState new_state) {
    * This function must be locked to prevent race conditions. A different thread might be able to change _state
    * successfully while this thread is still between the validity check and _state.exchange(new_state).
    */
-  const auto lock = std::lock_guard<std::mutex>(_transition_to_mutex);
+  const auto lock = std::lock_guard<std::mutex>{_transition_to_mutex};
   switch (new_state) {
     case TaskState::Scheduled:
       if (_state >= TaskState::Scheduled) {

--- a/src/lib/scheduler/abstract_task.cpp
+++ b/src/lib/scheduler/abstract_task.cpp
@@ -153,7 +153,7 @@ void AbstractTask::execute() {
   }
 
   {
-    std::lock_guard<std::mutex> lock(_done_condition_variable_mutex);
+    const auto lock = std::lock_guard<std::mutex>(_done_condition_variable_mutex);
     _done_condition_variable.notify_all();
   }
 }
@@ -206,7 +206,7 @@ bool AbstractTask::_try_transition_to(TaskState new_state) {
    * This function must be locked to prevent race conditions. A different thread might be able to change _state
    * successfully while this thread is still between the validity check and _state.exchange(new_state).
    */
-  std::lock_guard<std::mutex> lock(_transition_to_mutex);
+  const auto lock = std::lock_guard<std::mutex>(_transition_to_mutex);
   switch (new_state) {
     case TaskState::Scheduled:
       if (_state >= TaskState::Scheduled) {

--- a/src/lib/scheduler/immediate_execution_scheduler.cpp
+++ b/src/lib/scheduler/immediate_execution_scheduler.cpp
@@ -16,8 +16,8 @@ const std::vector<std::shared_ptr<TaskQueue>>& ImmediateExecutionScheduler::queu
   return _queues;
 }
 
-void ImmediateExecutionScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID preferred_node_id,
-                                           SchedulePriority priority) {
+void ImmediateExecutionScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID /*preferred_node_id*/,
+                                           SchedulePriority /*priority*/) {
   DebugAssert(task->is_scheduled(), "Don't call ImmediateExecutionScheduler::schedule(), call schedule() on the task");
 
   if (task->is_ready()) {

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -34,7 +34,7 @@ void NodeQueueScheduler::begin() {
   _queue_count = Hyrise::get().topology.nodes().size();
   _queues.reserve(_queue_count);
 
-  for (auto node_id = NodeID{0}; node_id < Hyrise::get().topology.nodes().size(); node_id++) {
+  for (auto node_id = NodeID{0}; node_id < Hyrise::get().topology.nodes().size(); ++node_id) {
     auto queue = std::make_shared<TaskQueue>(node_id);
 
     _queues.emplace_back(queue);

--- a/src/lib/scheduler/node_queue_scheduler.cpp
+++ b/src/lib/scheduler/node_queue_scheduler.cpp
@@ -118,14 +118,13 @@ void NodeQueueScheduler::schedule(std::shared_ptr<AbstractTask> task, NodeID pre
     return;
   }
 
-  const auto node_id_for_queue = determine_queue_id_for_task(task, preferred_node_id);
+  const auto node_id_for_queue = determine_queue_id(preferred_node_id);
   DebugAssert((static_cast<size_t>(node_id_for_queue) < _queues.size()),
               "Node ID is not within range of available nodes.");
   _queues[node_id_for_queue]->push(task, priority);
 }
 
-NodeID NodeQueueScheduler::determine_queue_id_for_task(const std::shared_ptr<AbstractTask>& task,
-                                                       const NodeID preferred_node_id) const {
+NodeID NodeQueueScheduler::determine_queue_id(const NodeID preferred_node_id) const {
   // Early out: no need to check for preferred node or other queues, if there is only a single node queue.
   if (_queue_count == 1) {
     return NodeID{0};

--- a/src/lib/scheduler/node_queue_scheduler.hpp
+++ b/src/lib/scheduler/node_queue_scheduler.hpp
@@ -108,13 +108,12 @@ class NodeQueueScheduler : public AbstractScheduler {
                 SchedulePriority priority = SchedulePriority::Default) override;
 
   /**
-   * @param task
    * @param preferred_node_id
    * @return `preferred_node_id` if a non-default preferred node ID is passed. When the node is the default of
    *         CURRENT_NODE_ID but no current node (where the task is executed) can be obtained, the node ID of the node
    *         with the lowest queue pressure is returned.
    */
-  NodeID determine_queue_id_for_task(const std::shared_ptr<AbstractTask>& task, const NodeID preferred_node_id) const;
+  NodeID determine_queue_id(const NodeID preferred_node_id) const;
 
   void wait_for_all_tasks() override;
 

--- a/src/lib/server/read_buffer.cpp
+++ b/src/lib/server/read_buffer.cpp
@@ -84,7 +84,7 @@ void ReadBuffer<SocketType>::_receive_if_necessary(const size_t bytes_required) 
   // Buffer might contain unread data, so cannot read full buffer size
   const auto maximum_readable_size = maximum_capacity() - size();
 
-  size_t bytes_read;
+  auto bytes_read = size_t{0};
   boost::system::error_code error_code;
   // We cannot forward an iterator to the read system call. Hence, we need to use raw pointers. Therefore, we need to
   // distinguish between reading into continuous memory or partially read the data.

--- a/src/lib/server/write_buffer.cpp
+++ b/src/lib/server/write_buffer.cpp
@@ -52,7 +52,7 @@ template <typename SocketType>
 void WriteBuffer<SocketType>::flush(const size_t bytes_required) {
   Assert(bytes_required <= size(), "Cannot flush more byte than available");
   const auto bytes_to_send = bytes_required ? bytes_required : size();
-  size_t bytes_sent;
+  auto bytes_sent = size_t{0};
 
   boost::system::error_code error_code;
   if (std::distance(&*_start_position, &*_current_position) < 0) {

--- a/src/lib/sql/sql_identifier_resolver.cpp
+++ b/src/lib/sql/sql_identifier_resolver.cpp
@@ -64,7 +64,7 @@ std::vector<SQLIdentifier> SQLIdentifierResolver::get_expression_identifiers(
     return identifiers;
   }
   for (const auto& column_name : entry_iter->column_names) {
-    identifiers.emplace_back(SQLIdentifier(column_name, entry_iter->table_name));
+    identifiers.emplace_back(column_name, entry_iter->table_name);
   }
   return identifiers;
 }
@@ -91,7 +91,7 @@ SQLIdentifierContextEntry& SQLIdentifierResolver::_find_or_create_expression_ent
 
   // If there is no entry for this Expression, just add one
   if (entry_iter == _entries.end()) {
-    SQLIdentifierContextEntry entry{expression, std::nullopt, {}};
+    const auto entry = SQLIdentifierContextEntry{expression, std::nullopt, {}};
     entry_iter = _entries.emplace(_entries.end(), entry);
   }
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -30,7 +30,7 @@ SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Transacti
   DebugAssert(!_transaction_context || !_transaction_context->is_auto_commit(),
               "Auto-commit transactions are created internally and should not be passed in.");
 
-  hsql::SQLParserResult parse_result;
+  auto parse_result = hsql::SQLParserResult{};
 
   const auto start = std::chrono::steady_clock::now();
   hsql::SQLParser::parse(sql, &parse_result);
@@ -43,7 +43,7 @@ SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Transacti
 
   _sql_pipeline_statements.reserve(parse_result.size());
 
-  std::vector<std::shared_ptr<hsql::SQLParserResult>> parsed_statements;
+  auto parsed_statements = std::vector<std::shared_ptr<hsql::SQLParserResult>>{};
   for (auto* statement : parse_result.releaseStatements()) {
     parsed_statements.emplace_back(std::make_shared<hsql::SQLParserResult>(statement));
   }
@@ -53,7 +53,7 @@ SQLPipeline::SQLPipeline(const std::string& sql, const std::shared_ptr<Transacti
   // We want to split the (multi-) statement SQL string into the strings for each statement. We can then use those
   // statement strings to cache query plans.
   // The sql parser only offers us the length of the string, so we need to split it manually.
-  auto sql_string_offset = 0u;
+  auto sql_string_offset = size_t{0};
 
   for (auto& parsed_statement : parsed_statements) {
     parsed_statement->setIsValid(true);
@@ -218,7 +218,7 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipeline::g
               "SQLPipeline::get_result_table() should either return Success or Failure");
 
   if (pipeline_status == SQLPipelineStatus::Failure) {
-    static std::shared_ptr<const Table> null_table;
+    static const auto null_table =  std::shared_ptr<const Table>{};
     return {pipeline_status, null_table};
   }
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -218,7 +218,7 @@ std::pair<SQLPipelineStatus, const std::shared_ptr<const Table>&> SQLPipeline::g
               "SQLPipeline::get_result_table() should either return Success or Failure");
 
   if (pipeline_status == SQLPipelineStatus::Failure) {
-    static const auto null_table =  std::shared_ptr<const Table>{};
+    static const auto null_table = std::shared_ptr<const Table>{};
     return {pipeline_status, null_table};
   }
 

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -367,7 +367,7 @@ void SQLPipelineStatement::_precheck_ddl_operators(const std::shared_ptr<Abstrac
     }
     case OperatorType::Import: {
       const auto import = std::dynamic_pointer_cast<Import>(pqp);
-      std::ifstream file(import->filename);
+      const auto file = std::ifstream{import->filename};
       AssertInput(file.good(), "There is no file '" + import->filename + "'.");
       break;
     }

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -138,7 +138,7 @@ bool is_trivial_join_predicate(const AbstractExpression& expression, const Abstr
     auto left_argument_found = false;
     auto right_argument_found = false;
 
-    input.iterate_output_expressions([&](const auto column_id, const auto& expression) {
+    input.iterate_output_expressions([&](const auto /*column_id*/, const auto& expression) {
       if (*expression == *binary_predicate_expression->left_operand()) {
         left_argument_found = true;
       } else if (*expression == *binary_predicate_expression->right_operand()) {
@@ -660,7 +660,7 @@ SQLTranslator::TableSourceState SQLTranslator::_translate_table_origin(const hsq
 
       for (const auto& expression : lqp->output_expressions()) {
         const auto identifiers = sql_identifier_resolver->get_expression_identifiers(expression);
-        select_list_elements.emplace_back(SelectListElement{expression, identifiers});
+        select_list_elements.emplace_back(expression, identifiers);
       }
     } break;
 
@@ -992,12 +992,12 @@ std::vector<SQLTranslator::SelectListElement> SQLTranslator::_translate_select_l
   auto post_select_sql_identifier_resolver = std::make_shared<SQLIdentifierResolver>(*_sql_identifier_resolver);
   for (const auto& hsql_select_expr : select_list) {
     if (hsql_select_expr->type == hsql::kExprStar) {
-      select_list_elements.emplace_back(SelectListElement{nullptr});
+      select_list_elements.emplace_back(nullptr);
     } else if (hsql_select_expr->type == hsql::kExprLiteralInterval) {
       FailInput("Interval can only be added to or substracted from a date");
     } else {
       auto expression = _translate_hsql_expr(*hsql_select_expr, _sql_identifier_resolver);
-      select_list_elements.emplace_back(SelectListElement{expression});
+      select_list_elements.emplace_back(expression);
       if (hsql_select_expr->name && hsql_select_expr->type != hsql::kExprFunctionRef &&
           hsql_select_expr->type != hsql::kExprExtract) {
         select_list_elements.back().identifiers.emplace_back(hsql_select_expr->name);
@@ -1148,7 +1148,7 @@ void SQLTranslator::_translate_select_groupby_having(const hsql::SelectStatement
             const auto identifiers = _sql_identifier_resolver->get_expression_identifiers(group_by_expression);
             for (const auto& identifier : identifiers) {
               if (identifier.table_name == hsql_expr->table) {
-                _inflated_select_list_elements.emplace_back(SelectListElement{group_by_expression});
+                _inflated_select_list_elements.emplace_back(group_by_expression);
               }
             }
           }
@@ -1166,7 +1166,7 @@ void SQLTranslator::_translate_select_groupby_having(const hsql::SelectStatement
         if (is_aggregate) {
           // Select all GROUP BY columns
           for (const auto& expression : group_by_expressions) {
-            _inflated_select_list_elements.emplace_back(SelectListElement{expression});
+            _inflated_select_list_elements.emplace_back(expression);
           }
         } else {
           // Select all columns from the FROM elements

--- a/src/lib/statistics/base_attribute_statistics.cpp
+++ b/src/lib/statistics/base_attribute_statistics.cpp
@@ -5,8 +5,8 @@ namespace hyrise {
 BaseAttributeStatistics::BaseAttributeStatistics(const DataType init_data_type) : data_type(init_data_type) {}
 
 std::shared_ptr<BaseAttributeStatistics> BaseAttributeStatistics::pruned(
-    const size_t /*num_values_pruned*/, const PredicateCondition /*predicate_condition*/, const AllTypeVariant& /*variant_value*/,
-    const std::optional<AllTypeVariant>& /*variant_value2*/) const {
+    const size_t /*num_values_pruned*/, const PredicateCondition /*predicate_condition*/,
+    const AllTypeVariant& /*variant_value*/, const std::optional<AllTypeVariant>& /*variant_value2*/) const {
   Fail("Pruning has not yet been implemented for the given statistics object");
 }
 

--- a/src/lib/statistics/base_attribute_statistics.cpp
+++ b/src/lib/statistics/base_attribute_statistics.cpp
@@ -5,8 +5,8 @@ namespace hyrise {
 BaseAttributeStatistics::BaseAttributeStatistics(const DataType init_data_type) : data_type(init_data_type) {}
 
 std::shared_ptr<BaseAttributeStatistics> BaseAttributeStatistics::pruned(
-    const size_t num_values_pruned, const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
-    const std::optional<AllTypeVariant>& variant_value2) const {
+    const size_t /*num_values_pruned*/, const PredicateCondition /*predicate_condition*/, const AllTypeVariant& /*variant_value*/,
+    const std::optional<AllTypeVariant>& /*variant_value2*/) const {
   Fail("Pruning has not yet been implemented for the given statistics object");
 }
 

--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -316,7 +316,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_aggregate_node(
 }
 
 std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_validate_node(
-    const ValidateNode& validate_node, const std::shared_ptr<TableStatistics>& input_table_statistics) {
+    const ValidateNode& /*validate_node*/, const std::shared_ptr<TableStatistics>& input_table_statistics) {
   // Currently no statistics available to base ValidateNode on
   return input_table_statistics;
 }
@@ -440,71 +440,71 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_join_node(
 
   if (join_node.join_mode == JoinMode::Cross) {
     return estimate_cross_join(*left_input_table_statistics, *right_input_table_statistics);
-  } else {
-    // TODO(anybody) Join cardinality estimation is consciously only performed for the primary join predicate. #1560
-    const auto primary_operator_join_predicate = OperatorJoinPredicate::from_expression(
-        *join_node.join_predicates()[0], *join_node.left_input(), *join_node.right_input());
+  }
 
-    if (primary_operator_join_predicate) {
-      switch (join_node.join_mode) {
-        // For now, handle outer joins just as inner joins
-        // TODO(anybody) Handle them more accurately, i.e., estimate how many tuples don't find matches. #1830
-        case JoinMode::Left:
-        case JoinMode::Right:
-        case JoinMode::FullOuter:
-        case JoinMode::Inner:
-          switch (primary_operator_join_predicate->predicate_condition) {
-            case PredicateCondition::Equals:
-              return estimate_inner_equi_join(primary_operator_join_predicate->column_ids.first,
-                                              primary_operator_join_predicate->column_ids.second,
-                                              *left_input_table_statistics, *right_input_table_statistics);
+  // TODO(anybody) Join cardinality estimation is consciously only performed for the primary join predicate. #1560
+  const auto primary_operator_join_predicate = OperatorJoinPredicate::from_expression(
+      *join_node.join_predicates()[0], *join_node.left_input(), *join_node.right_input());
 
-            // TODO(anybody) Implement estimation for non-equi joins. #1830
-            case PredicateCondition::NotEquals:
-            case PredicateCondition::LessThan:
-            case PredicateCondition::LessThanEquals:
-            case PredicateCondition::GreaterThan:
-            case PredicateCondition::GreaterThanEquals:
-            case PredicateCondition::BetweenInclusive:
-            case PredicateCondition::BetweenUpperExclusive:
-            case PredicateCondition::BetweenLowerExclusive:
-            case PredicateCondition::BetweenExclusive:
-            case PredicateCondition::In:
-            case PredicateCondition::NotIn:
-            case PredicateCondition::Like:
-            case PredicateCondition::NotLike:
-              return estimate_cross_join(*left_input_table_statistics, *right_input_table_statistics);
+  if (primary_operator_join_predicate) {
+    switch (join_node.join_mode) {
+      // For now, handle outer joins just as inner joins
+      // TODO(anybody) Handle them more accurately, i.e., estimate how many tuples don't find matches. #1830
+      case JoinMode::Left:
+      case JoinMode::Right:
+      case JoinMode::FullOuter:
+      case JoinMode::Inner:
+        switch (primary_operator_join_predicate->predicate_condition) {
+          case PredicateCondition::Equals:
+            return estimate_inner_equi_join(primary_operator_join_predicate->column_ids.first,
+                                            primary_operator_join_predicate->column_ids.second,
+                                            *left_input_table_statistics, *right_input_table_statistics);
 
-            case PredicateCondition::IsNull:
-            case PredicateCondition::IsNotNull:
-              Fail("IS NULL is an invalid join predicate");
-          }
-          Fail("Invalid enum value");
+          // TODO(anybody) Implement estimation for non-equi joins. #1830
+          case PredicateCondition::NotEquals:
+          case PredicateCondition::LessThan:
+          case PredicateCondition::LessThanEquals:
+          case PredicateCondition::GreaterThan:
+          case PredicateCondition::GreaterThanEquals:
+          case PredicateCondition::BetweenInclusive:
+          case PredicateCondition::BetweenUpperExclusive:
+          case PredicateCondition::BetweenLowerExclusive:
+          case PredicateCondition::BetweenExclusive:
+          case PredicateCondition::In:
+          case PredicateCondition::NotIn:
+          case PredicateCondition::Like:
+          case PredicateCondition::NotLike:
+            return estimate_cross_join(*left_input_table_statistics, *right_input_table_statistics);
 
-        case JoinMode::Cross:
-          // Should have been forwarded to estimate_cross_join()
-          Fail("Cross join is not a predicated join");
+          case PredicateCondition::IsNull:
+          case PredicateCondition::IsNotNull:
+            Fail("IS NULL is an invalid join predicate");
+        }
+        Fail("Invalid enum value");
 
-        case JoinMode::Semi:
-          return estimate_semi_join(primary_operator_join_predicate->column_ids.first,
-                                    primary_operator_join_predicate->column_ids.second, *left_input_table_statistics,
-                                    *right_input_table_statistics);
+      case JoinMode::Cross:
+        // Should have been forwarded to estimate_cross_join()
+        Fail("Cross join is not a predicated join");
 
-        case JoinMode::AntiNullAsTrue:
-        case JoinMode::AntiNullAsFalse:
-          return left_input_table_statistics;
-      }
-    } else {
-      // TODO(anybody) For now, estimate a selectivity of one. #1830
-      return estimate_cross_join(*left_input_table_statistics, *right_input_table_statistics);
+      case JoinMode::Semi:
+        return estimate_semi_join(primary_operator_join_predicate->column_ids.first,
+                                  primary_operator_join_predicate->column_ids.second, *left_input_table_statistics,
+                                  *right_input_table_statistics);
+
+      case JoinMode::AntiNullAsTrue:
+      case JoinMode::AntiNullAsFalse:
+        return left_input_table_statistics;
     }
   }
+
+  // TODO(anybody) For now, estimate a selectivity of one. #1830
+  return estimate_cross_join(*left_input_table_statistics, *right_input_table_statistics);
 
   Fail("Invalid enum value");
 }
 
 std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_union_node(
-    const UnionNode& union_node, const std::shared_ptr<TableStatistics>& left_input_table_statistics,
+    const UnionNode& /*union_node*/, const std::shared_ptr<TableStatistics>& left_input_table_statistics,
     const std::shared_ptr<TableStatistics>& right_input_table_statistics) {
   // Since UnionNodes are not really used right now, implementing an involved algorithm to union two TableStatistics
   // seems unjustified. For now, we just concatenate the two statistics objects

--- a/src/lib/statistics/cardinality_estimator.hpp
+++ b/src/lib/statistics/cardinality_estimator.hpp
@@ -50,7 +50,7 @@ class CardinalityEstimator : public AbstractCardinalityEstimator {
       const AggregateNode& aggregate_node, const std::shared_ptr<TableStatistics>& input_table_statistics);
 
   static std::shared_ptr<TableStatistics> estimate_validate_node(
-      const ValidateNode& validate_node, const std::shared_ptr<TableStatistics>& input_table_statistics);
+      const ValidateNode& /*validate_node*/, const std::shared_ptr<TableStatistics>& input_table_statistics);
 
   static std::shared_ptr<TableStatistics> estimate_predicate_node(
       const PredicateNode& predicate_node, const std::shared_ptr<TableStatistics>& input_table_statistics);
@@ -60,7 +60,7 @@ class CardinalityEstimator : public AbstractCardinalityEstimator {
       const std::shared_ptr<TableStatistics>& right_input_table_statistics);
 
   static std::shared_ptr<TableStatistics> estimate_union_node(
-      const UnionNode& union_node, const std::shared_ptr<TableStatistics>& left_input_table_statistics,
+      const UnionNode& /*union_node*/, const std::shared_ptr<TableStatistics>& left_input_table_statistics,
       const std::shared_ptr<TableStatistics>& right_input_table_statistics);
 
   static std::shared_ptr<TableStatistics> estimate_limit_node(

--- a/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
+++ b/src/lib/statistics/statistics_objects/equal_distinct_count_histogram.cpp
@@ -95,7 +95,7 @@ EqualDistinctCountHistogram<T>::EqualDistinctCountHistogram(std::vector<T>&& bin
   AbstractHistogram<T>::_assert_bin_validity();
 
   _total_count = std::accumulate(_bin_heights.cbegin(), _bin_heights.cend(), HistogramCountType{0});
-  _total_distinct_count = _distinct_count_per_bin * static_cast<HistogramCountType>(bin_count()) +
+  _total_distinct_count = _distinct_count_per_bin * static_cast<HistogramCountType>(_bin_heights.size()) +
                           static_cast<HistogramCountType>(_bin_count_with_extra_value);
 }
 

--- a/src/lib/statistics/statistics_objects/min_max_filter.cpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.cpp
@@ -18,9 +18,9 @@ MinMaxFilter<T>::MinMaxFilter(T init_min, T init_max)
     : AbstractStatisticsObject(data_type_from_type<T>()), min(init_min), max(init_max) {}
 
 template <typename T>
-Cardinality MinMaxFilter<T>::estimate_cardinality(const PredicateCondition predicate_condition,
-                                                  const AllTypeVariant& variant_value,
-                                                  const std::optional<AllTypeVariant>& variant_value2) const {
+Cardinality MinMaxFilter<T>::estimate_cardinality(const PredicateCondition /*predicate_condition*/,
+                                                  const AllTypeVariant& /*variant_value*/,
+                                                  const std::optional<AllTypeVariant>& /*variant_value2*/) const {
   // Theoretically, one could come up with some type of estimation (everything outside MinMax is 0, everything inside
   // is estimated assuming equi-distribution). For that, we would also need the cardinality of the underlying data.
   // Currently, as MinMaxFilters are on a per-segment basis and estimate_cardinality is called for an entire column,

--- a/src/lib/statistics/statistics_objects/min_max_filter.hpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.hpp
@@ -29,7 +29,8 @@ class MinMaxFilter : public AbstractStatisticsObject {
  public:
   explicit MinMaxFilter(T init_min, T init_max);
 
-  Cardinality estimate_cardinality(const PredicateCondition /*predicate_condition*/, const AllTypeVariant& /*variant_value*/,
+  Cardinality estimate_cardinality(const PredicateCondition /*predicate_condition*/,
+                                   const AllTypeVariant& /*variant_value*/,
                                    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   std::shared_ptr<AbstractStatisticsObject> sliced(

--- a/src/lib/statistics/statistics_objects/min_max_filter.hpp
+++ b/src/lib/statistics/statistics_objects/min_max_filter.hpp
@@ -29,7 +29,7 @@ class MinMaxFilter : public AbstractStatisticsObject {
  public:
   explicit MinMaxFilter(T init_min, T init_max);
 
-  Cardinality estimate_cardinality(const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
+  Cardinality estimate_cardinality(const PredicateCondition /*predicate_condition*/, const AllTypeVariant& /*variant_value*/,
                                    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   std::shared_ptr<AbstractStatisticsObject> sliced(

--- a/src/lib/statistics/statistics_objects/range_filter.cpp
+++ b/src/lib/statistics/statistics_objects/range_filter.cpp
@@ -21,9 +21,9 @@ RangeFilter<T>::RangeFilter(std::vector<std::pair<T, T>> init_ranges)
 }
 
 template <typename T>
-Cardinality RangeFilter<T>::estimate_cardinality(const PredicateCondition predicate_condition,
-                                                 const AllTypeVariant& variant_value,
-                                                 const std::optional<AllTypeVariant>& variant_value2) const {
+Cardinality RangeFilter<T>::estimate_cardinality(const PredicateCondition /*predicate_condition*/,
+                                                 const AllTypeVariant& /*variant_value*/,
+                                                 const std::optional<AllTypeVariant>& /*variant_value2*/) const {
   // Theoretically, one could come up with some type of estimation (everything outside the range is 0, everything inside
   // is estimated assuming equi-distribution). For that, we would also need the cardinality of the underlying data.
   // Currently, as RangeFilters are on a per-segment basis and estimate_cardinality is called for an entire column,

--- a/src/lib/statistics/statistics_objects/range_filter.hpp
+++ b/src/lib/statistics/statistics_objects/range_filter.hpp
@@ -39,7 +39,7 @@ class RangeFilter : public AbstractStatisticsObject {
   static std::unique_ptr<RangeFilter<T>> build_filter(const pmr_vector<T>& dictionary,
                                                       uint32_t max_ranges_count = DEFAULT_MAX_RANGES_COUNT);
 
-  Cardinality estimate_cardinality(const PredicateCondition predicate_condition, const AllTypeVariant& variant_value,
+  Cardinality estimate_cardinality(const PredicateCondition /*predicate_condition*/, const AllTypeVariant& /*variant_value*/,
                                    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   std::shared_ptr<AbstractStatisticsObject> sliced(

--- a/src/lib/statistics/statistics_objects/range_filter.hpp
+++ b/src/lib/statistics/statistics_objects/range_filter.hpp
@@ -39,7 +39,8 @@ class RangeFilter : public AbstractStatisticsObject {
   static std::unique_ptr<RangeFilter<T>> build_filter(const pmr_vector<T>& dictionary,
                                                       uint32_t max_ranges_count = DEFAULT_MAX_RANGES_COUNT);
 
-  Cardinality estimate_cardinality(const PredicateCondition /*predicate_condition*/, const AllTypeVariant& /*variant_value*/,
+  Cardinality estimate_cardinality(const PredicateCondition /*predicate_condition*/,
+                                   const AllTypeVariant& /*variant_value*/,
                                    const std::optional<AllTypeVariant>& variant_value2 = std::nullopt) const;
 
   std::shared_ptr<AbstractStatisticsObject> sliced(

--- a/src/lib/statistics/table_statistics.cpp
+++ b/src/lib/statistics/table_statistics.cpp
@@ -16,7 +16,7 @@ namespace hyrise {
 
 std::shared_ptr<TableStatistics> TableStatistics::from_table(const Table& table) {
   const auto column_count = table.column_count();
-  auto column_statistics = std::vector<std::shared_ptr<BaseAttributeStatistics>>(column_count);
+  auto column_statistics = std::vector<std::shared_ptr<BaseAttributeStatistics>>{column_count};
 
   /**
    * Determine bin count, within mostly arbitrarily chosen bounds: 5 (for tables with <=2k rows) up to 100 bins

--- a/src/lib/statistics/table_statistics.cpp
+++ b/src/lib/statistics/table_statistics.cpp
@@ -15,7 +15,8 @@
 namespace hyrise {
 
 std::shared_ptr<TableStatistics> TableStatistics::from_table(const Table& table) {
-  std::vector<std::shared_ptr<BaseAttributeStatistics>> column_statistics(table.column_count());
+  const auto column_count = table.column_count();
+  auto column_statistics = std::vector<std::shared_ptr<BaseAttributeStatistics>>(column_count);
 
   /**
    * Determine bin count, within mostly arbitrarily chosen bounds: 5 (for tables with <=2k rows) up to 100 bins
@@ -29,9 +30,9 @@ std::shared_ptr<TableStatistics> TableStatistics::from_table(const Table& table)
    */
 
   auto jobs = std::vector<std::shared_ptr<AbstractTask>>{};
-  jobs.reserve(table.column_count());
+  jobs.reserve(column_count);
 
-  for (auto column_id = ColumnID{0}; column_id < table.column_count(); ++column_id) {
+  for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     const auto generate_column_statistics = [&, column_id]() {
       const auto column_data_type = table.column_data_type(column_id);
       resolve_data_type(column_data_type, [&](auto type) {

--- a/src/lib/storage/constraints/table_key_constraint.cpp
+++ b/src/lib/storage/constraints/table_key_constraint.cpp
@@ -39,8 +39,8 @@ bool TableKeyConstraint::operator<(const TableKeyConstraint& rhs) const {
 
 namespace std {
 
-size_t hash<hyrise::TableKeyConstraint>::operator()(const hyrise::TableKeyConstraint& key_constraint) const {
-  return key_constraint.hash();
+size_t hash<hyrise::TableKeyConstraint>::operator()(const hyrise::TableKeyConstraint& table_key_constraint) const {
+  return table_key_constraint.hash();
 }
 
 }  // namespace std

--- a/src/lib/storage/constraints/table_key_constraint.hpp
+++ b/src/lib/storage/constraints/table_key_constraint.hpp
@@ -47,7 +47,7 @@ namespace std {
 
 template <>
 struct hash<hyrise::TableKeyConstraint> {
-  size_t operator()(const hyrise::TableKeyConstraint& table_constraint) const;
+  size_t operator()(const hyrise::TableKeyConstraint& table_key_constraint) const;
 };
 
 }  // namespace std

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.cpp
@@ -16,8 +16,8 @@
 
 namespace hyrise {
 
-size_t AdaptiveRadixTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
-                                                           uint32_t value_bytes) {
+size_t AdaptiveRadixTreeIndex::estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/,
+                                                           uint32_t /*value_bytes*/) {
   Fail("AdaptiveRadixTreeIndex::estimate_memory_consumption() is not implemented yet");
 }
 
@@ -32,14 +32,14 @@ AdaptiveRadixTreeIndex::AdaptiveRadixTreeIndex(
 
   // For each value ID in the attribute vector, create a pair consisting of a BinaryComparable of
   // this value ID and its ChunkOffset (needed for bulk-inserting).
-  std::vector<std::pair<BinaryComparable, ChunkOffset>> pairs_to_insert;
+  auto pairs_to_insert = std::vector<std::pair<BinaryComparable, ChunkOffset>>{};
   pairs_to_insert.reserve(_indexed_segment->attribute_vector()->size());
 
   const auto null_value_id = _indexed_segment->null_value_id();
   _null_positions.reserve(_indexed_segment->attribute_vector()->size());
 
   resolve_compressed_vector_type(*_indexed_segment->attribute_vector(), [&](const auto& attribute_vector) {
-    auto chunk_offset = ChunkOffset{0u};
+    auto chunk_offset = ChunkOffset{0};
     auto value_id_iter = attribute_vector.cbegin();
     for (; value_id_iter != attribute_vector.cend(); ++value_id_iter, ++chunk_offset) {
       if (static_cast<ValueID>(*value_id_iter) == null_value_id) {
@@ -59,7 +59,7 @@ AbstractChunkIndex::Iterator AdaptiveRadixTreeIndex::_lower_bound(const std::vec
   // the caller is responsible for not passing a NULL value
   Assert(!variant_is_null(values[0]), "Null was passed to lower_bound().");
 
-  ValueID value_id = _indexed_segment->lower_bound(values[0]);
+  const auto value_id = _indexed_segment->lower_bound(values[0]);
   if (value_id == INVALID_VALUE_ID) {
     return _chunk_offsets.end();
   }
@@ -77,7 +77,7 @@ AbstractChunkIndex::Iterator AdaptiveRadixTreeIndex::_upper_bound(const std::vec
   // the caller is responsible for not passing a NULL value
   Assert(!variant_is_null(values[0]), "Null was passed to upper_bound().");
 
-  ValueID value_id = _indexed_segment->upper_bound(values[0]);
+  const auto value_id = _indexed_segment->upper_bound(values[0]);
   if (value_id == INVALID_VALUE_ID) {
     return _chunk_offsets.end();
   }

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -41,7 +41,8 @@ class AdaptiveRadixTreeIndex : public AbstractChunkIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See AbstractChunkIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/, uint32_t /*value_bytes*/);
+  static size_t estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/,
+                                            uint32_t /*value_bytes*/);
 
   explicit AdaptiveRadixTreeIndex(const std::vector<std::shared_ptr<const AbstractSegment>>& segments_to_index);
 

--- a/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
+++ b/src/lib/storage/index/adaptive_radix_tree/adaptive_radix_tree_index.hpp
@@ -41,7 +41,7 @@ class AdaptiveRadixTreeIndex : public AbstractChunkIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See AbstractChunkIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/, uint32_t /*value_bytes*/);
 
   explicit AdaptiveRadixTreeIndex(const std::vector<std::shared_ptr<const AbstractSegment>>& segments_to_index);
 

--- a/src/lib/storage/index/b_tree/b_tree_index.cpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.cpp
@@ -5,8 +5,8 @@
 
 namespace hyrise {
 
-size_t BTreeIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
-                                               uint32_t value_bytes) {
+size_t BTreeIndex::estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/,
+                                               uint32_t /*value_bytes*/) {
   Fail("BTreeIndex::estimate_memory_consumption() is not implemented yet");
 }
 

--- a/src/lib/storage/index/b_tree/b_tree_index.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.hpp
@@ -22,7 +22,8 @@ class BTreeIndex : public AbstractChunkIndex {
    * The introduction of PMR strings increased this significantly (in one test from 320 to 896). If you are interested
    * in reducing the memory footprint of these indexes, this is probably the first place you should look.
    */
-  static size_t estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/, uint32_t /*value_bytes*/);
+  static size_t estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/,
+                                            uint32_t /*value_bytes*/);
 
   BTreeIndex() = delete;
   explicit BTreeIndex(const std::vector<std::shared_ptr<const AbstractSegment>>& segments_to_index);

--- a/src/lib/storage/index/b_tree/b_tree_index.hpp
+++ b/src/lib/storage/index/b_tree/b_tree_index.hpp
@@ -22,7 +22,7 @@ class BTreeIndex : public AbstractChunkIndex {
    * The introduction of PMR strings increased this significantly (in one test from 320 to 896). If you are interested
    * in reducing the memory footprint of these indexes, this is probably the first place you should look.
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset /*row_count*/, ChunkOffset /*distinct_count*/, uint32_t /*value_bytes*/);
 
   BTreeIndex() = delete;
   explicit BTreeIndex(const std::vector<std::shared_ptr<const AbstractSegment>>& segments_to_index);

--- a/src/lib/storage/index/group_key/group_key_index.cpp
+++ b/src/lib/storage/index/group_key/group_key_index.cpp
@@ -10,7 +10,7 @@
 namespace hyrise {
 
 size_t GroupKeyIndex::estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
-                                                  uint32_t value_bytes) {
+                                                  uint32_t /*value_bytes*/) {
   return row_count * sizeof(ChunkOffset) + distinct_count * sizeof(std::size_t);
 }
 
@@ -38,12 +38,12 @@ GroupKeyIndex::GroupKeyIndex(const std::vector<std::shared_ptr<const AbstractSeg
   //    and count the occurrences of each value id at their respective position in the dictionary,
   //    i.e. the position in the value histogram.
   const auto null_value_id = _indexed_segment->null_value_id();
-  auto null_count = 0u;
+  auto null_count = size_t{0};
 
   resolve_compressed_vector_type(*_indexed_segment->attribute_vector(), [&](auto& attribute_vector) {
     for (const auto value_id : attribute_vector) {
       if (static_cast<ValueID>(value_id) != null_value_id) {
-        value_histogram[value_id + 1u]++;
+        ++value_histogram[value_id + 1];
       } else {
         ++null_count;
       }
@@ -92,7 +92,7 @@ GroupKeyIndex::Iterator GroupKeyIndex::_lower_bound(const std::vector<AllTypeVar
   // the caller is responsible for not passing a NULL value
   Assert(!variant_is_null(values[0]), "Null was passed to lower_bound().");
 
-  ValueID value_id = _indexed_segment->lower_bound(values[0]);
+  const auto value_id = _indexed_segment->lower_bound(values[0]);
   return _get_positions_iterator_at(value_id);
 }
 
@@ -101,7 +101,7 @@ GroupKeyIndex::Iterator GroupKeyIndex::_upper_bound(const std::vector<AllTypeVar
   // the caller is responsible for not passing a NULL value
   Assert(!variant_is_null(values[0]), "Null was passed to upper_bound().");
 
-  ValueID value_id = _indexed_segment->upper_bound(values[0]);
+  const auto value_id = _indexed_segment->upper_bound(values[0]);
   return _get_positions_iterator_at(value_id);
 }
 
@@ -137,7 +137,7 @@ std::vector<std::shared_ptr<const AbstractSegment>> GroupKeyIndex::_get_indexed_
 }
 
 size_t GroupKeyIndex::_memory_consumption() const {
-  size_t bytes = sizeof(_indexed_segment);
+  auto bytes = sizeof(_indexed_segment);
   bytes += sizeof(std::vector<ChunkOffset>);  // _value_start_offsets
   bytes += sizeof(ChunkOffset) * _value_start_offsets.capacity();
   bytes += sizeof(std::vector<ChunkOffset>);  // _positions

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -58,7 +58,8 @@ class GroupKeyIndex : public AbstractChunkIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See AbstractChunkIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t /*value_bytes*/);
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count,
+                                            uint32_t /*value_bytes*/);
 
   GroupKeyIndex() = delete;
 

--- a/src/lib/storage/index/group_key/group_key_index.hpp
+++ b/src/lib/storage/index/group_key/group_key_index.hpp
@@ -58,7 +58,7 @@ class GroupKeyIndex : public AbstractChunkIndex {
    * Predicts the memory consumption in bytes of creating this index.
    * See AbstractChunkIndex::estimate_memory_consumption()
    */
-  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t value_bytes);
+  static size_t estimate_memory_consumption(ChunkOffset row_count, ChunkOffset distinct_count, uint32_t /*value_bytes*/);
 
   GroupKeyIndex() = delete;
 

--- a/src/lib/storage/lz4_segment.cpp
+++ b/src/lib/storage/lz4_segment.cpp
@@ -116,8 +116,8 @@ std::vector<T> LZ4Segment<T>::decompress() const {
   const auto num_blocks = _lz4_blocks.size();
 
   // This offset is needed to write directly into the decompressed data vector.
-  auto decompression_offset = size_t{0u};
-  for (auto block_index = size_t{0u}; block_index < num_blocks; ++block_index) {
+  auto decompression_offset = size_t{0};
+  for (auto block_index = size_t{0}; block_index < num_blocks; ++block_index) {
     _decompress_block(block_index, decompressed_data, decompression_offset);
     decompression_offset += _block_size;
   }
@@ -183,7 +183,7 @@ void LZ4Segment<T>::_decompress_block(const size_t block_index, std::vector<T>& 
   const auto& compressed_block = _lz4_blocks[block_index];
   const auto compressed_block_size = compressed_block.size();
 
-  int decompressed_result;
+  auto decompressed_result = int{0};
   if (_dictionary.empty()) {
     /**
      * If the dictionary is empty, we either have only a single block or had not enough data for a dictionary.
@@ -193,8 +193,7 @@ void LZ4Segment<T>::_decompress_block(const size_t block_index, std::vector<T>& 
      * dictionary) since the blocks were compressed independently.
      * This decoder needs to be reset via LZ4_setStreamDecode since LZ4 reuses the previous state instead.
      */
-    LZ4_streamDecode_t lz4_stream_decoder;
-    auto lz4_stream_decoder_ptr = std::make_unique<LZ4_streamDecode_t>(lz4_stream_decoder);
+    auto lz4_stream_decoder_ptr = std::make_unique<LZ4_streamDecode_t>();
     const auto reset_decoder_status = LZ4_setStreamDecode(lz4_stream_decoder_ptr.get(), nullptr, 0);
     Assert(reset_decoder_status == 1, "LZ4 decompression failed to reset stream decoder.");
 
@@ -242,7 +241,7 @@ void LZ4Segment<T>::_decompress_block_to_bytes(const size_t block_index, std::ve
   const auto& compressed_block = _lz4_blocks.at(block_index);
   const auto compressed_block_size = compressed_block.size();
 
-  int decompressed_result;
+  auto decompressed_result = int{0};
   if (_dictionary.empty()) {
     /**
      * If the dictionary is empty, we either have only a single block or had not enough data for a dictionary.
@@ -252,7 +251,7 @@ void LZ4Segment<T>::_decompress_block_to_bytes(const size_t block_index, std::ve
      * dictionary) since the blocks were compressed independently.
      * This decoder needs to be reset via LZ4_setStreamDecode since LZ4 reuses the previous state instead.
      */
-    LZ4_streamDecode_t lz4_stream_decoder;
+    auto lz4_stream_decoder = LZ4_streamDecode_t{};
     auto lz4_stream_decoder_ptr = std::make_unique<LZ4_streamDecode_t>(lz4_stream_decoder);
     const auto reset_decoder_status = LZ4_setStreamDecode(lz4_stream_decoder_ptr.get(), nullptr, 0);
     Assert(reset_decoder_status == 1, "LZ4 decompression failed to reset stream decoder.");
@@ -387,7 +386,7 @@ std::pair<pmr_string, size_t> LZ4Segment<pmr_string>::decompress(const ChunkOffs
 
   for (auto block_index = start_block; block_index <= end_block; ++block_index) {
     // Only decompress the current block if it's not cached.
-    if (!(use_caching && block_index == *cached_block_index)) {
+    if (!use_caching || block_index != *cached_block_index) {
       _decompress_block_to_bytes(block_index, cached_block);
       new_cached_block_index = block_index;
     }

--- a/src/lib/storage/pos_lists/row_id_pos_list.cpp
+++ b/src/lib/storage/pos_lists/row_id_pos_list.cpp
@@ -31,7 +31,7 @@ ChunkID RowIDPosList::common_chunk_id() const {
   return (*this)[0].chunk_id;
 }
 
-size_t RowIDPosList::memory_usage(const MemoryUsageCalculationMode mode) const {
+size_t RowIDPosList::memory_usage(const MemoryUsageCalculationMode /*mode*/) const {
   // Ignoring MemoryUsageCalculationMode because accurate calculation is efficient.
   return size() * sizeof(Vector::value_type);
 }

--- a/src/lib/storage/pos_lists/row_id_pos_list.hpp
+++ b/src/lib/storage/pos_lists/row_id_pos_list.hpp
@@ -125,7 +125,7 @@ class RowIDPosList final : public AbstractPosList, private pmr_vector<RowID> {
   using Vector::resize;
   using Vector::swap;
 
-  size_t memory_usage(const MemoryUsageCalculationMode mode) const final;
+  size_t memory_usage(const MemoryUsageCalculationMode /*mode*/) const final;
 
  private:
   bool _references_single_chunk = false;

--- a/src/lib/storage/reference_segment.cpp
+++ b/src/lib/storage/reference_segment.cpp
@@ -58,7 +58,7 @@ ChunkOffset ReferenceSegment::size() const {
 }
 
 std::shared_ptr<AbstractSegment> ReferenceSegment::copy_using_allocator(
-    const PolymorphicAllocator<size_t>& alloc) const {
+    const PolymorphicAllocator<size_t>& /*alloc*/) const {
   // ReferenceSegments are considered as intermediate data structures and are
   // therefore not subject to NUMA-aware chunk migrations.
   Fail("Cannot migrate a ReferenceSegment");

--- a/src/lib/storage/reference_segment.hpp
+++ b/src/lib/storage/reference_segment.hpp
@@ -33,7 +33,7 @@ class ReferenceSegment : public AbstractSegment {
 
   ColumnID referenced_column_id() const;
 
-  std::shared_ptr<AbstractSegment> copy_using_allocator(const PolymorphicAllocator<size_t>& alloc) const override;
+  std::shared_ptr<AbstractSegment> copy_using_allocator(const PolymorphicAllocator<size_t>& /*alloc*/) const override;
 
   size_t memory_usage(const MemoryUsageCalculationMode mode) const override;
 

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -222,8 +222,8 @@ void StorageManager::export_all_tables_as_csv(const std::string& path) {
       auto table_wrapper = std::make_shared<TableWrapper>(table);
       table_wrapper->execute();
 
-      auto export_csv =
-          std::make_shared<Export>(table_wrapper, path.append("/").append(name).append(".csv"), FileType::Csv);
+      // NOLINTNEXTLINE(performance-inefficient-string-concatenatio): not worth it, no performance-critical path.
+      auto export_csv = std::make_shared<Export>(table_wrapper, path + "/" + name + ".csv", FileType::Csv);
       export_csv->execute();
     });
     tasks.push_back(job_task);

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -222,7 +222,7 @@ void StorageManager::export_all_tables_as_csv(const std::string& path) {
       auto table_wrapper = std::make_shared<TableWrapper>(table);
       table_wrapper->execute();
 
-      // NOLINTNEXTLINE(performance-inefficient-string-concatenatio): not worth it, no performance-critical path.
+      // NOLINTNEXTLINE(performance-inefficient-string-concatenation): not worth it, no performance-critical path.
       auto export_csv = std::make_shared<Export>(table_wrapper, path + "/" + name + ".csv", FileType::Csv);
       export_csv->execute();
     });

--- a/src/lib/storage/storage_manager.cpp
+++ b/src/lib/storage/storage_manager.cpp
@@ -222,7 +222,8 @@ void StorageManager::export_all_tables_as_csv(const std::string& path) {
       auto table_wrapper = std::make_shared<TableWrapper>(table);
       table_wrapper->execute();
 
-      auto export_csv = std::make_shared<Export>(table_wrapper, path + "/" + name + ".csv", FileType::Csv);
+      auto export_csv =
+          std::make_shared<Export>(table_wrapper, path.append("/").append(name).append(".csv"), FileType::Csv);
       export_csv->execute();
     });
     tasks.push_back(job_task);

--- a/src/lib/storage/table.cpp
+++ b/src/lib/storage/table.cpp
@@ -149,7 +149,7 @@ void Table::append(const std::vector<AllTypeVariant>& values) {
 }
 
 void Table::append_mutable_chunk() {
-  Segments segments;
+  auto segments = Segments{};
   for (const auto& column_definition : _column_definitions) {
     resolve_data_type(column_definition.data_type, [&](auto type) {
       using ColumnDataType = typename decltype(type)::type;

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -134,10 +134,10 @@ void ValueSegment<T>::resize(const size_t size) {
 template <typename T>
 std::shared_ptr<AbstractSegment> ValueSegment<T>::copy_using_allocator(
     const PolymorphicAllocator<size_t>& alloc) const {
-  auto new_values = pmr_vector<T>(_values, alloc);  // NOLINT(cppcoreguidelines-slicing)
+  auto new_values = pmr_vector<T>{_values, alloc};  // NOLINT(cppcoreguidelines-slicing)
   auto copy = std::shared_ptr<AbstractSegment>{};
   if (is_nullable()) {
-    auto new_null_values = pmr_vector<bool>(*_null_values, alloc);  // NOLINT(cppcoreguidelines-slicing) (see above)
+    auto new_null_values = pmr_vector<bool>{*_null_values, alloc};  // NOLINT(cppcoreguidelines-slicing) (see above)
     copy = std::make_shared<ValueSegment<T>>(std::move(new_values), std::move(new_null_values));
   } else {
     copy = std::make_shared<ValueSegment<T>>(std::move(new_values));

--- a/src/lib/storage/value_segment.cpp
+++ b/src/lib/storage/value_segment.cpp
@@ -71,7 +71,7 @@ template <typename T>
 void ValueSegment<T>::append(const AllTypeVariant& val) {
   Assert(size() < _values.capacity(), "ValueSegment is full");
 
-  bool is_null = variant_is_null(val);
+  const auto is_null = variant_is_null(val);
   access_counter[SegmentAccessCounter::AccessType::Point] += 1;
 
   if (is_nullable()) {
@@ -111,7 +111,7 @@ template <typename T>
 void ValueSegment<T>::set_null_value(const ChunkOffset chunk_offset) {
   Assert(is_nullable(), "This ValueSegment does not support null values.");
 
-  std::lock_guard<std::mutex> lock{_null_value_modification_mutex};
+  const auto lock = std::lock_guard<std::mutex>{_null_value_modification_mutex};
   (*_null_values)[chunk_offset] = true;
 }
 
@@ -126,7 +126,7 @@ void ValueSegment<T>::resize(const size_t size) {
               "ValueSegments should not be shrunk or resized beyond their original capacity");
   _values.resize(size);
   if (is_nullable()) {
-    std::lock_guard<std::mutex> lock{_null_value_modification_mutex};
+    const auto lock = std::lock_guard<std::mutex>{_null_value_modification_mutex};
     _null_values->resize(size);
   }
 }
@@ -134,10 +134,10 @@ void ValueSegment<T>::resize(const size_t size) {
 template <typename T>
 std::shared_ptr<AbstractSegment> ValueSegment<T>::copy_using_allocator(
     const PolymorphicAllocator<size_t>& alloc) const {
-  pmr_vector<T> new_values(_values, alloc);  // NOLINT(cppcoreguidelines-slicing)
-  std::shared_ptr<AbstractSegment> copy;
+  auto new_values = pmr_vector<T>(_values, alloc);  // NOLINT(cppcoreguidelines-slicing)
+  auto copy = std::shared_ptr<AbstractSegment>{};
   if (is_nullable()) {
-    pmr_vector<bool> new_null_values(*_null_values, alloc);  // NOLINT(cppcoreguidelines-slicing) (see above)
+    auto new_null_values = pmr_vector<bool>(*_null_values, alloc);  // NOLINT(cppcoreguidelines-slicing) (see above)
     copy = std::make_shared<ValueSegment<T>>(std::move(new_values), std::move(new_null_values));
   } else {
     copy = std::make_shared<ValueSegment<T>>(std::move(new_values));

--- a/src/lib/storage/vector_compression/bitpacking/bitpacking_compressor.cpp
+++ b/src/lib/storage/vector_compression/bitpacking/bitpacking_compressor.cpp
@@ -12,10 +12,10 @@ class BitPackingVector;
 
 std::unique_ptr<const BaseCompressedVector> BitPackingCompressor::compress(const pmr_vector<uint32_t>& vector,
                                                                            const PolymorphicAllocator<size_t>& alloc,
-                                                                           const UncompressedVectorInfo& meta_info) {
+                                                                           const UncompressedVectorInfo& /*meta_info*/) {
   const auto max_element_it = std::max_element(vector.cbegin(), vector.cend());
 
-  auto required_bits = 1u;
+  auto required_bits = size_t{1};
   if (max_element_it != vector.cend() && *max_element_it != 0) {
     // add 1 to the maximum value because log2(1) = 0 but we need one bit to represent it.
     required_bits = static_cast<uint32_t>(std::ceil(log2(*max_element_it + 1u)));

--- a/src/lib/storage/vector_compression/bitpacking/bitpacking_compressor.cpp
+++ b/src/lib/storage/vector_compression/bitpacking/bitpacking_compressor.cpp
@@ -10,9 +10,9 @@ namespace hyrise {
 
 class BitPackingVector;
 
-std::unique_ptr<const BaseCompressedVector> BitPackingCompressor::compress(const pmr_vector<uint32_t>& vector,
-                                                                           const PolymorphicAllocator<size_t>& alloc,
-                                                                           const UncompressedVectorInfo& /*meta_info*/) {
+std::unique_ptr<const BaseCompressedVector> BitPackingCompressor::compress(
+    const pmr_vector<uint32_t>& vector, const PolymorphicAllocator<size_t>& alloc,
+    const UncompressedVectorInfo& /*meta_info*/) {
   const auto max_element_it = std::max_element(vector.cbegin(), vector.cend());
 
   auto required_bits = size_t{1};

--- a/src/lib/utils/meta_tables/abstract_meta_table.cpp
+++ b/src/lib/utils/meta_tables/abstract_meta_table.cpp
@@ -53,16 +53,16 @@ void AbstractMetaTable::_update(const std::vector<AllTypeVariant>& selected_valu
   _on_update(selected_values, update_values);
 }
 
-void AbstractMetaTable::_on_insert(const std::vector<AllTypeVariant>& values) {
+void AbstractMetaTable::_on_insert(const std::vector<AllTypeVariant>& /*values*/) {
   Fail("Cannot insert into " + MetaTableManager::META_PREFIX + name() + ".");
 }
 
-void AbstractMetaTable::_on_remove(const std::vector<AllTypeVariant>& values) {
+void AbstractMetaTable::_on_remove(const std::vector<AllTypeVariant>& /*values*/) {
   Fail("Cannot delete from " + MetaTableManager::META_PREFIX + name() + ".");
 }
 
-void AbstractMetaTable::_on_update(const std::vector<AllTypeVariant>& selected_values,
-                                   const std::vector<AllTypeVariant>& update_values) {
+void AbstractMetaTable::_on_update(const std::vector<AllTypeVariant>& /*selected_values*/,
+                                   const std::vector<AllTypeVariant>& /*update_values*/) {
   Fail("Cannot update " + MetaTableManager::META_PREFIX + name() + ".");
 }
 

--- a/src/lib/utils/meta_tables/abstract_meta_table.hpp
+++ b/src/lib/utils/meta_tables/abstract_meta_table.hpp
@@ -60,10 +60,10 @@ class AbstractMetaTable : public Noncopyable {
 
   // These methods actually perform the table creation and manipulation.
   virtual std::shared_ptr<Table> _on_generate() const = 0;
-  virtual void _on_insert(const std::vector<AllTypeVariant>& values);
-  virtual void _on_remove(const std::vector<AllTypeVariant>& values);
-  virtual void _on_update(const std::vector<AllTypeVariant>& selected_values,
-                          const std::vector<AllTypeVariant>& update_values);
+  virtual void _on_insert(const std::vector<AllTypeVariant>& /*values*/);
+  virtual void _on_remove(const std::vector<AllTypeVariant>& /*values*/);
+  virtual void _on_update(const std::vector<AllTypeVariant>& /*selected_values*/,
+                          const std::vector<AllTypeVariant>& /*update_values*/);
 
   const TableColumnDefinitions _column_definitions;
 };

--- a/src/lib/utils/meta_tables/meta_system_utilization_table.cpp
+++ b/src/lib/utils/meta_tables/meta_system_utilization_table.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<Table> MetaSystemUtilizationTable::_on_generate() const {
   * Returns the load average values for 1min, 5min, and 15min.
  */
 MetaSystemUtilizationTable::LoadAvg MetaSystemUtilizationTable::_get_load_avg() {
-  std::array<double, 3> load_avg{};
+  auto load_avg{} = std::array<double, 3>{};
   const int nelem = getloadavg(load_avg.data(), 3);
   Assert(nelem == 3, "Failed to read load averages");
   return {static_cast<float>(load_avg[0]), static_cast<float>(load_avg[1]), static_cast<float>(load_avg[2])};
@@ -85,8 +85,8 @@ uint64_t MetaSystemUtilizationTable::_get_total_time() {
 */
 uint64_t MetaSystemUtilizationTable::_get_system_cpu_time() {
 #ifdef __linux__
-  std::ifstream stat_file;
-  std::string cpu_line;
+  auto stat_file = std::ifstream{};
+  auto cpu_line = std::string{};
   try {
     stat_file.open("/proc/stat", std::ifstream::in);
 
@@ -112,7 +112,7 @@ uint64_t MetaSystemUtilizationTable::_get_system_cpu_time() {
 #endif
 
 #ifdef __APPLE__
-  host_cpu_load_info_data_t cpu_info;
+  auto cpu_info = host_cpu_load_info_data_t{};
   mach_msg_type_number_t count = HOST_CPU_LOAD_INFO_COUNT;
   const auto ret =
       host_statistics(mach_host_self(), HOST_CPU_LOAD_INFO, reinterpret_cast<host_info_t>(&cpu_info), &count);
@@ -169,12 +169,12 @@ uint64_t MetaSystemUtilizationTable::_get_process_cpu_time() {
  */
 MetaSystemUtilizationTable::SystemMemoryUsage MetaSystemUtilizationTable::_get_system_memory_usage() {
 #ifdef __linux__
-  std::ifstream meminfo_file;
-  MetaSystemUtilizationTable::SystemMemoryUsage memory_usage{};
+  auto meminfo_file = std::ifstream{};
+  auto memory_usage = MetaSystemUtilizationTable::SystemMemoryUsage{};
   try {
     meminfo_file.open("/proc/meminfo", std::ifstream::in);
 
-    std::string meminfo_line;
+    auto meminfo_line = std::string{};
     while (std::getline(meminfo_file, meminfo_line)) {
       if (meminfo_line.starts_with("MemFree")) {
         memory_usage.free_memory = _parse_value_string(meminfo_line)[0] * 1024;
@@ -191,14 +191,14 @@ MetaSystemUtilizationTable::SystemMemoryUsage MetaSystemUtilizationTable::_get_s
 #endif
 
 #ifdef __APPLE__
-  int64_t physical_memory;
-  size_t size = sizeof(physical_memory);
+  auto physical_memory = int64_t{0};
+  auto size = sizeof(physical_memory);
   auto ret = sysctlbyname("hw.memsize", &physical_memory, &size, nullptr, 0);
   Assert(ret == 0, "Failed to call sysctl hw.memsize");
 
   // see reference: https://stackoverflow.com/a/1911863
-  vm_size_t page_size;
-  vm_statistics64_data_t vm_statistics;
+  auto page_size = vm_size_t{};
+  auto vm_statistics = vm_statistics64_data_t{};
   mach_msg_type_number_t count = sizeof(vm_statistics) / sizeof(natural_t);
   ret = host_page_size(mach_host_self(), &page_size);
   Assert(ret == KERN_SUCCESS, "Failed to get page size");
@@ -222,12 +222,12 @@ MetaSystemUtilizationTable::SystemMemoryUsage MetaSystemUtilizationTable::_get_s
  */
 MetaSystemUtilizationTable::ProcessMemoryUsage MetaSystemUtilizationTable::_get_process_memory_usage() {
 #ifdef __linux__
-  std::ifstream self_status_file;
-  MetaSystemUtilizationTable::ProcessMemoryUsage memory_usage{};
+  auto self_status_file = std::ifstream{};
+  auto memory_usage = MetaSystemUtilizationTable::ProcessMemoryUsage{};
   try {
     self_status_file.open("/proc/self/status", std::ifstream::in);
 
-    std::string self_status_line;
+    auto self_status_line = std::string{};
     while (std::getline(self_status_file, self_status_line)) {
       if (self_status_line.starts_with("VmSize")) {
         memory_usage.virtual_memory = _parse_value_string(self_status_line)[0] * 1024;
@@ -286,8 +286,8 @@ std::optional<size_t> MetaSystemUtilizationTable::_get_allocated_memory() {
   if (HYRISE_DEBUG) {
     // Check that jemalloc was built with statistics support
 
-    bool stats_enabled;
-    size_t stats_enabled_size{sizeof(stats_enabled)};
+    auto stats_enabled = false;
+    auto stats_enabled_size = sizeof(stats_enabled);
 
     auto error_code = mallctl("config.stats", &stats_enabled, &stats_enabled_size, nullptr, 0);
     Assert(!error_code, "Cannot check if jemalloc was built with --stats_enabled");
@@ -297,13 +297,13 @@ std::optional<size_t> MetaSystemUtilizationTable::_get_allocated_memory() {
   // Before retrieving the statistics, we need to update jemalloc's epoch to get current values. See the mallctl
   // documentation for details.
   {
-    uint64_t epoch = 1;
+    auto epoch = uint64_t{1};
     auto epoch_size = sizeof(epoch);
     auto error_code = mallctl("epoch", &epoch, &epoch_size, &epoch, epoch_size);
     Assert(!error_code, "Setting epoch failed");
   }
 
-  size_t allocated;
+  auto allocated = size_t{0};
   auto allocated_size = sizeof(allocated);
 
   auto error_code = mallctl("stats.allocated", &allocated, &allocated_size, nullptr, 0);
@@ -319,12 +319,12 @@ std::optional<size_t> MetaSystemUtilizationTable::_get_allocated_memory() {
 
 #ifdef __linux__
 std::vector<int64_t> MetaSystemUtilizationTable::_parse_value_string(std::string& input_string) {
-  std::stringstream input_stream;
+  auto input_stream = std::stringstream{};
   input_stream << input_string;
-  std::vector<int64_t> output_values;
+  auto output_values = std::vector<int64_t>{};
 
-  std::string token;
-  int64_t value;
+  auto token = std::string{};
+  auto value = int64_t{0};
   while (!input_stream.eof()) {
     input_stream >> token;
     if (std::stringstream(token) >> value) {

--- a/src/lib/utils/meta_tables/meta_system_utilization_table.cpp
+++ b/src/lib/utils/meta_tables/meta_system_utilization_table.cpp
@@ -63,7 +63,7 @@ std::shared_ptr<Table> MetaSystemUtilizationTable::_on_generate() const {
   * Returns the load average values for 1min, 5min, and 15min.
  */
 MetaSystemUtilizationTable::LoadAvg MetaSystemUtilizationTable::_get_load_avg() {
-  auto load_avg{} = std::array<double, 3>{};
+  auto load_avg = std::array<double, 3>{};
   const int nelem = getloadavg(load_avg.data(), 3);
   Assert(nelem == 3, "Failed to read load averages");
   return {static_cast<float>(load_avg[0]), static_cast<float>(load_avg[1]), static_cast<float>(load_avg[2])};

--- a/src/lib/utils/performance_warning.hpp
+++ b/src/lib/utils/performance_warning.hpp
@@ -67,11 +67,11 @@ class PerformanceWarningDisabler {
   }
 };
 
-#define PerformanceWarning(text)                                                                       \
-  {                                                                                                    \
-    static PerformanceWarningClass warn(std::string(text) + " at " + trim_source_file_path(__FILE__) + \
-                                        ":" BOOST_PP_STRINGIZE(__LINE__));                             \
-  }                                                                                                    \
+#define PerformanceWarning(text)                                                                             \
+  {                                                                                                          \
+    const static PerformanceWarningClass warn(std::string(text) + " at " + trim_source_file_path(__FILE__) + \
+                                              ":" BOOST_PP_STRINGIZE(__LINE__));                             \
+  }                                                                                                          \
   static_assert(true, "End call of macro with a semicolon")
 
 }  // namespace hyrise

--- a/src/lib/utils/performance_warning.hpp
+++ b/src/lib/utils/performance_warning.hpp
@@ -69,7 +69,7 @@ class PerformanceWarningDisabler {
 
 #define PerformanceWarning(text)                                                                             \
   {                                                                                                          \
-    const static PerformanceWarningClass warn(std::string(text) + " at " + trim_source_file_path(__FILE__) + \
+    static const PerformanceWarningClass warn(std::string(text) + " at " + trim_source_file_path(__FILE__) + \
                                               ":" BOOST_PP_STRINGIZE(__LINE__));                             \
   }                                                                                                          \
   static_assert(true, "End call of macro with a semicolon")

--- a/src/lib/utils/sqlite_add_indices.cpp
+++ b/src/lib/utils/sqlite_add_indices.cpp
@@ -18,7 +18,7 @@ void add_indices_to_sqlite(const std::string& schema_file_path, const std::strin
   Assert(sqlite_wrapper, "sqlite_wrapper should be set");
 
   std::cout << "- Adding indexes to SQLite" << std::endl;
-  Timer timer;
+  auto timer = Timer{};
 
   // SQLite does not support adding primary keys to non-empty tables, so we rename the table, create an empty one from
   // the provided schema and copy the data.
@@ -35,10 +35,10 @@ void add_indices_to_sqlite(const std::string& schema_file_path, const std::strin
   }
 
   // Recreate tables using the passed schema sql file
-  std::ifstream schema_file(schema_file_path);
+  auto schema_file = std::ifstream{schema_file_path};
   Assert(schema_file.good(), std::string{"Schema file "} + schema_file_path +
                                  " not found - try running the binary from the Hyrise root or the build directory");
-  std::string schema_sql((std::istreambuf_iterator<char>(schema_file)), std::istreambuf_iterator<char>());
+  const auto schema_sql = std::string(std::istreambuf_iterator<char>(schema_file), std::istreambuf_iterator<char>());
   sqlite_wrapper->main_connection.raw_execute_query(schema_sql);
 
   // If indices are not part of the schema file, add them here
@@ -47,14 +47,14 @@ void add_indices_to_sqlite(const std::string& schema_file_path, const std::strin
     Assert(create_indices_file.good(),
            std::string{"Index file "} + create_indices_file_path +
                " not found - try running the binary from the Hyrise root or the build directory");
-    std::string create_indices_sql((std::istreambuf_iterator<char>(create_indices_file)),
-                                   std::istreambuf_iterator<char>());
+    const auto create_indices_sql =
+        std::string(std::istreambuf_iterator<char>(create_indices_file), std::istreambuf_iterator<char>());
     sqlite_wrapper->main_connection.raw_execute_query(create_indices_sql);
   }
 
   // Copy over data
   for (const auto& table_name : Hyrise::get().storage_manager.table_names()) {
-    Timer per_table_time;
+    auto per_table_time = Timer{};
     std::cout << "-  Adding indexes to SQLite table " << table_name << std::flush;
 
     const auto escaped_table_name = std::string{"\""} + table_name + "\"";

--- a/src/lib/utils/sqlite_add_indices.cpp
+++ b/src/lib/utils/sqlite_add_indices.cpp
@@ -38,7 +38,7 @@ void add_indices_to_sqlite(const std::string& schema_file_path, const std::strin
   auto schema_file = std::ifstream{schema_file_path};
   Assert(schema_file.good(), std::string{"Schema file "} + schema_file_path +
                                  " not found - try running the binary from the Hyrise root or the build directory");
-  const auto schema_sql = std::string(std::istreambuf_iterator<char>(schema_file), std::istreambuf_iterator<char>());
+  const auto schema_sql = std::string{std::istreambuf_iterator<char>(schema_file), std::istreambuf_iterator<char>()};
   sqlite_wrapper->main_connection.raw_execute_query(schema_sql);
 
   // If indices are not part of the schema file, add them here
@@ -48,7 +48,7 @@ void add_indices_to_sqlite(const std::string& schema_file_path, const std::strin
            std::string{"Index file "} + create_indices_file_path +
                " not found - try running the binary from the Hyrise root or the build directory");
     const auto create_indices_sql =
-        std::string(std::istreambuf_iterator<char>(create_indices_file), std::istreambuf_iterator<char>());
+        std::string{std::istreambuf_iterator<char>(create_indices_file), std::istreambuf_iterator<char>()};
     sqlite_wrapper->main_connection.raw_execute_query(create_indices_sql);
   }
 

--- a/src/lib/utils/sqlite_wrapper.cpp
+++ b/src/lib/utils/sqlite_wrapper.cpp
@@ -181,7 +181,7 @@ std::shared_ptr<Table> SQLiteWrapper::Connection::execute_query(const std::strin
 
   // We need to split the queries such that we only create columns/add rows from the final SELECT query
   const auto queries_before_select = std::vector<std::string>(queries.begin(), queries.end() - 1);
-  const auto select_query = queries.back();
+  const auto& select_query = queries.back();
 
   auto return_code = int{0};
   for (const auto& query : queries_before_select) {

--- a/src/lib/utils/sqlite_wrapper.cpp
+++ b/src/lib/utils/sqlite_wrapper.cpp
@@ -101,18 +101,17 @@ void copy_row_from_sqlite_to_hyrise(const std::shared_ptr<Table>& table, sqlite3
   for (auto column_id = int{0}; column_id < column_count; ++column_id) {
     switch (sqlite3_column_type(sqlite_statement, column_id)) {
       case SQLITE_INTEGER: {
-        row.emplace_back(AllTypeVariant{sqlite3_column_int(sqlite_statement, column_id)});
+        row.emplace_back(sqlite3_column_int(sqlite_statement, column_id));
         break;
       }
 
       case SQLITE_FLOAT: {
-        row.emplace_back(AllTypeVariant{sqlite3_column_double(sqlite_statement, column_id)});
+        row.emplace_back(sqlite3_column_double(sqlite_statement, column_id));
         break;
       }
 
       case SQLITE_TEXT: {
-        row.emplace_back(AllTypeVariant{
-            pmr_string(reinterpret_cast<const char*>(sqlite3_column_text(sqlite_statement, column_id)))});
+        row.emplace_back(pmr_string(reinterpret_cast<const char*>(sqlite3_column_text(sqlite_statement, column_id))));
         break;
       }
 
@@ -175,16 +174,16 @@ SQLiteWrapper::Connection SQLiteWrapper::new_connection() const {
 }
 
 std::shared_ptr<Table> SQLiteWrapper::Connection::execute_query(const std::string& sql) const {
-  sqlite3_stmt* sqlite_statement;
+  sqlite3_stmt* sqlite_statement = nullptr;
 
   auto sql_pipeline = SQLPipelineBuilder{sql}.create_pipeline();
   const auto& queries = sql_pipeline.get_sql_per_statement();
 
   // We need to split the queries such that we only create columns/add rows from the final SELECT query
-  std::vector<std::string> queries_before_select(queries.begin(), queries.end() - 1);
-  std::string select_query = queries.back();
+  const auto queries_before_select = std::vector<std::string>(queries.begin(), queries.end() - 1);
+  const auto select_query = queries.back();
 
-  auto return_code = int{};
+  auto return_code = int{0};
   for (const auto& query : queries_before_select) {
     return_code = sqlite3_prepare_v2(db, query.c_str(), -1, &sqlite_statement, nullptr);
 
@@ -227,7 +226,7 @@ std::shared_ptr<Table> SQLiteWrapper::Connection::execute_query(const std::strin
 }
 
 void SQLiteWrapper::Connection::raw_execute_query(const std::string& sql, const bool allow_failure) const {
-  char* err_msg;
+  char* err_msg = nullptr;
   auto return_code = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &err_msg);
 
   if (return_code != SQLITE_OK) {
@@ -287,7 +286,7 @@ void SQLiteWrapper::create_sqlite_table(const Table& table, const std::string& t
   insert_into_stream << ");";
   const auto insert_into_str = insert_into_stream.str();
 
-  sqlite3_stmt* insert_into_statement;
+  sqlite3_stmt* insert_into_statement = nullptr;
   const auto sqlite3_prepare_return_code =
       sqlite3_prepare_v2(main_connection.db, insert_into_str.c_str(), static_cast<int>(insert_into_str.size() + 1),
                          &insert_into_statement, nullptr);

--- a/src/lib/utils/sqlite_wrapper.cpp
+++ b/src/lib/utils/sqlite_wrapper.cpp
@@ -225,7 +225,7 @@ std::shared_ptr<Table> SQLiteWrapper::Connection::execute_query(const std::strin
   return result_table;
 }
 
-void SQLiteWrapper::Connection::raw_execute_query(const std::string& sql, const bool allow_failure) const {
+void SQLiteWrapper::Connection::raw_execute_query(const std::string& sql) const {
   char* err_msg = nullptr;
   auto return_code = sqlite3_exec(db, sql.c_str(), nullptr, nullptr, &err_msg);
 

--- a/src/lib/utils/sqlite_wrapper.hpp
+++ b/src/lib/utils/sqlite_wrapper.hpp
@@ -58,7 +58,7 @@ class SQLiteWrapper final {
      * Execute a SQL string on the wrapped sqlite db and ignores the result (i.e., does not convert the last
      * statement's result into a Hyrise table)
      */
-    void raw_execute_query(const std::string& sql, const bool allow_failure = false) const;
+    void raw_execute_query(const std::string& sql) const;
   };
 
   /**

--- a/src/test/base_test.cpp
+++ b/src/test/base_test.cpp
@@ -214,11 +214,11 @@ std::shared_ptr<const Table> to_simple_reference_table(const std::shared_ptr<con
   }
 
   const auto column_count = table->column_count();
-  Segments segments;
+  auto segments = Segments{};
   segments.reserve(column_count);
   TableColumnDefinitions column_definitions;
 
-  for (auto column_id = ColumnID{0u}; column_id < column_count; ++column_id) {
+  for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     column_definitions.emplace_back(table->column_name(column_id), table->column_data_type(column_id),
                                     table->column_is_nullable(column_id));
 

--- a/src/test/benchmarklib/sqlite_add_indices_test.cpp
+++ b/src/test/benchmarklib/sqlite_add_indices_test.cpp
@@ -33,7 +33,7 @@ class SQLiteAddIndicesTest : public BaseTest {
 
 TEST_F(SQLiteAddIndicesTest, AddIndexTest) {
   // DROP INDEX index_1 throws an exception if index_1 does not exist.
-  EXPECT_THROW(sqlite_wrapper->main_connection.raw_execute_query("DROP INDEX index_1;", true), std::logic_error);
+  EXPECT_THROW(sqlite_wrapper->main_connection.raw_execute_query("DROP INDEX index_1;"), std::logic_error);
   auto sqlite_table = sqlite_wrapper->main_connection.execute_query("SELECT * FROM table_1");
   EXPECT_TABLE_EQ_ORDERED(stored_table, sqlite_table);
   const auto schema_file_path = "resources/test_data/sqlite_add_index_schema.sql";

--- a/src/test/lib/expression/expression_evaluator_to_values_test.cpp
+++ b/src/test/lib/expression/expression_evaluator_to_values_test.cpp
@@ -71,7 +71,7 @@ class ExpressionEvaluatorToValuesTest : public BaseTest {
     empty_table_columns.emplace_back("s", DataType::String, false);
     table_empty = std::make_shared<Table>(empty_table_columns, TableType::Data);
 
-    Segments segments;
+    auto segments = Segments{};
     segments.emplace_back(std::make_shared<ValueSegment<int32_t>>(pmr_vector<int32_t>{}));
     segments.emplace_back(std::make_shared<ValueSegment<float>>(pmr_vector<float>{}, pmr_vector<bool>{}));
     segments.emplace_back(std::make_shared<ValueSegment<pmr_string>>(pmr_vector<pmr_string>{}));

--- a/src/test/lib/operators/table_scan_test.cpp
+++ b/src/test/lib/operators/table_scan_test.cpp
@@ -133,7 +133,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     auto segment_a = std::make_shared<ReferenceSegment>(test_table_part_compressed, ColumnID{0}, pos_list);
     auto segment_b = std::make_shared<ReferenceSegment>(test_table_part_compressed, ColumnID{1}, pos_list);
 
-    Segments segments({segment_a, segment_b});
+    const auto segments = Segments({segment_a, segment_b});
 
     table->append_chunk(segments);
     auto table_wrapper = std::make_shared<TableWrapper>(std::move(table));
@@ -145,7 +145,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
 
   std::shared_ptr<TableWrapper> get_table_op_with_n_dict_entries(const int num_entries) {
     // Set up dictionary encoded table with a dictionary consisting of num_entries entries.
-    TableColumnDefinitions table_column_definitions;
+    auto table_column_definitions = TableColumnDefinitions{};
     table_column_definitions.emplace_back("a", DataType::Int, false);
 
     const auto table = std::make_shared<Table>(table_column_definitions, TableType::Data, ChunkOffset{100'000});
@@ -187,7 +187,7 @@ class OperatorsTableScanTest : public BaseTest, public ::testing::WithParamInter
     column_definitions.emplace_back("b", DataType::Int, true);
     auto ref_table = std::make_shared<Table>(column_definitions, TableType::References);
 
-    Segments segments({ref_segment_a, ref_segment_b});
+    const auto segments = Segments({ref_segment_a, ref_segment_b});
 
     ref_table->append_chunk(segments);
 

--- a/src/test/lib/operators/validate_test.cpp
+++ b/src/test/lib/operators/validate_test.cpp
@@ -146,7 +146,7 @@ TEST_F(OperatorsValidateTest, ChunkEntirelyVisibleThrowsOnRefChunk) {
 
   auto snapshot_cid = CommitID{1};
   auto pos_list = std::make_shared<RowIDPosList>(std::initializer_list<RowID>({RowID{ChunkID{0}, ChunkOffset{0}}}));
-  Segments segments = {std::make_shared<ReferenceSegment>(_test_table, ColumnID{0}, pos_list)};
+  auto segments = Segments{std::make_shared<ReferenceSegment>(_test_table, ColumnID{0}, pos_list)};
   auto chunk = std::make_shared<Chunk>(segments);
 
   auto validate = std::make_shared<Validate>(nullptr);
@@ -228,8 +228,9 @@ TEST_F(OperatorsValidateTest, ValidateReferenceSegmentWithMultipleChunks) {
     }
   }
 
-  Segments segments;
-  for (auto column_id = ColumnID{0}; column_id < _test_table->column_count(); ++column_id) {
+  auto segments = Segments{};
+  const auto column_count = _test_table->column_count();
+  for (auto column_id = ColumnID{0}; column_id < column_count; ++column_id) {
     segments.emplace_back(std::make_shared<ReferenceSegment>(_test_table, column_id, pos_list));
   }
 

--- a/src/test/lib/scheduler/scheduler_test.cpp
+++ b/src/test/lib/scheduler/scheduler_test.cpp
@@ -327,12 +327,10 @@ TEST_F(SchedulerTest, DetermineQueueIDForTask) {
   const auto node_queue_scheduler = std::make_shared<NodeQueueScheduler>();
   Hyrise::get().set_scheduler(node_queue_scheduler);
 
-  const auto task = std::static_pointer_cast<AbstractTask>(std::make_shared<JobTask>([&]() {}));
-
-  EXPECT_EQ(node_queue_scheduler->determine_queue_id_for_task(task, NodeID{1}), NodeID{1});
+  EXPECT_EQ(node_queue_scheduler->determine_queue_id(NodeID{1}), NodeID{1});
 
   // For the case of no load on node ID 0 (which is the case here), tasks are always scheduled on this node.
-  EXPECT_EQ(node_queue_scheduler->determine_queue_id_for_task(task, CURRENT_NODE_ID), NodeID{0});
+  EXPECT_EQ(node_queue_scheduler->determine_queue_id(CURRENT_NODE_ID), NodeID{0});
 
   // The distribution of tasks under high load is tested in the concurrency stress tests.
 }

--- a/src/test/lib/storage/index/partial_hash/partial_hash_index_test.cpp
+++ b/src/test/lib/storage/index/partial_hash/partial_hash_index_test.cpp
@@ -22,8 +22,8 @@ class PartialHashIndexTest : public BaseTest {
     segment1 = std::make_shared<ValueSegment<pmr_string>>(std::move(values1), std::move(null_values_1));
     segment2 = std::make_shared<ValueSegment<pmr_string>>(std::move(values2), std::move(null_values_2));
 
-    Segments segments1 = {segment1};
-    Segments segments2 = {segment2};
+    auto segments1 = Segments{segment1};
+    auto segments2 = Segments{segment2};
 
     table->append_chunk(segments1);
     table->append_chunk(segments2);
@@ -545,11 +545,11 @@ TEST_F(PartialHashIndexTest, MemoryUsageNoNulls) {
   auto local_values = pmr_vector<pmr_string>{"h", "d", "f", "d", "a", "c", "c", "i", "b", "z", "x"};
   auto segment = std::make_shared<ValueSegment<pmr_string>>(std::move(local_values));
 
-  Segments segments = {segment};
+  auto segments = Segments{};
   auto chunk = std::make_shared<Chunk>(segments);
 
-  std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>> chunks_to_index;
-  chunks_to_index.push_back(std::make_pair(ChunkID{0}, chunk));
+  auto chunks_to_index = std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>>{};
+  chunks_to_index.emplace_back(ChunkID{0}, chunk);
 
   index = std::make_shared<PartialHashIndex>(chunks_to_index, ColumnID{0});
 
@@ -589,11 +589,11 @@ TEST_F(PartialHashIndexTest, MemoryUsageNulls) {
   const auto& dict_segment_string_nulls =
       create_dict_segment_by_type<pmr_string>(DataType::String, {std::nullopt, std::nullopt});
 
-  Segments segments = {dict_segment_string_nulls};
+  const auto segments = Segments{dict_segment_string_nulls};
   auto chunk = std::make_shared<Chunk>(segments);
 
-  std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>> chunks_to_index;
-  chunks_to_index.push_back(std::make_pair(ChunkID{0}, chunk));
+  auto chunks_to_index = std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>>{};
+  chunks_to_index.emplace_back(ChunkID{0}, chunk);
 
   index = std::make_shared<PartialHashIndex>(chunks_to_index, ColumnID{0});
 
@@ -634,11 +634,11 @@ TEST_F(PartialHashIndexTest, MemoryUsageMixed) {
       DataType::String, {std::nullopt, "h", "d", "f", "d", "a", std::nullopt, std::nullopt, "c", std::nullopt, "c", "i",
                          "b", "z", "x", std::nullopt});
 
-  Segments segments = {dict_segment_string_mixed};
+  const auto segments = Segments{dict_segment_string_mixed};
   auto chunk = std::make_shared<Chunk>(segments);
 
-  std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>> chunks_to_index;
-  chunks_to_index.push_back(std::make_pair(ChunkID{0}, chunk));
+  auto chunks_to_index = std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>>{};
+  chunks_to_index.emplace_back(ChunkID{0}, chunk);
 
   index = std::make_shared<PartialHashIndex>(chunks_to_index, ColumnID{0});
 
@@ -677,11 +677,11 @@ TEST_F(PartialHashIndexTest, MemoryUsageMixed) {
 TEST_F(PartialHashIndexTest, MemoryUsageEmpty) {
   const auto& dict_segment_string_empty = create_dict_segment_by_type<pmr_string>(DataType::String, {});
 
-  Segments segments = {dict_segment_string_empty};
+  const auto segments = Segments{dict_segment_string_empty};
   auto chunk = std::make_shared<Chunk>(segments);
 
-  std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>> chunks_to_index;
-  chunks_to_index.push_back(std::make_pair(ChunkID{0}, chunk));
+  auto chunks_to_index = std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>>{};
+  chunks_to_index.emplace_back(ChunkID{0}, chunk);
 
   index = std::make_shared<PartialHashIndex>(chunks_to_index, ColumnID{0});
 
@@ -719,11 +719,11 @@ TEST_F(PartialHashIndexTest, MemoryUsageEmpty) {
 TEST_F(PartialHashIndexTest, MemoryUsageNoChunk) {
   const auto& dict_segment_string_empty = create_dict_segment_by_type<pmr_string>(DataType::String, {});
 
-  Segments segments = {dict_segment_string_empty};
+  const auto segments = Segments{dict_segment_string_empty};
   auto chunk = std::make_shared<Chunk>(segments);
 
-  std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>> chunks_to_index;
-  chunks_to_index.push_back(std::make_pair(ChunkID{0}, chunk));
+  auto chunks_to_index = std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>>{};
+  chunks_to_index.emplace_back(ChunkID{0}, chunk);
 
   index = std::make_shared<PartialHashIndex>(chunks_to_index, ColumnID{0});
   EXPECT_EQ(index->remove(std::vector<ChunkID>{ChunkID{0}}), 1);

--- a/src/test/lib/storage/index/partial_hash/partial_hash_index_test.cpp
+++ b/src/test/lib/storage/index/partial_hash/partial_hash_index_test.cpp
@@ -545,7 +545,7 @@ TEST_F(PartialHashIndexTest, MemoryUsageNoNulls) {
   auto local_values = pmr_vector<pmr_string>{"h", "d", "f", "d", "a", "c", "c", "i", "b", "z", "x"};
   auto segment = std::make_shared<ValueSegment<pmr_string>>(std::move(local_values));
 
-  auto segments = Segments{};
+  auto segments = Segments{segment};
   auto chunk = std::make_shared<Chunk>(segments);
 
   auto chunks_to_index = std::vector<std::pair<ChunkID, std::shared_ptr<Chunk>>>{};

--- a/src/test/plugins/mvcc_delete_plugin_system_test.cpp
+++ b/src/test/plugins/mvcc_delete_plugin_system_test.cpp
@@ -42,7 +42,7 @@ class MvccDeletePluginSystemTest : public BaseTest {
       std::iota(values.begin(), values.end(), begin_value);
 
       const auto value_segment = std::make_shared<ValueSegment<int>>(std::move(values));
-      Segments segments;
+      auto segments = Segments{};
       segments.emplace_back(value_segment);
       const auto mvcc_data = std::make_shared<MvccData>(segments.front()->size(), CommitID{0});
       _table->append_chunk(segments, mvcc_data);


### PR DESCRIPTION
We found the `.clang-tidy` file was a bit outdated. This PR updates the file by removing a few no longer needed exceptions and fixing a few things that clang-tidy 15 complained about.