### PR TITLE
Remove superfluous DISTINCT

### DIFF
--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
@@ -96,13 +96,13 @@ void DependentGroupByReductionRule::_apply_to_plan_without_subqueries(
     if (group_by_columns.size() == node->node_expressions.size() &&
         node->left_input()->has_matching_ucc(group_by_columns)) {
       const auto& output_expressions = aggregate_node.output_expressions();
-      // Remove the AggregateNode if does not change the output expressions.
+      // Remove the AggregateNode if it does not limit or reorder the output expressions.
       if (expressions_equal(output_expressions, node->left_input()->output_expressions())) {
         lqp_remove_node(node);
         return LQPVisitation::VisitInputs;
       }
 
-      // Else, add a ProjectionNode.
+      // Else, replace it with a ProjectionNode.
       const auto projection_node = ProjectionNode::make(output_expressions);
       lqp_replace_node(node, projection_node);
       return LQPVisitation::VisitInputs;

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
@@ -33,7 +33,7 @@ namespace hyrise {
  * "TPC-H Analyzed: Hidden Messages and Lessons Learned from an Influential Benchmark" (Boncz et al.).
  * However, not all queries listed in the paper can be optimized yet, since Hyrise lacks foreign key support.
  *
- * Besides, this rule removes Aggregates that are inserted for SELECT DISTINCT clauses if the required columns are
+ * Besides, this rule removes AggregateNodes that are inserted for SELECT DISTINCT clauses if the required columns are
  * already distinct.
  */
 class DependentGroupByReductionRule : public AbstractRule {

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
@@ -33,7 +33,7 @@ namespace hyrise {
  * "TPC-H Analyzed: Hidden Messages and Lessons Learned from an Influential Benchmark" (Boncz et al.).
  * However, not all queries listed in the paper can be optimized yet, since Hyrise lacks foreign key support.
  *
- * Besides, this rule removes Aggregates that are inserted for SELECT DISTINCT clauses if the reqired columns are
+ * Besides, this rule removes Aggregates that are inserted for SELECT DISTINCT clauses if the required columns are
  * already distinct.
  */
 class DependentGroupByReductionRule : public AbstractRule {

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
@@ -1,14 +1,8 @@
 #pragma once
 
 #include "abstract_rule.hpp"
-#include "expression/abstract_expression.hpp"
-#include "expression/lqp_column_expression.hpp"
 
 namespace hyrise {
-
-class AbstractLQPNode;
-class AggregateNode;
-class StoredTableNode;
 
 /**
  * In SQL, the returned columns of an aggregate are either "group-by columns" or "aggregate columns", e.g., SUM(a). As
@@ -38,6 +32,9 @@ class StoredTableNode;
  * determinant column(s) in this case the group is ensured to be of size one). This rule implements choke point 1.4 of
  * "TPC-H Analyzed: Hidden Messages and Lessons Learned from an Influential Benchmark" (Boncz et al.).
  * However, not all queries listed in the paper can be optimized yet, since Hyrise lacks foreign key support.
+ *
+ * Besides, this rule removes Aggregates that are inserted for SELECT DISTINCT clauses if the reqired columns are
+ * already distinct.
  */
 class DependentGroupByReductionRule : public AbstractRule {
  public:

--- a/src/lib/sql/sql_translator.cpp
+++ b/src/lib/sql/sql_translator.cpp
@@ -1186,11 +1186,11 @@ void SQLTranslator::_translate_select_groupby_having(const hsql::SelectStatement
   //
   // This might create unnecessary aggregate nodes when we already have an aggregation that creates unique results:
   // `SELECT DISTINCT a, MIN(b) FROM t GROUP BY a` would have one aggregate that groups by a and calculates MIN(b), and
-  // one that groups by both a and MIN(b) without calculating anything. Fixing this should be done by an optimizer rule
-  // that checks for each GROUP BY whether it guarantees the results to be unique or not. Doable, but no priority.
+  // one that groups by both a and MIN(b) without calculating anything. Fixing this is done by an optimizer rule
+  // (DependentGroupByReductionRule) that checks if the respective columns are already unique.
   if (select.selectDistinct) {
-    _current_lqp = AggregateNode::make(_unwrap_elements(_inflated_select_list_elements),
-                                       std::vector<std::shared_ptr<AbstractExpression>>{}, _current_lqp);
+    _current_lqp =
+        AggregateNode::make(_unwrap_elements(_inflated_select_list_elements), expression_vector(), _current_lqp);
   }
 }
 

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -328,7 +328,7 @@ TEST_F(DependentGroupByReductionRuleTest, MultiKeyReduction) {
 TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateSimple) {
   // To guarantee distinct results for SELECT DISTINCT clauses, the SQLTranslator adds an AggregateNode with the
   // selected attributes as group by columns. If the AggregateNode's input is already unique for these columns,
-  // remove the whole node.
+  // remove the entire node.
 
   // Basic case: Column is unique due to a constraint (e.g., it is a primary key).
   // Example query: SELECT DISTINCT column0 FROM table_a;
@@ -347,7 +347,7 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateSimp
   }
 
   // More advanced case: Column is unique due to another operation (e.g., we grouped by it before).
-  // Example query: SELECT DISTINCT column1, MIN(column2) FROM table_a GROUP BY column0;
+  // Example query: SELECT DISTINCT column1, MIN(column2) FROM table_a GROUP BY column1;
   {
     // clang-format off
     const auto lqp =
@@ -402,8 +402,8 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousDistinctAggregateProj
 }
 
 TEST_F(DependentGroupByReductionRuleTest, DoNotRemoveRequiredDistinctAggregate) {
-  // Do not remove the AggregateNode when the grouped column is not unique (only a combination of two column0 and
-  // column1 is).
+  // Do not remove the AggregateNode when the grouped column is not unique (only a combination of the two columns
+  // column0 and column1 is unique).
   {
     // clang-format off
     const auto lqp =

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -19,8 +19,10 @@ class DependentGroupByReductionRuleTest : public StrategyBaseTest {
   void SetUp() override {
     auto& storage_manager = Hyrise::get().storage_manager;
 
-    TableColumnDefinitions column_definitions{
-        {"column0", DataType::Int, false}, {"column1", DataType::Int, false}, {"column2", DataType::Int, false}};
+    TableColumnDefinitions column_definitions{{"column0", DataType::Int, false},
+                                              {"column1", DataType::Int, false},
+                                              {"column2", DataType::Int, false},
+                                              {"column3", DataType::Int, false}};
 
     table_a = std::make_shared<Table>(column_definitions, TableType::Data, ChunkOffset{2}, UseMvcc::Yes);
     table_a->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::PRIMARY_KEY});
@@ -60,6 +62,7 @@ class DependentGroupByReductionRuleTest : public StrategyBaseTest {
     column_e_0 = stored_table_node_e->get_column("column0");
     column_e_1 = stored_table_node_e->get_column("column1");
     column_e_2 = stored_table_node_e->get_column("column2");
+    column_e_3 = stored_table_node_e->get_column("column3");
 
     rule = std::make_shared<DependentGroupByReductionRule>();
   }
@@ -73,7 +76,7 @@ class DependentGroupByReductionRuleTest : public StrategyBaseTest {
   std::shared_ptr<LQPColumnExpression> column_b_0, column_b_1, column_b_2;
   std::shared_ptr<LQPColumnExpression> column_c_0, column_c_1, column_c_2;
   std::shared_ptr<LQPColumnExpression> column_d_0;
-  std::shared_ptr<LQPColumnExpression> column_e_0, column_e_1, column_e_2;
+  std::shared_ptr<LQPColumnExpression> column_e_0, column_e_1, column_e_2, column_e_3;
 };
 
 // Test simple cases.
@@ -82,8 +85,8 @@ TEST_F(DependentGroupByReductionRuleTest, SimpleCases) {
   {
     const auto lqp = PredicateNode::make(equals_(column_a_0, 17), stored_table_node_a);
 
-    const auto actual_lqp = apply_rule(rule, lqp);
     const auto expected_lqp = lqp->deep_copy();
+    const auto actual_lqp = apply_rule(rule, lqp);
     EXPECT_LQP_EQ(actual_lqp, expected_lqp);
   }
 
@@ -92,8 +95,8 @@ TEST_F(DependentGroupByReductionRuleTest, SimpleCases) {
     const auto lqp =
         AggregateNode::make(expression_vector(column_d_0), expression_vector(sum_(column_d_0)), stored_table_node_d);
 
-    const auto actual_lqp = apply_rule(rule, lqp);
     const auto expected_lqp = lqp->deep_copy();
+    const auto actual_lqp = apply_rule(rule, lqp);
     EXPECT_LQP_EQ(actual_lqp, expected_lqp);
   }
 }
@@ -141,8 +144,8 @@ TEST_F(DependentGroupByReductionRuleTest, IncompleteKey) {
     stored_table_node_b);
   // clang-format on
 
-  const auto actual_lqp = apply_rule(rule, lqp);
   const auto expected_lqp = lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -155,8 +158,8 @@ TEST_F(DependentGroupByReductionRuleTest, FullKeyGroupBy) {
     stored_table_node_b);
   // clang-format on
 
-  const auto actual_lqp = apply_rule(rule, lqp);
   const auto expected_lqp = lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -267,8 +270,8 @@ TEST_F(DependentGroupByReductionRuleTest, NoAdaptionForNullableColumns) {
       stored_table_node_b));
   // clang-format on
 
-  const auto actual_lqp = apply_rule(rule, lqp);
   const auto expected_lqp = lqp->deep_copy();
+  const auto actual_lqp = apply_rule(rule, lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
@@ -277,12 +280,12 @@ TEST_F(DependentGroupByReductionRuleTest, NoAdaptionForNullableColumns) {
 TEST_F(DependentGroupByReductionRuleTest, ShortConstraintsFirst) {
   // clang-format off
   const auto lqp =
-  AggregateNode::make(expression_vector(column_e_0, column_e_1, column_e_2), expression_vector(),
+  AggregateNode::make(expression_vector(column_e_0, column_e_1, column_e_2), expression_vector(min_(column_e_3)),
     stored_table_node_e);
 
   const auto expected_lqp =
-  ProjectionNode::make(expression_vector(column_e_0, column_e_1, column_e_2),
-    AggregateNode::make(expression_vector(column_e_2), expression_vector(any_(column_e_1), any_(column_e_0)),
+  ProjectionNode::make(expression_vector(column_e_0, column_e_1, column_e_2, min_(column_e_3)),
+    AggregateNode::make(expression_vector(column_e_2), expression_vector(min_(column_e_3), any_(column_e_1), any_(column_e_0)),
       stored_table_node_e));
   // clang-format on
 
@@ -320,6 +323,57 @@ TEST_F(DependentGroupByReductionRuleTest, MultiKeyReduction) {
   const auto actual_lqp = apply_rule(rule, lqp);
 
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+}
+
+TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousGroupBys) {
+  // To guarantee distinct results for SELECT DISTINCT clauses, the SQLTranslator adds an AggregateNode with the
+  // selected attributes as group by columns. If the AggregateNode's input is already unique for these columns,
+  // remove the whole node.
+
+  // Basic case: Column is unique due to a constraint (e.g. it is a primary key).
+  // Example query: SELECT DISTINCT column0 FROM table_a;
+  {
+    // clang-format off
+    const auto lqp =
+    AggregateNode::make(expression_vector(column_a_0), expression_vector(),
+      stored_table_node_a);
+    // clang-format on
+
+    const auto expected_lqp = stored_table_node_a->deep_copy();
+    const auto actual_lqp = apply_rule(rule, lqp);
+    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+  }
+
+  // More advanced case: Column is unique due to another operation (e.g., we grouped by it before).
+  // Example query: SELECT DISTINCT column1, MIN(column2) FROM table_a GROUP BY column0;
+  {
+    // clang-format off
+    const auto lqp =
+    AggregateNode::make(expression_vector(column_a_1, min_(column_a_2)), expression_vector(),
+      AggregateNode::make(expression_vector(column_a_1), expression_vector(min_(column_a_2)),
+        stored_table_node_a));
+
+    const auto expected_lqp =
+    AggregateNode::make(expression_vector(column_a_1), expression_vector(min_(column_a_2)),
+      stored_table_node_a);
+    // clang-format on
+
+    const auto actual_lqp = apply_rule(rule, lqp);
+    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+  }
+
+  // Negative case: Column is not unique, only a combination of two columns.
+  {
+    // clang-format off
+    const auto lqp =
+    AggregateNode::make(expression_vector(column_b_0), expression_vector(),
+      stored_table_node_b);
+    // clang-format on
+
+    const auto expected_lqp = lqp->deep_copy();
+    const auto actual_lqp = apply_rule(rule, lqp);
+    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+  }
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -374,6 +374,19 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousGroupBys) {
     const auto actual_lqp = apply_rule(rule, lqp);
     EXPECT_LQP_EQ(actual_lqp, expected_lqp);
   }
+
+  // Negative case: There are further aggregates.
+  {
+    // clang-format off
+    const auto lqp =
+    AggregateNode::make(expression_vector(column_a_0), expression_vector(min_(column_a_1)),
+      stored_table_node_a);
+    // clang-format on
+
+    const auto expected_lqp = lqp->deep_copy();
+    const auto actual_lqp = apply_rule(rule, lqp);
+    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+  }
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -337,7 +337,26 @@ TEST_F(DependentGroupByReductionRuleTest, RemoveSuperfluousGroupBys) {
     const auto lqp =
     AggregateNode::make(expression_vector(column_a_0), expression_vector(),
       stored_table_node_a);
+
+    const auto expected_lqp =
+    ProjectionNode::make(expression_vector(column_a_0),
+      stored_table_node_a);
     // clang-format on
+
+    const auto actual_lqp = apply_rule(rule, lqp);
+    EXPECT_LQP_EQ(actual_lqp, expected_lqp);
+  }
+
+  // Basic case: Same as before, but no additional ProjectionNode is required as the AggregateNode does not change the
+  // output expressions.
+  {
+    // clang-format off
+    const auto lqp =
+    AggregateNode::make(expression_vector(column_a_0), expression_vector(),
+      stored_table_node_a);
+    // clang-format on
+
+    stored_table_node_a->set_pruned_column_ids({ColumnID{1}, ColumnID{2}, ColumnID{3}});
 
     const auto expected_lqp = stored_table_node_a->deep_copy();
     const auto actual_lqp = apply_rule(rule, lqp);

--- a/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/dependent_group_by_reduction_rule_test.cpp
@@ -285,7 +285,7 @@ TEST_F(DependentGroupByReductionRuleTest, ShortConstraintsFirst) {
 
   const auto expected_lqp =
   ProjectionNode::make(expression_vector(column_e_0, column_e_1, column_e_2, min_(column_e_3)),
-    AggregateNode::make(expression_vector(column_e_2), expression_vector(min_(column_e_3), any_(column_e_1), any_(column_e_0)),
+    AggregateNode::make(expression_vector(column_e_2), expression_vector(min_(column_e_3), any_(column_e_1), any_(column_e_0)),  // NOLINT(whitespace/line_length)
       stored_table_node_e));
   // clang-format on
 


### PR DESCRIPTION
Thanks to @Bouncner, I read the following note in [a paper](https://www.vldb.org/pvldb/vol16/p1208-liu.pdf):
> It took more than two years for PostgreSQL developers to implement a pattern that
removes the DISTINCT clause if the result is unique by definition, and this feature is
yet to be merged [26].

That's true and it does not look like they will even merge it soon: https://commitfest.postgresql.org/35/2433/

Thus, I was triggered to implement it in Hyrise and prove we can do this in less than half an hour. It does not change anything in benchmarks, but now, we have it.
(To be fair: The Postgres contributors had to implement passing UCCs in the LQP and tried multiple versions. Also, I needed more than half an hour with all tests and an edge case I forgot to cover.)