### PR TITLE
Fix some clang-tidy issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,9 @@ try {
 
             sh "mkdir clang-debug && cd clang-debug &&                                                   ${cmake} ${debug}          ${clang}  ${unity}  .. && make -j libjemalloc-build"
 
-            // Configure the rest in parallel
+            // Configure the rest in parallel.
+            // Note on the clang-debug-tidy stage: clang-tidy misses some flaws when running in a unity build. However, it runs very long and we agreed to life with that for now.
+            // See: https://gitlab.kitware.com/cmake/cmake/-/issues/20058
             sh "mkdir clang-debug-tidy && cd clang-debug-tidy &&                                         ${cmake} ${debug}          ${clang}   ${unity} -DENABLE_CLANG_TIDY=ON .. &\
             mkdir clang-debug-unity-odr && cd clang-debug-unity-odr &&                                   ${cmake} ${debug}          ${clang}   ${unity} -DCMAKE_UNITY_BUILD_BATCH_SIZE=0 .. &\
             mkdir clang-debug-disable-precompile-headers && cd clang-debug-disable-precompile-headers && ${cmake} ${debug}          ${clang}            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=On .. &\

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -10,11 +10,7 @@
 #include <ctime>
 #include <filesystem>
 #include <iomanip>
-#include <iostream>
-#include <memory>
 #include <regex>
-#include <string>
-#include <vector>
 
 #include <boost/algorithm/string/join.hpp>
 
@@ -51,13 +47,13 @@
 #include "visualization/lqp_visualizer.hpp"
 #include "visualization/pqp_visualizer.hpp"
 
-#define ANSI_COLOR_RED "\x1B[31m"
-#define ANSI_COLOR_GREEN "\x1B[32m"
-#define ANSI_COLOR_RESET "\x1B[0m"
+#define ANSI_COLOR_RED "\x1B[31m"    // NOLINT(cppcoreguidelines-macro-usage)
+#define ANSI_COLOR_GREEN "\x1B[32m"  // NOLINT(cppcoreguidelines-macro-usage)
+#define ANSI_COLOR_RESET "\x1B[0m"   // NOLINT(cppcoreguidelines-macro-usage)
 
-#define ANSI_COLOR_RED_RL "\001\x1B[31m\002"
-#define ANSI_COLOR_GREEN_RL "\001\x1B[32m\002"
-#define ANSI_COLOR_RESET_RL "\001\x1B[0m\002"
+#define ANSI_COLOR_RED_RL "\001\x1B[31m\002"    // NOLINT(cppcoreguidelines-macro-usage)
+#define ANSI_COLOR_GREEN_RL "\001\x1B[32m\002"  // NOLINT(cppcoreguidelines-macro-usage)
+#define ANSI_COLOR_RESET_RL "\001\x1B[0m\002"   // NOLINT(cppcoreguidelines-macro-usage)
 
 namespace {
 
@@ -128,7 +124,8 @@ Console::Console()
       _lqp_cache(std::make_shared<SQLLogicalPlanCache>()) {
   // Init readline basics, tells readline to use our custom command completion function
   rl_attempted_completion_function = &Console::_command_completion;
-  rl_completer_word_break_characters = const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");
+  rl_completer_word_break_characters =
+      const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");  // NOLINT(cppcoreguidelines-pro-type-const-cast)
 
   // Set Hyrise caches
   Hyrise::get().default_pqp_cache = _pqp_cache;
@@ -391,7 +388,7 @@ void Console::out(const std::shared_ptr<const Table>& table, const PrintFlags fl
   stream.str(stream_backup);
 
   static bool pagination_disabled = false;
-  if (!fits_on_one_page && !std::getenv("TERM") && !pagination_disabled) {  // NULL_VALUE(concurrency-mt-unsafe)
+  if (!fits_on_one_page && !std::getenv("TERM") && !pagination_disabled) {  // NOLINT(concurrency-mt-unsafe)
     out("Your TERM environment variable is not set - most likely because you are running the console from an IDE. "
         "Pagination is disabled.\n\n");
     pagination_disabled = true;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -2,7 +2,6 @@
 
 #include <readline/history.h>
 #include <readline/readline.h>
-#include <sys/stat.h>
 
 #include <chrono>
 #include <csetjmp>
@@ -838,18 +837,12 @@ int Console::_exec_script(const std::string& script_file) {
   boost::algorithm::trim(filepath);
   auto script = std::ifstream{filepath};
 
-  const auto is_regular_file = [](const std::string& path) {
-    struct stat path_stat {};
-    stat(path.c_str(), &path_stat);
-    return S_ISREG(path_stat.st_mode);
-  };
-
   if (!script.good()) {
     out("Error: Script file '" + filepath + "' does not exist.\n");
     return ReturnCode::Error;
   }
 
-  if (!is_regular_file(filepath)) {
+  if (!std::filesystem::is_regular_file(filepath)) {
     out("Error: '" + filepath + "' is not a regular file.\n");
     return ReturnCode::Error;
   }

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -124,8 +124,8 @@ Console::Console()
       _lqp_cache(std::make_shared<SQLLogicalPlanCache>()) {
   // Init readline basics, tells readline to use our custom command completion function
   rl_attempted_completion_function = &Console::_command_completion;
-  rl_completer_word_break_characters =
-      const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");  // NOLINT(cppcoreguidelines-pro-type-const-cast)
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+  rl_completer_word_break_characters = const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");
 
   // Set Hyrise caches
   Hyrise::get().default_pqp_cache = _pqp_cache;

--- a/src/bin/console/console.cpp
+++ b/src/bin/console/console.cpp
@@ -52,13 +52,13 @@
 #include "visualization/lqp_visualizer.hpp"
 #include "visualization/pqp_visualizer.hpp"
 
-#define ANSI_COLOR_RED "\x1B[31m"    // NOLINT
-#define ANSI_COLOR_GREEN "\x1B[32m"  // NOLINT
-#define ANSI_COLOR_RESET "\x1B[0m"   // NOLINT
+#define ANSI_COLOR_RED "\x1B[31m"
+#define ANSI_COLOR_GREEN "\x1B[32m"
+#define ANSI_COLOR_RESET "\x1B[0m"
 
-#define ANSI_COLOR_RED_RL "\001\x1B[31m\002"    // NOLINT
-#define ANSI_COLOR_GREEN_RL "\001\x1B[32m\002"  // NOLINT
-#define ANSI_COLOR_RESET_RL "\001\x1B[0m\002"   // NOLINT
+#define ANSI_COLOR_RED_RL "\001\x1B[31m\002"
+#define ANSI_COLOR_GREEN_RL "\001\x1B[32m\002"
+#define ANSI_COLOR_RESET_RL "\001\x1B[0m\002"
 
 namespace {
 
@@ -79,7 +79,7 @@ std::string current_timestamp() {
   auto time = std::time(nullptr);
   const auto local_time = *std::localtime(&time);  // NOLINT(concurrency-mt-unsafe) - not called concurrently
 
-  std::ostringstream oss;
+  auto oss = std::ostringstream{};
   oss << std::put_time(&local_time, "%Y-%m-%d %H:%M:%S");
   return oss.str();
 }
@@ -88,15 +88,15 @@ std::string current_timestamp() {
 // If remove_rl_codes_only is true, then it only removes the Readline specific escape sequences '\001' and '\002'
 std::string remove_coloring(const std::string& input, bool remove_rl_codes_only = false) {
   // matches any characters that need to be escaped in RegEx except for '|'
-  std::regex special_chars{R"([-[\]{}()*+?.,\^$#\s])"};
-  std::string sequences = "\x1B[31m|\x1B[32m|\x1B[0m|\001|\002";
+  const auto special_chars = std::regex{R"([-[\]{}()*+?.,\^$#\s])"};
+  auto sequences = std::string{"\x1B[31m|\x1B[32m|\x1B[0m|\001|\002"};
   if (remove_rl_codes_only) {
     sequences = "\001|\002";
   }
-  std::string sanitized_sequences = std::regex_replace(sequences, special_chars, R"(\$&)");
+  const auto sanitized_sequences = std::regex_replace(sequences, special_chars, R"(\$&)");
 
   // Remove coloring commands and escape sequences before writing to logfile
-  std::regex expression{"(" + sanitized_sequences + ")"};
+  const auto expression = std::regex{"(" + sanitized_sequences + ")"};
   return std::regex_replace(input, expression, "");
 }
 
@@ -104,10 +104,10 @@ std::vector<std::string> tokenize(std::string input) {
   boost::algorithm::trim<std::string>(input);
 
   // Remove whitespace duplicates to not get empty tokens after boost::algorithm::split
-  auto both_are_spaces = [](char left, char right) { return (left == right) && (left == ' '); };
+  const auto both_are_spaces = [](char left, char right) { return (left == right) && (left == ' '); };
   input.erase(std::unique(input.begin(), input.end(), both_are_spaces), input.end());
 
-  std::vector<std::string> tokens;
+  auto tokens = std::vector<std::string>{};
   boost::algorithm::split(tokens, input, boost::is_space());
 
   return tokens;
@@ -129,7 +129,7 @@ Console::Console()
       _lqp_cache(std::make_shared<SQLLogicalPlanCache>()) {
   // Init readline basics, tells readline to use our custom command completion function
   rl_attempted_completion_function = &Console::_command_completion;
-  rl_completer_word_break_characters = const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");  // NOLINT (legacy API)
+  rl_completer_word_break_characters = const_cast<char*>(" \t\n\"\\'`@$><=;|&{(");
 
   // Set Hyrise caches
   Hyrise::get().default_pqp_cache = _pqp_cache;
@@ -176,7 +176,7 @@ int Console::read() {
     return ReturnCode::Quit;
   }
 
-  std::string input(buffer);
+  auto input = std::string{buffer};
   boost::algorithm::trim<std::string>(input);
 
   // Only save non-empty commands to history
@@ -219,7 +219,7 @@ int Console::_eval(const std::string& input) {
     }
 
     // Regard query as complete if input is valid and not already in multiline
-    hsql::SQLParserResult parse_result;
+    auto parse_result = hsql::SQLParserResult{};
     hsql::SQLParser::parse(input, &parse_result);
     if (parse_result.isValid()) {
       return _eval_sql(input);
@@ -228,7 +228,7 @@ int Console::_eval(const std::string& input) {
 
   // Regard query as complete if last character is semicolon, regardless of multiline or not
   if (input.back() == ';') {
-    int return_code = _eval_sql(_multiline_input + input);
+    const auto return_code = _eval_sql(_multiline_input + input);
     _multiline_input = "";
     return return_code;
   }
@@ -240,24 +240,24 @@ int Console::_eval(const std::string& input) {
 }
 
 int Console::_eval_command(const CommandFunction& func, const std::string& command) {
-  std::string cmd = command;
+  auto cmd = command;
   if (command.back() == ';') {
     cmd = command.substr(0, command.size() - 1);
   }
   boost::algorithm::trim<std::string>(cmd);
 
-  size_t first = cmd.find(' ');
-  size_t last = cmd.find('\n');
+  const auto first = cmd.find(' ');
+  const auto last = cmd.find('\n');
 
   // If no whitespace is found, zero arguments are provided
   if (std::string::npos == first) {
     return static_cast<int>(func(""));
   }
 
-  std::string args = cmd.substr(first + 1, last - (first + 1));
+  auto args = cmd.substr(first + 1, last - (first + 1));
 
   // Remove whitespace duplicates in args
-  auto both_are_spaces = [](char left, char right) { return (left == right) && (left == ' '); };
+  const auto both_are_spaces = [](char left, char right) { return (left == right) && (left == ' '); };
   args.erase(std::unique(args.begin(), args.end(), both_are_spaces), args.end());
 
   return static_cast<int>(func(args));
@@ -305,7 +305,7 @@ int Console::_eval_sql(const std::string& sql) {
   // Failed (i.e., conflicted) pipelines should be impossible in the single-user console
   Assert(pipeline_status == SQLPipelineStatus::Success, "Unexpected pipeline status");
 
-  auto row_count = table ? table->row_count() : 0;
+  const auto row_count = table ? table->row_count() : 0;
 
   // Print result (to Console and logfile)
   if (table) {
@@ -315,7 +315,7 @@ int Console::_eval_sql(const std::string& sql) {
   out("===\n");
   out(std::to_string(row_count) + " rows total\n");
 
-  std::ostringstream stream;
+  auto stream = std::ostringstream{};
   stream << _sql_pipeline->metrics();
 
   out(stream.str());
@@ -347,7 +347,7 @@ void Console::load_history(const std::string& history_file) {
   _history_file = history_file;
 
   // Check if history file exist, create empty history file if not
-  auto file = std::ifstream{_history_file};
+  const auto file = std::ifstream{_history_file};
   if (!file.good()) {
     out("Creating history file: " + _history_file + "\n");
     if (write_history(_history_file.c_str()) != 0) {
@@ -379,9 +379,9 @@ void Console::out(const std::shared_ptr<const Table>& table, const PrintFlags fl
   Print::print(table, flags, stream);
 
   auto fits_on_one_page = true;
-  auto stream_backup = stream.str();
+  const auto stream_backup = stream.str();
   auto line = std::string{};
-  size_t line_count = 0;
+  auto line_count = size_t{0};
   while (std::getline(stream, line, '\n')) {
     ++line_count;
     if (line.length() > static_cast<uint64_t>(size_x) || line_count > static_cast<uint64_t>(size_y) - 2) {
@@ -392,7 +392,7 @@ void Console::out(const std::shared_ptr<const Table>& table, const PrintFlags fl
   stream.str(stream_backup);
 
   static bool pagination_disabled = false;
-  if (!fits_on_one_page && !std::getenv("TERM") && !pagination_disabled) {  // NOLINT(concurrency-mt-unsafe)
+  if (!fits_on_one_page && !std::getenv("TERM") && !pagination_disabled) {  // NULL_VALUE(concurrency-mt-unsafe)
     out("Your TERM environment variable is not set - most likely because you are running the console from an IDE. "
         "Pagination is disabled.\n\n");
     pagination_disabled = true;
@@ -421,7 +421,7 @@ int Console::_help(const std::string& /*args*/) {
   // Split the encoding options in lines of 120 and add padding. For each input line, it takes up to 120 characters
   // and replaces the following space(s) with a new line. `(?: +|$)` is a non-capturing group that matches either
   // a non-zero number of spaces or the end of the line.
-  auto line_wrap = std::regex{"(.{1,120})(?: +|$)"};
+  const auto line_wrap = std::regex{"(.{1,120})(?: +|$)"};
   encoding_options =
       regex_replace(encoding_options, line_wrap, "$1\n                                                    ");
   // Remove the 49 spaces and the new line added at the end
@@ -433,12 +433,12 @@ int Console::_help(const std::string& /*args*/) {
   out("  generate_tpcc NUM_WAREHOUSES [CHUNK_SIZE] - Generate all TPC-C tables\n");
   out("  generate_tpch SCALE_FACTOR [CHUNK_SIZE] - Generate all TPC-H tables\n");
   out("  generate_tpcds SCALE_FACTOR [CHUNK_SIZE] - Generate all TPC-DS tables\n");
-  out("  load FILEPATH [TABLENAME [ENCODING]]    - Load table from disk specified by filepath FILEPATH, store it with name TABLENAME\n");  // NOLINT
+  out("  load FILEPATH [TABLENAME [ENCODING]]    - Load table from disk specified by filepath FILEPATH, store it with name TABLENAME\n");  // NOLINT(whitespace/line_length)
   out("                                               The import type is chosen by the type of FILEPATH.\n");
   out("                                                 Supported types: '.bin', '.csv', '.tbl'\n");
-  out("                                               If no table name is specified, the filename without extension is used\n");  // NOLINT
-  out(encoding_options + "\n");  // NOLINT
-  out("  export TABLENAME FILEPATH               - Export table named TABLENAME from storage manager to filepath FILEPATH\n");  // NOLINT
+  out("                                               If no table name is specified, the filename without extension is used\n");  // NOLINT(whitespace/line_length)
+  out(encoding_options + "\n");
+  out("  export TABLENAME FILEPATH               - Export table named TABLENAME from storage manager to filepath FILEPATH\n");  // NOLINT(whitespace/line_length)
   out("                                               The export type is chosen by the type of FILEPATH.\n");
   out("                                                 Supported types: '.bin', '.csv'\n");
   out("  script SCRIPTFILE                       - Execute script specified by SCRIPTFILE\n");
@@ -447,8 +447,8 @@ int Console::_help(const std::string& /*args*/) {
   out("                                               Options\n");
   out("                                                - {exec, noexec} Execute the query before visualization.\n");
   out("                                                                 Default: exec\n");
-  out("                                                - {lqp, unoptlqp, pqp, joins} Type of plan to visualize. unoptlqp gives the\n");  // NOLINT
-  out("                                                                       unoptimized lqp; joins visualized the join graph.\n");  // NOLINT
+  out("                                                - {lqp, unoptlqp, pqp, joins} Type of plan to visualize. unoptlqp gives the\n");  // NOLINT(whitespace/line_length)
+  out("                                                                       unoptimized lqp; joins visualized the join graph.\n");  // NOLINT(whitespace/line_length)
   out("                                                                       Default: pqp\n");
   out("                                              SQL\n");
   out("                                                - Optional, a query to visualize. If not specified, the last\n");
@@ -456,7 +456,7 @@ int Console::_help(const std::string& /*args*/) {
   out("  txinfo                                  - Print information on the current transaction\n");
   out("  pwd                                     - Print current working directory\n");
   out("  load_plugin FILE                        - Load and start plugin stored at FILE\n");
-  out("  unload_plugin NAME                      - Stop and unload the plugin libNAME.so/dylib (also clears the query cache)\n");  // NOLINT
+  out("  unload_plugin NAME                      - Stop and unload the plugin libNAME.so/dylib (also clears the query cache)\n");  // NOLINT(whitespace/line_length)
   out("  quit                                    - Exit the HYRISE Console\n");
   out("  help                                    - Show this message\n\n");
   out("  setting [property] [value]              - Change a runtime setting\n\n");
@@ -472,13 +472,13 @@ int Console::_generate_tpcc(const std::string& args) {
   if (arguments.empty() || arguments.size() > 2) {
     // clang-format off
     out("Usage: ");
-    out("  generate_tpcc NUM_WAREHOUSES [CHUNK_SIZE]   Generate TPC-C tables with the specified number of warehouses. \n");  // NOLINT
-    out("                                              Chunk size is " + std::to_string(Chunk::DEFAULT_SIZE) + " by default. \n");  // NOLINT
+    out("  generate_tpcc NUM_WAREHOUSES [CHUNK_SIZE]   Generate TPC-C tables with the specified number of warehouses. \n");  // NOLINT(whitespace/line_length)
+    out("                                              Chunk size is " + std::to_string(Chunk::DEFAULT_SIZE) + " by default. \n");  // NOLINT(whitespace/line_length)
     // clang-format on
     return ReturnCode::Error;
   }
 
-  auto num_warehouses = std::stoull(arguments.at(0));
+  const auto num_warehouses = std::stoull(arguments.at(0));
 
   auto chunk_size = Chunk::DEFAULT_SIZE;
   if (arguments.size() > 1) {
@@ -498,12 +498,12 @@ int Console::_generate_tpch(const std::string& args) {
     // clang-format off
     out("Usage: ");
     out("  generate_tpch SCALE_FACTOR [CHUNK_SIZE]   Generate TPC-H tables with the specified scale factor. \n");
-    out("                                            Chunk size is " + std::to_string(Chunk::DEFAULT_SIZE) + " by default. \n");  // NOLINT
+    out("                                            Chunk size is " + std::to_string(Chunk::DEFAULT_SIZE) + " by default. \n");  // NOLINT(whitespace/line_length)
     // clang-format on
     return ReturnCode::Error;
   }
 
-  auto scale_factor = std::stof(arguments.at(0));
+  const auto scale_factor = std::stof(arguments.at(0));
 
   auto chunk_size = Chunk::DEFAULT_SIZE;
   if (arguments.size() > 1) {
@@ -527,7 +527,7 @@ int Console::_generate_tpcds(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  auto scale_factor = static_cast<uint32_t>(std::stoul(arguments.at(0)));
+  const auto scale_factor = static_cast<uint32_t>(std::stoul(arguments.at(0)));
 
   auto chunk_size = Chunk::DEFAULT_SIZE;
   if (arguments.size() > 1) {
@@ -541,7 +541,7 @@ int Console::_generate_tpcds(const std::string& args) {
 }
 
 int Console::_load_table(const std::string& args) {
-  std::vector<std::string> arguments = trim_and_split(args);
+  const auto arguments = trim_and_split(args);
 
   if (arguments.empty() || arguments.size() > 3) {
     out("Usage:\n");
@@ -559,14 +559,14 @@ int Console::_load_table(const std::string& args) {
   }
 
   try {
-    auto importer = std::make_shared<Import>(filepath, tablename, Chunk::DEFAULT_SIZE);
+    const auto importer = std::make_shared<Import>(filepath, tablename, Chunk::DEFAULT_SIZE);
     importer->execute();
   } catch (const std::exception& exception) {
     out("Error: Exception thrown while importing table:\n  " + std::string(exception.what()) + "\n");
     return ReturnCode::Error;
   }
 
-  const std::string encoding = arguments.size() == 3 ? arguments.at(2) : "Unencoded";
+  const auto encoding = arguments.size() == 3 ? arguments.at(2) : "Unencoded";
 
   const auto encoding_type = magic_enum::enum_cast<EncodingType>(encoding);
   if (!encoding_type) {
@@ -576,7 +576,7 @@ int Console::_load_table(const std::string& args) {
 
   // Check if the specified encoding can be used
   const auto& table = Hyrise::get().storage_manager.get_table(tablename);
-  bool supported = true;
+  auto supported = true;
   for (auto column_id = ColumnID{0}; column_id < table->column_count(); ++column_id) {
     if (!encoding_supports_data_type(*encoding_type, table->column_data_type(column_id))) {
       out("Encoding \"" + encoding + "\" not supported for column \"" + table->column_name(column_id) +
@@ -587,7 +587,7 @@ int Console::_load_table(const std::string& args) {
 
   if (supported) {
     out("Encoding \"" + tablename + "\" using " + encoding + "\n");
-    std::vector<ChunkID> immutable_chunks;
+    auto immutable_chunks = std::vector<ChunkID>{};
     for (ChunkID chunk_id(0); chunk_id < table->chunk_count(); ++chunk_id) {
       if (!table->get_chunk(chunk_id)->is_mutable()) {
         immutable_chunks.emplace_back(chunk_id);
@@ -600,7 +600,7 @@ int Console::_load_table(const std::string& args) {
 }
 
 int Console::_export_table(const std::string& args) {
-  std::vector<std::string> arguments = trim_and_split(args);
+  const auto arguments = trim_and_split(args);
 
   if (arguments.size() != 2) {
     out("Usage:\n");
@@ -608,13 +608,13 @@ int Console::_export_table(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  const std::string& tablename = arguments.at(0);
-  const std::string& filepath = arguments.at(1);
+  const auto& tablename = arguments.at(0);
+  const auto& filepath = arguments.at(1);
 
   const auto& storage_manager = Hyrise::get().storage_manager;
   const auto& meta_table_manager = Hyrise::get().meta_table_manager;
 
-  std::shared_ptr<AbstractOperator> table_operator = nullptr;
+  auto table_operator = std::shared_ptr<AbstractOperator>{};
   if (MetaTableManager::is_meta_table_name(tablename)) {
     if (!meta_table_manager.has_table(tablename)) {
       out("Error: MetaTable does not exist in MetaTableManager\n");
@@ -644,7 +644,7 @@ int Console::_export_table(const std::string& args) {
 }
 
 int Console::_print_table(const std::string& args) {
-  std::vector<std::string> arguments = trim_and_split(args);
+  const auto arguments = trim_and_split(args);
 
   if (arguments.size() != 1) {
     out("Usage:\n");
@@ -652,7 +652,7 @@ int Console::_print_table(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  const std::string& tablename = arguments.at(0);
+  const auto& tablename = arguments.at(0);
 
   const auto& storage_manager = Hyrise::get().storage_manager;
   if (!storage_manager.has_table(tablename)) {
@@ -660,7 +660,7 @@ int Console::_print_table(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  auto get_table = std::make_shared<GetTable>(tablename);
+  const auto get_table = std::make_shared<GetTable>(tablename);
   get_table->execute();
 
   out(get_table->get_output(), PrintFlags::Mvcc);
@@ -676,7 +676,7 @@ int Console::_visualize(const std::string& input) {
    *    - a sql query can either be specified or not. If it isn't, the last previously executed query is visualized
    */
 
-  std::vector<std::string> input_words;
+  auto input_words = std::vector<std::string>{};
   boost::algorithm::split(input_words, input, boost::is_any_of(" \n"));
 
   constexpr auto EXEC = "exec";
@@ -736,7 +736,7 @@ int Console::_visualize(const std::string& input) {
   switch (plan_type) {
     case PlanType::LQP:
     case PlanType::UnoptLQP: {
-      std::vector<std::shared_ptr<AbstractLQPNode>> lqp_roots;
+      auto lqp_roots = std::vector<std::shared_ptr<AbstractLQPNode>>{};
 
       const auto& lqps = (plan_type == PlanType::LQP) ? _sql_pipeline->get_optimized_logical_plans()
                                                       : _sql_pipeline->get_unoptimized_logical_plans();
@@ -747,7 +747,7 @@ int Console::_visualize(const std::string& input) {
         lqp_roots.emplace_back(lqp);
       }
 
-      LQPVisualizer visualizer;
+      auto visualizer = LQPVisualizer{};
       visualizer.visualize(lqp_roots, img_filename);
     } break;
 
@@ -760,7 +760,7 @@ int Console::_visualize(const std::string& input) {
         _explicitly_created_transaction_context = _sql_pipeline->transaction_context();
       }
 
-      PQPVisualizer visualizer;
+      auto visualizer = PQPVisualizer{};
       visualizer.visualize(_sql_pipeline->get_physical_plans(), img_filename);
     } break;
 
@@ -782,7 +782,7 @@ int Console::_visualize(const std::string& input) {
         }
       }
 
-      JoinGraphVisualizer visualizer;
+      auto visualizer = JoinGraphVisualizer{};
       visualizer.visualize(join_graphs, img_filename);
     } break;
   }
@@ -803,7 +803,7 @@ int Console::_visualize(const std::string& input) {
     return ReturnCode::Ok;
   }
 
-  auto cmd = scripts_dir + "/planviz/imgcat.sh " + img_filename;
+  const auto cmd = scripts_dir + "/planviz/imgcat.sh " + img_filename;
   ret = system(cmd.c_str());
   Assert(ret == 0, "Printing the image using ./scripts/imgcat.sh failed.");
   // NOLINTEND(concurrency-mt-unsafe)
@@ -812,8 +812,8 @@ int Console::_visualize(const std::string& input) {
 }
 
 int Console::_change_runtime_setting(const std::string& input) {
-  auto property = input.substr(0, input.find_first_of(" \n"));
-  auto value = input.substr(input.find_first_of(" \n") + 1, input.size());
+  const auto property = input.substr(0, input.find_first_of(" \n"));
+  const auto value = input.substr(input.find_first_of(" \n") + 1, input.size());
 
   if (property == "scheduler") {
     if (value == "on") {
@@ -836,12 +836,12 @@ int Console::_change_runtime_setting(const std::string& input) {
 int Console::_exec_script(const std::string& script_file) {
   auto filepath = script_file;
   boost::algorithm::trim(filepath);
-  std::ifstream script(filepath);
+  auto script = std::ifstream{filepath};
 
   const auto is_regular_file = [](const std::string& path) {
     struct stat path_stat {};
     stat(path.c_str(), &path_stat);
-    return S_ISREG(path_stat.st_mode);  // NOLINT
+    return S_ISREG(path_stat.st_mode);
   };
 
   if (!script.good()) {
@@ -856,8 +856,9 @@ int Console::_exec_script(const std::string& script_file) {
 
   out("Executing script file: " + filepath + "\n");
   _verbose = true;
-  std::string command;
-  int return_code = ReturnCode::Ok;
+  auto command = std::string{};
+  // TODO(anyone): Use std::to_underlying(ReturnCode::Ok) once we use C++23.
+  auto return_code = magic_enum::enum_underlying(ReturnCode::Ok);
   while (std::getline(script, command)) {
     return_code = _eval(command);
     if (return_code == ReturnCode::Error || return_code == ReturnCode::Quit) {
@@ -907,7 +908,7 @@ int Console::_print_current_working_directory() {
 }
 
 int Console::_load_plugin(const std::string& args) {
-  auto arguments = trim_and_split(args);
+  const auto arguments = trim_and_split(args);
 
   if (arguments.size() != 1) {
     out("Usage:\n");
@@ -915,9 +916,9 @@ int Console::_load_plugin(const std::string& args) {
     return ReturnCode::Error;
   }
 
-  const std::string& plugin_path_str = arguments.at(0);
+  const auto& plugin_path_str = arguments.at(0);
 
-  const std::filesystem::path plugin_path(plugin_path_str);
+  const auto plugin_path = std::filesystem::path{plugin_path_str};
   const auto plugin_name = plugin_name_from_path(plugin_path);
 
   Hyrise::get().plugin_manager.load_plugin(plugin_path);
@@ -928,7 +929,7 @@ int Console::_load_plugin(const std::string& args) {
 }
 
 int Console::_unload_plugin(const std::string& input) {
-  auto arguments = trim_and_split(input);
+  const auto arguments = trim_and_split(input);
 
   if (arguments.size() != 1) {
     out("Usage:\n");
@@ -936,7 +937,7 @@ int Console::_unload_plugin(const std::string& input) {
     return ReturnCode::Error;
   }
 
-  const std::string& plugin_name = arguments.at(0);
+  const auto& plugin_name = arguments.at(0);
 
   Hyrise::get().plugin_manager.unload_plugin(plugin_name);
 
@@ -1051,7 +1052,8 @@ int main(int argc, char** argv) {
   // Timestamp dump only to logfile
   console.out("--- Session start --- " + current_timestamp() + "\n", false);
 
-  int return_code = Return::Ok;
+  // TODO(anyone): Use std::to_underlying(ReturnCode::Ok) once we use C++23.
+  auto return_code = magic_enum::enum_underlying(Return::Ok);
 
   // Display Usage if too many arguments are provided
   if (argc > 2) {

--- a/src/bin/console/console.hpp
+++ b/src/bin/console/console.hpp
@@ -119,8 +119,8 @@ class Console : public Singleton<Console> {
   int _visualize(const std::string& input);
   int _change_runtime_setting(const std::string& input);
 
-  int _print_transaction_info(const std::string& input);
-  int _print_current_working_directory(const std::string& /*args*/);
+  int _print_transaction_info();
+  int _print_current_working_directory();
 
   int _load_plugin(const std::string& args);
   int _unload_plugin(const std::string& input);
@@ -134,7 +134,7 @@ class Console : public Singleton<Console> {
   bool _handle_rollback();
 
   // GNU readline interface to our commands
-  static char** _command_completion(const char* text, int start, int end);
+  static char** _command_completion(const char* text, const int start, const int /*end*/);
   static char* _command_generator(const char* text, int state, const std::vector<std::string>& commands);
   static char* _command_generator_default(const char* text, int state);
   static char* _command_generator_visualize(const char* text, int state);

--- a/src/bin/console/pagination.cpp
+++ b/src/bin/console/pagination.cpp
@@ -168,6 +168,7 @@ void Pagination::_print_page(size_t first_line, size_t first_column) {
     }
 
     if (_lines[i].length() > first_column) {
+      // NOLINTBEGIN(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
       printw("%s\n", _lines[i].substr(first_column, _size_x - 1).c_str());
     } else {
       printw("\n");
@@ -180,7 +181,7 @@ void Pagination::_print_page(size_t first_line, size_t first_column) {
 }
 
 void Pagination::_print_help_screen() {
-  auto help_screen = newwin(0, 0, 0, 0);
+  auto* help_screen = newwin(0, 0, 0, 0);
 
   wclear(help_screen);
 
@@ -197,6 +198,7 @@ void Pagination::_print_help_screen() {
   wprintw(help_screen, "  %-17s- Go to first column.\n", "a");
   wprintw(help_screen, "  %-17s- Go to last column.\n\n", "e");
   wprintw(help_screen, "  %-17s- Quit.\n", "q");
+  // NOLINTEND(cppcoreguidelines-pro-type-vararg,hicpp-vararg)
 
   wrefresh(help_screen);
 

--- a/src/lib/operators/aggregate_hash.cpp
+++ b/src/lib/operators/aggregate_hash.cpp
@@ -833,7 +833,7 @@ std::shared_ptr<const Table> AggregateHash::_on_execute() {
         input_column_id == INVALID_COLUMN_ID ? DataType::Long : input_table->column_data_type(input_column_id);
 
     resolve_data_type(data_type, [&, aggregate_idx](auto type) {
-      using ColumnDataType = typename decltype(type)::type; 
+      using ColumnDataType = typename decltype(type)::type;
       _write_aggregate_output<ColumnDataType>(aggregate_idx, aggregate->aggregate_function);
     });
 
@@ -1076,8 +1076,7 @@ void AggregateHash::_write_groupby_output(RowIDPosList& pos_list) {
 }
 
 template <typename ColumnDataType>
-void AggregateHash::_write_aggregate_output(const ColumnID column_index,
-                                            const AggregateFunction aggregate_function) {
+void AggregateHash::_write_aggregate_output(const ColumnID column_index, const AggregateFunction aggregate_function) {
   switch (aggregate_function) {
     case AggregateFunction::Min:
       write_aggregate_output<ColumnDataType, AggregateFunction::Min>(column_index);

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -144,10 +144,6 @@ class AggregateHash : public AbstractAggregateOperator {
 
   const std::string& name() const override;
 
-  // write the aggregated output for a given aggregate column
-  template <typename ColumnDataType, AggregateFunction aggregate_function>
-  void write_aggregate_output(ColumnID aggregate_index);
-
   enum class OperatorSteps : uint8_t {
     GroupByKeyPartitioning,
     Aggregating,
@@ -174,10 +170,10 @@ class AggregateHash : public AbstractAggregateOperator {
 
   void _on_cleanup() override;
 
-  template <typename ColumnDataType>
-  void _write_aggregate_output(const ColumnID column_index, const AggregateFunction aggregate_function);
-
   void _write_groupby_output(RowIDPosList& pos_list);
+
+  template <typename ColumnDataType, AggregateFunction aggregate_function>
+  void _write_aggregate_output(ColumnID aggregate_index);
 
   template <typename ColumnDataType, AggregateFunction aggregate_function, typename AggregateKey>
   void _aggregate_segment(ChunkID chunk_id, ColumnID column_index, const AbstractSegment& abstract_segment,

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -175,8 +175,7 @@ class AggregateHash : public AbstractAggregateOperator {
   void _on_cleanup() override;
 
   template <typename ColumnDataType>
-  void _write_aggregate_output(const ColumnID column_index,
-                               const AggregateFunction aggregate_function);
+  void _write_aggregate_output(const ColumnID column_index, const AggregateFunction aggregate_function);
 
   void _write_groupby_output(RowIDPosList& pos_list);
 

--- a/src/lib/operators/aggregate_hash.hpp
+++ b/src/lib/operators/aggregate_hash.hpp
@@ -175,8 +175,8 @@ class AggregateHash : public AbstractAggregateOperator {
   void _on_cleanup() override;
 
   template <typename ColumnDataType>
-  void _write_aggregate_output(boost::hana::basic_type<ColumnDataType> type, ColumnID column_index,
-                               AggregateFunction aggregate_function);
+  void _write_aggregate_output(const ColumnID column_index,
+                               const AggregateFunction aggregate_function);
 
   void _write_groupby_output(RowIDPosList& pos_list);
 

--- a/src/lib/operators/join_hash.cpp
+++ b/src/lib/operators/join_hash.cpp
@@ -48,14 +48,14 @@ const std::string& JoinHash::name() const {
 std::shared_ptr<AbstractOperator> JoinHash::_on_deep_copy(
     const std::shared_ptr<AbstractOperator>& copied_left_input,
     const std::shared_ptr<AbstractOperator>& copied_right_input,
-    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const {
+    std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const {
   return std::make_shared<JoinHash>(copied_left_input, copied_right_input, _mode, _primary_predicate,
                                     _secondary_predicates, _radix_bits);
 }
 
 void JoinHash::_on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) {}
 
-size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode) {
+size_t JoinHash::calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size) {
   /*
     The number of radix bits is used to determine the number of build partitions. The idea is to size the partitions in
     a way that keeps the whole hash map cache resident. We aim for the largest unshared cache (for most Intel systems
@@ -185,7 +185,7 @@ std::shared_ptr<const Table> JoinHash::_on_execute() {
 
       if constexpr (BOTH_ARE_STRING || NEITHER_IS_STRING) {
         if (!_radix_bits) {
-          _radix_bits = calculate_radix_bits(build_input_table->row_count(), probe_input_table->row_count(), _mode);
+          _radix_bits = calculate_radix_bits(build_input_table->row_count(), probe_input_table->row_count());
         }
 
         // It needs to be ensured that the build partitions do not get too large, because the used offsets in the

--- a/src/lib/operators/join_hash.hpp
+++ b/src/lib/operators/join_hash.hpp
@@ -33,7 +33,7 @@ class JoinHash : public AbstractJoinOperator {
 
   const std::string& name() const override;
 
-  static size_t calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size, const JoinMode mode);
+  static size_t calculate_radix_bits(const size_t build_side_size, const size_t probe_side_size);
 
   enum class OperatorSteps : uint8_t {
     BuildSideMaterializing,
@@ -70,7 +70,7 @@ class JoinHash : public AbstractJoinOperator {
   std::shared_ptr<AbstractOperator> _on_deep_copy(
       const std::shared_ptr<AbstractOperator>& copied_left_input,
       const std::shared_ptr<AbstractOperator>& copied_right_input,
-      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& copied_ops) const override;
+      std::unordered_map<const AbstractOperator*, std::shared_ptr<AbstractOperator>>& /*copied_ops*/) const override;
   void _on_set_parameters(const std::unordered_map<ParameterID, AllTypeVariant>& parameters) override;
   void _on_cleanup() override;
 

--- a/src/plugins/ucc_discovery_plugin.cpp
+++ b/src/plugins/ucc_discovery_plugin.cpp
@@ -147,7 +147,7 @@ void UccDiscoveryPlugin::_validate_ucc_candidates(const UccCandidates& ucc_candi
 }
 
 template <typename ColumnDataType>
-bool UccDiscoveryPlugin::_dictionary_segments_contain_duplicates(std::shared_ptr<Table> table, ColumnID column_id) {
+bool UccDiscoveryPlugin::_dictionary_segments_contain_duplicates(const std::shared_ptr<const Table>& table, const ColumnID column_id) {
   const auto chunk_count = table->chunk_count();
   // Trigger an early-out if a dictionary-encoded segment's attribute vector is larger than the dictionary. This indica-
   // tes that at least one duplicate value or a NULL value is contained.
@@ -179,7 +179,7 @@ bool UccDiscoveryPlugin::_dictionary_segments_contain_duplicates(std::shared_ptr
 }
 
 template <typename ColumnDataType>
-bool UccDiscoveryPlugin::_uniqueness_holds_across_segments(std::shared_ptr<Table> table, ColumnID column_id) {
+bool UccDiscoveryPlugin::_uniqueness_holds_across_segments(const std::shared_ptr<const Table>& table, const ColumnID column_id) {
   const auto chunk_count = table->chunk_count();
   // `distinct_values` collects the segment values from all chunks.
   auto distinct_values = std::unordered_set<ColumnDataType>{};
@@ -232,12 +232,12 @@ bool UccDiscoveryPlugin::_uniqueness_holds_across_segments(std::shared_ptr<Table
   return true;
 }
 
-void UccDiscoveryPlugin::_ucc_candidates_from_aggregate_node(std::shared_ptr<AbstractLQPNode> node,
+void UccDiscoveryPlugin::_ucc_candidates_from_aggregate_node(const std::shared_ptr<const AbstractLQPNode>& node,
                                                              UccCandidates& ucc_candidates) {
-  const auto& aggregate_node = static_cast<AggregateNode&>(*node);
+  const auto& aggregate_node = static_cast<const AggregateNode&>(*node);
   const auto column_candidates = std::vector<std::shared_ptr<AbstractExpression>>{
       aggregate_node.node_expressions.cbegin(),
-      aggregate_node.node_expressions.cbegin() + aggregate_node.aggregate_expressions_begin_idx};
+      aggregate_node.node_expressions.cbegin() + static_cast<int64_t>(aggregate_node.aggregate_expressions_begin_idx)};
 
   for (const auto& column_candidate : column_candidates) {
     const auto lqp_column_expression = std::dynamic_pointer_cast<LQPColumnExpression>(column_candidate);
@@ -250,9 +250,9 @@ void UccDiscoveryPlugin::_ucc_candidates_from_aggregate_node(std::shared_ptr<Abs
   }
 }
 
-void UccDiscoveryPlugin::_ucc_candidates_from_join_node(std::shared_ptr<AbstractLQPNode> node,
+void UccDiscoveryPlugin::_ucc_candidates_from_join_node(const std::shared_ptr<const AbstractLQPNode>& node,
                                                         UccCandidates& ucc_candidates) {
-  const auto& join_node = static_cast<JoinNode&>(*node);
+  const auto& join_node = static_cast<const JoinNode&>(*node);
   // Fetch the join predicate to extract the UCC candidates from. Right now, limited to single-predicate equi joins.
   const auto& join_predicates = join_node.join_predicates();
   if (join_predicates.size() != 1) {
@@ -324,7 +324,7 @@ void UccDiscoveryPlugin::_ucc_candidates_from_join_node(std::shared_ptr<Abstract
 }
 
 void UccDiscoveryPlugin::_ucc_candidates_from_removable_join_input(
-    std::shared_ptr<AbstractLQPNode> root_node, std::shared_ptr<LQPColumnExpression> column_candidate,
+    const std::shared_ptr<const AbstractLQPNode>& root_node, const std::shared_ptr<const LQPColumnExpression>& column_candidate,
     UccCandidates& ucc_candidates) {
   // The input node may already be a nullptr in case we try to get the right input of node with only one input. The can-
   // didate Column might be a nullptr when the join is not performed on bare columns but, e.g., on aggregates.

--- a/src/plugins/ucc_discovery_plugin.cpp
+++ b/src/plugins/ucc_discovery_plugin.cpp
@@ -147,7 +147,8 @@ void UccDiscoveryPlugin::_validate_ucc_candidates(const UccCandidates& ucc_candi
 }
 
 template <typename ColumnDataType>
-bool UccDiscoveryPlugin::_dictionary_segments_contain_duplicates(const std::shared_ptr<const Table>& table, const ColumnID column_id) {
+bool UccDiscoveryPlugin::_dictionary_segments_contain_duplicates(const std::shared_ptr<const Table>& table,
+                                                                 const ColumnID column_id) {
   const auto chunk_count = table->chunk_count();
   // Trigger an early-out if a dictionary-encoded segment's attribute vector is larger than the dictionary. This indica-
   // tes that at least one duplicate value or a NULL value is contained.
@@ -179,7 +180,8 @@ bool UccDiscoveryPlugin::_dictionary_segments_contain_duplicates(const std::shar
 }
 
 template <typename ColumnDataType>
-bool UccDiscoveryPlugin::_uniqueness_holds_across_segments(const std::shared_ptr<const Table>& table, const ColumnID column_id) {
+bool UccDiscoveryPlugin::_uniqueness_holds_across_segments(const std::shared_ptr<const Table>& table,
+                                                           const ColumnID column_id) {
   const auto chunk_count = table->chunk_count();
   // `distinct_values` collects the segment values from all chunks.
   auto distinct_values = std::unordered_set<ColumnDataType>{};
@@ -324,8 +326,8 @@ void UccDiscoveryPlugin::_ucc_candidates_from_join_node(const std::shared_ptr<co
 }
 
 void UccDiscoveryPlugin::_ucc_candidates_from_removable_join_input(
-    const std::shared_ptr<const AbstractLQPNode>& root_node, const std::shared_ptr<const LQPColumnExpression>& column_candidate,
-    UccCandidates& ucc_candidates) {
+    const std::shared_ptr<const AbstractLQPNode>& root_node,
+    const std::shared_ptr<const LQPColumnExpression>& column_candidate, UccCandidates& ucc_candidates) {
   // The input node may already be a nullptr in case we try to get the right input of node with only one input. The can-
   // didate Column might be a nullptr when the join is not performed on bare columns but, e.g., on aggregates.
   if (!root_node || !column_candidate) {

--- a/src/plugins/ucc_discovery_plugin.hpp
+++ b/src/plugins/ucc_discovery_plugin.hpp
@@ -53,7 +53,7 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * Takes a snapshot of the current LQP Cache. Iterates through the LQPs and tries to extract sensible columns as can-
    * didates for UCC validation from each of them. A column is added as candidates if being a UCC has the potential to
    * help optimize their respective LQP.
-   * 
+   *
    * Returns an unordered set of these candidates to be used in the UCC validation function.
    */
   static UccCandidates _identify_ucc_candidates();
@@ -71,7 +71,7 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * for an early-out before the more expensive cross-segment uniqueness check.
    */
   template <typename ColumnDataType>
-  static bool _dictionary_segments_contain_duplicates(std::shared_ptr<Table> table, ColumnID column_id);
+  static bool _dictionary_segments_contain_duplicates(const std::shared_ptr<const Table>& table, const ColumnID column_id);
 
   /**
    * Checks whether the given table contains only unique values by inserting all values into an unordered set. If for
@@ -79,12 +79,12 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * there must be a duplicate and return false. Otherwise, returns true.
    */
   template <typename ColumnDataType>
-  static bool _uniqueness_holds_across_segments(std::shared_ptr<Table> table, ColumnID column_id);
+  static bool _uniqueness_holds_across_segments(const std::shared_ptr<const Table>& table, const ColumnID column_id);
 
   /**
    * Extracts columns as candidates for UCC validation from a given aggregate node that is used in a groupby operation.
    */
-  static void _ucc_candidates_from_aggregate_node(std::shared_ptr<AbstractLQPNode> node, UccCandidates& ucc_candidates);
+  static void _ucc_candidates_from_aggregate_node(const std::shared_ptr<const AbstractLQPNode>& node, UccCandidates& ucc_candidates);
 
   /**
    * Extracts columns as UCC validation candidates from a join node. Some criteria have to be fulfilled for this to be
@@ -96,15 +96,15 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * and a column used in a PredicateNode may be added as a UCC candidate if the predicate filters the same table that
    * contains the join column.
    */
-  static void _ucc_candidates_from_join_node(std::shared_ptr<AbstractLQPNode> node, UccCandidates& ucc_candidates);
+  static void _ucc_candidates_from_join_node(const std::shared_ptr<const AbstractLQPNode>& node, UccCandidates& ucc_candidates);
 
   /**
    * Iterates through the LQP underneath the given root node. If a PredicateNode is encountered, checks whether it has a
    * binary predicate checking for `column` = `value`. If the predicate column is from the same table as the passed
    * column_candidate, adds both as UCC candidates.
    */
-  static void _ucc_candidates_from_removable_join_input(std::shared_ptr<AbstractLQPNode> root_node,
-                                                        std::shared_ptr<LQPColumnExpression> column_candidate,
+  static void _ucc_candidates_from_removable_join_input(const std::shared_ptr<const AbstractLQPNode>& root_node,
+                                                        const std::shared_ptr<const LQPColumnExpression>& column_candidate,
                                                         UccCandidates& ucc_candidates);
 };
 

--- a/src/plugins/ucc_discovery_plugin.hpp
+++ b/src/plugins/ucc_discovery_plugin.hpp
@@ -71,7 +71,8 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * for an early-out before the more expensive cross-segment uniqueness check.
    */
   template <typename ColumnDataType>
-  static bool _dictionary_segments_contain_duplicates(const std::shared_ptr<const Table>& table, const ColumnID column_id);
+  static bool _dictionary_segments_contain_duplicates(const std::shared_ptr<const Table>& table,
+                                                      const ColumnID column_id);
 
   /**
    * Checks whether the given table contains only unique values by inserting all values into an unordered set. If for
@@ -84,7 +85,8 @@ class UccDiscoveryPlugin : public AbstractPlugin {
   /**
    * Extracts columns as candidates for UCC validation from a given aggregate node that is used in a groupby operation.
    */
-  static void _ucc_candidates_from_aggregate_node(const std::shared_ptr<const AbstractLQPNode>& node, UccCandidates& ucc_candidates);
+  static void _ucc_candidates_from_aggregate_node(const std::shared_ptr<const AbstractLQPNode>& node,
+                                                  UccCandidates& ucc_candidates);
 
   /**
    * Extracts columns as UCC validation candidates from a join node. Some criteria have to be fulfilled for this to be
@@ -96,16 +98,17 @@ class UccDiscoveryPlugin : public AbstractPlugin {
    * and a column used in a PredicateNode may be added as a UCC candidate if the predicate filters the same table that
    * contains the join column.
    */
-  static void _ucc_candidates_from_join_node(const std::shared_ptr<const AbstractLQPNode>& node, UccCandidates& ucc_candidates);
+  static void _ucc_candidates_from_join_node(const std::shared_ptr<const AbstractLQPNode>& node,
+                                             UccCandidates& ucc_candidates);
 
   /**
    * Iterates through the LQP underneath the given root node. If a PredicateNode is encountered, checks whether it has a
    * binary predicate checking for `column` = `value`. If the predicate column is from the same table as the passed
    * column_candidate, adds both as UCC candidates.
    */
-  static void _ucc_candidates_from_removable_join_input(const std::shared_ptr<const AbstractLQPNode>& root_node,
-                                                        const std::shared_ptr<const LQPColumnExpression>& column_candidate,
-                                                        UccCandidates& ucc_candidates);
+  static void _ucc_candidates_from_removable_join_input(
+      const std::shared_ptr<const AbstractLQPNode>& root_node,
+      const std::shared_ptr<const LQPColumnExpression>& column_candidate, UccCandidates& ucc_candidates);
 };
 
 }  // namespace hyrise

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -108,12 +108,11 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
   // Simple tests to check that side switching and zero-sizes work.
-  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 0), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 1), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 0), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 1), 0ul);
-  EXPECT_GT(JoinHash::calculate_radix_bits(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()),
-            0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 0), 0);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 1), 0);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 0), 0);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 1), 0);
+  EXPECT_GT(JoinHash::calculate_radix_bits(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()), 0);
 }
 
 }  // namespace hyrise

--- a/src/test/lib/operators/join_hash_test.cpp
+++ b/src/test/lib/operators/join_hash_test.cpp
@@ -108,12 +108,11 @@ TEST_F(OperatorsJoinHashTest, DeepCopy) {
 
 TEST_F(OperatorsJoinHashTest, RadixBitCalculation) {
   // Simple tests to check that side switching and zero-sizes work.
-  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 0, JoinMode::Inner), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 1, JoinMode::Inner), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 0, JoinMode::Inner), 0ul);
-  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 1, JoinMode::Inner), 0ul);
-  EXPECT_GT(JoinHash::calculate_radix_bits(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max(),
-                                           JoinMode::Inner),
+  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 0), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 1), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(0, 0), 0ul);
+  EXPECT_EQ(JoinHash::calculate_radix_bits(1, 1), 0ul);
+  EXPECT_GT(JoinHash::calculate_radix_bits(std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()),
             0ul);
 }
 


### PR DESCRIPTION
We recently figured out ([again](https://gitlab.kitware.com/cmake/cmake/-/issues/20058)) that clang-tidy does not find all flaws in unity builds. However, the clang-tidy stage already runs quite long in the CI pipeline, so we do not want remove the unity option there. Thus, I re-ran a tidy build on nemea (clang-14) without unity build and fixed the errors.